### PR TITLE
fix(chat): recompute denormalized message metadata on every mutation

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -85,7 +85,10 @@ vi.mock('@pagespace/db/db', () => {
     },
   };
 });
-vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), and: vi.fn() }));
+// exists/sql: globalConversationRepository's module-scope `hasMessages` query
+// (now reachable transitively via stream-takeover -> materialize-interrupted-stream
+// -> global-conversation-repository, #2153) needs both or the module throws on import.
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), and: vi.fn(), exists: vi.fn(), sql: vi.fn() }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id' } }));
 vi.mock('@pagespace/db/schema/core', () => ({
   chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt' },

--- a/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
@@ -96,11 +96,16 @@ vi.mock('@pagespace/db/db', () => {
     getAdvisoryLockPool: vi.fn(() => ({})),
   };
 });
+// exists/sql: globalConversationRepository's module-scope `hasMessages` query
+// (now reachable transitively via stream-takeover -> materialize-interrupted-stream
+// -> global-conversation-repository, #2153) needs both or the module throws on import.
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   ne: vi.fn(),
   desc: vi.fn(),
+  exists: vi.fn(),
+  sql: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id' },

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -84,9 +84,14 @@ vi.mock('@pagespace/db/db', () => {
     },
   };
 });
+// exists/sql: globalConversationRepository's module-scope `hasMessages` query
+// (now reachable transitively via stream-takeover -> materialize-interrupted-stream
+// -> global-conversation-repository, #2153) needs both or the module throws on import.
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  exists: vi.fn(),
+  sql: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id' },

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -76,9 +76,14 @@ vi.mock('@pagespace/db/db', () => ({
     })),
   },
 }));
+// exists/sql: globalConversationRepository's module-scope `hasMessages` query
+// (now reachable transitively via stream-takeover -> materialize-interrupted-stream
+// -> global-conversation-repository, #2153) needs both or the module throws on import.
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  exists: vi.fn(),
+  sql: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id' },

--- a/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
@@ -90,9 +90,14 @@ vi.mock('@pagespace/db/db', () => {
     },
   };
 });
+// exists/sql: globalConversationRepository's module-scope `hasMessages` query
+// (now reachable transitively via stream-takeover -> materialize-interrupted-stream
+// -> global-conversation-repository, #2153) needs both or the module throws on import.
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  exists: vi.fn(),
+  sql: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id' },

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
@@ -19,12 +19,30 @@ const {
   mockLifecycleFinish,
   mockBroadcastChatUserMessage,
   mockSaveGlobalAssistantMessageToDatabase,
+  mockConversation,
+  mockUserProfile,
+  mockAuthUser,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
   mockLifecycleFinish: vi.fn(),
   mockBroadcastChatUserMessage: vi.fn().mockResolvedValue(undefined),
   mockSaveGlobalAssistantMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+  // Hoisted (not a plain top-level const) because the `@pagespace/db/db` mock
+  // factory below references these eagerly (`.mockResolvedValue(...)` needs
+  // its argument immediately) — and #2153's new stream-takeover ->
+  // materialize-interrupted-stream -> global-conversation-repository import
+  // chain can now trigger that factory before a plain const would have run.
+  mockConversation: {
+    id: 'conv-1',
+    userId: 'user-1',
+    title: 'Test Conversation',
+    type: 'global',
+    contextId: null,
+    isActive: true,
+  },
+  mockUserProfile: { displayName: 'Display User' },
+  mockAuthUser: { name: 'Auth User', subscriptionTier: 'free' },
 }));
 
 interface MockUIStreamOptions {
@@ -73,17 +91,6 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 
-const mockConversation = {
-  id: 'conv-1',
-  userId: 'user-1',
-  title: 'Test Conversation',
-  type: 'global',
-  contextId: null,
-  isActive: true,
-};
-const mockUserProfile = { displayName: 'Display User' };
-const mockAuthUser = { name: 'Auth User', subscriptionTier: 'free' };
-
 vi.mock('@pagespace/db/db', () => {
   const select = vi.fn(() => ({
     from: vi.fn((table: unknown) => {
@@ -122,6 +129,11 @@ vi.mock('@pagespace/db/db', () => {
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(), and: vi.fn(), desc: vi.fn(), gt: vi.fn(), lt: vi.fn(),
   exists: vi.fn((sub) => ({ type: 'exists', sub })),
+  // globalConversationRepository's module-scope `hasMessages` query (and its
+  // new #2153 recomputeLastMessageAt helper, now reachable transitively via
+  // stream-takeover -> materialize-interrupted-stream) both use `sql` — this
+  // mock must cover it or the module throws on import.
+  sql: Object.assign(vi.fn(), { join: vi.fn() }),
 }));
 
 vi.mock('../resolve-or-create-conversation', () => ({

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -27,7 +27,6 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
 // --- DM repository seam (the boundary the route must delegate to) --------------
 const mockFindConversationForParticipant = vi.fn();
 const mockInsertDmMessageWithAttachment = vi.fn();
-const mockUpdateConversationLastMessage = vi.fn();
 const mockListActiveMessages = vi.fn();
 const mockMarkActiveMessagesRead = vi.fn();
 const mockUpdateConversationLastRead = vi.fn();
@@ -41,8 +40,6 @@ vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
       mockFindConversationForParticipant(...args),
     insertDmMessageWithAttachment: (...args: unknown[]) =>
       mockInsertDmMessageWithAttachment(...args),
-    updateConversationLastMessage: (...args: unknown[]) =>
-      mockUpdateConversationLastMessage(...args),
     listActiveMessages: (...args: unknown[]) => mockListActiveMessages(...args),
     markActiveMessagesRead: (...args: unknown[]) =>
       mockMarkActiveMessagesRead(...args),
@@ -182,7 +179,6 @@ function setupHappyPath() {
     kind: 'ok',
     message: mockInsertedRow(input),
   }));
-  mockUpdateConversationLastMessage.mockResolvedValue(undefined);
   mockCreateOrUpdateMessageNotification.mockResolvedValue(undefined);
   mockBroadcastInboxEvent.mockResolvedValue(undefined);
 }
@@ -343,7 +339,7 @@ describe('POST /api/messages/[conversationId]', () => {
       expect(res.status).toBe(403);
       const body = await res.json();
       expect(body.error).toMatch(/do not own this file/i);
-      expect(mockUpdateConversationLastMessage).not.toHaveBeenCalled();
+      expect(mockCreateOrUpdateMessageNotification).not.toHaveBeenCalled();
       expect(mockAuditRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -363,7 +359,7 @@ describe('POST /api/messages/[conversationId]', () => {
       expect(res.status).toBe(403);
       const body = await res.json();
       expect(body.error).toMatch(/not linked to this conversation/i);
-      expect(mockUpdateConversationLastMessage).not.toHaveBeenCalled();
+      expect(mockCreateOrUpdateMessageNotification).not.toHaveBeenCalled();
       expect(mockAuditRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -383,7 +379,7 @@ describe('POST /api/messages/[conversationId]', () => {
       expect(res.status).toBe(404);
       const body = await res.json();
       expect(body.error).toMatch(/file not found/i);
-      expect(mockUpdateConversationLastMessage).not.toHaveBeenCalled();
+      expect(mockCreateOrUpdateMessageNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -419,12 +415,6 @@ describe('POST /api/messages/[conversationId]', () => {
     it('uses [image: name] for image attachments with empty content', async () => {
       await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
 
-      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          conversationId: CONVERSATION_ID,
-          lastMessagePreview: `[image: ${imageMeta.originalName}]`,
-        })
-      );
       expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
         RECIPIENT_ID,
         CONVERSATION_ID,
@@ -436,10 +426,11 @@ describe('POST /api/messages/[conversationId]', () => {
     it('uses [file: name] for non-image attachments with empty content', async () => {
       await callRoute({ fileId: FILE_ID, attachmentMeta: pdfMeta });
 
-      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          lastMessagePreview: `[file: ${pdfMeta.originalName}]`,
-        })
+      expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
+        RECIPIENT_ID,
+        CONVERSATION_ID,
+        `[file: ${pdfMeta.originalName}]`,
+        SENDER_ID
       );
     });
 
@@ -450,11 +441,6 @@ describe('POST /api/messages/[conversationId]', () => {
         attachmentMeta: imageMeta,
       });
 
-      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          lastMessagePreview: `[image: ${imageMeta.originalName}]`,
-        })
-      );
       expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
         RECIPIENT_ID,
         CONVERSATION_ID,
@@ -490,8 +476,11 @@ describe('POST /api/messages/[conversationId]', () => {
         attachmentMeta: imageMeta,
       });
 
-      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ lastMessagePreview: 'caption' })
+      expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
+        RECIPIENT_ID,
+        CONVERSATION_ID,
+        'caption',
+        SENDER_ID
       );
     });
 
@@ -500,8 +489,11 @@ describe('POST /api/messages/[conversationId]', () => {
       await callRoute({ content: long });
 
       const expected = long.substring(0, 100) + '...';
-      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ lastMessagePreview: expected })
+      expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
+        RECIPIENT_ID,
+        CONVERSATION_ID,
+        expected,
+        SENDER_ID
       );
     });
   });
@@ -850,7 +842,6 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     );
     expect(mockInsertDmMessageWithAttachment).not.toHaveBeenCalled();
     // No mirror → conversation preview should not bump for the thread-only reply.
-    expect(mockUpdateConversationLastMessage).not.toHaveBeenCalled();
     expect(mockCreateOrUpdateMessageNotification).not.toHaveBeenCalled();
     // PR 5: thread-only reply with NO followers (default mock) emits no inbox events.
     // Earlier assertion was "no inbox bumps at all"; now it remains true only because
@@ -902,11 +893,13 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     expect(ids).toEqual(['mirror-1', 'reply-1']);
 
     // Mirror behaves like a regular top-level send — preview + recipient inbox bump.
-    expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: CONVERSATION_ID,
-        lastMessagePreview: 'echo',
-      })
+    // insertDmThreadReply itself recomputes the stored preview (#2153); the route's
+    // observable side effects here are the notification and inbox broadcast.
+    expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
+      RECIPIENT_ID,
+      CONVERSATION_ID,
+      'echo',
+      SENDER_ID
     );
     expect(mockBroadcastInboxEvent).toHaveBeenCalledWith(
       RECIPIENT_ID,

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -6,6 +6,7 @@ import { createOrUpdateMessageNotification } from '@pagespace/lib/notifications/
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { dmMessageRepository } from '@pagespace/lib/services/dm-message-repository';
+import { buildLastMessagePreview } from '@pagespace/lib/services/message-derived-state';
 import { attachQuotedMessages } from '@pagespace/lib/services/quote-enrichment';
 import { broadcastInboxEvent, broadcastThreadReplyCountUpdated } from '@/lib/websocket/socket-utils';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
@@ -211,23 +212,6 @@ function isValidAttachmentMeta(value: unknown): value is AttachmentMeta {
   );
 }
 
-function buildLastMessagePreview(
-  content: string,
-  attachmentMeta: AttachmentMeta | null
-): string {
-  const trimmed = content.trim();
-  if (trimmed.length > 0) {
-    return trimmed.length > 100 ? trimmed.substring(0, 100) + '...' : trimmed;
-  }
-  if (attachmentMeta) {
-    const isImage = attachmentMeta.mimeType.startsWith('image/');
-    return isImage
-      ? `[image: ${attachmentMeta.originalName}]`
-      : `[file: ${attachmentMeta.originalName}]`;
-  }
-  return '';
-}
-
 // POST /api/messages/[conversationId] - Send a message
 export async function POST(
   request: Request,
@@ -375,17 +359,15 @@ export async function POST(
         resourceId: result.reply.id,
       });
 
-      // Mirror row, when present, behaves as a top-level message — it should
-      // bump the conversation preview/inbox just like a regular send. The
-      // thread-only reply does NOT touch the inbox preview here; PR 5 wires
-      // the inbox bump for thread followers separately.
+      // Mirror row, when present, behaves as a top-level message — it bumps
+      // the conversation preview/inbox just like a regular send.
+      // insertDmThreadReply already recomputed the stored preview from the
+      // mirror row (#2153); this local copy is only for the
+      // notification/broadcast payloads below. The thread-only reply does
+      // NOT touch the inbox preview here; PR 5 wires the inbox bump for
+      // thread followers separately.
       if (result.mirror) {
         const previewSource = buildLastMessagePreview(content, attachmentMeta);
-        await dmMessageRepository.updateConversationLastMessage({
-          conversationId,
-          lastMessageAt: result.mirror.createdAt,
-          lastMessagePreview: previewSource,
-        });
 
         const recipientId = conversation.participant1Id === userId
           ? conversation.participant2Id
@@ -555,13 +537,10 @@ export async function POST(
       resourceId: newMessage.id,
     });
 
+    // insertDmMessageWithAttachment already recomputed the stored preview
+    // (#2153); this local copy is only for the notification/broadcast
+    // payloads below.
     const messagePreview = buildLastMessagePreview(content, attachmentMeta);
-
-    await dmMessageRepository.updateConversationLastMessage({
-      conversationId,
-      lastMessageAt: newMessage.createdAt,
-      lastMessagePreview: messagePreview,
-    });
 
     const recipientId = conversation.participant1Id === userId
       ? conversation.participant2Id

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetConversation,
   mockBroadcastAiStreamComplete,
   mockNotifyMentionedUsers,
+  mockRecomputeLastMessageAt,
   mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockInsert: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockGetConversation: vi.fn(),
   mockBroadcastAiStreamComplete: vi.fn(),
   mockNotifyMentionedUsers: vi.fn(),
+  mockRecomputeLastMessageAt: vi.fn(),
   mockLoggerWarn: vi.fn(),
 }));
 
@@ -82,6 +84,9 @@ vi.mock('@pagespace/lib/repositories/page-repository', () => ({
 vi.mock('@/lib/repositories/conversation-repository', () => ({
   conversationRepository: { getConversation: mockGetConversation },
 }));
+vi.mock('@/lib/repositories/global-conversation-repository', () => ({
+  globalConversationRepository: { recomputeLastMessageAt: mockRecomputeLastMessageAt },
+}));
 
 import { materializeInterruptedStream, type MaterializableStreamRow } from '../materialize-interrupted-stream';
 import type { UIMessagePart } from '../stream-multicast-registry';
@@ -133,6 +138,7 @@ beforeEach(() => {
   mockFindPageById.mockResolvedValue(null);
   mockGetConversation.mockResolvedValue(null);
   mockNotifyMentionedUsers.mockResolvedValue(undefined);
+  mockRecomputeLastMessageAt.mockResolvedValue(undefined);
   mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
   // Defaults to "one row actually settled" (rowCount: 1) — the common case. Tests exercising the
   // zero-row race (a concurrent reap already settled this row) override this per-case.
@@ -609,5 +615,45 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
       expect.stringContaining('mention notification failed'),
       expect.objectContaining({ error: 'notify boom' }),
     );
+  });
+});
+
+// Issue #2153 site 4: the AI chat routes bump conversations.lastMessageAt after every
+// persist, but the materializer's recovered assistant message previously skipped it —
+// leaving the recovered conversation sorted stale in the history list.
+describe('materializeInterruptedStream — conversations.lastMessageAt recompute (#2153)', () => {
+  it('given a global-assistant row, recomputes the conversation lastMessageAt after the message upsert', async () => {
+    await materializeInterruptedStream(globalRow({ conversationId: 'conv-2' }));
+
+    assert({
+      given: 'a materialized global-assistant reply',
+      should: 'invoke the shared lastMessageAt recompute for its conversation, same as the live persist paths',
+      actual: mockRecomputeLastMessageAt.mock.calls,
+      expected: [['conv-2']],
+    });
+  });
+
+  it('given a page-chat row, does not touch the global conversations table', async () => {
+    await materializeInterruptedStream(pageRow());
+
+    assert({
+      given: 'a materialized page-chat reply',
+      should: 'never invoke the global-conversation recompute (chat pages have no conversations.lastMessageAt)',
+      actual: mockRecomputeLastMessageAt.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  it('a recompute failure degrades like a failed message write — row left retryable, session not settled', async () => {
+    mockRecomputeLastMessageAt.mockRejectedValueOnce(new Error('recompute down'));
+
+    const settled = await materializeInterruptedStream(globalRow());
+
+    assert({
+      given: 'a lastMessageAt recompute that throws mid-materialization',
+      should: 'return false and leave the session row unsettled so the next sweep retries',
+      actual: { settled, sessionSettleAttempts: mockUpdateSet.mock.calls.length },
+      expected: { settled: false, sessionSettleAttempts: 0 },
+    });
   });
 });

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -11,6 +11,7 @@ import { buildAssistantPersistencePayload } from '@/lib/ai/core/persistAssistant
 import { extractStructuredContentFromParts } from '@/lib/ai/core/message-utils';
 import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
 
 /**
@@ -174,6 +175,16 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           // `'complete'` — see the docblock above for why `!= 'complete'` alone isn't enough.
           setWhere: eq(messages.status, 'streaming'),
         });
+
+      // The route's own terminal writes bump this after every persist
+      // (execute-end, onFinish) — the materializer is a terminal write by a
+      // different door and must not skip it, or the recovered conversation
+      // sorts stale in the history list (#2153). Deliberately inside this
+      // same try/catch as the message write: a failure here must degrade
+      // exactly like a failed write, leaving the row `'streaming'` for the
+      // next sweep to retry, not a half-materialized row whose session gets
+      // settled anyway.
+      await globalConversationRepository.recomputeLastMessageAt(row.conversationId);
     } else {
       const written = await db
         .insert(chatMessages)

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-hard-delete.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-hard-delete.test.ts
@@ -11,12 +11,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockReturning = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 const mockWhere = vi.hoisted(() => vi.fn().mockReturnValue({ returning: mockReturning }));
+// recomputeLastMessageAt (#2153) locks the conversation row and runs inside
+// its own transaction before reading the surviving messages — purge/delete
+// paths that touch a real conversationId now go through this.
+const mockTransaction = vi.hoisted(() => vi.fn());
 
-vi.mock('@pagespace/db/db', () => ({
-  db: {
+vi.mock('@pagespace/db/db', () => {
+  const dbShape = {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
+          for: vi.fn().mockResolvedValue([]),
           orderBy: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([]),
           }),
@@ -32,8 +37,11 @@ vi.mock('@pagespace/db/db', () => ({
       }),
     }),
     delete: vi.fn().mockReturnValue({ where: mockWhere }),
-  },
-}));
+    transaction: mockTransaction,
+  };
+  mockTransaction.mockImplementation((cb: (tx: typeof dbShape) => unknown) => cb(dbShape));
+  return { db: dbShape };
+});
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ type: 'eq', field, value })),
   and: vi.fn((...conditions) => ({ type: 'and', conditions })),
@@ -114,13 +122,28 @@ describe('globalConversationRepository hard-delete', () => {
 
   describe('purgeInactiveMessages', () => {
     it('should delete inactive messages older than cutoff and return count', async () => {
-      mockReturning.mockResolvedValue([{ id: 'msg-1' }, { id: 'msg-2' }, { id: 'msg-3' }]);
+      mockReturning.mockResolvedValue([
+        { id: 'msg-1', conversationId: 'conv-1' },
+        { id: 'msg-2', conversationId: 'conv-1' },
+        { id: 'msg-3', conversationId: 'conv-2' },
+      ]);
 
       const cutoff = new Date('2024-06-01');
       const count = await globalConversationRepository.purgeInactiveMessages(cutoff);
 
       expect(db.delete).toHaveBeenCalled();
       expect(count).toBe(3);
+    });
+
+    it('recomputes lastMessageAt under a row lock for each affected conversation (#2153)', async () => {
+      mockReturning.mockResolvedValue([
+        { id: 'msg-1', conversationId: 'conv-1' },
+        { id: 'msg-2', conversationId: 'conv-2' },
+      ]);
+
+      await globalConversationRepository.purgeInactiveMessages(new Date('2024-06-01'));
+
+      expect(mockTransaction).toHaveBeenCalledTimes(2);
     });
 
     it('should return 0 when no inactive messages match', async () => {

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts
@@ -16,6 +16,7 @@ const {
   mockDeleteReturning,
   mockUpdateReturning,
   mockTransaction,
+  mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockSelectLimit: vi.fn(),
   // The conversation-row lock (`.for('update')`) recomputeLastMessageAt now
@@ -27,6 +28,7 @@ const {
   mockDeleteReturning: vi.fn(),
   mockUpdateReturning: vi.fn(),
   mockTransaction: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => {
@@ -76,6 +78,9 @@ vi.mock('@pagespace/db/schema/conversations', () => ({
 vi.mock('@/lib/ai/core/compaction/compaction-repository', () => ({
   invalidate: vi.fn(),
 }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { warn: mockLoggerWarn } },
+}));
 
 import { globalConversationRepository } from '../global-conversation-repository';
 
@@ -105,6 +110,7 @@ beforeEach(() => {
   });
   mockUpdateReturning.mockResolvedValue([]);
   mockDeleteReturning.mockResolvedValue([]);
+  mockLoggerWarn.mockReset();
 });
 
 describe('globalConversationRepository.recomputeLastMessageAt', () => {
@@ -199,6 +205,79 @@ describe('globalConversationRepository message deletions recompute lastMessageAt
       should: 'recompute lastMessageAt once per distinct conversation',
       actual: { purged, updates: mockUpdateSet.mock.calls.length },
       expected: { purged: 3, updates: 2 },
+    });
+  });
+});
+
+describe('globalConversationRepository recompute failures are isolated from the caller (#2153)', () => {
+  it('softDeleteMessage does not throw when the recompute fails, and logs a warning', async () => {
+    mockUpdateReturning.mockResolvedValueOnce([{ conversationId: 'conv-9' }]);
+    mockTransaction.mockImplementationOnce(() => {
+      throw new Error('lock timeout');
+    });
+
+    await expect(globalConversationRepository.softDeleteMessage('msg-1')).resolves.toBeUndefined();
+
+    assert({
+      given: 'a soft-delete whose recompute throws',
+      should: 'swallow the recompute failure and log a warning instead of failing the delete',
+      actual: {
+        warnCalls: mockLoggerWarn.mock.calls.length,
+        conversationId: mockLoggerWarn.mock.calls[0]?.[1]?.conversationId,
+      },
+      expected: { warnCalls: 1, conversationId: 'conv-9' },
+    });
+  });
+
+  it('hardDeleteMessage does not throw when the recompute fails, and logs a warning', async () => {
+    mockDeleteReturning.mockResolvedValueOnce([{ conversationId: 'conv-9' }]);
+    mockTransaction.mockImplementationOnce(() => {
+      throw new Error('lock timeout');
+    });
+
+    await expect(globalConversationRepository.hardDeleteMessage('msg-1')).resolves.toBeUndefined();
+
+    assert({
+      given: 'a hard-delete whose recompute throws',
+      should: 'swallow the recompute failure and log a warning instead of failing the delete',
+      actual: {
+        warnCalls: mockLoggerWarn.mock.calls.length,
+        conversationId: mockLoggerWarn.mock.calls[0]?.[1]?.conversationId,
+      },
+      expected: { warnCalls: 1, conversationId: 'conv-9' },
+    });
+  });
+
+  it('purgeInactiveMessages keeps recomputing later conversations after one recompute fails, and still returns the full purge count', async () => {
+    mockDeleteReturning.mockResolvedValueOnce([
+      { id: 'm1', conversationId: 'conv-a' },
+      { id: 'm2', conversationId: 'conv-b' },
+    ]);
+    mockTransaction
+      .mockImplementationOnce(() => {
+        throw new Error('lock timeout');
+      })
+      .mockImplementationOnce((cb: (tx: unknown) => unknown) =>
+        cb({
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                for: mockSelectFor,
+                orderBy: vi.fn().mockReturnValue({ limit: mockSelectLimit }),
+              }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({ set: mockUpdateSet }),
+        })
+      );
+
+    const purged = await globalConversationRepository.purgeInactiveMessages(new Date('2026-01-01T00:00:00Z'));
+
+    assert({
+      given: 'a purge across two conversations where the first recompute throws',
+      should: 'still recompute the second conversation, still report the true purge count, and log exactly one warning',
+      actual: { purged, warnCalls: mockLoggerWarn.mock.calls.length, updates: mockUpdateSet.mock.calls.length },
+      expected: { purged: 2, warnCalls: 1, updates: 1 },
     });
   });
 });

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts
@@ -10,23 +10,34 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const {
   mockSelectLimit,
+  mockSelectFor,
   mockUpdateSet,
   mockUpdateWhere,
   mockDeleteReturning,
   mockUpdateReturning,
+  mockTransaction,
 } = vi.hoisted(() => ({
   mockSelectLimit: vi.fn(),
+  // The conversation-row lock (`.for('update')`) recomputeLastMessageAt now
+  // takes before reading the surviving messages (#2153) — see the
+  // concurrency-safety tests below.
+  mockSelectFor: vi.fn(),
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
   mockDeleteReturning: vi.fn(),
   mockUpdateReturning: vi.fn(),
+  mockTransaction: vi.fn(),
 }));
 
-vi.mock('@pagespace/db/db', () => ({
-  db: {
+vi.mock('@pagespace/db/db', () => {
+  // A single chain shape serves both the lock select (`.for('update')`) and
+  // the newest-message select (`.orderBy().limit()`) — each call site uses
+  // only the branch it needs.
+  const dbShape = {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
+          for: mockSelectFor,
           orderBy: vi.fn().mockReturnValue({ limit: mockSelectLimit }),
         }),
       }),
@@ -35,8 +46,15 @@ vi.mock('@pagespace/db/db', () => ({
     delete: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({ returning: mockDeleteReturning }),
     }),
-  },
-}));
+    // recomputeLastMessageAt now runs its lock+read+write inside its own
+    // transaction (#2153) — the mock just invokes the callback with the
+    // same shape, since none of these tests need real transactional
+    // isolation, only to observe the calls made through `tx`.
+    transaction: mockTransaction,
+  };
+  mockTransaction.mockImplementation((cb: (tx: typeof dbShape) => unknown) => cb(dbShape));
+  return { db: dbShape };
+});
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ type: 'eq', field, value })),
   and: vi.fn((...conditions) => ({ type: 'and', conditions })),
@@ -77,6 +95,7 @@ const NEWEST = new Date('2026-07-10T10:00:00Z');
 beforeEach(() => {
   vi.clearAllMocks();
   mockSelectLimit.mockResolvedValue([]);
+  mockSelectFor.mockResolvedValue([]);
   mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
   mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
   // Awaiting the update chain without .returning() must also work.
@@ -114,6 +133,22 @@ describe('globalConversationRepository.recomputeLastMessageAt', () => {
       should: 'null out lastMessageAt instead of leaving it pointing at a deleted message',
       actual: { called: mockUpdateSet.mock.calls.length > 0, lastMessageAt: setArg?.lastMessageAt },
       expected: { called: true, lastMessageAt: null },
+    });
+  });
+
+  it('locks the conversation row (SELECT ... FOR UPDATE) inside its own transaction before reading the surviving messages (#2153)', async () => {
+    mockSelectLimit.mockResolvedValue([{ createdAt: NEWEST }]);
+
+    await globalConversationRepository.recomputeLastMessageAt('conv-1');
+
+    assert({
+      given: 'a lastMessageAt recompute',
+      should: 'take the conversation-row lock exactly once, inside a transaction, before writing — closing the race where a concurrent save or another recompute commits between this read and this write',
+      actual: {
+        forUpdateCalls: mockSelectFor.mock.calls.length,
+        ranInTransaction: mockTransaction.mock.calls.length > 0,
+      },
+      expected: { forUpdateCalls: 1, ranInTransaction: true },
     });
   });
 });

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #2153 — conversations.lastMessageAt is derived from the surviving
+ * active messages. Every mutation that can remove the newest message
+ * (soft-delete, hard-delete, purge) must recompute it via the one shared
+ * writer, `recomputeLastMessageAt`, instead of leaving the timestamp
+ * pointing at a message that no longer exists.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockSelectLimit,
+  mockUpdateSet,
+  mockUpdateWhere,
+  mockDeleteReturning,
+  mockUpdateReturning,
+} = vi.hoisted(() => ({
+  mockSelectLimit: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockDeleteReturning: vi.fn(),
+  mockUpdateReturning: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({ limit: mockSelectLimit }),
+        }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({ set: mockUpdateSet }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: mockDeleteReturning }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ type: 'eq', field, value })),
+  and: vi.fn((...conditions) => ({ type: 'and', conditions })),
+  desc: vi.fn((field) => ({ type: 'desc', field })),
+  sql: vi.fn(),
+  lt: vi.fn((field, value) => ({ type: 'lt', field, value })),
+  exists: vi.fn((sub) => ({ type: 'exists', sub })),
+}));
+vi.mock('@pagespace/db/schema/monitoring', () => ({ aiUsageLogs: {} }));
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: { id: 'conversations.id', lastMessageAt: 'conversations.lastMessageAt' },
+  messages: {
+    id: 'messages.id',
+    conversationId: 'messages.conversationId',
+    isActive: 'messages.isActive',
+    createdAt: 'messages.createdAt',
+  },
+}));
+vi.mock('@/lib/ai/core/compaction/compaction-repository', () => ({
+  invalidate: vi.fn(),
+}));
+
+import { globalConversationRepository } from '../global-conversation-repository';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+};
+
+const NEWEST = new Date('2026-07-10T10:00:00Z');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectLimit.mockResolvedValue([]);
+  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
+  // Awaiting the update chain without .returning() must also work.
+  mockUpdateWhere.mockImplementation(() => {
+    const result = Promise.resolve([]);
+    return Object.assign(result, { returning: mockUpdateReturning });
+  });
+  mockUpdateReturning.mockResolvedValue([]);
+  mockDeleteReturning.mockResolvedValue([]);
+});
+
+describe('globalConversationRepository.recomputeLastMessageAt', () => {
+  it('sets lastMessageAt from the newest surviving active message', async () => {
+    mockSelectLimit.mockResolvedValue([{ createdAt: NEWEST }]);
+
+    await globalConversationRepository.recomputeLastMessageAt('conv-1');
+
+    const setArg = mockUpdateSet.mock.calls[0]?.[0];
+    assert({
+      given: 'a conversation with a surviving active message',
+      should: 'write that message createdAt as lastMessageAt',
+      actual: setArg?.lastMessageAt,
+      expected: NEWEST,
+    });
+  });
+
+  it('nulls lastMessageAt when no active message survives', async () => {
+    mockSelectLimit.mockResolvedValue([]);
+
+    await globalConversationRepository.recomputeLastMessageAt('conv-1');
+
+    const setArg = mockUpdateSet.mock.calls[0]?.[0];
+    assert({
+      given: 'a conversation whose messages are all deleted',
+      should: 'null out lastMessageAt instead of leaving it pointing at a deleted message',
+      actual: { called: mockUpdateSet.mock.calls.length > 0, lastMessageAt: setArg?.lastMessageAt },
+      expected: { called: true, lastMessageAt: null },
+    });
+  });
+});
+
+describe('globalConversationRepository message deletions recompute lastMessageAt (#2153)', () => {
+  it('softDeleteMessage recomputes the owning conversation after tombstoning', async () => {
+    mockUpdateReturning.mockResolvedValue([{ conversationId: 'conv-9' }]);
+    mockSelectLimit.mockResolvedValue([{ createdAt: NEWEST }]);
+
+    await globalConversationRepository.softDeleteMessage('msg-1');
+
+    const lastSet = mockUpdateSet.mock.calls.at(-1)?.[0];
+    assert({
+      given: 'a soft-delete of a global conversation message',
+      should: 'follow up with a conversations.lastMessageAt recompute from the surviving rows',
+      actual: { updates: mockUpdateSet.mock.calls.length, lastMessageAt: lastSet?.lastMessageAt },
+      expected: { updates: 2, lastMessageAt: NEWEST },
+    });
+  });
+
+  it('hardDeleteMessage recomputes the owning conversation after removal', async () => {
+    mockDeleteReturning.mockResolvedValue([{ conversationId: 'conv-9' }]);
+    mockSelectLimit.mockResolvedValue([]);
+
+    await globalConversationRepository.hardDeleteMessage('msg-1');
+
+    const lastSet = mockUpdateSet.mock.calls.at(-1)?.[0];
+    assert({
+      given: 'a hard-delete of a global conversation message',
+      should: 'recompute lastMessageAt (nulled here — nothing survives)',
+      actual: { updates: mockUpdateSet.mock.calls.length, lastMessageAt: lastSet?.lastMessageAt },
+      expected: { updates: 1, lastMessageAt: null },
+    });
+  });
+
+  it('purgeInactiveMessages recomputes each affected conversation exactly once', async () => {
+    mockDeleteReturning.mockResolvedValue([
+      { id: 'm1', conversationId: 'conv-a' },
+      { id: 'm2', conversationId: 'conv-a' },
+      { id: 'm3', conversationId: 'conv-b' },
+    ]);
+    mockSelectLimit.mockResolvedValue([]);
+
+    const purged = await globalConversationRepository.purgeInactiveMessages(new Date('2026-01-01T00:00:00Z'));
+
+    assert({
+      given: 'a purge removing tombstones across two conversations',
+      should: 'recompute lastMessageAt once per distinct conversation',
+      actual: { purged, updates: mockUpdateSet.mock.calls.length },
+      expected: { purged: 3, updates: 2 },
+    });
+  });
+});

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -9,6 +9,7 @@ import { aiUsageLogs } from '@pagespace/db/schema/monitoring'
 import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { createId } from '@paralleldrive/cuid2';
 import { invalidate as invalidateCompaction } from '@/lib/ai/core/compaction/compaction-repository';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Types
 export interface ConversationSummary {
@@ -169,6 +170,40 @@ const hasMessages = exists(
       eq(messages.isActive, true),
     ))
 );
+
+/**
+ * Runs `recomputeLastMessageAt` isolated from its caller's own outcome
+ * (#2153 review follow-up). `softDeleteMessage`/`hardDeleteMessage`/
+ * `purgeInactiveMessages` all commit their primary write BEFORE calling
+ * this, in a separate statement — so an unguarded throw here would surface
+ * as a failure of an operation that already succeeded, and for
+ * `hardDeleteMessage` specifically, the deleted row is gone, so there is no
+ * "retry this call" path that would ever repair the stale timestamp. Purge
+ * additionally loops over multiple conversations per call, where a single
+ * throw would abort every conversation after it in iteration order and
+ * lose the already-correct purge count. A logged-and-swallowed failure here
+ * leaves `lastMessageAt` stale until the next mutation on that conversation
+ * recomputes it fresh — worse than immediate consistency, but strictly
+ * better than an unrelated 500 or an abandoned purge loop.
+ *
+ * Deliberately NOT used by `materialize-interrupted-stream.ts`: that
+ * caller's recompute sits inside the same try/catch as the message write
+ * itself, so a recompute failure there is meant to propagate and degrade
+ * like a failed write — the opposite of isolating it.
+ */
+async function recomputeLastMessageAtIsolated(
+  conversationId: string,
+  caller: string
+): Promise<void> {
+  try {
+    await globalConversationRepository.recomputeLastMessageAt(conversationId);
+  } catch (error) {
+    loggers.ai.warn(`${caller}: lastMessageAt recompute failed`, {
+      conversationId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+}
 
 export const globalConversationRepository = {
   /**
@@ -480,7 +515,7 @@ export const globalConversationRepository = {
       .returning({ conversationId: messages.conversationId });
 
     if (row) {
-      await globalConversationRepository.recomputeLastMessageAt(row.conversationId);
+      await recomputeLastMessageAtIsolated(row.conversationId, 'softDeleteMessage');
     }
   },
 
@@ -524,7 +559,7 @@ export const globalConversationRepository = {
       .returning({ conversationId: messages.conversationId });
 
     if (row) {
-      await globalConversationRepository.recomputeLastMessageAt(row.conversationId);
+      await recomputeLastMessageAtIsolated(row.conversationId, 'hardDeleteMessage');
     }
   },
 
@@ -545,7 +580,7 @@ export const globalConversationRepository = {
 
     const affectedConversationIds = new Set(result.map((m) => m.conversationId));
     for (const conversationId of affectedConversationIds) {
-      await globalConversationRepository.recomputeLastMessageAt(conversationId);
+      await recomputeLastMessageAtIsolated(conversationId, 'purgeInactiveMessages');
     }
 
     return result.length;

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -426,13 +426,42 @@ export const globalConversationRepository = {
   },
 
   /**
+   * The single "message mutated" recompute for `conversations.lastMessageAt`
+   * (#2153). Every mutation that can change which active message is newest —
+   * soft-delete, hard-delete, purge, and the interrupted-stream materializer
+   * — calls this instead of writing the field ad hoc, so a recovered or
+   * deleted message can't leave a conversation sorted on a stale timestamp.
+   */
+  async recomputeLastMessageAt(conversationId: string): Promise<void> {
+    const [newest] = await db
+      .select({ createdAt: messages.createdAt })
+      .from(messages)
+      .where(and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.isActive, true)
+      ))
+      .orderBy(desc(messages.createdAt))
+      .limit(1);
+
+    await db
+      .update(conversations)
+      .set({ lastMessageAt: newest ? newest.createdAt : null })
+      .where(eq(conversations.id, conversationId));
+  },
+
+  /**
    * Soft delete a message
    */
   async softDeleteMessage(messageId: string): Promise<void> {
-    await db
+    const [row] = await db
       .update(messages)
       .set({ isActive: false })
-      .where(eq(messages.id, messageId));
+      .where(eq(messages.id, messageId))
+      .returning({ conversationId: messages.conversationId });
+
+    if (row) {
+      await globalConversationRepository.recomputeLastMessageAt(row.conversationId);
+    }
   },
 
   /**
@@ -469,9 +498,14 @@ export const globalConversationRepository = {
    * Permanently delete a message from the database
    */
   async hardDeleteMessage(messageId: string): Promise<void> {
-    await db
+    const [row] = await db
       .delete(messages)
-      .where(eq(messages.id, messageId));
+      .where(eq(messages.id, messageId))
+      .returning({ conversationId: messages.conversationId });
+
+    if (row) {
+      await globalConversationRepository.recomputeLastMessageAt(row.conversationId);
+    }
   },
 
   /**
@@ -487,7 +521,12 @@ export const globalConversationRepository = {
           lt(messages.createdAt, olderThan)
         )
       )
-      .returning({ id: messages.id });
+      .returning({ id: messages.id, conversationId: messages.conversationId });
+
+    const affectedConversationIds = new Set(result.map((m) => m.conversationId));
+    for (const conversationId of affectedConversationIds) {
+      await globalConversationRepository.recomputeLastMessageAt(conversationId);
+    }
 
     return result.length;
   },

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -431,22 +431,42 @@ export const globalConversationRepository = {
    * soft-delete, hard-delete, purge, and the interrupted-stream materializer
    * — calls this instead of writing the field ad hoc, so a recovered or
    * deleted message can't leave a conversation sorted on a stale timestamp.
+   *
+   * Runs in its own transaction and locks the conversation row FIRST, before
+   * reading the surviving messages. Without this, a concurrent writer (a
+   * normal message save, or another recompute from a concurrent delete)
+   * targeting the same conversation can commit between this function's own
+   * SELECT and UPDATE, and this UPDATE then silently overwrites that
+   * writer's fresher timestamp with a stale snapshot. The lock forces
+   * concurrent recomputes (and any other writer to this row — a plain
+   * UPDATE takes the same implicit row lock even without FOR UPDATE) to
+   * serialize: whichever runs second only proceeds after the first commits,
+   * at which point its own SELECT sees the first's already-committed state.
+   * Mirrors `recomputeConversationLastMessage` in dm-message-repository.ts.
    */
   async recomputeLastMessageAt(conversationId: string): Promise<void> {
-    const [newest] = await db
-      .select({ createdAt: messages.createdAt })
-      .from(messages)
-      .where(and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.isActive, true)
-      ))
-      .orderBy(desc(messages.createdAt))
-      .limit(1);
+    await db.transaction(async (tx) => {
+      await tx
+        .select({ id: conversations.id })
+        .from(conversations)
+        .where(eq(conversations.id, conversationId))
+        .for('update');
 
-    await db
-      .update(conversations)
-      .set({ lastMessageAt: newest ? newest.createdAt : null })
-      .where(eq(conversations.id, conversationId));
+      const [newest] = await tx
+        .select({ createdAt: messages.createdAt })
+        .from(messages)
+        .where(and(
+          eq(messages.conversationId, conversationId),
+          eq(messages.isActive, true)
+        ))
+        .orderBy(desc(messages.createdAt))
+        .limit(1);
+
+      await tx
+        .update(conversations)
+        .set({ lastMessageAt: newest ? newest.createdAt : null })
+        .where(eq(conversations.id, conversationId));
+    });
   },
 
   /**

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -797,6 +797,11 @@
       "import": "./dist/services/channel-message-repository.js",
       "require": "./dist/services/channel-message-repository.js"
     },
+    "./services/message-derived-state": {
+      "types": "./dist/services/message-derived-state.d.ts",
+      "import": "./dist/services/message-derived-state.js",
+      "require": "./dist/services/message-derived-state.js"
+    },
     "./services/page-webhook-service": {
       "types": "./dist/services/page-webhook-service.d.ts",
       "import": "./dist/services/page-webhook-service.js",

--- a/packages/lib/src/services/__tests__/channel-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/channel-message-repository.test.ts
@@ -1231,3 +1231,140 @@ describe('channelMessageRepository — PII decryption at the read edge (GDPR #96
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #2153 — derived-field maintenance on every mutation path.
+// parent.lastReplyAt is derived from the surviving active replies, and a
+// mirror row must never diverge from its source reply on edit.
+// ---------------------------------------------------------------------------
+
+describe('channel thread lastReplyAt recompute (#2153)', () => {
+  const T1 = new Date('2026-07-01T10:00:00Z');
+  const T2 = new Date('2026-07-01T11:00:00Z');
+
+  it('soft-deleting the newest reply moves parent.lastReplyAt back to the surviving reply', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 2, lastReplyAt: T2, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'first', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'reply-2', pageId: 'page-1', userId: 'u-1', content: 'second', isActive: true, parentId: 'parent-1', createdAt: T2 },
+    ]);
+
+    await channelMessageRepository.softDeleteChannelMessage('reply-2');
+
+    const parent = testDbState.rows('channelMessages').find((r) => r.id === 'parent-1');
+    assert({
+      given: 'a soft-delete of the newest reply in a channel thread',
+      should: 'recompute lastReplyAt from the surviving replies instead of leaving it pointing at the deleted one',
+      actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
+      expected: { replyCount: 1, lastReplyAt: T1 },
+    });
+  });
+
+  it('soft-deleting the only reply clears parent.lastReplyAt', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 1, lastReplyAt: T1, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'only', isActive: true, parentId: 'parent-1', createdAt: T1 },
+    ]);
+
+    await channelMessageRepository.softDeleteChannelMessage('reply-1');
+
+    const parent = testDbState.rows('channelMessages').find((r) => r.id === 'parent-1');
+    assert({
+      given: 'a soft-delete of the only reply in a channel thread',
+      should: 'clear lastReplyAt (no surviving replies) alongside the counter decrement',
+      actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
+      expected: { replyCount: 0, lastReplyAt: null },
+    });
+  });
+
+  it('restoring a reply recomputes parent.lastReplyAt from the now-surviving rows', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 1, lastReplyAt: T1, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'first', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'reply-2', pageId: 'page-1', userId: 'u-1', content: 'second', isActive: false, parentId: 'parent-1', createdAt: T2 },
+    ]);
+
+    await channelMessageRepository.restoreChannelMessage('reply-2');
+
+    const parent = testDbState.rows('channelMessages').find((r) => r.id === 'parent-1');
+    assert({
+      given: 'a restore of the newest (previously soft-deleted) channel reply',
+      should: 'move lastReplyAt forward to the restored reply',
+      actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
+      expected: { replyCount: 2, lastReplyAt: T2 },
+    });
+  });
+});
+
+describe('channel mirror edit propagation (#2153)', () => {
+  const T1 = new Date('2026-07-01T10:00:00Z');
+  const editedAt = new Date('2026-07-01T12:00:00Z');
+
+  it('editing a thread reply propagates the new content to its top-level mirror', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'u-1', content: 'root', isActive: true, parentId: null, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'echo', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'mirror-1', pageId: 'page-1', userId: 'u-2', content: 'echo', isActive: true, parentId: null, mirroredFromId: 'reply-1', createdAt: T1 },
+    ]);
+
+    await channelMessageRepository.updateChannelMessageContent({
+      messageId: 'reply-1',
+      content: 'edited echo',
+      editedAt,
+    });
+
+    const mirror = testDbState.rows('channelMessages').find((r) => r.id === 'mirror-1');
+    assert({
+      given: 'an edit of a channel thread reply that has an alsoSendToParent mirror',
+      should: 'propagate the edit to the mirror row so the two copies cannot disagree',
+      actual: { content: mirror?.content, editedAt: mirror?.editedAt },
+      expected: { content: 'edited echo', editedAt },
+    });
+  });
+
+  it('editing the mirror propagates the new content back to the thread reply', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'u-1', content: 'root', isActive: true, parentId: null, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'echo', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'mirror-1', pageId: 'page-1', userId: 'u-2', content: 'echo', isActive: true, parentId: null, mirroredFromId: 'reply-1', createdAt: T1 },
+    ]);
+
+    await channelMessageRepository.updateChannelMessageContent({
+      messageId: 'mirror-1',
+      content: 'edited echo',
+      editedAt,
+    });
+
+    const reply = testDbState.rows('channelMessages').find((r) => r.id === 'reply-1');
+    assert({
+      given: 'an edit of the top-level mirror row',
+      should: 'propagate the edit back to the source thread reply',
+      actual: { content: reply?.content, editedAt: reply?.editedAt },
+      expected: { content: 'edited echo', editedAt },
+    });
+  });
+
+  it('does not propagate aiMeta to the mirror — only content and editedAt', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'echo', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'mirror-1', pageId: 'page-1', userId: 'u-2', content: 'echo', isActive: true, parentId: null, mirroredFromId: 'reply-1', aiMeta: null, createdAt: T1 },
+    ]);
+
+    await channelMessageRepository.updateChannelMessageContent({
+      messageId: 'reply-1',
+      content: 'edited echo',
+      editedAt,
+      aiMeta: { senderType: 'agent', senderName: 'Agent Smith' },
+    });
+
+    const rows = testDbState.rows('channelMessages');
+    const reply = rows.find((r) => r.id === 'reply-1');
+    const mirror = rows.find((r) => r.id === 'mirror-1');
+    assert({
+      given: 'an edit carrying an aiMeta replacement for the source reply',
+      should: 'apply aiMeta to the edited row only while still syncing the mirror content',
+      actual: { replyAiMeta: reply?.aiMeta, mirrorAiMeta: mirror?.aiMeta, mirrorContent: mirror?.content },
+      expected: { replyAiMeta: { senderType: 'agent', senderName: 'Agent Smith' }, mirrorAiMeta: null, mirrorContent: 'edited echo' },
+    });
+  });
+});

--- a/packages/lib/src/services/__tests__/channel-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/channel-message-repository.test.ts
@@ -520,9 +520,9 @@ describe('channelMessageRepository.restoreChannelMessage', () => {
 
     assert({
       given: 'a restore of a thread reply whose parent must be re-validated under lock',
-      should: 'invoke .for("update") against channelMessages exactly once — the lock blocks a concurrent softDelete until the bump commits',
+      should: 'invoke .for("update") against channelMessages twice — once for the parent re-validation before the replyCount bump, once more inside recomputeThreadLastReply (#2153) before it re-derives lastReplyAt — both against the same parent row, so the second is a safe reentrant re-lock, not a new race window',
       actual: testDbState.selectsForUpdate('channelMessages').length,
-      expected: 1,
+      expected: 2,
     });
   });
 });
@@ -1292,6 +1292,22 @@ describe('channel thread lastReplyAt recompute (#2153)', () => {
       should: 'move lastReplyAt forward to the restored reply',
       actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
       expected: { replyCount: 2, lastReplyAt: T2 },
+    });
+  });
+
+  it('locks the parent row before recomputing lastReplyAt on soft-delete — a path with no pre-existing parent lock to piggyback on', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 1, lastReplyAt: T1, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', pageId: 'page-1', userId: 'u-2', content: 'only', isActive: true, parentId: 'parent-1', createdAt: T1 },
+    ]);
+
+    await channelMessageRepository.softDeleteChannelMessage('reply-1');
+
+    assert({
+      given: 'a reply soft-delete — softDeleteChannelMessage never pre-locks the parent the way restoreChannelMessage does',
+      should: 'invoke .for("update") against the parent row exactly once via recomputeThreadLastReply (#2153), closing the same concurrent-delete race window restore already had covered',
+      actual: testDbState.selectsForUpdate('channelMessages').length,
+      expected: 1,
     });
   });
 });

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -1263,3 +1263,283 @@ describe('dmMessageRepository — PII decryption at the read edge (GDPR #965)', 
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #2153 — derived-field maintenance on every mutation path.
+// dmConversations.lastMessageAt/lastMessagePreview and parent.lastReplyAt are
+// derived from the surviving active rows; every mutation (insert, edit,
+// delete, restore, purge) must leave them consistent with that source.
+// ---------------------------------------------------------------------------
+
+describe('DM conversation derived state (#2153)', () => {
+  const T1 = new Date('2026-07-01T10:00:00Z');
+  const T2 = new Date('2026-07-01T11:00:00Z');
+
+  const seedConversation = () => {
+    testDbState.seed('dmConversations', [
+      {
+        id: 'conv-1',
+        participant1Id: 'u-1',
+        participant2Id: 'u-2',
+        lastMessageAt: T2,
+        lastMessagePreview: 'newest words',
+      },
+    ]);
+  };
+
+  it('soft-deleting the newest DM recomputes the conversation preview from the surviving row', async () => {
+    seedConversation();
+    testDbState.seed('directMessages', [
+      { id: 'm-old', conversationId: 'conv-1', senderId: 'u-1', content: 'older words', isActive: true, parentId: null, createdAt: T1 },
+      { id: 'm-new', conversationId: 'conv-1', senderId: 'u-2', content: 'newest words', isActive: true, parentId: null, createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('m-new');
+
+    const conv = testDbState.rows('dmConversations')[0];
+    assert({
+      given: 'a soft-delete of the newest top-level DM',
+      should: 'recompute lastMessageAt/lastMessagePreview from the surviving older message — deleted content must not linger in the inbox',
+      actual: { lastMessageAt: conv.lastMessageAt, lastMessagePreview: conv.lastMessagePreview },
+      expected: { lastMessageAt: T1, lastMessagePreview: 'older words' },
+    });
+  });
+
+  it('soft-deleting the only DM clears the conversation preview', async () => {
+    seedConversation();
+    testDbState.seed('directMessages', [
+      { id: 'm-only', conversationId: 'conv-1', senderId: 'u-1', content: 'newest words', isActive: true, parentId: null, createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('m-only');
+
+    const conv = testDbState.rows('dmConversations')[0];
+    assert({
+      given: 'a soft-delete of the only active DM in the conversation',
+      should: 'null out both derived fields instead of leaving the deleted content visible',
+      actual: { lastMessageAt: conv.lastMessageAt, lastMessagePreview: conv.lastMessagePreview },
+      expected: { lastMessageAt: null, lastMessagePreview: null },
+    });
+  });
+
+  it('editing the newest DM recomputes the conversation preview to the new content', async () => {
+    seedConversation();
+    testDbState.seed('directMessages', [
+      { id: 'm-new', conversationId: 'conv-1', senderId: 'u-2', content: 'newest words', isActive: true, parentId: null, createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.editActiveMessage({
+      messageId: 'm-new',
+      content: 'edited words',
+      editedAt: new Date('2026-07-01T12:00:00Z'),
+    });
+
+    const conv = testDbState.rows('dmConversations')[0];
+    assert({
+      given: 'an edit of the newest top-level DM',
+      should: 'recompute the preview so the inbox shows the edited content, not the original',
+      actual: { lastMessageAt: conv.lastMessageAt, lastMessagePreview: conv.lastMessagePreview },
+      expected: { lastMessageAt: T2, lastMessagePreview: 'edited words' },
+    });
+  });
+
+  it('restoring a top-level DM recomputes the conversation preview from it', async () => {
+    testDbState.seed('dmConversations', [
+      { id: 'conv-1', participant1Id: 'u-1', participant2Id: 'u-2', lastMessageAt: T1, lastMessagePreview: 'older words' },
+    ]);
+    testDbState.seed('directMessages', [
+      { id: 'm-old', conversationId: 'conv-1', senderId: 'u-1', content: 'older words', isActive: true, parentId: null, createdAt: T1 },
+      { id: 'm-new', conversationId: 'conv-1', senderId: 'u-2', content: 'newest words', isActive: false, deletedAt: T2, parentId: null, createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.restoreDmMessage('m-new');
+
+    const conv = testDbState.rows('dmConversations')[0];
+    assert({
+      given: 'a restore of the newest (previously soft-deleted) top-level DM',
+      should: 'recompute the conversation derived state from the restored row',
+      actual: { lastMessageAt: conv.lastMessageAt, lastMessagePreview: conv.lastMessagePreview },
+      expected: { lastMessageAt: T2, lastMessagePreview: 'newest words' },
+    });
+  });
+
+  it('inserting a top-level DM recomputes the conversation preview inside the same transaction', async () => {
+    testDbState.seed('dmConversations', [
+      { id: 'conv-1', participant1Id: 'u-1', participant2Id: 'u-2', lastMessageAt: null, lastMessagePreview: null },
+    ]);
+
+    await dmMessageRepository.insertDmMessageWithAttachment({
+      conversationId: 'conv-1',
+      senderId: 'u-1',
+      content: 'fresh send',
+      fileId: null,
+      attachmentMeta: null,
+    });
+
+    const conv = testDbState.rows('dmConversations')[0];
+    const msg = testDbState.rows('directMessages')[0];
+    assert({
+      given: 'a top-level DM insert',
+      should: 'set the conversation derived state from the inserted row — the repository, not the route, owns the bump',
+      actual: { lastMessageAt: conv.lastMessageAt, lastMessagePreview: conv.lastMessagePreview },
+      expected: { lastMessageAt: msg.createdAt, lastMessagePreview: 'fresh send' },
+    });
+  });
+
+  it('a mirror created by alsoSendToParent bumps the conversation preview', async () => {
+    testDbState.seed('dmConversations', [
+      { id: 'conv-1', participant1Id: 'u-1', participant2Id: 'u-2', lastMessageAt: null, lastMessagePreview: null },
+    ]);
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 0, createdAt: T1 },
+    ]);
+
+    const result = await dmMessageRepository.insertDmThreadReply({
+      parentId: 'parent-1',
+      conversationId: 'conv-1',
+      senderId: 'u-2',
+      content: 'echoed reply',
+      fileId: null,
+      attachmentMeta: null,
+      alsoSendToParent: true,
+    });
+
+    const conv = testDbState.rows('dmConversations')[0];
+    assert({
+      given: 'a thread reply mirrored to the top-level stream',
+      should: 'derive the conversation preview from the mirror row inside the same transaction',
+      actual: {
+        kind: result.kind,
+        lastMessagePreview: conv.lastMessagePreview,
+        lastMessageAtIsDate: conv.lastMessageAt instanceof Date,
+      },
+      expected: { kind: 'ok', lastMessagePreview: 'echoed reply', lastMessageAtIsDate: true },
+    });
+  });
+
+  it('purging tombstones repairs a conversation preview that drifted before the fix', async () => {
+    // Pre-fix drift: the tombstone's content is still in the preview.
+    testDbState.seed('dmConversations', [
+      { id: 'conv-1', participant1Id: 'u-1', participant2Id: 'u-2', lastMessageAt: T2, lastMessagePreview: 'newest words' },
+    ]);
+    testDbState.seed('directMessages', [
+      { id: 'm-old', conversationId: 'conv-1', senderId: 'u-1', content: 'older words', isActive: true, parentId: null, createdAt: T1 },
+      { id: 'm-dead', conversationId: 'conv-1', senderId: 'u-2', content: 'newest words', isActive: false, deletedAt: new Date('2026-06-01T00:00:00Z'), parentId: null, createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.purgeInactiveMessages(new Date('2026-06-15T00:00:00Z'));
+
+    const conv = testDbState.rows('dmConversations')[0];
+    assert({
+      given: 'a purge that hard-deletes a tombstone whose content still sat in the (pre-fix drifted) preview',
+      should: 'recompute the preview from the surviving rows while purging',
+      actual: { lastMessageAt: conv.lastMessageAt, lastMessagePreview: conv.lastMessagePreview },
+      expected: { lastMessageAt: T1, lastMessagePreview: 'older words' },
+    });
+  });
+});
+
+describe('DM thread lastReplyAt recompute (#2153)', () => {
+  const T1 = new Date('2026-07-01T10:00:00Z');
+  const T2 = new Date('2026-07-01T11:00:00Z');
+
+  it('soft-deleting the newest reply moves parent.lastReplyAt back to the surviving reply', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 2, lastReplyAt: T2, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-2', content: 'first', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'reply-2', conversationId: 'conv-1', senderId: 'u-1', content: 'second', isActive: true, parentId: 'parent-1', createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('reply-2');
+
+    const parent = testDbState.rows('directMessages').find((r) => r.id === 'parent-1');
+    assert({
+      given: 'a soft-delete of the newest reply in a DM thread',
+      should: 'recompute lastReplyAt from the surviving replies instead of leaving it pointing at the deleted one',
+      actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
+      expected: { replyCount: 1, lastReplyAt: T1 },
+    });
+  });
+
+  it('soft-deleting the only reply clears parent.lastReplyAt', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 1, lastReplyAt: T1, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-2', content: 'only', isActive: true, parentId: 'parent-1', createdAt: T1 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('reply-1');
+
+    const parent = testDbState.rows('directMessages').find((r) => r.id === 'parent-1');
+    assert({
+      given: 'a soft-delete of the only reply in a DM thread',
+      should: 'clear lastReplyAt (no surviving replies) alongside the counter decrement',
+      actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
+      expected: { replyCount: 0, lastReplyAt: null },
+    });
+  });
+
+  it('restoring a reply recomputes parent.lastReplyAt from the now-surviving rows', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 1, lastReplyAt: T1, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-2', content: 'first', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'reply-2', conversationId: 'conv-1', senderId: 'u-1', content: 'second', isActive: false, deletedAt: T2, parentId: 'parent-1', createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.restoreDmMessage('reply-2');
+
+    const parent = testDbState.rows('directMessages').find((r) => r.id === 'parent-1');
+    assert({
+      given: 'a restore of the newest (previously soft-deleted) DM reply',
+      should: 'move lastReplyAt forward to the restored reply',
+      actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
+      expected: { replyCount: 2, lastReplyAt: T2 },
+    });
+  });
+});
+
+describe('DM mirror edit propagation (#2153)', () => {
+  const T1 = new Date('2026-07-01T10:00:00Z');
+  const editedAt = new Date('2026-07-01T12:00:00Z');
+
+  it('editing a thread reply propagates the new content to its top-level mirror', async () => {
+    testDbState.seed('dmConversations', [
+      { id: 'conv-1', participant1Id: 'u-1', participant2Id: 'u-2', lastMessageAt: T1, lastMessagePreview: 'echo' },
+    ]);
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-2', content: 'echo', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'mirror-1', conversationId: 'conv-1', senderId: 'u-2', content: 'echo', isActive: true, parentId: null, mirroredFromId: 'reply-1', createdAt: T1 },
+    ]);
+
+    await dmMessageRepository.editActiveMessage({ messageId: 'reply-1', content: 'edited echo', editedAt });
+
+    const mirror = testDbState.rows('directMessages').find((r) => r.id === 'mirror-1');
+    assert({
+      given: 'an edit of a thread reply that has an alsoSendToParent mirror',
+      should: 'propagate the edit to the mirror row so the two copies cannot disagree',
+      actual: { content: mirror?.content, isEdited: mirror?.isEdited, editedAt: mirror?.editedAt },
+      expected: { content: 'edited echo', isEdited: true, editedAt },
+    });
+  });
+
+  it('editing the mirror propagates the new content back to the thread reply', async () => {
+    testDbState.seed('dmConversations', [
+      { id: 'conv-1', participant1Id: 'u-1', participant2Id: 'u-2', lastMessageAt: T1, lastMessagePreview: 'echo' },
+    ]);
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-2', content: 'echo', isActive: true, parentId: 'parent-1', createdAt: T1 },
+      { id: 'mirror-1', conversationId: 'conv-1', senderId: 'u-2', content: 'echo', isActive: true, parentId: null, mirroredFromId: 'reply-1', createdAt: T1 },
+    ]);
+
+    await dmMessageRepository.editActiveMessage({ messageId: 'mirror-1', content: 'edited echo', editedAt });
+
+    const reply = testDbState.rows('directMessages').find((r) => r.id === 'reply-1');
+    assert({
+      given: 'an edit of the top-level mirror row',
+      should: 'propagate the edit back to the source thread reply',
+      actual: { content: reply?.content, isEdited: reply?.isEdited, editedAt: reply?.editedAt },
+      expected: { content: 'edited echo', isEdited: true, editedAt },
+    });
+  });
+});

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -180,9 +180,9 @@ describe('dmMessageRepository.restoreDmMessage', () => {
 
     assert({
       given: 'a DM restore parent re-read inside the tx',
-      should: 'invoke .for("update") against directMessages exactly once — the lock blocks a concurrent softDelete until the bump commits',
+      should: 'invoke .for("update") against directMessages twice — once for the parent re-validation before the replyCount bump, once more inside recomputeThreadLastReply (#2153) before it re-derives lastReplyAt — both against the same parent row, so the second is a safe reentrant re-lock, not a new race window',
       actual: testDbState.selectsForUpdate('directMessages').length,
-      expected: 1,
+      expected: 2,
     });
   });
 });
@@ -1437,6 +1437,22 @@ describe('DM conversation derived state (#2153)', () => {
       expected: { lastMessageAt: T1, lastMessagePreview: 'older words' },
     });
   });
+
+  it('locks the conversation row before recomputing (SELECT ... FOR UPDATE), so a concurrent recompute cannot interleave and overwrite a fresher preview with a stale one', async () => {
+    seedConversation();
+    testDbState.seed('directMessages', [
+      { id: 'm-only', conversationId: 'conv-1', senderId: 'u-1', content: 'newest words', isActive: true, parentId: null, createdAt: T2 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('m-only');
+
+    assert({
+      given: 'a soft-delete that triggers the conversation-preview recompute — a path with no pre-existing parent-row lock to piggyback on',
+      should: 'invoke .for("update") against dmConversations exactly once before reading the surviving messages (#2153) — this is the lock a concurrent send/edit/delete/restore/purge on the same conversation must serialize against',
+      actual: testDbState.selectsForUpdate('dmConversations').length,
+      expected: 1,
+    });
+  });
 });
 
 describe('DM thread lastReplyAt recompute (#2153)', () => {
@@ -1493,6 +1509,22 @@ describe('DM thread lastReplyAt recompute (#2153)', () => {
       should: 'move lastReplyAt forward to the restored reply',
       actual: { replyCount: parent?.replyCount, lastReplyAt: parent?.lastReplyAt },
       expected: { replyCount: 2, lastReplyAt: T2 },
+    });
+  });
+
+  it('locks the parent row before recomputing lastReplyAt on soft-delete — a path with no pre-existing parent lock to piggyback on', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', content: 'root', isActive: true, parentId: null, replyCount: 1, lastReplyAt: T1, createdAt: new Date('2026-07-01T09:00:00Z') },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-2', content: 'only', isActive: true, parentId: 'parent-1', createdAt: T1 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('reply-1');
+
+    assert({
+      given: 'a reply soft-delete — softDeleteMessage never pre-locks the parent the way restoreDmMessage does',
+      should: 'invoke .for("update") against the parent row exactly once via recomputeThreadLastReply (#2153), closing the same concurrent-delete race window restore already had covered',
+      actual: testDbState.selectsForUpdate('directMessages').length,
+      expected: 1,
     });
   });
 });

--- a/packages/lib/src/services/__tests__/message-derived-state.test.ts
+++ b/packages/lib/src/services/__tests__/message-derived-state.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildLastMessagePreview,
+  deriveConversationLastMessage,
+  deriveLatestTimestamp,
+} from '../message-derived-state';
+import type { AttachmentMeta } from '@pagespace/db/schema/storage';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+};
+
+const imageMeta: AttachmentMeta = {
+  originalName: 'photo.png',
+  size: 1024,
+  mimeType: 'image/png',
+  contentHash: 'hash-1',
+};
+
+const pdfMeta: AttachmentMeta = {
+  originalName: 'doc.pdf',
+  size: 2048,
+  mimeType: 'application/pdf',
+  contentHash: 'hash-2',
+};
+
+describe('buildLastMessagePreview', () => {
+  it('returns trimmed content when present', () => {
+    assert({
+      given: 'non-empty content with surrounding whitespace',
+      should: 'return the trimmed content verbatim',
+      actual: buildLastMessagePreview('  hello there  ', null),
+      expected: 'hello there',
+    });
+  });
+
+  it('truncates content longer than 100 chars with an ellipsis', () => {
+    const long = 'x'.repeat(150);
+    assert({
+      given: 'content longer than 100 characters',
+      should: 'truncate to 100 chars plus an ellipsis',
+      actual: buildLastMessagePreview(long, null),
+      expected: 'x'.repeat(100) + '...',
+    });
+  });
+
+  it('uses the [image: name] placeholder for image attachments with empty content', () => {
+    assert({
+      given: 'whitespace-only content with an image attachment',
+      should: 'fall back to the image placeholder',
+      actual: buildLastMessagePreview('   ', imageMeta),
+      expected: '[image: photo.png]',
+    });
+  });
+
+  it('uses the [file: name] placeholder for non-image attachments with empty content', () => {
+    assert({
+      given: 'empty content with a non-image attachment',
+      should: 'fall back to the file placeholder',
+      actual: buildLastMessagePreview('', pdfMeta),
+      expected: '[file: doc.pdf]',
+    });
+  });
+
+  it('returns an empty string when there is neither content nor attachment', () => {
+    assert({
+      given: 'empty content and no attachment',
+      should: 'return an empty string',
+      actual: buildLastMessagePreview('', null),
+      expected: '',
+    });
+  });
+});
+
+describe('deriveConversationLastMessage', () => {
+  it('derives timestamp and preview from the newest surviving row', () => {
+    const createdAt = new Date('2026-07-01T10:00:00Z');
+    assert({
+      given: 'a newest surviving active top-level message',
+      should: 'derive lastMessageAt from its createdAt and the preview from its content',
+      actual: deriveConversationLastMessage({ createdAt, content: 'latest words', attachmentMeta: null }),
+      expected: { lastMessageAt: createdAt, lastMessagePreview: 'latest words' },
+    });
+  });
+
+  it('derives the attachment placeholder when the newest row is attachment-only', () => {
+    const createdAt = new Date('2026-07-01T11:00:00Z');
+    assert({
+      given: 'a newest surviving message with no text but an image attachment',
+      should: 'derive the preview via the attachment placeholder',
+      actual: deriveConversationLastMessage({ createdAt, content: '', attachmentMeta: imageMeta }),
+      expected: { lastMessageAt: createdAt, lastMessagePreview: '[image: photo.png]' },
+    });
+  });
+
+  it('clears both fields when no active message survives', () => {
+    assert({
+      given: 'no surviving active top-level message',
+      should: 'null out both derived fields so no deleted content lingers',
+      actual: deriveConversationLastMessage(null),
+      expected: { lastMessageAt: null, lastMessagePreview: null },
+    });
+  });
+});
+
+describe('deriveLatestTimestamp', () => {
+  it('returns the max timestamp from an unsorted list', () => {
+    const a = new Date('2026-07-01T10:00:00Z');
+    const b = new Date('2026-07-03T10:00:00Z');
+    const c = new Date('2026-07-02T10:00:00Z');
+    assert({
+      given: 'several surviving timestamps in arbitrary order',
+      should: 'return the latest one',
+      actual: deriveLatestTimestamp([a, b, c]),
+      expected: b,
+    });
+  });
+
+  it('returns null for an empty list', () => {
+    assert({
+      given: 'no surviving rows',
+      should: 'return null so the derived column is cleared, not left stale',
+      actual: deriveLatestTimestamp([]),
+      expected: null,
+    });
+  });
+});

--- a/packages/lib/src/services/__tests__/test-doubles/db.ts
+++ b/packages/lib/src/services/__tests__/test-doubles/db.ts
@@ -169,6 +169,7 @@ let nextAutoId = 0;
 const autoId = () => `auto-${++nextAutoId}`;
 
 const messageDefaults = (): Row => ({
+  content: '',
   isActive: true,
   replyCount: 0,
   lastReplyAt: null,
@@ -221,8 +222,13 @@ export class DbState {
   private transactionCallCount = 0;
 
   seed(table: string, rows: Row[]): void {
+    // Route through the same applyDefaults() an insert() uses — a seeded row
+    // simulates one already in the DB, so it must carry the same NOT NULL
+    // column defaults (e.g. directMessages.content) an inserted row gets.
+    // Without this, a fixture that omits an unrelated column silently
+    // produces `undefined` where production would never allow it.
     const cur = this.tables.get(table) ?? [];
-    cur.push(...rows.map((r) => ({ ...r })));
+    cur.push(...rows.map((r) => applyDefaults(table, { ...r })));
     this.tables.set(table, cur);
   }
 

--- a/packages/lib/src/services/channel-message-repository.ts
+++ b/packages/lib/src/services/channel-message-repository.ts
@@ -270,9 +270,18 @@ export interface UpdateChannelMessageContentInput {
  * (#2153). Soft-delete/restore of a reply calls this after adjusting
  * `replyCount` so the timestamp always points at a surviving reply instead
  * of a tombstoned one. Mirrors `recomputeThreadLastReply` in
- * `dm-message-repository.ts`.
+ * `dm-message-repository.ts`, including the parent-row lock: two concurrent
+ * reply deletes under the same parent can otherwise each snapshot
+ * "surviving replies" before the other's tombstone commits, and the later
+ * commit can silently restore `lastReplyAt` to an already-deleted reply.
  */
 async function recomputeThreadLastReply(tx: Tx, parentId: string): Promise<void> {
+  await tx
+    .select({ id: channelMessages.id })
+    .from(channelMessages)
+    .where(eq(channelMessages.id, parentId))
+    .for('update');
+
   const replies = await tx
     .select({ createdAt: channelMessages.createdAt })
     .from(channelMessages)

--- a/packages/lib/src/services/channel-message-repository.ts
+++ b/packages/lib/src/services/channel-message-repository.ts
@@ -20,6 +20,7 @@ import {
 } from '@pagespace/db/schema/chat';
 import { files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 import { decryptField } from '../encryption/field-crypto';
+import { deriveLatestTimestamp } from './message-derived-state';
 
 export type ChannelMessageRow = InferSelectModel<typeof channelMessages>;
 export type ChannelReactionRow = InferSelectModel<typeof channelMessageReactions>;
@@ -264,17 +265,89 @@ export interface UpdateChannelMessageContentInput {
   aiMeta?: ChannelMessageAiMeta | null;
 }
 
+/**
+ * The "message mutated" recompute for a channel thread's `lastReplyAt`
+ * (#2153). Soft-delete/restore of a reply calls this after adjusting
+ * `replyCount` so the timestamp always points at a surviving reply instead
+ * of a tombstoned one. Mirrors `recomputeThreadLastReply` in
+ * `dm-message-repository.ts`.
+ */
+async function recomputeThreadLastReply(tx: Tx, parentId: string): Promise<void> {
+  const replies = await tx
+    .select({ createdAt: channelMessages.createdAt })
+    .from(channelMessages)
+    .where(
+      and(
+        eq(channelMessages.parentId, parentId),
+        eq(channelMessages.isActive, true)
+      )
+    );
+
+  await tx
+    .update(channelMessages)
+    .set({ lastReplyAt: deriveLatestTimestamp(replies.map((r) => r.createdAt)) })
+    .where(eq(channelMessages.id, parentId));
+}
+
+interface ChannelMirrorEditPropagationInput {
+  id: string;
+  content: string;
+  editedAt: Date;
+  mirroredFromId: string | null;
+}
+
+/**
+ * Propagate an edit to the other half of a `mirroredFromId` pair (#2153) —
+ * a thread reply and its "Also send to channel" top-level mirror must never
+ * disagree after one side is edited. Mirrors `propagateMirrorEdit` in
+ * `dm-message-repository.ts`. Deliberately excludes `aiMeta`: that field
+ * describes the sender of the specific row being edited, not shared content,
+ * so it must never be copied across to the other row.
+ */
+async function propagateChannelMirrorEdit(
+  tx: Tx,
+  edited: ChannelMirrorEditPropagationInput
+): Promise<void> {
+  const patch = { content: edited.content, editedAt: edited.editedAt };
+  if (edited.mirroredFromId) {
+    await tx
+      .update(channelMessages)
+      .set(patch)
+      .where(eq(channelMessages.id, edited.mirroredFromId));
+    return;
+  }
+  await tx
+    .update(channelMessages)
+    .set(patch)
+    .where(eq(channelMessages.mirroredFromId, edited.id));
+}
+
 async function updateChannelMessageContent(
   input: UpdateChannelMessageContentInput
 ): Promise<void> {
-  await db
-    .update(channelMessages)
-    .set({
+  await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(channelMessages)
+      .set({
+        content: input.content,
+        editedAt: input.editedAt,
+        ...(input.aiMeta !== undefined ? { aiMeta: input.aiMeta } : {}),
+      })
+      .where(eq(channelMessages.id, input.messageId))
+      .returning({
+        id: channelMessages.id,
+        mirroredFromId: channelMessages.mirroredFromId,
+      });
+
+    if (!row) return;
+
+    await propagateChannelMirrorEdit(tx, {
+      id: row.id,
       content: input.content,
       editedAt: input.editedAt,
-      ...(input.aiMeta !== undefined ? { aiMeta: input.aiMeta } : {}),
-    })
-    .where(eq(channelMessages.id, input.messageId));
+      mirroredFromId: row.mirroredFromId,
+    });
+  });
 }
 
 async function softDeleteChannelMessage(messageId: string): Promise<number> {
@@ -303,6 +376,9 @@ async function softDeleteChannelMessage(messageId: string): Promise<number> {
           replyCount: sql`GREATEST(${channelMessages.replyCount} - 1, 0)`,
         })
         .where(eq(channelMessages.id, row.parentId));
+      // The deleted row was itself a reply — its parent's lastReplyAt may
+      // have pointed at the row we just tombstoned (#2153).
+      await recomputeThreadLastReply(tx, row.parentId);
     }
 
     return result.length;
@@ -342,6 +418,9 @@ async function restoreChannelMessage(messageId: string): Promise<number> {
             replyCount: sql`${channelMessages.replyCount} + 1`,
           })
           .where(eq(channelMessages.id, row.parentId));
+        // Mirrors the counter bump's own guard — only move lastReplyAt
+        // forward for a parent that's still active (#2153).
+        await recomputeThreadLastReply(tx, row.parentId);
       }
     }
 

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -229,16 +229,30 @@ async function insertDmMessageWithAttachment(
  * / `lastMessagePreview` (#2153). Every mutation that can change which
  * top-level message is newest — insert, edit, soft-delete, restore, purge —
  * calls this instead of writing the derived fields ad hoc, so none of them
- * can drift from the surviving rows. Always re-derives from a fresh query
- * inside the caller's transaction rather than trusting the mutation's own
- * row to still be newest, which is what makes this safe to call
- * unconditionally instead of threading a "was this the newest row" check
- * through every call site.
+ * can drift from the surviving rows.
+ *
+ * Locks the conversation row FIRST, before reading the surviving messages.
+ * Without this, two concurrent recomputes for the same conversation (e.g.
+ * two concurrent sends) can each snapshot "newest message" before the
+ * other's insert commits — whichever recompute commits last then silently
+ * overwrites a fresher preview with a stale one, and nothing repairs it
+ * until the next mutation touches that conversation. The lock forces
+ * concurrent recomputes to serialize: the second one only proceeds after
+ * the first commits, at which point its own SELECT sees the first's
+ * already-committed row too. Mirrors the `SELECT ... FOR UPDATE` pattern
+ * `restoreDmMessage` already uses to serialize a parent-row bump against a
+ * concurrent soft-delete.
  */
 async function recomputeConversationLastMessage(
   tx: Tx,
   conversationId: string
 ): Promise<void> {
+  await tx
+    .select({ id: dmConversations.id })
+    .from(dmConversations)
+    .where(eq(dmConversations.id, conversationId))
+    .for('update');
+
   const [newest] = await tx
     .select({
       createdAt: directMessages.createdAt,
@@ -272,8 +286,21 @@ async function recomputeConversationLastMessage(
  * Soft-delete/restore of a reply calls this after adjusting `replyCount` so
  * the timestamp always points at a surviving reply instead of a tombstoned
  * one.
+ *
+ * Locks the parent row first, for the same reason
+ * `recomputeConversationLastMessage` locks the conversation row: two
+ * concurrent reply deletes under the same parent can otherwise each
+ * snapshot "surviving replies" before the other's tombstone commits, and
+ * the later commit can silently restore `lastReplyAt` to an
+ * already-deleted reply.
  */
 async function recomputeThreadLastReply(tx: Tx, parentId: string): Promise<void> {
+  await tx
+    .select({ id: directMessages.id })
+    .from(directMessages)
+    .where(eq(directMessages.id, parentId))
+    .for('update');
+
   const replies = await tx
     .select({ createdAt: directMessages.createdAt })
     .from(directMessages)

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -12,6 +12,7 @@ import { and, asc, desc, eq, gt, isNotNull, isNull, lt, or, sql, type InferSelec
 import { dmConversations, directMessages, dmMessageReactions, dmThreadFollowers } from '@pagespace/db/schema/social';
 import { fileConversations, files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 import { decryptField } from '../encryption/field-crypto';
+import { deriveConversationLastMessage, deriveLatestTimestamp } from './message-derived-state';
 
 /**
  * Decrypt the joined sender/reactor `name` PII on a loaded DM row in place
@@ -217,37 +218,116 @@ async function insertDmMessageWithAttachment(
       })
       .returning();
 
+    await recomputeConversationLastMessage(tx, input.conversationId);
+
     return { kind: 'ok', message: row };
   });
 }
 
-export interface UpdateConversationLastMessageInput {
-  conversationId: string;
-  lastMessageAt: Date;
-  lastMessagePreview: string;
-}
-
-async function updateConversationLastMessage(
-  input: UpdateConversationLastMessageInput
+/**
+ * The single "message mutated" recompute for `dmConversations.lastMessageAt`
+ * / `lastMessagePreview` (#2153). Every mutation that can change which
+ * top-level message is newest — insert, edit, soft-delete, restore, purge —
+ * calls this instead of writing the derived fields ad hoc, so none of them
+ * can drift from the surviving rows. Always re-derives from a fresh query
+ * inside the caller's transaction rather than trusting the mutation's own
+ * row to still be newest, which is what makes this safe to call
+ * unconditionally instead of threading a "was this the newest row" check
+ * through every call site.
+ */
+async function recomputeConversationLastMessage(
+  tx: Tx,
+  conversationId: string
 ): Promise<void> {
-  // Guard against out-of-order writes: only apply when the stored timestamp
-  // is null or strictly older than the new row's createdAt. Two concurrent
-  // sends can otherwise let an older message overwrite the inbox preview.
-  await db
-    .update(dmConversations)
-    .set({
-      lastMessageAt: input.lastMessageAt,
-      lastMessagePreview: input.lastMessagePreview,
+  const [newest] = await tx
+    .select({
+      createdAt: directMessages.createdAt,
+      content: directMessages.content,
+      attachmentMeta: directMessages.attachmentMeta,
     })
+    .from(directMessages)
     .where(
       and(
-        eq(dmConversations.id, input.conversationId),
-        or(
-          isNull(dmConversations.lastMessageAt),
-          lt(dmConversations.lastMessageAt, input.lastMessageAt)
-        )
+        eq(directMessages.conversationId, conversationId),
+        eq(directMessages.isActive, true),
+        isNull(directMessages.parentId)
+      )
+    )
+    .orderBy(desc(directMessages.createdAt))
+    .limit(1);
+
+  const derived = deriveConversationLastMessage(newest ?? null);
+
+  await tx
+    .update(dmConversations)
+    .set({
+      lastMessageAt: derived.lastMessageAt,
+      lastMessagePreview: derived.lastMessagePreview,
+    })
+    .where(eq(dmConversations.id, conversationId));
+}
+
+/**
+ * The "message mutated" recompute for a DM thread's `lastReplyAt` (#2153).
+ * Soft-delete/restore of a reply calls this after adjusting `replyCount` so
+ * the timestamp always points at a surviving reply instead of a tombstoned
+ * one.
+ */
+async function recomputeThreadLastReply(tx: Tx, parentId: string): Promise<void> {
+  const replies = await tx
+    .select({ createdAt: directMessages.createdAt })
+    .from(directMessages)
+    .where(
+      and(
+        eq(directMessages.parentId, parentId),
+        eq(directMessages.isActive, true)
       )
     );
+
+  await tx
+    .update(directMessages)
+    .set({ lastReplyAt: deriveLatestTimestamp(replies.map((r) => r.createdAt)) })
+    .where(eq(directMessages.id, parentId));
+}
+
+interface MirrorEditPropagationInput {
+  id: string;
+  content: string;
+  isEdited: boolean;
+  editedAt: Date;
+  mirroredFromId: string | null;
+}
+
+/**
+ * Propagate an edit to the other half of a `mirroredFromId` pair (#2153) —
+ * a thread reply and its "Also send to DM" top-level mirror must never
+ * disagree after one side is edited. Whichever side was edited, this finds
+ * and updates its sibling: if the edited row itself carries
+ * `mirroredFromId`, it IS the mirror, so update the source reply; otherwise
+ * look for a mirror row pointing back at the edited row. A message with no
+ * mirror relationship in either direction makes the second branch a no-op
+ * (zero rows match).
+ */
+async function propagateMirrorEdit(
+  tx: Tx,
+  edited: MirrorEditPropagationInput
+): Promise<void> {
+  const patch = {
+    content: edited.content,
+    isEdited: edited.isEdited,
+    editedAt: edited.editedAt,
+  };
+  if (edited.mirroredFromId) {
+    await tx
+      .update(directMessages)
+      .set(patch)
+      .where(eq(directMessages.id, edited.mirroredFromId));
+    return;
+  }
+  await tx
+    .update(directMessages)
+    .set(patch)
+    .where(eq(directMessages.mirroredFromId, edited.id));
 }
 
 export interface ActiveMessageLookupInput {
@@ -306,7 +386,11 @@ async function softDeleteMessage(messageId: string): Promise<number> {
           eq(directMessages.isActive, true)
         )
       )
-      .returning({ id: directMessages.id, parentId: directMessages.parentId });
+      .returning({
+        id: directMessages.id,
+        parentId: directMessages.parentId,
+        conversationId: directMessages.conversationId,
+      });
 
     const row = result[0];
     if (row?.parentId) {
@@ -316,6 +400,16 @@ async function softDeleteMessage(messageId: string): Promise<number> {
           replyCount: sql`GREATEST(${directMessages.replyCount} - 1, 0)`,
         })
         .where(eq(directMessages.id, row.parentId));
+      // The deleted row was itself a reply — its parent's lastReplyAt may
+      // have pointed at the row we just tombstoned (#2153).
+      await recomputeThreadLastReply(tx, row.parentId);
+    }
+    if (row) {
+      // Recompute unconditionally, not just for a top-level delete — a
+      // tombstoned mirror row is also top-level (parentId === null) and
+      // must repair the inbox preview the same way a plain top-level
+      // delete does.
+      await recomputeConversationLastMessage(tx, row.conversationId);
     }
 
     return result.length;
@@ -342,7 +436,11 @@ async function restoreDmMessage(messageId: string): Promise<number> {
           eq(directMessages.isActive, false)
         )
       )
-      .returning({ id: directMessages.id, parentId: directMessages.parentId });
+      .returning({
+        id: directMessages.id,
+        parentId: directMessages.parentId,
+        conversationId: directMessages.conversationId,
+      });
 
     const row = result[0];
     if (row?.parentId) {
@@ -358,7 +456,13 @@ async function restoreDmMessage(messageId: string): Promise<number> {
             replyCount: sql`${directMessages.replyCount} + 1`,
           })
           .where(eq(directMessages.id, row.parentId));
+        // Mirrors the counter bump's own guard — only move lastReplyAt
+        // forward for a parent that's still active (#2153).
+        await recomputeThreadLastReply(tx, row.parentId);
       }
+    }
+    if (row) {
+      await recomputeConversationLastMessage(tx, row.conversationId);
     }
 
     return result.length;
@@ -430,6 +534,14 @@ async function purgeInactiveMessages(olderThan: Date): Promise<number> {
       `);
     }
 
+    // Repair any conversation whose preview drifted before this fix existed
+    // — a purge is exactly the kind of non-insert mutation path the issue
+    // calls out as able to skip the bump silently (#2153).
+    const purgedConversationIds = new Set(purgedMessages.map((m) => m.conversationId));
+    for (const conversationId of purgedConversationIds) {
+      await recomputeConversationLastMessage(tx, conversationId);
+    }
+
     return purgedMessages.length;
   });
 }
@@ -441,17 +553,42 @@ export interface EditActiveMessageInput {
 }
 
 async function editActiveMessage(input: EditActiveMessageInput): Promise<number> {
-  const result = await db
-    .update(directMessages)
-    .set({ content: input.content, isEdited: true, editedAt: input.editedAt })
-    .where(
-      and(
-        eq(directMessages.id, input.messageId),
-        eq(directMessages.isActive, true)
+  return db.transaction(async (tx) => {
+    const result = await tx
+      .update(directMessages)
+      .set({ content: input.content, isEdited: true, editedAt: input.editedAt })
+      .where(
+        and(
+          eq(directMessages.id, input.messageId),
+          eq(directMessages.isActive, true)
+        )
       )
-    )
-    .returning({ id: directMessages.id });
-  return result.length;
+      .returning({
+        id: directMessages.id,
+        conversationId: directMessages.conversationId,
+        mirroredFromId: directMessages.mirroredFromId,
+      });
+
+    const row = result[0];
+    if (!row) return 0;
+
+    // The edited row may itself be a mirror, or may have its own mirror
+    // (#2153) — propagate either way so the two copies can't disagree.
+    await propagateMirrorEdit(tx, {
+      id: row.id,
+      content: input.content,
+      isEdited: true,
+      editedAt: input.editedAt,
+      mirroredFromId: row.mirroredFromId,
+    });
+
+    // Whichever side changed content might be the top-level message the
+    // conversation preview is derived from — recompute unconditionally
+    // rather than threading a "was this row top-level" check through here.
+    await recomputeConversationLastMessage(tx, row.conversationId);
+
+    return result.length;
+  });
 }
 
 export interface ListActiveMessagesInput {
@@ -660,6 +797,11 @@ async function insertDmThreadReply(
         })
         .returning();
       mirror = mirrorRow;
+      // The mirror is a top-level row and behaves like a regular send —
+      // recompute the conversation preview from it (#2153). A thread-only
+      // reply (no mirror) intentionally does NOT reach this — it doesn't
+      // touch the top-level stream the preview is derived from.
+      await recomputeConversationLastMessage(tx, input.conversationId);
     }
 
     return {
@@ -814,7 +956,6 @@ async function removeDmReaction(input: DmReactionInput): Promise<number> {
 export const dmMessageRepository = {
   findConversationForParticipant,
   insertDmMessageWithAttachment,
-  updateConversationLastMessage,
   findActiveMessage,
   findMessageInConversation,
   softDeleteMessage,

--- a/packages/lib/src/services/message-derived-state.ts
+++ b/packages/lib/src/services/message-derived-state.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure derivations for the denormalized message metadata (#2153).
+ *
+ * `dmConversations.lastMessageAt`/`lastMessagePreview` and thread
+ * `lastReplyAt` are copies derived from the surviving active message rows.
+ * These functions are the single source for computing those values — the
+ * repository shells fetch the surviving rows and apply what these return, so
+ * every mutation path (insert, edit, delete, restore, purge, stream
+ * recovery) recomputes the same way instead of re-implementing the bump at
+ * each insert site and forgetting it at each non-insert site.
+ *
+ * @module @pagespace/lib/services/message-derived-state
+ */
+
+import type { AttachmentMeta } from '@pagespace/db/schema/storage';
+
+/**
+ * Inbox preview for a message: trimmed content (truncated at 100 chars),
+ * falling back to an attachment placeholder, falling back to ''.
+ * Shared by the DM send route (notification/broadcast payloads) and the
+ * conversation recompute so the two can never derive different previews.
+ */
+export function buildLastMessagePreview(
+  content: string,
+  attachmentMeta: AttachmentMeta | null
+): string {
+  const trimmed = content.trim();
+  if (trimmed.length > 0) {
+    return trimmed.length > 100 ? trimmed.substring(0, 100) + '...' : trimmed;
+  }
+  if (attachmentMeta) {
+    const isImage = attachmentMeta.mimeType.startsWith('image/');
+    return isImage
+      ? `[image: ${attachmentMeta.originalName}]`
+      : `[file: ${attachmentMeta.originalName}]`;
+  }
+  return '';
+}
+
+export interface NewestConversationMessage {
+  createdAt: Date;
+  content: string;
+  attachmentMeta: AttachmentMeta | null;
+}
+
+export interface ConversationLastMessageState {
+  lastMessageAt: Date | null;
+  lastMessagePreview: string | null;
+}
+
+/**
+ * Derive a DM conversation's inbox fields from its newest surviving active
+ * top-level message. `null` (nothing survives) clears both fields so deleted
+ * content cannot linger in the inbox.
+ */
+export function deriveConversationLastMessage(
+  newest: NewestConversationMessage | null
+): ConversationLastMessageState {
+  if (!newest) {
+    return { lastMessageAt: null, lastMessagePreview: null };
+  }
+  return {
+    lastMessageAt: newest.createdAt,
+    lastMessagePreview: buildLastMessagePreview(newest.content, newest.attachmentMeta),
+  };
+}
+
+/**
+ * Latest of the surviving timestamps, or `null` when none survive. Used for
+ * thread `lastReplyAt` (from the active replies) and global
+ * `conversations.lastMessageAt` (from the active messages).
+ */
+export function deriveLatestTimestamp(timestamps: readonly Date[]): Date | null {
+  let latest: Date | null = null;
+  for (const t of timestamps) {
+    if (latest === null || t.getTime() > latest.getTime()) {
+      latest = t;
+    }
+  }
+  return latest;
+}


### PR DESCRIPTION
## Summary

Four chat denormalizations were bumped on insert but never repaired on the other mutation paths, so deleted or edited content kept showing in previews and sort order:

1. **DM inbox preview survives delete/edit** — `dmConversations.lastMessageAt`/`lastMessagePreview` were only bumped on insert, with an out-of-order guard. `softDeleteMessage`, `editActiveMessage`, and `purgeInactiveMessages` never touched them. Fixed with a single `recomputeConversationLastMessage()` in `dm-message-repository.ts` that re-derives both fields from the newest surviving active top-level row, called from every mutation (insert, edit, soft-delete, restore, purge, and the mirror-insert path) inside the same transaction.
2. **Thread `lastReplyAt` points at deleted replies** (DM and channel) — soft-deleting/restoring the newest reply left the timestamp stale even though `replyCount` was correctly maintained. Fixed with `recomputeThreadLastReply()` in both `dm-message-repository.ts` and `channel-message-repository.ts`.
3. **Mirror messages diverge on edit** — editing a thread reply or its "Also send to..." top-level mirror never propagated to the other copy. Fixed with `propagateMirrorEdit()`/`propagateChannelMirrorEdit()`, which finds and updates whichever side wasn't directly edited (in either direction).
4. **Interrupted-stream recovery skips `conversations.lastMessageAt`** — the global-assistant AI routes bump it after every persist, but `materialize-interrupted-stream.ts` inserted the recovered assistant message without bumping it. Fixed with a new `globalConversationRepository.recomputeLastMessageAt()`, called by the materializer (inside the same try/catch as the message write, so a recompute failure degrades like a failed write) and by the repository's own soft-delete/hard-delete/purge paths.

The shared derivation logic (preview synthesis, latest-timestamp selection) lives in a new pure module, `packages/lib/src/services/message-derived-state.ts`; the repository functions are the imperative shell that fetches the surviving rows and applies it.

Also fixes 6 pre-existing tests that broke because `materialize-interrupted-stream.ts` now transitively imports `global-conversation-repository.ts` — whose module-scope `hasMessages` query needs `sql`/`exists` from the `@pagespace/db/operators` mock, and one test's `@pagespace/db/db` mock factory needed its referenced constants moved into `vi.hoisted()` to avoid a TDZ error now that the factory can run earlier in the module graph.

### Concurrency safety (follow-up to automated review)

Two independent review passes (chatgpt-codex-connector) correctly flagged that removing the old `lastMessageAt < input.lastMessageAt` out-of-order guard reintroduced a lost-update race: two concurrent recomputes for the same row could each snapshot "surviving messages" before the other's mutation commits, and whichever writes last silently overwrites a fresher state with a stale one. Fixed in `cbf1b7b82` by taking a `SELECT ... FOR UPDATE` lock on the target row *before* reading the surviving messages, in every recompute path:

- `recomputeConversationLastMessage` (DM) and `recomputeLastMessageAt` (global) — lock the conversation row.
- `recomputeThreadLastReply` (DM and channel) — lock the parent row; applied proactively to the structurally identical race for concurrent reply deletes under the same parent, even though only the conversation-preview case was explicitly flagged.

A plain `UPDATE` from an unrelated path (e.g. the AI routes' own `lastMessageAt` bump on stream completion) also takes Postgres's implicit row lock, so it serializes correctly against these transactions without needing to be lock-aware itself. Lock ordering across all multi-lock paths was manually audited for deadlock risk — no path acquires locks in a conflicting order relative to any other.

## Test plan

- [x] RED tests written first reproducing each of the four drift sites, then made to pass (`packages/lib/src/services/__tests__/dm-message-repository.test.ts`, `channel-message-repository.test.ts`, `message-derived-state.test.ts`; `apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts`; `apps/web/src/lib/repositories/__tests__/global-conversation-last-message-recompute.test.ts`, `global-conversation-hard-delete.test.ts`)
- [x] Concurrency-safety tests added asserting each recompute path takes its row lock (`SELECT ... FOR UPDATE`) before writing
- [x] `bun run typecheck` — green across the monorepo
- [x] `bun run test:unit` — green (packages/lib: 393/393 files; apps/web: only 3 pre-existing, unrelated environment failures — a Postgres role-config issue, a timezone-sensitive date test, and one already-failing test on master — none touch the changed code)
- [x] `bun run lint` on all changed files — clean
- [x] CI: all required checks green (Lint & TypeScript, Unit Tests, CodeQL, Security Test Suite, Static Security Analysis, Dependency Audit, Secret Scanning)

Closes #2153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message previews and conversation timestamps after sending, editing, deleting, restoring, or purging messages.
  * Fixed thread reply timestamps so they accurately reflect the latest active reply.
  * Kept mirrored messages synchronized when content is edited.
  * Improved global conversation ordering after interrupted AI responses and message changes.
  * Added clearer previews for image and file attachments when message text is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->