### PR TITLE
fix(web): unblock ask_user selections in developer/machine chats

### DIFF
--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAskUserAnswering.logic.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAskUserAnswering.logic.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { UIMessage } from 'ai';
+import { getAnswerableAskUserToolCallIds } from '../useAskUserAnswering';
+
+const assistantMessage = (parts: Array<Record<string, unknown>>): UIMessage =>
+  ({ id: 'a1', role: 'assistant', parts } as unknown as UIMessage);
+
+describe('getAnswerableAskUserToolCallIds', () => {
+  it('given ask_user on the last assistant message with input-available, should mark it answerable', () => {
+    const ids = getAnswerableAskUserToolCallIds([
+      assistantMessage([
+        { type: 'tool-ask_user', toolCallId: 'q1', state: 'input-available', input: { questions: [] } },
+      ]),
+    ]);
+
+    expect(ids.has('q1')).toBe(true);
+  });
+
+  it('given ask_user not on the last message, should return no answerable ids', () => {
+    const ids = getAnswerableAskUserToolCallIds([
+      assistantMessage([
+        { type: 'tool-ask_user', toolCallId: 'q1', state: 'input-available', input: { questions: [] } },
+      ]),
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'later message' }] } as unknown as UIMessage,
+    ]);
+
+    expect(ids.size).toBe(0);
+  });
+
+  it('given ask_user already output-available, should return no answerable ids', () => {
+    const ids = getAnswerableAskUserToolCallIds([
+      assistantMessage([
+        { type: 'tool-ask_user', toolCallId: 'q1', state: 'output-available', output: { answers: [] } },
+      ]),
+    ]);
+
+    expect(ids.size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/useAskUserAnswering.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAskUserAnswering.ts
@@ -30,25 +30,30 @@ export interface AskUserAnsweringApi {
  * Shared answer plumbing for the ask_user interactive question tool.
  *
  * A question is only answerable when its part sits on the conversation's
- * LAST message (addToolOutput only patches the last message) and the chat is
- * idle — otherwise it renders read-only (historical, mid-stream, or a later
- * message already exists).
+ * LAST message (addToolOutput only patches the last message) and the part is
+ * still pending input. We intentionally do NOT gate on transport status here:
+ * status is surface-local and can be stale/non-conversation-scoped on complex
+ * surfaces (machines/sidebar mode switches), which can incorrectly lock a
+ * valid ask_user card behind disabled options.
  */
+export function getAnswerableAskUserToolCallIds(messages: UIMessage[]): ReadonlySet<string> {
+  const ids = new Set<string>();
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant' || !last.parts) return ids;
+
+  for (const part of last.parts) {
+    if (part.type !== ASK_USER_PART_TYPE) continue;
+    const p = part as { toolCallId: string; state?: string };
+    if (p.state === 'input-available') ids.add(p.toolCallId);
+  }
+
+  return ids;
+}
+
 export function useAskUserAnswering(params: UseAskUserAnsweringParams): AskUserAnsweringApi {
-  const { messages, status, addToolResult, wrapSend, buildBody } = params;
+  const { messages, addToolResult, wrapSend, buildBody } = params;
 
-  const answerableToolCallIds = useMemo(() => {
-    const ids = new Set<string>();
-    const last = messages[messages.length - 1];
-    if (!last || last.role !== 'assistant' || status !== 'ready' || !last.parts) return ids;
-
-    for (const part of last.parts) {
-      if (part.type !== ASK_USER_PART_TYPE) continue;
-      const p = part as { toolCallId: string; state?: string };
-      if (p.state === 'input-available') ids.add(p.toolCallId);
-    }
-    return ids;
-  }, [messages, status]);
+  const answerableToolCallIds = useMemo(() => getAnswerableAskUserToolCallIds(messages), [messages]);
 
   const submitAnswers = useCallback(
     (toolCallId: string, output: AskUserOutput) => {


### PR DESCRIPTION
## Summary
- fixes ask_user option cards becoming non-interactive in developer/machine-style chat surfaces
- removes the `status === 'ready'` gate from ask_user answerability computation
- keeps answerability scoped to pending `tool-ask_user` parts on the **last assistant message**
- adds a focused logic test suite for answerability selection

## Root cause
`useAskUserAnswering` required transport `status` to be `ready` before exposing answerable tool call ids. In complex surfaces (mode switches / machine/developer contexts), status can be surface-local or stale relative to the rendered conversation, causing ask_user cards to render in a disabled state (`not-allowed` cursor) even when the last message has a pending `input-available` question.

## Changes
- `apps/web/src/lib/ai/shared/hooks/useAskUserAnswering.ts`
  - extracted `getAnswerableAskUserToolCallIds(messages)` helper
  - removed status gate from answerable-id selection
- `apps/web/src/lib/ai/shared/hooks/__tests__/useAskUserAnswering.logic.test.ts`
  - verifies:
    - pending ask_user on last assistant message is answerable
    - ask_user not on last message is not answerable
    - output-available ask_user is not answerable

## Verification
- ✅ `bun run test src/lib/ai/shared/hooks/__tests__/useAskUserAnswering.logic.test.ts`
- ✅ `bun run lint` (warnings only, pre-existing)
- ⚠️ `bun run typecheck` in `apps/web` could not complete in sandbox (tool execution failed/timeout despite increased memory and timeout)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “Ask User” prompts so response options remain available when appropriate.
  * Prevented completed prompts or prompts from earlier messages from being treated as answerable.

* **Tests**
  * Added coverage for active, completed, and outdated “Ask User” prompt scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->