### PR TITLE
fix(web): list_pages returns empty results for parentId: "" at drive root

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -231,6 +231,36 @@ describe('page-read-tools', () => {
         });
       });
 
+      it('treats parentId: "" the same as omitting parentId at drive root', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, parentId: '' },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        assert({
+          given: 'list_pages with parentId: "" at drive root',
+          should: 'return success',
+          actual: result.success,
+          expected: true,
+        });
+
+        const pages = result.pages as Array<{ id: string }>;
+        assert({
+          given: 'list_pages with parentId: "" at drive root',
+          should: 'return the same root-level pages as omitting parentId (2, not 0)',
+          actual: pages.length,
+          expected: 2,
+        });
+
+        assert({
+          given: 'list_pages with parentId: "" at drive root',
+          should: 'not include the nested child page',
+          actual: pages.some(p => p.id === 'child-1'),
+          expected: false,
+        });
+      });
+
       it('includes hasChildren flag indicating whether folder has children', async () => {
         setupDriveAccess();
         const result = await pageReadTools.list_pages.execute!(

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -233,7 +233,11 @@ describe('page-read-tools', () => {
 
       it('treats parentId: "" the same as omitting parentId at drive root', async () => {
         setupDriveAccess();
-        const result = await pageReadTools.list_pages.execute!(
+        const omittedResult = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug },
+          createAuthContext()
+        ) as Record<string, unknown>;
+        const emptyStringResult = await pageReadTools.list_pages.execute!(
           { driveId, driveSlug, parentId: '' },
           createAuthContext()
         ) as Record<string, unknown>;
@@ -241,22 +245,31 @@ describe('page-read-tools', () => {
         assert({
           given: 'list_pages with parentId: "" at drive root',
           should: 'return success',
-          actual: result.success,
+          actual: emptyStringResult.success,
           expected: true,
         });
 
-        const pages = result.pages as Array<{ id: string }>;
+        const omittedPageIds = (omittedResult.pages as Array<{ id: string }>).map(p => p.id).sort();
+        const emptyStringPageIds = (emptyStringResult.pages as Array<{ id: string }>).map(p => p.id).sort();
+
         assert({
           given: 'list_pages with parentId: "" at drive root',
-          should: 'return the same root-level pages as omitting parentId (2, not 0)',
-          actual: pages.length,
-          expected: 2,
+          should: 'return the same pages as omitting parentId',
+          actual: emptyStringPageIds,
+          expected: omittedPageIds,
+        });
+
+        assert({
+          given: 'list_pages with parentId: "" at drive root',
+          should: 'return the same location as omitting parentId',
+          actual: emptyStringResult.location,
+          expected: omittedResult.location,
         });
 
         assert({
           given: 'list_pages with parentId: "" at drive root',
           should: 'not include the nested child page',
-          actual: pages.some(p => p.id === 'child-1'),
+          actual: emptyStringPageIds.includes('child-1'),
           expected: false,
         });
       });

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -55,6 +55,8 @@ export const pageReadTools = {
         throw new Error('User authentication required');
       }
 
+      const normalizedParentId = parentId ? parentId : undefined;
+
       try {
         if (!await canActorAccessDrive(context as ToolExecutionContext, driveId)) {
           return { success: false, error: `You don't have access to the "${driveSlug}" workspace` };
@@ -66,8 +68,8 @@ export const pageReadTools = {
 
         const pageMap = new Map(visiblePages.map(p => [p.id, p]));
 
-        if (parentId && !pageMap.has(parentId)) {
-          return { success: false, error: `Page "${parentId}" not found or not accessible in this workspace` };
+        if (normalizedParentId && !pageMap.has(normalizedParentId)) {
+          return { success: false, error: `Page "${normalizedParentId}" not found or not accessible in this workspace` };
         }
 
         // Get task-linked page IDs to mark them
@@ -113,7 +115,7 @@ export const pageReadTools = {
         let resultPages: PageEntry[];
 
         if (!recursive) {
-          const target = parentId ?? null;
+          const target = normalizedParentId ?? null;
           const children = visiblePages.filter(p => p.parentId === target);
           resultPages = children.map(p => ({
             id: p.id,
@@ -142,7 +144,7 @@ export const pageReadTools = {
             }
             return result;
           };
-          resultPages = collectSubtree(parentId ?? null);
+          resultPages = collectSubtree(normalizedParentId ?? null);
         }
 
         // Batch content onto the result set in one additional query, rather than
@@ -195,8 +197,8 @@ export const pageReadTools = {
         }
 
         const driveLabel = driveSlug || driveId;
-        const breadcrumb = buildBreadcrumb(parentId);
-        const location = parentId ? buildPath(parentId) : `/${driveLabel}`;
+        const breadcrumb = buildBreadcrumb(normalizedParentId);
+        const location = normalizedParentId ? buildPath(normalizedParentId) : `/${driveLabel}`;
         const locationLabel = breadcrumb.length > 0 ? breadcrumb.map(c => c.title).join(' / ') : driveLabel;
 
         return {


### PR DESCRIPTION
## Summary
- `list_pages`'s root-scope handling used `parentId ?? null`, which only substitutes for `null`/`undefined`, never for an empty string. Root-level pages have `parentId === null` in the DB, so calling `list_pages` with `parentId: ""` at drive root filtered against `""` and matched nothing — silently returning `count: 0, pages: []` while `totalInDrive` stayed correct. This broke list-first exploration for autonomous AI agents (issue reproduced broadly across many drives).
- Added a single `normalizedParentId` derived once after destructuring the tool args (empty string treated as omitted), and swapped it in everywhere `list_pages`'s `execute()` reads `parentId`: the not-found guard, the non-recursive filter target, the recursive subtree seed, and the breadcrumb/location computation.
- Scope is intentionally narrow — no changes to `getActorAccessiblePagesInDrive`, `actor-permissions.ts`, or any other caller; their `parentId` handling was checked and is correct.

## Test plan
- [x] Added a regression test (`treats parentId: "" the same as omitting parentId at drive root`) reusing the existing `ls-mode navigation` fixtures, asserting `parentId: ''` returns the same root-level pages as omitting the arg.
- [x] `bun run --filter=web typecheck` — clean
- [x] `vitest run src/lib/ai/tools/__tests__/page-read-tools.test.ts` (apps/web) — 66/66 passed

Fixes #2230

https://claude.ai/code/session_0182ZA91gLnjJV3Yq73eq8Ki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page listing at the drive root when an empty parent identifier is provided.
  * Root-level listings now correctly match listings where no parent identifier is supplied.
  * Prevented nested pages from appearing in root-level results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->