### PR TITLE
fix(ai): make generate_image and web_search callable on the Global Assistant

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -81,7 +81,7 @@ import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
 import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
 import { getUserPersonalization } from '@/lib/ai/core/personalization-utils';
-import { applyToolExposureMode } from '@/lib/ai/tools/tool-exposure';
+import { applyToolExposureMode, ALWAYS_UPFRONT_TOOLS } from '@/lib/ai/tools/tool-exposure';
 import {
   buildVolatileTurnContext,
   appendTurnContextToLastUserMessage,
@@ -90,11 +90,6 @@ import {
 import { prepareHistoryForModel, finishModelRequest } from '@/lib/ai/core/context-assembly';
 import { getAgentMemoryContext, buildAgentMemorySection } from '@/lib/ai/core/agent-memory';
 
-// Runtime-toggled tools that must stay directly callable even in search mode.
-// Runtime-override tools: added independently of the agent's saved allowlist, so they
-// must stay directly callable in 'search' exposure mode — routing them through
-// execute_tool would hit that tool's allowlist check and be rejected.
-const ALWAYS_UPFRONT_TOOLS = new Set(['web_search', 'generate_image']);
 import { db } from '@pagespace/db/db'
 import { eq, and, ne } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -53,7 +53,7 @@ import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree
 import { getModelCapabilities, DEFAULT_IMAGE_MODEL } from '@/lib/ai/core/model-capabilities';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
 import { getUserPersonalization, getUserTimezone } from '@/lib/ai/core/personalization-utils';
-import { splitToolsForExposure, selectToolSearchCatalog } from '@/lib/ai/tools/tool-exposure';
+import { splitToolsForExposure, excludeAlwaysUpfront, ALWAYS_UPFRONT_TOOLS } from '@/lib/ai/tools/tool-exposure';
 import { createExecuteTool } from '@/lib/ai/tools/execute-tool';
 import { db } from '@pagespace/db/db'
 import { eq, and, desc, gt, lt, ne } from '@pagespace/db/operators'
@@ -97,13 +97,6 @@ export const maxDuration = 300;
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
-
-// Runtime-toggled tools that must stay directly callable rather than being deferred
-// behind execute_tool. Mirrors ALWAYS_UPFRONT_TOOLS in apps/web/src/app/api/ai/chat/route.ts
-// — see the rationale comment there (Step 5, above applyToolExposureMode): these tools
-// are added by composer toggles independently of the saved allowlist, so routing them
-// through execute_tool trips its allowlist check. Keep the two lists in sync.
-const ALWAYS_UPFRONT_TOOLS = new Set(['web_search', 'generate_image']);
 
 /**
  * GET - Get all messages for a conversation
@@ -874,7 +867,7 @@ MENTION PROCESSING:
 
     let finalTools: ToolSet = {
       ...coreTools,
-      tool_search: createToolSearchTool(selectToolSearchCatalog(filteredAllTools, ALWAYS_UPFRONT_TOOLS)),
+      tool_search: createToolSearchTool(excludeAlwaysUpfront(filteredAllTools, ALWAYS_UPFRONT_TOOLS)),
       execute_tool: createExecuteTool(nonCoreTools),
     };
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -53,7 +53,7 @@ import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree
 import { getModelCapabilities, DEFAULT_IMAGE_MODEL } from '@/lib/ai/core/model-capabilities';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
 import { getUserPersonalization, getUserTimezone } from '@/lib/ai/core/personalization-utils';
-import { CORE_TOOL_NAMES } from '@/lib/ai/core/stub-tools';
+import { splitToolsForExposure } from '@/lib/ai/tools/tool-exposure';
 import { createExecuteTool } from '@/lib/ai/tools/execute-tool';
 import { db } from '@pagespace/db/db'
 import { eq, and, desc, gt, lt, ne } from '@pagespace/db/operators'
@@ -97,6 +97,13 @@ export const maxDuration = 300;
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+// Runtime-toggled tools that must stay directly callable rather than being deferred
+// behind execute_tool. Mirrors ALWAYS_UPFRONT_TOOLS in apps/web/src/app/api/ai/chat/route.ts
+// — see the rationale comment there (Step 5, above applyToolExposureMode): these tools
+// are added by composer toggles independently of the saved allowlist, so routing them
+// through execute_tool trips its allowlist check. Keep the two lists in sync.
+const ALWAYS_UPFRONT_TOOLS = new Set(['web_search', 'generate_image']);
 
 /**
  * GET - Get all messages for a conversation
@@ -854,15 +861,10 @@ MENTION PROCESSING:
       })
     ) as ToolSet;
 
-    // Core tools go to the model with full schemas
-    const coreTools = Object.fromEntries(
-      Object.entries(filteredAllTools).filter(([name]) => CORE_TOOL_NAMES.has(name))
-    ) as ToolSet;
-
-    // Non-core tools hidden from model; accessible only via execute_tool
-    const nonCoreTools = Object.fromEntries(
-      Object.entries(filteredAllTools).filter(([name]) => !CORE_TOOL_NAMES.has(name))
-    ) as ToolSet;
+    // Core tools (plus the always-upfront runtime toggles) go to the model with full
+    // schemas; everything else is hidden from the model and reachable only via
+    // execute_tool.
+    const { coreTools, nonCoreTools } = splitToolsForExposure(filteredAllTools, ALWAYS_UPFRONT_TOOLS);
 
     const nonCoreToolNamesPrompt = buildNonCoreToolNamesPrompt(Object.keys(nonCoreTools));
     const finalSystemPrompt = systemPrompt

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -53,7 +53,7 @@ import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree
 import { getModelCapabilities, DEFAULT_IMAGE_MODEL } from '@/lib/ai/core/model-capabilities';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
 import { getUserPersonalization, getUserTimezone } from '@/lib/ai/core/personalization-utils';
-import { splitToolsForExposure } from '@/lib/ai/tools/tool-exposure';
+import { splitToolsForExposure, selectToolSearchCatalog } from '@/lib/ai/tools/tool-exposure';
 import { createExecuteTool } from '@/lib/ai/tools/execute-tool';
 import { db } from '@pagespace/db/db'
 import { eq, and, desc, gt, lt, ne } from '@pagespace/db/operators'
@@ -874,7 +874,7 @@ MENTION PROCESSING:
 
     let finalTools: ToolSet = {
       ...coreTools,
-      tool_search: createToolSearchTool(filteredAllTools),
+      tool_search: createToolSearchTool(selectToolSearchCatalog(filteredAllTools, ALWAYS_UPFRONT_TOOLS)),
       execute_tool: createExecuteTool(nonCoreTools),
     };
 

--- a/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import type { Tool, ToolSet } from 'ai';
-import { applyToolExposureMode } from '../tool-exposure';
+import { applyToolExposureMode, splitToolsForExposure } from '../tool-exposure';
+import { CORE_TOOL_NAMES } from '../../core/stub-tools';
 
 // A minimal but real tool definition (matches the AI SDK Tool shape closely enough
 // for the catalog/dispatch logic under test).
@@ -22,6 +23,82 @@ function sampleTools(): ToolSet {
     create_calendar_event: makeTool('Create a calendar event'), // non-core
   } as ToolSet;
 }
+
+describe('splitToolsForExposure', () => {
+  it('keeps always-upfront tools alongside core tools, deferring only the rest', () => {
+    // The Global Assistant bug: generate_image/web_search were advertised by name in
+    // the system prompt but only ever reachable via execute_tool, so a direct call
+    // was rejected as an unknown tool. They must land in coreTools.
+    const tools: ToolSet = {
+      generate_image: makeTool('Generate an image'),
+      web_search: makeTool('Search the web'),
+      read_page: makeTool('Read a page'), // core
+      list_agents: makeTool('List agents'), // non-core
+    } as ToolSet;
+
+    const { coreTools, nonCoreTools } = splitToolsForExposure(
+      tools,
+      new Set(['web_search', 'generate_image'])
+    );
+
+    expect(Object.keys(coreTools).sort()).toEqual(['generate_image', 'read_page', 'web_search']);
+    expect(Object.keys(nonCoreTools)).toEqual(['list_agents']);
+    // The tool values are passed through untouched.
+    expect(coreTools.generate_image).toBe(tools.generate_image);
+    expect(nonCoreTools.list_agents).toBe(tools.list_agents);
+  });
+
+  it('falls back to CORE_TOOL_NAMES-only behaviour for an empty or omitted alwaysUpfront', () => {
+    const tools = sampleTools();
+    const expectedCore = Object.keys(tools).filter((n) => CORE_TOOL_NAMES.has(n));
+    const expectedNonCore = Object.keys(tools).filter((n) => !CORE_TOOL_NAMES.has(n));
+
+    const withEmptySet = splitToolsForExposure(tools, new Set());
+    const withDefault = splitToolsForExposure(tools);
+
+    for (const result of [withEmptySet, withDefault]) {
+      expect(Object.keys(result.coreTools)).toEqual(expectedCore);
+      expect(Object.keys(result.nonCoreTools)).toEqual(expectedNonCore);
+    }
+    // The defaulted-argument call is byte-identical to the explicit empty-set call.
+    expect(Object.keys(withDefault.coreTools)).toEqual(Object.keys(withEmptySet.coreTools));
+    expect(Object.keys(withDefault.nonCoreTools)).toEqual(Object.keys(withEmptySet.nonCoreTools));
+  });
+
+  it('returns two empty objects for an empty tool set', () => {
+    const { coreTools, nonCoreTools } = splitToolsForExposure({} as ToolSet, new Set(['web_search']));
+
+    expect(coreTools).toEqual({});
+    expect(nonCoreTools).toEqual({});
+  });
+
+  it('does not duplicate or drop a tool that is both core and always-upfront', () => {
+    const tools: ToolSet = {
+      read_page: makeTool('Read a page'), // core AND named in alwaysUpfront
+      list_agents: makeTool('List agents'), // non-core
+    } as ToolSet;
+
+    const { coreTools, nonCoreTools } = splitToolsForExposure(tools, new Set(['read_page']));
+
+    expect(Object.keys(coreTools)).toEqual(['read_page']);
+    expect(Object.keys(nonCoreTools)).toEqual(['list_agents']);
+  });
+
+  it('never places the same tool in both halves', () => {
+    const tools: ToolSet = {
+      read_page: makeTool('Read a page'),
+      web_search: makeTool('Search the web'),
+      list_agents: makeTool('List agents'),
+    } as ToolSet;
+
+    const { coreTools, nonCoreTools } = splitToolsForExposure(tools, new Set(['web_search']));
+
+    const coreNames = Object.keys(coreTools);
+    const nonCoreNames = Object.keys(nonCoreTools);
+    expect(coreNames.filter((n) => nonCoreNames.includes(n))).toEqual([]);
+    expect([...coreNames, ...nonCoreNames].sort()).toEqual(Object.keys(tools).sort());
+  });
+});
 
 describe('applyToolExposureMode', () => {
   describe('upfront mode', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import type { Tool, ToolSet } from 'ai';
-import { applyToolExposureMode, splitToolsForExposure } from '../tool-exposure';
+import { applyToolExposureMode, splitToolsForExposure, selectToolSearchCatalog } from '../tool-exposure';
 import { CORE_TOOL_NAMES } from '../../core/stub-tools';
 
 // A minimal but real tool definition (matches the AI SDK Tool shape closely enough
@@ -97,6 +97,71 @@ describe('splitToolsForExposure', () => {
     const nonCoreNames = Object.keys(nonCoreTools);
     expect(coreNames.filter((n) => nonCoreNames.includes(n))).toEqual([]);
     expect([...coreNames, ...nonCoreNames].sort()).toEqual(Object.keys(tools).sort());
+  });
+});
+
+describe('selectToolSearchCatalog', () => {
+  it('omits always-upfront tools so they are never discovered as execute_tool targets', () => {
+    // TOOL_DISCOVERY_PROMPT tells the model to run anything it discovers via
+    // execute_tool. An always-upfront tool is NOT in execute_tool's dispatch map,
+    // so leaving it in the searchable catalog invites a dead-end call — the same
+    // "advertised but not callable" failure this module exists to prevent.
+    const tools: ToolSet = {
+      read_page: makeTool('Read a page'), // core
+      generate_image: makeTool('Generate an image'), // always-upfront
+      web_search: makeTool('Search the web'), // always-upfront
+      list_agents: makeTool('List agents'), // non-core
+    } as ToolSet;
+
+    const catalog = selectToolSearchCatalog(tools, new Set(['web_search', 'generate_image']));
+
+    expect(Object.keys(catalog).sort()).toEqual(['list_agents', 'read_page']);
+  });
+
+  it('keeps core tools searchable (they carry schemas the model may still want)', () => {
+    const tools: ToolSet = {
+      read_page: makeTool('Read a page'),
+      list_agents: makeTool('List agents'),
+    } as ToolSet;
+
+    expect(Object.keys(selectToolSearchCatalog(tools, new Set(['web_search'])))).toEqual([
+      'read_page',
+      'list_agents',
+    ]);
+  });
+
+  it('returns the full set for an empty or omitted alwaysUpfront', () => {
+    const tools = sampleTools();
+
+    expect(Object.keys(selectToolSearchCatalog(tools, new Set()))).toEqual(Object.keys(tools));
+    expect(Object.keys(selectToolSearchCatalog(tools))).toEqual(Object.keys(tools));
+  });
+
+  it('returns an empty catalog for an empty tool set', () => {
+    expect(selectToolSearchCatalog({} as ToolSet, new Set(['web_search']))).toEqual({});
+  });
+
+  it('never surfaces a tool that is absent from the execute_tool dispatch map', () => {
+    // Ties the two halves together: everything left in the catalog must be either a
+    // core tool (callable directly) or present in nonCoreTools (callable via
+    // execute_tool). Nothing may be discoverable yet unreachable.
+    const tools: ToolSet = {
+      read_page: makeTool('Read a page'),
+      generate_image: makeTool('Generate an image'),
+      list_agents: makeTool('List agents'),
+    } as ToolSet;
+    const alwaysUpfront = new Set(['generate_image']);
+
+    const { coreTools, nonCoreTools } = splitToolsForExposure(tools, alwaysUpfront);
+    const catalog = selectToolSearchCatalog(tools, alwaysUpfront);
+
+    for (const name of Object.keys(catalog)) {
+      const reachable = CORE_TOOL_NAMES.has(name) || name in nonCoreTools;
+      expect(reachable, `${name} is searchable but unreachable`).toBe(true);
+    }
+    // generate_image stays reachable — directly, as a top-level tool.
+    expect(coreTools.generate_image).toBeDefined();
+    expect(catalog.generate_image).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
@@ -30,11 +30,15 @@ function sampleTools(): ToolSet {
 }
 
 describe('ALWAYS_UPFRONT_TOOLS', () => {
-  it('covers exactly the composer-toggled tools both AI routes share', () => {
+  it('covers exactly the tools that bypass the agent allowlist on the way in', () => {
     // One shared set, imported by api/ai/chat and api/ai/global/[id]/messages, so a new
-    // composer toggle cannot be wired into one route and forgotten in the other.
-    // web_fetch is knowingly excluded — see the constant's doc comment.
+    // allowlist-bypassing override cannot be wired into one route and forgotten in the
+    // other. Membership is NOT "shares a composer toggle" — it is "re-added after
+    // filterToolsForAgentAllowlist", which is what makes execute_tool's re-check reject
+    // it if deferred. web_fetch shares the web-search toggle but has no such bypass, so
+    // it is correctly absent. See the constant's doc comment.
     expect([...ALWAYS_UPFRONT_TOOLS].sort()).toEqual(['generate_image', 'web_search']);
+    expect(ALWAYS_UPFRONT_TOOLS.has('web_fetch')).toBe(false);
   });
 
   it('promotes its members past the core-only split', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import type { Tool, ToolSet } from 'ai';
-import { applyToolExposureMode, splitToolsForExposure, selectToolSearchCatalog } from '../tool-exposure';
+import {
+  applyToolExposureMode,
+  splitToolsForExposure,
+  excludeAlwaysUpfront,
+  ALWAYS_UPFRONT_TOOLS,
+} from '../tool-exposure';
 import { CORE_TOOL_NAMES } from '../../core/stub-tools';
 
 // A minimal but real tool definition (matches the AI SDK Tool shape closely enough
@@ -23,6 +28,31 @@ function sampleTools(): ToolSet {
     create_calendar_event: makeTool('Create a calendar event'), // non-core
   } as ToolSet;
 }
+
+describe('ALWAYS_UPFRONT_TOOLS', () => {
+  it('covers exactly the composer-toggled tools both AI routes share', () => {
+    // One shared set, imported by api/ai/chat and api/ai/global/[id]/messages, so a new
+    // composer toggle cannot be wired into one route and forgotten in the other.
+    // web_fetch is knowingly excluded — see the constant's doc comment.
+    expect([...ALWAYS_UPFRONT_TOOLS].sort()).toEqual(['generate_image', 'web_search']);
+  });
+
+  it('promotes its members past the core-only split', () => {
+    const tools: ToolSet = {
+      read_page: makeTool('Read a page'),
+      generate_image: makeTool('Generate an image'),
+      web_search: makeTool('Search the web'),
+      list_agents: makeTool('List agents'),
+    } as ToolSet;
+
+    const { coreTools, nonCoreTools } = splitToolsForExposure(tools, ALWAYS_UPFRONT_TOOLS);
+
+    for (const name of ALWAYS_UPFRONT_TOOLS) {
+      expect(coreTools[name], `${name} must be directly callable`).toBeDefined();
+      expect(nonCoreTools[name]).toBeUndefined();
+    }
+  });
+});
 
 describe('splitToolsForExposure', () => {
   it('keeps always-upfront tools alongside core tools, deferring only the rest', () => {
@@ -60,9 +90,6 @@ describe('splitToolsForExposure', () => {
       expect(Object.keys(result.coreTools)).toEqual(expectedCore);
       expect(Object.keys(result.nonCoreTools)).toEqual(expectedNonCore);
     }
-    // The defaulted-argument call is byte-identical to the explicit empty-set call.
-    expect(Object.keys(withDefault.coreTools)).toEqual(Object.keys(withEmptySet.coreTools));
-    expect(Object.keys(withDefault.nonCoreTools)).toEqual(Object.keys(withEmptySet.nonCoreTools));
   });
 
   it('returns two empty objects for an empty tool set', () => {
@@ -100,7 +127,7 @@ describe('splitToolsForExposure', () => {
   });
 });
 
-describe('selectToolSearchCatalog', () => {
+describe('excludeAlwaysUpfront', () => {
   it('omits always-upfront tools so they are never discovered as execute_tool targets', () => {
     // TOOL_DISCOVERY_PROMPT tells the model to run anything it discovers via
     // execute_tool. An always-upfront tool is NOT in execute_tool's dispatch map,
@@ -113,32 +140,20 @@ describe('selectToolSearchCatalog', () => {
       list_agents: makeTool('List agents'), // non-core
     } as ToolSet;
 
-    const catalog = selectToolSearchCatalog(tools, new Set(['web_search', 'generate_image']));
+    const catalog = excludeAlwaysUpfront(tools, new Set(['web_search', 'generate_image']));
 
     expect(Object.keys(catalog).sort()).toEqual(['list_agents', 'read_page']);
-  });
-
-  it('keeps core tools searchable (they carry schemas the model may still want)', () => {
-    const tools: ToolSet = {
-      read_page: makeTool('Read a page'),
-      list_agents: makeTool('List agents'),
-    } as ToolSet;
-
-    expect(Object.keys(selectToolSearchCatalog(tools, new Set(['web_search'])))).toEqual([
-      'read_page',
-      'list_agents',
-    ]);
   });
 
   it('returns the full set for an empty or omitted alwaysUpfront', () => {
     const tools = sampleTools();
 
-    expect(Object.keys(selectToolSearchCatalog(tools, new Set()))).toEqual(Object.keys(tools));
-    expect(Object.keys(selectToolSearchCatalog(tools))).toEqual(Object.keys(tools));
+    expect(Object.keys(excludeAlwaysUpfront(tools, new Set()))).toEqual(Object.keys(tools));
+    expect(Object.keys(excludeAlwaysUpfront(tools))).toEqual(Object.keys(tools));
   });
 
   it('returns an empty catalog for an empty tool set', () => {
-    expect(selectToolSearchCatalog({} as ToolSet, new Set(['web_search']))).toEqual({});
+    expect(excludeAlwaysUpfront({} as ToolSet, new Set(['web_search']))).toEqual({});
   });
 
   it('never surfaces a tool that is absent from the execute_tool dispatch map', () => {
@@ -153,7 +168,7 @@ describe('selectToolSearchCatalog', () => {
     const alwaysUpfront = new Set(['generate_image']);
 
     const { coreTools, nonCoreTools } = splitToolsForExposure(tools, alwaysUpfront);
-    const catalog = selectToolSearchCatalog(tools, alwaysUpfront);
+    const catalog = excludeAlwaysUpfront(tools, alwaysUpfront);
 
     for (const name of Object.keys(catalog)) {
       const reachable = CORE_TOOL_NAMES.has(name) || name in nonCoreTools;

--- a/apps/web/src/lib/ai/tools/tool-exposure.ts
+++ b/apps/web/src/lib/ai/tools/tool-exposure.ts
@@ -38,6 +38,24 @@ export function splitToolsForExposure(
 }
 
 /**
+ * The catalog tool_search is allowed to return.
+ *
+ * Always-upfront tools are omitted. They are already handed to the model with full
+ * schemas and are deliberately NOT in execute_tool's dispatch map, so surfacing them
+ * here would invite a dead-end `execute_tool({tool_name: 'generate_image'})` —
+ * TOOL_DISCOVERY_PROMPT instructs the model to run anything it discovers that way.
+ * Core tools stay searchable: they are directly callable, so a lookup is harmless.
+ */
+export function selectToolSearchCatalog(
+  tools: ToolSet,
+  alwaysUpfront: ReadonlySet<string> = new Set(),
+): ToolSet {
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => !alwaysUpfront.has(name))
+  ) as ToolSet;
+}
+
+/**
  * Decide how an agent's tools are presented to the model.
  *
  * - `upfront` (default): every tool is handed to the model with its full schema.
@@ -69,9 +87,7 @@ export function applyToolExposureMode(
 
   // Tools forced upfront (e.g. the web_search runtime override) are excluded from
   // both the deferral split and the searchable catalog.
-  const deferrable = Object.fromEntries(
-    Object.entries(tools).filter(([name]) => !alwaysUpfront.has(name))
-  ) as ToolSet;
+  const deferrable = selectToolSearchCatalog(tools, alwaysUpfront);
 
   const nonCoreTools = Object.fromEntries(
     Object.entries(deferrable).filter(([name]) => !CORE_TOOL_NAMES.has(name))

--- a/apps/web/src/lib/ai/tools/tool-exposure.ts
+++ b/apps/web/src/lib/ai/tools/tool-exposure.ts
@@ -7,6 +7,37 @@ import { createExecuteTool } from './execute-tool';
 export type ToolExposureMode = 'upfront' | 'search';
 
 /**
+ * Split a tool set into the tools handed to the model with full schemas ("core")
+ * and the tools deferred behind execute_tool ("non-core").
+ *
+ * A tool is upfront when it is a core page/drive tool OR is named in
+ * `alwaysUpfront`. The latter covers runtime-toggled tools (`web_search`,
+ * `generate_image`) which are added independently of an agent's saved allowlist:
+ * deferring them behind execute_tool makes them uncallable while their names are
+ * still advertised in the system prompt, so the model calls them directly and the
+ * AI SDK rejects them as unknown tools.
+ *
+ * Pure: no prompt assembly, no tool construction. Key order within each half
+ * follows the input's key order.
+ */
+export function splitToolsForExposure(
+  tools: ToolSet,
+  alwaysUpfront: ReadonlySet<string> = new Set(),
+): { coreTools: ToolSet; nonCoreTools: ToolSet } {
+  const isUpfront = (name: string) => CORE_TOOL_NAMES.has(name) || alwaysUpfront.has(name);
+
+  const coreTools = Object.fromEntries(
+    Object.entries(tools).filter(([name]) => isUpfront(name))
+  ) as ToolSet;
+
+  const nonCoreTools = Object.fromEntries(
+    Object.entries(tools).filter(([name]) => !isUpfront(name))
+  ) as ToolSet;
+
+  return { coreTools, nonCoreTools };
+}
+
+/**
  * Decide how an agent's tools are presented to the model.
  *
  * - `upfront` (default): every tool is handed to the model with its full schema.

--- a/apps/web/src/lib/ai/tools/tool-exposure.ts
+++ b/apps/web/src/lib/ai/tools/tool-exposure.ts
@@ -19,9 +19,23 @@ export type ToolExposureMode = 'upfront' | 'search';
  *   deferred tools by name in the system prompt without sending their schemas, so the
  *   model calls them directly and the AI SDK rejects them as unknown tools.
  *
- * NOTE: the web-search toggle also gates `web_fetch` (see WEB_SEARCH_TOOLS in
- * core/tool-filtering.ts), which is deliberately NOT listed here — see the PR
- * discussion; promoting it changes page-chat behaviour and belongs in its own change.
+ * KNOWN GAP — `web_fetch`. The web-search toggle gates two tools, not one
+ * (`WEB_SEARCH_TOOLS = {web_search, web_fetch}` in core/tool-filtering.ts), so by the
+ * definition above `web_fetch` belongs here. It is deliberately omitted because adding
+ * it to this shared set is the wrong trade today:
+ * - On page chat it IS broken — an agent whose saved allowlist omits `web_fetch` but
+ *   who toggles web search on gets it rejected at dispatch. A real bug.
+ * - On the Global Assistant it is NOT broken — that route sets no allowlist, so
+ *   `web_fetch` still dispatches fine through execute_tool. Promoting it there only
+ *   adds its schema to every request, on the one surface deliberately engineered to
+ *   keep upfront schemas small (see PR #1310, which dropped 29 schemas to save
+ *   ~5-12k tokens/turn).
+ *
+ * So the shared default would buy a page-chat fix by charging the Global Assistant
+ * context it gains nothing from. The fix likely wants to be page-chat-specific, which
+ * this design already permits — `alwaysUpfront` stays a per-call parameter, so that
+ * route can pass `new Set([...ALWAYS_UPFRONT_TOOLS, 'web_fetch'])` without disturbing
+ * anyone else. Left for its own change with its own tests.
  */
 export const ALWAYS_UPFRONT_TOOLS: ReadonlySet<string> = new Set(['web_search', 'generate_image']);
 

--- a/apps/web/src/lib/ai/tools/tool-exposure.ts
+++ b/apps/web/src/lib/ai/tools/tool-exposure.ts
@@ -7,6 +7,25 @@ import { createExecuteTool } from './execute-tool';
 export type ToolExposureMode = 'upfront' | 'search';
 
 /**
+ * Tools added by runtime composer toggles rather than by an agent's saved allowlist,
+ * which therefore must stay directly callable instead of being deferred behind
+ * execute_tool. Both routes that expose the composer toggles share this set so a new
+ * toggle cannot be wired into one and silently forgotten in the other.
+ *
+ * They break in different ways if deferred, which is why both routes need them upfront:
+ * - Page chat (`api/ai/chat`) passes the agent's saved `enabledTools` to execute_tool,
+ *   so a toggled-on tool absent from that allowlist is rejected at dispatch.
+ * - Global Assistant (`api/ai/global/[id]/messages`) sets no allowlist, but advertises
+ *   deferred tools by name in the system prompt without sending their schemas, so the
+ *   model calls them directly and the AI SDK rejects them as unknown tools.
+ *
+ * NOTE: the web-search toggle also gates `web_fetch` (see WEB_SEARCH_TOOLS in
+ * core/tool-filtering.ts), which is deliberately NOT listed here — see the PR
+ * discussion; promoting it changes page-chat behaviour and belongs in its own change.
+ */
+export const ALWAYS_UPFRONT_TOOLS: ReadonlySet<string> = new Set(['web_search', 'generate_image']);
+
+/**
  * Split a tool set into the tools handed to the model with full schemas ("core")
  * and the tools deferred behind execute_tool ("non-core").
  *
@@ -38,15 +57,17 @@ export function splitToolsForExposure(
 }
 
 /**
- * The catalog tool_search is allowed to return.
+ * Drop the always-upfront tools from a tool set, preserving key order.
  *
- * Always-upfront tools are omitted. They are already handed to the model with full
- * schemas and are deliberately NOT in execute_tool's dispatch map, so surfacing them
- * here would invite a dead-end `execute_tool({tool_name: 'generate_image'})` —
- * TOOL_DISCOVERY_PROMPT instructs the model to run anything it discovers that way.
- * Core tools stay searchable: they are directly callable, so a lookup is harmless.
+ * Used for both halves of the exposure decision: the set eligible for deferral, and
+ * the catalog tool_search may return. An always-upfront tool must appear in neither —
+ * it is already served with a full schema and is deliberately absent from
+ * execute_tool's dispatch map, so surfacing it in the catalog would invite a dead-end
+ * `execute_tool({tool_name: 'generate_image'})`; TOOL_DISCOVERY_PROMPT instructs the
+ * model to run anything it discovers that way. Core tools stay searchable: they are
+ * directly callable, so a lookup is harmless.
  */
-export function selectToolSearchCatalog(
+export function excludeAlwaysUpfront(
   tools: ToolSet,
   alwaysUpfront: ReadonlySet<string> = new Set(),
 ): ToolSet {
@@ -87,11 +108,11 @@ export function applyToolExposureMode(
 
   // Tools forced upfront (e.g. the web_search runtime override) are excluded from
   // both the deferral split and the searchable catalog.
-  const deferrable = selectToolSearchCatalog(tools, alwaysUpfront);
+  const deferrable = excludeAlwaysUpfront(tools, alwaysUpfront);
 
-  const nonCoreTools = Object.fromEntries(
-    Object.entries(deferrable).filter(([name]) => !CORE_TOOL_NAMES.has(name))
-  ) as ToolSet;
+  // Same predicate as the split's non-core half — derived from it so the rule for
+  // "what gets deferred" is defined in exactly one place.
+  const { nonCoreTools } = splitToolsForExposure(tools, alwaysUpfront);
 
   if (Object.keys(nonCoreTools).length === 0) {
     return { tools, toolDiscoveryPrompt: '' };

--- a/apps/web/src/lib/ai/tools/tool-exposure.ts
+++ b/apps/web/src/lib/ai/tools/tool-exposure.ts
@@ -19,23 +19,20 @@ export type ToolExposureMode = 'upfront' | 'search';
  *   deferred tools by name in the system prompt without sending their schemas, so the
  *   model calls them directly and the AI SDK rejects them as unknown tools.
  *
- * KNOWN GAP — `web_fetch`. The web-search toggle gates two tools, not one
- * (`WEB_SEARCH_TOOLS = {web_search, web_fetch}` in core/tool-filtering.ts), so by the
- * definition above `web_fetch` belongs here. It is deliberately omitted because adding
- * it to this shared set is the wrong trade today:
- * - On page chat it IS broken — an agent whose saved allowlist omits `web_fetch` but
- *   who toggles web search on gets it rejected at dispatch. A real bug.
- * - On the Global Assistant it is NOT broken — that route sets no allowlist, so
- *   `web_fetch` still dispatches fine through execute_tool. Promoting it there only
- *   adds its schema to every request, on the one surface deliberately engineered to
- *   keep upfront schemas small (see PR #1310, which dropped 29 schemas to save
- *   ~5-12k tokens/turn).
+ * Membership rule — why exactly these two, and not every toggled tool. Page chat
+ * destructures `web_search` and `generate_image` out of the baseline BEFORE applying
+ * the agent's saved allowlist, then re-adds them after it when the composer toggle is
+ * on (chat/route.ts, Steps 2 / 4 / 4b). Bypassing the allowlist on the way IN is what
+ * makes them fail on the way OUT: execute_tool re-checks the same allowlist, so a
+ * deferred override is rejected as "not permitted" precisely when it was toggled on.
+ * A tool is a member iff it has that bypass property.
  *
- * So the shared default would buy a page-chat fix by charging the Global Assistant
- * context it gains nothing from. The fix likely wants to be page-chat-specific, which
- * this design already permits — `alwaysUpfront` stays a per-call parameter, so that
- * route can pass `new Set([...ALWAYS_UPFRONT_TOOLS, 'web_fetch'])` without disturbing
- * anyone else. Left for its own change with its own tests.
+ * NOT `web_fetch`, despite sharing the web-search toggle (`WEB_SEARCH_TOOLS =
+ * {web_search, web_fetch}` in core/tool-filtering.ts). It is never destructured as an
+ * override and never re-added, so it flows through the normal allowlist path: either
+ * the allowlist permits it (execute_tool's check passes, dispatch works) or the
+ * allowlist drops it entirely (the model never sees it). It can never be
+ * present-but-rejected, so it has nothing to be rescued from.
  */
 export const ALWAYS_UPFRONT_TOOLS: ReadonlySet<string> = new Set(['web_search', 'generate_image']);
 


### PR DESCRIPTION
## Problem

A user asked the Global Assistant to generate three images. The model emitted three `generate_image` tool calls, all three failed, and it told the user *"image gen isn't wired into the tool set yet on this environment."*

Image generation is fully built and working — the OpenRouter backend, the admin gate, the credit check and the UI renderer are all correct. The only thing broken was **tool exposure** on the Global Assistant route.

`apps/web/src/app/api/ai/global/[id]/messages/route.ts` hand-rolled its own core/non-core split using only `CORE_TOOL_NAMES` (nine page/drive tools). `generate_image` is not one of them, so it landed in `nonCoreTools` and was **never sent to the model as a callable tool** — while its bare name *was* still injected into the system prompt by `buildNonCoreToolNamesPrompt`. The model read the name, called it directly, and the AI SDK rejected it as an unknown tool.

`web_search` on the same route had the identical latent defect. Both are fixed here.

The page-chat route already solved exactly this with an `ALWAYS_UPFRONT_TOOLS` set passed to `applyToolExposureMode`. The Global Assistant never got that treatment.

## Changes

### 1. Make the tools callable (`8134af3`)

- **New pure helper** `splitToolsForExposure(tools, alwaysUpfront)` in `apps/web/src/lib/ai/tools/tool-exposure.ts` — the file that already owns this logic. A tool is upfront when `CORE_TOOL_NAMES.has(name) || alwaysUpfront.has(name)`.
- The global route's two `Object.fromEntries(...filter...)` blocks collapse to one call to it.
- `buildNonCoreToolNamesPrompt` now receives the reduced `nonCoreTools`, so the upfront tools correctly stop being advertised as `execute_tool` targets.

### 2. Close the same dead end in the `tool_search` catalog (`defb1f5`)

Found while self-reviewing commit 1. The route still passed the **full** `filteredAllTools` as the `tool_search` catalog, so `generate_image`/`web_search` stayed discoverable there — but they are no longer in `execute_tool`'s dispatch map.

`TOOL_DISCOVERY_PROMPT` (`system-prompt.ts:32`) tells the model: *"All other tools ... call `execute_tool({tool_name, parameters})` to run them. Use `tool_search("select:tool_name")` to get parameter schemas first."* So a model running `tool_search("image")` would find `generate_image` and dispatch it via `execute_tool` → `Unknown tool "generate_image"`. Same advertised-but-not-callable dead end, one level deeper.

- **New pure helper** `excludeAlwaysUpfront(tools, alwaysUpfront)`, wired into the route's `createToolSearchTool`. Core tools stay searchable (they're directly callable, so a lookup is harmless).

### 3. Share the constant, and fix its rationale (`60059cd`)

From a four-angle review pass (reuse / simplification / efficiency / altitude) over commits 1–2:

- **The rationale comment was factually wrong for this route.** It was copied from `chat/route.ts` and claimed deferral *"trips execute_tool's allowlist check"*. That check is `enabledTools != null && !enabledTools.includes(name)` — and the Global Assistant route never sets `enabledTools` in `experimental_context`, so it is a permanent no-op there. The real failure on this route is prompt advertising without schemas. Wrong reasoning attached to correct code is worse than none: a maintainer who verified the stated reason would correctly conclude the set was unnecessary and delete it, reintroducing the bug.
- **The set was duplicated as a literal in two route files**, kept in sync only by that comment. It is now exported once from `tool-exposure.ts` and imported by both `api/ai/chat` and `api/ai/global/[id]/messages`. The `alwaysUpfront` parameter stays, so a route wanting a different set still passes one — `/v1/chat/completions` keeps its deliberately narrower `{web_search}`. Behaviour unchanged: both literals were already identical.
- **`selectToolSearchCatalog` → `excludeAlwaysUpfront`.** It has two callers — the `tool_search` catalog and the deferral candidate set inside `applyToolExposureMode` — and the old name described only the first, making `const deferrable = selectToolSearchCatalog(...)` read as a contradiction.
- **`applyToolExposureMode` derives `nonCoreTools` from `splitToolsForExposure`** instead of re-filtering `deferrable`, so the deferral rule is defined once. Provably identical: `!alwaysUpfront && !CORE` ≡ `!(CORE || alwaysUpfront)`, and both preserve input key order, so the object fed to `buildNonCoreToolNamesPrompt` and `createExecuteTool` is byte-identical.

## Correction: the `web_fetch` claim in earlier revisions was wrong

Earlier revisions of this description (and two comments below) claimed `web_fetch` was a live page-chat bug being deferred. **That was incorrect** — retracted in `b2560f9`. Recording it here rather than quietly deleting it, since reviewers may have read it.

The claim came from a review finding I under-verified: I confirmed `WEB_SEARCH_TOOLS = {web_search, web_fetch}` (`core/tool-filtering.ts:128`) and inferred the rest. But `web_fetch` appears **nowhere** in `chat/route.ts`. It is never destructured as a runtime override (Step 2 takes only `web_search` and `generate_image`) and never re-added after the allowlist (Steps 4/4b), so it flows through `filterToolsForAgentAllowlist` like any ordinary tool. That yields two outcomes and no third:

- allowlist permits it (or is `null`) → present, and `execute_tool`'s re-check passes → dispatches fine;
- allowlist omits it → removed entirely at Step 3 → not upfront, not in `execute_tool`'s dispatch map, not in the `tool_search` catalog → the model never sees it.

There is no present-but-rejected state, so there is no bug to fix.

### The actual membership rule for `ALWAYS_UPFRONT_TOOLS`

The correction is sharper than the mistake. Membership is **not** "shares a composer toggle" — it is:

> a tool belongs iff it **bypasses the agent allowlist on the way in** (destructured out of the baseline *before* `filterToolsForAgentAllowlist`, re-added *after* it when the toggle is on).

That bypass is precisely what makes `execute_tool`'s re-check reject the tool on the way out: it is present in the tool set but absent from `enabledTools`, so deferring it produces "not permitted" exactly when the user toggled it on. `web_search` and `generate_image` are the only two tools with that property. `web_fetch` has no bypass, so it has nothing to be rescued from — it is correctly absent, not deferred.

This rule is now stated in the constant's doc comment and pinned by an explicit `expect(ALWAYS_UPFRONT_TOOLS.has('web_fetch')).toBe(false)`, so the set's boundary is asserted rather than merely described.

## Scope guarantees

- **Reachability only.** `filterToolsForImageGen` and `shouldExposeImageGen` are untouched. Verified both gates *remove* the tool from the set entirely when off (`tool-filtering.ts:250-259`, `344-353`), so `ALWAYS_UPFRONT_TOOLS` can only promote a tool that already survived the gate — it **cannot** widen who can generate images. `image-gen-exposure.test.ts` passes **unmodified** (verified: empty diff).
- **No `applyToolExposureMode` wholesale swap** on the global route. That route injects `TOOL_DISCOVERY_PROMPT` itself under an explicit "Stable order" comment (prompt-cache sensitive); the helper would emit a second copy and reorder it, and it short-circuits when there are no non-core tools, whereas the route always wants the `execute_tool` scaffolding.
- **`applyToolExposureMode`'s `coreTools`/`upfrontOverrides` spread left alone.** It orders core-then-overrides, whereas `splitToolsForExposure` preserves input key order — collapsing them would change the tool array order sent to the provider, which is prompt-cache sensitive, so it would not be behaviour-identical.

## Testing (TDD)

Both helpers were written RED first and observed failing before implementation:

```
SyntaxError: Export named 'splitToolsForExposure' not found in module '.../tool-exposure.ts'
SyntaxError: Export named 'selectToolSearchCatalog' not found in module '.../tool-exposure.ts'
```

`splitToolsForExposure` — 100% branch coverage (`core=true` short-circuit, `core=false`+`always=true`, `core=false`+`always=false`, explicit-empty vs defaulted `alwaysUpfront`, empty tool set): the four required cases plus "no tool appears in both halves; union equals the input".

`excludeAlwaysUpfront` — omits always-upfront tools, handles empty/defaulted args, plus an **invariant test**: every tool left in the catalog is either core (directly callable) or present in `nonCoreTools` (callable via `execute_tool`). Nothing may be discoverable yet unreachable.

`ALWAYS_UPFRONT_TOOLS` — pins the set's contents (so a new toggle can't be added to one route and forgotten in the other) and asserts its members are promoted past the core-only split.

### Gates

| Gate | Result |
|---|---|
| `bun run typecheck` | ✅ 16/16 tasks |
| `bun run lint` | ✅ 14/14 tasks |
| `bun test .../tool-exposure.test.ts` | ✅ 23 pass |
| `bun test .../image-gen-exposure.test.ts` (unmodified) | ✅ 5 pass |
| `bun run test:unit` — `@pagespace/lib` | ✅ 407 files / 9209 tests |
| `bun run test:unit` — `web` | ✅ 1041 files / 15713 tests, 1 pre-existing failure below |

Reproducing locally: `test:unit` needs `DATABASE_URL` pointed at the migrated test Postgres (as `scripts/test-with-db.sh` does); without it ~24 DB-backed tests fail on `relation "users" does not exist`. Run `typecheck` and `lint` sequentially — both trigger `web:build`, and racing them leaves `.next/types` partially written, producing spurious `TS6053` errors.

## Pre-existing / flaky failures (not caused by this PR)

1. `apps/web/src/lib/messages/__tests__/grouping.test.ts > isFirstInGroup > breaks the group when messages cross midnight even within the 5-minute window` — `AssertionError: expected false to be true`. Verified pre-existing: the same test fails identically on `master` in a separate checkout, and this diff changes no files it touches. Timezone-dependent, environmental.
2. `packages/lib/src/security/__tests__/distributed-rate-limit.integration.test.ts > weighted sliding window` — failed once under full-suite parallel load, then passed 7/7 twice in isolation. Timing-sensitive flake; this diff touches zero `packages/lib` files.
3. `bun run test:security` locally reports 6/50 suites failing (Session Service, Device Auth Utilities, Permissions, Login Route, Signup Route, Mobile Login) — all auth/session suites, none touching AI tool exposure. Running the identical command on `master` in a separate checkout fails **9/50**, a strict superset of the same six. So this branch introduces zero new security-suite failures, and CI's Security Test Suite check passes on the PR.

## Files changed

- `apps/web/src/lib/ai/tools/tool-exposure.ts`
- `apps/web/src/app/api/ai/global/[id]/messages/route.ts`
- `apps/web/src/app/api/ai/chat/route.ts` (import shared constant; literal removed)
- `apps/web/src/lib/ai/tools/__tests__/tool-exposure.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ukUtoKKTgQDH35docNcE6


