### PR TITLE
fix(activity-log): stop writing conversation ids into activity_logs.pageId

### DIFF
--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
@@ -320,7 +320,7 @@ describe('PATCH /api/ai/global/[id]/messages/[messageId]', () => {
         'message_update',
         expect.objectContaining({
           id: mockMessageId,
-          pageId: mockConversationId,
+          pageId: null,
           driveId: null,
           conversationType: 'global',
         }),
@@ -534,7 +534,7 @@ describe('DELETE /api/ai/global/[id]/messages/[messageId]', () => {
         'message_delete',
         expect.objectContaining({
           id: mockMessageId,
-          pageId: mockConversationId,
+          pageId: null,
           driveId: null,
           conversationType: 'global',
         }),

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -115,7 +115,10 @@ export async function PATCH(
       const actorInfo = await getActorInfo(userId);
       logMessageActivity(userId, 'message_update', {
         id: messageId,
-        pageId: conversationId, // Global conversations use conversationId as identifier
+        // Global conversations aren't page-backed - conversationId belongs to the
+        // `conversations` table, so writing it to activity_logs.pageId violates the
+        // pages FK. Linkage is carried by aiConversationId + metadata.conversationType.
+        pageId: null,
         driveId: null, // Global conversations are user-level, not drive-level
         conversationType: 'global',
       }, actorInfo, {
@@ -242,7 +245,10 @@ export async function DELETE(
       const actorInfo = await getActorInfo(userId);
       logMessageActivity(userId, 'message_delete', {
         id: messageId,
-        pageId: conversationId, // Global conversations use conversationId as identifier
+        // Global conversations aren't page-backed - conversationId belongs to the
+        // `conversations` table, so writing it to activity_logs.pageId violates the
+        // pages FK. Linkage is carried by aiConversationId + metadata.conversationType.
+        pageId: null,
         driveId: null, // Global conversations are user-level, not drive-level
         conversationType: 'global',
       }, actorInfo, {

--- a/apps/web/src/services/api/rollback/__tests__/page-mutation-plan.test.ts
+++ b/apps/web/src/services/api/rollback/__tests__/page-mutation-plan.test.ts
@@ -269,6 +269,18 @@ describe('pickConversationTable', () => {
     });
   });
 
+  it('routes global conversations with no pageId to the messages table', () => {
+    assert({
+      given: "conversationType 'global' with no pageId (how global-assistant message activities are logged)",
+      should: 'select messages and mark isGlobal',
+      actual: (() => {
+        const r = pickConversationTable({ conversationType: 'global', hasPageId: false });
+        return { isChannel: r.isChannel, isGlobal: r.isGlobal, label: r.label, isGlobalTable: r.table === messages };
+      })(),
+      expected: { isChannel: false, isGlobal: true, label: 'global', isGlobalTable: true },
+    });
+  });
+
   it('treats a missing pageId as global', () => {
     assert({
       given: 'no conversationType and no pageId',

--- a/packages/lib/src/monitoring/__tests__/activity-log-errors.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-log-errors.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for activity-log-errors.ts — pageId FK violation detection.
+ *
+ * Drizzle wraps driver errors, so the pg error fields live under `.cause`.
+ * These cases pin both the wrapped and the flat (legacy) shapes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isPageIdForeignKeyError } from '../activity-log-errors';
+
+describe('isPageIdForeignKeyError', () => {
+  it('should detect the production shape: pg error nested under .cause', () => {
+    const error = Object.assign(
+      new Error('Failed query: insert into "activity_logs" ("id", "userId") values ($1, $2)'),
+      {
+        cause: Object.assign(
+          new Error('insert or update on table "activity_logs" violates foreign key constraint'),
+          {
+            code: '23503',
+            constraint: 'activity_logs_pageId_pages_id_fk',
+            detail: 'Key (pageId)=(c2npdiezknc9adz0f91masv6) is not present in table "pages".',
+          }
+        ),
+      }
+    );
+    expect(isPageIdForeignKeyError(error)).toBe(true);
+  });
+
+  it('should detect a flat error carrying code and constraint', () => {
+    const error = Object.assign(new Error('FK error'), {
+      code: '23503',
+      constraint: 'activity_logs_pageId_pages_id_fk',
+    });
+    expect(isPageIdForeignKeyError(error)).toBe(true);
+  });
+
+  it('should detect an FK error nested two cause levels deep', () => {
+    const error = Object.assign(new Error('outer'), {
+      cause: Object.assign(new Error('middle'), {
+        cause: Object.assign(new Error('inner'), {
+          code: '23503',
+          constraint: 'activity_logs_pageId_pages_id_fk',
+        }),
+      }),
+    });
+    expect(isPageIdForeignKeyError(error)).toBe(true);
+  });
+
+  it('should fall back to detail when constraint is absent', () => {
+    const error = Object.assign(new Error('FK violation'), {
+      code: '23503',
+      detail: 'Key (pageId)=(page-1) is not present in table "pages".',
+    });
+    expect(isPageIdForeignKeyError(error)).toBe(true);
+  });
+
+  it('should return false for a 23503 on a different column', () => {
+    const error = Object.assign(new Error('FK violation'), {
+      code: '23503',
+      constraint: 'activity_logs_driveId_drives_id_fk',
+      detail: 'Key (driveId)=(drive-1) is not present in table "drives".',
+    });
+    expect(isPageIdForeignKeyError(error)).toBe(false);
+  });
+
+  it('should return false for a 23503 with no constraint and no detail', () => {
+    const error = Object.assign(new Error('FK violation'), { code: '23503' });
+    expect(isPageIdForeignKeyError(error)).toBe(false);
+  });
+
+  it('should return false for a non-23503 code even on the pageId constraint', () => {
+    const error = Object.assign(new Error('unique violation'), {
+      code: '23505',
+      constraint: 'activity_logs_pageId_pages_id_fk',
+    });
+    expect(isPageIdForeignKeyError(error)).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isPageIdForeignKeyError(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isPageIdForeignKeyError(undefined)).toBe(false);
+  });
+
+  it('should return false for a string', () => {
+    expect(isPageIdForeignKeyError('23503 activity_logs_pageId_pages_id_fk')).toBe(false);
+  });
+
+  it('should return false for a plain object with no pg fields', () => {
+    expect(isPageIdForeignKeyError({ message: 'nope' })).toBe(false);
+  });
+
+  it('should detect a non-Error object carrying the pg fields', () => {
+    expect(
+      isPageIdForeignKeyError({ code: '23503', constraint: 'activity_logs_pageId_pages_id_fk' })
+    ).toBe(true);
+  });
+
+  it('should return false for an Error with no extra fields', () => {
+    expect(isPageIdForeignKeyError(new Error('boom'))).toBe(false);
+  });
+
+  it('should return false when detail is present but not a string', () => {
+    const error = Object.assign(new Error('FK violation'), {
+      code: '23503',
+      detail: { column: 'pageId' },
+    });
+    expect(isPageIdForeignKeyError(error)).toBe(false);
+  });
+
+  it('should terminate on a cyclic cause chain', () => {
+    const a = Object.assign(new Error('a'), { cause: undefined as unknown });
+    const b = Object.assign(new Error('b'), { cause: a });
+    a.cause = b;
+    expect(isPageIdForeignKeyError(a)).toBe(false);
+  });
+
+  it('should stop walking beyond the depth limit', () => {
+    // 10 nested wrappers before the real error — deeper than any real driver chain
+    let error: unknown = Object.assign(new Error('inner'), {
+      code: '23503',
+      constraint: 'activity_logs_pageId_pages_id_fk',
+    });
+    for (let i = 0; i < 10; i++) {
+      error = Object.assign(new Error(`wrapper-${i}`), { cause: error });
+    }
+    expect(isPageIdForeignKeyError(error)).toBe(false);
+  });
+});

--- a/packages/lib/src/monitoring/__tests__/activity-logger-fk-retry.integration.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-logger-fk-retry.integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Activity-log pageId FK retry — integration tests (Postgres)
+ *
+ * Tests against a real Postgres database. Skips gracefully when DB is
+ * unavailable — same convention as `machine-panes-store.integration.test.ts`.
+ *
+ * The unit tests for `isPageIdForeignKeyError` construct the Drizzle wrapper
+ * error by hand, so they can only prove the predicate matches the shape we
+ * *believe* Drizzle throws. These tests remove that assumption: a real FK
+ * violation is provoked against a real `activity_logs` table, wrapped by the
+ * real driver, and the retry either fires or it does not.
+ *
+ * This is the regression that matters. The previous top-level-only guard
+ * passed every hand-built unit test while never firing in production.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq, sql } from '@pagespace/db/operators';
+import { activityLogs } from '@pagespace/db/schema/monitoring';
+import { factories } from '@pagespace/db/test/factories';
+import { logActivity, logMessageActivity } from '../activity-logger';
+
+let dbAvailable = false;
+
+beforeAll(async () => {
+  try {
+    await db.execute(sql`SELECT 1`);
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  }
+});
+
+/** Read back the single row a test wrote, keyed by its unique resourceId. */
+async function readRowByResourceId(resourceId: string) {
+  return db.query.activityLogs.findFirst({ where: eq(activityLogs.resourceId, resourceId) });
+}
+
+/** Let the fire-and-forget logging settle before asserting on the database. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('activity-log pageId FK retry (Postgres)', () => {
+  it('persists the row against a real page, keeping the pageId', async () => {
+    if (!dbAvailable) return;
+
+    const user = await factories.createUser();
+    const drive = await factories.createDrive(user.id);
+    const page = await factories.createPage(drive.id);
+    const resourceId = createId();
+
+    await logActivity({
+      userId: user.id,
+      actorEmail: user.email,
+      operation: 'update',
+      resourceType: 'page',
+      resourceId,
+      driveId: drive.id,
+      pageId: page.id,
+    });
+    await flush();
+
+    const row = await readRowByResourceId(resourceId);
+    expect(row?.pageId).toBe(page.id);
+  });
+
+  it('still records the activity when the page is gone, dropping only the pageId', async () => {
+    if (!dbAvailable) return;
+
+    const user = await factories.createUser();
+    const drive = await factories.createDrive(user.id);
+    const resourceId = createId();
+
+    // A page id that is well-formed but absent from `pages` — exactly the state
+    // left behind when a page is deleted mid-log. Postgres raises 23503, and
+    // node-postgres' error is wrapped by DrizzleQueryError with the pg fields
+    // reachable only via `.cause`.
+    await logActivity({
+      userId: user.id,
+      actorEmail: user.email,
+      operation: 'update',
+      resourceType: 'page',
+      resourceId,
+      driveId: drive.id,
+      pageId: createId(),
+    });
+    await flush();
+
+    const row = await readRowByResourceId(resourceId);
+    // Before the fix this row did not exist at all: the FK guard never matched
+    // the wrapped error, so the retry was skipped and the insert was dropped.
+    expect(row).toBeDefined();
+    expect(row?.pageId).toBeNull();
+    expect(row?.driveId).toBe(drive.id);
+  });
+
+  it('records a global-assistant message edit, which has no backing page', async () => {
+    if (!dbAvailable) return;
+
+    const user = await factories.createUser();
+    const messageId = createId();
+    const conversationId = createId();
+
+    // How the Global Assistant route logs today: user-level, not page-backed.
+    // Passing `conversationId` here as `pageId` is what caused the FK violation.
+    logMessageActivity(
+      user.id,
+      'message_delete',
+      { id: messageId, pageId: null, driveId: null, conversationType: 'global' },
+      { actorEmail: user.email },
+      { previousContent: 'deleted text', aiConversationId: conversationId }
+    );
+    await flush();
+
+    const row = await readRowByResourceId(messageId);
+    expect(row).toBeDefined();
+    expect(row?.pageId).toBeNull();
+    expect(row?.driveId).toBeNull();
+    expect(row?.aiConversationId).toBe(conversationId);
+    expect((row?.metadata as Record<string, unknown>)?.conversationType).toBe('global');
+  });
+});

--- a/packages/lib/src/monitoring/__tests__/activity-logger-fk-retry.integration.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-logger-fk-retry.integration.test.ts
@@ -33,13 +33,27 @@ beforeAll(async () => {
   }
 });
 
-/** Read back the single row a test wrote, keyed by its unique resourceId. */
-async function readRowByResourceId(resourceId: string) {
-  return db.query.activityLogs.findFirst({ where: eq(activityLogs.resourceId, resourceId) });
+/**
+ * Read back the single row a test wrote, keyed by its unique resourceId.
+ *
+ * Activity logging is fire-and-forget, so the write may still be in flight when
+ * the caller returns. Poll rather than sleeping a fixed interval: a macrotask
+ * yield does not wait on a database round-trip, and a fixed sleep long enough
+ * to be safe on CI would be dead time on every run.
+ *
+ * Returns undefined once the budget is exhausted so the "row is absent" case
+ * stays assertable — it just costs the full budget to prove.
+ */
+async function readRowByResourceId(resourceId: string, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const row = await db.query.activityLogs.findFirst({
+      where: eq(activityLogs.resourceId, resourceId),
+    });
+    if (row || Date.now() >= deadline) return row;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
 }
-
-/** Let the fire-and-forget logging settle before asserting on the database. */
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('activity-log pageId FK retry (Postgres)', () => {
   it('persists the row against a real page, keeping the pageId', async () => {
@@ -59,7 +73,6 @@ describe('activity-log pageId FK retry (Postgres)', () => {
       driveId: drive.id,
       pageId: page.id,
     });
-    await flush();
 
     const row = await readRowByResourceId(resourceId);
     expect(row?.pageId).toBe(page.id);
@@ -85,7 +98,6 @@ describe('activity-log pageId FK retry (Postgres)', () => {
       driveId: drive.id,
       pageId: createId(),
     });
-    await flush();
 
     const row = await readRowByResourceId(resourceId);
     // Before the fix this row did not exist at all: the FK guard never matched
@@ -111,7 +123,6 @@ describe('activity-log pageId FK retry (Postgres)', () => {
       { actorEmail: user.email },
       { previousContent: 'deleted text', aiConversationId: conversationId }
     );
-    await flush();
 
     const row = await readRowByResourceId(messageId);
     expect(row).toBeDefined();

--- a/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
@@ -618,6 +618,32 @@ describe('activity-logger', () => {
       expect(callCount).toBe(2);
       expect(capturedState.insertValues?.pageId).toBeUndefined();
     });
+
+    it('should retry without pageId when the FK error is nested under .cause (Drizzle wrapper)', async () => {
+      const fkError = Object.assign(
+        new Error('Failed query: insert into "activity_logs" ("id", "userId") values ($1, $2)'),
+        {
+          cause: Object.assign(
+            new Error('insert or update on table "activity_logs" violates foreign key constraint'),
+            {
+              code: '23503',
+              constraint: 'activity_logs_pageId_pages_id_fk',
+              detail: 'Key (pageId)=(page-1) is not present in table "pages".',
+            }
+          ),
+        }
+      );
+      let callCount = 0;
+      mockInsertValues.mockImplementation((values: Record<string, unknown>) => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(fkError);
+        capturedState.insertValues = values;
+        return Promise.resolve(undefined);
+      });
+      await logActivity({ ...baseInput, pageId: 'page-1' });
+      expect(callCount).toBe(2);
+      expect(capturedState.insertValues?.pageId).toBeUndefined();
+    });
   });
 
   // ── logActivityWithTx ─────────────────────────────────────────────────────
@@ -1006,6 +1032,20 @@ describe('activity-logger', () => {
     it('should include conversationType in metadata', async () => {
       logMessageActivity('u1', 'message_delete', { id: 'msg-1', pageId: 'p1', driveId: null, conversationType: 'global' }, { actorEmail: 'a@b.com' });
       await flush();
+      expect((capturedState.insertValues?.metadata as Record<string, unknown>)?.conversationType).toBe('global');
+    });
+
+    it('should forward a null pageId as undefined for global conversations', async () => {
+      logMessageActivity(
+        'u1',
+        'message_delete',
+        { id: 'msg-1', pageId: null, driveId: null, conversationType: 'global' },
+        { actorEmail: 'a@b.com' },
+        { previousContent: 'old', aiConversationId: 'conv-1' }
+      );
+      await flush();
+      expect(capturedState.insertValues?.pageId).toBeUndefined();
+      expect(capturedState.insertValues?.aiConversationId).toBe('conv-1');
       expect((capturedState.insertValues?.metadata as Record<string, unknown>)?.conversationType).toBe('global');
     });
 

--- a/packages/lib/src/monitoring/activity-log-errors.ts
+++ b/packages/lib/src/monitoring/activity-log-errors.ts
@@ -14,7 +14,8 @@ const PAGE_ID_CONSTRAINT = 'activity_logs_pageId_pages_id_fk';
 /**
  * How many `.cause` links to follow. Drizzle wraps the driver error exactly
  * one level deep ("Failed query: …" with the pg error under `.cause`); a small
- * fixed budget absorbs any extra wrapping without walking an unbounded chain.
+ * fixed budget absorbs any extra wrapping without walking an unbounded chain,
+ * and bounds cyclic `cause` chains without needing to track visited links.
  */
 const MAX_CAUSE_DEPTH = 5;
 
@@ -49,15 +50,11 @@ function isPageIdFkLink(fields: PgErrorFields): boolean {
  * Walks up to {@link MAX_CAUSE_DEPTH} cause links and tolerates cyclic chains.
  */
 export function isPageIdForeignKeyError(error: unknown): boolean {
-  const seen = new Set<object>();
   let current: unknown = error;
 
   for (let depth = 0; depth <= MAX_CAUSE_DEPTH; depth++) {
     const fields = asPgErrorFields(current);
     if (!fields) return false;
-    if (seen.has(fields as object)) return false;
-    seen.add(fields as object);
-
     if (isPageIdFkLink(fields)) return true;
     current = fields.cause;
   }

--- a/packages/lib/src/monitoring/activity-log-errors.ts
+++ b/packages/lib/src/monitoring/activity-log-errors.ts
@@ -1,0 +1,66 @@
+/**
+ * Error classification helpers for activity logging.
+ *
+ * Kept as a standalone pure module so it can be exercised without the
+ * database mocks that `activity-logger.ts` requires.
+ */
+
+/** Postgres `foreign_key_violation`. */
+const FK_VIOLATION_CODE = '23503';
+
+/** The FK that links `activity_logs.pageId` to `pages.id`. */
+const PAGE_ID_CONSTRAINT = 'activity_logs_pageId_pages_id_fk';
+
+/**
+ * How many `.cause` links to follow. Drizzle wraps the driver error exactly
+ * one level deep ("Failed query: …" with the pg error under `.cause`); a small
+ * fixed budget absorbs any extra wrapping without walking an unbounded chain.
+ */
+const MAX_CAUSE_DEPTH = 5;
+
+interface PgErrorFields {
+  code?: unknown;
+  constraint?: unknown;
+  detail?: unknown;
+  cause?: unknown;
+}
+
+/** Read the pg error fields off a value, or null if it can't carry them. */
+function asPgErrorFields(value: unknown): PgErrorFields | null {
+  if (typeof value !== 'object' || value === null) return null;
+  return value as PgErrorFields;
+}
+
+/** True when this single link is an `activity_logs.pageId` FK violation. */
+function isPageIdFkLink(fields: PgErrorFields): boolean {
+  if (fields.code !== FK_VIOLATION_CODE) return false;
+  if (fields.constraint === PAGE_ID_CONSTRAINT) return true;
+  return typeof fields.detail === 'string' && fields.detail.includes('pageId');
+}
+
+/**
+ * Detect a foreign key violation on `activity_logs.pageId`, including when the
+ * driver error is nested under `.cause`.
+ *
+ * Drizzle throws a wrapper `Error: Failed query: insert into "activity_logs" …`
+ * and hangs the real pg error (with `code` / `constraint` / `detail`) off its
+ * `cause`, so a top-level-only check never matches in production.
+ *
+ * Walks up to {@link MAX_CAUSE_DEPTH} cause links and tolerates cyclic chains.
+ */
+export function isPageIdForeignKeyError(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH; depth++) {
+    const fields = asPgErrorFields(current);
+    if (!fields) return false;
+    if (seen.has(fields as object)) return false;
+    seen.add(fields as object);
+
+    if (isPageIdFkLink(fields)) return true;
+    current = fields.cause;
+  }
+
+  return false;
+}

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -14,9 +14,9 @@ import { createId } from '@paralleldrive/cuid2';
 import { createHash, randomBytes } from 'crypto';
 import { desc, isNotNull, sql } from 'drizzle-orm';
 import { stableStringify } from '../utils/stable-stringify';
-import { isPageIdForeignKeyError } from './activity-log-errors';
 import { classifyProcessing } from '../compliance/art30/classify-processing';
 import { decryptField } from '../encryption/field-crypto';
+import { isPageIdForeignKeyError } from './activity-log-errors';
 
 /**
  * Advisory lock key for serializing activity log hash chain writes.

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -14,6 +14,7 @@ import { createId } from '@paralleldrive/cuid2';
 import { createHash, randomBytes } from 'crypto';
 import { desc, isNotNull, sql } from 'drizzle-orm';
 import { stableStringify } from '../utils/stable-stringify';
+import { isPageIdForeignKeyError } from './activity-log-errors';
 import { classifyProcessing } from '../compliance/art30/classify-processing';
 import { decryptField } from '../encryption/field-crypto';
 
@@ -562,17 +563,10 @@ export async function logActivity(input: ActivityLogInput): Promise<void> {
   try {
     await insertActivityLog(input.pageId);
   } catch (error) {
-    // Check for FK constraint violation on pageId (page was deleted during async logging)
-    const pgError = error as { code?: string; constraint?: string; detail?: string };
-    const isPageIdFkError =
-      error instanceof Error &&
-      pgError.code === '23503' &&
-      (
-        pgError.constraint === 'activity_logs_pageId_pages_id_fk' ||
-        (typeof pgError.detail === 'string' && pgError.detail.includes('pageId'))
-      );
-
-    if (isPageIdFkError && input.pageId) {
+    // Check for FK constraint violation on pageId (page was deleted during async logging).
+    // Drizzle wraps the driver error, so the pg fields live under `.cause` - see
+    // isPageIdForeignKeyError.
+    if (isPageIdForeignKeyError(error) && input.pageId) {
       // Retry without pageId - the page was deleted but we still want to log the activity
       try {
         await insertActivityLog(undefined);
@@ -1146,7 +1140,7 @@ export function logMessageActivity(
   operation: 'create' | 'message_update' | 'message_delete',
   message: {
     id: string;
-    pageId: string;
+    pageId: string | null; // null for conversations that aren't page-backed (global assistant)
     driveId: string | null; // null for user-level conversations (global assistant)
     conversationType: 'ai_chat' | 'global' | 'channel';
   },
@@ -1169,7 +1163,7 @@ export function logMessageActivity(
     resourceType: 'message',
     resourceId: message.id,
     driveId: message.driveId,
-    pageId: message.pageId,
+    pageId: message.pageId ?? undefined,
     previousValues: options?.previousContent ? { content: options.previousContent } : undefined,
     newValues: options?.newContent ? { content: options.newContent } : undefined,
     isAiGenerated: options?.isAiGenerated ?? false,

--- a/tasks/reviews/pu-activity-log-fk.md
+++ b/tasks/reviews/pu-activity-log-fk.md
@@ -11,7 +11,10 @@ wrapper error, so it never fired in production.
 
 Gates run locally, all green:
 - `bun run typecheck` ✅ 16/16 · `bun run lint` ✅ 14/14 · `bun x knip` ✅ (no new findings)
-- `bun run test:unit` (with test DB, `TZ=UTC`) — lib **9227 pass / 0 fail**, web **15704 pass / 0 fail**, exit 0
+- `bun run test:unit` (with test DB, `TZ=UTC`) — lib **9230 pass / 0 fail**, web **15704 pass / 0 fail**, exit 0
+- Post-review addition: `activity-logger-fk-retry.integration.test.ts` provokes a real 23503 against
+  real Postgres so the retry is proven end to end rather than against a hand-built error. Verified as a
+  true regression test — restoring the old guard drops the audit row (`expected undefined to be defined`).
 - `activity-log-errors.ts` at **100% branch coverage** (v8)
 - CI: all checks green on the head commit
 

--- a/tasks/reviews/pu-activity-log-fk.md
+++ b/tasks/reviews/pu-activity-log-fk.md
@@ -1,0 +1,70 @@
+# Code Review — `pu/activity-log-fk` (PR #2240)
+
+Reviewed 2026-07-27 against `master` (branch 0 commits behind, zero conflicts). 2 commits;
+~20 added / 12 removed lines of non-test source across 3 files, plus 4 test files. No schema,
+migration, or dependency changes.
+
+Scope: two stacked defects that silently dropped the audit trail for every Global Assistant message
+edit/delete — (1) the global route wrote a `conversations` id into `activity_logs.pageId`, guaranteeing
+an FK violation; (2) `logActivity`'s FK-retry fallback read pg fields off the top level of a Drizzle
+wrapper error, so it never fired in production.
+
+Gates run locally, all green:
+- `bun run typecheck` ✅ 16/16 · `bun run lint` ✅ 14/14 · `bun x knip` ✅ (no new findings)
+- `bun run test:unit` (with test DB, `TZ=UTC`) — lib **9227 pass / 0 fail**, web **15704 pass / 0 fail**, exit 0
+- `activity-log-errors.ts` at **100% branch coverage** (v8)
+- CI: all checks green on the head commit
+
+Churn cross-reference (`npx aidd churn`): none of the touched files are hotspots. The adjacent
+`apps/web/src/app/api/ai/global/[id]/messages/route.ts` ranks #2 repo-wide but is a *different* file,
+owned by PR #2241 — no overlap with this diff.
+
+## Verified clean (no finding)
+
+- **A01 Broken Access Control** — the new `pageId: null` + `driveId: null` rows land in the existing
+  user-level branch of `api/activities/[activityId]/route.ts:64-86` (`activity.userId !== userId` → 403).
+  Owner-accessible, everyone else denied; fail-closed. `integrations/providers/install/route.ts:57`
+  already emits this exact shape, so it is an established representation, not a new one.
+- **A08 Data Integrity** — hash chain, advisory lock and `prepareActivityInsert` untouched. `chainSeq`
+  is `bigserial`, so failed inserts permanently burned sequence values; `hash-chain-verifier.ts` uses
+  `chainSeq` only for `orderBy`, never for contiguity, so the gaps are cosmetic and this fix reduces them.
+- **A09 Logging/Monitoring Failures** — this is the defect class being fixed; strict improvement.
+- A02/A03/A04/A05/A06/A07/A10 — no crypto, SQL-string, dependency, auth or outbound-request surface touched.
+- **Newly-live path** — the retry branch was dead in production until this fix. Verified re-entrant:
+  `insertActivityLog` rebuilds `values` per attempt inside its own transaction, so the failed first
+  attempt rolls back fully and the retry chains off the last committed row.
+- **Downstream consumers** — `pickConversationTable` keys off `conversationType === 'global'` before
+  `hasPageId`; `planMessageRollback` never reads `pageId`; `broadcastActivityEvent` derives channels
+  from truthy `driveId`/`pageId` so a user-level row is a graceful no-op, not an error.
+- **Scope correctness** — `pageId: agentId` in the page-agents route is correct (agents *are* pages;
+  validated via `canPrincipalEditPage(auth, agentId)`). The global route was genuinely the only offender.
+- No stray files, no dead code, no TODO/FIXME markers, tests colocated.
+
+## Findings
+
+- [ ] **nit** · `packages/lib/src/monitoring/activity-log-errors.ts:9-20` · Module constants use
+  ALL_CAPS (`FK_VIOLATION_CODE`, `PAGE_ID_CONSTRAINT`, `MAX_CAUSE_DEPTH`), which /aidd-javascript
+  NamingConstraints explicitly discourages · Correct per the skill would be camelCase; correct per the
+  consuming module is ALL_CAPS (`ACTIVITY_CHAIN_LOCK_KEY` in `activity-logger.ts`). Recommend keeping
+  for local consistency and settling this repo-wide rather than in this PR.
+- [ ] **nit** · `packages/lib/src/monitoring/__tests__/activity-log-errors.test.ts` · Uses vitest
+  `it`/`expect` rather than the Riteway `assert({ given, should, actual, expected })` form /aidd-tdd
+  mandates · The sibling `activity-logger.test.ts` is 100% `it`/`expect`, and PR #781 is consolidating
+  riteway helpers repo-wide. Recommend deferring to that migration rather than mixing two styles in one
+  directory. (The `page-mutation-plan.test.ts` addition *does* use `assert`, matching its file.)
+- [ ] **nit** · `packages/lib/src/monitoring/activity-log-errors.ts:52-63` · Manual `for` loop where
+  /aidd-javascript favors composition · A bounded linked-list walk with early exit; the functional
+  alternative (recursion with a default `depth` parameter) leaks an implementation parameter into the
+  public signature. Recommend keeping the loop.
+- [ ] **info** · `packages/lib/src/monitoring/activity-log-errors.ts:52` · The extracted predicate drops
+  the `error instanceof Error` precondition the old inline guard carried · Strictly widening: a non-Error
+  object bearing `code`/`constraint` now matches. Worst case is one benign retry without `pageId`; the
+  behaviour is pinned by an explicit test. No change recommended.
+- [ ] **info** · `packages/lib/src/monitoring/activity-logger.ts:~601` · `logActivityWithTx` has no FK
+  retry at all, so the page-deleted-mid-log race remains unhandled on the transactional path · Correct
+  would be the same predicate applied there, but it needs different handling (a failed insert aborts the
+  caller's transaction, so it cannot simply be retried in place). Out of scope; flagged in the PR body.
+
+**Verdict:** 0 blockers / 0 majors / 3 nits / 2 informational; 0 requiring change before merge.
+The diff is minimal, root-cause-correct at both layers, and verified end-to-end through the
+authorization, rollback, and realtime consumers. Merge-ready.


### PR DESCRIPTION
Two stacked defects were silently dropping the audit trail for every Global Assistant message edit and delete.

```
[ActivityLogger] Failed to log activity: Error: Failed query: insert into "activity_logs" ...
  [cause]: error: ... violates foreign key constraint "activity_logs_pageId_pages_id_fk"
    detail: 'Key (pageId)=(c2npdiezknc9adz0f91masv6) is not present in table "pages".'
```

The failing INSERT runs inside the transaction holding `pg_advisory_xact_lock(ACTIVITY_CHAIN_LOCK_KEY)` — the global serialization point for all activity logging — and burns a `chainSeq` on every failure.

## Defect 1 — conversation id written into `activity_logs.pageId`

`apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts` passed `pageId: conversationId` in both PATCH and DELETE. `conversationId` is validated against the `conversations` table, which has no relationship to `pages`, so the FK violation was guaranteed — not a race.

Both call sites now pass `pageId: null` with a corrected comment. `logMessageActivity` accepts `pageId: string | null`, mirroring the `driveId: string | null` field beside it, and forwards `message.pageId ?? undefined`.

A repo-wide grep for `pageId: conversationId` returned exactly these two lines; every other message call site already passes a real page id and is untouched.

### `pageId: null` + `driveId: null` is the platform's existing shape for user-level activity

This is not a fallback — the consumers already model it as a first-class case, which I traced end to end:

- **Authorization** (`api/activities/[activityId]/route.ts:64-86`) branches `pageId` → page-view check, `driveId` → drive-member check, else `activity.userId !== userId` → 403. Global-assistant rows land in that third branch, so the **owner can view and roll back their own activity and everyone else gets 403** — fail-closed, no new exposure. `api/integrations/providers/install/route.ts:57` already writes user-level rows in exactly this shape.
- **Table routing** (`pickConversationTable`, `page-mutation-plan.ts:198-207`) computes `isGlobal` from `conversationType === 'global'` *before* consulting `hasPageId`, so rollback/redo/preview keep resolving to the `messages` table. All three consumers pass `hasPageId: !!activity.pageId`.
- **Rollback planning** (`planMessageRollback`) never reads `pageId`; the `!activity.pageId` guards in `rollback-plans.ts` are on page-oriented plans only.
- **Realtime** (`broadcastActivityEvent`) derives its channels from truthy `driveId`/`pageId`, so a user-level row broadcasts to nothing — a graceful no-op, not an error, and already the case for existing user-level rows. The message edit/delete broadcasts on this route (`broadcastAiMessageEdited`/`Deleted`) are separate and unaffected, so the chat UI still updates live; only the *activity-feed* event is absent, which is inherent to user-level activity and out of scope here.

Conversation linkage is carried by `aiConversationId` + `metadata.conversationType: 'global'`, both already passed today.

## Defect 2 — the FK-retry fallback never fired in production

`logActivity` read `code` / `constraint` / `detail` off the **top level** of the caught error. Drizzle 0.45.2 (`drizzle-orm/errors.ts`) throws:

```ts
export class DrizzleQueryError extends Error {
  constructor(public query: string, public params: any[], public override cause?: Error) {
    super(`Failed query: ${query}\nparams: ${params}`);
    if (cause) (this as any).cause = cause;   // the pg error lives here
  }
}
```

The wrapper carries **no** `code`, `constraint`, or `detail` of its own — they are only on `.cause`. So the guard read `undefined` for all three and skipped the retry. The production log confirms it: it printed the no-retry branch, not `... after FK retry:`.

Notably #1319 ("harden FK error detection") already half-diagnosed this — it observed that Drizzle wraps the error, but concluded it "wraps without forwarding `.constraint`" and added a `detail` fallback *at the top level*. Given the constructor above, `detail` was `undefined` there too, so that fallback never fired either. This PR supersedes that fix while keeping the `detail` signal, now evaluated at whatever depth the pg error actually sits.

Consequence: the page-deleted-mid-log race the fallback was written for (`ae2cc0a0a`) was unhandled for *every* caller, not just this route.

New pure module `packages/lib/src/monitoring/activity-log-errors.ts` exports `isPageIdForeignKeyError`, which walks a bounded (5-link) `.cause` chain — the cap also terminates cyclic chains without tracking visited nodes. `logActivity` now calls it; the `&& input.pageId` condition is unchanged.

## Tests (RED first)

Every test below was written and observed **failing** before the implementation:

- `activity-log-errors.test.ts` — 16 cases at **100% branch coverage**: the exact production nested shape, flat legacy shape, two-level nesting, `detail` fallback, wrong constraint, wrong code, non-string `detail`, `null`/`undefined`/string/plain-object/bare-`Error`, a cyclic `cause` chain, and past the depth limit.
- `activity-logger.test.ts` — added a nested-cause retry case (`expected 2, received 1` against the old guard — the retry was provably skipped) and a `pageId: null` forwarding case. The five existing flat-error cases are intact and still pass, since flat errors remain supported.
- The two assertions in the global route tests that pinned `pageId: mockConversationId` failed after the route fix and were corrected to `pageId: null`.
- `page-mutation-plan.test.ts` — added the `conversationType: 'global'` + **no** pageId case. The suite covered global-with-pageId and no-type-without-pageId, but not the exact shape this PR now emits.

### And an integration test, because hand-built errors are what let this ship

Every unit test above constructs the Drizzle wrapper by hand, so it can only show the predicate matches
the shape we *believe* the driver throws — exactly the gap that hid this bug for two attempts.
`activity-logger-fk-retry.integration.test.ts` provokes a real `23503` against the real `activity_logs`
table and lets the real driver wrap it: a real page id round-trips; a well-formed but absent page id
(a page deleted mid-log) still records the activity with only the `pageId` dropped; and a
global-assistant delete records with `pageId` null while preserving `aiConversationId` and
`metadata.conversationType`.

Confirmed to be a genuine regression test: temporarily restoring the old top-level guard fails the
middle case with `expected undefined to be defined` — the audit row is dropped entirely, which is the
production bug reproduced without synthesizing anything. `ci.yml` provisions `postgres:17-alpine` and
runs `db:migrate` before `turbo run test:coverage`, so these execute in CI rather than skipping.

## Notes

- **No migration.** Because Defect 2 suppressed the retry, these rows were never written — there are no orphaned or mislinked activity rows to repair. Schema, FK, advisory lock and hash-chain logic are untouched.
- **Out of scope, flagged:** `logActivityWithTx` has no FK retry at all.

## Validation

- `bun run typecheck` — 16/16 packages pass
- `bun run lint` — 14/14 pass
- `bun run test:unit` — lib **9230 passed / 0 failed**; web **15704 passed / 0 failed** (run with `TZ=UTC`; `src/lib/messages/__tests__/grouping.test.ts` holds a pre-existing timezone-dependent case unrelated to this change)
- `bun run --filter '@pagespace/lib' test:coverage` — passes the package's gate (branches ≥94) at
  96.06% statements / 94.84% branches / 88.82% functions. This is what CI's Unit Tests job enforces;
  `activity-log-errors.ts` itself is at 100% on all four metrics, so it lifts rather than dilutes the
  branch figure, whose margin over the threshold is thin.
- `bun x knip` — no new findings
- Branch is 0 commits behind `master` with zero conflicts; see the checks tab for current CI state

A full review of this diff (OWASP pass, consumer-chain verification, and three deferred
standards nits) is recorded at `tasks/reviews/pu-activity-log-fk.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiqgtMFz5y6gJTLn3aLJRd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed activity logging for Global Assistant message edits and deletions so entries no longer reference an invalid page.
  * Improved recovery when activity logs encounter missing or deleted page references, preserving other activity details.

* **Tests**
  * Added coverage for wrapped database errors, global conversations, missing pages, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->