### PR TITLE
feat(machines): dirty-checkout migration path for project promotion

### DIFF
--- a/apps/web/src/app/api/machines/projects/promote/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/projects/promote/__tests__/route.test.ts
@@ -74,12 +74,12 @@ describe('POST /api/machines/projects/promote', () => {
   });
 
   it('given a successful promotion, returns the new sandboxId and promoted:true', async () => {
-    mockPromoteProject.mockResolvedValue({ ok: true, sandboxId: 'sbx-p1', sessionKey: 'pgs-prj-x', promoted: true, resumed: false });
+    mockPromoteProject.mockResolvedValue({ ok: true, sandboxId: 'sbx-p1', sessionKey: 'pgs-prj-x', promoted: true, resumed: false, carried: false });
     const res = await POST(post({ machineId: 'm-1', name: 'repo' }));
     expect(res.status).toBe(200);
-    // Exactly these three fields: the `sessionKey` is a server-held HMAC Sprite
+    // Exactly these fields: the `sessionKey` is a server-held HMAC Sprite
     // name and is deliberately NOT echoed to a client.
-    expect(await res.json()).toEqual({ sandboxId: 'sbx-p1', promoted: true, resumed: false });
+    expect(await res.json()).toEqual({ sandboxId: 'sbx-p1', promoted: true, resumed: false, carried: false });
   });
 
   it('given a DIRTY checkout, returns 409 with the actionable detail', async () => {
@@ -97,5 +97,48 @@ describe('POST /api/machines/projects/promote', () => {
   it('given the kill switch off, returns 503', async () => {
     mockPromoteProject.mockResolvedValue({ ok: false, reason: 'kill_switch_off' });
     expect((await POST(post({ machineId: 'm-1', name: 'repo' }))).status).toBe(503);
+  });
+});
+
+/**
+ * Issue #2207 — the carry opt-in. The operator route is the ONLY surface that
+ * exposes it: an implicit project-scoped spawn must never silently relocate
+ * someone's uncommitted work.
+ */
+describe('POST /api/machines/projects/promote — carryDirty (#2207)', () => {
+  it('given carryDirty:true, threads it to the service and reports what was carried', async () => {
+    mockPromoteProject.mockResolvedValue({ ok: true, sandboxId: 'sbx-p1', sessionKey: 'pgs-prj-x', promoted: true, resumed: false, carried: true });
+    const res = await POST(post({ machineId: 'm-1', name: 'repo', carryDirty: true }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sandboxId: 'sbx-p1', promoted: true, resumed: false, carried: true });
+    expect(mockPromoteProject).toHaveBeenCalledWith(expect.objectContaining({ carryDirty: true }));
+  });
+
+  it('given carryDirty omitted, defaults to NOT carrying', async () => {
+    mockPromoteProject.mockResolvedValue({ ok: true, sandboxId: 'sbx-p1', sessionKey: 'pgs-prj-x', promoted: true, resumed: false, carried: false });
+    await POST(post({ machineId: 'm-1', name: 'repo' }));
+    expect(mockPromoteProject).toHaveBeenCalledWith(expect.objectContaining({ carryDirty: false }));
+  });
+
+  it('given a non-boolean carryDirty, returns 400 without promoting', async () => {
+    // A truthy string would silently opt a caller into moving their work.
+    const res = await POST(post({ machineId: 'm-1', name: 'repo', carryDirty: 'yes' }));
+    expect(res.status).toBe(400);
+    expect(mockPromoteProject).not.toHaveBeenCalled();
+  });
+
+  it('given UNPUSHED commits, returns 409 — a refusal the caller can act on, not a server fault', async () => {
+    mockPromoteProject.mockResolvedValue({ ok: false, reason: 'unpushed_commits', detail: 'push the branch' });
+    expect((await POST(post({ machineId: 'm-1', name: 'repo' }))).status).toBe(409);
+  });
+
+  it('given a bundle over the size cap, returns 409', async () => {
+    mockPromoteProject.mockResolvedValue({ ok: false, reason: 'carry_too_large', detail: 'too big' });
+    expect((await POST(post({ machineId: 'm-1', name: 'repo', carryDirty: true }))).status).toBe(409);
+  });
+
+  it('given the carry itself failing, returns 502 — the sandbox side let us down', async () => {
+    mockPromoteProject.mockResolvedValue({ ok: false, reason: 'carry_failed', detail: 'bundle is corrupt' });
+    expect((await POST(post({ machineId: 'm-1', name: 'repo', carryDirty: true }))).status).toBe(502);
   });
 });

--- a/apps/web/src/app/api/machines/projects/promote/route.ts
+++ b/apps/web/src/app/api/machines/projects/promote/route.ts
@@ -2,7 +2,7 @@
  * Machine Project PROMOTION API — give a project its OWN Sprite (issue #2204
  * phase 7, `machine-project-promotion.ts`).
  *
- * POST { machineId, name } → promote (provision + clone + credential + CAS)
+ * POST { machineId, name, carryDirty? } → promote (provision + clone + credential + CAS)
  *
  * The explicit entry point for lazy promotion: a project stays a checkout on
  * the owning Machine's Sprite until something promotes it, and this is the
@@ -17,6 +17,12 @@
  * `name` is FREE TEXT, normalized server-side exactly as `addProject`
  * normalized it before persisting, so whatever text created a project can also
  * promote it.
+ *
+ * `carryDirty` (issue #2207) is the migration path out of the dirty/unpushed
+ * refusals: it bundles the machine-side work and restores it on the promoted
+ * Sprite. THIS ROUTE IS ITS ONLY SURFACE — the implicit spawn path deliberately
+ * keeps refusing, because relocating someone's uncommitted work is a decision
+ * they have to make, not a side effect of opening a terminal.
  */
 
 import { NextResponse } from 'next/server';
@@ -35,6 +41,13 @@ const PROMOTE_DENIAL_STATUS: Record<string, number> = {
   project_not_found: 404,
   // A refusal the CALLER can fix (commit or discard the work) — 409, not 400.
   dirty_checkout: 409,
+  // Likewise fixable, by pushing or by retrying with `carryDirty` — it is not a
+  // server fault, and without this entry it fell through to a misleading 500.
+  unpushed_commits: 409,
+  // The work is too big to carry; pushing and promoting without a carry works.
+  carry_too_large: 409,
+  // The carry itself broke down inside the sandbox — nothing was promoted.
+  carry_failed: 502,
   // We could not verify the checkout is clean; retrying later may succeed.
   dirty_check_failed: 409,
   kill_switch_off: 503,
@@ -48,7 +61,7 @@ export async function POST(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
 
-  let body: { machineId?: unknown; name?: unknown };
+  let body: { machineId?: unknown; name?: unknown; carryDirty?: unknown };
   try {
     body = await request.json();
   } catch {
@@ -64,6 +77,11 @@ export async function POST(request: Request) {
   if (typeof body.name !== 'string' || !hasNameContent(body.name)) {
     return NextResponse.json({ error: 'name is required' }, { status: 400 });
   }
+  // Strictly boolean: a truthy string like "no" would opt a caller into MOVING
+  // their uncommitted work without them ever having said yes.
+  if (body.carryDirty !== undefined && typeof body.carryDirty !== 'boolean') {
+    return NextResponse.json({ error: 'carryDirty must be a boolean' }, { status: 400 });
+  }
 
   if (!(await canAccessMachine(auth.userId, body.machineId))) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
@@ -72,7 +90,13 @@ export async function POST(request: Request) {
   const actor = await resolveMachineActorContext(auth.userId);
   const deps = buildPromoteProjectDeps({ actorUserId: auth.userId });
 
-  const result = await promoteProject({ machineId: body.machineId, projectName: body.name, actor, deps });
+  const result = await promoteProject({
+    machineId: body.machineId,
+    projectName: body.name,
+    actor,
+    carryDirty: body.carryDirty === true,
+    deps,
+  });
   if (!result.ok) {
     return NextResponse.json(
       { error: result.detail ?? result.reason, reason: result.reason },
@@ -87,5 +111,8 @@ export async function POST(request: Request) {
     // not "promoted just now".
     promoted: result.promoted,
     resumed: result.resumed,
+    // `true` when work was moved across — the caller should tell the user their
+    // changes are waiting UNCOMMITTED on the new Sprite.
+    carried: result.carried,
   });
 }

--- a/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
@@ -10,6 +10,7 @@ import {
   buildCarryPlan,
   parseFileSizeBytes,
   isReclaimableAfterCarry,
+  isMissingParentCommitError,
   MAX_CARRY_BUNDLE_BYTES,
   type PromoteProjectDeps,
   type ProjectStorageMeasurement,
@@ -1003,6 +1004,17 @@ describe('isReclaimableAfterCarry', () => {
   });
 });
 
+describe('isMissingParentCommitError', () => {
+  it('given the exact message git raises for a parentless HEAD~1, should recognize it', () => {
+    expect(isMissingParentCommitError("fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.")).toBe(true);
+  });
+
+  it('given an unrelated reset failure, should not misclassify it as the root-commit case', () => {
+    expect(isMissingParentCommitError('fatal: Could not reset index file to revision \'HEAD~1\'.')).toBe(false);
+    expect(isMissingParentCommitError('')).toBe(false);
+  });
+});
+
 describe('promoteProject — carryDirty opt-in (#2207)', () => {
   const DIRTY_STATUS = `${CLEAN_STATUS} M src/index.ts\n?? notes.md\n`;
   /** What the machine checkout looks like AFTER the carry commit: clean, one ahead. */
@@ -1307,6 +1319,72 @@ describe('promoteProject — every step of the carry fails closed (#2207)', () =
     const machine = makeMachineSandbox({ status: DIRTY });
     const { deps, killCalls } = makeDeps({}, { machine });
     failProjectGit(deps, 'reset');
+
+    expect(await carry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(killCalls).toEqual(['sbx-project-1']);
+  });
+
+  it('given a carry commit that is the repository ROOT (cloned from an empty remote), should restore the work instead of failing the promotion', async () => {
+    // `HEAD~1` does not exist for a parentless commit — git refuses the reset
+    // with exactly this message, not a generic failure. That refusal is the
+    // signal to fall back to the root-commit path, not a reason to give up.
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const { deps, byId } = makeDeps({}, { machine });
+    const host = deps.host;
+    deps.host = {
+      ...host,
+      provision: async (args) => {
+        const handle = await host.provision(args);
+        return {
+          ...handle,
+          exec: async (e) =>
+            gitSubcommand(e.args) === 'reset' && e.args?.includes('HEAD~1')
+              ? {
+                  exitCode: 128,
+                  stdout: '',
+                  stderr: "fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.",
+                }
+              : handle.exec(e),
+        };
+      },
+    };
+
+    const result = await carry(deps);
+
+    expect(result).toMatchObject({ ok: true, carried: true });
+    // The failed `HEAD~1` attempt is intercepted before it reaches the fake
+    // Sprite's own log (it never really ran against a repo), so only the
+    // fallback pair shows up after `checkout`.
+    const projectGit = byId.get('sbx-project-1')?.execLog.filter((e) => e.cmd === 'git').map((e) => gitSubcommand(e.args));
+    expect(projectGit).toEqual(['clone', 'fetch', 'checkout', 'update-ref', 'reset']);
+    const unref = byId.get('sbx-project-1')?.execLog.find((e) => gitSubcommand(e.args) === 'update-ref');
+    expect(unref?.args).toEqual(['update-ref', '-d', 'refs/heads/main']);
+  });
+
+  it('given the root-commit fallback unable to clear the ref, should fail the carry', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const { deps, killCalls } = makeDeps({}, { machine });
+    const host = deps.host;
+    deps.host = {
+      ...host,
+      provision: async (args) => {
+        const handle = await host.provision(args);
+        return {
+          ...handle,
+          exec: async (e) => {
+            if (gitSubcommand(e.args) === 'reset' && e.args?.includes('HEAD~1')) {
+              return {
+                exitCode: 128,
+                stdout: '',
+                stderr: "fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.",
+              };
+            }
+            if (gitSubcommand(e.args) === 'update-ref') return { exitCode: 1, stdout: '', stderr: 'fatal: cannot lock ref' };
+            return handle.exec(e);
+          },
+        };
+      },
+    };
 
     expect(await carry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
     expect(killCalls).toEqual(['sbx-project-1']);

--- a/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
@@ -5,6 +5,12 @@ import {
   PROJECT_REPO_PATH,
   classifyCheckoutStatus,
   isCloneBlockedByExistingCheckout,
+  parseCheckoutBranchName,
+  isCarryableState,
+  buildCarryPlan,
+  parseFileSizeBytes,
+  isReclaimableAfterCarry,
+  MAX_CARRY_BUNDLE_BYTES,
   type PromoteProjectDeps,
   type ProjectStorageMeasurement,
 } from '../machine-project-promotion';
@@ -109,7 +115,12 @@ function makeFakeHost() {
         return { exitCode: 0, stdout: '', stderr: '' };
       },
       writeFiles: async (files) => {
-        for (const f of files) state.files.set(f.path, String(f.content));
+        // Binary-faithful: the carry transfers a bundle as bytes, and a
+        // `String(Uint8Array)` here would quietly turn it into "66,85,78,…"
+        // and hide a real corruption bug behind a passing test.
+        for (const f of files) {
+          state.files.set(f.path, typeof f.content === 'string' ? f.content : Buffer.from(f.content).toString('utf8'));
+        }
       },
       readFile: async ({ path }) => {
         const content = state.files.get(path);
@@ -156,18 +167,50 @@ function makeFakeHost() {
 const CLEAN_STATUS = '## main...origin/main\n';
 
 /**
+ * The git SUBCOMMAND of an invocation, skipping any leading `-c key=value`
+ * pairs — `['-c','user.name=x','commit','-m','…']` is a `commit`.
+ */
+function gitSubcommand(args: string[] | undefined): string | null {
+  if (!args) return null;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '-c') {
+      i += 1;
+      continue;
+    }
+    if (!args[i].startsWith('-')) return args[i];
+  }
+  return null;
+}
+
+const CARRY_SHA = 'c0ffee1234567890';
+
+/**
  * The OWNING Machine's Sprite: `test -e` reports the checkout present, and
  * `git status --porcelain -b` reports it clean and pushed, unless a test says
  * otherwise. The branch header is part of the fixture because it is part of the
  * command — a clean tree alone no longer licenses promotion (F1).
+ *
+ * The carry path (#2207) drives more than `status` here — `add`, `commit`,
+ * `rev-parse`, `bundle`, a `stat` size probe and a binary read of the bundle —
+ * so every one of those is routable per test.
  */
 function makeMachineSandbox({
   checkoutExists = true,
   status = { exitCode: 0, stdout: CLEAN_STATUS, stderr: '' },
+  git = {},
+  bundleBytes = 4096,
+  bundleContent = 'BUNDLE-BYTES' as string | null,
+  statResult,
 }: {
   checkoutExists?: boolean;
   /** One result for every `git status`, or a sequence consumed per call (last one repeats). */
   status?: SandboxRunResult | SandboxRunResult[];
+  /** Per-subcommand overrides for every git call that is NOT `status`. */
+  git?: Record<string, SandboxRunResult>;
+  bundleBytes?: number;
+  /** `null` makes the bundle unreadable — the transfer-failure case. */
+  bundleContent?: string | null;
+  statResult?: SandboxRunResult;
 } = {}) {
   const calls: RunCommandArgs[] = [];
   const statusQueue = Array.isArray(status) ? [...status] : [status];
@@ -177,13 +220,18 @@ function makeMachineSandbox({
     runCommand: async (opts) => {
       calls.push(opts);
       if (opts.cmd === 'test') return { exitCode: checkoutExists ? 0 : 1, stdout: '', stderr: '' };
-      if (opts.cmd === 'git' || opts.args?.includes('status')) {
-        return statusQueue.length > 1 ? statusQueue.shift()! : statusQueue[0];
+      if (opts.cmd === 'stat') return statResult ?? { exitCode: 0, stdout: `${bundleBytes}\n`, stderr: '' };
+      if (opts.cmd === 'git') {
+        const sub = gitSubcommand(opts.args);
+        if (sub === 'status') return statusQueue.length > 1 ? statusQueue.shift()! : statusQueue[0];
+        if (sub && git[sub]) return git[sub];
+        if (sub === 'rev-parse') return { exitCode: 0, stdout: `${CARRY_SHA}\n`, stderr: '' };
+        return { exitCode: 0, stdout: '', stderr: '' };
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     },
     writeFiles: async () => {},
-    readFileToBuffer: async () => null,
+    readFileToBuffer: async () => (bundleContent === null ? null : Buffer.from(bundleContent)),
     createCheckpoint: async () => {},
   };
   return { sandbox, calls };
@@ -260,7 +308,7 @@ describe('promoteProject — first promotion', () => {
 
     const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
 
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-project-1', sessionKey: SESSION_KEY, promoted: true, resumed: false });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-project-1', sessionKey: SESSION_KEY, promoted: true, resumed: false, carried: false });
     expect(provisionCalls).toEqual([SESSION_KEY]);
     expect(promoteCalls).toEqual([{ id: PROJECT_ID, previousSandboxId: null, sandboxId: 'sbx-project-1' }]);
 
@@ -316,6 +364,7 @@ describe('promoteProject — first promotion', () => {
       sessionKey: SESSION_KEY,
       promoted: false,
       resumed: true,
+      carried: false,
     });
     expect(seeded.promoteCalls).toEqual([]);
     // Only the manual pre-promotion above ever provisioned — the reattach did not.
@@ -425,6 +474,7 @@ describe('promoteProject — races and half-promotions', () => {
       sessionKey: SESSION_KEY,
       promoted: false,
       resumed: true,
+      carried: false,
     });
     expect(killCalls).toEqual([]);
   });
@@ -459,7 +509,7 @@ describe('promoteProject — races and half-promotions', () => {
 
     const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
 
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-winner', sessionKey: SESSION_KEY, promoted: false, resumed: true });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-winner', sessionKey: SESSION_KEY, promoted: false, resumed: true, carried: false });
     expect(killCalls).toEqual(['sbx-project-1']);
   });
 
@@ -822,5 +872,554 @@ describe('checkout classifiers — linear on hostile input', () => {
 
   it('given mixed-case git output, should still recognise the shared-Sprite signal', () => {
     expect(isCloneBlockedByExistingCheckout("fatal: destination path 'X' ALREADY EXISTS.")).toBe(true);
+  });
+});
+
+/**
+ * Issue #2207 — the DIRTY-CHECKOUT MIGRATION PATH.
+ *
+ * The refusal that makes promotion safe used to be a dead end: the only way past
+ * it was to go and commit/push by hand on the machine Sprite. `carryDirty` is
+ * the opt-in that carries the work across instead — as a git BUNDLE, moved as
+ * bytes, so nothing about the transfer can silently corrupt it.
+ */
+describe('parseCheckoutBranchName', () => {
+  it('given a tracked branch, should take the local name only', () => {
+    expect(parseCheckoutBranchName('## main...origin/main [ahead 2]\n')).toBe('main');
+  });
+
+  it('given a branch with NO upstream, should still name it', () => {
+    expect(parseCheckoutBranchName('## scratch\n')).toBe('scratch');
+  });
+
+  it('given a detached HEAD, should report no branch', () => {
+    expect(parseCheckoutBranchName('## HEAD (no branch)\n')).toBeNull();
+  });
+
+  it('given an unborn branch on a fresh repo, should name it', () => {
+    expect(parseCheckoutBranchName('## No commits yet on main\n')).toBe('main');
+  });
+
+  it('given no branch header at all, should report no branch', () => {
+    expect(parseCheckoutBranchName(' M a.ts\n')).toBeNull();
+  });
+
+  it('given an empty header, should report no branch rather than an empty name', () => {
+    expect(parseCheckoutBranchName('## \n')).toBeNull();
+  });
+});
+
+describe('isCarryableState', () => {
+  it('given work a clone cannot reproduce, should be carryable', () => {
+    expect(isCarryableState({ kind: 'dirty', detail: ' M a.ts' })).toBe(true);
+    expect(isCarryableState({ kind: 'unpushed', detail: '2 commit(s)' })).toBe(true);
+  });
+
+  it('given nothing at risk, should not be — there is nothing to carry', () => {
+    expect(isCarryableState({ kind: 'clean' })).toBe(false);
+    expect(isCarryableState({ kind: 'absent' })).toBe(false);
+  });
+
+  it('given an UNVERIFIABLE checkout, should NOT be carryable — we cannot bundle what we cannot read', () => {
+    expect(isCarryableState({ kind: 'unknown', detail: 'git status did not complete' })).toBe(false);
+  });
+});
+
+describe('buildCarryPlan', () => {
+  it('given a DIRTY checkout on a named branch, should commit, bundle, and reset the carry commit away', () => {
+    const plan = buildCarryPlan({ state: { kind: 'dirty', detail: ' M a.ts' }, branchName: 'main', projectId: PROJECT_ID });
+    expect(plan).toEqual({
+      needsCommit: true,
+      needsBranchCreate: false,
+      needsReset: true,
+      branch: 'main',
+      bundlePath: '/home/sprite/pagespace-carry-p1.bundle',
+      fetchRefspec: '+refs/heads/*:refs/remotes/pagespace-carry/*',
+      checkoutTarget: 'pagespace-carry/main',
+    });
+  });
+
+  it('given an UNPUSHED-only checkout, should bundle WITHOUT committing — and therefore without resetting', () => {
+    // A clean tree has nothing to commit, and an empty carry commit would make
+    // the `reset --mixed HEAD~1` on the far side throw away a real commit.
+    const plan = buildCarryPlan({ state: { kind: 'unpushed', detail: '2 commit(s)' }, branchName: 'feature', projectId: PROJECT_ID });
+    expect(plan.needsCommit).toBe(false);
+    expect(plan.needsReset).toBe(false);
+    expect(plan.checkoutTarget).toBe('pagespace-carry/feature');
+  });
+
+  it('given a DETACHED HEAD, should create a named ref first — `bundle --all` can only carry refs', () => {
+    const plan = buildCarryPlan({ state: { kind: 'dirty', detail: ' M a.ts' }, branchName: null, projectId: PROJECT_ID });
+    expect(plan.needsBranchCreate).toBe(true);
+    expect(plan.branch).toBe('pagespace-carry');
+    expect(plan.checkoutTarget).toBe('pagespace-carry/pagespace-carry');
+  });
+
+  it('given a project id with path-hostile characters, should keep the bundle path a single tame filename', () => {
+    const plan = buildCarryPlan({ state: { kind: 'clean' }, branchName: 'main', projectId: '../../etc/pas swd' });
+    expect(plan.bundlePath).toBe('/home/sprite/pagespace-carry-etcpasswd.bundle');
+  });
+});
+
+describe('parseFileSizeBytes', () => {
+  it('given stat output, should read the byte count', () => {
+    expect(parseFileSizeBytes('4096\n')).toBe(4096);
+  });
+
+  it('given zero, should read zero rather than falsy-collapse to null', () => {
+    expect(parseFileSizeBytes('0')).toBe(0);
+  });
+
+  it('given anything that is not a plain integer, should report unknown so the caller fails closed', () => {
+    expect(parseFileSizeBytes('')).toBeNull();
+    expect(parseFileSizeBytes('stat: cannot stat')).toBeNull();
+    expect(parseFileSizeBytes('12x')).toBeNull();
+  });
+});
+
+describe('isReclaimableAfterCarry', () => {
+  const carrySha = 'abc123';
+
+  it('given a tree that is exactly the carry commit we made, should reclaim', () => {
+    // The carry left the machine tree clean but one commit ahead, so the
+    // ordinary `clean` recheck would refuse and leak the old checkout forever.
+    expect(isReclaimableAfterCarry({ recheckKind: 'unpushed', headSha: carrySha, carrySha })).toBe(true);
+    expect(isReclaimableAfterCarry({ recheckKind: 'clean', headSha: carrySha, carrySha })).toBe(true);
+  });
+
+  it('given NEW work written during the promotion, should refuse — deleting it is the unrecoverable mistake', () => {
+    expect(isReclaimableAfterCarry({ recheckKind: 'dirty', headSha: carrySha, carrySha })).toBe(false);
+    expect(isReclaimableAfterCarry({ recheckKind: 'unknown', headSha: carrySha, carrySha })).toBe(false);
+    expect(isReclaimableAfterCarry({ recheckKind: 'absent', headSha: carrySha, carrySha })).toBe(false);
+  });
+
+  it('given a HEAD that moved past the carry commit, should refuse', () => {
+    expect(isReclaimableAfterCarry({ recheckKind: 'unpushed', headSha: 'def456', carrySha })).toBe(false);
+  });
+
+  it('given an unreadable sha on either side, should refuse', () => {
+    expect(isReclaimableAfterCarry({ recheckKind: 'clean', headSha: null, carrySha })).toBe(false);
+    expect(isReclaimableAfterCarry({ recheckKind: 'clean', headSha: carrySha, carrySha: null })).toBe(false);
+  });
+});
+
+describe('promoteProject — carryDirty opt-in (#2207)', () => {
+  const DIRTY_STATUS = `${CLEAN_STATUS} M src/index.ts\n?? notes.md\n`;
+  /** What the machine checkout looks like AFTER the carry commit: clean, one ahead. */
+  const CARRIED_STATUS = '## main...origin/main [ahead 1]\n';
+
+  it('given carryDirty NOT set, should still refuse a dirty checkout and point at the way out', async () => {
+    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: DIRTY_STATUS, stderr: '' } });
+    const { deps, provisionCalls } = makeDeps({}, { machine });
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
+
+    expect(result).toMatchObject({ ok: false, reason: 'dirty_checkout' });
+    expect(result.ok === false && result.detail).toContain('carryDirty');
+    expect(provisionCalls).toEqual([]);
+  });
+
+  it('given carryDirty and a DIRTY checkout, should commit + bundle on the machine, transfer the bytes, and restore the work on the new Sprite', async () => {
+    const machine = makeMachineSandbox({
+      status: [
+        { exitCode: 0, stdout: DIRTY_STATUS, stderr: '' }, // the gate
+        { exitCode: 0, stdout: CARRIED_STATUS, stderr: '' }, // the pre-reclaim recheck
+      ],
+    });
+    const { deps, byId, rows, machineSandbox } = makeDeps({}, { machine });
+
+    const result = await promoteProject({
+      machineId: MACHINE_ID,
+      projectName: PROJECT_NAME,
+      actor,
+      carryDirty: true,
+      deps,
+    });
+
+    expect(result).toMatchObject({ ok: true, promoted: true, carried: true });
+    expect(rows.get(PROJECT_ID)?.sandboxId).toBe('sbx-project-1');
+
+    // MACHINE side: everything in the tree became one commit, then a bundle.
+    const machineGit = machineSandbox.calls.filter((c) => c.cmd === 'git').map((c) => gitSubcommand(c.args));
+    expect(machineGit).toEqual(expect.arrayContaining(['add', 'commit', 'rev-parse', 'bundle']));
+
+    // TRANSFER: the bundle landed on the project Sprite as bytes.
+    const projectState = byId.get('sbx-project-1');
+    expect(projectState?.files.get('/home/sprite/pagespace-carry-p1.bundle')).toBe('BUNDLE-BYTES');
+
+    // PROJECT side: fetched from the bundle, checked the branch out, then put
+    // the carried work back in the working tree as uncommitted changes.
+    const projectGit = projectState?.execLog.filter((e) => e.cmd === 'git').map((e) => gitSubcommand(e.args));
+    expect(projectGit).toEqual(['clone', 'fetch', 'checkout', 'reset']);
+    const reset = projectState?.execLog.find((e) => gitSubcommand(e.args) === 'reset');
+    expect(reset?.args).toEqual(['reset', '--mixed', 'HEAD~1']);
+  });
+
+  it('given carryDirty and an UNPUSHED-only checkout, should carry the commits without inventing one', async () => {
+    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: '## main...origin/main [ahead 2]\n', stderr: '' } });
+    const { deps, byId, machineSandbox } = makeDeps({}, { machine });
+
+    const result = await promoteProject({
+      machineId: MACHINE_ID,
+      projectName: PROJECT_NAME,
+      actor,
+      carryDirty: true,
+      deps,
+    });
+
+    expect(result).toMatchObject({ ok: true, carried: true });
+    const machineGit = machineSandbox.calls.filter((c) => c.cmd === 'git').map((c) => gitSubcommand(c.args));
+    expect(machineGit).not.toContain('commit');
+    expect(machineGit).toContain('bundle');
+    const projectGit = byId.get('sbx-project-1')?.execLog.filter((e) => e.cmd === 'git').map((e) => gitSubcommand(e.args));
+    expect(projectGit).toEqual(['clone', 'fetch', 'checkout']);
+  });
+
+  it('given carryDirty on a CLEAN checkout, should carry nothing and behave exactly as before', async () => {
+    const { deps, machineSandbox } = makeDeps();
+
+    const result = await promoteProject({
+      machineId: MACHINE_ID,
+      projectName: PROJECT_NAME,
+      actor,
+      carryDirty: true,
+      deps,
+    });
+
+    expect(result).toMatchObject({ ok: true, carried: false });
+    expect(machineSandbox.calls.filter((c) => c.cmd === 'git').map((c) => gitSubcommand(c.args))).toEqual(['status', 'status']);
+  });
+
+  it('given an UNVERIFIABLE checkout, should refuse even WITH carryDirty', async () => {
+    const machine = makeMachineSandbox({ status: { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository' } });
+    const { deps, provisionCalls } = makeDeps({}, { machine });
+
+    const result = await promoteProject({
+      machineId: MACHINE_ID,
+      projectName: PROJECT_NAME,
+      actor,
+      carryDirty: true,
+      deps,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'dirty_check_failed' });
+    expect(provisionCalls).toEqual([]);
+  });
+});
+
+describe('promoteProject — carry failures leave nothing behind (#2207)', () => {
+  const DIRTY = { exitCode: 0, stdout: `${CLEAN_STATUS} M src/index.ts\n`, stderr: '' };
+
+  async function promoteWithCarry(deps: PromoteProjectDeps) {
+    return promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps });
+  }
+
+  it('given the bundle failing to build, should kill the provisioned Sprite and leave the row unpromoted', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY, git: { bundle: { exitCode: 128, stdout: '', stderr: 'fatal: refusing to create empty bundle' } } });
+    const { deps, killCalls, rows } = makeDeps({}, { machine });
+
+    const result = await promoteWithCarry(deps);
+
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('empty bundle');
+    expect(killCalls).toEqual(['sbx-project-1']);
+    expect(rows.get(PROJECT_ID)?.sandboxId).toBeNull();
+  });
+
+  it('given a bundle that cannot be read back, should fail the carry rather than promote without the work', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY, bundleContent: null });
+    const { deps, killCalls, rows } = makeDeps({}, { machine });
+
+    expect(await promoteWithCarry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(killCalls).toEqual(['sbx-project-1']);
+    expect(rows.get(PROJECT_ID)?.sandboxId).toBeNull();
+  });
+
+  it('given an unreadable bundle SIZE, should fail closed — an unbounded read is an OOM', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY, statResult: { exitCode: 1, stdout: '', stderr: 'stat: cannot stat' } });
+    const { deps } = makeDeps({}, { machine });
+
+    expect(await promoteWithCarry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+  });
+
+  it('given a bundle larger than the cap, should refuse with its own actionable reason', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY, bundleBytes: MAX_CARRY_BUNDLE_BYTES + 1 });
+    const { deps, killCalls } = makeDeps({}, { machine });
+
+    const result = await promoteWithCarry(deps);
+
+    expect(result).toMatchObject({ ok: false, reason: 'carry_too_large' });
+    expect(killCalls).toEqual(['sbx-project-1']);
+  });
+
+  it('given the far-side fetch failing, should fail the carry — a promoted project missing the work is the loss we refuse', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const { deps, killCalls, rows } = makeDeps({}, { machine });
+    const host = deps.host;
+    deps.host = {
+      ...host,
+      provision: async (args) => {
+        const handle = await host.provision(args);
+        return {
+          ...handle,
+          exec: async (e) =>
+            gitSubcommand(e.args) === 'fetch'
+              ? { exitCode: 128, stdout: '', stderr: 'fatal: bundle is corrupt' }
+              : handle.exec(e),
+        };
+      },
+    };
+
+    const result = await promoteWithCarry(deps);
+
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(killCalls).toEqual(['sbx-project-1']);
+    expect(rows.get(PROJECT_ID)?.sandboxId).toBeNull();
+  });
+});
+
+describe('promoteProject — reclaim after a carry (#2207)', () => {
+  const DIRTY = { exitCode: 0, stdout: `${CLEAN_STATUS} M src/index.ts\n`, stderr: '' };
+
+  it('given the machine tree left exactly at our carry commit, should reclaim the old checkout', async () => {
+    const machine = makeMachineSandbox({
+      status: [DIRTY, { exitCode: 0, stdout: '## main...origin/main [ahead 1]\n', stderr: '' }],
+    });
+    const { deps, machineSandbox } = makeDeps({}, { machine });
+
+    await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps });
+
+    // The CHECKOUT reclaim is the `-rf`; the carry's own `rm -f` of the staged
+    // bundle is housekeeping, not the reclaim under test.
+    expect(machineSandbox.calls.filter((c) => c.args?.[0] === '-rf').map((c) => c.args)).toEqual([['-rf', PROJECT_PATH]]);
+  });
+
+  it('given someone committing on the machine DURING the promotion, should not reclaim', async () => {
+    let revParseCalls = 0;
+    const machine = makeMachineSandbox({
+      status: [DIRTY, { exitCode: 0, stdout: '## main...origin/main [ahead 2]\n', stderr: '' }],
+    });
+    const inner = machine.sandbox.runCommand;
+    machine.sandbox.runCommand = async (opts) => {
+      if (opts.cmd === 'git' && gitSubcommand(opts.args) === 'rev-parse') {
+        revParseCalls += 1;
+        // The carry's own read, then a DIFFERENT head at reclaim time.
+        return { exitCode: 0, stdout: revParseCalls === 1 ? 'carry-sha\n' : 'someone-elses-sha\n', stderr: '' };
+      }
+      return inner(opts);
+    };
+    const { deps, machineSandbox } = makeDeps({}, { machine });
+
+    await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps });
+
+    expect(machineSandbox.calls.filter((c) => c.args?.[0] === '-rf')).toEqual([]);
+  });
+});
+
+describe('promoteProject — every step of the carry fails closed (#2207)', () => {
+  const DIRTY = { exitCode: 0, stdout: `${CLEAN_STATUS} M src/index.ts\n`, stderr: '' };
+
+  async function carry(deps: PromoteProjectDeps) {
+    return promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps });
+  }
+
+  /** Fails ONE git subcommand on the project Sprite, leaving the rest working. */
+  function failProjectGit(deps: PromoteProjectDeps, sub: string): void {
+    const host = deps.host;
+    deps.host = {
+      ...host,
+      provision: async (args) => {
+        const handle = await host.provision(args);
+        return {
+          ...handle,
+          exec: async (e) =>
+            gitSubcommand(e.args) === sub
+              ? { exitCode: 1, stdout: '', stderr: `fatal: ${sub} refused` }
+              : handle.exec(e),
+        };
+      },
+    };
+  }
+
+  it('given the branch read failing, should not guess at a branch name', async () => {
+    const machine = makeMachineSandbox({ status: [DIRTY, { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository' }] });
+    const { deps, killCalls } = makeDeps({}, { machine });
+
+    expect(await carry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(killCalls).toEqual(['sbx-project-1']);
+  });
+
+  it('given staging failing, should stop before committing anything', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY, git: { add: { exitCode: 1, stdout: '', stderr: 'fatal: pathspec' } } });
+    const { deps, machineSandbox } = makeDeps({}, { machine });
+
+    const result = await carry(deps);
+
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('staging');
+    expect(machineSandbox.calls.map((c) => gitSubcommand(c.args))).not.toContain('commit');
+  });
+
+  it('given the carry commit failing, should fail the promotion', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY, git: { commit: { exitCode: 1, stdout: '', stderr: 'fatal: no identity' } } });
+    const { deps } = makeDeps({}, { machine });
+
+    const result = await carry(deps);
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('committing');
+  });
+
+  it('given a DETACHED HEAD, should mint a ref so the bundle has something to carry', async () => {
+    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: '## HEAD (no branch)\n M src/index.ts\n', stderr: '' } });
+    const { deps, byId, machineSandbox } = makeDeps({}, { machine });
+
+    expect(await carry(deps)).toMatchObject({ ok: true, carried: true });
+
+    const branched = machineSandbox.calls.find((c) => gitSubcommand(c.args) === 'branch');
+    expect(branched?.args).toEqual(['branch', '-f', 'pagespace-carry', 'HEAD']);
+    const checkout = byId.get('sbx-project-1')?.execLog.find((e) => gitSubcommand(e.args) === 'checkout');
+    expect(checkout?.args).toEqual(['checkout', '-B', 'pagespace-carry', 'pagespace-carry/pagespace-carry']);
+  });
+
+  it('given the detached-HEAD ref failing to mint, should fail the carry', async () => {
+    const machine = makeMachineSandbox({
+      status: { exitCode: 0, stdout: '## HEAD (no branch)\n M src/index.ts\n', stderr: '' },
+      git: { branch: { exitCode: 1, stdout: '', stderr: 'fatal: bad ref' } },
+    });
+    const { deps } = makeDeps({}, { machine });
+
+    expect(await carry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+  });
+
+  it('given the far-side checkout failing, should fail the carry', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const { deps } = makeDeps({}, { machine });
+    failProjectGit(deps, 'checkout');
+
+    const result = await carry(deps);
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('checking out');
+  });
+
+  it('given the far-side reset failing, should fail rather than leave the carry commit in the history', async () => {
+    // The work IS on the Sprite at that point, but as a commit the user never
+    // made. Reporting success would hand them a repo whose history is a lie.
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const { deps, killCalls } = makeDeps({}, { machine });
+    failProjectGit(deps, 'reset');
+
+    expect(await carry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(killCalls).toEqual(['sbx-project-1']);
+  });
+
+  it('given the bundle READ throwing, should fail closed', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    machine.sandbox.readFileToBuffer = async () => {
+      throw new Error('sprite disk error');
+    };
+    const { deps } = makeDeps({}, { machine });
+
+    const result = await carry(deps);
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('sprite disk error');
+  });
+
+  it('given the bundle WRITE throwing, should fail closed', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const { deps } = makeDeps({}, { machine });
+    const host = deps.host;
+    deps.host = {
+      ...host,
+      provision: async (args) => {
+        const handle = await host.provision(args);
+        return {
+          ...handle,
+          writeFiles: async () => {
+            throw new Error('sprite write error');
+          },
+        };
+      },
+    };
+
+    const result = await carry(deps);
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('sprite write error');
+  });
+
+  it('given the SIZE PROBE throwing, should fail closed rather than read an unbounded file', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    const inner = machine.sandbox.runCommand;
+    machine.sandbox.runCommand = async (opts) => {
+      if (opts.cmd === 'stat') throw new Error('stat blew up');
+      return inner(opts);
+    };
+    const { deps } = makeDeps({}, { machine });
+
+    expect(await carry(deps)).toMatchObject({ ok: false, reason: 'carry_failed' });
+  });
+
+  it('given the machine Sprite going unreachable mid-carry, should fail closed', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    let bundled = false;
+    const inner = machine.sandbox.runCommand;
+    machine.sandbox.runCommand = async (opts) => {
+      if (opts.cmd === 'git' && gitSubcommand(opts.args) === 'bundle') bundled = true;
+      return inner(opts);
+    };
+    const { deps } = makeDeps({}, { machine });
+    // Everything up to and including the bundle works; the reconnect that the
+    // byte transfer needs does not.
+    deps.reconnect = async () => (bundled ? null : machine.sandbox);
+
+    const result = await carry(deps);
+    expect(result).toMatchObject({ ok: false, reason: 'carry_failed' });
+    expect(result.ok === false && result.detail).toContain('unreachable');
+  });
+});
+
+describe('promoteProject — an unconfirmable carry sha never licenses a delete (#2207)', () => {
+  const DIRTY = { exitCode: 0, stdout: `${CLEAN_STATUS} M src/index.ts\n`, stderr: '' };
+
+  it('given HEAD unreadable after the carry commit, should promote but leave the old checkout alone', async () => {
+    const machine = makeMachineSandbox({
+      status: [DIRTY, { exitCode: 0, stdout: '## main...origin/main [ahead 1]\n', stderr: '' }],
+      git: { 'rev-parse': { exitCode: 128, stdout: '', stderr: 'fatal: ambiguous argument' } },
+    });
+    const { deps, machineSandbox } = makeDeps({}, { machine });
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps });
+
+    expect(result).toMatchObject({ ok: true, carried: true });
+    expect(machineSandbox.calls.filter((c) => c.args?.[0] === '-rf')).toEqual([]);
+  });
+
+  it('given an EMPTY sha, should treat it as unreadable rather than as a match', async () => {
+    const machine = makeMachineSandbox({
+      status: [DIRTY, { exitCode: 0, stdout: '## main...origin/main [ahead 1]\n', stderr: '' }],
+      git: { 'rev-parse': { exitCode: 0, stdout: '\n', stderr: '' } },
+    });
+    const { deps, machineSandbox } = makeDeps({}, { machine });
+
+    await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps });
+
+    expect(machineSandbox.calls.filter((c) => c.args?.[0] === '-rf')).toEqual([]);
+  });
+
+  it('given the machine Sprite unacquirable for the byte transfer, should fail the carry', async () => {
+    const machine = makeMachineSandbox({ status: DIRTY });
+    let bundled = false;
+    const inner = machine.sandbox.runCommand;
+    machine.sandbox.runCommand = async (opts) => {
+      if (opts.cmd === 'git' && gitSubcommand(opts.args) === 'bundle') bundled = true;
+      return inner(opts);
+    };
+    const { deps } = makeDeps({}, { machine });
+    deps.acquireMachineSandbox = async () =>
+      bundled ? { ok: false, reason: 'machine_unavailable' } : { ok: true, sandboxId: MACHINE_SANDBOX_ID, resumed: false };
+
+    expect(await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, carryDirty: true, deps })).toMatchObject({
+      ok: false,
+      reason: 'carry_failed',
+    });
   });
 });

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -453,6 +453,19 @@ export function isReclaimableAfterCarry({
 }
 
 /**
+ * Is this the specific failure `git reset --mixed HEAD~1` produces when
+ * `HEAD` has NO parent — a carry commit born on an empty remote, which makes
+ * it the repository's root commit? (Pure.)
+ *
+ * Distinguishing this from a genuine reset failure matters: treating it as
+ * `carry_failed` would destroy the freshly-provisioned Sprite and refuse a
+ * promotion that the carry actually could have completed.
+ */
+export function isMissingParentCommitError(gitOutput: string): boolean {
+  return /ambiguous argument|unknown revision/i.test(gitOutput);
+}
+
+/**
  * Inspect the project's OLD home on the machine Sprite. Promotion is only safe
  * when this returns `absent` or `clean`.
  *
@@ -692,7 +705,22 @@ async function carryCheckoutToProjectSprite({
     // untracked return untracked. The staged/unstaged split is the one thing
     // not preserved — everything comes back unstaged.
     const reset = await runOnProject(['reset', '--mixed', 'HEAD~1']);
-    if (!reset.success || reset.exitCode !== 0) return failed('restoring the carried working tree', reset);
+    if (!reset.success || reset.exitCode !== 0) {
+      // A checkout carried from an EMPTY remote makes the carry commit the
+      // repo's ROOT commit — it has no parent, so `HEAD~1` does not resolve
+      // and git refuses with "ambiguous argument … unknown revision" rather
+      // than resetting. That is not a real failure, just a parent that
+      // cannot exist; un-name the branch (HEAD becomes unborn) and `reset`
+      // with no target, which unstages against the implicit empty tree —
+      // the same "everything comes back uncommitted" outcome, for a commit
+      // that has nothing to point "back" to.
+      const resetOutput = reset.success ? reset.stderr || reset.stdout : '';
+      if (!isMissingParentCommitError(resetOutput)) return failed('restoring the carried working tree', reset);
+      const unref = await runOnProject(['update-ref', '-d', `refs/heads/${plan.branch}`]);
+      if (!unref.success || unref.exitCode !== 0) return failed('clearing the root carry commit', unref);
+      const rootReset = await runOnProject(['reset']);
+      if (!rootReset.success || rootReset.exitCode !== 0) return failed('restoring the carried working tree', rootReset);
+    }
   }
 
   // Best-effort cleanup of the staged bundle on both sides: it is a duplicate of

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -62,11 +62,36 @@ export { PROJECT_REPO_PATH };
 const PROMOTION_RACE_POLLS = 3;
 const PROMOTION_RACE_POLL_MS = 250;
 
+/**
+ * Where a carry bundle is staged on BOTH Sprites.
+ *
+ * The Sprite user's persistent home, deliberately OUTSIDE `SANDBOX_ROOT` — the
+ * same rule `GH_CONFIG_DIR` follows (`git-tool-runners.ts`): a stray file under
+ * `/workspace` makes the root non-empty and breaks a no-path `git clone`.
+ */
+const CARRY_BUNDLE_DIR = '/home/sprite';
+/** The ref namespace the bundle is fetched into on the project Sprite, and the fallback branch name for a detached HEAD. */
+const CARRY_REF_NAMESPACE = 'pagespace-carry';
+const CARRY_COMMIT_MESSAGE = 'pagespace: carried working tree during project promotion';
+
+/**
+ * Hard cap on a carry bundle, because the transfer reads the WHOLE file into
+ * this process's memory (`readFileToBuffer` → `writeFiles`). Without it, one
+ * project with a large history is an OOM of the web server, not a failed
+ * promotion. Refusing over the cap is recoverable — the user can push and
+ * promote without a carry — so the cap is the safe side.
+ */
+export const MAX_CARRY_BUNDLE_BYTES = 64 * 1024 * 1024;
+
 export type PromoteProjectDenialReason =
   | 'kill_switch_off'
   | 'project_not_found'
   /** The machine-side checkout has uncommitted work — promoting would destroy it. */
   | 'dirty_checkout'
+  /** `carryDirty` was asked for and the carry could not be completed (issue #2207). */
+  | 'carry_failed'
+  /** The carry bundle exceeds `MAX_CARRY_BUNDLE_BYTES` — see that constant. */
+  | 'carry_too_large'
   /**
    * The machine-side checkout is CLEAN but holds commits that exist nowhere
    * else. A fresh clone from `repoUrl` cannot reproduce them. (Issue #2204
@@ -165,6 +190,13 @@ export type PromoteProjectResult =
       promoted: boolean;
       /** `true` when the Sprite already existed (an already-promoted project, or a race we lost). */
       resumed: boolean;
+      /**
+       * `true` when work was CARRIED from the machine checkout onto this Sprite
+       * (issue #2207). The carried working-tree changes land as UNCOMMITTED
+       * changes, but the staged/unstaged split is not preserved — everything
+       * comes back unstaged.
+       */
+      carried: boolean;
     }
   | { ok: false; reason: PromoteProjectDenialReason | FullEgressDenialReason; detail?: string };
 
@@ -229,7 +261,7 @@ function buildGitDepsForMachine(machineId: string, deps: PromoteProjectDeps): Gi
   };
 }
 
-type CheckoutState =
+export type CheckoutState =
   /** Nothing to lose — the machine-side checkout is gone (or was never cloned). */
   | { kind: 'absent' }
   | { kind: 'clean' }
@@ -311,6 +343,116 @@ export function classifyCheckoutStatus(stdout: string): CheckoutState {
 }
 
 /**
+ * The LOCAL branch name from a porcelain branch header, or `null` when the
+ * checkout has none (detached HEAD, or output we cannot read). Pure.
+ *
+ * The carry needs a NAME because `git bundle` can only carry refs and the far
+ * side has to check something out. A detached HEAD has none, which is why
+ * `buildCarryPlan` answers that case by MAKING one rather than failing.
+ */
+export function parseCheckoutBranchName(stdout: string): string | null {
+  const branchLine = stdout.split('\n').find((line) => line.startsWith('## '));
+  if (!branchLine) return null;
+  const header = branchLine.slice(3).trim();
+  if (header.startsWith('HEAD (no branch)')) return null;
+  // A repo with no commits yet: `## No commits yet on main`. The branch exists
+  // (it is just unborn), and the carry commit is what gives it a tip.
+  const unborn = 'No commits yet on ';
+  const named = header.startsWith(unborn) ? header.slice(unborn.length) : header;
+  // A branch name can contain neither a space nor `...` (git forbids both), so
+  // cutting at the first of each leaves exactly the local name — and, unlike a
+  // pattern, cannot backtrack on a hostile name (see `classifyCheckoutStatus`).
+  const local = named.split(' ')[0].split('...')[0];
+  return local.length > 0 ? local : null;
+}
+
+/**
+ * Is this checkout state one a carry could rescue? (Pure.)
+ *
+ * `unknown` is deliberately NOT carryable, and that is the whole fail-closed
+ * argument restated: we could not read the checkout, so we cannot bundle it
+ * either — carrying would mean promoting on the PROMISE that the work came
+ * across, which is exactly the silent loss the refusal exists to prevent.
+ */
+export function isCarryableState(state: CheckoutState): boolean {
+  return state.kind === 'dirty' || state.kind === 'unpushed';
+}
+
+/** The ordered decisions a carry makes, derived from the checkout state alone. */
+export interface CarryPlan {
+  /** Dirty tree ⇒ everything becomes one commit first. A clean-but-unpushed tree has nothing to commit. */
+  needsCommit: boolean;
+  /** Detached HEAD ⇒ mint `pagespace-carry` so `bundle --all` has a ref to carry. */
+  needsBranchCreate: boolean;
+  /** Undo the carry commit on the FAR side, so the work reappears as uncommitted changes. Exactly `needsCommit`. */
+  needsReset: boolean;
+  branch: string;
+  bundlePath: string;
+  fetchRefspec: string;
+  checkoutTarget: string;
+}
+
+export function buildCarryPlan({
+  state,
+  branchName,
+  projectId,
+}: {
+  state: CheckoutState;
+  branchName: string | null;
+  projectId: string;
+}): CarryPlan {
+  const needsCommit = state.kind === 'dirty';
+  const branch = branchName ?? CARRY_REF_NAMESPACE;
+  // The id is ours (a database key), but it reaches a filesystem path, so it is
+  // reduced to a tame filename rather than trusted — a path component that
+  // escapes would stage the bundle somewhere nobody expects.
+  const safeId = projectId.replace(/[^A-Za-z0-9_-]/g, '');
+  return {
+    needsCommit,
+    needsBranchCreate: branchName === null,
+    needsReset: needsCommit,
+    branch,
+    bundlePath: `${CARRY_BUNDLE_DIR}/${CARRY_REF_NAMESPACE}-${safeId}.bundle`,
+    fetchRefspec: `+refs/heads/*:refs/remotes/${CARRY_REF_NAMESPACE}/*`,
+    checkoutTarget: `${CARRY_REF_NAMESPACE}/${branch}`,
+  };
+}
+
+/** `stat -c %s` output → byte count, or `null` when it is not a plain integer (the caller then fails closed). Pure. */
+export function parseFileSizeBytes(stdout: string): number | null {
+  const text = stdout.trim();
+  if (!/^\d+$/.test(text)) return null;
+  return Number(text);
+}
+
+/**
+ * May the old checkout be reclaimed after a CARRY? (Pure.)
+ *
+ * The ordinary reclaim gate demands a fresh `clean`, which a carried checkout
+ * can never be: we committed the work, so the tree is clean but one commit
+ * ahead — `unpushed`. Left at that, every carried promotion would leak its old
+ * checkout, billed on the machine AND on the new Sprite forever.
+ *
+ * So the question becomes "is this tree still EXACTLY what we bundled": no
+ * working-tree changes, and HEAD at the very commit we made. Anything else —
+ * new edits, a HEAD someone moved, a sha we could not read — skips the `rm`,
+ * because leftover bytes are an annoyance and deleted work is not.
+ */
+export function isReclaimableAfterCarry({
+  recheckKind,
+  headSha,
+  carrySha,
+}: {
+  recheckKind: CheckoutState['kind'];
+  headSha: string | null;
+  carrySha: string | null;
+}): boolean {
+  if (recheckKind !== 'clean' && recheckKind !== 'unpushed') return false;
+  if (headSha === null || carrySha === null) return false;
+  return headSha === carrySha;
+}
+
+/**
  * Inspect the project's OLD home on the machine Sprite. Promotion is only safe
  * when this returns `absent` or `clean`.
  *
@@ -363,6 +505,205 @@ async function inspectMachineCheckout({
   if (status.exitCode !== 0) return { kind: 'unknown', detail: status.stderr || status.stdout };
 
   return classifyCheckoutStatus(status.stdout);
+}
+
+/** Acquire + reconnect the OWNING Machine's Sprite, or `null` when either step fails. */
+async function openMachineSandbox(machineId: string, deps: PromoteProjectDeps): Promise<ExecutableSandbox | null> {
+  const acquired = await deps.acquireMachineSandbox(machineId);
+  if (!acquired.ok) return null;
+  return deps.reconnect(acquired.sandboxId);
+}
+
+/** The machine checkout's current HEAD sha, or `null` when it cannot be read (the reclaim guard then refuses). */
+async function readMachineHeadSha({
+  machineId,
+  project,
+  actor,
+  deps,
+}: {
+  machineId: string;
+  project: MachineProjectRecord;
+  actor: MachineActorContext;
+  deps: PromoteProjectDeps;
+}): Promise<string | null> {
+  const head = await runGitInSandbox({
+    cmd: 'git',
+    args: ['rev-parse', 'HEAD'],
+    cwd: project.path,
+    ctx: buildActorCtx(`${machineId}:${project.name}`, actor),
+    deps: buildGitDepsForMachine(machineId, deps),
+  });
+  if (!head.success || head.exitCode !== 0) return null;
+  const sha = head.stdout.trim();
+  return sha.length > 0 ? sha : null;
+}
+
+type CarryOutcome =
+  | { ok: true; carrySha: string | null }
+  | { ok: false; reason: 'carry_failed' | 'carry_too_large'; detail: string };
+
+/**
+ * Carry the machine-side work onto the freshly-cloned project Sprite (issue
+ * #2207) — the migration path out of the dirty/unpushed refusals.
+ *
+ * A GIT BUNDLE, moved as BYTES, is the mechanism, and both halves of that are
+ * load-bearing:
+ *
+ *  • A bundle is a self-contained pack of REFS, so one mechanism carries both
+ *    kinds of loss — uncommitted work (committed here first, un-committed again
+ *    on the far side) and commits that never reached the remote.
+ *  • It travels through `readFileToBuffer` → `writeFiles`, NOT through command
+ *    stdout. Everything `runGitInSandbox` returns is screened for injection and
+ *    truncated at `SANDBOX_MAX_OUTPUT_BYTES`; a patch that came back that way
+ *    would apply SILENTLY CORRUPTED, which is the same data loss the refusal
+ *    exists to prevent, wearing a success message.
+ *
+ * Runs AFTER the clone (it needs a repo to fetch into) and BEFORE the CAS, so a
+ * failure is still a promotion that never happened: the caller kills the Sprite
+ * and the machine checkout keeps everything (at worst plus a recoverable carry
+ * commit).
+ */
+async function carryCheckoutToProjectSprite({
+  machineId,
+  project,
+  projectName,
+  state,
+  actor,
+  handle,
+  deps,
+}: {
+  machineId: string;
+  project: MachineProjectRecord;
+  projectName: string;
+  state: CheckoutState;
+  actor: MachineActorContext;
+  handle: MachineHandle;
+  deps: PromoteProjectDeps;
+}): Promise<CarryOutcome> {
+  const ctx = buildActorCtx(`${machineId}:${projectName}`, actor);
+  const machineGit = buildGitDepsForMachine(machineId, deps);
+  const projectGit = buildGitDepsForHandle(handle, deps);
+
+  const runOnMachine = (args: string[]) =>
+    runGitInSandbox({ cmd: 'git', args, cwd: project.path, ctx, deps: machineGit });
+  const runOnProject = (args: string[]) =>
+    runGitInSandbox({ cmd: 'git', args, cwd: PROJECT_REPO_PATH, ctx, deps: projectGit });
+
+  const failed = (step: string, result: Awaited<ReturnType<typeof runOnMachine>>): CarryOutcome => ({
+    ok: false,
+    reason: 'carry_failed',
+    detail: `${step} failed: ${result.success ? result.stderr || result.stdout : (result.error ?? 'no detail')}`,
+  });
+
+  const branchStatus = await runOnMachine(['status', '--porcelain', '-b']);
+  if (!branchStatus.success || branchStatus.exitCode !== 0) return failed('reading the checkout branch', branchStatus);
+  const plan = buildCarryPlan({
+    state,
+    branchName: parseCheckoutBranchName(branchStatus.stdout),
+    projectId: project.id,
+  });
+
+  if (plan.needsCommit) {
+    const staged = await runOnMachine(['add', '-A']);
+    if (!staged.success || staged.exitCode !== 0) return failed('staging the working tree', staged);
+    // Identity supplied per-invocation: a Sprite has no configured committer,
+    // and `--no-verify` because a repo's own hooks are not ours to run on a
+    // commit the user did not ask for.
+    const committed = await runOnMachine([
+      '-c',
+      `user.email=${actor.actorEmail}`,
+      '-c',
+      'user.name=PageSpace Carry',
+      'commit',
+      '--no-verify',
+      '-m',
+      CARRY_COMMIT_MESSAGE,
+    ]);
+    if (!committed.success || committed.exitCode !== 0) return failed('committing the working tree', committed);
+  }
+
+  if (plan.needsBranchCreate) {
+    const branched = await runOnMachine(['branch', '-f', plan.branch, 'HEAD']);
+    if (!branched.success || branched.exitCode !== 0) return failed('naming the detached HEAD', branched);
+  }
+
+  // Read AFTER the carry commit: this sha is what licenses the post-promotion
+  // reclaim (`isReclaimableAfterCarry`).
+  const carrySha = await readMachineHeadSha({ machineId, project, actor, deps });
+
+  const bundled = await runOnMachine(['bundle', 'create', plan.bundlePath, '--all']);
+  if (!bundled.success || bundled.exitCode !== 0) return failed('bundling the checkout', bundled);
+
+  const machineSandbox = await openMachineSandbox(machineId, deps);
+  if (!machineSandbox) {
+    return { ok: false, reason: 'carry_failed', detail: 'the machine sandbox became unreachable mid-carry' };
+  }
+
+  // Size BEFORE the read — the read is what would OOM.
+  let bytes: number | null;
+  try {
+    const sized = await machineSandbox.runCommand({
+      cmd: 'stat',
+      args: ['-c', '%s', plan.bundlePath],
+      timeoutMs: SANDBOX_TIMEOUT_MS,
+      maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
+    });
+    bytes = sized.exitCode === 0 ? parseFileSizeBytes(sized.stdout) : null;
+  } catch (error) {
+    bytes = null;
+    void error;
+  }
+  if (bytes === null) {
+    return { ok: false, reason: 'carry_failed', detail: `could not measure the carry bundle at ${plan.bundlePath}` };
+  }
+  if (bytes > MAX_CARRY_BUNDLE_BYTES) {
+    return {
+      ok: false,
+      reason: 'carry_too_large',
+      detail:
+        `The work to carry is ${bytes} bytes, over the ${MAX_CARRY_BUNDLE_BYTES}-byte carry limit. Push the ` +
+        `branch (git -C ${project.path} push) and promote without a carry instead.`,
+    };
+  }
+
+  let bundle: Buffer | null;
+  try {
+    bundle = await machineSandbox.readFileToBuffer({ path: plan.bundlePath });
+  } catch (error) {
+    return { ok: false, reason: 'carry_failed', detail: error instanceof Error ? error.message : String(error) };
+  }
+  if (!bundle) return { ok: false, reason: 'carry_failed', detail: 'the carry bundle could not be read back' };
+
+  try {
+    await handle.writeFiles([{ path: plan.bundlePath, content: new Uint8Array(bundle) }]);
+  } catch (error) {
+    return { ok: false, reason: 'carry_failed', detail: error instanceof Error ? error.message : String(error) };
+  }
+
+  const fetched = await runOnProject(['fetch', plan.bundlePath, plan.fetchRefspec]);
+  if (!fetched.success || fetched.exitCode !== 0) return failed('fetching the carried refs', fetched);
+
+  const checkedOut = await runOnProject(['checkout', '-B', plan.branch, plan.checkoutTarget]);
+  if (!checkedOut.success || checkedOut.exitCode !== 0) return failed('checking out the carried branch', checkedOut);
+
+  if (plan.needsReset) {
+    // `--mixed`, so the carry commit dissolves back into the working tree:
+    // modified files return modified-but-unstaged, and files that were
+    // untracked return untracked. The staged/unstaged split is the one thing
+    // not preserved — everything comes back unstaged.
+    const reset = await runOnProject(['reset', '--mixed', 'HEAD~1']);
+    if (!reset.success || reset.exitCode !== 0) return failed('restoring the carried working tree', reset);
+  }
+
+  // Best-effort cleanup of the staged bundle on both sides: it is a duplicate of
+  // work that now lives in a repo, and neither copy is worth failing a completed
+  // carry over.
+  await Promise.allSettled([
+    machineSandbox.runCommand({ cmd: 'rm', args: ['-f', plan.bundlePath], timeoutMs: SANDBOX_TIMEOUT_MS, maxBytes: SANDBOX_MAX_OUTPUT_BYTES }),
+    handle.exec({ cmd: 'rm', args: ['-f', plan.bundlePath], timeoutMs: SANDBOX_TIMEOUT_MS, maxBytes: SANDBOX_MAX_OUTPUT_BYTES }),
+  ]);
+
+  return { ok: true, carrySha };
 }
 
 /**
@@ -465,7 +806,7 @@ async function reconcilePromotionCollision({
       row.sandboxId === handle.machineId &&
       (row.spriteInstanceId ?? null) === (handle.spriteInstanceId ?? null);
     if (!isPersistedInstance) await safeKillSprite(deps.host, handle);
-    return { ok: true, sandboxId: row.sandboxId, sessionKey: row.sessionKey, promoted: false, resumed: true };
+    return { ok: true, sandboxId: row.sandboxId, sessionKey: row.sessionKey, promoted: false, resumed: true, carried: false };
   }
   // Nobody actually won (the row vanished, or the CAS failed for a reason other
   // than a competing promotion) — our Sprite is unrecorded, so it can only be
@@ -519,11 +860,19 @@ export async function promoteProject({
   machineId,
   projectName: requestedProjectName,
   actor,
+  carryDirty = false,
   deps,
 }: {
   machineId: string;
   projectName: string;
   actor: MachineActorContext;
+  /**
+   * Opt in to CARRYING the machine-side work across instead of refusing
+   * (issue #2207). Off by default, and exposed only on the explicit operator
+   * route — a project-scoped SPAWN must never silently relocate someone's
+   * uncommitted work as a side effect of starting a terminal.
+   */
+  carryDirty?: boolean;
   deps: PromoteProjectDeps;
 }): Promise<PromoteProjectResult> {
   if (!deps.isEnabled()) return { ok: false, reason: 'kill_switch_off' };
@@ -540,7 +889,7 @@ export async function promoteProject({
       // reason `spawnBranch` re-copies on every reattach).
       await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
       noteProjectStorage(deps.measureProjectStorage, { machineProjectId: project.id, machinePageId: machineId, handle });
-      return { ok: true, sandboxId: handle.machineId, sessionKey: project.sessionKey, promoted: false, resumed: true };
+      return { ok: true, sandboxId: handle.machineId, sessionKey: project.sessionKey, promoted: false, resumed: true, carried: false };
     }
     // Vanished — fall through and re-provision under the SAME session key.
   }
@@ -550,24 +899,30 @@ export async function promoteProject({
   // provisioned for a promotion we are about to refuse would have to be cleaned
   // up on a path that has no reason to exist.
   const checkout = await inspectMachineCheckout({ machineId, project, actor, deps });
-  if (checkout.kind === 'dirty') {
+  // `carryDirty` moves the work instead of refusing it (issue #2207) — but only
+  // for the two states we can actually READ and bundle. `unknown` still refuses
+  // below: carrying what we could not inspect would promote on a promise.
+  const carrying = carryDirty && isCarryableState(checkout);
+  if (checkout.kind === 'dirty' && !carrying) {
     return {
       ok: false,
       reason: 'dirty_checkout',
       detail:
         `The checkout at ${project.path} has uncommitted changes, and promoting this project would ` +
         `replace it with a fresh clone on its own sandbox — losing that work. Commit or discard the ` +
-        `changes (git -C ${project.path} status) and retry.\n${checkout.detail}`,
+        `changes (git -C ${project.path} status) and retry, or promote with carryDirty to bring the ` +
+        `work across.\n${checkout.detail}`,
     };
   }
-  if (checkout.kind === 'unpushed') {
+  if (checkout.kind === 'unpushed' && !carrying) {
     return {
       ok: false,
       reason: 'unpushed_commits',
       detail:
         `The checkout at ${project.path} holds commits that are not on the remote, and promoting this ` +
         `project would replace it with a fresh clone of ${project.repoUrl} — losing them. Push the ` +
-        `branch (git -C ${project.path} push) and retry.\n${checkout.detail}`,
+        `branch (git -C ${project.path} push) and retry, or promote with carryDirty to bring the ` +
+        `commits across.\n${checkout.detail}`,
     };
   }
   if (checkout.kind === 'unknown') {
@@ -606,7 +961,7 @@ export async function promoteProject({
     // exists"). Reconcile before treating this as a failure.
     const row = await deps.store.findById(project.id);
     if (row?.sandboxId === handle.machineId && row.sessionKey) {
-      return { ok: true, sandboxId: row.sandboxId, sessionKey: row.sessionKey, promoted: false, resumed: true };
+      return { ok: true, sandboxId: row.sandboxId, sessionKey: row.sessionKey, promoted: false, resumed: true, carried: false };
     }
     const detail = clone.success ? clone.stderr || clone.stdout : clone.error;
     // The winner may not have PERSISTED yet — provision is name-keyed, so the
@@ -641,10 +996,31 @@ export async function promoteProject({
       ? await awaitPromotionWinner(project.id, deps)
       : null;
     if (winner?.sandboxId && winner.sessionKey) {
-      return { ok: true, sandboxId: winner.sandboxId, sessionKey: winner.sessionKey, promoted: false, resumed: true };
+      return { ok: true, sandboxId: winner.sandboxId, sessionKey: winner.sessionKey, promoted: false, resumed: true, carried: false };
     }
     await safeKillSprite(deps.host, handle);
     return { ok: false, reason: 'clone_failed', detail };
+  }
+
+  // The carry sits between the clone (which it needs) and the CAS (which it must
+  // precede): until the row points here, a failed carry is a promotion that
+  // never happened, and the only cleanup owed is the Sprite.
+  let carrySha: string | null = null;
+  if (carrying) {
+    const carried = await carryCheckoutToProjectSprite({
+      machineId,
+      project,
+      projectName,
+      state: checkout,
+      actor,
+      handle,
+      deps,
+    });
+    if (!carried.ok) {
+      await safeKillSprite(deps.host, handle);
+      return { ok: false, reason: carried.reason, detail: carried.detail };
+    }
+    carrySha = carried.carrySha;
   }
 
   let persisted: boolean;
@@ -677,15 +1053,26 @@ export async function promoteProject({
   // redundant one and kill it. Everything below is best-effort follow-up work
   // on a promotion that has already succeeded.
   await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
-  if (checkout.kind === 'clean') {
+  if (checkout.kind === 'clean' || carrying) {
     // Re-inspected IMMEDIATELY before the rm: the gate above ran before the
     // slow provision+clone, and a terminal or tool may have written into the
     // old checkout in that window. Anything but a fresh `clean` skips the
     // reclaim — a leftover directory is an annoyance; deleting work someone
     // just wrote is a loss. (The window between this recheck and the rm is
     // milliseconds; the one it closes was the whole clone.)
+    //
+    // A CARRIED checkout can never come back `clean` — we committed the work
+    // there, so it is clean-but-one-ahead — hence its own predicate, which asks
+    // the equivalent question: is this still exactly the tree we bundled?
     const recheck = await inspectMachineCheckout({ machineId, project, actor, deps });
-    if (recheck.kind === 'clean') {
+    const reclaimable = carrying
+      ? isReclaimableAfterCarry({
+          recheckKind: recheck.kind,
+          headSha: await readMachineHeadSha({ machineId, project, actor, deps }),
+          carrySha,
+        })
+      : recheck.kind === 'clean';
+    if (reclaimable) {
       const reclaimed = await reclaimMachineCheckout(machineId, project.path, deps);
       // The ROOT just got smaller, and its last persisted measurement still
       // includes the bytes we removed. Until some unrelated root operation
@@ -701,5 +1088,5 @@ export async function promoteProject({
   // footprint — the one moment its bytes are guaranteed non-trivial.
   noteProjectStorage(deps.measureProjectStorage, { machineProjectId: project.id, machinePageId: machineId, handle });
 
-  return { ok: true, sandboxId: handle.machineId, sessionKey, promoted: true, resumed: false };
+  return { ok: true, sandboxId: handle.machineId, sessionKey, promoted: true, resumed: false, carried: carrying };
 }


### PR DESCRIPTION
## Summary

- Adds an opt-in `carryDirty` to `promoteProject` that carries machine-side work (uncommitted changes and/or unpushed commits) onto the freshly promoted project Sprite instead of refusing the promotion.
- Mechanism: commit the working tree (only when dirty) → `git bundle --all` on the machine → transfer as bytes (`readFileToBuffer` → `writeFiles`, never through screened/truncated command stdout) → `fetch` + `checkout -B` + `reset --mixed` on the project Sprite so the work reappears as uncommitted changes. A 64 MiB size cap refuses closed rather than risk an OOM reading an oversized bundle.
- Five new pure cores drive the decision logic (`parseCheckoutBranchName`, `isCarryableState`, `buildCarryPlan`, `parseFileSizeBytes`, `isReclaimableAfterCarry`), each with full branch coverage. The post-carry reclaim of the old checkout is gated on its own predicate, since a carried tree is clean-but-one-commit-ahead, never bare `clean`.
- Exposed only on the operator route (`POST /api/machines/projects/promote { carryDirty: true }`) — the implicit spawn path keeps refusing, since relocating someone's uncommitted work must be a decision the caller makes, not a side effect of opening a terminal.
- Bonus fix: `unpushed_commits` now maps to 409 (was falling through to 500); adds `carry_too_large` (409) and `carry_failed` (502).

Closes #2207

## Test plan

- [x] `bun run typecheck` (full monorepo, green)
- [x] `bun x vitest run` on `machine-project-promotion.test.ts` (92 tests) and the promote route test (13 tests) — all green
- [x] `bun run lint` on `packages/lib` and `apps/web` — no new issues
- [x] `bun run test:security` — 43/50 suites pass; the 7 failures are pre-existing env-only issues (DB setup / test-file exclusion mismatches in `Session Service`, `Device Auth Utilities`, `Permissions`, `Login Route`, `Signup Route`, `Mobile Login`, `Admin Role Versioning`) unrelated to this change, none touching promotion or the promote route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QueAQbwcz6vmMoDcQqfe2W