### PR TITLE
fix(cli): sync CLI_VERSION constant and bun.lock to the 1.7.0 bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -440,7 +440,7 @@
     },
     "packages/cli": {
       "name": "@pagespace/cli",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "bin": {
         "pagespace": "./dist/bin.js",
         "pagespace-mcp": "./dist/bin-pagespace-mcp.js",

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -7,7 +7,7 @@ import type { CommandHandler } from '../router/router.js';
  * guarded by `commands/__tests__/version.test.ts`, which reads package.json
  * directly, so bumping one without the other fails the suite.
  */
-export const CLI_VERSION = '1.6.1';
+export const CLI_VERSION = '1.7.0';
 
 export const versionHandler: CommandHandler = async (ctx, intent) => {
   if (intent.flags.json) {


### PR DESCRIPTION
## Summary

master's `37ebc1c9a` (chore: bump @pagespace/cli to 1.7.0) bumped `packages/cli/package.json`'s `version` field but left two things behind in sync with the old 1.6.1:

- `CLI_VERSION` (packages/cli/src/commands/version.ts) — the string constant `version.test.ts`'s drift guard checks against `package.json`. Bumping one side without the other fails that test by design.
- `bun.lock`'s recorded version for `packages/cli`.

This currently breaks `ci / Unit Tests` **on master itself** (confirmed via the commit's own check-runs: `ci / Unit Tests` = failure), which in turn breaks CI for every PR based on or rebased onto master since that commit — discovered while converging PR #2220.

One-line constant fix + lockfile re-sync via `bun install`. No functional change.

## Test plan

- [x] `bunx vitest run` in `packages/cli` — 1115/1115 passing (was 1 failing: `CLI_VERSION > strictly equals package.json "version"`)
- [x] `bunx vitest run` in `packages/sdk` — 763/763 passing (unaffected, confirming no cross-package regression)

https://claude.ai/code/session_01TELaLTrkWRAqdV35n6vPbF