### PR TITLE
processor: stuck-page reconciler cron for pages.processingStatus vs pg-boss drift

### DIFF
--- a/apps/processor/src/types/index.ts
+++ b/apps/processor/src/types/index.ts
@@ -73,6 +73,12 @@ export interface VideoProcessJobData {
 export interface PullVerifyJobData {
   pageId: string;
   contentHash: string;
+  /**
+   * Set only by the stuck-page reconciler (#2159): 1-based count of automatic
+   * re-enqueues for this page. The next reconciler run reads the max tag back
+   * out of pgboss.job/archive to know when attempts are exhausted.
+   */
+  reconcileAttempt?: number;
 }
 
 export interface VideoProcessResult {
@@ -114,6 +120,7 @@ export type JobDataMap = {
   'account-erasure': AccountErasureJobData;
   'audit-chainer': Record<string, never>;
   'email-broadcast': EmailBroadcastJobData;
+  'stuck-page-reconciler': Record<string, never>;
 };
 
 export type QueueName = keyof JobDataMap;

--- a/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
@@ -123,7 +123,7 @@ describe('QueueManager', () => {
       await qm.initialize();
 
       expect(mockBossStart).toHaveBeenCalledTimes(1);
-      expect(mockBossWork).toHaveBeenCalledTimes(10);
+      expect(mockBossWork).toHaveBeenCalledTimes(11);
       expect(mockBossWork.mock.calls[0][0]).toBe('ingest-file');
       expect(mockBossWork.mock.calls[1][0]).toBe('image-optimize');
       expect(mockBossWork.mock.calls[2][0]).toBe('text-extract');
@@ -134,7 +134,8 @@ describe('QueueManager', () => {
       expect(mockBossWork.mock.calls[7][0]).toBe('account-erasure');
       expect(mockBossWork.mock.calls[8][0]).toBe('audit-chainer');
       expect(mockBossWork.mock.calls[9][0]).toBe('email-broadcast');
-      expect(mockBossCreateQueue).toHaveBeenCalledTimes(10);
+      expect(mockBossWork.mock.calls[10][0]).toBe('stuck-page-reconciler');
+      expect(mockBossCreateQueue).toHaveBeenCalledTimes(11);
       expect(mockBossCreateQueue).toHaveBeenCalledWith('ingest-file');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('pull-verify');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('image-optimize');
@@ -145,11 +146,15 @@ describe('QueueManager', () => {
       expect(mockBossCreateQueue).toHaveBeenCalledWith('account-erasure');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('audit-chainer');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('email-broadcast');
+      expect(mockBossCreateQueue).toHaveBeenCalledWith('stuck-page-reconciler');
       expect(mockBossSchedule).toHaveBeenCalledWith('siem-delivery', '*/30 * * * * *', {}, { retryLimit: 0 });
       // Same cadence + no-stack pattern as siem-delivery: retryLimit 0 so
       // overlapping scheduled runs never pile up; the advisory lock inside
       // the worker serializes any overlap that still happens.
       expect(mockBossSchedule).toHaveBeenCalledWith('audit-chainer', '*/30 * * * * *', {}, { retryLimit: 0 });
+      // Same no-stack pattern for the stuck-page reconciler (#2159); its own
+      // advisory lock serializes any overlap that still happens.
+      expect(mockBossSchedule).toHaveBeenCalledWith('stuck-page-reconciler', '*/5 * * * *', {}, { retryLimit: 0 });
     }, 30000);
 
     it('handles queue creation errors gracefully', async () => {

--- a/apps/processor/src/workers/__tests__/stuck-page-reconciler-core.test.ts
+++ b/apps/processor/src/workers/__tests__/stuck-page-reconciler-core.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure-core tests for the stuck-page reconciler (#2159).
+ *
+ * classifyStalePage is the decision function: given the evidence gathered
+ * about one stuck page (status, age, live-job existence, prior reconcile
+ * attempts, content-hash validity) and the policy (staleness threshold, max
+ * attempts), it decides skip / re-enqueue / fail. All branches covered here.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifyStalePage,
+  resolveReconcilerPolicy,
+  DEFAULT_STALE_THRESHOLD_MS,
+  DEFAULT_MAX_RECONCILE_ATTEMPTS,
+  DEFAULT_BATCH_LIMIT,
+  type StalePageEvidence,
+  type ReconcilerPolicy,
+} from '../stuck-page-reconciler-core';
+
+const POLICY: ReconcilerPolicy = {
+  staleThresholdMs: 15 * 60 * 1000,
+  maxReconcileAttempts: 3,
+  batchLimit: 50,
+};
+
+function evidence(overrides: Partial<StalePageEvidence> = {}): StalePageEvidence {
+  return {
+    pageId: 'page_1',
+    processingStatus: 'pending',
+    statusAgeMs: 60 * 60 * 1000, // 1h — stale under POLICY
+    hasLiveJob: false,
+    priorReconcileAttempts: 0,
+    hasValidContentHash: true,
+    ...overrides,
+  };
+}
+
+describe('classifyStalePage', () => {
+  it('skips when a live pg-boss job exists for the page', () => {
+    expect(classifyStalePage(evidence({ hasLiveJob: true }), POLICY)).toEqual({
+      action: 'skip',
+      reason: 'live-job',
+    });
+  });
+
+  it('live-job wins even when the page is also out of attempts', () => {
+    expect(
+      classifyStalePage(evidence({ hasLiveJob: true, priorReconcileAttempts: 99 }), POLICY),
+    ).toEqual({ action: 'skip', reason: 'live-job' });
+  });
+
+  it('skips when the page is younger than the staleness threshold', () => {
+    expect(
+      classifyStalePage(evidence({ statusAgeMs: POLICY.staleThresholdMs - 1 }), POLICY),
+    ).toEqual({ action: 'skip', reason: 'not-stale' });
+  });
+
+  it('treats exactly-at-threshold age as stale', () => {
+    const decision = classifyStalePage(evidence({ statusAgeMs: POLICY.staleThresholdMs }), POLICY);
+    expect(decision.action).toBe('reenqueue');
+  });
+
+  it('re-enqueues a stale pending page with no live job, tagging attempt 1', () => {
+    expect(classifyStalePage(evidence(), POLICY)).toEqual({ action: 'reenqueue', attempt: 1 });
+  });
+
+  it('re-enqueues a stale processing page (crashed worker, expired job)', () => {
+    expect(classifyStalePage(evidence({ processingStatus: 'processing' }), POLICY)).toEqual({
+      action: 'reenqueue',
+      attempt: 1,
+    });
+  });
+
+  it('increments the attempt tag past prior reconcile attempts', () => {
+    expect(classifyStalePage(evidence({ priorReconcileAttempts: 2 }), POLICY)).toEqual({
+      action: 'reenqueue',
+      attempt: 3,
+    });
+  });
+
+  it('fails the page once reconcile attempts are exhausted', () => {
+    const decision = classifyStalePage(evidence({ priorReconcileAttempts: 3 }), POLICY);
+    expect(decision.action).toBe('fail');
+    if (decision.action !== 'fail') throw new Error('unreachable');
+    expect(decision.reason).toBe('attempts-exhausted');
+    expect(decision.message).toContain('3');
+  });
+
+  it('fails immediately when maxReconcileAttempts is 0', () => {
+    const decision = classifyStalePage(evidence(), { ...POLICY, maxReconcileAttempts: 0 });
+    expect(decision.action).toBe('fail');
+    if (decision.action !== 'fail') throw new Error('unreachable');
+    expect(decision.reason).toBe('attempts-exhausted');
+  });
+
+  it('fails a stale page whose content hash is missing or invalid — it can never be re-enqueued', () => {
+    const decision = classifyStalePage(evidence({ hasValidContentHash: false }), POLICY);
+    expect(decision.action).toBe('fail');
+    if (decision.action !== 'fail') throw new Error('unreachable');
+    expect(decision.reason).toBe('missing-content-hash');
+    expect(decision.message.length).toBeGreaterThan(0);
+  });
+
+  it('missing-content-hash is checked before attempt exhaustion (message says why it can never work)', () => {
+    const decision = classifyStalePage(
+      evidence({ hasValidContentHash: false, priorReconcileAttempts: 99 }),
+      POLICY,
+    );
+    expect(decision).toMatchObject({ action: 'fail', reason: 'missing-content-hash' });
+  });
+});
+
+describe('resolveReconcilerPolicy', () => {
+  it('returns documented defaults for an empty env', () => {
+    expect(resolveReconcilerPolicy({})).toEqual({
+      staleThresholdMs: DEFAULT_STALE_THRESHOLD_MS,
+      maxReconcileAttempts: DEFAULT_MAX_RECONCILE_ATTEMPTS,
+      batchLimit: DEFAULT_BATCH_LIMIT,
+    });
+  });
+
+  it('reads RECONCILER_STALE_MINUTES / RECONCILER_MAX_ATTEMPTS / RECONCILER_BATCH_LIMIT', () => {
+    expect(
+      resolveReconcilerPolicy({
+        RECONCILER_STALE_MINUTES: '30',
+        RECONCILER_MAX_ATTEMPTS: '5',
+        RECONCILER_BATCH_LIMIT: '10',
+      }),
+    ).toEqual({ staleThresholdMs: 30 * 60 * 1000, maxReconcileAttempts: 5, batchLimit: 10 });
+  });
+
+  it('falls back to defaults for non-numeric values', () => {
+    expect(
+      resolveReconcilerPolicy({
+        RECONCILER_STALE_MINUTES: 'soon',
+        RECONCILER_MAX_ATTEMPTS: 'lots',
+        RECONCILER_BATCH_LIMIT: 'many',
+      }),
+    ).toEqual({
+      staleThresholdMs: DEFAULT_STALE_THRESHOLD_MS,
+      maxReconcileAttempts: DEFAULT_MAX_RECONCILE_ATTEMPTS,
+      batchLimit: DEFAULT_BATCH_LIMIT,
+    });
+  });
+
+  it('falls back to defaults for zero/negative values (a zero batch would scan nothing forever)', () => {
+    expect(
+      resolveReconcilerPolicy({
+        RECONCILER_STALE_MINUTES: '0',
+        RECONCILER_MAX_ATTEMPTS: '-1',
+        RECONCILER_BATCH_LIMIT: '0',
+      }),
+    ).toEqual({
+      staleThresholdMs: DEFAULT_STALE_THRESHOLD_MS,
+      maxReconcileAttempts: DEFAULT_MAX_RECONCILE_ATTEMPTS,
+      batchLimit: DEFAULT_BATCH_LIMIT,
+    });
+  });
+});

--- a/apps/processor/src/workers/__tests__/stuck-page-reconciler-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/stuck-page-reconciler-worker.test.ts
@@ -3,9 +3,10 @@
  *
  * The worker is the imperative shell around classifyStalePage: advisory-lock
  * the run, query pages stuck in 'pending'/'processing' with no live pg-boss
- * job, then act on each decision (re-enqueue pull-verify / mark failed) and
- * alert when pages had to be failed. All I/O is injected, so these tests use
- * fakes — no vi.mock of db modules needed.
+ * job (excluded inside the query itself, before LIMIT — see the "live-job
+ * exclusion" test), then act on each decision (re-enqueue pull-verify / a
+ * conditional mark-failed UPDATE) and alert on failures. All I/O is
+ * injected, so these tests use fakes — no vi.mock of db modules needed.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -15,8 +16,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
 }));
 
+const { mockSentryCaptureMessage } = vi.hoisted(() => ({ mockSentryCaptureMessage: vi.fn() }));
+vi.mock('@sentry/node', () => ({
+  captureMessage: mockSentryCaptureMessage,
+}));
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   runStuckPageReconciler,
+  defaultReconcilerAlert,
   type StuckPageReconcilerDeps,
 } from '../stuck-page-reconciler-worker';
 
@@ -34,17 +42,23 @@ interface FakeDb {
 function makeFakeDb(data: {
   locked?: boolean;
   candidates?: Record<string, unknown>[];
-  livePageIds?: string[];
   attempts?: Record<string, number>;
+  /** pageId -> rowCount the mark-failed UPDATE reports (default 1 = succeeded). */
+  failUpdateRowCounts?: Record<string, number>;
 }): FakeDb {
   const queries: string[] = [];
-  const query = vi.fn(async (text: string): Promise<QueryResult> => {
+  const query = vi.fn(async (text: string, values?: unknown[]): Promise<QueryResult> => {
     queries.push(text);
     if (text.includes('pg_try_advisory_lock')) {
       return { rows: [{ locked: data.locked ?? true }], rowCount: 1 };
     }
     if (text.includes('pg_advisory_unlock')) {
       return { rows: [], rowCount: null };
+    }
+    if (text.includes('UPDATE pages')) {
+      const pageId = String(values?.[1]);
+      const rowCount = data.failUpdateRowCounts?.[pageId] ?? 1;
+      return { rows: [], rowCount };
     }
     if (text.includes('FROM pages')) {
       return { rows: data.candidates ?? [], rowCount: (data.candidates ?? []).length };
@@ -54,10 +68,6 @@ function makeFakeDb(data: {
         pageId,
         attempts,
       }));
-      return { rows, rowCount: rows.length };
-    }
-    if (text.includes('pgboss.job')) {
-      const rows = (data.livePageIds ?? []).map((pageId) => ({ pageId }));
       return { rows, rowCount: rows.length };
     }
     throw new Error(`Unexpected query: ${text}`);
@@ -79,7 +89,6 @@ function makeDeps(db: FakeDb, overrides: Partial<StuckPageReconcilerDeps> = {}):
   return {
     connect: vi.fn(async () => db.client),
     enqueuePullVerify: vi.fn(async () => 'job_1'),
-    markPageFailed: vi.fn(async () => {}),
     alert: vi.fn(),
     policy: { staleThresholdMs: 15 * 60 * 1000, maxReconcileAttempts: 3, batchLimit: 50 },
     ...overrides,
@@ -104,6 +113,22 @@ describe('runStuckPageReconciler', () => {
     expect(db.client.release).toHaveBeenCalledTimes(1);
   });
 
+  it('excludes pages with a live owning job inside the candidate query, before LIMIT', async () => {
+    const db = makeFakeDb({ candidates: [candidate()] });
+    const deps = makeDeps(db);
+
+    await runStuckPageReconciler(deps);
+
+    const candidatesQuery = db.queries.find((q) => q.includes('FROM pages'));
+    expect(candidatesQuery).toContain('NOT EXISTS');
+    expect(candidatesQuery).toContain('pgboss.job');
+    expect(candidatesQuery).toContain('state IN (\'created\', \'retry\', \'active\')');
+    // The live-job exclusion must be inside the same query as the LIMIT — a
+    // separate post-filter would let a persistent front batch of live-job
+    // pages crowd out genuinely orphaned pages ordered behind them.
+    expect(candidatesQuery!.indexOf('NOT EXISTS')).toBeLessThan(candidatesQuery!.indexOf('LIMIT'));
+  });
+
   it('re-enqueues a stale pending page with no live job, tagged with attempt 1', async () => {
     const db = makeFakeDb({ candidates: [candidate()] });
     const deps = makeDeps(db);
@@ -116,18 +141,7 @@ describe('runStuckPageReconciler', () => {
       reconcileAttempt: 1,
     });
     expect(summary).toMatchObject({ lockHeld: true, scanned: 1, reenqueued: 1, failed: 0 });
-    expect(deps.markPageFailed).not.toHaveBeenCalled();
     expect(deps.alert).not.toHaveBeenCalled();
-  });
-
-  it('skips pages that still have a live pg-boss job', async () => {
-    const db = makeFakeDb({ candidates: [candidate()], livePageIds: ['page_1'] });
-    const deps = makeDeps(db);
-
-    const summary = await runStuckPageReconciler(deps);
-
-    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
-    expect(summary).toMatchObject({ scanned: 1, reenqueued: 0, failed: 0, skipped: 1 });
   });
 
   it('resumes the attempt count from prior reconciler-tagged jobs', async () => {
@@ -148,10 +162,14 @@ describe('runStuckPageReconciler', () => {
     const summary = await runStuckPageReconciler(deps);
 
     expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
-    expect(deps.markPageFailed).toHaveBeenCalledTimes(1);
-    expect(deps.markPageFailed).toHaveBeenCalledWith('page_1', expect.stringContaining('3'));
-    expect(summary).toMatchObject({ failed: 1 });
+    const updateQuery = db.queries.find((q) => q.includes('UPDATE pages'));
+    expect(updateQuery).toContain('"processingStatus" IN (\'pending\', \'processing\')');
+    expect(summary).toMatchObject({ failed: 1, skipped: 0 });
     expect(deps.alert).toHaveBeenCalledTimes(1);
+    expect(deps.alert).toHaveBeenCalledWith(
+      expect.stringContaining('1 page(s) failed'),
+      expect.objectContaining({ failedPages: [{ pageId: 'page_1', reason: 'attempts-exhausted' }] }),
+    );
   });
 
   it('marks a page with an invalid content hash failed instead of re-enqueueing', async () => {
@@ -161,9 +179,42 @@ describe('runStuckPageReconciler', () => {
     const summary = await runStuckPageReconciler(deps);
 
     expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
-    expect(deps.markPageFailed).toHaveBeenCalledWith('page_1', expect.any(String));
     expect(summary).toMatchObject({ failed: 1 });
     expect(deps.alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a page with a null content hash failed (not silently excluded from the scan)', async () => {
+    const db = makeFakeDb({ candidates: [candidate({ contentHash: null })] });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ failed: 1 });
+  });
+
+  it('does not filter out null-contentHash pages from the SQL candidate scan', async () => {
+    const db = makeFakeDb({ candidates: [] });
+    const deps = makeDeps(db);
+
+    await runStuckPageReconciler(deps);
+
+    const candidatesQuery = db.queries.find((q) => q.includes('FROM pages'));
+    expect(candidatesQuery).not.toContain('"filePath" IS NOT NULL');
+  });
+
+  it('treats a zero-row mark-failed update as skipped, not failed — the page resolved itself', async () => {
+    const db = makeFakeDb({
+      candidates: [candidate()],
+      attempts: { page_1: 3 },
+      failUpdateRowCounts: { page_1: 0 },
+    });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(summary).toMatchObject({ failed: 0, skipped: 1 });
+    expect(deps.alert).not.toHaveBeenCalled();
   });
 
   it('handles a mixed batch independently — one enqueue failure does not stop the rest', async () => {
@@ -181,6 +232,39 @@ describe('runStuckPageReconciler', () => {
 
     expect(deps.enqueuePullVerify).toHaveBeenCalledTimes(3);
     expect(summary).toMatchObject({ scanned: 3, reenqueued: 2, enqueueErrors: 1 });
+    expect(deps.alert).toHaveBeenCalledWith(
+      expect.stringContaining('1 re-enqueue error(s)'),
+      expect.anything(),
+    );
+  });
+
+  it('isolates a mark-failed update failure — the batch continues and it is counted separately', async () => {
+    const db = makeFakeDb({
+      candidates: [candidate(), candidate({ id: 'page_2' })],
+      attempts: { page_1: 3, page_2: 3 },
+    });
+    let calls = 0;
+    db.client.query.mockImplementation(async (text: string, values?: unknown[]) => {
+      db.queries.push(text);
+      if (text.includes('pg_try_advisory_lock')) return { rows: [{ locked: true }], rowCount: 1 };
+      if (text.includes('pg_advisory_unlock')) return { rows: [], rowCount: null };
+      if (text.includes('UPDATE pages')) {
+        calls += 1;
+        if (calls === 1) throw new Error('connection blip');
+        return { rows: [], rowCount: 1 };
+      }
+      if (text.includes('FROM pages')) return { rows: [candidate(), candidate({ id: 'page_2' })], rowCount: 2 };
+      if (text.includes('reconcileAttempt')) {
+        return { rows: [{ pageId: 'page_1', attempts: 3 }, { pageId: 'page_2', attempts: 3 }], rowCount: 2 };
+      }
+      throw new Error(`Unexpected query: ${text} ${JSON.stringify(values)}`);
+    });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(summary).toMatchObject({ failed: 1, failUpdateErrors: 1 });
+    expect(deps.alert).toHaveBeenCalledTimes(2); // one failedPages alert, one error-threshold alert
   });
 
   it('releases the advisory lock and the client even when the page scan throws', async () => {
@@ -201,13 +285,100 @@ describe('runStuckPageReconciler', () => {
     expect(db.client.release).toHaveBeenCalledTimes(1);
   });
 
-  it('returns an empty summary without querying job state when nothing is stuck', async () => {
+  it('returns an empty summary without querying job attempts when nothing is stuck', async () => {
     const db = makeFakeDb({ candidates: [] });
     const deps = makeDeps(db);
 
     const summary = await runStuckPageReconciler(deps);
 
     expect(summary).toMatchObject({ lockHeld: true, scanned: 0, reenqueued: 0, failed: 0 });
-    expect(db.queries.some((q) => q.includes('pgboss.job'))).toBe(false);
+    expect(db.queries.some((q) => q.includes('reconcileAttempt'))).toBe(false);
+  });
+
+  it('skips a page whose recomputed age falls under the threshold (defensive; SQL should already exclude it)', async () => {
+    const db = makeFakeDb({ candidates: [candidate({ ageMs: '1000' })] });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ scanned: 1, skipped: 1, reenqueued: 0, failed: 0 });
+  });
+
+  it('warns when the batch hits the configured batchLimit — more stuck pages remain', async () => {
+    const db = makeFakeDb({ candidates: [candidate()] });
+    const deps = makeDeps(db, {
+      policy: { staleThresholdMs: 15 * 60 * 1000, maxReconcileAttempts: 3, batchLimit: 1 },
+    });
+
+    await runStuckPageReconciler(deps);
+
+    expect(loggers.processor.warn).toHaveBeenCalledWith(expect.stringContaining('batch limit 1 hit'));
+  });
+
+  it('resolves the default policy from the environment when deps.policy is omitted', async () => {
+    const originalEnv = { ...process.env };
+    delete process.env.RECONCILER_STALE_MINUTES;
+    delete process.env.RECONCILER_MAX_ATTEMPTS;
+    delete process.env.RECONCILER_BATCH_LIMIT;
+    try {
+      // 20 minutes old clears the documented 15-minute default threshold.
+      const db = makeFakeDb({ candidates: [candidate({ ageMs: String(20 * 60 * 1000) })] });
+      const deps = makeDeps(db, { policy: undefined });
+
+      const summary = await runStuckPageReconciler(deps);
+
+      expect(deps.enqueuePullVerify).toHaveBeenCalledWith(
+        expect.objectContaining({ reconcileAttempt: 1 }),
+      );
+      expect(summary).toMatchObject({ reenqueued: 1 });
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  it('handles a non-Error rejection from enqueuePullVerify', async () => {
+    const db = makeFakeDb({ candidates: [candidate()] });
+    const deps = makeDeps(db, { enqueuePullVerify: vi.fn().mockRejectedValue('boom') });
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(summary).toMatchObject({ enqueueErrors: 1 });
+    expect(loggers.processor.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('handles a non-Error rejection from the mark-failed UPDATE', async () => {
+    const db = makeFakeDb({ candidates: [candidate()], attempts: { page_1: 3 } });
+    db.client.query.mockImplementation(async (text: string) => {
+      db.queries.push(text);
+      if (text.includes('pg_try_advisory_lock')) return { rows: [{ locked: true }], rowCount: 1 };
+      if (text.includes('pg_advisory_unlock')) return { rows: [], rowCount: null };
+      if (text.includes('UPDATE pages')) throw 'db offline';
+      if (text.includes('FROM pages')) return { rows: [candidate()], rowCount: 1 };
+      if (text.includes('reconcileAttempt')) {
+        return { rows: [{ pageId: 'page_1', attempts: 3 }], rowCount: 1 };
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(summary).toMatchObject({ failUpdateErrors: 1, failed: 0 });
+    expect(loggers.processor.warn).toHaveBeenCalledWith(expect.stringContaining('db offline'));
+  });
+});
+
+describe('defaultReconcilerAlert', () => {
+  it('logs an error and captures a Sentry message with the given context', () => {
+    defaultReconcilerAlert('something is wrong', { pageIds: ['page_1'] });
+
+    expect(loggers.processor.error).toHaveBeenCalledWith('something is wrong', {
+      pageIds: ['page_1'],
+    });
+    expect(mockSentryCaptureMessage).toHaveBeenCalledWith('something is wrong', {
+      level: 'error',
+      extra: { pageIds: ['page_1'] },
+    });
   });
 });

--- a/apps/processor/src/workers/__tests__/stuck-page-reconciler-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/stuck-page-reconciler-worker.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Shell tests for the stuck-page reconciler worker (#2159).
+ *
+ * The worker is the imperative shell around classifyStalePage: advisory-lock
+ * the run, query pages stuck in 'pending'/'processing' with no live pg-boss
+ * job, then act on each decision (re-enqueue pull-verify / mark failed) and
+ * alert when pages had to be failed. All I/O is injected, so these tests use
+ * fakes — no vi.mock of db modules needed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    processor: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+import {
+  runStuckPageReconciler,
+  type StuckPageReconcilerDeps,
+} from '../stuck-page-reconciler-worker';
+
+interface QueryResult {
+  rows: Record<string, unknown>[];
+  rowCount: number | null;
+}
+
+interface FakeDb {
+  client: { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> };
+  queries: string[];
+}
+
+/** Routes queries by recognizable SQL fragments; order-independent. */
+function makeFakeDb(data: {
+  locked?: boolean;
+  candidates?: Record<string, unknown>[];
+  livePageIds?: string[];
+  attempts?: Record<string, number>;
+}): FakeDb {
+  const queries: string[] = [];
+  const query = vi.fn(async (text: string): Promise<QueryResult> => {
+    queries.push(text);
+    if (text.includes('pg_try_advisory_lock')) {
+      return { rows: [{ locked: data.locked ?? true }], rowCount: 1 };
+    }
+    if (text.includes('pg_advisory_unlock')) {
+      return { rows: [], rowCount: null };
+    }
+    if (text.includes('FROM pages')) {
+      return { rows: data.candidates ?? [], rowCount: (data.candidates ?? []).length };
+    }
+    if (text.includes('reconcileAttempt')) {
+      const rows = Object.entries(data.attempts ?? {}).map(([pageId, attempts]) => ({
+        pageId,
+        attempts,
+      }));
+      return { rows, rowCount: rows.length };
+    }
+    if (text.includes('pgboss.job')) {
+      const rows = (data.livePageIds ?? []).map((pageId) => ({ pageId }));
+      return { rows, rowCount: rows.length };
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  });
+  return { client: { query, release: vi.fn() }, queries };
+}
+
+function candidate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'page_1',
+    processingStatus: 'pending',
+    contentHash: 'a'.repeat(64),
+    ageMs: String(60 * 60 * 1000),
+    ...overrides,
+  };
+}
+
+function makeDeps(db: FakeDb, overrides: Partial<StuckPageReconcilerDeps> = {}): StuckPageReconcilerDeps {
+  return {
+    connect: vi.fn(async () => db.client),
+    enqueuePullVerify: vi.fn(async () => 'job_1'),
+    markPageFailed: vi.fn(async () => {}),
+    alert: vi.fn(),
+    policy: { staleThresholdMs: 15 * 60 * 1000, maxReconcileAttempts: 3, batchLimit: 50 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runStuckPageReconciler', () => {
+  it('no-ops (and reports lockHeld=false) when another run holds the advisory lock', async () => {
+    const db = makeFakeDb({ locked: false });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(summary.lockHeld).toBe(false);
+    expect(summary.scanned).toBe(0);
+    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
+    expect(db.queries.some((q) => q.includes('FROM pages'))).toBe(false);
+    expect(db.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-enqueues a stale pending page with no live job, tagged with attempt 1', async () => {
+    const db = makeFakeDb({ candidates: [candidate()] });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).toHaveBeenCalledWith({
+      pageId: 'page_1',
+      contentHash: 'a'.repeat(64),
+      reconcileAttempt: 1,
+    });
+    expect(summary).toMatchObject({ lockHeld: true, scanned: 1, reenqueued: 1, failed: 0 });
+    expect(deps.markPageFailed).not.toHaveBeenCalled();
+    expect(deps.alert).not.toHaveBeenCalled();
+  });
+
+  it('skips pages that still have a live pg-boss job', async () => {
+    const db = makeFakeDb({ candidates: [candidate()], livePageIds: ['page_1'] });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ scanned: 1, reenqueued: 0, failed: 0, skipped: 1 });
+  });
+
+  it('resumes the attempt count from prior reconciler-tagged jobs', async () => {
+    const db = makeFakeDb({ candidates: [candidate()], attempts: { page_1: 2 } });
+    const deps = makeDeps(db);
+
+    await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).toHaveBeenCalledWith(
+      expect.objectContaining({ reconcileAttempt: 3 }),
+    );
+  });
+
+  it('marks a page failed and alerts once reconcile attempts are exhausted', async () => {
+    const db = makeFakeDb({ candidates: [candidate()], attempts: { page_1: 3 } });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
+    expect(deps.markPageFailed).toHaveBeenCalledTimes(1);
+    expect(deps.markPageFailed).toHaveBeenCalledWith('page_1', expect.stringContaining('3'));
+    expect(summary).toMatchObject({ failed: 1 });
+    expect(deps.alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a page with an invalid content hash failed instead of re-enqueueing', async () => {
+    const db = makeFakeDb({ candidates: [candidate({ contentHash: 'not-a-hash' })] });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).not.toHaveBeenCalled();
+    expect(deps.markPageFailed).toHaveBeenCalledWith('page_1', expect.any(String));
+    expect(summary).toMatchObject({ failed: 1 });
+    expect(deps.alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles a mixed batch independently — one enqueue failure does not stop the rest', async () => {
+    const db = makeFakeDb({
+      candidates: [candidate(), candidate({ id: 'page_2' }), candidate({ id: 'page_3' })],
+    });
+    const deps = makeDeps(db, {
+      enqueuePullVerify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('duplicate or rejected'))
+        .mockResolvedValue('job_x'),
+    });
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(deps.enqueuePullVerify).toHaveBeenCalledTimes(3);
+    expect(summary).toMatchObject({ scanned: 3, reenqueued: 2, enqueueErrors: 1 });
+  });
+
+  it('releases the advisory lock and the client even when the page scan throws', async () => {
+    const db = makeFakeDb({});
+    db.client.query.mockImplementation(async (text: string) => {
+      if (text.includes('pg_try_advisory_lock')) return { rows: [{ locked: true }], rowCount: 1 };
+      if (text.includes('pg_advisory_unlock')) return { rows: [], rowCount: null };
+      throw new Error('db exploded');
+    });
+    const deps = makeDeps(db);
+
+    await expect(runStuckPageReconciler(deps)).rejects.toThrow('db exploded');
+
+    const ranUnlock = db.client.query.mock.calls.some(([q]) =>
+      String(q).includes('pg_advisory_unlock'),
+    );
+    expect(ranUnlock).toBe(true);
+    expect(db.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty summary without querying job state when nothing is stuck', async () => {
+    const db = makeFakeDb({ candidates: [] });
+    const deps = makeDeps(db);
+
+    const summary = await runStuckPageReconciler(deps);
+
+    expect(summary).toMatchObject({ lockHeld: true, scanned: 0, reenqueued: 0, failed: 0 });
+    expect(db.queries.some((q) => q.includes('pgboss.job'))).toBe(false);
+  });
+});

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -90,6 +90,7 @@ export class QueueManager {
       await this.boss.createQueue('account-erasure');
       await this.boss.createQueue('audit-chainer');
       await this.boss.createQueue('email-broadcast');
+      await this.boss.createQueue('stuck-page-reconciler');
       console.log('PgBoss queues created/verified');
     } catch (err) {
       console.warn('Queue creation warning:', err instanceof Error ? err.message : err);
@@ -284,6 +285,34 @@ export class QueueManager {
         return { success: true };
       }
     );
+
+    // Stuck-page reconciler (#2159) — closes the pages.processingStatus vs
+    // pg-boss gap: pages stuck 'pending'/'processing' past the staleness
+    // threshold with no live job get re-enqueued through pull-verify (tagged
+    // with reconcileAttempt) or, once attempts are exhausted, marked 'failed'
+    // with an alert. Poll-based like siem-delivery (ignores job data);
+    // retryLimit 0 + run-level advisory lock keep overlapping runs from
+    // double-enqueueing.
+    const { runStuckPageReconciler, defaultReconcilerAlert } = await import('./stuck-page-reconciler-worker');
+    const { getPoolForWorker, setPageFailed: markPageFailed } = await import('../db');
+    await this.boss.work('stuck-page-reconciler',
+      async () => {
+        await runStuckPageReconciler({
+          connect: () => getPoolForWorker().connect(),
+          // singletonKey collapses racing re-enqueues for the same page into
+          // one queued job; a duplicate rejection surfaces as an enqueue
+          // error the worker logs and skips.
+          enqueuePullVerify: (data) =>
+            this.addJob('pull-verify', data, { singletonKey: `reconcile:${data.pageId}` }),
+          markPageFailed,
+          alert: defaultReconcilerAlert,
+        });
+      }
+    );
+
+    // Every 5 minutes — minutes-scale detection is plenty for a gap that
+    // previously went unnoticed for weeks, and each run is a few indexed reads.
+    await this.boss.schedule('stuck-page-reconciler', '*/5 * * * *', {}, { retryLimit: 0 });
   }
 
   async addJob<Q extends QueueName>(
@@ -364,7 +393,7 @@ export class QueueManager {
   }
 
   getQueueStatus(): Record<QueueName, QueueStats> {
-    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery', 'account-erasure', 'audit-chainer', 'email-broadcast'];
+    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery', 'account-erasure', 'audit-chainer', 'email-broadcast', 'stuck-page-reconciler'];
     const perQueue = this.cachedStates?.queues ?? {};
 
     const status = {} as Record<QueueName, QueueStats>;

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -294,7 +294,7 @@ export class QueueManager {
     // retryLimit 0 + run-level advisory lock keep overlapping runs from
     // double-enqueueing.
     const { runStuckPageReconciler, defaultReconcilerAlert } = await import('./stuck-page-reconciler-worker');
-    const { getPoolForWorker, setPageFailed: markPageFailed } = await import('../db');
+    const { getPoolForWorker } = await import('../db');
     await this.boss.work('stuck-page-reconciler',
       async () => {
         await runStuckPageReconciler({
@@ -304,7 +304,6 @@ export class QueueManager {
           // error the worker logs and skips.
           enqueuePullVerify: (data) =>
             this.addJob('pull-verify', data, { singletonKey: `reconcile:${data.pageId}` }),
-          markPageFailed,
           alert: defaultReconcilerAlert,
         });
       }

--- a/apps/processor/src/workers/stuck-page-reconciler-core.ts
+++ b/apps/processor/src/workers/stuck-page-reconciler-core.ts
@@ -1,0 +1,101 @@
+/**
+ * Stuck-page reconciler — pure core (#2159).
+ *
+ * pages.processingStatus and pg-boss job state have no invariant tying them
+ * together: the post-upload enqueue is fire-and-forget, so a dropped enqueue
+ * leaves a page claiming 'pending' forever with no job behind it (proven in
+ * production between the direct-to-S3 cutover and the UPLOAD_SCOPES fix,
+ * repaired by hand with scripts/reenqueue-unprocessed-uploads.ts). This core
+ * is the decision half of the reconciler that makes that repair automatic:
+ * given the evidence gathered about one stuck page, decide whether to leave
+ * it alone, re-enqueue the verified pull pipeline, or mark it 'failed' so the
+ * gap is visible and retryable via the reprocess route.
+ */
+
+export type StuckPageStatus = 'pending' | 'processing';
+
+/** Everything the shell learned about one candidate page. */
+export interface StalePageEvidence {
+  pageId: string;
+  processingStatus: StuckPageStatus;
+  /** ms since the page row last moved (GREATEST(createdAt, updatedAt)). */
+  statusAgeMs: number;
+  /** A pull-verify/ingest-file job in created/retry/active references this page. */
+  hasLiveJob: boolean;
+  /** Highest reconcileAttempt tag on any pull-verify job for this page (0 = none). */
+  priorReconcileAttempts: number;
+  /** filePath present and shaped like a content hash — re-enqueue is possible. */
+  hasValidContentHash: boolean;
+}
+
+export interface ReconcilerPolicy {
+  staleThresholdMs: number;
+  maxReconcileAttempts: number;
+  batchLimit: number;
+}
+
+export type ReconcileDecision =
+  | { action: 'skip'; reason: 'live-job' | 'not-stale' }
+  | { action: 'reenqueue'; attempt: number }
+  | { action: 'fail'; reason: 'attempts-exhausted' | 'missing-content-hash'; message: string };
+
+export function classifyStalePage(
+  evidence: StalePageEvidence,
+  policy: ReconcilerPolicy,
+): ReconcileDecision {
+  // A live job means the queue still owns this page — however stale the row
+  // looks, the worker will move it when the job settles.
+  if (evidence.hasLiveJob) {
+    return { action: 'skip', reason: 'live-job' };
+  }
+
+  if (evidence.statusAgeMs < policy.staleThresholdMs) {
+    return { action: 'skip', reason: 'not-stale' };
+  }
+
+  // No hash → no bytes to pull; re-enqueueing can never succeed, so surface
+  // the page as failed instead of leaving it invisibly pending forever.
+  if (!evidence.hasValidContentHash) {
+    return {
+      action: 'fail',
+      reason: 'missing-content-hash',
+      message:
+        'File processing never completed and the page has no valid content hash to re-enqueue. Re-upload the file.',
+    };
+  }
+
+  if (evidence.priorReconcileAttempts >= policy.maxReconcileAttempts) {
+    return {
+      action: 'fail',
+      reason: 'attempts-exhausted',
+      message: `File processing did not complete after ${evidence.priorReconcileAttempts} automatic re-enqueue attempts. Use reprocess to retry.`,
+    };
+  }
+
+  return { action: 'reenqueue', attempt: evidence.priorReconcileAttempts + 1 };
+}
+
+export const DEFAULT_STALE_THRESHOLD_MS = 15 * 60 * 1000;
+export const DEFAULT_MAX_RECONCILE_ATTEMPTS = 3;
+export const DEFAULT_BATCH_LIMIT = 50;
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveReconcilerPolicy(
+  env: Record<string, string | undefined>,
+): ReconcilerPolicy {
+  return {
+    staleThresholdMs:
+      positiveInt(env.RECONCILER_STALE_MINUTES, DEFAULT_STALE_THRESHOLD_MS / (60 * 1000)) *
+      60 *
+      1000,
+    maxReconcileAttempts: positiveInt(
+      env.RECONCILER_MAX_ATTEMPTS,
+      DEFAULT_MAX_RECONCILE_ATTEMPTS,
+    ),
+    batchLimit: positiveInt(env.RECONCILER_BATCH_LIMIT, DEFAULT_BATCH_LIMIT),
+  };
+}

--- a/apps/processor/src/workers/stuck-page-reconciler-worker.ts
+++ b/apps/processor/src/workers/stuck-page-reconciler-worker.ts
@@ -1,0 +1,226 @@
+/**
+ * Stuck-page reconciler — imperative shell (#2159).
+ *
+ * Productionizes scripts/reenqueue-unprocessed-uploads.ts (the one-shot repair
+ * run after the UPLOAD_SCOPES incident left pages 'pending' with no job):
+ * scheduled by pg-boss, it finds FILE pages stuck in 'pending'/'processing'
+ * past the staleness threshold with no live pg-boss job, and per the pure
+ * core's decision either re-enqueues the verified pull pipeline (the same
+ * queue /api/ingest/pull uses — it re-hashes the stored bytes, so a duplicate
+ * enqueue is harmless) or marks the page 'failed' (visible, retryable via the
+ * reprocess route). Marked-failed pages fire an alert: that means uploads are
+ * being dropped faster than automatic re-enqueueing can absorb.
+ *
+ * Serialization follows the audit-chainer pattern: scheduled with retryLimit 0
+ * so runs never stack, plus a run-level advisory lock so any overlap that
+ * still happens no-ops instead of double-enqueueing.
+ *
+ * Attempt tracking needs no schema change: each reconciler enqueue tags its
+ * pull-verify job data with `reconcileAttempt: n`, and the next run reads the
+ * max tag back out of pgboss.job + pgboss.archive. Archive retention (7 days)
+ * comfortably outlasts the minutes-scale reconcile cadence.
+ */
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import * as Sentry from '@sentry/node';
+import { isValidContentHash } from '../cache/content-store';
+import {
+  classifyStalePage,
+  resolveReconcilerPolicy,
+  type ReconcilerPolicy,
+  type StalePageEvidence,
+  type StuckPageStatus,
+} from './stuck-page-reconciler-core';
+
+export interface ReconcilerDbClient {
+  query(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+
+export interface StuckPageReconcilerDeps {
+  connect(): Promise<ReconcilerDbClient>;
+  enqueuePullVerify(data: {
+    pageId: string;
+    contentHash: string;
+    reconcileAttempt: number;
+  }): Promise<string>;
+  markPageFailed(pageId: string, message: string): Promise<void>;
+  alert(message: string, context: Record<string, unknown>): void;
+  policy?: ReconcilerPolicy;
+}
+
+export interface ReconcilerRunSummary {
+  lockHeld: boolean;
+  scanned: number;
+  reenqueued: number;
+  failed: number;
+  skipped: number;
+  enqueueErrors: number;
+}
+
+// Same try-lock idiom as the audit chainer: hashtext keys the lock slot, so
+// this string is a wire format — renaming it would stop serializing against
+// still-running old deploys.
+const ADVISORY_LOCK_KEY = 'stuck_page_reconciler';
+
+// Only these two queues keep a page in 'pending'/'processing': every other
+// worker (image-optimize, ocr, video) runs after the page already moved to
+// 'visual'/'completed'.
+const OWNING_QUEUES = ['pull-verify', 'ingest-file'];
+
+export function defaultReconcilerAlert(
+  message: string,
+  context: Record<string, unknown>,
+): void {
+  loggers.processor.error(message, context);
+  Sentry.captureMessage(message, { level: 'error', extra: context });
+}
+
+export async function runStuckPageReconciler(
+  deps: StuckPageReconcilerDeps,
+): Promise<ReconcilerRunSummary> {
+  const policy = deps.policy ?? resolveReconcilerPolicy(process.env);
+  const summary: ReconcilerRunSummary = {
+    lockHeld: false,
+    scanned: 0,
+    reenqueued: 0,
+    failed: 0,
+    skipped: 0,
+    enqueueErrors: 0,
+  };
+
+  const client = await deps.connect();
+  try {
+    const lockResult = await client.query(
+      `SELECT pg_try_advisory_lock(hashtext($1)) AS locked`,
+      [ADVISORY_LOCK_KEY],
+    );
+    if (lockResult.rows[0]?.locked !== true) {
+      loggers.processor.info('stuck-page reconciler: another run holds the lock, skipping');
+      return summary;
+    }
+    summary.lockHeld = true;
+
+    try {
+      // 'failed' is deliberately excluded: it means the processor ran and
+      // rejected the file, and rejectAndFail deletes the object — re-enqueueing
+      // can never succeed (same reasoning as the manual repair script).
+      const candidates = await client.query(
+        `SELECT id,
+                "processingStatus",
+                "filePath" AS "contentHash",
+                EXTRACT(EPOCH FROM (NOW() - GREATEST("createdAt", "updatedAt"))) * 1000 AS "ageMs"
+           FROM pages
+          WHERE type = 'FILE'
+            AND "isTrashed" = false
+            AND "processingStatus" IN ('pending', 'processing')
+            AND "filePath" IS NOT NULL
+            AND GREATEST("createdAt", "updatedAt") < NOW() - ($1::bigint * interval '1 millisecond')
+          ORDER BY GREATEST("createdAt", "updatedAt") ASC
+          LIMIT $2`,
+        [policy.staleThresholdMs, policy.batchLimit],
+      );
+      summary.scanned = candidates.rows.length;
+      if (candidates.rows.length === 0) {
+        return summary;
+      }
+      if (candidates.rows.length === policy.batchLimit) {
+        loggers.processor.warn(
+          `stuck-page reconciler: batch limit ${policy.batchLimit} hit — more stuck pages remain for the next run`,
+        );
+      }
+
+      const pageIds = candidates.rows.map((row) => String(row.id));
+
+      const liveJobs = await client.query(
+        `SELECT DISTINCT COALESCE(data->>'pageId', data->>'fileId') AS "pageId"
+           FROM pgboss.job
+          WHERE name = ANY($1::text[])
+            AND state IN ('created', 'retry', 'active')
+            AND COALESCE(data->>'pageId', data->>'fileId') = ANY($2::text[])`,
+        [OWNING_QUEUES, pageIds],
+      );
+      const livePageIds = new Set(liveJobs.rows.map((row) => String(row.pageId)));
+
+      const attempts = await client.query(
+        `SELECT data->>'pageId' AS "pageId",
+                MAX((data->>'reconcileAttempt')::int) AS attempts
+           FROM (SELECT name, data FROM pgboss.job
+                 UNION ALL
+                 SELECT name, data FROM pgboss.archive) jobs
+          WHERE name = 'pull-verify'
+            AND data->>'reconcileAttempt' IS NOT NULL
+            AND data->>'pageId' = ANY($1::text[])
+          GROUP BY data->>'pageId'`,
+        [pageIds],
+      );
+      const priorAttempts = new Map(
+        attempts.rows.map((row) => [String(row.pageId), Number(row.attempts)]),
+      );
+
+      const failedPages: { pageId: string; reason: string }[] = [];
+
+      for (const row of candidates.rows) {
+        const pageId = String(row.id);
+        const contentHash = row.contentHash == null ? '' : String(row.contentHash);
+        const evidence: StalePageEvidence = {
+          pageId,
+          processingStatus: row.processingStatus as StuckPageStatus,
+          statusAgeMs: Number(row.ageMs),
+          hasLiveJob: livePageIds.has(pageId),
+          priorReconcileAttempts: priorAttempts.get(pageId) ?? 0,
+          hasValidContentHash: isValidContentHash(contentHash),
+        };
+
+        const decision = classifyStalePage(evidence, policy);
+        switch (decision.action) {
+          case 'skip':
+            summary.skipped += 1;
+            break;
+          case 'reenqueue':
+            try {
+              const jobId = await deps.enqueuePullVerify({
+                pageId,
+                contentHash,
+                reconcileAttempt: decision.attempt,
+              });
+              summary.reenqueued += 1;
+              loggers.processor.warn(
+                `stuck-page reconciler: re-enqueued page ${pageId} (status=${evidence.processingStatus}, attempt=${decision.attempt}, job=${jobId})`,
+              );
+            } catch (err) {
+              summary.enqueueErrors += 1;
+              loggers.processor.warn(
+                `stuck-page reconciler: re-enqueue failed for page ${pageId}: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+            break;
+          case 'fail':
+            await deps.markPageFailed(pageId, decision.message);
+            summary.failed += 1;
+            failedPages.push({ pageId, reason: decision.reason });
+            break;
+        }
+      }
+
+      if (failedPages.length > 0) {
+        deps.alert(
+          `stuck-page reconciler marked ${failedPages.length} page(s) failed — enqueues are being dropped or re-enqueues cannot succeed`,
+          { failedPages, summary: { ...summary } },
+        );
+      }
+
+      loggers.processor.info(
+        `stuck-page reconciler: scanned=${summary.scanned} reenqueued=${summary.reenqueued} failed=${summary.failed} skipped=${summary.skipped} enqueueErrors=${summary.enqueueErrors}`,
+      );
+      return summary;
+    } finally {
+      await client.query(`SELECT pg_advisory_unlock(hashtext($1))`, [ADVISORY_LOCK_KEY]);
+    }
+  } finally {
+    client.release();
+  }
+}

--- a/apps/processor/src/workers/stuck-page-reconciler-worker.ts
+++ b/apps/processor/src/workers/stuck-page-reconciler-worker.ts
@@ -19,6 +19,17 @@
  * pull-verify job data with `reconcileAttempt: n`, and the next run reads the
  * max tag back out of pgboss.job + pgboss.archive. Archive retention (7 days)
  * comfortably outlasts the minutes-scale reconcile cadence.
+ *
+ * Live-job exclusion happens INSIDE the candidate query (NOT EXISTS against
+ * pgboss.job), not as a separate post-filter: filtering after LIMIT would let
+ * a persistent front batch of live-job pages crowd out genuinely orphaned
+ * pages ordered behind them, starving them indefinitely (#2159 review).
+ *
+ * The 'fail' transition is a conditional UPDATE ... WHERE "processingStatus"
+ * IN ('pending','processing'), not an unconditional one: the owning worker
+ * can complete a page between the candidate scan and this update landing, and
+ * an unconditional write would stomp that success back to 'failed' (#2159
+ * review). A zero-row update means the page resolved itself — nothing to do.
  */
 
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -47,7 +58,6 @@ export interface StuckPageReconcilerDeps {
     contentHash: string;
     reconcileAttempt: number;
   }): Promise<string>;
-  markPageFailed(pageId: string, message: string): Promise<void>;
   alert(message: string, context: Record<string, unknown>): void;
   policy?: ReconcilerPolicy;
 }
@@ -59,6 +69,7 @@ export interface ReconcilerRunSummary {
   failed: number;
   skipped: number;
   enqueueErrors: number;
+  failUpdateErrors: number;
 }
 
 // Same try-lock idiom as the audit chainer: hashtext keys the lock slot, so
@@ -90,6 +101,7 @@ export async function runStuckPageReconciler(
     failed: 0,
     skipped: 0,
     enqueueErrors: 0,
+    failUpdateErrors: 0,
   };
 
   const client = await deps.connect();
@@ -107,21 +119,29 @@ export async function runStuckPageReconciler(
     try {
       // 'failed' is deliberately excluded: it means the processor ran and
       // rejected the file, and rejectAndFail deletes the object — re-enqueueing
-      // can never succeed (same reasoning as the manual repair script).
+      // can never succeed (same reasoning as the manual repair script). A
+      // missing/invalid "filePath" is NOT excluded here — those pages must
+      // reach classifyStalePage so its missing-content-hash branch can mark
+      // them failed instead of leaving them stuck forever.
       const candidates = await client.query(
-        `SELECT id,
-                "processingStatus",
-                "filePath" AS "contentHash",
-                EXTRACT(EPOCH FROM (NOW() - GREATEST("createdAt", "updatedAt"))) * 1000 AS "ageMs"
-           FROM pages
-          WHERE type = 'FILE'
-            AND "isTrashed" = false
-            AND "processingStatus" IN ('pending', 'processing')
-            AND "filePath" IS NOT NULL
-            AND GREATEST("createdAt", "updatedAt") < NOW() - ($1::bigint * interval '1 millisecond')
-          ORDER BY GREATEST("createdAt", "updatedAt") ASC
-          LIMIT $2`,
-        [policy.staleThresholdMs, policy.batchLimit],
+        `SELECT p.id,
+                p."processingStatus",
+                p."filePath" AS "contentHash",
+                EXTRACT(EPOCH FROM (NOW() - GREATEST(p."createdAt", p."updatedAt"))) * 1000 AS "ageMs"
+           FROM pages p
+          WHERE p.type = 'FILE'
+            AND p."isTrashed" = false
+            AND p."processingStatus" IN ('pending', 'processing')
+            AND GREATEST(p."createdAt", p."updatedAt") < NOW() - ($1::bigint * interval '1 millisecond')
+            AND NOT EXISTS (
+              SELECT 1 FROM pgboss.job j
+               WHERE j.name = ANY($2::text[])
+                 AND j.state IN ('created', 'retry', 'active')
+                 AND COALESCE(j.data->>'pageId', j.data->>'fileId') = p.id
+            )
+          ORDER BY GREATEST(p."createdAt", p."updatedAt") ASC
+          LIMIT $3`,
+        [policy.staleThresholdMs, OWNING_QUEUES, policy.batchLimit],
       );
       summary.scanned = candidates.rows.length;
       if (candidates.rows.length === 0) {
@@ -134,16 +154,6 @@ export async function runStuckPageReconciler(
       }
 
       const pageIds = candidates.rows.map((row) => String(row.id));
-
-      const liveJobs = await client.query(
-        `SELECT DISTINCT COALESCE(data->>'pageId', data->>'fileId') AS "pageId"
-           FROM pgboss.job
-          WHERE name = ANY($1::text[])
-            AND state IN ('created', 'retry', 'active')
-            AND COALESCE(data->>'pageId', data->>'fileId') = ANY($2::text[])`,
-        [OWNING_QUEUES, pageIds],
-      );
-      const livePageIds = new Set(liveJobs.rows.map((row) => String(row.pageId)));
 
       const attempts = await client.query(
         `SELECT data->>'pageId' AS "pageId",
@@ -170,7 +180,11 @@ export async function runStuckPageReconciler(
           pageId,
           processingStatus: row.processingStatus as StuckPageStatus,
           statusAgeMs: Number(row.ageMs),
-          hasLiveJob: livePageIds.has(pageId),
+          // The candidate query's NOT EXISTS already excludes pages with a
+          // live owning job — this is always false for rows reaching here.
+          // classifyStalePage still branches on it (tested in isolation) as
+          // a defensive check should evidence ever be sourced differently.
+          hasLiveJob: false,
           priorReconcileAttempts: priorAttempts.get(pageId) ?? 0,
           hasValidContentHash: isValidContentHash(contentHash),
         };
@@ -199,9 +213,28 @@ export async function runStuckPageReconciler(
             }
             break;
           case 'fail':
-            await deps.markPageFailed(pageId, decision.message);
-            summary.failed += 1;
-            failedPages.push({ pageId, reason: decision.reason });
+            try {
+              const result = await client.query(
+                `UPDATE pages
+                    SET "processingStatus" = 'failed', "processingError" = $1, "processedAt" = NOW()
+                  WHERE id = $2
+                    AND "processingStatus" IN ('pending', 'processing')`,
+                [decision.message, pageId],
+              );
+              if (result.rowCount && result.rowCount > 0) {
+                summary.failed += 1;
+                failedPages.push({ pageId, reason: decision.reason });
+              } else {
+                // The owning worker completed the page between the candidate
+                // scan and this update — nothing to overwrite.
+                summary.skipped += 1;
+              }
+            } catch (err) {
+              summary.failUpdateErrors += 1;
+              loggers.processor.warn(
+                `stuck-page reconciler: mark-failed update failed for page ${pageId}: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
             break;
         }
       }
@@ -212,9 +245,18 @@ export async function runStuckPageReconciler(
           { failedPages, summary: { ...summary } },
         );
       }
+      // Persistent re-enqueue/update failures are their own signal (DB or
+      // queue trouble), independent of whether any page was actually marked
+      // failed this run.
+      if (summary.enqueueErrors > 0 || summary.failUpdateErrors > 0) {
+        deps.alert(
+          `stuck-page reconciler hit ${summary.enqueueErrors} re-enqueue error(s) and ${summary.failUpdateErrors} mark-failed error(s) this run`,
+          { summary: { ...summary } },
+        );
+      }
 
       loggers.processor.info(
-        `stuck-page reconciler: scanned=${summary.scanned} reenqueued=${summary.reenqueued} failed=${summary.failed} skipped=${summary.skipped} enqueueErrors=${summary.enqueueErrors}`,
+        `stuck-page reconciler: scanned=${summary.scanned} reenqueued=${summary.reenqueued} failed=${summary.failed} skipped=${summary.skipped} enqueueErrors=${summary.enqueueErrors} failUpdateErrors=${summary.failUpdateErrors}`,
       );
       return summary;
     } finally {


### PR DESCRIPTION
Closes #2159

## Summary

`pages.processingStatus`/`processedAt` and pg-boss job state (`mapJobState()`) had no invariant tying them together — enqueue is fire-and-forget, so a dropped enqueue leaves a page claiming `'pending'` forever with no job behind it. This already happened in production between the direct-to-S3 cutover and the UPLOAD_SCOPES fix, and was repaired by hand with `scripts/reenqueue-unprocessed-uploads.ts`.

This adds the reconciler that script proves is needed (epic #2161 decision rule 2: reconciler-with-alerting), scoped entirely to `apps/processor`:

- A pg-boss-scheduled `stuck-page-reconciler` job runs every 5 minutes (retryLimit 0 + a run-level advisory lock, same no-stack pattern as `audit-chainer`/`siem-delivery`).
- The candidate query finds FILE pages `processingStatus IN ('pending','processing')` older than a staleness threshold (default 15m) with `NOT EXISTS` a live `pull-verify`/`ingest-file` job in `pgboss.job` — the live-job check is inside the query, before `LIMIT`, so a persistent front batch of live-job pages can't starve orphaned pages ordered behind them.
- Pure core (`classifyStalePage`) decides per page: skip (live job / not stale — both currently unreachable via this query's guarantees, kept as defensive branches) / re-enqueue the verified pull pipeline / mark `'failed'` once attempts are exhausted (default 3) or the page has no valid content hash to pull. Pages with a null/invalid `filePath` are *not* filtered out of the scan — they must reach the core so its missing-content-hash path can fail and alert on them instead of leaving them stuck forever.
- Re-enqueues tag the pull-verify job data with `reconcileAttempt`; the next run reads the max tag back from `pgboss.job` + `pgboss.archive` — no schema change needed. `singletonKey` collapses racing re-enqueues for the same page.
- The `fail` transition is a conditional `UPDATE ... WHERE "processingStatus" IN ('pending','processing')`, checked via `rowCount` — if the owning worker completes the page between the candidate scan and this write landing, the update becomes a no-op (counted as skipped) instead of overwriting a successful completion.
- Enqueue and mark-failed failures are isolated per page (their own try/catch + counters) so one DB/queue hiccup doesn't abort the rest of the batch. `defaultReconcilerAlert` (Sentry + logs) fires when any page is marked `'failed'`, and separately when enqueue/update errors persist across a run — both are signals worth paging on.
- `RECONCILER_STALE_MINUTES` / `RECONCILER_MAX_ATTEMPTS` / `RECONCILER_BATCH_LIMIT` env vars tune the policy; all default sensibly.

`apps/processor/src/workers/stuck-page-reconciler-core.ts` is the pure functional core (100% branch coverage). `stuck-page-reconciler-worker.ts` is the imperative shell — fully dependency-injected, tested with fakes (no `vi.mock` of db modules) — also at 100% lines/branches/functions/statements.

## Scope

Fully isolated to `apps/processor` per lane instructions — no changes to `apps/web` or `packages/db` schema. `PullVerifyJobData.reconcileAttempt` and the `stuck-page-reconciler` queue name are additive to `apps/processor/src/types/index.ts`. `pgboss` is a vendor-managed schema (not `packages/db`), so no migration is added there — see the indexing discussion on the review thread.

## Review history

Codex and CodeRabbit raised 5 actionable threads (null-hash pages silently excluded from the scan, live-job filtering applied after `LIMIT`, a completed-page race in the fail branch, unguarded `markPageFailed` aborting the batch, and no alert on persistent enqueue errors) — all fixed in a follow-up commit; replies with specifics are on each thread.

## Test plan

- [x] RED-first: wrote failing tests for `classifyStalePage`/`resolveReconcilerPolicy` and the worker shell before implementation
- [x] `bunx vitest run` in `apps/processor` — 43 reconciler tests pass; both `stuck-page-reconciler-core.ts` and `stuck-page-reconciler-worker.ts` at 100% lines/branches/functions/statements
- [x] Updated `queue-manager-full.test.ts` expectations for the new queue (10 → 11 workers/queues, new schedule assertion)
- [x] `bun run typecheck` (root) green
- [x] `bun run lint` (processor) green
- [x] Full `apps/processor` suite: 1119 passing; only 2 pre-existing, unrelated magika-fixture test-env failures
- [x] `bun run test:unit` (root) — pre-existing failures only, all in unrelated `apps/web` files (DB-connectivity test-env issue, not touched by this change)
