### PR TITLE
fix(machines): sweep dangling MachineRefs on every hard-delete path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Permanently deleting a Terminal machine, its drive, or letting it age out of Trash no longer
+  leaves "Unknown machine" behind** — an agent or the global assistant's machine list kept a
+  reference to a Terminal after the machine page was gone for good, so it showed as "Unknown
+  machine" and any subsequent save of that config failed. Permanent delete, permanent drive
+  delete, and the daily trash-purge now clean up the stale reference; a machine that's merely in
+  Trash (not yet purged) is left alone since it can still be restored.
 - **Toast notifications now actually appear** — member management, role editing, drive AI
   settings, drive deletion, invites, and version-history/activity rollback actions had been
   silently logging success and error feedback to the browser console instead of showing a

--- a/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockPageRepo, mockAudit, mockReapOrphanedFiles } = vi.hoisted(() => ({
+const { mockPageRepo, mockAudit, mockReapOrphanedFiles, mockSweepMachineRefs } = vi.hoisted(() => ({
   mockPageRepo: { purgeExpiredTrashedPages: vi.fn() },
   mockAudit: vi.fn(),
   mockReapOrphanedFiles: vi.fn(),
+  mockSweepMachineRefs: vi.fn(),
+}));
+
+vi.mock('@/lib/machines/machine-ref-sweep-runtime', () => ({
+  sweepDanglingMachineRefs: mockSweepMachineRefs,
 }));
 
 vi.mock('@/lib/auth/cron-auth', () => ({
@@ -53,6 +58,12 @@ describe('/api/cron/purge-trashed-pages', () => {
       physicalFilesDeleted: 0,
       dbRecordsDeleted: 0,
       failedPhysicalDeletes: [],
+    });
+    mockSweepMachineRefs.mockResolvedValue({
+      deadMachineIds: [],
+      agentsUpdated: 0,
+      globalConfigsUpdated: 0,
+      failures: 0,
     });
   });
 
@@ -126,7 +137,7 @@ describe('/api/cron/purge-trashed-pages', () => {
         eventType: 'data.delete',
         resourceType: 'cron_job',
         resourceId: 'purge_trashed_pages',
-        details: { pagesPurged: 3, filesReaped: 0 },
+        details: { pagesPurged: 3, filesReaped: 0, machineRefsScrubbed: 0 },
       })
     );
   });
@@ -147,7 +158,7 @@ describe('/api/cron/purge-trashed-pages', () => {
     expect(body.filesReaped).toBe(2);
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({
-        details: { pagesPurged: 4, filesReaped: 2 },
+        details: { pagesPurged: 4, filesReaped: 2, machineRefsScrubbed: 0 },
       })
     );
   });
@@ -163,6 +174,44 @@ describe('/api/cron/purge-trashed-pages', () => {
     expect(body.success).toBe(true);
     expect(body.pagesPurged).toBe(5);
     expect(body.filesReaped).toBe(0);
+  });
+
+  it('sweeps dangling machine refs after the purge and surfaces the repair count', async () => {
+    // The purge is the moment a trashed Machine page stops existing, so it is
+    // the moment its denormalized MachineRefs become permanently dangling.
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(1);
+    mockSweepMachineRefs.mockResolvedValue({
+      deadMachineIds: ['machine-gone'],
+      agentsUpdated: 2,
+      globalConfigsUpdated: 1,
+      failures: 0,
+    });
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    // Unscoped: this run must also catch refs orphaned by paths no call site
+    // covers (account erasure, drive cascades).
+    expect(mockSweepMachineRefs).toHaveBeenCalledWith();
+    expect(body.machineRefsScrubbed).toBe(3);
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: { pagesPurged: 1, filesReaped: 0, machineRefsScrubbed: 3 },
+      })
+    );
+  });
+
+  it('still purges successfully when the machine-ref sweep fails', async () => {
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(6);
+    mockSweepMachineRefs.mockRejectedValue(new Error('deadlock detected'));
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.pagesPurged).toBe(6);
+    expect(body.machineRefsScrubbed).toBe(0);
   });
 
   it('given invalid HMAC, should not log audit event', async () => {

--- a/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
@@ -5,6 +5,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { reapOrphanedFiles } from '@/lib/storage/reap-orphaned-files';
+import { sweepDanglingMachineRefs } from '@/lib/machines/machine-ref-sweep-runtime';
 
 /**
  * Cron endpoint to hard-delete pages that have been in the trash for 30+ days.
@@ -13,6 +14,14 @@ import { reapOrphanedFiles } from '@/lib/storage/reap-orphaned-files';
  * then permanently removed after the 30-day retention window.
  *
  * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce, X-Cron-Signature headers.
+ *
+ * This is also where denormalized MachineRefs are reconciled (issue #2156). The
+ * purge is the moment a Machine page stops existing, and its refs — copied into
+ * `pages.machines` on agent pages and `global_assistant_config.machines` — have
+ * no FK to cascade them away. The sweep runs UNSCOPED here on purpose: it is the
+ * backstop for every path that can destroy a Machine page without telling
+ * anyone (account erasure, permanent drive delete, manual DB surgery), not just
+ * for the rows this run purged.
  */
 export async function GET(request: Request) {
   const authError = validateSignedCronRequest(request);
@@ -38,19 +47,42 @@ export async function GET(request: Request) {
       console.warn('[Cron] Inline orphan reap after purge failed; weekly cron will retry:', error);
     }
 
-    console.log(`[Cron] Purged trashed pages: ${pagesPurged}, reaped orphaned files: ${filesReaped}`);
+    // Drop MachineRefs left pointing at machines that no longer exist. Same
+    // best-effort contract as the reap above: a sweep failure must not fail the
+    // purge — the next daily run retries it, and a dangling ref degrades only to
+    // today's behavior.
+    let machineRefsScrubbed = 0;
+    try {
+      const swept = await sweepDanglingMachineRefs();
+      machineRefsScrubbed = swept.agentsUpdated + swept.globalConfigsUpdated;
+      if (swept.failures > 0) {
+        loggers.system.warn('[Cron] Some machine-ref rewrites failed; next run will retry', {
+          failures: swept.failures,
+          deadMachineIds: swept.deadMachineIds,
+        });
+      }
+    } catch (error) {
+      loggers.system.warn('[Cron] Dangling machine-ref sweep failed; next run will retry', {
+        error: error as Error,
+      });
+    }
+
+    console.log(
+      `[Cron] Purged trashed pages: ${pagesPurged}, reaped orphaned files: ${filesReaped}, scrubbed machine refs: ${machineRefsScrubbed}`,
+    );
 
     audit({
       eventType: 'data.delete',
       resourceType: 'cron_job',
       resourceId: 'purge_trashed_pages',
-      details: { pagesPurged, filesReaped },
+      details: { pagesPurged, filesReaped, machineRefsScrubbed },
     });
 
     return NextResponse.json({
       success: true,
       pagesPurged,
       filesReaped,
+      machineRefsScrubbed,
       timestamp: now.toISOString(),
     });
   } catch (error) {

--- a/apps/web/src/app/api/trash/[pageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/trash/[pageId]/__tests__/route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Permanent page delete — the machine-ref repair (issue #2156).
+ *
+ * This route is one of the paths that makes a MachineRef permanently dangling:
+ * it hard-deletes the page rows, and nothing FK-cascades the denormalized
+ * `machines` blobs on agent pages / the global assistant config. The MACHINE
+ * page ids must therefore be snapshotted BEFORE the delete (afterwards the rows
+ * are gone and the set is unrecoverable), and swept afterwards.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockFindPage,
+  mockTransaction,
+  mockExecute,
+  mockCanDelete,
+  mockAuthenticate,
+  mockReapOrphanedFiles,
+  mockCollectMachineIds,
+  mockSweepMachineRefs,
+  callOrder,
+} = vi.hoisted(() => {
+  const order: string[] = [];
+  return {
+    mockFindPage: vi.fn(),
+    mockTransaction: vi.fn(),
+    mockExecute: vi.fn(),
+    mockCanDelete: vi.fn(),
+    mockAuthenticate: vi.fn(),
+    mockReapOrphanedFiles: vi.fn(),
+    mockCollectMachineIds: vi.fn(),
+    mockSweepMachineRefs: vi.fn(),
+    callOrder: order,
+  };
+});
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { pages: { findFirst: (...args: unknown[]) => mockFindPage(...args) } },
+    execute: (...args: unknown[]) => mockExecute(...args),
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings.join('?'), values })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: {}, favorites: {}, pageTags: {}, chatMessages: {},
+}));
+vi.mock('@pagespace/db/schema/members', () => ({ pagePermissions: {} }));
+vi.mock('@pagespace/db/schema/chat', () => ({ channelMessages: {} }));
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticate(...args),
+  isAuthError: (value: unknown) => typeof value === 'object' && value !== null && 'error' in value,
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserDeletePage: (...args: unknown[]) => mockCanDelete(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn(async () => ({ actorEmail: 'a@x.test', actorDisplayName: 'A' })),
+  logPageActivity: vi.fn(),
+}));
+vi.mock('@/lib/storage/reap-orphaned-files', () => ({
+  reapOrphanedFiles: (...args: unknown[]) => mockReapOrphanedFiles(...args),
+}));
+vi.mock('@/lib/machines/machine-ref-sweep-runtime', () => ({
+  collectMachinePageIdsInSubtree: (...args: unknown[]) => mockCollectMachineIds(...args),
+  sweepDanglingMachineRefs: (...args: unknown[]) => mockSweepMachineRefs(...args),
+}));
+vi.mock('next/server', () => ({
+  NextResponse: Object.assign(
+    function NextResponse(body: string, init?: ResponseInit) {
+      return new Response(body, init);
+    },
+    {
+      json: (body: unknown, init?: ResponseInit) =>
+        new Response(JSON.stringify(body), { status: init?.status ?? 200 }),
+    },
+  ),
+}));
+
+import { DELETE } from '../route';
+
+function makeRequest(): Request {
+  return new Request('http://localhost:3000/api/trash/page-1', { method: 'DELETE' });
+}
+
+const params = Promise.resolve({ pageId: 'page-1' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  callOrder.length = 0;
+  mockAuthenticate.mockResolvedValue({ userId: 'user-1' });
+  mockCanDelete.mockResolvedValue(true);
+  mockFindPage.mockResolvedValue({ id: 'page-1', title: 'Folder', driveId: 'drive-1', isTrashed: true });
+  mockExecute.mockResolvedValue({ rows: [] });
+  mockTransaction.mockImplementation(async () => {
+    callOrder.push('delete');
+  });
+  mockReapOrphanedFiles.mockResolvedValue({ dbRecordsDeleted: 0 });
+  mockCollectMachineIds.mockImplementation(async () => {
+    callOrder.push('collect');
+    return ['machine-1'];
+  });
+  mockSweepMachineRefs.mockImplementation(async () => {
+    callOrder.push('sweep');
+    return { deadMachineIds: ['machine-1'], agentsUpdated: 1, globalConfigsUpdated: 0, failures: 0 };
+  });
+});
+
+describe('DELETE /api/trash/[pageId]', () => {
+  it('snapshots the subtree MACHINE ids before deleting and sweeps their refs after', async () => {
+    const response = await DELETE(makeRequest(), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockCollectMachineIds).toHaveBeenCalledWith('page-1');
+    expect(mockSweepMachineRefs).toHaveBeenCalledWith(['machine-1']);
+    // Order is the whole point: after the delete the rows are gone, so a
+    // snapshot taken then would come back empty.
+    expect(callOrder).toEqual(['collect', 'delete', 'sweep']);
+  });
+
+  it('skips the sweep entirely when the subtree held no machines', async () => {
+    mockCollectMachineIds.mockResolvedValue([]);
+
+    await DELETE(makeRequest(), { params });
+
+    expect(mockSweepMachineRefs).not.toHaveBeenCalled();
+  });
+
+  it('still reports success when the sweep fails', async () => {
+    mockSweepMachineRefs.mockRejectedValue(new Error('deadlock detected'));
+
+    const response = await DELETE(makeRequest(), { params });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('does not sweep when the page is not in the trash', async () => {
+    mockFindPage.mockResolvedValue({ id: 'page-1', isTrashed: false, driveId: 'drive-1' });
+
+    const response = await DELETE(makeRequest(), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockSweepMachineRefs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/trash/[pageId]/route.ts
+++ b/apps/web/src/app/api/trash/[pageId]/route.ts
@@ -76,15 +76,17 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
     const driveId = page.driveId;
 
     // Snapshot the files this subtree references BEFORE deleting — afterwards the
-    // cascaded file_pages links are gone and the set can't be recovered.
-    const candidateFileIds = await collectSubtreeFileIds(pageId);
-
-    // Same snapshot-before-delete rule for Machines (issue #2156): the
-    // `machines` MachineRef blobs on agent pages and on the global assistant
-    // config are denormalized copies with no FK, so nothing cascades them away
-    // — and once these rows are gone there is no way to learn which ids the
-    // subtree held.
-    const machinePageIds = await collectMachinePageIdsInSubtree(pageId);
+    // cascaded file_pages links are gone and the set can't be recovered. Same
+    // snapshot-before-delete rule for Machines (issue #2156): the `machines`
+    // MachineRef blobs on agent pages and on the global assistant config are
+    // denormalized copies with no FK, so nothing cascades them away — and once
+    // these rows are gone there is no way to learn which ids the subtree held.
+    // Both are independent read-only traversals of the same subtree, so they run
+    // concurrently.
+    const [candidateFileIds, machinePageIds] = await Promise.all([
+      collectSubtreeFileIds(pageId),
+      collectMachinePageIdsInSubtree(pageId),
+    ]);
 
     await db.transaction(async (tx) => {
       await recursivelyDelete(pageId, tx);

--- a/apps/web/src/app/api/trash/[pageId]/route.ts
+++ b/apps/web/src/app/api/trash/[pageId]/route.ts
@@ -10,6 +10,10 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { reapOrphanedFiles } from '@/lib/storage/reap-orphaned-files';
+import {
+  collectMachinePageIdsInSubtree,
+  sweepDanglingMachineRefs,
+} from '@/lib/machines/machine-ref-sweep-runtime';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -75,6 +79,13 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
     // cascaded file_pages links are gone and the set can't be recovered.
     const candidateFileIds = await collectSubtreeFileIds(pageId);
 
+    // Same snapshot-before-delete rule for Machines (issue #2156): the
+    // `machines` MachineRef blobs on agent pages and on the global assistant
+    // config are denormalized copies with no FK, so nothing cascades them away
+    // — and once these rows are gone there is no way to learn which ids the
+    // subtree held.
+    const machinePageIds = await collectMachinePageIdsInSubtree(pageId);
+
     await db.transaction(async (tx) => {
       await recursivelyDelete(pageId, tx);
     });
@@ -93,6 +104,24 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
         }
       } catch (error) {
         loggers.api.warn('Inline orphan reap after permanent delete failed; weekly cron will retry', { pageId, error: error as Error });
+      }
+    }
+
+    // Drop the now-dangling MachineRefs, scoped to just the machines this
+    // delete destroyed. Best-effort: the daily purge cron sweeps unscoped, so a
+    // failure here only delays the repair — it must never fail the delete.
+    if (machinePageIds.length > 0) {
+      try {
+        const swept = await sweepDanglingMachineRefs(machinePageIds);
+        if (swept.agentsUpdated + swept.globalConfigsUpdated > 0) {
+          loggers.api.info('Permanent delete scrubbed dangling machine refs', {
+            pageId,
+            agentsUpdated: swept.agentsUpdated,
+            globalConfigsUpdated: swept.globalConfigsUpdated,
+          });
+        }
+      } catch (error) {
+        loggers.api.warn('Machine-ref sweep after permanent delete failed; daily cron will retry', { pageId, error: error as Error });
       }
     }
 

--- a/apps/web/src/app/api/trash/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/trash/drives/[driveId]/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Permanent drive delete — the machine-ref repair (issue #2156).
+ *
+ * Deleting the drive FK-cascades its pages away, MACHINE pages included, so the
+ * denormalized `machines` blobs elsewhere are left pointing at nothing. The ids
+ * must be snapshotted before the delete and swept after.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockFindDrive,
+  mockDeleteWhere,
+  mockAuthenticate,
+  mockGetRecipients,
+  mockBroadcast,
+  mockCollectMachineIds,
+  mockSweepMachineRefs,
+  callOrder,
+} = vi.hoisted(() => {
+  const order: string[] = [];
+  return {
+    mockFindDrive: vi.fn(),
+    mockDeleteWhere: vi.fn(),
+    mockAuthenticate: vi.fn(),
+    mockGetRecipients: vi.fn(),
+    mockBroadcast: vi.fn(),
+    mockCollectMachineIds: vi.fn(),
+    mockSweepMachineRefs: vi.fn(),
+    callOrder: order,
+  };
+});
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { drives: { findFirst: (...args: unknown[]) => mockFindDrive(...args) } },
+    delete: () => ({ where: (...args: unknown[]) => mockDeleteWhere(...args) }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ drives: {} }));
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticate(...args),
+  isAuthError: (value: unknown) => typeof value === 'object' && value !== null && 'error' in value,
+}));
+vi.mock('@pagespace/lib/services/drive-guards', () => ({
+  isHomeDrive: vi.fn(() => false),
+  homeDriveActionError: vi.fn(() => 'nope'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@/lib/websocket', () => ({
+  broadcastDriveEvent: (...args: unknown[]) => mockBroadcast(...args),
+  createDriveEventPayload: vi.fn((...args: unknown[]) => args),
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: (...args: unknown[]) => mockGetRecipients(...args),
+}));
+vi.mock('@/lib/machines/machine-ref-sweep-runtime', () => ({
+  collectMachinePageIdsInDrive: (...args: unknown[]) => mockCollectMachineIds(...args),
+  sweepDanglingMachineRefs: (...args: unknown[]) => mockSweepMachineRefs(...args),
+}));
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => new Response(JSON.stringify(body), { status: init?.status ?? 200 }),
+  },
+}));
+
+import { DELETE } from '../route';
+
+function makeRequest(): Request {
+  return new Request('http://localhost:3000/api/trash/drives/drive-1', { method: 'DELETE' });
+}
+
+const context = { params: Promise.resolve({ driveId: 'drive-1' }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  callOrder.length = 0;
+  mockAuthenticate.mockResolvedValue({ userId: 'user-1' });
+  mockFindDrive.mockResolvedValue({ id: 'drive-1', name: 'Work', slug: 'work', isTrashed: true, ownerId: 'user-1' });
+  mockGetRecipients.mockResolvedValue(['user-1']);
+  mockBroadcast.mockResolvedValue(undefined);
+  mockDeleteWhere.mockImplementation(async () => {
+    callOrder.push('delete');
+  });
+  mockCollectMachineIds.mockImplementation(async () => {
+    callOrder.push('collect');
+    return ['machine-1'];
+  });
+  mockSweepMachineRefs.mockImplementation(async () => {
+    callOrder.push('sweep');
+    return { deadMachineIds: ['machine-1'], agentsUpdated: 1, globalConfigsUpdated: 1, failures: 0 };
+  });
+});
+
+describe('DELETE /api/trash/drives/[driveId]', () => {
+  it('snapshots the drive MACHINE ids before deleting and sweeps their refs after', async () => {
+    const response = await DELETE(makeRequest(), context);
+
+    expect(response.status).toBe(200);
+    expect(mockCollectMachineIds).toHaveBeenCalledWith('drive-1');
+    expect(mockSweepMachineRefs).toHaveBeenCalledWith(['machine-1']);
+    expect(callOrder).toEqual(['collect', 'delete', 'sweep']);
+  });
+
+  it('skips the sweep when the drive held no machines', async () => {
+    mockCollectMachineIds.mockResolvedValue([]);
+
+    await DELETE(makeRequest(), context);
+
+    expect(mockSweepMachineRefs).not.toHaveBeenCalled();
+  });
+
+  it('still reports success when the sweep fails', async () => {
+    mockSweepMachineRefs.mockRejectedValue(new Error('deadlock detected'));
+
+    const response = await DELETE(makeRequest(), context);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('does not sweep when the drive is not in the trash', async () => {
+    mockFindDrive.mockResolvedValue({ id: 'drive-1', isTrashed: false });
+
+    const response = await DELETE(makeRequest(), context);
+
+    expect(response.status).toBe(400);
+    expect(mockCollectMachineIds).not.toHaveBeenCalled();
+    expect(mockSweepMachineRefs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/trash/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/trash/drives/[driveId]/route.ts
@@ -8,6 +8,10 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import {
+  collectMachinePageIdsInDrive,
+  sweepDanglingMachineRefs,
+} from '@/lib/machines/machine-ref-sweep-runtime';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -49,10 +53,29 @@ export async function DELETE(
     // Get recipients BEFORE deleting (ensures we have valid member list)
     const recipientUserIds = await getDriveRecipientUserIds(drive.id);
 
+    // Likewise the drive's MACHINE page ids (issue #2156): the cascade below
+    // destroys the pages, but the denormalized MachineRefs copied into agent
+    // pages / the global assistant config have no FK to cascade them — and
+    // afterwards there is nothing left to learn the ids from.
+    const machinePageIds = await collectMachinePageIdsInDrive(drive.id);
+
     // Permanently delete the drive (cascade will delete all pages)
     await db
       .delete(drives)
       .where(eq(drives.id, drive.id));
+
+    // Drop the refs the cascade just orphaned. Best-effort — the daily purge
+    // cron sweeps unscoped, so a failure here only delays the repair.
+    if (machinePageIds.length > 0) {
+      try {
+        await sweepDanglingMachineRefs(machinePageIds);
+      } catch (error) {
+        loggers.api.warn('Machine-ref sweep after permanent drive delete failed; daily cron will retry', {
+          driveId,
+          error: error as Error,
+        });
+      }
+    }
 
     // Broadcast drive deletion event (permanent delete)
     await broadcastDriveEvent(

--- a/apps/web/src/lib/machines/__tests__/machine-ref-sweep-runtime.test.ts
+++ b/apps/web/src/lib/machines/__tests__/machine-ref-sweep-runtime.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for the dangling-MachineRef sweep's DB wiring (issue #2156).
+ *
+ * The decisions live in the pure core (@pagespace/lib services/machines/
+ * machine-ref-sweep, separately tested to 100% branches); what THIS module owns
+ * — and what these tests pin — is the wiring:
+ *
+ * - liveness is "a `pages` row exists", with NO isTrashed filter (a trashed
+ *   Machine is restorable, so its refs must survive the sweep);
+ * - agent blobs are rewritten through the canonical `applyPageMutation` with a
+ *   revision CAS and a REAL actor (the page's drive owner) — never a raw
+ *   `db.update`, which would skip the revision bump/version/activity entry;
+ * - the global-assistant blob has no revision to CAS on, so its rewrite re-reads
+ *   the row under `SELECT … FOR UPDATE` and re-applies the same dead set, rather
+ *   than clobbering a concurrent settings save with a stale array.
+ *
+ * DB access is mocked; these tests verify routing, filtering and locking.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockApplyPageMutation,
+  mockGetActorInfo,
+  mockPagesSelectWhere,
+  mockGlobalSelectWhere,
+  mockFindDrive,
+  mockExecute,
+  mockTxGlobalSelectFor,
+  mockTxUpdateSet,
+  mockTxUpdateWhere,
+} = vi.hoisted(() => ({
+  mockApplyPageMutation: vi.fn(),
+  mockGetActorInfo: vi.fn(),
+  mockPagesSelectWhere: vi.fn(),
+  mockGlobalSelectWhere: vi.fn(),
+  mockFindDrive: vi.fn(),
+  mockExecute: vi.fn(),
+  mockTxGlobalSelectFor: vi.fn(),
+  mockTxUpdateSet: vi.fn(),
+  mockTxUpdateWhere: vi.fn(),
+}));
+
+function tableName(table: unknown): string {
+  return (table as { __table?: string } | undefined)?.__table ?? '';
+}
+
+const tx = {
+  select: () => ({
+    from: () => ({
+      where: () => ({ for: (...args: unknown[]) => mockTxGlobalSelectFor(...args) }),
+    }),
+  }),
+  update: () => ({
+    set: (values: unknown) => {
+      mockTxUpdateSet(values);
+      return { where: (...args: unknown[]) => mockTxUpdateWhere(...args) };
+    },
+  }),
+};
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: (...args: unknown[]) =>
+          tableName(table) === 'global_assistant_config'
+            ? mockGlobalSelectWhere(...args)
+            : mockPagesSelectWhere(...args),
+      }),
+    }),
+    query: { drives: { findFirst: (...args: unknown[]) => mockFindDrive(...args) } },
+    execute: (...args: unknown[]) => mockExecute(...args),
+    transaction: (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  inArray: vi.fn((...args: unknown[]) => ({ inArray: args })),
+  sql: Object.assign(
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings.join('?'), values })),
+    { raw: vi.fn((text: string) => ({ raw: text })) },
+  ),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: {
+    __table: 'pages',
+    id: 'id',
+    type: 'type',
+    driveId: 'driveId',
+    revision: 'revision',
+    machines: 'machines',
+    machineAccess: 'machineAccess',
+    isTrashed: 'isTrashed',
+  },
+  drives: { __table: 'drives', id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/integrations', () => ({
+  globalAssistantConfig: {
+    __table: 'global_assistant_config',
+    userId: 'userId',
+    machines: 'machines',
+    machineAccess: 'machineAccess',
+  },
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: (...args: unknown[]) => mockGetActorInfo(...args),
+}));
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: (...args: unknown[]) => mockApplyPageMutation(...args),
+}));
+
+import {
+  sweepDanglingMachineRefs,
+  collectMachinePageIdsInSubtree,
+  collectMachinePageIdsInDrive,
+} from '../machine-ref-sweep-runtime';
+
+const DEAD = 'machine-gone';
+const LIVE = 'machine-live';
+
+const AGENT_ROW = {
+  pageId: 'agent-1',
+  revision: 7,
+  driveId: 'drive-1',
+  entries: [{ kind: 'existing', machineId: DEAD }],
+  machineAccess: true,
+};
+const GLOBAL_ROW = {
+  userId: 'user-1',
+  entries: [{ kind: 'existing', machineId: DEAD }],
+  machineAccess: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetActorInfo.mockResolvedValue({ actorEmail: 'owner@x.test', actorDisplayName: 'Owner' });
+  mockFindDrive.mockResolvedValue({ ownerId: 'drive-owner-1' });
+  mockApplyPageMutation.mockResolvedValue({});
+  mockGlobalSelectWhere.mockResolvedValue([GLOBAL_ROW]);
+  mockTxGlobalSelectFor.mockResolvedValue([{ machines: GLOBAL_ROW.entries, machineAccess: true }]);
+  mockTxUpdateWhere.mockResolvedValue(undefined);
+  // First pages query = the agent listing; second = the liveness lookup, which
+  // finds nothing (DEAD really is gone).
+  mockPagesSelectWhere.mockResolvedValueOnce([AGENT_ROW]).mockResolvedValue([]);
+});
+
+describe('sweepDanglingMachineRefs', () => {
+  it('rewrites an agent blob through applyPageMutation with a revision CAS and the drive owner as actor', async () => {
+    const result = await sweepDanglingMachineRefs();
+
+    expect(result.deadMachineIds).toEqual([DEAD]);
+    expect(result.agentsUpdated).toBe(1);
+    expect(mockApplyPageMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageId: 'agent-1',
+        operation: 'agent_config_update',
+        // The scrub empties the list, so access must go off with it — otherwise
+        // resolveConfiguredMachines falls back to {kind:'own'}.
+        updates: { machines: [], machineAccess: false },
+        updatedFields: ['machines', 'machineAccess'],
+        expectedRevision: 7,
+        context: expect.objectContaining({
+          userId: 'drive-owner-1',
+          changeGroupType: 'system',
+          resourceType: 'agent',
+          metadata: { cascade: 'machine_purge', machineIds: [DEAD] },
+        }),
+      }),
+    );
+  });
+
+  it('leaves machineAccess alone when refs survive the rewrite', async () => {
+    mockPagesSelectWhere.mockReset();
+    mockPagesSelectWhere
+      .mockResolvedValueOnce([
+        { ...AGENT_ROW, entries: [{ kind: 'existing', machineId: DEAD }, { kind: 'existing', machineId: LIVE }] },
+      ])
+      .mockResolvedValue([{ id: LIVE }]);
+    mockGlobalSelectWhere.mockResolvedValue([]);
+
+    await sweepDanglingMachineRefs();
+
+    expect(mockApplyPageMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updates: { machines: [{ kind: 'existing', machineId: LIVE }] },
+        updatedFields: ['machines'],
+      }),
+    );
+  });
+
+  it('counts a rejected agent write as a failure without aborting the sweep', async () => {
+    mockApplyPageMutation.mockRejectedValue(new Error('revision moved'));
+
+    const result = await sweepDanglingMachineRefs();
+
+    expect(result.failures).toBe(1);
+    expect(result.agentsUpdated).toBe(0);
+    // The global blob is still repaired.
+    expect(result.globalConfigsUpdated).toBe(1);
+  });
+
+  it('fails the agent write rather than inventing an actor when the drive has no owner', async () => {
+    mockFindDrive.mockResolvedValue(undefined);
+
+    const result = await sweepDanglingMachineRefs();
+
+    expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    expect(result.failures).toBe(1);
+  });
+
+  it('rewrites the global blob under a row lock, re-reading it inside the transaction', async () => {
+    const result = await sweepDanglingMachineRefs();
+
+    expect(mockTxGlobalSelectFor).toHaveBeenCalledWith('update');
+    expect(mockTxUpdateSet).toHaveBeenCalledWith({ machines: [], machineAccess: false });
+    expect(result.globalConfigsUpdated).toBe(1);
+  });
+
+  it('re-applies the dead set to what the lock actually found, not to the stale read', async () => {
+    // A concurrent settings save added a live machine between the listing and
+    // the lock: the sweep must drop only the dead ref, keeping the new one.
+    mockTxGlobalSelectFor.mockResolvedValue([
+      {
+        machines: [{ kind: 'existing', machineId: DEAD }, { kind: 'existing', machineId: LIVE }],
+        machineAccess: true,
+      },
+    ]);
+
+    await sweepDanglingMachineRefs();
+
+    expect(mockTxUpdateSet).toHaveBeenCalledWith({
+      machines: [{ kind: 'existing', machineId: LIVE }],
+      machineAccess: true,
+    });
+  });
+
+  it('writes nothing when the locked row no longer holds a dead ref', async () => {
+    mockTxGlobalSelectFor.mockResolvedValue([{ machines: [{ kind: 'own' }], machineAccess: true }]);
+
+    const result = await sweepDanglingMachineRefs();
+
+    expect(mockTxUpdateSet).not.toHaveBeenCalled();
+    expect(result.globalConfigsUpdated).toBe(0);
+  });
+
+  it('writes nothing when the config row vanished under the lock', async () => {
+    mockTxGlobalSelectFor.mockResolvedValue([]);
+
+    const result = await sweepDanglingMachineRefs();
+
+    expect(mockTxUpdateSet).not.toHaveBeenCalled();
+    expect(result.globalConfigsUpdated).toBe(0);
+  });
+
+  it('is a no-op for an empty candidate list, without touching the database', async () => {
+    const result = await sweepDanglingMachineRefs([]);
+
+    expect(result).toEqual({ deadMachineIds: [], agentsUpdated: 0, globalConfigsUpdated: 0, failures: 0 });
+    expect(mockPagesSelectWhere).not.toHaveBeenCalled();
+    expect(mockGlobalSelectWhere).not.toHaveBeenCalled();
+  });
+});
+
+describe('collectMachinePageIdsInSubtree', () => {
+  it('returns the MACHINE page ids under a root, including the root itself', async () => {
+    mockExecute.mockResolvedValue({ rows: [{ id: 'm1' }, { id: 'm2' }] });
+    await expect(collectMachinePageIdsInSubtree('root-1')).resolves.toEqual(['m1', 'm2']);
+  });
+});
+
+describe('collectMachinePageIdsInDrive', () => {
+  it('returns every MACHINE page id in the drive', async () => {
+    mockPagesSelectWhere.mockReset();
+    mockPagesSelectWhere.mockResolvedValue([{ id: 'm1' }]);
+    await expect(collectMachinePageIdsInDrive('drive-1')).resolves.toEqual(['m1']);
+  });
+});

--- a/apps/web/src/lib/machines/machine-ref-sweep-runtime.ts
+++ b/apps/web/src/lib/machines/machine-ref-sweep-runtime.ts
@@ -1,0 +1,236 @@
+/**
+ * Production wiring for the dangling-MachineRef sweep (issue #2156).
+ *
+ * Binds the provider-agnostic reconcile (`@pagespace/lib/services/machines/
+ * machine-ref-sweep` — read its module doc first; it explains WHY this is a
+ * reconcile and not a guard on each delete path) to the real DB.
+ *
+ * Three seams carry the weight:
+ *
+ * `findExistingPageIds` asks only whether a `pages` row EXISTS. There is
+ * deliberately NO `isTrashed` filter: a trashed Machine is restorable, and
+ * dropping its refs would silently destroy a setting the user can still get
+ * back. Only a HARD-deleted machine is dead. (Same line the orphan reconciler
+ * draws before it kills a Sprite.)
+ *
+ * `writeAgentConfig` goes through the canonical `applyPageMutation` — same call
+ * `createDbMachineRefScrub` makes — so each rewritten agent gets its revision
+ * bump, page version and activity entry, and so the write is a compare-and-swap
+ * on the revision we read: an agent whose owner saved a new machine list while
+ * the sweep was running loses the CAS and is simply retried on the next run,
+ * rather than being clobbered with our stale array. The ACTOR is the agent
+ * page's drive owner — a real user, because activity/audit rows are FK'd to
+ * `users` and this repo has no system-user convention. A drive with no owner row
+ * is left alone (reported as a failure) instead of being written under a
+ * fabricated actor.
+ *
+ * `writeGlobalConfig` has no revision to CAS on — `global_assistant_config` is
+ * not a page. So it re-reads the row inside a transaction under `SELECT … FOR
+ * UPDATE` (the lock `getOrCreateOwnMachinePageId` already uses on this table)
+ * and re-applies the SAME dead set to whatever it finds. A concurrent settings
+ * save is therefore either serialized behind us or observed by us; either way
+ * the machine the user just added survives and only the dead refs go.
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, inArray, sql } from '@pagespace/db/operators';
+import { pages, drives } from '@pagespace/db/schema/core';
+import { globalAssistantConfig } from '@pagespace/db/schema/integrations';
+import {
+  planMachineRefRewrite,
+  sweepMachineRefs,
+  type MachineRefHolder,
+  type MachineRefWrite,
+  type SweepMachineRefsDeps,
+  type SweepMachineRefsResult,
+} from '@pagespace/lib/services/machines/machine-ref-sweep';
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import { applyPageMutation } from '@/services/api/page-mutation-service';
+
+type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+interface AgentConfigRow extends MachineRefHolder {
+  pageId: string;
+  revision: number;
+  driveId: string;
+}
+
+interface GlobalConfigRow extends MachineRefHolder {
+  userId: string;
+}
+
+/**
+ * Rows whose blob holds at least one `{kind:'existing'}` element — the only
+ * shape a dangling ref can take. Written as a jsonb containment so it is
+ * index-friendly AND total: containment on a non-array blob is simply false,
+ * where `jsonb_array_length` would raise.
+ */
+const HOLDS_AN_EXISTING_REF = sql`@> '[{"kind":"existing"}]'::jsonb`;
+
+function holdsAnyOf(column: unknown, candidateMachineIds: readonly string[]) {
+  // The `jsonb_typeof` guard is not belt-and-braces: `jsonb_array_elements`
+  // RAISES on a non-array blob, so without it one malformed row would abort the
+  // whole listing. The containment form below is total for the same reason.
+  return sql`jsonb_typeof(${column}) = 'array' AND EXISTS (
+    SELECT 1 FROM jsonb_array_elements(${column}) AS elem
+    WHERE elem->>'kind' = 'existing' AND elem->>'machineId' = ANY(${[...candidateMachineIds]}::text[])
+  )`;
+}
+
+function machinesFilter(column: unknown, candidateMachineIds?: readonly string[]) {
+  return candidateMachineIds
+    ? holdsAnyOf(column, candidateMachineIds)
+    : sql`${column} ${HOLDS_AN_EXISTING_REF}`;
+}
+
+/**
+ * The actor to attribute a system rewrite of an agent page to: that page's
+ * drive owner. Cached per sweep run — a purge typically hits many agents in the
+ * same drive.
+ */
+function createDriveOwnerLookup() {
+  const cache = new Map<string, string | null>();
+  return async function lookupDriveOwner(driveId: string): Promise<string | null> {
+    const cached = cache.get(driveId);
+    if (cached !== undefined) return cached;
+    const drive = await db.query.drives.findFirst({
+      where: eq(drives.id, driveId),
+      columns: { ownerId: true },
+    });
+    const ownerId = drive?.ownerId ?? null;
+    cache.set(driveId, ownerId);
+    return ownerId;
+  };
+}
+
+function createDeps(candidateMachineIds?: readonly string[]): SweepMachineRefsDeps<AgentConfigRow, GlobalConfigRow> {
+  const lookupDriveOwner = createDriveOwnerLookup();
+
+  return {
+    candidateMachineIds,
+
+    listAgentConfigs: (ids) =>
+      db
+        .select({
+          pageId: pages.id,
+          revision: pages.revision,
+          driveId: pages.driveId,
+          entries: pages.machines,
+          machineAccess: pages.machineAccess,
+        })
+        .from(pages)
+        .where(and(eq(pages.type, 'AI_CHAT'), machinesFilter(pages.machines, ids))),
+
+    listGlobalConfigs: (ids) =>
+      db
+        .select({
+          userId: globalAssistantConfig.userId,
+          entries: globalAssistantConfig.machines,
+          machineAccess: globalAssistantConfig.machineAccess,
+        })
+        .from(globalAssistantConfig)
+        .where(machinesFilter(globalAssistantConfig.machines, ids)),
+
+    findExistingPageIds: async (ids) => {
+      // No isTrashed filter — see the module doc. A trashed Machine is alive.
+      const rows = await db.select({ id: pages.id }).from(pages).where(inArray(pages.id, [...ids]));
+      return rows.map((row) => row.id);
+    },
+
+    writeAgentConfig: async ({ config, machines, machineAccess, deadMachineIds }: MachineRefWrite<AgentConfigRow>) => {
+      const actorUserId = await lookupDriveOwner(config.driveId);
+      if (!actorUserId) {
+        // No real user to attribute the mutation to. Throwing reports it as a
+        // failure and leaves the blob for a later run, which is strictly better
+        // than writing page history under an invented actor.
+        throw new Error(`No drive owner for agent page ${config.pageId}; cannot attribute machine-ref sweep`);
+      }
+      const actorInfo = await getActorInfo(actorUserId);
+      // machineAccess is only written when it actually changed, so an unrelated
+      // toggle never shows up in this page's history.
+      const accessChanged = machineAccess !== config.machineAccess;
+      await applyPageMutation({
+        pageId: config.pageId,
+        operation: 'agent_config_update',
+        updates: accessChanged ? { machines, machineAccess } : { machines },
+        updatedFields: accessChanged ? ['machines', 'machineAccess'] : ['machines'],
+        expectedRevision: config.revision,
+        context: {
+          userId: actorUserId,
+          actorEmail: actorInfo?.actorEmail,
+          actorDisplayName: actorInfo?.actorDisplayName ?? undefined,
+          changeGroupType: 'system',
+          resourceType: 'agent',
+          metadata: { cascade: 'machine_purge', machineIds: [...deadMachineIds] },
+        },
+      });
+      return true;
+    },
+
+    writeGlobalConfig: async ({ config, deadMachineIds }: MachineRefWrite<GlobalConfigRow>) =>
+      db.transaction(async (tx: TransactionType) => {
+        const [locked] = await tx
+          .select({ machines: globalAssistantConfig.machines, machineAccess: globalAssistantConfig.machineAccess })
+          .from(globalAssistantConfig)
+          .where(eq(globalAssistantConfig.userId, config.userId))
+          .for('update');
+        // The row can have been deleted (account erasure) or already repaired by
+        // a concurrent run between the listing and the lock.
+        if (!locked) return false;
+
+        const plan = planMachineRefRewrite({
+          entries: locked.machines,
+          machineAccess: locked.machineAccess,
+          deadMachineIds,
+        });
+        if (!plan.changed) return false;
+
+        await tx
+          .update(globalAssistantConfig)
+          .set({ machines: plan.machines, machineAccess: plan.machineAccess })
+          .where(eq(globalAssistantConfig.userId, config.userId));
+        return true;
+      }),
+  };
+}
+
+/**
+ * Drop every MachineRef pointing at a machine page that no longer exists.
+ *
+ * `candidateMachineIds` scopes the run to machines a caller just hard-deleted
+ * (cheap, immediate healing on the interactive delete routes); omitting it
+ * sweeps everything, which is the cron backstop for the paths no call site can
+ * cover — account erasure, drive cascades, manual DB surgery.
+ */
+export function sweepDanglingMachineRefs(
+  candidateMachineIds?: readonly string[],
+): Promise<SweepMachineRefsResult> {
+  return sweepMachineRefs(createDeps(candidateMachineIds));
+}
+
+/**
+ * The MACHINE page ids in a page subtree, root included — collected BEFORE a
+ * hard delete, because afterwards the rows are gone and the set is
+ * unrecoverable. Mirrors the recursive CTE the same route already uses to
+ * snapshot its files.
+ */
+export async function collectMachinePageIdsInSubtree(rootPageId: string): Promise<string[]> {
+  const result = await db.execute(sql`
+    WITH RECURSIVE subtree AS (
+      SELECT id, type FROM pages WHERE id = ${rootPageId}
+      UNION ALL
+      SELECT p.id, p.type FROM pages p JOIN subtree s ON p."parentId" = s.id
+    )
+    SELECT id FROM subtree WHERE type = 'MACHINE'
+  `);
+  return (result.rows as Array<{ id: string }>).map((row) => row.id);
+}
+
+/** Every MACHINE page id in a drive — the same snapshot, for a permanent drive delete. */
+export async function collectMachinePageIdsInDrive(driveId: string): Promise<string[]> {
+  const rows = await db
+    .select({ id: pages.id })
+    .from(pages)
+    .where(and(eq(pages.driveId, driveId), eq(pages.type, 'MACHINE')));
+  return rows.map((row) => row.id);
+}

--- a/apps/web/src/lib/machines/machine-ref-sweep-runtime.ts
+++ b/apps/web/src/lib/machines/machine-ref-sweep-runtime.ts
@@ -68,11 +68,16 @@ interface GlobalConfigRow extends MachineRefHolder {
 const HOLDS_AN_EXISTING_REF = sql`@> '[{"kind":"existing"}]'::jsonb`;
 
 function holdsAnyOf(column: unknown, candidateMachineIds: readonly string[]) {
-  // The `jsonb_typeof` guard is not belt-and-braces: `jsonb_array_elements`
-  // RAISES on a non-array blob, so without it one malformed row would abort the
-  // whole listing. The containment form below is total for the same reason.
-  return sql`jsonb_typeof(${column}) = 'array' AND EXISTS (
-    SELECT 1 FROM jsonb_array_elements(${column}) AS elem
+  // `jsonb_array_elements` RAISES on a non-array blob, so a malformed row would
+  // abort the whole listing — and Postgres does NOT guarantee left-to-right `AND`
+  // evaluation, so a separate `jsonb_typeof(...) = 'array' AND EXISTS(...)`
+  // guard is not reliable: the planner may evaluate the EXISTS branch first. The
+  // guard is instead baked directly into `jsonb_array_elements`'s own argument
+  // via CASE, which Postgres must evaluate before the call can run.
+  return sql`EXISTS (
+    SELECT 1 FROM jsonb_array_elements(
+      CASE WHEN jsonb_typeof(${column}) = 'array' THEN ${column} ELSE '[]'::jsonb END
+    ) AS elem
     WHERE elem->>'kind' = 'existing' AND elem->>'machineId' = ANY(${[...candidateMachineIds]}::text[])
   )`;
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -677,6 +677,11 @@
       "import": "./dist/services/machines/machine-settings.js",
       "require": "./dist/services/machines/machine-settings.js"
     },
+    "./services/machines/machine-ref-sweep": {
+      "types": "./dist/services/machines/machine-ref-sweep.d.ts",
+      "import": "./dist/services/machines/machine-ref-sweep.js",
+      "require": "./dist/services/machines/machine-ref-sweep.js"
+    },
     "./services/machines/agent-terminal-types": {
       "types": "./dist/services/machines/agent-terminal-types.d.ts",
       "import": "./dist/services/machines/agent-terminal-types.js",
@@ -1942,6 +1947,9 @@
       ],
       "services/machines/machine-settings": [
         "./dist/services/machines/machine-settings.d.ts"
+      ],
+      "services/machines/machine-ref-sweep": [
+        "./dist/services/machines/machine-ref-sweep.d.ts"
       ],
       "services/machines/agent-terminal-types": [
         "./dist/services/machines/agent-terminal-types.d.ts"

--- a/packages/lib/src/services/machines/__tests__/machine-ref-sweep.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-ref-sweep.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  collectReferencedMachineIds,
+  planMachineRefRewrite,
+  sweepMachineRefs,
+  type MachineRefHolder,
+  type SweepMachineRefsDeps,
+} from '../machine-ref-sweep';
+
+const DEAD = 'machine-gone';
+const LIVE = 'machine-live';
+
+function agent(overrides: Partial<MachineRefHolder & { pageId: string }> = {}) {
+  return {
+    pageId: 'agent-1',
+    entries: [{ kind: 'existing', machineId: DEAD }] as unknown[],
+    machineAccess: true,
+    ...overrides,
+  };
+}
+
+function global_(overrides: Partial<MachineRefHolder & { userId: string }> = {}) {
+  return {
+    userId: 'user-1',
+    entries: [{ kind: 'existing', machineId: DEAD }] as unknown[],
+    machineAccess: true,
+    ...overrides,
+  };
+}
+
+type Agent = ReturnType<typeof agent>;
+type Global = ReturnType<typeof global_>;
+
+function makeDeps(
+  overrides: Partial<SweepMachineRefsDeps<Agent, Global>> = {},
+): SweepMachineRefsDeps<Agent, Global> {
+  return {
+    listAgentConfigs: vi.fn().mockResolvedValue([agent()]),
+    listGlobalConfigs: vi.fn().mockResolvedValue([global_()]),
+    // Only LIVE still has a page row; DEAD was hard-deleted.
+    findExistingPageIds: vi.fn().mockImplementation(async (ids: readonly string[]) =>
+      ids.filter((id) => id !== DEAD),
+    ),
+    writeAgentConfig: vi.fn().mockResolvedValue(true),
+    writeGlobalConfig: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('collectReferencedMachineIds', () => {
+  it('collects every existing-ref machineId across holders, de-duplicated', () => {
+    const ids = collectReferencedMachineIds([
+      { entries: [{ kind: 'existing', machineId: 'a' }, { kind: 'own' }], machineAccess: true },
+      { entries: [{ kind: 'existing', machineId: 'a' }, { kind: 'existing', machineId: 'b' }], machineAccess: false },
+    ]);
+    expect([...ids].sort()).toEqual(['a', 'b']);
+  });
+
+  it('ignores malformed entries and non-array blobs', () => {
+    const ids = collectReferencedMachineIds([
+      { entries: [null, 42, { kind: 'existing' }, { kind: 'existing', machineId: '' }, 'nope'], machineAccess: true },
+    ]);
+    expect(ids.size).toBe(0);
+  });
+});
+
+describe('planMachineRefRewrite', () => {
+  it('drops refs to dead machines', () => {
+    const plan = planMachineRefRewrite({
+      entries: [{ kind: 'existing', machineId: DEAD }, { kind: 'existing', machineId: LIVE }],
+      machineAccess: true,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(plan).toEqual({
+      changed: true,
+      machines: [{ kind: 'existing', machineId: LIVE }],
+      machineAccess: true,
+    });
+  });
+
+  it('reports no change when every ref is still live', () => {
+    const entries = [{ kind: 'existing', machineId: LIVE }];
+    const plan = planMachineRefRewrite({ entries, machineAccess: true, deadMachineIds: new Set([DEAD]) });
+    expect(plan.changed).toBe(false);
+  });
+
+  it('preserves an own-machine ref', () => {
+    const plan = planMachineRefRewrite({
+      entries: [{ kind: 'own' }, { kind: 'existing', machineId: DEAD }],
+      machineAccess: true,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(plan.machines).toEqual([{ kind: 'own' }]);
+    expect(plan.machineAccess).toBe(true);
+  });
+
+  it('preserves malformed entries byte-for-byte', () => {
+    const junk = { kind: 'existing' };
+    const plan = planMachineRefRewrite({
+      entries: [junk, null, { kind: 'existing', machineId: DEAD }],
+      machineAccess: true,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(plan.changed).toBe(true);
+    expect(plan.machines).toEqual([junk, null]);
+    expect(plan.machines[0]).toBe(junk);
+  });
+
+  it('turns machineAccess off when the rewrite empties the list', () => {
+    const plan = planMachineRefRewrite({
+      entries: [{ kind: 'existing', machineId: DEAD }],
+      machineAccess: true,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(plan).toEqual({ changed: true, machines: [], machineAccess: false });
+  });
+
+  it('leaves an already-off machineAccess off when the rewrite empties the list', () => {
+    const plan = planMachineRefRewrite({
+      entries: [{ kind: 'existing', machineId: DEAD }],
+      machineAccess: false,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(plan).toEqual({ changed: true, machines: [], machineAccess: false });
+  });
+
+  it('does not touch machineAccess for a config that was already empty', () => {
+    const plan = planMachineRefRewrite({ entries: [], machineAccess: true, deadMachineIds: new Set([DEAD]) });
+    expect(plan).toEqual({ changed: false, machines: [], machineAccess: true });
+  });
+
+  it('treats a non-array blob as empty', () => {
+    const plan = planMachineRefRewrite({
+      entries: undefined,
+      machineAccess: true,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(plan).toEqual({ changed: false, machines: [], machineAccess: true });
+  });
+});
+
+describe('sweepMachineRefs', () => {
+  it('rewrites both blobs when a referenced machine has no page row', async () => {
+    const deps = makeDeps();
+    const result = await sweepMachineRefs(deps);
+
+    expect(result).toEqual({
+      deadMachineIds: [DEAD],
+      agentsUpdated: 1,
+      globalConfigsUpdated: 1,
+      failures: 0,
+    });
+    expect(deps.writeAgentConfig).toHaveBeenCalledWith({
+      config: agent(),
+      machines: [],
+      machineAccess: false,
+      deadMachineIds: new Set([DEAD]),
+    });
+    expect(deps.writeGlobalConfig).toHaveBeenCalledWith({
+      config: global_(),
+      machines: [],
+      machineAccess: false,
+      deadMachineIds: new Set([DEAD]),
+    });
+  });
+
+  it('treats a trashed-but-existing machine page as alive and writes nothing', async () => {
+    // A trash is reversible: the page row still exists, so its refs must survive.
+    const deps = makeDeps({ findExistingPageIds: vi.fn().mockImplementation(async (ids: readonly string[]) => ids) });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result).toEqual({ deadMachineIds: [], agentsUpdated: 0, globalConfigsUpdated: 0, failures: 0 });
+    expect(deps.writeAgentConfig).not.toHaveBeenCalled();
+    expect(deps.writeGlobalConfig).not.toHaveBeenCalled();
+  });
+
+  it('never queries page liveness when nothing references a machine', async () => {
+    const deps = makeDeps({
+      listAgentConfigs: vi.fn().mockResolvedValue([]),
+      listGlobalConfigs: vi.fn().mockResolvedValue([global_({ entries: [{ kind: 'own' }] })]),
+    });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result.deadMachineIds).toEqual([]);
+    expect(deps.findExistingPageIds).not.toHaveBeenCalled();
+  });
+
+  it('skips configs the rewrite would not change', async () => {
+    const deps = makeDeps({
+      listAgentConfigs: vi
+        .fn()
+        .mockResolvedValue([agent(), agent({ pageId: 'agent-2', entries: [{ kind: 'existing', machineId: LIVE }] })]),
+    });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result.agentsUpdated).toBe(1);
+    expect(deps.writeAgentConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a global config the rewrite would not change', async () => {
+    const deps = makeDeps({
+      listGlobalConfigs: vi
+        .fn()
+        .mockResolvedValue([global_({ entries: [{ kind: 'existing', machineId: LIVE }] }), global_({ userId: 'user-2' })]),
+    });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result.globalConfigsUpdated).toBe(1);
+    expect(deps.writeGlobalConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not count a write that reported it wrote nothing', async () => {
+    // A lost compare-and-swap, or a row someone else already repaired.
+    const deps = makeDeps({
+      writeAgentConfig: vi.fn().mockResolvedValue(false),
+      writeGlobalConfig: vi.fn().mockResolvedValue(false),
+    });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result).toEqual({
+      deadMachineIds: [DEAD],
+      agentsUpdated: 0,
+      globalConfigsUpdated: 0,
+      failures: 0,
+    });
+  });
+
+  it('keeps sweeping when one write fails, and reports it', async () => {
+    const writeAgentConfig = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('revision moved'))
+      .mockResolvedValue(true);
+    const deps = makeDeps({
+      listAgentConfigs: vi.fn().mockResolvedValue([agent(), agent({ pageId: 'agent-2' })]),
+      writeAgentConfig,
+    });
+    const result = await sweepMachineRefs(deps);
+
+    expect(writeAgentConfig).toHaveBeenCalledTimes(2);
+    expect(result.agentsUpdated).toBe(1);
+    expect(result.failures).toBe(1);
+    // A failed agent write must not skip the global blob.
+    expect(deps.writeGlobalConfig).toHaveBeenCalledTimes(1);
+    expect(result.globalConfigsUpdated).toBe(1);
+  });
+
+  it('reports a failing global-config write without losing the agent counts', async () => {
+    const deps = makeDeps({ writeGlobalConfig: vi.fn().mockRejectedValue(new Error('locked')) });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result).toEqual({
+      deadMachineIds: [DEAD],
+      agentsUpdated: 1,
+      globalConfigsUpdated: 0,
+      failures: 1,
+    });
+  });
+
+  it('narrows the listing to the candidate machine ids when given', async () => {
+    const deps = makeDeps({ candidateMachineIds: [DEAD] });
+    await sweepMachineRefs(deps);
+
+    expect(deps.listAgentConfigs).toHaveBeenCalledWith([DEAD]);
+    expect(deps.listGlobalConfigs).toHaveBeenCalledWith([DEAD]);
+  });
+
+  it('does nothing at all when the candidate list is empty', async () => {
+    const deps = makeDeps({ candidateMachineIds: [] });
+    const result = await sweepMachineRefs(deps);
+
+    expect(result).toEqual({ deadMachineIds: [], agentsUpdated: 0, globalConfigsUpdated: 0, failures: 0 });
+    expect(deps.listAgentConfigs).not.toHaveBeenCalled();
+    expect(deps.listGlobalConfigs).not.toHaveBeenCalled();
+    expect(deps.findExistingPageIds).not.toHaveBeenCalled();
+  });
+
+  it('only considers candidate machines dead, even if another ref is also dangling', async () => {
+    // A scoped sweep proves nothing about machines outside its candidate set —
+    // asserting one is dead would let an unrelated concurrent create be scrubbed.
+    const other = 'machine-other';
+    const deps = makeDeps({
+      candidateMachineIds: [DEAD],
+      listAgentConfigs: vi
+        .fn()
+        .mockResolvedValue([
+          agent({ entries: [{ kind: 'existing', machineId: DEAD }, { kind: 'existing', machineId: other }] }),
+        ]),
+      listGlobalConfigs: vi.fn().mockResolvedValue([]),
+      findExistingPageIds: vi.fn().mockResolvedValue([]),
+    });
+    const result = await sweepMachineRefs(deps);
+
+    expect(deps.findExistingPageIds).toHaveBeenCalledWith([DEAD]);
+    expect(result.deadMachineIds).toEqual([DEAD]);
+    expect(deps.writeAgentConfig).toHaveBeenCalledWith({
+      config: expect.anything(),
+      machines: [{ kind: 'existing', machineId: other }],
+      machineAccess: true,
+      deadMachineIds: new Set([DEAD]),
+    });
+  });
+});

--- a/packages/lib/src/services/machines/machine-ref-sweep.ts
+++ b/packages/lib/src/services/machines/machine-ref-sweep.ts
@@ -154,6 +154,42 @@ export interface SweepMachineRefsResult {
   failures: number;
 }
 
+/**
+ * Plans and applies one holder's rewrite, isolated from every other holder's
+ * outcome: a throw is caught and counted as a failure rather than propagated,
+ * so one blocked write (e.g. a concurrent config save bumped its revision)
+ * never stops the rest of the batch. Shared by the agent and global-config
+ * loops below — the two differ only in which `write` callback they pass.
+ */
+async function applyRewrite<T extends MachineRefHolder>(
+  config: T,
+  dead: ReadonlySet<string>,
+  write: (input: MachineRefWrite<T>) => Promise<boolean>,
+): Promise<'updated' | 'skipped' | 'failed'> {
+  const plan = planMachineRefRewrite({ ...config, deadMachineIds: dead });
+  if (!plan.changed) return 'skipped';
+  try {
+    const wrote = await write({ config, machines: plan.machines, machineAccess: plan.machineAccess, deadMachineIds: dead });
+    return wrote ? 'updated' : 'skipped';
+  } catch {
+    return 'failed';
+  }
+}
+
+async function applyRewrites<T extends MachineRefHolder>(
+  configs: readonly T[],
+  dead: ReadonlySet<string>,
+  write: (input: MachineRefWrite<T>) => Promise<boolean>,
+): Promise<{ updated: number; failures: number }> {
+  // Every holder's write is independent (its own CAS or its own row lock), so
+  // they run concurrently rather than one at a time.
+  const outcomes = await Promise.all(configs.map((config) => applyRewrite(config, dead, write)));
+  return {
+    updated: outcomes.filter((o) => o === 'updated').length,
+    failures: outcomes.filter((o) => o === 'failed').length,
+  };
+}
+
 export async function sweepMachineRefs<A extends MachineRefHolder, G extends MachineRefHolder>(
   deps: SweepMachineRefsDeps<A, G>,
 ): Promise<SweepMachineRefsResult> {
@@ -186,43 +222,15 @@ export async function sweepMachineRefs<A extends MachineRefHolder, G extends Mac
   if (deadMachineIds.length === 0) return empty;
 
   const dead = new Set(deadMachineIds);
-  let agentsUpdated = 0;
-  let globalConfigsUpdated = 0;
-  let failures = 0;
+  const [agentResult, globalResult] = await Promise.all([
+    applyRewrites(agents, dead, deps.writeAgentConfig),
+    applyRewrites(globals, dead, deps.writeGlobalConfig),
+  ]);
 
-  for (const config of agents) {
-    const plan = planMachineRefRewrite({ ...config, deadMachineIds: dead });
-    if (!plan.changed) continue;
-    try {
-      const wrote = await deps.writeAgentConfig({
-        config,
-        machines: plan.machines,
-        machineAccess: plan.machineAccess,
-        deadMachineIds: dead,
-      });
-      if (wrote) agentsUpdated += 1;
-    } catch {
-      // Keep sweeping: one blocked agent (a concurrent config save bumped its
-      // revision) must not leave every other blob dangling.
-      failures += 1;
-    }
-  }
-
-  for (const config of globals) {
-    const plan = planMachineRefRewrite({ ...config, deadMachineIds: dead });
-    if (!plan.changed) continue;
-    try {
-      const wrote = await deps.writeGlobalConfig({
-        config,
-        machines: plan.machines,
-        machineAccess: plan.machineAccess,
-        deadMachineIds: dead,
-      });
-      if (wrote) globalConfigsUpdated += 1;
-    } catch {
-      failures += 1;
-    }
-  }
-
-  return { deadMachineIds, agentsUpdated, globalConfigsUpdated, failures };
+  return {
+    deadMachineIds,
+    agentsUpdated: agentResult.updated,
+    globalConfigsUpdated: globalResult.updated,
+    failures: agentResult.failures + globalResult.failures,
+  };
 }

--- a/packages/lib/src/services/machines/machine-ref-sweep.ts
+++ b/packages/lib/src/services/machines/machine-ref-sweep.ts
@@ -1,0 +1,228 @@
+/**
+ * Dangling-MachineRef sweep (issue #2156) — the self-healing counterpart to
+ * `createDbMachineRefScrub`.
+ *
+ * A Machine reference is stored TWICE: once as the Machine's own
+ * `PageType.MACHINE` page row, and again — denormalized — as a `MachineRef`
+ * inside two JSONB blobs, `pages.machines` on AI_CHAT agent pages and
+ * `global_assistant_config.machines` per user. Only ONE code path keeps the
+ * blobs honest: the Machine Settings delete (`deleteMachine` →
+ * `MachineRefScrub`, machine-settings.ts). Every OTHER way a Machine page can
+ * cease to exist bypasses it — "delete permanently" from the trash, a permanent
+ * drive delete (pages FK-cascade), the 30-day purge cron, account erasure — and
+ * each leaves a `{kind:'existing', machineId}` pointing at nothing, forever.
+ *
+ * Guarding each of those call sites is the same losing game the Sprite-reclaim
+ * outbox already rejected (see machine-orphan-reconcile.ts's module doc): there
+ * is always one more delete path, and erasure must never be blocked by
+ * bookkeeping. So this module does not guard deletes — it RECONCILES: whatever
+ * ids the blobs still reference, minus the ids that still have a page row, is
+ * the dead set, and dead refs are dropped. That converges no matter how the row
+ * vanished, including by hand in psql.
+ *
+ * DEAD MEANS "NO `pages` ROW AT ALL" — a TRASHED machine is ALIVE here. This is
+ * the load-bearing distinction of the whole module. A trash is REVERSIBLE
+ * (`pageService.trashPage`, bulk delete, folder cascade-trash all hide a MACHINE
+ * page and a restore brings it back), while dropping a ref is NOT: a scrubbed
+ * ref is never re-added on restore, because a `MachineRef` is the REFERENCING
+ * agent's setting and only its owner re-links it (machine-settings.ts's
+ * `deleteMachine` doc). Scrubbing on trash would therefore destroy a setting
+ * that the user can still legitimately expect back. Same reason the orphan
+ * reconciler refuses to kill a merely-trashed Machine's Sprite.
+ *
+ * Every effect is injected, so the decisions below are unit-testable without a
+ * database. Runtime wiring: `apps/web/src/lib/machines/machine-ref-sweep-runtime.ts`.
+ */
+
+/**
+ * Structural mirror of the canonical `MachineRef`
+ * (apps/web/src/lib/repositories/page-agent-repository.ts) — same trick, and the
+ * same reason, as `machine-session.ts`: @pagespace/lib must not import from the
+ * web app.
+ */
+export type MachineRefLike = { kind: 'own' } | { kind: 'existing'; machineId: string };
+
+/** The two blob homes, reduced to what a rewrite decision actually needs. */
+export interface MachineRefHolder {
+  /** The raw JSONB value. Deliberately `unknown` — a blob written by an older shape must not crash the sweep. */
+  entries: unknown;
+  machineAccess: boolean;
+}
+
+export interface MachineRefRewrite {
+  /** False when no ref was dropped — the caller MUST skip the write (no revision churn, no activity noise). */
+  changed: boolean;
+  /** The surviving entries, in order. Non-ref elements are passed through by IDENTITY, never re-serialized. */
+  machines: unknown[];
+  machineAccess: boolean;
+}
+
+function isExistingRef(value: unknown): value is { kind: 'existing'; machineId: string } {
+  if (typeof value !== 'object' || value === null) return false;
+  const { kind, machineId } = value as { kind?: unknown; machineId?: unknown };
+  return kind === 'existing' && typeof machineId === 'string' && machineId.length > 0;
+}
+
+function toEntryArray(entries: unknown): unknown[] {
+  return Array.isArray(entries) ? entries : [];
+}
+
+/** Every machine id referenced by a batch of holders. Malformed elements contribute nothing. */
+export function collectReferencedMachineIds(holders: readonly MachineRefHolder[]): Set<string> {
+  const ids = new Set<string>();
+  for (const holder of holders) {
+    for (const entry of toEntryArray(holder.entries)) {
+      if (isExistingRef(entry)) ids.add(entry.machineId);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Decide one blob's rewrite. Mirrors `createDbMachineRefScrub`'s semantics
+ * exactly, deliberately:
+ *
+ *  - only `{kind:'existing'}` elements naming a DEAD machine are removed;
+ *  - `{kind:'own'}` and any malformed element survive untouched (we are fixing
+ *    dangling pointers, not normalizing user data);
+ *  - when the removal EMPTIES a list whose access was on, access is turned off
+ *    too. `resolveConfiguredMachines`/`resolveGlobalConfiguredMachines`
+ *    (sandbox-tools-runtime.ts) read `machineAccess=true` + `machines=[]` as
+ *    "fall back to {kind:'own'}", so leaving access on would silently repoint
+ *    the agent at a DIFFERENT machine instead of removing the one it lost.
+ */
+export function planMachineRefRewrite(input: {
+  entries: unknown;
+  machineAccess: boolean;
+  deadMachineIds: ReadonlySet<string>;
+}): MachineRefRewrite {
+  const entries = toEntryArray(input.entries);
+  const machines = entries.filter((entry) => !(isExistingRef(entry) && input.deadMachineIds.has(entry.machineId)));
+  const changed = machines.length !== entries.length;
+  return {
+    changed,
+    machines,
+    // Only a rewrite that emptied the list flips access; a config that was
+    // ALREADY empty is left exactly as the user configured it.
+    machineAccess: changed && machines.length === 0 ? false : input.machineAccess,
+  };
+}
+
+export interface MachineRefWrite<T extends MachineRefHolder> {
+  config: T;
+  machines: unknown[];
+  machineAccess: boolean;
+  /**
+   * The dead set this rewrite was derived from. Passed to the writer so a
+   * write that must re-read its row under a lock (the global-config blob has no
+   * revision to compare-and-swap on) can re-apply the SAME decision to whatever
+   * it finds, instead of clobbering a concurrent edit with a stale array.
+   */
+  deadMachineIds: ReadonlySet<string>;
+}
+
+export interface SweepMachineRefsDeps<A extends MachineRefHolder, G extends MachineRefHolder> {
+  /**
+   * Restricts the sweep to these machine ids — the ids a caller just hard-deleted.
+   * Absent = sweep everything (the cron backstop). An EMPTY array means "nothing
+   * was deleted", and is a no-op, NOT a full sweep.
+   *
+   * Scoping also bounds what may be declared dead: a scoped run proves nothing
+   * about ids outside its set, so it never scrubs them.
+   */
+  candidateMachineIds?: readonly string[];
+  listAgentConfigs: (candidateMachineIds?: readonly string[]) => Promise<A[]>;
+  listGlobalConfigs: (candidateMachineIds?: readonly string[]) => Promise<G[]>;
+  /** Which of these ids still have a `pages` row — trashed or not. */
+  findExistingPageIds: (ids: readonly string[]) => Promise<readonly string[]>;
+  /**
+   * Applies a rewrite. Resolves `false` when it deliberately wrote NOTHING — a
+   * compare-and-swap that lost, or a row already repaired by the time the write
+   * reached it. Not an error, and not an update: counting it as one would report
+   * repairs that never happened.
+   */
+  writeAgentConfig: (input: MachineRefWrite<A>) => Promise<boolean>;
+  writeGlobalConfig: (input: MachineRefWrite<G>) => Promise<boolean>;
+}
+
+export interface SweepMachineRefsResult {
+  /** The ids found referenced with no page row behind them. */
+  deadMachineIds: string[];
+  agentsUpdated: number;
+  globalConfigsUpdated: number;
+  /** Writes that threw. Isolated per config — one blocked write never leaves the rest dangling. */
+  failures: number;
+}
+
+export async function sweepMachineRefs<A extends MachineRefHolder, G extends MachineRefHolder>(
+  deps: SweepMachineRefsDeps<A, G>,
+): Promise<SweepMachineRefsResult> {
+  const empty: SweepMachineRefsResult = {
+    deadMachineIds: [],
+    agentsUpdated: 0,
+    globalConfigsUpdated: 0,
+    failures: 0,
+  };
+
+  const { candidateMachineIds } = deps;
+  if (candidateMachineIds && candidateMachineIds.length === 0) return empty;
+
+  const [agents, globals] = await Promise.all([
+    deps.listAgentConfigs(candidateMachineIds),
+    deps.listGlobalConfigs(candidateMachineIds),
+  ]);
+
+  const referenced = collectReferencedMachineIds([...agents, ...globals]);
+  // A scoped run may only ever declare its OWN candidates dead: a ref to some
+  // other machine in the same blob is none of this run's business (and its page
+  // may simply not have been queried).
+  const suspects = candidateMachineIds
+    ? [...referenced].filter((id) => candidateMachineIds.includes(id))
+    : [...referenced];
+  if (suspects.length === 0) return empty;
+
+  const alive = new Set(await deps.findExistingPageIds(suspects));
+  const deadMachineIds = suspects.filter((id) => !alive.has(id));
+  if (deadMachineIds.length === 0) return empty;
+
+  const dead = new Set(deadMachineIds);
+  let agentsUpdated = 0;
+  let globalConfigsUpdated = 0;
+  let failures = 0;
+
+  for (const config of agents) {
+    const plan = planMachineRefRewrite({ ...config, deadMachineIds: dead });
+    if (!plan.changed) continue;
+    try {
+      const wrote = await deps.writeAgentConfig({
+        config,
+        machines: plan.machines,
+        machineAccess: plan.machineAccess,
+        deadMachineIds: dead,
+      });
+      if (wrote) agentsUpdated += 1;
+    } catch {
+      // Keep sweeping: one blocked agent (a concurrent config save bumped its
+      // revision) must not leave every other blob dangling.
+      failures += 1;
+    }
+  }
+
+  for (const config of globals) {
+    const plan = planMachineRefRewrite({ ...config, deadMachineIds: dead });
+    if (!plan.changed) continue;
+    try {
+      const wrote = await deps.writeGlobalConfig({
+        config,
+        machines: plan.machines,
+        machineAccess: plan.machineAccess,
+        deadMachineIds: dead,
+      });
+      if (wrote) globalConfigsUpdated += 1;
+    } catch {
+      failures += 1;
+    }
+  }
+
+  return { deadMachineIds, agentsUpdated, globalConfigsUpdated, failures };
+}


### PR DESCRIPTION
## Summary

Machine references live twice: once as `PageType.MACHINE` page rows, and again denormalized as `MachineRef` entries in `pages.machines` (AI_CHAT agent configs) and `global_assistant_config.machines`. The only code keeping these consistent was `createDbMachineRefScrub`, wired from exactly one call site (Machine Settings delete). Every other way a Machine page can stop existing bypassed it — permanent page delete, permanent drive delete (FK cascade), and the 30-day trash-expiry purge — leaving `{kind:'existing', machineId}` refs pointing at nothing forever.

- New pure core `packages/lib/src/services/machines/machine-ref-sweep.ts`: computes `referenced − existing = dead`, drops dead `{kind:'existing'}` refs, preserves `{kind:'own'}` and malformed entries, and turns off `machineAccess` when a rewrite empties the list (otherwise `resolveConfiguredMachines` silently falls back to `{kind:'own'}` and repoints the agent). 100% branch coverage.
- "Dead" means **no `pages` row at all** — a trashed machine is alive, since trash is reversible and the scrub is not.
- New runtime shell `apps/web/src/lib/machines/machine-ref-sweep-runtime.ts`: rewrites agent configs through `applyPageMutation` (revision CAS, real actor = drive owner, activity trail), and the global config under `SELECT … FOR UPDATE` so a concurrent settings save is never clobbered.
- Wired into `trash/[pageId]` and `trash/drives/[driveId]` (scoped sweep, immediate healing) and into the `purge-trashed-pages` cron (unscoped sweep, backstop for account erasure / manual DB surgery). All best-effort — a sweep failure never blocks the delete/purge.

Deliberately unchanged: generic page trash / bulk delete / folder cascade-trash — a trash is reversible, so refs there are not yet dangling.

Flagged, not fixed here: `validateMachines` still 400s a PATCH that merely touches a config holding a ref to a *trashed* (not yet purged) machine — worth a separate issue.

## Follow-up fixes (post-review)

- Fixed a Postgres AND-short-circuit-ordering bug in the scoped jsonb filter flagged by automated review: `jsonb_array_elements` could hit a non-array blob before the `jsonb_typeof` guard ran, since Postgres doesn't guarantee left-to-right `AND` evaluation. The guard is now baked into `jsonb_array_elements`'s own argument via `CASE`.
- Proactive quality pass: deduped the sweep's two copy-paste write loops into a shared helper, and made independent writes/snapshot queries run concurrently instead of sequentially. No behavior change — 100% branch coverage holds, all tests pass unmodified.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run test:unit -- machine-ref-sweep` — pure core + runtime, all green
- [x] `bun run test:unit -- purge-trashed-pages trash` — route tests, all green
- [x] All CI checks green (Lint & TypeScript, Unit Tests, Security Test Suite, CodeQL, Dependency Audit, Secret Scanning)
- [x] Branch rebased onto current `master`, no merge conflicts

Closes #2156

https://claude.ai/code/session_01YAEGrS3LYoNPsbGfxpthpC
