### PR TITLE
fix(machines): correct branch vs default-checkout semantics for agent sandbox targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **A machine-bound agent addressing its own project's default checkout as `branch: "main"`/`"master"` is no longer silently denied** —
+  a bound conversation's `target` only ever resolved against explicitly created branch worktrees, so a model reasoning in ordinary
+  git terms (where "main" means "my own checkout") got refused with a generic scope error even when addressing itself. The system
+  prompt now explains that "branch" here names a separately created worktree, not "whatever branch a project happens to be on," and
+  the denial message points at `list_sessions` to check real state instead of prescribing a specific retry.
 - **Permanently deleting a Terminal machine, its drive, or letting it age out of Trash no longer
   leaves "Unknown machine" behind** — an agent or the global assistant's machine list kept a
   reference to a Terminal after the machine page was gone for good, so it showed as "Unknown

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -74,4 +74,37 @@ describe('buildMachineBindingPrompt', () => {
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });
+
+  // Codex review (PR #2232, second pass): a conversation bound DIRECTLY to a
+  // branch has `handles: [self]` — nothing beneath it at all. The live-branch
+  // check must still recognize `self` itself as a live default-named branch,
+  // or it wrongly concludes "no such branch exists" about the very branch
+  // the conversation IS, and recommends target: { project } — which a
+  // branch-scoped conversation can't even address (its handle set has no
+  // project handle in it).
+  it('given self IS a live branch named "main" (branch-bound conversation, nothing beneath it), should NOT warn', () => {
+    const branchSelf: MachineNodeHandleSet['self'] = {
+      kind: 'branch',
+      machineId: 'm1',
+      project: 'my-repo',
+      branch: 'main',
+      cwd: '/workspace/branches/main',
+    };
+    const binding: MachineNodeHandleSet = { self: branchSelf, handles: [branchSelf] };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+  });
+
+  it('given self is a branch NOT named main/master (branch-bound, nothing beneath it), should still warn (it is genuinely not a default-checkout name)', () => {
+    const branchSelf: MachineNodeHandleSet['self'] = {
+      kind: 'branch',
+      machineId: 'm1',
+      project: 'my-repo',
+      branch: 'feature-x',
+      cwd: '/workspace/branches/feature-x',
+    };
+    const binding: MachineNodeHandleSet = { self: branchSelf, handles: [branchSelf] };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+  });
 });

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -27,6 +27,13 @@ describe('buildMachineBindingPrompt', () => {
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
     expect(prompt).toContain('there is no such branch here');
+    // Codex review (PR #2232, fourth pass): "feature-x" IS a real, listed
+    // branch here — the warning must not claim no branch at all is listed
+    // (only that no main/master one is), or it contradicts the "Currently
+    // reachable" line directly above it and could make the model ignore a
+    // genuinely valid target.
+    expect(prompt).toContain('branch: "feature-x"');
+    expect(prompt).not.toContain('(none is currently listed above)');
   });
 
   it('given a LIVE branch actually named "main", should NOT warn against using branch: "main"', () => {

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -59,7 +59,7 @@ describe('buildMachineBindingPrompt', () => {
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
     expect(prompt).toContain('pass target: { project } alone and omit branch');
-    expect(prompt).toContain('even if a branch named "main"/"master" is listed below');
+    expect(prompt).toContain('even if a branch named "main"/"master" is listed above');
     expect(prompt).toContain('branch: "main"'); // reachable list still names the separate worktree — untouched by the warning
   });
 

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -20,11 +20,11 @@ describe('buildMachineBindingPrompt', () => {
   // the warning is now unconditional (for any non-branch self) and makes no
   // claim about the set's contents — it just tells the reader to check the
   // "Currently reachable" list, which is always itemized and accurate.
-  it('given a project self with no branches at all beneath it, should warn and defer to the reachable list', () => {
+  it('given a project self with no branches at all beneath it, should warn and instruct omitting branch for default-checkout intent', () => {
     const binding: MachineNodeHandleSet = { self: PROJECT_SELF, handles: [PROJECT_SELF] };
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
-    expect(prompt).toContain('only add branch: "main"/"master" if that exact project+branch pairing is listed above');
+    expect(prompt).toContain('pass target: { project } alone and omit branch');
   });
 
   it('given a project self with a non-default branch listed (e.g. feature-x), should still warn without claiming no branch is listed', () => {
@@ -40,10 +40,15 @@ describe('buildMachineBindingPrompt', () => {
     expect(prompt).toContain('branch: "feature-x"'); // the reachable list still names it — untouched by the warning
   });
 
-  it('given a project self with a LIVE branch actually named "main", should still warn — the warning is conditional advice, not a false claim', () => {
-    // The warning says "only use branch: main if it's listed above" — which
-    // remains TRUE and safe to show even when "main" genuinely is listed:
-    // following it correctly leads the reader to use it, since it IS listed.
+  // Codex review (PR #2232, fifth pass): a separately created worktree named
+  // "main"/"master" is still a DIFFERENT Sprite from the project's own
+  // default checkout. Telling the model "add branch: main if it's listed" is
+  // wrong when the model's actual intent is its own default checkout —
+  // following that advice would route the call to the wrong worktree, the
+  // exact risk this warning exists to prevent. The fix: default-checkout
+  // intent always means target: { project } alone, regardless of what's
+  // listed; the warning must say so unconditionally, not "if listed".
+  it('given a project self with a LIVE branch actually named "main", should still instruct omitting branch for default-checkout intent — not "add branch: main since it is listed"', () => {
     const binding: MachineNodeHandleSet = {
       self: PROJECT_SELF,
       handles: [
@@ -53,7 +58,9 @@ describe('buildMachineBindingPrompt', () => {
     };
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
-    expect(prompt).toContain('branch: "main"'); // reachable list names it — the source of truth
+    expect(prompt).toContain('pass target: { project } alone and omit branch');
+    expect(prompt).toContain('even if a branch named "main"/"master" is listed below');
+    expect(prompt).toContain('branch: "main"'); // reachable list still names the separate worktree — untouched by the warning
   });
 
   // Codex review (PR #2232, fifth pass): a machine-root binding can reach

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -10,13 +10,24 @@ const PROJECT_SELF: MachineNodeHandleSet['self'] = {
 };
 
 describe('buildMachineBindingPrompt', () => {
-  // Codex review (PR #2232): a project can have a genuinely LIVE branch
-  // worktree named "main"/"master" (spawnBranch doesn't reserve these names).
-  // A blanket "never use branch: main" instruction would be actively wrong
-  // advice for that case — it would make the model omit a branch qualifier
-  // it should have used, running tool calls in the project's checkout
-  // instead of the correctly separate branch Sprite.
-  it('given no live branch named main/master, should warn that "branch" never means the project\'s own default checkout', () => {
+  // PR #2232 history: earlier versions tried to assert whether a live
+  // main/master branch worktree existed, and suppress or word the warning
+  // based on that single yes/no answer. Four rounds of review each found a
+  // case where that answer was wrong for SOME part of the reachable set —
+  // most fundamentally, a machine-root binding can reach many projects, and
+  // one project having a live "main" branch says nothing about a different,
+  // also-reachable project that doesn't. Rather than track this per project,
+  // the warning is now unconditional (for any non-branch self) and makes no
+  // claim about the set's contents — it just tells the reader to check the
+  // "Currently reachable" list, which is always itemized and accurate.
+  it('given a project self with no branches at all beneath it, should warn and defer to the reachable list', () => {
+    const binding: MachineNodeHandleSet = { self: PROJECT_SELF, handles: [PROJECT_SELF] };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+    expect(prompt).toContain('only add branch: "main"/"master" if that exact project+branch pairing is listed above');
+  });
+
+  it('given a project self with a non-default branch listed (e.g. feature-x), should still warn without claiming no branch is listed', () => {
     const binding: MachineNodeHandleSet = {
       self: PROJECT_SELF,
       handles: [
@@ -26,17 +37,13 @@ describe('buildMachineBindingPrompt', () => {
     };
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
-    expect(prompt).toContain('there is no such branch here');
-    // Codex review (PR #2232, fourth pass): "feature-x" IS a real, listed
-    // branch here — the warning must not claim no branch at all is listed
-    // (only that no main/master one is), or it contradicts the "Currently
-    // reachable" line directly above it and could make the model ignore a
-    // genuinely valid target.
-    expect(prompt).toContain('branch: "feature-x"');
-    expect(prompt).not.toContain('(none is currently listed above)');
+    expect(prompt).toContain('branch: "feature-x"'); // the reachable list still names it — untouched by the warning
   });
 
-  it('given a LIVE branch actually named "main", should NOT warn against using branch: "main"', () => {
+  it('given a project self with a LIVE branch actually named "main", should still warn — the warning is conditional advice, not a false claim', () => {
+    // The warning says "only use branch: main if it's listed above" — which
+    // remains TRUE and safe to show even when "main" genuinely is listed:
+    // following it correctly leads the reader to use it, since it IS listed.
     const binding: MachineNodeHandleSet = {
       self: PROJECT_SELF,
       handles: [
@@ -45,51 +52,35 @@ describe('buildMachineBindingPrompt', () => {
       ],
     };
     const prompt = buildMachineBindingPrompt(binding);
-    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
-    // The reachable listing itself still names it — that's the real source of truth.
-    expect(prompt).toContain('branch: "main"');
+    expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+    expect(prompt).toContain('branch: "main"'); // reachable list names it — the source of truth
   });
 
-  it('given a LIVE branch named "master" (the other alias), should also NOT warn', () => {
-    const binding: MachineNodeHandleSet = {
-      self: PROJECT_SELF,
-      handles: [
-        PROJECT_SELF,
-        { kind: 'branch', machineId: 'm1', project: 'my-repo', branch: 'master', cwd: '/workspace/branches/master' },
-      ],
-    };
-    const prompt = buildMachineBindingPrompt(binding);
-    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
-  });
-
-  it('given a live "main" branch under ANY reachable project, should suppress the warning globally rather than assert something false', () => {
-    // The warning is a blanket statement ("there is no such branch here") —
-    // if it's false for even one reachable project, asserting it anyway would
-    // be actively wrong advice for that project. Safer to omit the statement
-    // entirely and let the always-accurate "Currently reachable" list (which
-    // names every real branch by its own project) carry the information,
-    // than to risk telling the model something false.
+  // Codex review (PR #2232, fifth pass): a machine-root binding can reach
+  // MULTIPLE projects. One having a live "main" branch must not silence the
+  // warning for a DIFFERENT, also-reachable project that has none — the
+  // unconditional wording (deferring to the per-project reachable list)
+  // is what actually fixes this, rather than any global yes/no tracking.
+  it('given a machine-root self reaching one project WITH a live main branch and another WITHOUT one, should still warn (not globally suppressed)', () => {
     const machineSelf: MachineNodeHandleSet['self'] = { kind: 'machine', machineId: 'm1', cwd: '/workspace' };
     const binding: MachineNodeHandleSet = {
       self: machineSelf,
       handles: [
         machineSelf,
-        { kind: 'project', machineId: 'm1', project: 'other-repo', cwd: '/workspace/projects/other-repo' },
-        { kind: 'branch', machineId: 'm1', project: 'other-repo', branch: 'main', cwd: '/workspace/branches/main' },
+        { kind: 'project', machineId: 'm1', project: 'has-main', cwd: '/workspace/projects/has-main' },
+        { kind: 'branch', machineId: 'm1', project: 'has-main', branch: 'main', cwd: '/workspace/branches/main' },
+        { kind: 'project', machineId: 'm1', project: 'no-main', cwd: '/workspace/projects/no-main' },
       ],
     };
     const prompt = buildMachineBindingPrompt(binding);
-    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+    expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });
 
-  // Codex review (PR #2232, third pass): the warning's OWN advice — "to run
-  // at a project, pass target: { project }" — is unreachable from ANY
-  // branch-scoped self, not just one named main/master. deriveMachinePaneBinding
-  // gives a branch pane handles: [self] only — no project handle is EVER in
-  // scope from there, regardless of what this branch is named. Recommending
-  // it would just trade one target_not_in_set for another, so the whole
-  // warning is skipped for a branch self unconditionally.
-  it('given self IS a live branch named "main" (branch-bound conversation, nothing beneath it), should NOT warn', () => {
+  // A conversation bound DIRECTLY to a branch has handles: [self] only — no
+  // project handle is EVER in scope from there, regardless of what this
+  // branch is named. The warning's own advice ("pass target: { project }")
+  // is unreachable in that case, so it's skipped entirely for a branch self.
+  it('given self IS a branch (branch-bound conversation, nothing beneath it), should NOT warn regardless of the branch\'s name', () => {
     const branchSelf: MachineNodeHandleSet['self'] = {
       kind: 'branch',
       machineId: 'm1',
@@ -102,7 +93,7 @@ describe('buildMachineBindingPrompt', () => {
     expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });
 
-  it('given self is a branch NOT named main/master (branch-bound, nothing beneath it), should ALSO not warn — recommending target: { project } would be unreachable advice regardless of this branch\'s name', () => {
+  it('given self is a branch with a non-default name, should ALSO not warn — the advice is unreachable regardless of this branch\'s name', () => {
     const branchSelf: MachineNodeHandleSet['self'] = {
       kind: 'branch',
       machineId: 'm1',
@@ -113,14 +104,5 @@ describe('buildMachineBindingPrompt', () => {
     const binding: MachineNodeHandleSet = { self: branchSelf, handles: [branchSelf] };
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
-  });
-
-  it('given a project-scoped self with no live default branch beneath it, should still warn (the project handle IS reachable, so the advice is valid here)', () => {
-    // Regression guard: the branch-self suppression above must not
-    // accidentally widen to suppress the warning for project/machine selfs
-    // too, where the recommended target: { project } genuinely does resolve.
-    const binding: MachineNodeHandleSet = { self: PROJECT_SELF, handles: [PROJECT_SELF] };
-    const prompt = buildMachineBindingPrompt(binding);
-    expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });
 });

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { buildMachineBindingPrompt } from '../machine-binding-prompt';
+import type { MachineNodeHandleSet } from '@pagespace/lib/services/machines/machine-pane-binding';
+
+const PROJECT_SELF: MachineNodeHandleSet['self'] = {
+  kind: 'project',
+  machineId: 'm1',
+  project: 'my-repo',
+  cwd: '/workspace/projects/my-repo',
+};
+
+describe('buildMachineBindingPrompt', () => {
+  // Codex review (PR #2232): a project can have a genuinely LIVE branch
+  // worktree named "main"/"master" (spawnBranch doesn't reserve these names).
+  // A blanket "never use branch: main" instruction would be actively wrong
+  // advice for that case — it would make the model omit a branch qualifier
+  // it should have used, running tool calls in the project's checkout
+  // instead of the correctly separate branch Sprite.
+  it('given no live branch named main/master, should warn that "branch" never means the project\'s own default checkout', () => {
+    const binding: MachineNodeHandleSet = {
+      self: PROJECT_SELF,
+      handles: [
+        PROJECT_SELF,
+        { kind: 'branch', machineId: 'm1', project: 'my-repo', branch: 'feature-x', cwd: '/workspace/branches/x' },
+      ],
+    };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+    expect(prompt).toContain('there is no such branch here');
+  });
+
+  it('given a LIVE branch actually named "main", should NOT warn against using branch: "main"', () => {
+    const binding: MachineNodeHandleSet = {
+      self: PROJECT_SELF,
+      handles: [
+        PROJECT_SELF,
+        { kind: 'branch', machineId: 'm1', project: 'my-repo', branch: 'main', cwd: '/workspace/branches/main' },
+      ],
+    };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+    // The reachable listing itself still names it — that's the real source of truth.
+    expect(prompt).toContain('branch: "main"');
+  });
+
+  it('given a LIVE branch named "master" (the other alias), should also NOT warn', () => {
+    const binding: MachineNodeHandleSet = {
+      self: PROJECT_SELF,
+      handles: [
+        PROJECT_SELF,
+        { kind: 'branch', machineId: 'm1', project: 'my-repo', branch: 'master', cwd: '/workspace/branches/master' },
+      ],
+    };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+  });
+
+  it('given a live "main" branch under ANY reachable project, should suppress the warning globally rather than assert something false', () => {
+    // The warning is a blanket statement ("there is no such branch here") —
+    // if it's false for even one reachable project, asserting it anyway would
+    // be actively wrong advice for that project. Safer to omit the statement
+    // entirely and let the always-accurate "Currently reachable" list (which
+    // names every real branch by its own project) carry the information,
+    // than to risk telling the model something false.
+    const machineSelf: MachineNodeHandleSet['self'] = { kind: 'machine', machineId: 'm1', cwd: '/workspace' };
+    const binding: MachineNodeHandleSet = {
+      self: machineSelf,
+      handles: [
+        machineSelf,
+        { kind: 'project', machineId: 'm1', project: 'other-repo', cwd: '/workspace/projects/other-repo' },
+        { kind: 'branch', machineId: 'm1', project: 'other-repo', branch: 'main', cwd: '/workspace/branches/main' },
+      ],
+    };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+  });
+});

--- a/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/machine-binding-prompt.test.ts
@@ -75,13 +75,13 @@ describe('buildMachineBindingPrompt', () => {
     expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });
 
-  // Codex review (PR #2232, second pass): a conversation bound DIRECTLY to a
-  // branch has `handles: [self]` — nothing beneath it at all. The live-branch
-  // check must still recognize `self` itself as a live default-named branch,
-  // or it wrongly concludes "no such branch exists" about the very branch
-  // the conversation IS, and recommends target: { project } — which a
-  // branch-scoped conversation can't even address (its handle set has no
-  // project handle in it).
+  // Codex review (PR #2232, third pass): the warning's OWN advice — "to run
+  // at a project, pass target: { project }" — is unreachable from ANY
+  // branch-scoped self, not just one named main/master. deriveMachinePaneBinding
+  // gives a branch pane handles: [self] only — no project handle is EVER in
+  // scope from there, regardless of what this branch is named. Recommending
+  // it would just trade one target_not_in_set for another, so the whole
+  // warning is skipped for a branch self unconditionally.
   it('given self IS a live branch named "main" (branch-bound conversation, nothing beneath it), should NOT warn', () => {
     const branchSelf: MachineNodeHandleSet['self'] = {
       kind: 'branch',
@@ -95,7 +95,7 @@ describe('buildMachineBindingPrompt', () => {
     expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });
 
-  it('given self is a branch NOT named main/master (branch-bound, nothing beneath it), should still warn (it is genuinely not a default-checkout name)', () => {
+  it('given self is a branch NOT named main/master (branch-bound, nothing beneath it), should ALSO not warn — recommending target: { project } would be unreachable advice regardless of this branch\'s name', () => {
     const branchSelf: MachineNodeHandleSet['self'] = {
       kind: 'branch',
       machineId: 'm1',
@@ -104,6 +104,15 @@ describe('buildMachineBindingPrompt', () => {
       cwd: '/workspace/branches/feature-x',
     };
     const binding: MachineNodeHandleSet = { self: branchSelf, handles: [branchSelf] };
+    const prompt = buildMachineBindingPrompt(binding);
+    expect(prompt).not.toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
+  });
+
+  it('given a project-scoped self with no live default branch beneath it, should still warn (the project handle IS reachable, so the advice is valid here)', () => {
+    // Regression guard: the branch-self suppression above must not
+    // accidentally widen to suppress the warning for project/machine selfs
+    // too, where the recommended target: { project } genuinely does resolve.
+    const binding: MachineNodeHandleSet = { self: PROJECT_SELF, handles: [PROJECT_SELF] };
     const prompt = buildMachineBindingPrompt(binding);
     expect(prompt).toContain('"branch" here is NOT "whatever git branch a project happens to be on"');
   });

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -43,13 +43,11 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
               : `project "${handle.project}"`,
           )
           .join(', ')}.`;
-  const branchWarning =
-    '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (listed above, if any exist). A project\'s own default checkout (its "main"/"master") has no branch of its own to address: to run at a project, pass target: { project } alone, never target: { project, branch: "main" }.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +
     `\n${reachable}` +
-    branchWarning +
+    `\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (listed above, if any exist). A project's own default checkout (its "main"/"master") has no branch of its own to address: to run at a project, pass target: { project } alone, never target: { project, branch: "main" }.` +
     `\n• A node outside this scope (a sibling project or branch, another machine) is not addressable — such a target is refused.` +
     `\n• Call list_sessions to see the nodes in this scope and what is running in them; it is the only discovery tool for this machine.` +
     `\n• switch_machine and list_machines are unavailable — this conversation cannot leave its bound machine`

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -61,6 +61,18 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
   // can be answered correctly. No claim here can be wrong for any subset of
   // the set, because it makes no claim about the set's contents at all.
   //
+  // Fifth round of review: telling the model "add branch: main/master if
+  // that pairing is listed" is itself wrong when the model's actual INTENT
+  // is the project's own default checkout — a separately created worktree
+  // that happens to be named "main"/"master" is still a DIFFERENT Sprite
+  // from the project's default checkout, so following that advice for
+  // default-checkout intent routes the call to the wrong worktree, exactly
+  // the risk this whole warning exists to prevent. The fix isn't about what
+  // is listed at all: default-checkout intent always means target: { project
+  // } alone, full stop, regardless of what branch names happen to be
+  // reachable. branch is only ever for when the caller specifically means
+  // that separate worktree, not as an alternate spelling of "my own checkout".
+  //
   // Skipped when self.kind === 'branch': deriveMachinePaneBinding gives a
   // branch pane handles: [self] only — no project handle is EVER in scope
   // from there, so "pass target: { project }" would just trade one denial
@@ -68,7 +80,7 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
   const branchWarning =
     self.kind === 'branch'
       ? ''
-      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree. A project\'s own default checkout has no branch of its own to address UNLESS the reachable list above explicitly names one for it: pass target: { project } alone to run at a project\'s own checkout, and only add branch: "main"/"master" if that exact project+branch pairing is listed above — otherwise it will be refused.';
+      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it names a separately created branch worktree that runs in its own Sprite, distinct from the project\'s default checkout. To address a project\'s own default checkout, pass target: { project } alone and omit branch — do this even if a branch named "main"/"master" is listed below, since that pairing names a different, separately created worktree, not the project\'s own checkout. Only add branch: "<name>" when you specifically intend to address that separate worktree, and only if the exact project+branch pairing is listed above — otherwise it will be refused.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -23,7 +23,6 @@
  */
 
 import type { MachineNodeHandleSet } from '@pagespace/lib/services/machines/machine-pane-binding';
-import { isMainBranchName } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 
 export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string {
   const { self, handles } = binding;
@@ -44,24 +43,32 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
               : `project "${handle.project}"`,
           )
           .join(', ')}.`;
-  // A project can have a genuinely LIVE branch worktree named "main"/"master"
-  // (spawnBranch doesn't reserve these names) — when one is actually in the
-  // reachable list, targeting it by name is correct, so the blanket "never"
-  // below would be actively wrong advice for that case. Only warn when no
-  // such live branch is listed (Codex review, PR #2232): the reachable list
-  // itself is always the source of truth, this is just interpreting it.
-  const hasLiveDefaultBranch = beneath.some((h) => h.kind === 'branch' && h.branch !== undefined && isMainBranchName(h.branch));
-  // The warning's advice ("run at a project via target: { project }") is
-  // UNREACHABLE from a branch-scoped self: deriveMachinePaneBinding gives a
-  // branch pane handles: [self] only — no project handle in scope, ever,
-  // regardless of what this branch happens to be named. Recommending it
-  // would just trade one target_not_in_set for another (Codex review, third
-  // pass) — so the whole warning is skipped for a branch self, not only when
-  // that branch happens to be named main/master.
+  // "branch" only ever names an EXPLICITLY created branch worktree — never
+  // "whatever git branch a project's own checkout happens to be on". A model
+  // reasoning in ordinary git terms may add branch: "main"/"master" assuming
+  // it addresses a project's own state, which is wrong unless that exact
+  // pairing happens to be a real, separately created worktree.
+  //
+  // This used to assert whether such a worktree existed (`hasLiveDefaultBranch`,
+  // computed once over the whole reachable set) — four rounds of review (PR
+  // #2232) kept finding cases where that single yes/no answer was wrong for
+  // SOME part of the set: a live branch under one project said nothing about
+  // a different, also-reachable project without one (and machine-root scope
+  // can reach many projects, each independently). Rather than track this
+  // per-project, the warning is now unconditional whenever self isn't itself
+  // a branch — it defers entirely to the "Currently reachable" list above,
+  // which is already itemized per project/branch and is the only place this
+  // can be answered correctly. No claim here can be wrong for any subset of
+  // the set, because it makes no claim about the set's contents at all.
+  //
+  // Skipped when self.kind === 'branch': deriveMachinePaneBinding gives a
+  // branch pane handles: [self] only — no project handle is EVER in scope
+  // from there, so "pass target: { project }" would just trade one denial
+  // for another, regardless of what this branch happens to be named.
   const branchWarning =
-    self.kind === 'branch' || hasLiveDefaultBranch
+    self.kind === 'branch'
       ? ''
-      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree, and no branch named "main"/"master" is currently listed above (other branches may be, if any exist — that listing is authoritative). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';
+      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree. A project\'s own default checkout has no branch of its own to address UNLESS the reachable list above explicitly names one for it: pass target: { project } alone to run at a project\'s own checkout, and only add branch: "main"/"master" if that exact project+branch pairing is listed above — otherwise it will be refused.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -50,7 +50,13 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
   // below would be actively wrong advice for that case. Only warn when no
   // such live branch is listed (Codex review, PR #2232): the reachable list
   // itself is always the source of truth, this is just interpreting it.
-  const hasLiveDefaultBranch = beneath.some((h) => h.kind === 'branch' && h.branch !== undefined && isMainBranchName(h.branch));
+  //
+  // Checked against the FULL `handles` (self included), not just `beneath`:
+  // a conversation bound DIRECTLY to a branch named "main"/"master" has
+  // `handles: [self]` with nothing beneath it at all (Codex review, second
+  // pass) — self itself is that live branch, so the warning must not fire
+  // just because there's nothing else in scope to list.
+  const hasLiveDefaultBranch = handles.some((h) => h.kind === 'branch' && h.branch !== undefined && isMainBranchName(h.branch));
   const branchWarning = hasLiveDefaultBranch
     ? ''
     : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (none is currently listed above). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -50,16 +50,18 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
   // below would be actively wrong advice for that case. Only warn when no
   // such live branch is listed (Codex review, PR #2232): the reachable list
   // itself is always the source of truth, this is just interpreting it.
-  //
-  // Checked against the FULL `handles` (self included), not just `beneath`:
-  // a conversation bound DIRECTLY to a branch named "main"/"master" has
-  // `handles: [self]` with nothing beneath it at all (Codex review, second
-  // pass) — self itself is that live branch, so the warning must not fire
-  // just because there's nothing else in scope to list.
-  const hasLiveDefaultBranch = handles.some((h) => h.kind === 'branch' && h.branch !== undefined && isMainBranchName(h.branch));
-  const branchWarning = hasLiveDefaultBranch
-    ? ''
-    : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (none is currently listed above). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';
+  const hasLiveDefaultBranch = beneath.some((h) => h.kind === 'branch' && h.branch !== undefined && isMainBranchName(h.branch));
+  // The warning's advice ("run at a project via target: { project }") is
+  // UNREACHABLE from a branch-scoped self: deriveMachinePaneBinding gives a
+  // branch pane handles: [self] only — no project handle in scope, ever,
+  // regardless of what this branch happens to be named. Recommending it
+  // would just trade one target_not_in_set for another (Codex review, third
+  // pass) — so the whole warning is skipped for a branch self, not only when
+  // that branch happens to be named main/master.
+  const branchWarning =
+    self.kind === 'branch' || hasLiveDefaultBranch
+      ? ''
+      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (none is currently listed above). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -80,7 +80,7 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
   const branchWarning =
     self.kind === 'branch'
       ? ''
-      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it names a separately created branch worktree that runs in its own Sprite, distinct from the project\'s default checkout. To address a project\'s own default checkout, pass target: { project } alone and omit branch — do this even if a branch named "main"/"master" is listed below, since that pairing names a different, separately created worktree, not the project\'s own checkout. Only add branch: "<name>" when you specifically intend to address that separate worktree, and only if the exact project+branch pairing is listed above — otherwise it will be refused.';
+      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it names a separately created branch worktree that runs in its own Sprite, distinct from the project\'s default checkout. To address a project\'s own default checkout, pass target: { project } alone and omit branch — do this even if a branch named "main"/"master" is listed above, since that pairing names a different, separately created worktree, not the project\'s own checkout. Only add branch: "<name>" when you specifically intend to address that separate worktree, and only if the exact project+branch pairing is listed above — otherwise it will be refused.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -23,6 +23,7 @@
  */
 
 import type { MachineNodeHandleSet } from '@pagespace/lib/services/machines/machine-pane-binding';
+import { isMainBranchName } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 
 export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string {
   const { self, handles } = binding;
@@ -43,11 +44,21 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
               : `project "${handle.project}"`,
           )
           .join(', ')}.`;
+  // A project can have a genuinely LIVE branch worktree named "main"/"master"
+  // (spawnBranch doesn't reserve these names) — when one is actually in the
+  // reachable list, targeting it by name is correct, so the blanket "never"
+  // below would be actively wrong advice for that case. Only warn when no
+  // such live branch is listed (Codex review, PR #2232): the reachable list
+  // itself is always the source of truth, this is just interpreting it.
+  const hasLiveDefaultBranch = beneath.some((h) => h.kind === 'branch' && h.branch !== undefined && isMainBranchName(h.branch));
+  const branchWarning = hasLiveDefaultBranch
+    ? ''
+    : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (none is currently listed above). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +
     `\n${reachable}` +
-    `\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (listed above, if any exist). A project's own default checkout (its "main"/"master") has no branch of its own to address: to run at a project, pass target: { project } alone, never target: { project, branch: "main" }.` +
+    branchWarning +
     `\n• A node outside this scope (a sibling project or branch, another machine) is not addressable — such a target is refused.` +
     `\n• Call list_sessions to see the nodes in this scope and what is running in them; it is the only discovery tool for this machine.` +
     `\n• switch_machine and list_machines are unavailable — this conversation cannot leave its bound machine`

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -43,10 +43,13 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
               : `project "${handle.project}"`,
           )
           .join(', ')}.`;
+  const branchWarning =
+    '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (listed above, if any exist). A project\'s own default checkout (its "main"/"master") has no branch of its own to address: to run at a project, pass target: { project } alone, never target: { project, branch: "main" }.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +
     `\n${reachable}` +
+    branchWarning +
     `\n• A node outside this scope (a sibling project or branch, another machine) is not addressable — such a target is refused.` +
     `\n• Call list_sessions to see the nodes in this scope and what is running in them; it is the only discovery tool for this machine.` +
     `\n• switch_machine and list_machines are unavailable — this conversation cannot leave its bound machine`

--- a/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
+++ b/apps/web/src/lib/ai/machines/machine-binding-prompt.ts
@@ -61,7 +61,7 @@ export function buildMachineBindingPrompt(binding: MachineNodeHandleSet): string
   const branchWarning =
     self.kind === 'branch' || hasLiveDefaultBranch
       ? ''
-      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree (none is currently listed above). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';
+      : '\n• "branch" here is NOT "whatever git branch a project happens to be on" — it only names a separately created branch worktree, and no branch named "main"/"master" is currently listed above (other branches may be, if any exist — that listing is authoritative). A project\'s own default checkout has no branch of its own to address: to run at a project, pass target: { project } alone, not target: { project, branch: "main" } — there is no such branch here.';
   return (
     `\n\nMACHINE BINDING (this conversation)` +
     `\n• This conversation is bound to machine "${self.machineId}" at ${where} — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${self.cwd}` +

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -1009,34 +1009,45 @@ describe('createSandboxTools', () => {
     // handle instead of a denial. Three rounds of review found different ways
     // that substitution could route a tool call to the wrong worktree (a
     // typo, a torn-down branch, a branch explicitly killed with no trace
-    // left). The fallback is gone — an unresolved target always denies now —
-    // and this hint is the replacement: it tells the caller exactly what to
-    // do differently on its NEXT call instead of the runtime guessing for it.
-    it('given target_not_in_set with a default-checkout-shaped branch ("main"), should append a corrective hint naming the fix', () => {
+    // left). The fallback is gone — an unresolved target always denies now.
+    // The hint below is deliberately NEUTRAL about why this specific target
+    // was denied (never tracked vs. torn down vs. project out of scope) and
+    // does NOT prescribe "just retry against the project" — a further Codex
+    // finding showed that specific instruction could recreate the same
+    // wrong-worktree risk for the torn-down/out-of-scope cases, where the
+    // project isn't actually what the caller should hit either.
+    it('given target_not_in_set with a default-checkout-shaped branch ("main"), should append a neutral hint pointing at list_sessions', () => {
       const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo', branch: 'main' });
       expect(result.error).toContain('is not part of this conversation\'s machine scope');
-      expect(result.error).toContain('"main" isn\'t a separately tracked branch here');
-      expect(result.error).toContain('target: { project: "my-repo" } without a branch');
+      expect(result.error).toContain('never an implicit alias for a project\'s own default checkout');
+      expect(result.error).not.toContain('target: { project:');
     });
 
     it('given target_not_in_set with "master", should also append the hint (the other default-checkout alias)', () => {
       const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo', branch: 'master' });
-      expect(result.error).toContain('"master" isn\'t a separately tracked branch here');
+      expect(result.error).toContain('"master" is never an implicit alias');
     });
 
     it('given target_not_in_set with a non-default branch name, should NOT append the hint', () => {
       const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo', branch: 'feature-x' });
-      expect(result.error).not.toContain('isn\'t a separately tracked branch here');
+      expect(result.error).not.toContain('is never an implicit alias');
+    });
+
+    it('given target_not_in_set with a default-checkout branch but NO project (bare branch target), should still append the hint', () => {
+      // The hint is about the branch name's meaning in general — it doesn't
+      // require a project to be present to be true.
+      const result = nodeTargetDeniedError('target_not_in_set', { branch: 'main' });
+      expect(result.error).toContain('"main" is never an implicit alias');
     });
 
     it('given target_not_in_set with no branch at all (project-only target), should NOT append the hint', () => {
       const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo' });
-      expect(result.error).not.toContain('isn\'t a separately tracked branch here');
+      expect(result.error).not.toContain('is never an implicit alias');
     });
 
     it('given ambiguous_target, should NOT append the hint even with a default-checkout branch name', () => {
       const result = nodeTargetDeniedError('ambiguous_target', { project: 'my-repo', branch: 'main' });
-      expect(result.error).not.toContain('isn\'t a separately tracked branch here');
+      expect(result.error).not.toContain('is never an implicit alias');
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 // The factory is provider-agnostic and imports no DB or backing-provider SDK, so
 // it is exercised directly with injected fakes (the production wiring + the Fly
 // Sprites driver live in sandbox-tools-runtime.ts).
-import { createSandboxTools, nodeScopedPath, type MachineDirectoryDeps, type ResolveSandboxContext, type SandboxGate } from '../sandbox-tools';
+import { createSandboxTools, nodeScopedPath, nodeTargetDeniedError, type MachineDirectoryDeps, type ResolveSandboxContext, type SandboxGate } from '../sandbox-tools';
 import type { SandboxRunDeps, SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
 import type { ToolExecutionContext } from '../../core/types';
 import type { MachineNodeHandle, MachineNodeHandleSet } from '@pagespace/lib/services/machines/machine-pane-binding';
@@ -1001,6 +1001,42 @@ describe('createSandboxTools', () => {
       await exec(tools.readFile, { path: 'a.txt' }, {});
       await exec(tools.editFile, { path: 'a.txt', oldString: 'data', newString: 'X' }, {});
       expect(listMachines).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe('nodeTargetDeniedError', () => {
+    // PR #2232 history: this used to be a silent fallback to the project
+    // handle instead of a denial. Three rounds of review found different ways
+    // that substitution could route a tool call to the wrong worktree (a
+    // typo, a torn-down branch, a branch explicitly killed with no trace
+    // left). The fallback is gone — an unresolved target always denies now —
+    // and this hint is the replacement: it tells the caller exactly what to
+    // do differently on its NEXT call instead of the runtime guessing for it.
+    it('given target_not_in_set with a default-checkout-shaped branch ("main"), should append a corrective hint naming the fix', () => {
+      const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo', branch: 'main' });
+      expect(result.error).toContain('is not part of this conversation\'s machine scope');
+      expect(result.error).toContain('"main" isn\'t a separately tracked branch here');
+      expect(result.error).toContain('target: { project: "my-repo" } without a branch');
+    });
+
+    it('given target_not_in_set with "master", should also append the hint (the other default-checkout alias)', () => {
+      const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo', branch: 'master' });
+      expect(result.error).toContain('"master" isn\'t a separately tracked branch here');
+    });
+
+    it('given target_not_in_set with a non-default branch name, should NOT append the hint', () => {
+      const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo', branch: 'feature-x' });
+      expect(result.error).not.toContain('isn\'t a separately tracked branch here');
+    });
+
+    it('given target_not_in_set with no branch at all (project-only target), should NOT append the hint', () => {
+      const result = nodeTargetDeniedError('target_not_in_set', { project: 'my-repo' });
+      expect(result.error).not.toContain('isn\'t a separately tracked branch here');
+    });
+
+    it('given ambiguous_target, should NOT append the hint even with a default-checkout branch name', () => {
+      const result = nodeTargetDeniedError('ambiguous_target', { project: 'my-repo', branch: 'main' });
+      expect(result.error).not.toContain('isn\'t a separately tracked branch here');
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -125,15 +125,17 @@ export function nodeTargetDeniedError(
     };
   }
   // A model reasoning in ordinary git terms often adds `branch: "main"` (or
-  // "master") to address a project's own default checkout — but `branch`
-  // here only ever names a separately created branch worktree, so that
-  // target is always denied (deliberately: see resolveMachineNodeTarget's
-  // doc comment on why guessing a substitute isn't safe). Naming the actual
-  // fix inline gets the very next call right instead of leaving the caller
-  // to guess or re-derive it from list_sessions.
+  // "master") assuming it addresses a project's own default checkout. This
+  // hint stays deliberately NEUTRAL about why THIS particular target was
+  // denied — it could be a name that was never tracked, one that existed and
+  // was torn down, or a project that isn't even in scope, and only
+  // list_sessions (already pointed to below) can tell those apart. Naming a
+  // specific "just retry with the project instead" fix here would recreate
+  // the exact wrong-worktree risk this denial exists to prevent, for
+  // whichever of those cases isn't "never tracked" (Codex review, PR #2232).
   const defaultBranchHint =
-    target.project && target.branch && isMainBranchName(target.branch)
-      ? ` "${target.branch}" isn't a separately tracked branch here — to run at the project's own checkout, pass target: { project: "${target.project}" } without a branch.`
+    target.branch && isMainBranchName(target.branch)
+      ? ` Note: "${target.branch}" is never an implicit alias for a project's own default checkout — it only resolves if list_sessions lists it as an actual branch.`
       : '';
   return {
     success: false,

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -29,6 +29,7 @@ import {
   type SandboxRunDeps,
 } from '@pagespace/lib/services/sandbox/tool-runners';
 import { MAX_COMMAND_BYTES } from '@pagespace/lib/services/sandbox/command-policy';
+import { isMainBranchName } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 import type { SandboxToolGateResult } from '@pagespace/lib/services/sandbox/tool-gate';
 import type { MachineToggleDenialCode } from '@pagespace/lib/services/machines/machine-access';
 import {
@@ -123,9 +124,20 @@ export function nodeTargetDeniedError(
       error: `This conversation is not bound to a machine, so it has no node scope to address — remove the target (${described}).`,
     };
   }
+  // A model reasoning in ordinary git terms often adds `branch: "main"` (or
+  // "master") to address a project's own default checkout — but `branch`
+  // here only ever names a separately created branch worktree, so that
+  // target is always denied (deliberately: see resolveMachineNodeTarget's
+  // doc comment on why guessing a substitute isn't safe). Naming the actual
+  // fix inline gets the very next call right instead of leaving the caller
+  // to guess or re-derive it from list_sessions.
+  const defaultBranchHint =
+    target.project && target.branch && isMainBranchName(target.branch)
+      ? ` "${target.branch}" isn't a separately tracked branch here — to run at the project's own checkout, pass target: { project: "${target.project}" } without a branch.`
+      : '';
   return {
     success: false,
-    error: `The target ${described} is not part of this conversation's machine scope. Call list_sessions to see the nodes you can address.`,
+    error: `The target ${described} is not part of this conversation's machine scope. Call list_sessions to see the nodes you can address.${defaultBranchHint}`,
   };
 }
 

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -473,4 +473,15 @@ describe('resolveMachineNodeTarget', () => {
       handle: PROJECT_HANDLE,
     });
   });
+
+  it('given a BRANCH-scoped self (no project handle in its own set) + an unresolved bare branch name, should refuse rather than fall back', () => {
+    // A branch pane's derived set is [self] only (deriveMachinePaneBinding) — its
+    // own enclosing project is never itself a handle here, so there is nothing
+    // for the fallback to find even though `project` defaults to self.project.
+    const branchOnlySet = { self: BRANCH_HANDLE, handles: [BRANCH_HANDLE] };
+    expect(resolveMachineNodeTarget(branchOnlySet, { branch: 'main' })).toEqual({
+      ok: false,
+      reason: 'target_not_in_set',
+    });
+  });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -466,14 +466,6 @@ describe('resolveMachineNodeTarget', () => {
     });
   });
 
-  it('given a project in the set with a REAL branch handle + a different unresolved branch name, should still fall back to the project handle', () => {
-    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE, BRANCH_HANDLE] };
-    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
-      ok: true,
-      handle: PROJECT_HANDLE,
-    });
-  });
-
   // Codex review (PR #2232): the fallback must NOT catch every unresolved
   // branch name — only the conventional default-checkout aliases. Otherwise a
   // genuinely misspelled or deleted branch name would silently redirect

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -366,6 +366,33 @@ describe('deriveMachinePaneBinding — handle-set derivation (cascade)', () => {
     expect(binding.handles).toContainEqual(SIBLING_BRANCH_HANDLE);
   });
 
+  // Codex review (PR #2232): a torn-down branch's name must still be
+  // reported (separately from `handles`) so resolveMachineNodeTarget's
+  // default-checkout fallback can tell "torn down" apart from "never
+  // existed" — the fallback must not treat these the same way.
+  it('given a torn-down branch in a machine-root closure, should report it in tornDownBranches', async () => {
+    const row = makeRow({ scope: 'machine', projectName: null, machineBranchId: null });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      projectLookup: makeProjectLookup(PROJECT_ROWS),
+      branchLookup: makeBranchLookup([{ ...BRANCH_ROWS[0], spriteTornDownAt: NOW }, BRANCH_ROWS[1]]),
+    });
+    const binding = await deriveOk(deps);
+    expect(binding.tornDownBranches).toEqual([{ project: PROJECT_NAME, branch: 'feature' }]);
+  });
+
+  it('given a torn-down branch in a project-scoped binding, should report it in tornDownBranches', async () => {
+    const row = makeRow({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      projectLookup: makeProjectLookup(PROJECT_ROWS),
+      branchLookup: makeBranchLookup([{ ...BRANCH_ROWS[0], spriteTornDownAt: NOW }]),
+    });
+    const binding = await deriveOk(deps);
+    expect(binding.tornDownBranches).toEqual([{ project: PROJECT_NAME, branch: 'feature' }]);
+    expect(binding.handles.some((h) => h.branch === 'feature')).toBe(false);
+  });
+
   it('given every handle in a derived set, should carry the owning machine page id (the billing/payer key)', async () => {
     const row = makeRow({ scope: 'machine', projectName: null, machineBranchId: null });
     const binding = await deriveOk(makeCascadeDeps(row));
@@ -495,6 +522,34 @@ describe('resolveMachineNodeTarget', () => {
     expect(resolveMachineNodeTarget(branchOnlySet, { branch: 'main' })).toEqual({
       ok: false,
       reason: 'target_not_in_set',
+    });
+  });
+
+  // Codex review (PR #2232, second finding): a default-named branch that WAS
+  // explicitly created and later torn down must stay denied, never silently
+  // rerouted to the project's (different) checkout — "torn down" is not
+  // "never existed", and the two must not be treated the same by the fallback.
+  it('given a torn-down "main" branch on record for the project, should refuse rather than fall back', () => {
+    const projectSet = {
+      self: PROJECT_HANDLE,
+      handles: [PROJECT_HANDLE],
+      tornDownBranches: [{ project: PROJECT_NAME, branch: 'main' }],
+    };
+    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
+      ok: false,
+      reason: 'target_not_in_set',
+    });
+  });
+
+  it('given tornDownBranches recorded for a DIFFERENT project/branch, should not block this project\'s own fallback', () => {
+    const projectSet = {
+      self: PROJECT_HANDLE,
+      handles: [PROJECT_HANDLE],
+      tornDownBranches: [{ project: SIBLING_PROJECT_NAME, branch: 'main' }],
+    };
+    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
+      ok: true,
+      handle: PROJECT_HANDLE,
     });
   });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -474,6 +474,27 @@ describe('resolveMachineNodeTarget', () => {
     });
   });
 
+  // Codex review (PR #2232): the fallback must NOT catch every unresolved
+  // branch name — only the conventional default-checkout aliases. Otherwise a
+  // genuinely misspelled or deleted branch name would silently redirect
+  // tool calls to the project's default checkout instead of denying, and the
+  // caller would never learn its target didn't exist.
+  it('given a project in the set + a branch name that is NOT a default-checkout alias, should still refuse as out of set (not fall back)', () => {
+    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE] };
+    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'feature-typo' })).toEqual({
+      ok: false,
+      reason: 'target_not_in_set',
+    });
+  });
+
+  it('given a project in the set + "master" (the other default-checkout alias) unresolved, should fall back to the project handle', () => {
+    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE] };
+    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'master' })).toEqual({
+      ok: true,
+      handle: PROJECT_HANDLE,
+    });
+  });
+
   it('given a BRANCH-scoped self (no project handle in its own set) + an unresolved bare branch name, should refuse rather than fall back', () => {
     // A branch pane's derived set is [self] only (deriveMachinePaneBinding) — its
     // own enclosing project is never itself a handle here, so there is nothing

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -444,4 +444,33 @@ describe('resolveMachineNodeTarget', () => {
       reason: 'target_not_in_set',
     });
   });
+
+  // Field bug: a model reasoning in ordinary git terms asks for a project's
+  // own default branch (commonly "main") as if it were an addressable branch
+  // node — but a branch handle only ever exists for an EXPLICITLY created
+  // worktree. Denying the whole target here reads as "you have no access to
+  // this project at all", when the project itself was right there in scope.
+  it('given a project in the set + a branch name that has no branch handle, should fall back to the project handle', () => {
+    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE] };
+    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
+      ok: true,
+      handle: PROJECT_HANDLE,
+    });
+  });
+
+  it('given a project OUTSIDE the set + an unresolved branch name, should still refuse as out of set', () => {
+    const branchSet = { self: BRANCH_HANDLE, handles: [BRANCH_HANDLE] };
+    expect(resolveMachineNodeTarget(branchSet, { project: SIBLING_PROJECT_NAME, branch: 'main' })).toEqual({
+      ok: false,
+      reason: 'target_not_in_set',
+    });
+  });
+
+  it('given a project in the set with a REAL branch handle + a different unresolved branch name, should still fall back to the project handle', () => {
+    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE, BRANCH_HANDLE] };
+    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
+      ok: true,
+      handle: PROJECT_HANDLE,
+    });
+  });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -366,33 +366,6 @@ describe('deriveMachinePaneBinding — handle-set derivation (cascade)', () => {
     expect(binding.handles).toContainEqual(SIBLING_BRANCH_HANDLE);
   });
 
-  // Codex review (PR #2232): a torn-down branch's name must still be
-  // reported (separately from `handles`) so resolveMachineNodeTarget's
-  // default-checkout fallback can tell "torn down" apart from "never
-  // existed" — the fallback must not treat these the same way.
-  it('given a torn-down branch in a machine-root closure, should report it in tornDownBranches', async () => {
-    const row = makeRow({ scope: 'machine', projectName: null, machineBranchId: null });
-    const deps = makeDeps({
-      terminalStore: makeTerminalStore(row),
-      projectLookup: makeProjectLookup(PROJECT_ROWS),
-      branchLookup: makeBranchLookup([{ ...BRANCH_ROWS[0], spriteTornDownAt: NOW }, BRANCH_ROWS[1]]),
-    });
-    const binding = await deriveOk(deps);
-    expect(binding.tornDownBranches).toEqual([{ project: PROJECT_NAME, branch: 'feature' }]);
-  });
-
-  it('given a torn-down branch in a project-scoped binding, should report it in tornDownBranches', async () => {
-    const row = makeRow({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
-    const deps = makeDeps({
-      terminalStore: makeTerminalStore(row),
-      projectLookup: makeProjectLookup(PROJECT_ROWS),
-      branchLookup: makeBranchLookup([{ ...BRANCH_ROWS[0], spriteTornDownAt: NOW }]),
-    });
-    const binding = await deriveOk(deps);
-    expect(binding.tornDownBranches).toEqual([{ project: PROJECT_NAME, branch: 'feature' }]);
-    expect(binding.handles.some((h) => h.branch === 'feature')).toBe(false);
-  });
-
   it('given every handle in a derived set, should carry the owning machine page id (the billing/payer key)', async () => {
     const row = makeRow({ scope: 'machine', projectName: null, machineBranchId: null });
     const binding = await deriveOk(makeCascadeDeps(row));
@@ -472,84 +445,21 @@ describe('resolveMachineNodeTarget', () => {
     });
   });
 
-  // Field bug: a model reasoning in ordinary git terms asks for a project's
-  // own default branch (commonly "main") as if it were an addressable branch
-  // node — but a branch handle only ever exists for an EXPLICITLY created
-  // worktree. Denying the whole target here reads as "you have no access to
-  // this project at all", when the project itself was right there in scope.
-  it('given a project in the set + a branch name that has no branch handle, should fall back to the project handle', () => {
+  // PR #2232 history: an earlier version of this function fell back to the
+  // project handle when an unresolved branch name was a conventional
+  // default-checkout alias ("main"/"master"). Three rounds of review each
+  // found a different way that silent substitution could route a tool call
+  // to the WRONG worktree (an unrelated typo, a torn-down branch, a branch
+  // explicitly killed and hard-deleted with no trace left to distinguish it
+  // from "never existed"). The fallback was removed entirely rather than
+  // patched again — an unresolved target of ANY shape always denies. This
+  // pins that a caller cannot get a project handle back just by naming a
+  // conventional default branch that doesn't actually have a tracked handle.
+  it('given a project in the set + an unresolved default-checkout-shaped branch name ("main"), should refuse as out of set, not fall back to the project', () => {
     const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE] };
     expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
-      ok: true,
-      handle: PROJECT_HANDLE,
-    });
-  });
-
-  it('given a project OUTSIDE the set + an unresolved branch name, should still refuse as out of set', () => {
-    const branchSet = { self: BRANCH_HANDLE, handles: [BRANCH_HANDLE] };
-    expect(resolveMachineNodeTarget(branchSet, { project: SIBLING_PROJECT_NAME, branch: 'main' })).toEqual({
       ok: false,
       reason: 'target_not_in_set',
-    });
-  });
-
-  // Codex review (PR #2232): the fallback must NOT catch every unresolved
-  // branch name — only the conventional default-checkout aliases. Otherwise a
-  // genuinely misspelled or deleted branch name would silently redirect
-  // tool calls to the project's default checkout instead of denying, and the
-  // caller would never learn its target didn't exist.
-  it('given a project in the set + a branch name that is NOT a default-checkout alias, should still refuse as out of set (not fall back)', () => {
-    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE] };
-    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'feature-typo' })).toEqual({
-      ok: false,
-      reason: 'target_not_in_set',
-    });
-  });
-
-  it('given a project in the set + "master" (the other default-checkout alias) unresolved, should fall back to the project handle', () => {
-    const projectSet = { self: PROJECT_HANDLE, handles: [PROJECT_HANDLE] };
-    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'master' })).toEqual({
-      ok: true,
-      handle: PROJECT_HANDLE,
-    });
-  });
-
-  it('given a BRANCH-scoped self (no project handle in its own set) + an unresolved bare branch name, should refuse rather than fall back', () => {
-    // A branch pane's derived set is [self] only (deriveMachinePaneBinding) — its
-    // own enclosing project is never itself a handle here, so there is nothing
-    // for the fallback to find even though `project` defaults to self.project.
-    const branchOnlySet = { self: BRANCH_HANDLE, handles: [BRANCH_HANDLE] };
-    expect(resolveMachineNodeTarget(branchOnlySet, { branch: 'main' })).toEqual({
-      ok: false,
-      reason: 'target_not_in_set',
-    });
-  });
-
-  // Codex review (PR #2232, second finding): a default-named branch that WAS
-  // explicitly created and later torn down must stay denied, never silently
-  // rerouted to the project's (different) checkout — "torn down" is not
-  // "never existed", and the two must not be treated the same by the fallback.
-  it('given a torn-down "main" branch on record for the project, should refuse rather than fall back', () => {
-    const projectSet = {
-      self: PROJECT_HANDLE,
-      handles: [PROJECT_HANDLE],
-      tornDownBranches: [{ project: PROJECT_NAME, branch: 'main' }],
-    };
-    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
-      ok: false,
-      reason: 'target_not_in_set',
-    });
-  });
-
-  it('given tornDownBranches recorded for a DIFFERENT project/branch, should not block this project\'s own fallback', () => {
-    const projectSet = {
-      self: PROJECT_HANDLE,
-      handles: [PROJECT_HANDLE],
-      tornDownBranches: [{ project: SIBLING_PROJECT_NAME, branch: 'main' }],
-    };
-    expect(resolveMachineNodeTarget(projectSet, { project: PROJECT_NAME, branch: 'main' })).toEqual({
-      ok: true,
-      handle: PROJECT_HANDLE,
     });
   });
 });

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -131,6 +131,17 @@ export type MachineNodeTargetResolution =
  * when self is inside one; from the machine root a bare branch name resolves
  * only when it is unambiguous across the whole set, so two projects sharing a
  * branch name can never silently route to the wrong one.
+ *
+ * A `branch` here only ever names an EXPLICITLY created branch worktree (its
+ * own row, its own Sprite) — never "whatever git branch the project's own
+ * checkout happens to be on". A project's default checkout has no branch
+ * handle of its own, so a caller (a model reasoning in ordinary git terms)
+ * naturally but incorrectly asks for `{ project, branch: "main" }` to mean
+ * "this project's own state". When the branch half of that target doesn't
+ * resolve but the project half does, we fall back to the PROJECT handle
+ * rather than denying the whole target — the project was already in `set`,
+ * so this grants nothing new, it just stops a wrong-shaped-but-harmless
+ * target from reading as "get out of this machine entirely".
  */
 export function resolveMachineNodeTarget(
   set: MachineNodeHandleSet,
@@ -144,7 +155,12 @@ export function resolveMachineNodeTarget(
       (h) => h.kind === 'branch' && h.branch === target.branch && (project === undefined || h.project === project),
     );
     if (matches.length === 1) return { ok: true, handle: matches[0] };
-    return { ok: false, reason: matches.length === 0 ? 'target_not_in_set' : 'ambiguous_target' };
+    if (matches.length > 1) return { ok: false, reason: 'ambiguous_target' };
+    if (project !== undefined) {
+      const projectHandle = set.handles.find((h) => h.kind === 'project' && h.project === project);
+      if (projectHandle) return { ok: true, handle: projectHandle };
+    }
+    return { ok: false, reason: 'target_not_in_set' };
   }
 
   const project = set.handles.find((h) => h.kind === 'project' && h.project === target.project);

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -137,12 +137,20 @@ export type MachineNodeTargetResolution =
  * checkout happens to be on". A project's default checkout has no branch
  * handle of its own, so a caller (a model reasoning in ordinary git terms)
  * naturally but incorrectly asks for `{ project, branch: "main" }` to mean
- * "this project's own state". When the branch half of that target doesn't
- * resolve but the project half does, we fall back to the PROJECT handle
- * rather than denying the whole target — the project was already in `set`,
- * so this grants nothing new, it just stops a wrong-shaped-but-harmless
- * target from reading as "get out of this machine entirely".
+ * "this project's own state". When that branch name is a conventional
+ * default-checkout alias (`main`/`master`) and doesn't resolve, but the
+ * project half of the target does, we fall back to the PROJECT handle rather
+ * than denying the whole target — the project was already in `set`, so this
+ * grants nothing new.
+ *
+ * This fallback is DELIBERATELY narrow — only those two alias names, never
+ * any other unresolved branch. A misspelled or deleted branch name must
+ * still deny outright: silently redirecting it to the project's default
+ * checkout would let bash/file/git tools run against the wrong worktree
+ * without the caller ever finding out.
  */
+const DEFAULT_CHECKOUT_BRANCH_ALIASES = new Set(['main', 'master']);
+
 export function resolveMachineNodeTarget(
   set: MachineNodeHandleSet,
   target: MachineNodeTarget | undefined,
@@ -156,7 +164,7 @@ export function resolveMachineNodeTarget(
     );
     if (matches.length === 1) return { ok: true, handle: matches[0] };
     if (matches.length > 1) return { ok: false, reason: 'ambiguous_target' };
-    if (project !== undefined) {
+    if (project !== undefined && DEFAULT_CHECKOUT_BRANCH_ALIASES.has(target.branch)) {
       const projectHandle = set.handles.find((h) => h.kind === 'project' && h.project === project);
       if (projectHandle) return { ok: true, handle: projectHandle };
     }

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -149,9 +149,8 @@ export type MachineNodeTargetResolution =
  * "never existed"). There is no data this function can see that closes that
  * gap for every case, so the fallback is gone: an unresolved target ALWAYS
  * denies, full stop. The caller-facing error (`sandbox-tools.ts`'s
- * `nodeTargetDeniedError`) carries the corrective guidance instead — telling
- * the caller to drop the `branch` field rather than the runtime guessing on
- * its behalf.
+ * `nodeTargetDeniedError`) provides neutral guidance to inspect
+ * `list_sessions`, rather than the runtime guessing on its behalf.
  */
 export function resolveMachineNodeTarget(
   set: MachineNodeHandleSet,

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -27,6 +27,7 @@
 
 import type { MachineAgentTerminalStore } from './agent-terminals-store';
 import { SANDBOX_ROOT, BRANCH_REPO_PATH, PROJECT_REPO_PATH } from '../sandbox/sandbox-paths';
+import { isMainBranchName } from '../sandbox/machine-diff-scope';
 import { isAgentRuntimeType, isPtyAgentType } from './agent-terminal-types';
 
 export type MachinePaneBindingFailureReason = 'binding_page_mismatch' | 'project_not_found' | 'branch_not_found';
@@ -121,10 +122,12 @@ export type MachineNodeTargetResolution =
   | { ok: false; reason: 'ambiguous_target' };
 
 /**
- * Resolve a tool call's `target` against a derived handle set. PURE LOOKUP —
- * it makes no policy decision of its own, because the set already IS the
- * policy (see `MachineNodeHandleSet`): "not in the set" is the same fact as
- * "never derived", so there is no second place that can decide differently.
+ * Resolve a tool call's `target` against a derived handle set. Mostly a PURE
+ * LOOKUP — the set already IS the policy (see `MachineNodeHandleSet`): "not
+ * in the set" is normally the same fact as "never derived". The one
+ * exception is the default-checkout branch-name fallback below, which is a
+ * deliberately narrow carve-out, not a second place deciding node access —
+ * see its own note for why it doesn't widen the set.
  *
  * An omitted `target` (or an empty one) is the node the conversation is
  * natively bound to. A bare `branch` defaults its project to `self.project`
@@ -137,20 +140,19 @@ export type MachineNodeTargetResolution =
  * checkout happens to be on". A project's default checkout has no branch
  * handle of its own, so a caller (a model reasoning in ordinary git terms)
  * naturally but incorrectly asks for `{ project, branch: "main" }` to mean
- * "this project's own state". When that branch name is a conventional
- * default-checkout alias (`main`/`master`) and doesn't resolve, but the
- * project half of the target does, we fall back to the PROJECT handle rather
- * than denying the whole target — the project was already in `set`, so this
- * grants nothing new.
+ * "this project's own state". When that branch name is the repo's own
+ * default-branch name (`isMainBranchName` — same main/master convention as
+ * `machine-diff-scope.ts`) and doesn't resolve, but the project half of the
+ * target does, we fall back to the PROJECT handle rather than denying the
+ * whole target — the project was already in `set`, so this grants nothing
+ * new, it only re-resolves a request for a node that was already reachable.
  *
- * This fallback is DELIBERATELY narrow — only those two alias names, never
+ * This fallback is DELIBERATELY narrow — only that default-branch name, never
  * any other unresolved branch. A misspelled or deleted branch name must
  * still deny outright: silently redirecting it to the project's default
  * checkout would let bash/file/git tools run against the wrong worktree
  * without the caller ever finding out.
  */
-const DEFAULT_CHECKOUT_BRANCH_ALIASES = new Set(['main', 'master']);
-
 export function resolveMachineNodeTarget(
   set: MachineNodeHandleSet,
   target: MachineNodeTarget | undefined,
@@ -164,7 +166,7 @@ export function resolveMachineNodeTarget(
     );
     if (matches.length === 1) return { ok: true, handle: matches[0] };
     if (matches.length > 1) return { ok: false, reason: 'ambiguous_target' };
-    if (project !== undefined && DEFAULT_CHECKOUT_BRANCH_ALIASES.has(target.branch)) {
+    if (project !== undefined && isMainBranchName(target.branch)) {
       const projectHandle = set.handles.find((h) => h.kind === 'project' && h.project === project);
       if (projectHandle) return { ok: true, handle: projectHandle };
     }

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -27,7 +27,6 @@
 
 import type { MachineAgentTerminalStore } from './agent-terminals-store';
 import { SANDBOX_ROOT, BRANCH_REPO_PATH, PROJECT_REPO_PATH } from '../sandbox/sandbox-paths';
-import { isMainBranchName } from '../sandbox/machine-diff-scope';
 import { isAgentRuntimeType, isPtyAgentType } from './agent-terminal-types';
 
 export type MachinePaneBindingFailureReason = 'binding_page_mismatch' | 'project_not_found' | 'branch_not_found';
@@ -104,16 +103,6 @@ export interface MachineNodeHandleSet {
   self: MachineNodeHandle;
   /** self + the downward closure, self first, then depth-first by project. */
   handles: readonly MachineNodeHandle[];
-  /**
-   * Branches that HAD a row here but whose Sprite was torn down — omitted
-   * from `handles` (fail-closed, same as any other torn-down branch), but
-   * still recorded here so `resolveMachineNodeTarget`'s default-checkout
-   * fallback can tell "this name was never tracked" (fall back to the
-   * project) apart from "this name existed and was deliberately torn down"
-   * (must stay denied, never silently reroute to a DIFFERENT checkout).
-   * Empty/absent means nothing by that name was ever tracked under this set.
-   */
-  tornDownBranches?: readonly { project: string; branch: string }[];
 }
 
 export type MachinePaneBinding = MachineNodeHandleSet;
@@ -132,12 +121,10 @@ export type MachineNodeTargetResolution =
   | { ok: false; reason: 'ambiguous_target' };
 
 /**
- * Resolve a tool call's `target` against a derived handle set. Mostly a PURE
- * LOOKUP — the set already IS the policy (see `MachineNodeHandleSet`): "not
- * in the set" is normally the same fact as "never derived". The one
- * exception is the default-checkout branch-name fallback below, which is a
- * deliberately narrow carve-out, not a second place deciding node access —
- * see its own note for why it doesn't widen the set.
+ * Resolve a tool call's `target` against a derived handle set. PURE LOOKUP —
+ * it makes no policy decision of its own, because the set already IS the
+ * policy (see `MachineNodeHandleSet`): "not in the set" is the same fact as
+ * "never derived", so there is no second place that can decide differently.
  *
  * An omitted `target` (or an empty one) is the node the conversation is
  * natively bound to. A bare `branch` defaults its project to `self.project`
@@ -149,22 +136,22 @@ export type MachineNodeTargetResolution =
  * own row, its own Sprite) — never "whatever git branch the project's own
  * checkout happens to be on". A project's default checkout has no branch
  * handle of its own, so a caller (a model reasoning in ordinary git terms)
- * naturally but incorrectly asks for `{ project, branch: "main" }` to mean
- * "this project's own state". When that branch name is the repo's own
- * default-branch name (`isMainBranchName` — same main/master convention as
- * `machine-diff-scope.ts`) and doesn't resolve, but the project half of the
- * target does, we fall back to the PROJECT handle rather than denying the
- * whole target — the project was already in `set`, so this grants nothing
- * new, it only re-resolves a request for a node that was already reachable.
+ * may naturally but incorrectly ask for `{ project, branch: "main" }` to mean
+ * "this project's own state".
  *
- * This fallback is DELIBERATELY narrow — only that default-branch name, never
- * any other unresolved branch. A misspelled or deleted branch name must
- * still deny outright: silently redirecting it to the project's default
- * checkout would let bash/file/git tools run against the wrong worktree
- * without the caller ever finding out. That includes a default-named branch
- * that WAS explicitly created and later torn down (`set.tornDownBranches`):
- * it stays denied exactly as before, never rerouted to the project's
- * (different) checkout — "torn down" is not "never existed".
+ * An earlier version of this function tried to help by falling back to the
+ * PROJECT handle when the unresolved branch name was a conventional
+ * default-checkout alias (`main`/`master`). Three rounds of review (#2232)
+ * kept finding new ways that silent substitution could route a tool call to
+ * the WRONG worktree: an unrelated typo, a branch that existed and was torn
+ * down, a branch explicitly killed (`killBranch` hard-deletes its row —
+ * `machine-branches.ts` — leaving no trace to distinguish "deleted" from
+ * "never existed"). There is no data this function can see that closes that
+ * gap for every case, so the fallback is gone: an unresolved target ALWAYS
+ * denies, full stop. The caller-facing error (`sandbox-tools.ts`'s
+ * `nodeTargetDeniedError`) carries the corrective guidance instead — telling
+ * the caller to drop the `branch` field rather than the runtime guessing on
+ * its behalf.
  */
 export function resolveMachineNodeTarget(
   set: MachineNodeHandleSet,
@@ -178,15 +165,7 @@ export function resolveMachineNodeTarget(
       (h) => h.kind === 'branch' && h.branch === target.branch && (project === undefined || h.project === project),
     );
     if (matches.length === 1) return { ok: true, handle: matches[0] };
-    if (matches.length > 1) return { ok: false, reason: 'ambiguous_target' };
-    const wasTornDown = set.tornDownBranches?.some(
-      (b) => b.project === project && b.branch === target.branch,
-    );
-    if (project !== undefined && isMainBranchName(target.branch) && !wasTornDown) {
-      const projectHandle = set.handles.find((h) => h.kind === 'project' && h.project === project);
-      if (projectHandle) return { ok: true, handle: projectHandle };
-    }
-    return { ok: false, reason: 'target_not_in_set' };
+    return { ok: false, reason: matches.length === 0 ? 'target_not_in_set' : 'ambiguous_target' };
   }
 
   const project = set.handles.find((h) => h.kind === 'project' && h.project === target.project);
@@ -299,8 +278,7 @@ export async function deriveMachinePaneBinding(
     const project = await deps.projectLookup.findByName(row.machineId, row.projectName);
     if (!project) return { ok: false, reason: 'project_not_found' };
     const self = projectHandle(row.machineId, project);
-    const { handles: branches, tornDown } = await branchHandles(row.machineId, project, deps);
-    return { ok: true, binding: { self, handles: [self, ...branches], tornDownBranches: tornDown } };
+    return { ok: true, binding: { self, handles: [self, ...(await branchHandles(row.machineId, project, deps))] } };
   }
 
   const self: MachineNodeHandle = { kind: 'machine', machineId: row.machineId, cwd: SANDBOX_ROOT };
@@ -310,12 +288,8 @@ export async function deriveMachinePaneBinding(
     deps.branchLookup.listAll(row.machineId),
   ]);
   const liveBranchesByProject = new Map<string, MachinePaneBindingBranch[]>();
-  const tornDownBranches: { project: string; branch: string }[] = [];
   for (const branch of allBranches) {
-    if (branch.spriteTornDownAt !== null) {
-      tornDownBranches.push({ project: branch.projectName, branch: branch.branchName });
-      continue; // same fail-closed rule as `branchHandles`
-    }
+    if (branch.spriteTornDownAt !== null) continue; // same fail-closed rule as `branchHandles`
     const group = liveBranchesByProject.get(branch.projectName) ?? [];
     group.push(branch);
     liveBranchesByProject.set(branch.projectName, group);
@@ -327,7 +301,7 @@ export async function deriveMachinePaneBinding(
     projectHandle(row.machineId, project),
     ...(liveBranchesByProject.get(project.name) ?? []).map((b) => branchHandle(row.machineId, b)),
   ]);
-  return { ok: true, binding: { self, handles: [self, ...descendants], tornDownBranches } };
+  return { ok: true, binding: { self, handles: [self, ...descendants] } };
 }
 
 function projectHandle(machineId: string, project: MachinePaneBindingProject): MachineNodeHandle {
@@ -371,25 +345,17 @@ function branchHandle(machineId: string, branch: MachinePaneBindingBranch): Mach
 }
 
 /**
- * The live branches of one project, plus the names of any torn-down ones. A
- * branch whose Sprite is CONFIRMED destroyed (`spriteTornDownAt`) is omitted
- * from `handles` rather than derived-then-denied: that is the same
- * fail-closed rule the natively-bound branch path applies (`branch_not_found`),
- * expressed as absence from the set. A torn-down branch is unaddressable from
- * anywhere — its name is still returned (separately) so a caller resolving a
- * target can tell it apart from a name that was never tracked at all.
+ * The live branches of one project. A branch whose Sprite is CONFIRMED
+ * destroyed (`spriteTornDownAt`) is omitted rather than derived-then-denied:
+ * that is the same fail-closed rule the natively-bound branch path applies
+ * (`branch_not_found`), expressed as absence from the set. A torn-down branch
+ * is unaddressable from anywhere.
  */
 async function branchHandles(
   machineId: string,
   project: MachinePaneBindingProject,
   deps: DeriveMachinePaneBindingDeps,
-): Promise<{ handles: MachineNodeHandle[]; tornDown: { project: string; branch: string }[] }> {
+): Promise<MachineNodeHandle[]> {
   const branches = await deps.branchLookup.list(machineId, project.name);
-  const handles: MachineNodeHandle[] = [];
-  const tornDown: { project: string; branch: string }[] = [];
-  for (const b of branches) {
-    if (b.spriteTornDownAt === null) handles.push(branchHandle(machineId, b));
-    else tornDown.push({ project: b.projectName, branch: b.branchName });
-  }
-  return { handles, tornDown };
+  return branches.filter((b) => b.spriteTornDownAt === null).map((b) => branchHandle(machineId, b));
 }

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -104,6 +104,16 @@ export interface MachineNodeHandleSet {
   self: MachineNodeHandle;
   /** self + the downward closure, self first, then depth-first by project. */
   handles: readonly MachineNodeHandle[];
+  /**
+   * Branches that HAD a row here but whose Sprite was torn down — omitted
+   * from `handles` (fail-closed, same as any other torn-down branch), but
+   * still recorded here so `resolveMachineNodeTarget`'s default-checkout
+   * fallback can tell "this name was never tracked" (fall back to the
+   * project) apart from "this name existed and was deliberately torn down"
+   * (must stay denied, never silently reroute to a DIFFERENT checkout).
+   * Empty/absent means nothing by that name was ever tracked under this set.
+   */
+  tornDownBranches?: readonly { project: string; branch: string }[];
 }
 
 export type MachinePaneBinding = MachineNodeHandleSet;
@@ -151,7 +161,10 @@ export type MachineNodeTargetResolution =
  * any other unresolved branch. A misspelled or deleted branch name must
  * still deny outright: silently redirecting it to the project's default
  * checkout would let bash/file/git tools run against the wrong worktree
- * without the caller ever finding out.
+ * without the caller ever finding out. That includes a default-named branch
+ * that WAS explicitly created and later torn down (`set.tornDownBranches`):
+ * it stays denied exactly as before, never rerouted to the project's
+ * (different) checkout — "torn down" is not "never existed".
  */
 export function resolveMachineNodeTarget(
   set: MachineNodeHandleSet,
@@ -166,7 +179,10 @@ export function resolveMachineNodeTarget(
     );
     if (matches.length === 1) return { ok: true, handle: matches[0] };
     if (matches.length > 1) return { ok: false, reason: 'ambiguous_target' };
-    if (project !== undefined && isMainBranchName(target.branch)) {
+    const wasTornDown = set.tornDownBranches?.some(
+      (b) => b.project === project && b.branch === target.branch,
+    );
+    if (project !== undefined && isMainBranchName(target.branch) && !wasTornDown) {
       const projectHandle = set.handles.find((h) => h.kind === 'project' && h.project === project);
       if (projectHandle) return { ok: true, handle: projectHandle };
     }
@@ -283,7 +299,8 @@ export async function deriveMachinePaneBinding(
     const project = await deps.projectLookup.findByName(row.machineId, row.projectName);
     if (!project) return { ok: false, reason: 'project_not_found' };
     const self = projectHandle(row.machineId, project);
-    return { ok: true, binding: { self, handles: [self, ...(await branchHandles(row.machineId, project, deps))] } };
+    const { handles: branches, tornDown } = await branchHandles(row.machineId, project, deps);
+    return { ok: true, binding: { self, handles: [self, ...branches], tornDownBranches: tornDown } };
   }
 
   const self: MachineNodeHandle = { kind: 'machine', machineId: row.machineId, cwd: SANDBOX_ROOT };
@@ -293,8 +310,12 @@ export async function deriveMachinePaneBinding(
     deps.branchLookup.listAll(row.machineId),
   ]);
   const liveBranchesByProject = new Map<string, MachinePaneBindingBranch[]>();
+  const tornDownBranches: { project: string; branch: string }[] = [];
   for (const branch of allBranches) {
-    if (branch.spriteTornDownAt !== null) continue; // same fail-closed rule as `branchHandles`
+    if (branch.spriteTornDownAt !== null) {
+      tornDownBranches.push({ project: branch.projectName, branch: branch.branchName });
+      continue; // same fail-closed rule as `branchHandles`
+    }
     const group = liveBranchesByProject.get(branch.projectName) ?? [];
     group.push(branch);
     liveBranchesByProject.set(branch.projectName, group);
@@ -306,7 +327,7 @@ export async function deriveMachinePaneBinding(
     projectHandle(row.machineId, project),
     ...(liveBranchesByProject.get(project.name) ?? []).map((b) => branchHandle(row.machineId, b)),
   ]);
-  return { ok: true, binding: { self, handles: [self, ...descendants] } };
+  return { ok: true, binding: { self, handles: [self, ...descendants], tornDownBranches } };
 }
 
 function projectHandle(machineId: string, project: MachinePaneBindingProject): MachineNodeHandle {
@@ -350,17 +371,25 @@ function branchHandle(machineId: string, branch: MachinePaneBindingBranch): Mach
 }
 
 /**
- * The live branches of one project. A branch whose Sprite is CONFIRMED
- * destroyed (`spriteTornDownAt`) is omitted rather than derived-then-denied:
- * that is the same fail-closed rule the natively-bound branch path applies
- * (`branch_not_found`), expressed as absence from the set. A torn-down branch
- * is unaddressable from anywhere.
+ * The live branches of one project, plus the names of any torn-down ones. A
+ * branch whose Sprite is CONFIRMED destroyed (`spriteTornDownAt`) is omitted
+ * from `handles` rather than derived-then-denied: that is the same
+ * fail-closed rule the natively-bound branch path applies (`branch_not_found`),
+ * expressed as absence from the set. A torn-down branch is unaddressable from
+ * anywhere — its name is still returned (separately) so a caller resolving a
+ * target can tell it apart from a name that was never tracked at all.
  */
 async function branchHandles(
   machineId: string,
   project: MachinePaneBindingProject,
   deps: DeriveMachinePaneBindingDeps,
-): Promise<MachineNodeHandle[]> {
+): Promise<{ handles: MachineNodeHandle[]; tornDown: { project: string; branch: string }[] }> {
   const branches = await deps.branchLookup.list(machineId, project.name);
-  return branches.filter((b) => b.spriteTornDownAt === null).map((b) => branchHandle(machineId, b));
+  const handles: MachineNodeHandle[] = [];
+  const tornDown: { project: string; branch: string }[] = [];
+  for (const b of branches) {
+    if (b.spriteTornDownAt === null) handles.push(branchHandle(machineId, b));
+    else tornDown.push({ project: b.projectName, branch: b.branchName });
+  }
+  return { handles, tornDown };
 }


### PR DESCRIPTION
## Summary
- Agents/models bound to a machine pane naturally address their own project using ordinary git terms, e.g. `target: { project: "PageSpace", branch: "main" }`. But a `branch` handle in this system only ever represents an *explicitly created* branch worktree (its own row, its own Sprite) — a project's own default checkout has no branch handle of its own, unless a branch happens to be separately created under that exact name.
- `resolveMachineNodeTarget` was denying the **whole** target whenever the branch half didn't resolve, even though the project half did — which reads as "this agent has no sandbox access at all" the moment it tries to touch its own project, since the project was already in scope.
- **Final approach**: the denial always stays a denial — no fallback, no substitution, ever. The corrective *message* (not the runtime) carries the guidance: `nodeTargetDeniedError` appends a neutral hint when the denied branch name is a conventional default-checkout alias, and the machine-binding system prompt explains that `branch` only names an explicitly created worktree, and that default-checkout intent always means `target: { project }` alone regardless of what branch names happen to be reachable — deferring entirely to the always-accurate `list_sessions`/reachable-node list rather than asserting anything about what does or doesn't exist.

## Root cause
Confirmed against a real failing case: `The target project "PageSpace" / branch "main" is not part of this conversation's machine scope.` — `deriveMachinePaneBinding` only derives branch handles from explicitly-created `MachinePaneBindingBranch` rows; a brand-new project has zero of them, so any `{project, branch: "main"}` target was guaranteed to fail even though the project is the caller's own bound node.

## Review history — eleven rounds, converging on "never assert, always defer to the list"
This PR went through 11 rounds of automated review findings (Codex + CodeRabbit). The first three were on the RUNTIME (a project-handle fallback that silently substituted for an unresolved branch target): a typo falling back, a torn-down-but-tracked branch needing to stay denied, and a manually-killed branch leaving no trace to distinguish from "never existed." Three different ways for the same substitution mechanism to misfire meant the mechanism itself was the problem — removed entirely (`0fa298e5d`): `resolveMachineNodeTarget` is a pure lookup again, an unresolved target always denies, full stop.

Rounds 4-9 were on the *replacement guidance* (the denial hint + system prompt warning), each catching a case where an attempt to assert "this branch doesn't exist" was wrong for some part of the actual state: the hint recommending an unsafe retry, the prompt's `self` exclusion, unreachable advice for branch-scoped selfs, imprecise wording, and finally a mixed machine-root binding (one project with a live default branch, a different reachable project without one) that no single global yes/no answer could handle correctly. `8c8744796` stopped trying to assert anything about the reachable set at all — the warning became unconditional and purely conceptual ("branch" ≠ a project's implicit default state), deferring entirely to the always-accurate, per-project "Currently reachable" listing already in the prompt.

Round 10 (Codex, `4629b0a17`) caught that even the *unconditional* wording still had a bug: telling the model "add `branch: main/master` if that pairing is listed" is wrong when the model's actual intent is the project's own default checkout, because a separately created worktree literally named `main`/`master` is still a *different* Sprite — following that advice for default-checkout intent would silently misroute to the wrong worktree, the exact risk the whole warning exists to prevent. Fixed by making default-checkout intent unconditional too: always `target: { project }` alone, regardless of what's reachable.

Round 11 (CodeRabbit + Codex, `ebf41c221`) caught two smaller correctness issues introduced along the way: a stale doc comment in `machine-pane-binding.ts` still claiming the denial message tells callers to "drop the branch field" (it doesn't — it neutrally points at `list_sessions`), and a self-contradictory "listed below" vs. "listed above" in the same sentence of the prompt warning (the reachable list is concatenated *before* the warning, so "above" is correct throughout).

A CHANGELOG.md entry was added under Unreleased/Fixed per repo convention for this user-visible behavior change (`ebddd2384`).

`/simplify` pass (4 parallel review angles) also landed early on and is preserved: reused the existing `isMainBranchName` helper in `sandbox-tools.ts`'s hint instead of a local copy of the main/master convention.

## Test plan
- [x] `bun test src/services/machines/__tests__/machine-pane-binding.test.ts` — 32/32 pass (pure lookup, no fallback).
- [x] `vitest run` on `sandbox-tools`, `sandbox-git-tools`, `session-tools`, `headless-session-run`, `machine-binding-prompt` — 300+ pass, including cases for the neutral denial hint and the unconditional, list-deferring prompt warning (project self with/without live branches, a live branch literally named main/master, mixed machine-root sets, branch-scoped self skipped entirely).
- [x] `machine-diff-scope`'s own test suite — 43/43 pass, unaffected.
- [x] `bun run knip:check` passes; no lint/typecheck errors in touched files.
- [x] CI: `ci / Unit Tests`, `ci / Lint & TypeScript Check`, `Static Security Analysis`, `CodeQL Security Analysis`/`CodeQL`, `Security Test Suite`, `Dependency Audit`, `Secret Scanning` all green on the final commit.
- [ ] Manual: address a machine-bound project with `target: { project: <self>, branch: "main" }` (no branch rows created) and confirm the denial is neutral (no unsafe prescribed retry), and that list_sessions correctly shows what's really reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eLa7X5Mt8Xy5tFvJY1QMX
