### PR TITLE
feat(ai): let agents move pages across drives, and stop defaulting to Home

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -114,7 +114,8 @@ import {
 } from '@/lib/ai/core/stream-abort-registry';
 import { runAgentWithRetry, AGENT_MAX_STEPS, isRunAborted, type RunAgentWithRetryResult } from '@/lib/ai/core/run-agent-with-retry';
 import { resolveRequestContext } from '@/lib/ai/core/resolve-request-context';
-import { locationContextToPageContext } from '@/lib/ai/shared/buildPageContext';
+import { locationContextToPageContext, pageContextToLocationContext } from '@/lib/ai/shared/buildPageContext';
+import type { LocationContext } from '@/lib/ai/shared/chat-types';
 import type { ContextRef } from '@/lib/ai/shared/buildContextRef';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
@@ -326,6 +327,15 @@ export async function POST(request: Request) {
     const pageContext = contextRef
       ? locationContextToPageContext(resolvedLocation)
       : legacyPageContext;
+
+    // ONE normalized location for this turn, feeding both the model prompt and
+    // the tool context. PageContext can't represent a drive-level location (it
+    // requires a page), so deriving the prompt from it alone left the model told
+    // "operating from the dashboard" on /dashboard/<drive>/<section> while tools
+    // defaulted `driveId` to that very drive.
+    const turnLocation: LocationContext | null = contextRef
+      ? resolvedLocation
+      : pageContextToLocationContext(legacyPageContext);
 
     const mcpScopeError = await checkMCPPageScope(authResult, chatId);
     if (mcpScopeError) {
@@ -1197,18 +1207,10 @@ export async function POST(request: Request) {
       systemPrompt += buildInlineInstructions(allowedToolNames);
     }
 
-    const locationPrompt = buildLocationTurnPrompt(pageContext ? {
-      currentPage: {
-        title: pageContext.pageTitle,
-        type: pageContext.pageType,
-        path: pageContext.pagePath,
-      },
-      currentDrive: pageContext.driveId ? {
-        id: pageContext.driveId,
-        name: pageContext.driveName,
-        slug: pageContext.driveSlug,
-      } : undefined,
-      breadcrumbs: pageContext.breadcrumbs,
+    const locationPrompt = buildLocationTurnPrompt(turnLocation ? {
+      currentPage: turnLocation.currentPage,
+      currentDrive: turnLocation.currentDrive,
+      breadcrumbs: turnLocation.breadcrumbs,
     } : undefined);
 
     // Cross-drive membership context applies uniformly regardless of whether
@@ -1543,27 +1545,12 @@ export async function POST(request: Request) {
                 aiProvider: currentProvider,
                 aiModel: currentModel,
                 conversationId,
-                locationContext: pageContext ? {
-                  currentPage: {
-                    id: pageContext.pageId,
-                    title: pageContext.pageTitle,
-                    type: pageContext.pageType,
-                    path: pageContext.pagePath,
-                  },
-                  currentDrive: pageContext.driveId ? {
-                    id: pageContext.driveId,
-                    name: pageContext.driveName,
-                    slug: pageContext.driveSlug,
-                  } : undefined,
-                  breadcrumbs: pageContext.breadcrumbs,
-                } : resolvedLocation?.currentDrive ? {
-                  // Drive-level route (a workspace is in view but no page):
-                  // PageContext can't represent that shape, so tools would
-                  // otherwise see no location at all and `driveId` defaulting
-                  // would be dead on this route.
-                  currentPage: undefined,
-                  currentDrive: resolvedLocation.currentDrive,
-                  breadcrumbs: resolvedLocation.breadcrumbs,
+                // Same normalized location the model prompt was built from, so
+                // the two can never disagree about which workspace is in view.
+                locationContext: turnLocation ? {
+                  currentPage: turnLocation.currentPage ?? undefined,
+                  currentDrive: turnLocation.currentDrive ?? undefined,
+                  breadcrumbs: turnLocation.breadcrumbs,
                 } : undefined,
                 // Turn-start snapshot of the agent's working page — tools that
                 // shift focus (e.g. create_page) mutate this in place so later

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1555,11 +1555,13 @@ export async function POST(request: Request) {
                 // Turn-start snapshot of the agent's working page — tools that
                 // shift focus (e.g. create_page) mutate this in place so later
                 // tool calls in the same turn track the agent's own actions
-                // rather than staying pinned to the turn-start snapshot.
-                currentWorkingPage: pageContext ? {
-                  id: pageContext.pageId,
-                  title: pageContext.pageTitle,
-                  type: pageContext.pageType,
+                // rather than staying pinned to the turn-start snapshot. Derived
+                // from the same turnLocation as everything else above, so there
+                // is exactly one answer to "where is the user" in this route.
+                currentWorkingPage: turnLocation?.currentPage ? {
+                  id: turnLocation.currentPage.id,
+                  title: turnLocation.currentPage.title,
+                  type: turnLocation.currentPage.type,
                 } : undefined,
                 modelCapabilities: modelCapabilitiesForTools,
                 isAdmin: isAdminUser,
@@ -1797,9 +1799,12 @@ export async function POST(request: Request) {
               conversationId, // Use actual conversation ID instead of pageId
               messageId,
               pageId: chatId,
-              // Empty string (no drive in view) must read as "no drive", not a
-              // literal '' driveId — matches the truthy-guards used elsewhere
-              // in this file for the same pageContext.driveId field.
+              // Deliberately still pageContext, NOT turnLocation: usage is
+              // attributed to the drive of the PAGE in view, and turnLocation
+              // also carries a drive on drive-level routes where no page is
+              // open. Switching would start attributing spend to a drive this
+              // metric never counted. The `|| undefined` keeps an empty-string
+              // driveId reading as "no drive".
               driveId: pageContext?.driveId || undefined,
               // 'exhausted' = retry shell gave up (failure); clean/terminal = a real
               // completion. Cost still settles regardless (the provider charged us).

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -311,8 +311,8 @@ export async function POST(request: Request) {
     // the legacy client-computed pageContext only for old clients that never sent a
     // contextRef at all. Deferred until after the required-field checks above so an
     // invalid request (no messages/chatId) fails fast without an extra DB round-trip.
-    const pageContext = contextRef
-      ? locationContextToPageContext(await resolveRequestContext(authResult, contextRef, (denied) => {
+    const resolvedLocation = contextRef
+      ? await resolveRequestContext(authResult, contextRef, (denied) => {
           auditRequest(request, {
             eventType: 'authz.access.denied',
             userId,
@@ -321,7 +321,10 @@ export async function POST(request: Request) {
             details: { reason: 'context_ref_denied', method: 'POST', chatId },
             riskScore: 0.3,
           });
-        }))
+        })
+      : null;
+    const pageContext = contextRef
+      ? locationContextToPageContext(resolvedLocation)
       : legacyPageContext;
 
     const mcpScopeError = await checkMCPPageScope(authResult, chatId);
@@ -1553,6 +1556,14 @@ export async function POST(request: Request) {
                     slug: pageContext.driveSlug,
                   } : undefined,
                   breadcrumbs: pageContext.breadcrumbs,
+                } : resolvedLocation?.currentDrive ? {
+                  // Drive-level route (a workspace is in view but no page):
+                  // PageContext can't represent that shape, so tools would
+                  // otherwise see no location at all and `driveId` defaulting
+                  // would be dead on this route.
+                  currentPage: undefined,
+                  currentDrive: resolvedLocation.currentDrive,
+                  breadcrumbs: resolvedLocation.breadcrumbs,
                 } : undefined,
                 // Turn-start snapshot of the agent's working page — tools that
                 // shift focus (e.g. create_page) mutate this in place so later

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -789,9 +789,9 @@ SMART EXPLORATION RULES:
    - Default scope: current drive/location (see LOCATION context) is your primary workspace
    - Only explore OTHER drives when explicitly mentioned
    - When user says "here" or "this", they mean current context
-   - If LOCATION context shows no drive, you're in the dashboard — use list_drives when you need to work across multiple workspaces; always check existing drives before suggesting new drive creation
+   - If LOCATION context shows no drive, you're in the dashboard — use list_drives when you need to work across multiple workspaces; always check existing drives before suggesting new drive creation — never fall back to the Home drive as a guess
 3. Efficient exploration pattern:
-   - FIRST: list_pages with driveId on current drive (if in a drive)
+   - FIRST: list_pages on the current drive — omit driveId and it uses the drive in your LOCATION context
    - THEN: read specific pages as needed
    - ONLY IF NEEDED: explore other drives/workspaces
 4. Proactive assistance:

--- a/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
@@ -116,6 +116,9 @@ vi.mock('@pagespace/db/schema/members', () => ({
 
 vi.mock('@/services/api/task-sync-service', () => ({
   syncTaskItemOnMove: vi.fn().mockResolvedValue(undefined),
+  // The move service now also scrubs drive-scoped task associations (agent
+  // assignees, workflow triggers) for the moved roots and their descendants.
+  scrubDriveScopedTaskAssociations: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/canvas/publish-page', () => ({

--- a/apps/web/src/app/api/pages/bulk-move/route.ts
+++ b/apps/web/src/app/api/pages/bulk-move/route.ts
@@ -4,15 +4,12 @@ import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db'
-import { and, eq, inArray, desc, isNull, isNotNull } from '@pagespace/db/operators'
-import { pages, drives } from '@pagespace/db/schema/core'
+import { and, eq, isNotNull } from '@pagespace/db/operators'
+import { drives } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, getAllowedDriveIds, isMCPAuthResult, isScopedMCPAuth, canPrincipalEditPage } from '@/lib/auth';
 import { getAppDriveMembership } from '@pagespace/lib/permissions/app-permissions';
-import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
-import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
-import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
+import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
 import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -43,217 +40,78 @@ export async function POST(request: Request) {
 
     const { pageIds, targetDriveId, targetParentId } = parseResult.data;
 
-    // Verify target drive exists
-    const targetDrive = await db.query.drives.findFirst({
-      where: eq(drives.id, targetDriveId),
-    });
-
-    if (!targetDrive) {
-      return NextResponse.json({ error: 'Target drive not found' }, { status: 404 });
-    }
-
-    // Check MCP token scope for target drive
+    // Check MCP token scope for target drive. Stays in the route because it
+    // returns the route's own NextResponse; the service's scope hook below
+    // therefore only has the SOURCE drives left to gate.
     const targetScopeError = checkMCPDriveScope(auth, targetDriveId);
     if (targetScopeError) {
       return targetScopeError;
     }
 
-    // Check the principal has edit access to target drive. A scoped MCP token
-    // is its own drive member — use the TOKEN's role, not its owning user's.
-    let canEditDrive: boolean;
-    const tokenMembership = isScopedMCPAuth(auth)
-      ? await getAppDriveMembership(auth.tokenId, targetDriveId)
-      : null;
-    if (isScopedMCPAuth(auth) && tokenMembership?.role !== null) {
-      // Explicit-role keys need OWNER/ADMIN; inherited keys (role null) fall
-      // through to the owner's own authority below.
-      canEditDrive = tokenMembership?.role === 'OWNER' || tokenMembership?.role === 'ADMIN';
-    } else {
-      const isOwner = targetDrive.ownerId === userId;
-      canEditDrive = isOwner;
-
-      if (!isOwner) {
-        // Authz read: a pending invitee (acceptedAt IS NULL) with role ADMIN
-        // would otherwise pass the role check and be allowed to write into a
-        // drive they have not accepted into. Closes Review C2.
-        const membership = await db.query.driveMembers.findFirst({
-          where: and(
-            eq(driveMembers.driveId, targetDriveId),
-            eq(driveMembers.userId, userId),
-            isNotNull(driveMembers.acceptedAt)
-          ),
-        });
-        canEditDrive = membership?.role === 'OWNER' || membership?.role === 'ADMIN';
-      }
-    }
-
-    if (!canEditDrive) {
-      return NextResponse.json(
-        { error: 'You do not have permission to move pages to this drive' },
-        { status: 403 }
-      );
-    }
-
-    // Verify target parent exists if specified
-    if (targetParentId) {
-      const targetParent = await db.query.pages.findFirst({
-        where: and(
-          eq(pages.id, targetParentId),
-          eq(pages.driveId, targetDriveId),
-          eq(pages.isTrashed, false)
-        ),
-      });
-      if (!targetParent) {
-        return NextResponse.json({ error: 'Target folder not found' }, { status: 404 });
-      }
-    }
-
-    // Check user has edit access to all source pages
-    // eslint-disable-next-line no-restricted-syntax -- pre-existing unbounded findMany, not fixed by Phase 8 (PageSpace epic j44e35jwzlhr54fbmruk3k4i follow-up)
-    const sourcePages = await db.query.pages.findMany({
-      where: inArray(pages.id, pageIds),
-    });
-
-    if (sourcePages.length !== pageIds.length) {
-      return NextResponse.json({ error: 'Some pages not found' }, { status: 404 });
-    }
-
-    // Check MCP token scope for all source pages
     const allowedDriveIds = getAllowedDriveIds(auth);
-    if (allowedDriveIds.length > 0) {
-      const allowedSet = new Set(allowedDriveIds);
-      for (const page of sourcePages) {
-        if (!allowedSet.has(page.driveId)) {
-          return NextResponse.json(
-            { error: 'This token does not have access to one or more source pages' },
-            { status: 403 }
-          );
-        }
-      }
-    }
+    const allowedSet = allowedDriveIds.length > 0 ? new Set(allowedDriveIds) : null;
 
-    // Verify edit permissions for all pages
-    for (const page of sourcePages) {
-      const canEdit = await canPrincipalEditPage(auth, page.id);
-      if (!canEdit) {
-        return NextResponse.json(
-          { error: `You do not have permission to move page: ${page.title}` },
-          { status: 403 }
-        );
-      }
-    }
+    const result = await movePagesToDrive({
+      pageIds,
+      targetDriveId,
+      targetParentId,
+      userId,
+      authorize: {
+        isDriveInScope: (driveId) =>
+          // The target drive was already gated by checkMCPDriveScope above;
+          // allowedDriveIds gates the source drives, exactly as before.
+          driveId === targetDriveId || !allowedSet || allowedSet.has(driveId),
 
-    // Validate move doesn't create circular references
-    for (const pageId of pageIds) {
-      if (targetParentId) {
-        const validation = await validatePageMove(pageId, targetParentId);
-        if (!validation.valid) {
-          return NextResponse.json({ error: validation.error }, { status: 400 });
-        }
-      }
-    }
+        // Check the principal has edit access to target drive. A scoped MCP token
+        // is its own drive member — use the TOKEN's role, not its owning user's.
+        canAdministerDrive: async (driveId) => {
+          const targetDrive = await db.query.drives.findFirst({
+            where: eq(drives.id, driveId),
+            columns: { ownerId: true },
+          });
 
-    // Get the max position in target parent
-    const lastPage = await db.query.pages.findFirst({
-      where: and(
-        eq(pages.driveId, targetDriveId),
-        targetParentId ? eq(pages.parentId, targetParentId) : isNull(pages.parentId),
-        eq(pages.isTrashed, false)
-      ),
-      orderBy: [desc(pages.position)],
-    });
+          const tokenMembership = isScopedMCPAuth(auth)
+            ? await getAppDriveMembership(auth.tokenId, driveId)
+            : null;
+          if (isScopedMCPAuth(auth) && tokenMembership?.role !== null) {
+            // Explicit-role keys need OWNER/ADMIN; inherited keys (role null) fall
+            // through to the owner's own authority below.
+            return tokenMembership?.role === 'OWNER' || tokenMembership?.role === 'ADMIN';
+          }
 
-    let nextPosition = (lastPage?.position || 0) + 1;
+          if (targetDrive?.ownerId === userId) return true;
 
-    // Track affected drives for broadcast events
-    const affectedDriveIds = new Set<string>();
-    affectedDriveIds.add(targetDriveId);
+          // Authz read: a pending invitee (acceptedAt IS NULL) with role ADMIN
+          // would otherwise pass the role check and be allowed to write into a
+          // drive they have not accepted into. Closes Review C2.
+          const membership = await db.query.driveMembers.findFirst({
+            where: and(
+              eq(driveMembers.driveId, driveId),
+              eq(driveMembers.userId, userId),
+              isNotNull(driveMembers.acceptedAt)
+            ),
+          });
+          return membership?.role === 'OWNER' || membership?.role === 'ADMIN';
+        },
 
-    // Drives whose homePageId was cleared during the move (synced after tx commits).
-    const clearedHomePageDriveIds: string[] = [];
-
-    // Move pages in transaction
-    await db.transaction(async (tx) => {
-      for (const page of sourcePages) {
-        const sourceDriveId = page.driveId;
-        affectedDriveIds.add(sourceDriveId);
-
-        // Update page with new drive, parent, and position
-        await tx.update(pages)
-          .set({
-            driveId: targetDriveId,
-            parentId: targetParentId,
-            position: nextPosition,
-            updatedAt: new Date(),
-          })
-          .where(eq(pages.id, page.id));
-
-        // If moving to a different drive, recursively update all children's driveId
-        if (page.driveId !== targetDriveId) {
-          await updateChildrenDriveId(tx, page.id, targetDriveId);
-        }
-
-        await syncTaskItemOnMove(tx, {
-          movedPageId: page.id,
-          movedPageType: page.type,
-          oldParentId: page.parentId,
-          newParentId: targetParentId,
-          userId,
-        });
-
-        nextPosition += 1;
-      }
-
-      // A drive's home page must live in that drive. Clearing here (after the
-      // moves, same transaction) also covers home pages that left as
-      // descendants of a moved subtree via updateChildrenDriveId.
-      const sourceDriveIds = [...affectedDriveIds].filter((id) => id !== targetDriveId);
-      for (const sourceDriveId of sourceDriveIds) {
-        const sourceDrive = await tx.query.drives.findFirst({
-          where: eq(drives.id, sourceDriveId),
-          columns: { homePageId: true },
-        });
-        if (!sourceDrive?.homePageId) continue;
-
-        const homePageStillInDrive = await tx.query.pages.findFirst({
-          where: and(eq(pages.id, sourceDrive.homePageId), eq(pages.driveId, sourceDriveId)),
-          columns: { id: true },
-        });
-        if (!homePageStillInDrive) {
-          await tx.update(drives)
-            .set({ homePageId: null })
-            .where(eq(drives.id, sourceDriveId));
-          clearedHomePageDriveIds.push(sourceDriveId);
-        }
-      }
-    });
-
-    // Log activity for each moved page
-    const actorInfo = await getActorInfo(userId);
-    const isMCP = isMCPAuthResult(auth);
-    const changeGroupId = createChangeGroupId();
-    for (const page of sourcePages) {
-      logPageActivity(userId, 'move', {
-        id: page.id,
-        title: page.title ?? undefined,
-        driveId: targetDriveId,
-      }, {
-        ...actorInfo,
-        changeGroupId,
+        canEditPage: (pageId) => canPrincipalEditPage(auth, pageId),
+      },
+      activity: {
         changeGroupType: 'user',
-        updatedFields: ['driveId', 'parentId', 'position'],
-        previousValues: { driveId: page.driveId, parentId: page.parentId },
-        newValues: { driveId: targetDriveId, parentId: targetParentId },
         metadata: {
           bulkOperation: 'move',
           totalPages: pageIds.length,
-          ...(isMCP && { source: 'mcp' }),
+          ...(isMCPAuthResult(auth) && { source: 'mcp' }),
         },
-      });
+      },
+    });
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.message }, { status: result.status });
     }
 
     // Broadcast events
-    for (const driveId of affectedDriveIds) {
+    for (const driveId of result.affectedDriveIds) {
       await broadcastPageEvent(
         createPageEventPayload(driveId, '', 'moved')
       );
@@ -261,7 +119,7 @@ export async function POST(request: Request) {
 
     // Sync the subdomain root for drives whose home page was bulk-moved away.
     // Fire-and-forget: never blocks the response; syncPublishedHomeRoot swallows errors.
-    for (const driveId of clearedHomePageDriveIds) {
+    for (const driveId of result.clearedHomePageDriveIds) {
       void syncPublishedHomeRoot(driveId);
     }
 
@@ -277,26 +135,5 @@ export async function POST(request: Request) {
       { error: 'Failed to move pages' },
       { status: 500 }
     );
-  }
-}
-
-// Recursively update driveId for all children
-async function updateChildrenDriveId(
-  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
-  parentId: string,
-  newDriveId: string
-) {
-  // eslint-disable-next-line no-restricted-syntax -- pre-existing unbounded findMany, not fixed by Phase 8 (PageSpace epic j44e35jwzlhr54fbmruk3k4i follow-up)
-  const children = await tx.query.pages.findMany({
-    where: eq(pages.parentId, parentId),
-  });
-
-  for (const child of children) {
-    await tx.update(pages)
-      .set({ driveId: newDriveId })
-      .where(eq(pages.id, child.id));
-
-    // Recursively update grandchildren
-    await updateChildrenDriveId(tx, child.id, newDriveId);
   }
 }

--- a/apps/web/src/lib/ai/core/__tests__/resolve-request-context.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/resolve-request-context.test.ts
@@ -32,6 +32,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 }));
 
 import { resolveRequestContext } from '../resolve-request-context';
+import { buildContextRef } from '@/lib/ai/shared/buildContextRef';
 import { canPrincipalViewPage, isPrincipalDriveMember } from '@/lib/auth/principal-permissions';
 import { getPageBreadcrumbTrail } from '@/lib/pages/get-page-breadcrumb-trail';
 
@@ -175,6 +176,37 @@ describe('resolveRequestContext', () => {
       currentPage: null,
       currentDrive: { id: 'drive-1', name: 'Engineering', slug: 'engineering' },
       breadcrumbs: ['Engineering'],
+    });
+  });
+
+  // Composition with buildContextRef: drive SUB-routes (tasks, members, settings…)
+  // now resolve as routeType 'drive' rather than falling through to 'other'. They
+  // must inherit the same membership gate the bare drive route already passes
+  // through — widening the location must not widen access.
+  describe('drive sub-routes (composed with buildContextRef)', () => {
+    const DRIVES = [{ id: 'drive-1', slug: 'engineering', name: 'Engineering' }];
+
+    it('given a member on /dashboard/drive-1/files, should resolve currentDrive', async () => {
+      vi.mocked(isPrincipalDriveMember).mockResolvedValue(true);
+      dbLimitMock.mockResolvedValue([{ id: 'drive-1', name: 'Engineering', slug: 'engineering' }]);
+
+      const ref = buildContextRef('/dashboard/drive-1/files', DRIVES);
+
+      expect(await resolveRequestContext(AUTH, ref)).toEqual({
+        currentPage: null,
+        currentDrive: { id: 'drive-1', name: 'Engineering', slug: 'engineering' },
+        breadcrumbs: ['Engineering'],
+      });
+    });
+
+    it('given a NON-member on /dashboard/drive-1/files, should DENY and return null', async () => {
+      vi.mocked(isPrincipalDriveMember).mockResolvedValue(false);
+      const onAccessDenied = vi.fn();
+
+      const ref = buildContextRef('/dashboard/drive-1/files', DRIVES);
+
+      expect(await resolveRequestContext(AUTH, ref, onAccessDenied)).toBeNull();
+      expect(onAccessDenied).toHaveBeenCalledWith({ routeType: 'drive', driveId: 'drive-1' });
     });
   });
 

--- a/apps/web/src/lib/ai/core/location-prompt.ts
+++ b/apps/web/src/lib/ai/core/location-prompt.ts
@@ -30,7 +30,8 @@ export function buildLocationTurnPrompt(input: LocationPromptInput | undefined):
     return `LOCATION (current, this turn):
 • Operating from the dashboard — no specific workspace or page is currently in view
 • Use list_drives to discover available workspaces before suggesting new drive creation
-• When the user says "here" or "this", ask which workspace/page they mean, or use list_drives/list_pages to find out`;
+• When the user says "here" or "this", ask which workspace/page they mean, or use list_drives/list_pages to find out
+• Do NOT assume the Home drive — ask which workspace, or use list_drives`;
   }
 
   const lines: string[] = ['LOCATION (current, this turn):'];
@@ -57,6 +58,7 @@ export function buildLocationTurnPrompt(input: LocationPromptInput | undefined):
 
   if (input.currentDrive?.id) {
     lines.push('• Start with list_pages on this drive (driveId above) before exploring elsewhere');
+    lines.push('• Omit driveId on create_page, list_pages, glob_search, regex_search and generate_image to act on THIS workspace — never substitute a different drive, and never the Home drive, unless the user names one');
   }
 
   return lines.join('\n');

--- a/apps/web/src/lib/ai/core/types.ts
+++ b/apps/web/src/lib/ai/core/types.ts
@@ -94,6 +94,14 @@ export interface ToolExecutionContext {
   // `pageId` argument on read/write page tools.
   currentWorkingPage?: { id: string; title: string; type: string };
 
+  // Drive-level twin of currentWorkingPage: mutated in place by create_page (and
+  // create_drive) so a later tool call in the SAME turn that omits `driveId`
+  // follows the agent's own action rather than snapping back to the turn-start
+  // location. Read by resolveDefaultDriveId (drive-context-defaults.ts). Not
+  // seeded at route level — the resolver already falls through to
+  // locationContext.currentDrive.
+  currentWorkingDrive?: { id: string; name?: string };
+
   // Sprites Platform Alignment 5-2: a stable id for THIS agent turn (one
   // streamText run), lazily stamped once by `resolveSandboxActorContext`
   // (apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts) the first time a

--- a/apps/web/src/lib/ai/shared/__tests__/buildContextRef.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/buildContextRef.test.ts
@@ -66,4 +66,56 @@ describe('buildContextRef', () => {
       routeType: 'other',
     });
   });
+
+  // A user sitting on /dashboard/<id>/tasks is plainly inside a workspace. These
+  // sub-routes used to fall through to routeType 'other', which resolved to a
+  // null location server-side — so the assistant was told "operating from the
+  // dashboard" and guessed a drive (usually Home) for anything it created.
+  describe('drive sub-routes keep the workspace in context', () => {
+    const SUB_ROUTES = [
+      'tasks', 'activity', 'members', 'settings',
+      'trash', 'calendar', 'channels', 'files', 'workflows',
+    ];
+
+    it.each(SUB_ROUTES)('given /dashboard/drive-1/%s, should return routeType drive with the driveId', (section) => {
+      expect(buildContextRef(`/dashboard/drive-1/${section}`, DRIVES)).toEqual({
+        routeType: 'drive',
+        driveId: 'drive-1',
+      });
+    });
+
+    it('given a members sub-route (invite), should still return routeType drive', () => {
+      expect(buildContextRef('/dashboard/drive-1/members/invite', DRIVES)).toEqual({
+        routeType: 'drive',
+        driveId: 'drive-1',
+      });
+    });
+
+    it('given a members sub-route (single user), should still return routeType drive', () => {
+      expect(buildContextRef('/dashboard/drive-1/members/user-9', DRIVES)).toEqual({
+        routeType: 'drive',
+        driveId: 'drive-1',
+      });
+    });
+
+    // The known-drives trim applies on sub-routes exactly as on the bare route.
+    it('given a sub-route of an unrecognized drive, should return routeType drive with no driveId', () => {
+      expect(buildContextRef('/dashboard/unknown-drive/settings', DRIVES)).toEqual({
+        routeType: 'drive',
+        driveId: undefined,
+      });
+    });
+  });
+
+  describe('routes that are NOT drive-scoped stay routeType other', () => {
+    it.each([
+      ['the global drive list', '/dashboard/drives'],
+      ['global tasks', '/dashboard/tasks'],
+      ['global calendar', '/dashboard/calendar'],
+      ['global storage', '/dashboard/storage'],
+      ['account settings', '/account'],
+    ])('given %s, should return routeType other', (_label, path) => {
+      expect(buildContextRef(path, DRIVES)).toEqual({ routeType: 'other' });
+    });
+  });
 });

--- a/apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts
@@ -50,6 +50,21 @@ describe('pageContextToLocationContext', () => {
     expect(result?.currentPage?.id).toBe('page-1');
   });
 
+  // The legacy client payload is untrusted: TypeScript's view of it is a claim.
+  // An unguarded name would be printed verbatim into the turn prompt, telling the
+  // model it is in a workspace called "undefined".
+  it('never yields an undefined drive name, falling back through slug to id', () => {
+    const noName = pageContextToLocationContext({ ...PAGE, driveName: undefined as unknown as string });
+    expect(noName?.currentDrive?.name).toBe('engineering');
+
+    const noNameOrSlug = pageContextToLocationContext({
+      ...PAGE,
+      driveName: undefined as unknown as string,
+      driveSlug: undefined,
+    });
+    expect(noNameOrSlug?.currentDrive?.name).toBe('drive-1');
+  });
+
   it('round-trips through locationContextToPageContext without losing location', () => {
     const round = locationContextToPageContext(pageContextToLocationContext(PAGE));
     expect(round).toMatchObject({

--- a/apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the LocationContext <-> PageContext adapters.
+ *
+ * `pageContextToLocationContext` exists so /api/ai/chat can normalize BOTH of its
+ * location sources (a server-resolved contextRef, and the legacy client-supplied
+ * pageContext) to one shape. The model prompt and the tool context are then built
+ * from that single object, which is what keeps them from disagreeing about which
+ * workspace is in view.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  pageContextToLocationContext,
+  locationContextToPageContext,
+  type PageContext,
+} from '../buildPageContext';
+
+const PAGE: PageContext = {
+  pageId: 'page-1',
+  pageTitle: 'Spec',
+  pageType: 'DOCUMENT',
+  pagePath: '/engineering/Docs/Spec',
+  parentPath: '/engineering/Docs',
+  breadcrumbs: ['Engineering', 'Docs', 'Spec'],
+  driveId: 'drive-1',
+  driveName: 'Engineering',
+  driveSlug: 'engineering',
+};
+
+describe('pageContextToLocationContext', () => {
+  it('lifts a flat page context into the nested location shape', () => {
+    expect(pageContextToLocationContext(PAGE)).toEqual({
+      currentPage: { id: 'page-1', title: 'Spec', type: 'DOCUMENT', path: '/engineering/Docs/Spec' },
+      currentDrive: { id: 'drive-1', name: 'Engineering', slug: 'engineering' },
+      breadcrumbs: ['Engineering', 'Docs', 'Spec'],
+    });
+  });
+
+  it('returns null for an absent page context', () => {
+    expect(pageContextToLocationContext(undefined)).toBeNull();
+    expect(pageContextToLocationContext(null)).toBeNull();
+  });
+
+  // The legacy client shape carries an optional driveId; an orphaned page must
+  // not synthesize a drive with an empty id, which would then be handed to
+  // driveId-defaulting as if it were a real workspace.
+  it('yields a null currentDrive when the page carries no drive', () => {
+    const result = pageContextToLocationContext({ ...PAGE, driveId: undefined });
+    expect(result?.currentDrive).toBeNull();
+    expect(result?.currentPage?.id).toBe('page-1');
+  });
+
+  it('round-trips through locationContextToPageContext without losing location', () => {
+    const round = locationContextToPageContext(pageContextToLocationContext(PAGE));
+    expect(round).toMatchObject({
+      pageId: PAGE.pageId,
+      pageTitle: PAGE.pageTitle,
+      pagePath: PAGE.pagePath,
+      parentPath: PAGE.parentPath,
+      driveId: PAGE.driveId,
+      driveName: PAGE.driveName,
+      driveSlug: PAGE.driveSlug,
+      breadcrumbs: PAGE.breadcrumbs,
+    });
+  });
+
+  // The asymmetry that made the normalization necessary in the first place:
+  // a drive-level location survives as LocationContext but cannot be expressed
+  // as a PageContext at all.
+  it('cannot be expressed as a PageContext when there is no page (the reason the seam exists)', () => {
+    const driveOnly = { currentPage: null, currentDrive: { id: 'drive-1', name: 'Engineering', slug: 'engineering' }, breadcrumbs: ['Engineering'] };
+    expect(locationContextToPageContext(driveOnly)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/shared/buildContextRef.ts
+++ b/apps/web/src/lib/ai/shared/buildContextRef.ts
@@ -1,4 +1,4 @@
-import { parseTabPath } from '@/lib/tabs/tab-title';
+import { parseTabPath, isDriveScopedPath } from '@/lib/tabs/tab-title';
 import type { DriveEntry } from './resolveLocationContext';
 
 export type ContextRefRouteType = 'page' | 'channel' | 'drive' | 'dm' | 'other';
@@ -35,11 +35,17 @@ export const buildContextRef = (pathname: string, drives: DriveEntry[]): Context
       return { routeType: 'page', pageId: parsed.pageId, driveId: knownDriveId(parsed.driveId) };
     case 'channel':
       return { routeType: 'channel', pageId: parsed.pageId };
-    case 'drive':
-      return { routeType: 'drive', driveId: knownDriveId(parsed.driveId) };
     case 'dm':
       return { routeType: 'dm', dmConversationId: parsed.conversationId };
     default:
+      // Every drive-LEVEL route resolves as 'drive' — the bare
+      // /dashboard/[driveId] and its sub-routes (tasks, members, settings, …)
+      // alike. Previously only the bare route did and the rest fell through to
+      // 'other', so the assistant lost the workspace the user was plainly
+      // standing in and "put this here" landed in their Home drive instead.
+      if (isDriveScopedPath(parsed)) {
+        return { routeType: 'drive', driveId: knownDriveId(parsed.driveId) };
+      }
       return { routeType: 'other' };
   }
 };

--- a/apps/web/src/lib/ai/shared/buildPageContext.ts
+++ b/apps/web/src/lib/ai/shared/buildPageContext.ts
@@ -18,6 +18,40 @@ export type PageContext = {
  * undefined when there's no current page — matches `pageContext`'s existing
  * optionality server-side.
  */
+/**
+ * Inverse of `locationContextToPageContext`, for the one caller that still
+ * receives a flat `PageContext` first: legacy clients that send no `contextRef`.
+ *
+ * `PageContext` cannot represent a drive-level location (it requires a page), so
+ * the chat route normalizes BOTH sources to `LocationContext` before use — one
+ * object feeds the model prompt and the tool context alike. Without that, a
+ * drive-only route gave tools a `currentDrive` while the prompt still said
+ * "operating from the dashboard": tools would quietly act on a workspace the
+ * model had been told it wasn't in.
+ */
+export function pageContextToLocationContext(
+  // Structural, not `PageContext`: the legacy client-supplied shape carries an
+  // OPTIONAL driveId, and this adapter exists precisely to serve that caller.
+  page:
+    | (Omit<PageContext, 'driveId' | 'driveSlug'> & { driveId?: string; driveSlug?: string })
+    | null
+    | undefined,
+): LocationContext | null {
+  if (!page) return null;
+  return {
+    currentPage: {
+      id: page.pageId,
+      title: page.pageTitle,
+      type: page.pageType,
+      path: page.pagePath,
+    },
+    currentDrive: page.driveId
+      ? { id: page.driveId, name: page.driveName, slug: page.driveSlug ?? '' }
+      : null,
+    breadcrumbs: page.breadcrumbs,
+  };
+}
+
 export function locationContextToPageContext(loc: LocationContext | null | undefined): PageContext | undefined {
   const page = loc?.currentPage;
   if (!page) return undefined;

--- a/apps/web/src/lib/ai/shared/buildPageContext.ts
+++ b/apps/web/src/lib/ai/shared/buildPageContext.ts
@@ -13,12 +13,6 @@ export type PageContext = {
 };
 
 /**
- * Adapt the sidebar's nested `LocationContext` (currentPage/currentDrive) to
- * the flat `PageContext` shape `/api/ai/chat` actually reads. Returns
- * undefined when there's no current page — matches `pageContext`'s existing
- * optionality server-side.
- */
-/**
  * Inverse of `locationContextToPageContext`, for the one caller that still
  * receives a flat `PageContext` first: legacy clients that send no `contextRef`.
  *
@@ -52,6 +46,12 @@ export function pageContextToLocationContext(
   };
 }
 
+/**
+ * Adapt the sidebar's nested `LocationContext` (currentPage/currentDrive) to
+ * the flat `PageContext` shape `/api/ai/chat` actually reads. Returns
+ * undefined when there's no current page — matches `pageContext`'s existing
+ * optionality server-side.
+ */
 export function locationContextToPageContext(loc: LocationContext | null | undefined): PageContext | undefined {
   const page = loc?.currentPage;
   if (!page) return undefined;

--- a/apps/web/src/lib/ai/shared/buildPageContext.ts
+++ b/apps/web/src/lib/ai/shared/buildPageContext.ts
@@ -27,7 +27,11 @@ export function pageContextToLocationContext(
   // Structural, not `PageContext`: the legacy client-supplied shape carries an
   // OPTIONAL driveId, and this adapter exists precisely to serve that caller.
   page:
-    | (Omit<PageContext, 'driveId' | 'driveSlug'> & { driveId?: string; driveSlug?: string })
+    | (Omit<PageContext, 'driveId' | 'driveSlug' | 'driveName'> & {
+        driveId?: string;
+        driveName?: string;
+        driveSlug?: string;
+      })
     | null
     | undefined,
 ): LocationContext | null {
@@ -39,8 +43,18 @@ export function pageContextToLocationContext(
       type: page.pageType,
       path: page.pagePath,
     },
+    // Every drive field is optional at runtime: this is the LEGACY client-supplied
+    // payload, so the compiler's view of it is a claim, not a guarantee. An
+    // unguarded name reaches buildLocationTurnPrompt, which prints it verbatim —
+    // the model would be told it is in a workspace called "undefined" by the very
+    // function added to keep prompt and tools consistent. Falling back through
+    // slug to id keeps the line identifying rather than merely non-broken.
     currentDrive: page.driveId
-      ? { id: page.driveId, name: page.driveName, slug: page.driveSlug ?? '' }
+      ? {
+          id: page.driveId,
+          name: page.driveName || page.driveSlug || page.driveId,
+          slug: page.driveSlug ?? '',
+        }
       : null,
     breadcrumbs: page.breadcrumbs,
   };

--- a/apps/web/src/lib/ai/shared/resolveLocationContext.ts
+++ b/apps/web/src/lib/ai/shared/resolveLocationContext.ts
@@ -99,6 +99,10 @@ export async function resolveLocationContext(
       }
 
       // A whole drive — use the drive name from the store.
+      // NOTE: deliberately narrower than isDriveScopedPath (tab-title.ts), which
+      // also treats /dashboard/<drive>/<section> as drive-scoped. This legacy
+      // path is superseded by contextRef for the AI routes; widening it here
+      // would change the composer's own drive scoping, so it is left alone.
       case 'drive': {
         currentDrive = resolveDrive(parsed.driveId, drives);
         label = currentDrive?.name ?? null;

--- a/apps/web/src/lib/ai/tools/__tests__/drive-context-defaults.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-context-defaults.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for apps/web/src/lib/ai/tools/drive-context-defaults.ts
+ *
+ * Covers the shared "default an omitted driveId tool argument" logic used by
+ * create_page, list_pages, regex_search, glob_search and generate_image. Mirrors
+ * page-context-defaults.test.ts — the two seams must not drift.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveDefaultDriveId, resolveOrThrowDriveId } from '../drive-context-defaults';
+import type { ToolExecutionContext } from '../../core/types';
+
+const withCurrentDrive = (id: string) =>
+  ({
+    locationContext: { currentDrive: { id, name: 'Viewed', slug: 'viewed' } },
+  }) as ToolExecutionContext;
+
+describe('resolveDefaultDriveId', () => {
+  it('prefers currentWorkingDrive over locationContext.currentDrive', () => {
+    const context = {
+      currentWorkingDrive: { id: 'working-drive' },
+      locationContext: { currentDrive: { id: 'viewed-drive', name: 'Viewed', slug: 'viewed' } },
+    } as ToolExecutionContext;
+    expect(resolveDefaultDriveId(context)).toBe('working-drive');
+  });
+
+  it('falls back to locationContext.currentDrive.id when currentWorkingDrive is absent', () => {
+    expect(resolveDefaultDriveId(withCurrentDrive('viewed-drive'))).toBe('viewed-drive');
+  });
+
+  it('returns undefined when neither is present', () => {
+    expect(resolveDefaultDriveId({} as ToolExecutionContext)).toBeUndefined();
+  });
+
+  it('returns undefined when context itself is undefined', () => {
+    expect(resolveDefaultDriveId(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveOrThrowDriveId', () => {
+  it('returns the explicit driveId argument when provided, ignoring context', () => {
+    const context = { currentWorkingDrive: { id: 'working-drive' } } as ToolExecutionContext;
+    expect(resolveOrThrowDriveId('explicit-drive', context)).toBe('explicit-drive');
+  });
+
+  it('falls back to the default when the driveId argument is omitted', () => {
+    expect(resolveOrThrowDriveId(undefined, withCurrentDrive('viewed-drive'))).toBe('viewed-drive');
+  });
+
+  // The message must point the model at list_drives — a bare "driveId is
+  // required" is what pushed it to guess (and land in Home) in the first place.
+  it('throws a clear error naming list_drives when no drive can be resolved', () => {
+    expect(() => resolveOrThrowDriveId(undefined, {} as ToolExecutionContext)).toThrow(
+      'driveId is required: no workspace is currently in view and none was provided. Use list_drives to choose one.',
+    );
+  });
+
+  it('throws when context itself is undefined and no explicit driveId is given', () => {
+    expect(() => resolveOrThrowDriveId(undefined, undefined)).toThrow('driveId is required');
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -8,6 +8,17 @@ vi.mock('@pagespace/db/db', () => ({
     },
     select: vi.fn(),
     selectDistinct: vi.fn(),
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        insert: () => ({
+          values: () => ({
+            returning: async () => [
+              { id: 'drive-new', name: 'Test Drive', slug: 'test-drive', drivePrompt: null },
+            ],
+          }),
+        }),
+      }),
+    ),
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
@@ -240,6 +251,26 @@ describe('drive-tools', () => {
       await expect(
         driveTools.create_drive.execute!({ name: '' }, context)
       ).rejects.toThrow('Drive name is required');
+    });
+
+    // create_page parks the agent in the drive it wrote to; create_drive must do
+    // the same, or a "make me a workspace and put these pages in it" turn either
+    // throws ("no workspace is currently in view") from the dashboard or, worse,
+    // quietly fills whichever workspace the user happened to be standing in.
+    it('parks the agent in the workspace it just created', async () => {
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await driveTools.create_drive.execute!({ name: 'Test Drive' }, context) as
+        { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(context.experimental_context.currentWorkingDrive).toEqual({
+        id: 'drive-new',
+        name: 'Test Drive',
+      });
     });
 
     it('does not block a plain user (non-agent) call at the agent gate', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/image-generation-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/image-generation-tools.test.ts
@@ -127,9 +127,10 @@ describe('generate_image destination', () => {
     expect(createImageFilePage).toHaveBeenCalledWith(
       expect.objectContaining({ targetDriveId: undefined, targetParentId: undefined }),
     );
-    expect(res.savedTo).toBe('home_gallery');
+    expect(res.savedTo).toBe('home_no_location');
     // The relocate hint is what closes the loop for the model.
     expect(res.nextSteps?.[0]).toContain('move_page');
+    expect(res.nextSteps?.[0]).toContain('no workspace was in view');
   });
 
   it('degrades to the Home gallery when the drive in view is view-only', async () => {
@@ -138,7 +139,24 @@ describe('generate_image destination', () => {
 
     const res = (await run({ prompt: 'a diagram' }, admin(inDrive('drive-readonly')))) as { savedTo: string };
 
-    expect(res.savedTo).toBe('home_gallery');
+    expect(res.savedTo).toBe('home_unwritable_location');
+  });
+
+  // The two Home outcomes must stay distinguishable: reporting "no workspace was
+  // in view" when the real cause was a read-only workspace makes the assistant
+  // explain the wrong thing, and buries a permissions problem under a
+  // navigation one that navigating cannot fix.
+  it('reports a read-only workspace as the reason, not an absent one', async () => {
+    okGeneration();
+    canActorEditPage.mockResolvedValue(false);
+
+    const res = (await run({ prompt: 'a diagram' }, admin(inDrive('drive-readonly')))) as
+      { savedTo: string; nextSteps?: string[]; summary: string };
+
+    expect(res.nextSteps?.[0]).toContain('read-only');
+    expect(res.nextSteps?.[0]).not.toContain('no workspace was in view');
+    // Both Home outcomes still tell the user where the file actually is.
+    expect(res.summary).toContain('Home workspace gallery');
   });
 
   // An explicitly named destination must fail loudly rather than silently

--- a/apps/web/src/lib/ai/tools/__tests__/image-generation-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/image-generation-tools.test.ts
@@ -36,6 +36,24 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+
+// Destination resolution: the tool authorizes the target itself (create-file-page
+// deliberately does not), so both seams it uses are mocked here.
+const canActorEditPage = vi.fn<(...a: unknown[]) => Promise<boolean>>(async () => true);
+const findPageById = vi.fn<(...a: unknown[]) => unknown>();
+// Partial mocks: the test also imports the full tool registry, which pulls in
+// every other export of these modules.
+vi.mock('../actor-permissions', async (orig) => ({
+  ...(await orig<typeof import('../actor-permissions')>()),
+  canActorEditPage: (...a: unknown[]) => canActorEditPage(...a),
+}));
+vi.mock('@pagespace/lib/repositories/page-repository', async (orig) => {
+  const actual = await orig<typeof import('@pagespace/lib/repositories/page-repository')>();
+  return {
+    ...actual,
+    pageRepository: { ...actual.pageRepository, findById: (...a: unknown[]) => findPageById(...a) },
+  };
+});
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', role: 'role', subscriptionTier: 'subscriptionTier' } }));
 
 import { imageGenerationTools } from '../image-generation-tools';
@@ -60,6 +78,123 @@ beforeEach(() => {
   createImageFilePage.mockReset();
   dbState.role = 'user';
   dbState.tier = 'pro';
+  canActorEditPage.mockReset();
+  canActorEditPage.mockResolvedValue(true);
+  findPageById.mockReset();
+});
+
+// --- destination targeting -------------------------------------------------
+//
+// Generated images used to land in the user's Home drive unconditionally, which
+// stranded them: the workspace the user was actually working in never got the
+// file, and no agent tool could move it there.
+describe('generate_image destination', () => {
+  const okGeneration = () => {
+    canConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+    generateImageBytes.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      mediaType: 'image/png',
+      providerCostDollars: 0.01,
+      generationIds: ['gen-1'],
+    });
+    createImageFilePage.mockResolvedValue({ pageId: 'page-9', driveId: 'drive-work', parentId: 'gallery-1' });
+  };
+
+  const admin = (extra: Partial<ToolExecutionContext> = {}) => ({
+    userId: 'u1', isAdmin: true, subscriptionTier: 'pro', ...extra,
+  });
+
+  const inDrive = (id: string) => ({
+    locationContext: { currentDrive: { id, name: 'Work', slug: 'work' } },
+  }) as Partial<ToolExecutionContext>;
+
+  it('files into the workspace currently in view', async () => {
+    okGeneration();
+
+    const res = (await run({ prompt: 'a diagram' }, admin(inDrive('drive-work')))) as { savedTo: string };
+
+    expect(createImageFilePage).toHaveBeenCalledWith(
+      expect.objectContaining({ targetDriveId: 'drive-work', targetParentId: undefined }),
+    );
+    expect(res.savedTo).toBe('current_drive');
+  });
+
+  it('falls back to the Home gallery when no workspace is in view, and says so', async () => {
+    okGeneration();
+
+    const res = (await run({ prompt: 'a diagram' }, admin())) as { savedTo: string; nextSteps?: string[] };
+
+    expect(createImageFilePage).toHaveBeenCalledWith(
+      expect.objectContaining({ targetDriveId: undefined, targetParentId: undefined }),
+    );
+    expect(res.savedTo).toBe('home_gallery');
+    // The relocate hint is what closes the loop for the model.
+    expect(res.nextSteps?.[0]).toContain('move_page');
+  });
+
+  it('degrades to the Home gallery when the drive in view is view-only', async () => {
+    okGeneration();
+    canActorEditPage.mockResolvedValue(false);
+
+    const res = (await run({ prompt: 'a diagram' }, admin(inDrive('drive-readonly')))) as { savedTo: string };
+
+    expect(res.savedTo).toBe('home_gallery');
+  });
+
+  // An explicitly named destination must fail loudly rather than silently
+  // redirecting to Home — and it must fail BEFORE any spend.
+  it('rejects an unwritable explicit driveId without reserving credits or calling the provider', async () => {
+    okGeneration();
+    canActorEditPage.mockResolvedValue(false);
+
+    const res = (await run({ prompt: 'a diagram', driveId: 'drive-forbidden' }, admin())) as
+      { success: boolean; error: string };
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Insufficient permissions');
+    expect(canConsumeAI).not.toHaveBeenCalled();
+    expect(generateImageBytes).not.toHaveBeenCalled();
+    expect(releaseHold).not.toHaveBeenCalled();
+    expect(trackUsage).not.toHaveBeenCalled();
+    expect(createImageFilePage).not.toHaveBeenCalled();
+  });
+
+  it('files under an explicit parent, forwarding the parent\'s own drive', async () => {
+    okGeneration();
+    findPageById.mockResolvedValue({ id: 'folder-1', driveId: 'drive-work', isTrashed: false });
+
+    const res = (await run({ prompt: 'a diagram', parentId: 'folder-1' }, admin())) as { savedTo: string };
+
+    expect(createImageFilePage).toHaveBeenCalledWith(
+      expect.objectContaining({ targetDriveId: 'drive-work', targetParentId: 'folder-1' }),
+    );
+    expect(res.savedTo).toBe('requested');
+  });
+
+  it('rejects a parent that is not in the named drive, with no spend', async () => {
+    okGeneration();
+    findPageById.mockResolvedValue({ id: 'folder-1', driveId: 'drive-other', isTrashed: false });
+
+    const res = (await run(
+      { prompt: 'a diagram', parentId: 'folder-1', driveId: 'drive-work' },
+      admin(),
+    )) as { success: boolean; error: string };
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('is not in drive');
+    expect(canConsumeAI).not.toHaveBeenCalled();
+  });
+
+  it('rejects a trashed parent', async () => {
+    okGeneration();
+    findPageById.mockResolvedValue({ id: 'folder-1', driveId: 'drive-work', isTrashed: true });
+
+    const res = (await run({ prompt: 'a diagram', parentId: 'folder-1' }, admin())) as
+      { success: boolean; error: string };
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('was not found');
+  });
 });
 
 describe('generate_image registration', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -183,6 +183,78 @@ describe('page-read-tools', () => {
       expect(result).toMatchObject({ success: false });
     });
 
+    // driveId used to be required, which pushed the model into guessing a
+    // workspace whenever it didn't have one in its arguments.
+    describe('resolving an omitted driveId', () => {
+      const contextInDrive = (driveId: string) => ({
+        toolCallId: '1',
+        messages: [],
+        experimental_context: {
+          userId: 'user-123',
+          locationContext: { currentDrive: { id: driveId, name: 'Work', slug: 'work' } },
+        } as ToolExecutionContext,
+      });
+
+      const allowDrive = () => {
+        mockGetUserDriveAccess.mockResolvedValue(true as unknown as never);
+        mockGetUserAccessiblePagesInDrive.mockResolvedValue([] as unknown as never);
+        (mockDb.selectDistinct as ReturnType<typeof vi.fn>).mockReturnValue({
+          from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+        });
+      };
+
+      // The echo matters: a defaulted scope that looked in the wrong workspace
+      // returns an empty list, and an empty list reads as "it doesn't exist"
+      // unless the model can see where we actually looked.
+      it('lists the workspace in view and echoes the scope it used', async () => {
+        allowDrive();
+
+        const result = await pageReadTools.list_pages.execute!(
+          {},
+          contextInDrive('drive-loc')
+        ) as Record<string, unknown>;
+
+        expect(result).toMatchObject({
+          success: true,
+          driveId: 'drive-loc',
+          scopeSource: 'current_location',
+        });
+      });
+
+      it('marks an explicitly supplied driveId as an explicit scope', async () => {
+        allowDrive();
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId: 'drive-explicit' },
+          contextInDrive('drive-loc')
+        ) as Record<string, unknown>;
+
+        expect(result).toMatchObject({ driveId: 'drive-explicit', scopeSource: 'explicit' });
+      });
+
+      it('asks rather than guessing when no workspace is in view', async () => {
+        allowDrive();
+
+        await expect(
+          pageReadTools.list_pages.execute!({}, createAuthContext())
+        ).rejects.toThrow('no workspace is currently in view');
+      });
+
+      // Defaulting must not widen reach.
+      it('still denies a defaulted drive the actor cannot access', async () => {
+        mockGetUserDriveAccess.mockResolvedValue(false as unknown as never);
+
+        const result = await pageReadTools.list_pages.execute!(
+          {},
+          contextInDrive('drive-forbidden')
+        ) as Record<string, unknown>;
+
+        expect(result.success).toBe(false);
+        // driveSlug is absent on a defaulted scope — the message must not say "undefined".
+        expect(result.error).toContain('drive-forbidden');
+      });
+    });
+
     describe('ls-mode navigation (new behavior)', () => {
       const driveSlug = 'my-drive';
       const driveId = 'drive-1';

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -106,7 +106,9 @@ vi.mock('@pagespace/lib/repositories/drive-repository', () => ({
 }));
 
 vi.mock('@/services/api/page-mutation-service', () => ({
-  applyPageMutation: vi.fn().mockResolvedValue(undefined),
+  // Real applyPageMutation resolves to a result object carrying deferredTrigger,
+  // which callers passing their own tx must fire after commit.
+  applyPageMutation: vi.fn().mockResolvedValue({ deferredTrigger: undefined }),
 }));
 
 vi.mock('@/lib/websocket', () => ({
@@ -127,6 +129,7 @@ vi.mock('@pagespace/lib/services/drive-member-service', () => ({
 
 vi.mock('@/services/api/task-sync-service', () => ({
   ensureTaskListForPage: vi.fn().mockResolvedValue({ id: 'tasklist-1' }),
+  syncTaskItemOnMove: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@pagespace/lib/pages/circular-reference-guard', () => ({
@@ -147,7 +150,10 @@ vi.mock('@/lib/canvas/publish-page', () => ({
 // interceptable by mocking the module's exports. AI_CHAT: these agent fixtures
 // are real agent pages, so they keep the agent-scoped path.
 vi.mock('@pagespace/db/db', () => ({
-  db: { select: () => ({ from: () => ({ where: () => Promise.resolve([{ type: 'AI_CHAT', userScopedAccess: false }]) }) }) },
+  db: {
+    select: () => ({ from: () => ({ where: () => Promise.resolve([{ type: 'AI_CHAT', userScopedAccess: false }]) }) }),
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+  },
 }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -155,7 +161,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 }));
 
 import { pageWriteTools } from '../page-write-tools';
-import { ensureTaskListForPage } from '@/services/api/task-sync-service';
+import { ensureTaskListForPage, syncTaskItemOnMove } from '@/services/api/task-sync-service';
 import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { getAgentAccessLevel, hasAgentDriveMembership, hasAgentDriveAdminRole } from '@pagespace/lib/permissions/agent-permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
@@ -176,6 +182,7 @@ const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
 const mockEnsureTaskListForPage = vi.mocked(ensureTaskListForPage);
+const mockSyncTaskItemOnMove = vi.mocked(syncTaskItemOnMove);
 const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
 const mockValidatePageMove = vi.mocked(validatePageMove);
 const mockMovePagesToDrive = vi.mocked(movePagesToDrive);
@@ -1465,6 +1472,31 @@ describe('page-write-tools', () => {
       expect(result.success).toBe(true);
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
         expect.objectContaining({ pageId: 'page-1', operation: 'move' })
+      );
+    });
+
+    // Every other move path in the codebase syncs task_items; this one did not,
+    // so after the cross-drive work landed the SAME tool kept the row correct
+    // only when the move happened to cross a drive boundary.
+    it('syncs the task_items row on a same-drive move, like every other move path', async () => {
+      mockPageRepo.findById.mockResolvedValue(sourcePageRow({ id: 'page-1', parentId: 'old-parent' }));
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockPageRepo.existsInDrive.mockResolvedValue(true);
+      mockValidatePageMove.mockResolvedValue({ valid: true });
+
+      await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', newParentId: 'new-parent', position: 1 },
+        crossDriveContext('admin-user')
+      );
+
+      expect(mockSyncTaskItemOnMove).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          movedPageId: 'page-1',
+          oldParentId: 'old-parent',
+          newParentId: 'new-parent',
+          userId: 'admin-user',
+        }),
       );
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -128,6 +128,18 @@ vi.mock('@/services/api/task-sync-service', () => ({
   ensureTaskListForPage: vi.fn().mockResolvedValue({ id: 'tasklist-1' }),
 }));
 
+vi.mock('@pagespace/lib/pages/circular-reference-guard', () => ({
+  validatePageMove: vi.fn().mockResolvedValue({ valid: true }),
+}));
+
+vi.mock('@/services/api/page-cross-drive-move-service', () => ({
+  movePagesToDrive: vi.fn(),
+}));
+
+vi.mock('@/lib/canvas/publish-page', () => ({
+  syncPublishedHomeRoot: vi.fn(),
+}));
+
 // resolveActingAgentId (internal to actor-permissions.ts) queries the acting
 // page's type/userScopedAccess directly via db — mock that query boundary rather
 // than the actor-permissions exports, since same-module internal calls aren't
@@ -144,25 +156,52 @@ vi.mock('@pagespace/db/schema/core', () => ({
 import { pageWriteTools } from '../page-write-tools';
 import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
-import { getAgentAccessLevel } from '@pagespace/lib/permissions/agent-permissions';
+import { getAgentAccessLevel, hasAgentDriveMembership } from '@pagespace/lib/permissions/agent-permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
+import { broadcastPageEvent } from '@/lib/websocket';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
 const mockCanUserDeletePage = vi.mocked(canUserDeletePage);
 const mockGetAgentAccessLevel = vi.mocked(getAgentAccessLevel);
+const mockHasAgentDriveMembership = vi.mocked(hasAgentDriveMembership);
 const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
 const mockEnsureTaskListForPage = vi.mocked(ensureTaskListForPage);
 const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
+const mockValidatePageMove = vi.mocked(validatePageMove);
+const mockMovePagesToDrive = vi.mocked(movePagesToDrive);
+const mockBroadcastPageEvent = vi.mocked(broadcastPageEvent);
 
 const ownerAccess = { isOwner: true, isAdmin: true, isMember: true, drive: null };
 const adminAccess = { isOwner: false, isAdmin: true, isMember: true, drive: null };
 const deniedAccess = { isOwner: false, isAdmin: false, isMember: true, drive: null };
+
+// ── Cross-drive move fixtures ───────────────────────────────────────────
+const SOURCE_DRIVE = 'drive-1';
+const TARGET_DRIVE = 'drive-2';
+const HOME_DRIVE = 'drive-home';
+
+const sourcePageRow = (
+  overrides: Partial<{ id: string; title: string; driveId: string; parentId: string | null }> = {},
+) => ({
+  id: 'page-1', title: 'Test Page', type: 'DOCUMENT' as const,
+  content: '', contentMode: 'html' as const,
+  driveId: SOURCE_DRIVE, parentId: null as string | null, position: 1,
+  isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+  ...overrides,
+});
+
+const crossDriveContext = (userId: string) => ({
+  toolCallId: '1', messages: [],
+  experimental_context: { userId } as ToolExecutionContext,
+});
 
 describe('page-write-tools', () => {
   beforeEach(() => {
@@ -400,6 +439,102 @@ describe('page-write-tools', () => {
           context
         )
       ).rejects.toThrow('User authentication required');
+    });
+
+    // The bug this fixes: driveId used to be REQUIRED with no fallback, so a
+    // model with no drive in its arguments guessed one — usually the user's Home
+    // drive — and the page was created in the wrong workspace.
+    describe('resolving an omitted driveId', () => {
+      const setupCreate = () => {
+        mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-loc', ownerId: 'owner-999' });
+        mockCanUserEditPage.mockResolvedValue(true);
+        mockPageRepo.getNextPosition.mockResolvedValue(1);
+        mockPageRepo.create.mockResolvedValue({ id: 'new-page-1', title: 'New Page', type: 'DOCUMENT' } as never);
+      };
+
+      const contextInDrive = (driveId: string) => ({
+        toolCallId: '1', messages: [],
+        experimental_context: {
+          userId: 'user-123',
+          locationContext: { currentDrive: { id: driveId, name: 'Work', slug: 'work' } },
+        } as ToolExecutionContext,
+      });
+
+      it('uses the workspace currently in view', async () => {
+        setupCreate();
+
+        await pageWriteTools.create_page.execute!(
+          { title: 'New Page', type: 'DOCUMENT' },
+          contextInDrive('drive-loc')
+        );
+
+        expect(mockDriveRepo.findByIdBasic).toHaveBeenCalledWith('drive-loc');
+      });
+
+      // An explicit parent names the drive unambiguously; a location-derived
+      // guess must never override it.
+      it("prefers the parent's drive over the drive in view", async () => {
+        setupCreate();
+        mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-of-parent', ownerId: 'owner-999' });
+        mockPageRepo.findById.mockResolvedValue(sourcePageRow({ id: 'parent-1', driveId: 'drive-of-parent' }));
+        mockPageRepo.existsInDrive.mockResolvedValue(true);
+
+        await pageWriteTools.create_page.execute!(
+          { title: 'New Page', type: 'DOCUMENT', parentId: 'parent-1' },
+          contextInDrive('drive-loc')
+        );
+
+        expect(mockDriveRepo.findByIdBasic).toHaveBeenCalledWith('drive-of-parent');
+      });
+
+      it('asks rather than guessing when no workspace is in view', async () => {
+        setupCreate();
+
+        await expect(
+          pageWriteTools.create_page.execute!(
+            { title: 'New Page', type: 'DOCUMENT' },
+            { toolCallId: '1', messages: [], experimental_context: { userId: 'user-123' } as ToolExecutionContext }
+          )
+        ).rejects.toThrow('no workspace is currently in view');
+      });
+
+      it('still honors an explicit driveId over the drive in view', async () => {
+        setupCreate();
+        mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-explicit', ownerId: 'owner-999' });
+
+        await pageWriteTools.create_page.execute!(
+          { driveId: 'drive-explicit', title: 'New Page', type: 'DOCUMENT' },
+          contextInDrive('drive-loc')
+        );
+
+        expect(mockDriveRepo.findByIdBasic).toHaveBeenCalledWith('drive-explicit');
+      });
+
+      // Defaulting must not widen authority: the resolved drive goes through the
+      // same canActorEditPage gate an explicit one does.
+      it('still denies a defaulted drive the actor cannot write to', async () => {
+        setupCreate();
+        mockCanUserEditPage.mockResolvedValue(false);
+
+        await expect(
+          pageWriteTools.create_page.execute!(
+            { title: 'New Page', type: 'DOCUMENT' },
+            contextInDrive('drive-loc')
+          )
+        ).rejects.toThrow('Insufficient permissions to create pages in this drive');
+      });
+
+      it('parks the agent in the drive it just wrote to for the rest of the turn', async () => {
+        setupCreate();
+        const context = contextInDrive('drive-loc');
+
+        await pageWriteTools.create_page.execute!(
+          { title: 'New Page', type: 'DOCUMENT' },
+          context
+        );
+
+        expect(context.experimental_context.currentWorkingDrive).toEqual({ id: 'drive-loc' });
+      });
     });
 
     it('throws error when drive not found', async () => {
@@ -1329,6 +1464,262 @@ describe('page-write-tools', () => {
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
         expect.objectContaining({ pageId: 'page-1', operation: 'move' })
       );
+    });
+
+    // Cycle guard was missing on this path entirely: /api/pages/reorder and
+    // /api/pages/bulk-move both run validatePageMove, the AI tool did not, so an
+    // agent could reparent a page under its own descendant.
+    it('refuses a same-drive move that would create a circular reference', async () => {
+      mockPageRepo.findById.mockResolvedValue(sourcePageRow());
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockPageRepo.existsInDrive.mockResolvedValue(true);
+      mockValidatePageMove.mockResolvedValue({
+        valid: false,
+        error: 'Cannot set parent: would create circular reference in page tree',
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'admin-user' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', newParentId: 'descendant-1', position: 1 },
+          context
+        )
+      ).rejects.toThrow('circular reference');
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Cross-drive moves ─────────────────────────────────────────────────
+  //
+  // The reason this path exists: content the assistant files in the user's Home
+  // drive (generated images, drafts, plans) was previously unreachable from any
+  // other workspace, because move_page could not cross a drive boundary.
+  describe('move_page across drives', () => {
+    beforeEach(() => {
+      mockPageRepo.findById.mockResolvedValue(sourcePageRow());
+      mockDriveRepo.findById.mockImplementation(async (id: string) =>
+        ({ id, name: id === TARGET_DRIVE ? 'Work' : 'Home', slug: id }) as never
+      );
+      // Faithful stand-in for the service: same authorization ORDER as the real
+      // implementation (covered by page-cross-drive-move-service.test.ts), so
+      // these tests exercise the tool's authorizer wiring for real.
+      mockMovePagesToDrive.mockImplementation((async (params: Parameters<typeof movePagesToDrive>[0]) => {
+        if (!(await params.authorize.isDriveInScope(params.targetDriveId))) {
+          return { success: false, code: 'TARGET_DRIVE_OUT_OF_SCOPE', status: 403,
+            message: 'This token does not have access to the target drive' };
+        }
+        if (!(await params.authorize.canAdministerDrive(params.targetDriveId))) {
+          return { success: false, code: 'TARGET_DRIVE_FORBIDDEN', status: 403,
+            message: 'You do not have permission to move pages to this drive' };
+        }
+        for (const id of params.pageIds) {
+          if (!(await params.authorize.canEditPage(id))) {
+            return { success: false, code: 'SOURCE_PAGE_FORBIDDEN', status: 403,
+              message: `You do not have permission to move page: ${id}` };
+          }
+        }
+        return {
+          success: true,
+          moved: [{ id: 'page-1', title: 'Test Page', type: 'DOCUMENT',
+            previousDriveId: SOURCE_DRIVE, previousParentId: null, position: 7 }],
+          descendantCount: 2,
+          affectedDriveIds: [params.targetDriveId, SOURCE_DRIVE],
+          clearedHomePageDriveIds: [],
+        };
+      }) as never);
+    });
+
+    it('does not take the cross-drive path when targetDriveId is omitted', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+
+      await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', position: 1 },
+        crossDriveContext('admin-user')
+      );
+
+      expect(mockMovePagesToDrive).not.toHaveBeenCalled();
+      expect(mockApplyPageMutation).toHaveBeenCalled();
+    });
+
+    // A model that helpfully echoes back the CURRENT workspace id must not
+    // thereby swap which authorization bar applies.
+    it('takes the same-drive path when targetDriveId equals the current drive', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+
+      await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', targetDriveId: SOURCE_DRIVE, position: 1 },
+        crossDriveContext('admin-user')
+      );
+
+      expect(mockMovePagesToDrive).not.toHaveBeenCalled();
+      expect(mockCheckDriveAccess).toHaveBeenCalledWith(SOURCE_DRIVE, 'admin-user');
+    });
+
+    it('denies when the actor cannot administer the DESTINATION drive', async () => {
+      mockCheckDriveAccess.mockImplementation(async (driveId: string) =>
+        driveId === TARGET_DRIVE ? deniedAccess : adminAccess
+      );
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+          crossDriveContext('user-1')
+        )
+      ).rejects.toThrow('You do not have permission to move pages to this drive');
+    });
+
+    it('denies when the actor cannot edit the source page', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(false);
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+          crossDriveContext('user-1')
+        )
+      ).rejects.toThrow('You do not have permission to move page');
+    });
+
+    // THE ACCEPTED AUTHORITY DELTA, pinned deliberately. Before this change
+    // move_page required owner/admin on the page's own drive for any move. The
+    // cross-drive bar mirrors /api/pages/bulk-move instead: edit on the page plus
+    // admin on the DESTINATION. So a user who is merely an editor in the source
+    // drive can now move a page out of it. That is parity with what the Move
+    // dialog already allows — not an escalation beyond the user's own reach.
+    it('allows an editor in the source drive who administers the destination', async () => {
+      mockCheckDriveAccess.mockImplementation(async (driveId: string) =>
+        driveId === TARGET_DRIVE ? adminAccess : deniedAccess
+      );
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const result = await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+        crossDriveContext('editor-user')
+      ) as { success: boolean; crossDrive: boolean };
+
+      expect(result.success).toBe(true);
+      expect(result.crossDrive).toBe(true);
+      expect(mockMovePagesToDrive).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageIds: ['page-1'],
+          targetDriveId: TARGET_DRIVE,
+          targetParentId: null,
+        })
+      );
+    });
+
+    // The Home drive is an exfiltration boundary for rename/trash/share/publish
+    // (drive-guards), never for move. Moving generated images and drafts OUT of
+    // Home is the whole point — this pins that decision against a future "helpful"
+    // Home guard.
+    it('moves out of the Home drive without special-casing it', async () => {
+      mockPageRepo.findById.mockResolvedValue(sourcePageRow({ driveId: HOME_DRIVE }));
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const result = await pageWriteTools.move_page.execute!(
+        { title: 'Generated image', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+        crossDriveContext('owner-user')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockMovePagesToDrive).toHaveBeenCalled();
+    });
+
+    it('denies an agent actor without membership in the destination drive', async () => {
+      mockGetAgentAccessLevel.mockResolvedValue({ canView: true, canEdit: true, canShare: false, canDelete: false });
+      mockHasAgentDriveMembership.mockImplementation(async (_agentId: string, driveId: string) =>
+        driveId !== TARGET_DRIVE
+      );
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+          {
+            toolCallId: '1', messages: [],
+            experimental_context: {
+              userId: 'user-1',
+              chatSource: { type: 'page', agentPageId: 'agent-1' },
+            } as ToolExecutionContext,
+          }
+        )
+      ).rejects.toThrow('You do not have permission to move pages to this drive');
+    });
+
+    it('denies a scoped MCP caller whose token cannot reach the destination drive', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+          {
+            toolCallId: '1', messages: [],
+            experimental_context: {
+              userId: 'user-1',
+              mcpAllowedDriveIds: [SOURCE_DRIVE],
+            } as ToolExecutionContext,
+          }
+        )
+      ).rejects.toThrow('does not have access to the target drive');
+    });
+
+    it('reports the new location, the previous one, and the subtree size', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const result = await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+        crossDriveContext('owner-user')
+      ) as Record<string, unknown>;
+
+      expect(result).toMatchObject({
+        crossDrive: true,
+        driveId: TARGET_DRIVE,
+        driveName: 'Work',
+        previousDriveId: SOURCE_DRIVE,
+        previousDriveName: 'Home',
+        movedDescendants: 2,
+        position: 7,
+      });
+      expect(result.message).toContain('2 nested pages');
+      expect(result.message).toContain('"Home"');
+      expect(result.message).toContain('"Work"');
+    });
+
+    // Broadcasting only to the destination leaves a ghost row in the source
+    // drive's sidebar until the next full refresh.
+    it('broadcasts to the source drive as well as the destination', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+        crossDriveContext('owner-user')
+      );
+
+      expect(mockBroadcastPageEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces a service failure through the tool error envelope', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockMovePagesToDrive.mockResolvedValue({
+        success: false, code: 'TARGET_PARENT_NOT_FOUND', status: 404,
+        message: 'Target folder not found',
+      } as never);
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, newParentId: 'nope', position: 1 },
+          crossDriveContext('owner-user')
+        )
+      ).rejects.toThrow('Failed to move page "Test Page": Target folder not found');
     });
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -18,6 +18,7 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 vi.mock('@pagespace/lib/permissions/agent-permissions', () => ({
     getAgentAccessLevel: vi.fn(),
     hasAgentDriveMembership: vi.fn(),
+    hasAgentDriveAdminRole: vi.fn(),
     getAgentAccessiblePagesInDrive: vi.fn(),
 }));
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
@@ -156,7 +157,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 import { pageWriteTools } from '../page-write-tools';
 import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
-import { getAgentAccessLevel, hasAgentDriveMembership } from '@pagespace/lib/permissions/agent-permissions';
+import { getAgentAccessLevel, hasAgentDriveMembership, hasAgentDriveAdminRole } from '@pagespace/lib/permissions/agent-permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
@@ -170,6 +171,7 @@ const mockCanUserEditPage = vi.mocked(canUserEditPage);
 const mockCanUserDeletePage = vi.mocked(canUserDeletePage);
 const mockGetAgentAccessLevel = vi.mocked(getAgentAccessLevel);
 const mockHasAgentDriveMembership = vi.mocked(hasAgentDriveMembership);
+const mockHasAgentDriveAdminRole = vi.mocked(hasAgentDriveAdminRole);
 const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
@@ -1631,24 +1633,53 @@ describe('page-write-tools', () => {
       expect(mockMovePagesToDrive).toHaveBeenCalled();
     });
 
+    const agentContext = () => ({
+      toolCallId: '1', messages: [],
+      experimental_context: {
+        userId: 'user-1',
+        chatSource: { type: 'page' as const, agentPageId: 'agent-1' },
+      } as ToolExecutionContext,
+    });
+
     it('denies an agent actor without membership in the destination drive', async () => {
       mockGetAgentAccessLevel.mockResolvedValue({ canView: true, canEdit: true, canShare: false, canDelete: false });
-      mockHasAgentDriveMembership.mockImplementation(async (_agentId: string, driveId: string) =>
-        driveId !== TARGET_DRIVE
-      );
+      mockHasAgentDriveAdminRole.mockResolvedValue(false);
 
       await expect(
         pageWriteTools.move_page.execute!(
           { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
-          {
-            toolCallId: '1', messages: [],
-            experimental_context: {
-              userId: 'user-1',
-              chatSource: { type: 'page', agentPageId: 'agent-1' },
-            } as ToolExecutionContext,
-          }
+          agentContext()
         )
       ).rejects.toThrow('You do not have permission to move pages to this drive');
+    });
+
+    // The destination bar is OWNER/ADMIN, not "has a membership row". Agent
+    // authority is normally resolved via hasAgentDriveMembership, which ignores
+    // `role` entirely — using it here would let a plain MEMBER agent pull a whole
+    // subtree into a drive that bulk-move guards with OWNER/ADMIN for humans.
+    it('denies an agent that is only a MEMBER of the destination drive', async () => {
+      mockGetAgentAccessLevel.mockResolvedValue({ canView: true, canEdit: true, canShare: false, canDelete: false });
+      mockHasAgentDriveMembership.mockResolvedValue(true);   // a row exists...
+      mockHasAgentDriveAdminRole.mockResolvedValue(false);   // ...but it is not OWNER/ADMIN
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+          agentContext()
+        )
+      ).rejects.toThrow('You do not have permission to move pages to this drive');
+    });
+
+    it('allows an agent that administers the destination drive', async () => {
+      mockGetAgentAccessLevel.mockResolvedValue({ canView: true, canEdit: true, canShare: false, canDelete: false });
+      mockHasAgentDriveAdminRole.mockResolvedValue(true);
+
+      const result = await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, position: 1 },
+        agentContext()
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
     });
 
     it('denies a scoped MCP caller whose token cannot reach the destination drive', async () => {
@@ -1704,6 +1735,23 @@ describe('page-write-tools', () => {
       );
 
       expect(mockBroadcastPageEvent).toHaveBeenCalledTimes(2);
+    });
+
+    // parentId and newParentTitle are independently optional; keying the message
+    // off the title alone reported "at the top level" while the same result
+    // carried a parentId.
+    it('names the destination folder even when no parent title was supplied', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const result = await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', targetDriveId: TARGET_DRIVE, newParentId: 'folder-x', position: 1 },
+        crossDriveContext('owner-user')
+      ) as { parentId: string; message: string };
+
+      expect(result.parentId).toBe('folder-x');
+      expect(result.message).not.toContain('at the top level');
+      expect(result.message).toContain('destination folder');
     });
 
     it('surfaces a service failure through the tool error envelope', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
@@ -96,6 +96,61 @@ describe('search-tools', () => {
     });
   });
 
+  // driveId was required on both search tools, so a model without one in its
+  // arguments guessed a workspace — and a search in the wrong workspace returns
+  // zero hits, which reads as "the content doesn't exist".
+  describe('resolving an omitted driveId', () => {
+    const contextInDrive = (driveId: string) => ({
+      toolCallId: '1',
+      messages: [],
+      experimental_context: {
+        userId: 'user-123',
+        locationContext: { currentDrive: { id: driveId, name: 'Work', slug: 'work' } },
+      } as ToolExecutionContext,
+    });
+
+    it('regex_search scopes to the workspace in view', async () => {
+      mockCanActorAccessDrive.mockResolvedValue(false);
+
+      // Access is checked against the RESOLVED drive — defaulting must not widen reach.
+      await expect(
+        searchTools.regex_search.execute!(
+          { pattern: 'TODO.*', searchIn: 'both', maxResults: 10, contentTypes: ['documents'] },
+          contextInDrive('drive-loc')
+        )
+      ).rejects.toThrow("You don't have access to this drive");
+      expect(mockCanActorAccessDrive).toHaveBeenCalledWith(expect.anything(), 'drive-loc');
+    });
+
+    it('glob_search scopes to the workspace in view', async () => {
+      mockCanActorAccessDrive.mockResolvedValue(false);
+
+      await expect(
+        searchTools.glob_search.execute!(
+          { pattern: '**/README*', maxResults: 10 },
+          contextInDrive('drive-loc')
+        )
+      ).rejects.toThrow("You don't have access to this drive");
+      expect(mockCanActorAccessDrive).toHaveBeenCalledWith(expect.anything(), 'drive-loc');
+    });
+
+    it('asks rather than guessing when no workspace is in view', async () => {
+      await expect(
+        searchTools.regex_search.execute!(
+          { pattern: 'TODO.*', searchIn: 'both', maxResults: 10, contentTypes: ['documents'] },
+          createAuthContext()
+        )
+      ).rejects.toThrow('no workspace is currently in view');
+
+      await expect(
+        searchTools.glob_search.execute!(
+          { pattern: '**/README*', maxResults: 10 },
+          createAuthContext()
+        )
+      ).rejects.toThrow('no workspace is currently in view');
+    });
+  });
+
   describe('glob_search', () => {
     it('has correct tool definition', () => {
       expect(typeof searchTools.glob_search).toBe('object');

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -287,10 +287,25 @@ export async function canActorManageDrive(
   context: ToolExecutionContext,
   driveId: string,
 ): Promise<boolean> {
+  return driveGateWithAgentCheck(context, driveId, hasAgentDriveMembership);
+}
+
+/**
+ * Shared body of the two drive-level gates. The MCP scope ceiling, the
+ * app-token ceiling and the user owner/admin fallback are identical for both
+ * and MUST stay that way — if one of those ever tightens and only one gate
+ * picks it up, the looser gate becomes the way in. Only the agent question
+ * differs, so that is the one thing injected.
+ */
+async function driveGateWithAgentCheck(
+  context: ToolExecutionContext,
+  driveId: string,
+  agentCheck: (agentPageId: string, driveId: string) => Promise<boolean>,
+): Promise<boolean> {
   if (driveOutsideMcpScope(context, driveId)) return false;
   if (await driveDeniedByAppToken(context, driveId, 'manage')) return false;
   const agentPageId = await resolveActingAgentId(context);
-  if (agentPageId) return hasAgentDriveMembership(agentPageId, driveId);
+  if (agentPageId) return agentCheck(agentPageId, driveId);
   const access = await checkDriveAccess(driveId, context.userId);
   return access.isOwner || access.isAdmin;
 }
@@ -312,12 +327,7 @@ export async function canActorAdministerDrive(
   context: ToolExecutionContext,
   driveId: string,
 ): Promise<boolean> {
-  if (driveOutsideMcpScope(context, driveId)) return false;
-  if (await driveDeniedByAppToken(context, driveId, 'manage')) return false;
-  const agentPageId = await resolveActingAgentId(context);
-  if (agentPageId) return hasAgentDriveAdminRole(agentPageId, driveId);
-  const access = await checkDriveAccess(driveId, context.userId);
-  return access.isOwner || access.isAdmin;
+  return driveGateWithAgentCheck(context, driveId, hasAgentDriveAdminRole);
 }
 
 export async function getActorAccessiblePagesInDrive(

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -11,6 +11,7 @@ import {
   getAgentAccessLevel,
   getAgentAccessiblePagesInDrive,
   hasAgentDriveMembership,
+  hasAgentDriveAdminRole,
 } from '@pagespace/lib/permissions/agent-permissions';
 import {
   getAppAccessLevel,
@@ -290,6 +291,31 @@ export async function canActorManageDrive(
   if (await driveDeniedByAppToken(context, driveId, 'manage')) return false;
   const agentPageId = await resolveActingAgentId(context);
   if (agentPageId) return hasAgentDriveMembership(agentPageId, driveId);
+  const access = await checkDriveAccess(driveId, context.userId);
+  return access.isOwner || access.isAdmin;
+}
+
+/**
+ * Whether the actor may ADMINISTER a drive — the owner/admin bar, enforced
+ * uniformly for user and agent actors alike.
+ *
+ * Deliberately separate from `canActorManageDrive`. That helper resolves an
+ * agent actor to `hasAgentDriveMembership`, a bare row-existence check that
+ * ignores `role`, which is the right model for tools whose reach is already
+ * bounded by the agent's enabledTools allowlist. It is the WRONG model for
+ * accepting content into a drive from outside it: a plain MEMBER agent would
+ * clear a bar that /api/pages/bulk-move denies to a human without OWNER/ADMIN,
+ * and the moved subtree would land in a drive on weaker authority than the REST
+ * path requires. Used by the cross-drive move's destination check.
+ */
+export async function canActorAdministerDrive(
+  context: ToolExecutionContext,
+  driveId: string,
+): Promise<boolean> {
+  if (driveOutsideMcpScope(context, driveId)) return false;
+  if (await driveDeniedByAppToken(context, driveId, 'manage')) return false;
+  const agentPageId = await resolveActingAgentId(context);
+  if (agentPageId) return hasAgentDriveAdminRole(agentPageId, driveId);
   const access = await checkDriveAccess(driveId, context.userId);
   return access.isOwner || access.isAdmin;
 }

--- a/apps/web/src/lib/ai/tools/drive-context-defaults.ts
+++ b/apps/web/src/lib/ai/tools/drive-context-defaults.ts
@@ -1,0 +1,37 @@
+import type { ToolExecutionContext } from '../core/types';
+
+/**
+ * Resolve the drive a tool should act on when the LLM omits `driveId`: the
+ * agent's own in-turn focus (currentWorkingDrive, e.g. after create_page)
+ * wins over the workspace the user was in when the turn started
+ * (locationContext.currentDrive) — the drive-level mirror of
+ * resolveDefaultPageId (page-context-defaults.ts).
+ *
+ * Only wire this into tools where "act on the workspace in view" is safe and
+ * unambiguous. NOT for drive administration (rename_drive, update_drive_context,
+ * set_home_page) and NOT for trash/restore, where an implicit target is a
+ * footgun. Read tools that adopt it must echo the resolved drive back in their
+ * result, so the model can tell "not there" from "looked in the wrong place".
+ */
+export function resolveDefaultDriveId(context: ToolExecutionContext | undefined): string | undefined {
+  return context?.currentWorkingDrive?.id ?? context?.locationContext?.currentDrive?.id;
+}
+
+/**
+ * Resolve an omitted `driveId` tool argument the same way across every drive
+ * tool that supports the default, or throw the identical, tool-agnostic error.
+ * Mirrors resolveOrThrowPageId so the two seams cannot drift in behavior or
+ * wording.
+ */
+export function resolveOrThrowDriveId(
+  driveIdArg: string | undefined,
+  context: ToolExecutionContext | undefined,
+): string {
+  const driveId = driveIdArg ?? resolveDefaultDriveId(context);
+  if (!driveId) {
+    throw new Error(
+      'driveId is required: no workspace is currently in view and none was provided. Use list_drives to choose one.',
+    );
+  }
+  return driveId;
+}

--- a/apps/web/src/lib/ai/tools/drive-context-defaults.ts
+++ b/apps/web/src/lib/ai/tools/drive-context-defaults.ts
@@ -27,11 +27,33 @@ export function resolveOrThrowDriveId(
   driveIdArg: string | undefined,
   context: ToolExecutionContext | undefined,
 ): string {
-  const driveId = driveIdArg ?? resolveDefaultDriveId(context);
+  return resolveDriveScope(driveIdArg, context).driveId;
+}
+
+/** How a tool arrived at the drive it acted on, for echoing back to the model. */
+export type DriveScopeSource = 'explicit' | 'current_location';
+
+/**
+ * Same resolution as `resolveOrThrowDriveId`, plus the label describing WHICH
+ * branch produced the id. Read tools echo that label, because a defaulted scope
+ * that searched the wrong workspace returns an empty result — and an empty
+ * result reads as "it doesn't exist" unless the model can see where we looked.
+ *
+ * The label is produced HERE, next to the decision, rather than re-derived from
+ * the argument at each call site: those two can drift the moment a tool resolves
+ * its drive some other way, and a stale `'explicit'` is a lie the model can't
+ * detect.
+ */
+export function resolveDriveScope(
+  driveIdArg: string | undefined,
+  context: ToolExecutionContext | undefined,
+): { driveId: string; scopeSource: DriveScopeSource } {
+  if (driveIdArg) return { driveId: driveIdArg, scopeSource: 'explicit' };
+  const driveId = resolveDefaultDriveId(context);
   if (!driveId) {
     throw new Error(
       'driveId is required: no workspace is currently in view and none was provided. Use list_drives to choose one.',
     );
   }
-  return driveId;
+  return { driveId, scopeSource: 'current_location' };
 }

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -209,6 +209,16 @@ export const driveTools = {
           name: newDrive.name,
         }, await getAiContextWithActor(context as ToolExecutionContext));
 
+        // Creating a workspace shifts the agent's focus into it for the rest of
+        // this turn — the same mutate-in-place pattern create_page uses for
+        // currentWorkingPage. Without this, a "create a workspace, then put these
+        // pages in it" turn either throws ("no workspace is currently in view")
+        // or, worse, silently fills the workspace the user happened to be in.
+        const rawContext = context as ToolExecutionContext | undefined;
+        if (rawContext) {
+          rawContext.currentWorkingDrive = { id: newDrive.id, name: newDrive.name };
+        }
+
         const contextMessage = driveContext ? ` with initial context (${driveContext.length} chars)` : '';
 
         return {

--- a/apps/web/src/lib/ai/tools/image-generation-tools.ts
+++ b/apps/web/src/lib/ai/tools/image-generation-tools.ts
@@ -15,6 +15,9 @@ import { DEFAULT_IMAGE_MODEL } from '../core/model-capabilities';
 import { generateImageBytes, ImageGenerationError } from '../core/image-generation';
 import { isImageGenerationAllowed } from '../core/image-gen-access';
 import { createImageFilePage, ImageStorageQuotaError } from '@/lib/upload/create-file-page';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
+import { canActorEditPage } from './actor-permissions';
+import { resolveDefaultDriveId } from './drive-context-defaults';
 
 const imageLogger = loggers.ai.child({ module: 'image-generation-tools' });
 
@@ -40,12 +43,69 @@ function titleFromPrompt(prompt: string): string {
   return trimmed.length > 60 ? `${trimmed.slice(0, 57)}…` : trimmed || 'Generated image';
 }
 
+interface ImageTarget {
+  targetDriveId?: string;
+  targetParentId?: string;
+  savedTo: 'requested' | 'current_drive' | 'home_gallery';
+}
+
+/**
+ * Decide where a generated image is filed, and authorize it.
+ *
+ * Explicit targets HARD-FAIL when the actor can't edit them: silently redirecting a
+ * named workspace to the Home gallery is exactly the surprise this tool used to
+ * produce. An IMPLICIT default (nothing named, so we inferred the workspace in view)
+ * degrades to the Home gallery instead — the user never scoped the request, so a
+ * view-only current drive shouldn't fail it.
+ *
+ * Deliberately called BEFORE the credit hold and the provider round-trip: a denial
+ * then costs nothing. Checking after generation would land permission failures in the
+ * `store_failed` path — billed, unsaved, and indistinguishable from an S3 outage.
+ */
+async function resolveImageTarget(
+  context: ToolExecutionContext,
+  args: { driveId?: string; parentId?: string },
+): Promise<{ ok: true; target: ImageTarget } | { ok: false; error: string }> {
+  if (args.parentId) {
+    const parent = await pageRepository.findById(args.parentId);
+    if (!parent || parent.isTrashed) {
+      return { ok: false, error: `Page "${args.parentId}" was not found.` };
+    }
+    if (args.driveId && parent.driveId !== args.driveId) {
+      return { ok: false, error: `Page "${args.parentId}" is not in drive "${args.driveId}".` };
+    }
+    if (!(await canActorEditPage(context, args.parentId))) {
+      return { ok: false, error: 'Insufficient permissions to save an image in that location.' };
+    }
+    return {
+      ok: true,
+      target: { targetDriveId: parent.driveId, targetParentId: args.parentId, savedTo: 'requested' },
+    };
+  }
+
+  if (args.driveId) {
+    // Same convention as create_page's root path: the drive is the parent of root pages.
+    if (!(await canActorEditPage(context, args.driveId))) {
+      return { ok: false, error: 'Insufficient permissions to save an image in that workspace.' };
+    }
+    return { ok: true, target: { targetDriveId: args.driveId, savedTo: 'requested' } };
+  }
+
+  const defaultDriveId = resolveDefaultDriveId(context);
+  if (defaultDriveId && (await canActorEditPage(context, defaultDriveId))) {
+    return { ok: true, target: { targetDriveId: defaultDriveId, savedTo: 'current_drive' } };
+  }
+  return { ok: true, target: { savedTo: 'home_gallery' } };
+}
+
 export const imageGenerationTools = {
   generate_image: tool({
     description: `Generate an image from a text prompt using the user's configured image model.
-The image is saved to the user's drive (a "Generated Images" folder in their Home drive by default)
-and shown inline in the conversation. Use this when the user asks you to create, draw, generate, or
-illustrate an image, logo, diagram, or picture. Currently restricted to app administrators.`,
+The image is saved into the workspace the user is currently in (a "Generated Images" folder at that
+drive's root), or into driveId/parentId when you pass them; it falls back to the user's Home drive
+only when no workspace is in view. It is shown inline in the conversation. Use this when the user
+asks you to create, draw, generate, or illustrate an image, logo, diagram, or picture. Currently
+restricted to app administrators.`,
     inputSchema: z.object({
       prompt: z
         .string()
@@ -55,9 +115,17 @@ illustrate an image, logo, diagram, or picture. Currently restricted to app admi
         .enum(['1:1', '16:9', '9:16', '4:3', '3:4'])
         .optional()
         .describe('Optional aspect ratio hint (default square). Some models may ignore it.'),
+      driveId: z
+        .string()
+        .optional()
+        .describe('Drive to save the image into. Omit to use the workspace currently in view; the image lands in that drive\'s "Generated Images" folder.'),
+      parentId: z
+        .string()
+        .optional()
+        .describe('Exact page or folder to save the image under (must be inside driveId). Omit to use the drive\'s "Generated Images" folder.'),
     }),
     execute: async (
-      { prompt, aspectRatio },
+      { prompt, aspectRatio, driveId, parentId },
       { experimental_context: rawContext },
     ) => {
       const context = rawContext as ToolExecutionContext | undefined;
@@ -81,6 +149,15 @@ illustrate an image, logo, diagram, or picture. Currently restricted to app admi
           error: 'Image generation is currently restricted to app administrators.',
         };
       }
+
+      // Resolve + authorize the destination BEFORE reserving credits or calling the
+      // provider, so a permission failure costs nothing and can never be confused with
+      // a storage failure after a billable generation.
+      const targetResult = await resolveImageTarget(context as ToolExecutionContext, { driveId, parentId });
+      if (!targetResult.ok) {
+        return { success: false, error: targetResult.error };
+      }
+      const target = targetResult.target;
 
       const model = context?.imageGenerationModel || DEFAULT_IMAGE_MODEL;
 
@@ -225,6 +302,8 @@ illustrate an image, logo, diagram, or picture. Currently restricted to app admi
           mimeType: image.mediaType,
           title,
           prompt,
+          targetDriveId: target.targetDriveId,
+          targetParentId: target.targetParentId,
         });
       } catch (error) {
         // The image WAS generated (and billed) — settle the spend rather than release,
@@ -264,11 +343,24 @@ illustrate an image, logo, diagram, or picture. Currently restricted to app admi
         success: true,
         pageId: created.pageId,
         driveId: created.driveId,
+        parentId: created.parentId,
+        savedTo: target.savedTo,
         viewUrl: `/api/files/${created.pageId}/view`,
         title,
         mediaType: image.mediaType,
         prompt,
-        summary: `Generated an image for "${title}" and saved it to the drive.`,
+        summary:
+          target.savedTo === 'home_gallery'
+            ? `Generated an image for "${title}" and saved it to the user's Home workspace gallery.`
+            : `Generated an image for "${title}" and saved it to this workspace.`,
+        // The Home fallback is where generated images used to get stranded — say so
+        // at the moment it happens, so the model can offer to relocate rather than
+        // leaving the user to discover the file in the wrong workspace later.
+        ...(target.savedTo === 'home_gallery' && {
+          nextSteps: [
+            "This image was saved to the user's Home workspace because no workspace was in view. If it belongs elsewhere, call move_page with targetDriveId to relocate it.",
+          ],
+        }),
       };
     },
   }),

--- a/apps/web/src/lib/ai/tools/image-generation-tools.ts
+++ b/apps/web/src/lib/ai/tools/image-generation-tools.ts
@@ -46,7 +46,18 @@ function titleFromPrompt(prompt: string): string {
 interface ImageTarget {
   targetDriveId?: string;
   targetParentId?: string;
-  savedTo: 'requested' | 'current_drive' | 'home_gallery';
+  /**
+   * Why the image landed where it did. The two Home outcomes are kept DISTINCT
+   * on purpose: telling the model "no workspace was in view" when the real
+   * reason was a read-only current workspace makes it explain the wrong thing
+   * to the user, and hides a permissions problem behind a navigation one.
+   */
+  savedTo: 'requested' | 'current_drive' | 'home_no_location' | 'home_unwritable_location';
+}
+
+/** Both Home outcomes, for the branches that only care that it went Home. */
+function isHomeGallery(savedTo: ImageTarget['savedTo']): boolean {
+  return savedTo === 'home_no_location' || savedTo === 'home_unwritable_location';
 }
 
 /**
@@ -92,10 +103,13 @@ async function resolveImageTarget(
   }
 
   const defaultDriveId = resolveDefaultDriveId(context);
-  if (defaultDriveId && (await canActorEditPage(context, defaultDriveId))) {
+  if (!defaultDriveId) {
+    return { ok: true, target: { savedTo: 'home_no_location' } };
+  }
+  if (await canActorEditPage(context, defaultDriveId)) {
     return { ok: true, target: { targetDriveId: defaultDriveId, savedTo: 'current_drive' } };
   }
-  return { ok: true, target: { savedTo: 'home_gallery' } };
+  return { ok: true, target: { savedTo: 'home_unwritable_location' } };
 }
 
 export const imageGenerationTools = {
@@ -349,16 +363,20 @@ restricted to app administrators.`,
         title,
         mediaType: image.mediaType,
         prompt,
-        summary:
-          target.savedTo === 'home_gallery'
-            ? `Generated an image for "${title}" and saved it to the user's Home workspace gallery.`
-            : `Generated an image for "${title}" and saved it to this workspace.`,
+        summary: isHomeGallery(target.savedTo)
+          ? `Generated an image for "${title}" and saved it to the user's Home workspace gallery.`
+          : `Generated an image for "${title}" and saved it to this workspace.`,
         // The Home fallback is where generated images used to get stranded — say so
         // at the moment it happens, so the model can offer to relocate rather than
-        // leaving the user to discover the file in the wrong workspace later.
-        ...(target.savedTo === 'home_gallery' && {
+        // leaving the user to discover the file in the wrong workspace later. The
+        // reason is reported accurately: "you can't write there" is a different
+        // problem from "I didn't know where you were", and only one of them is
+        // fixed by navigating somewhere first.
+        ...(isHomeGallery(target.savedTo) && {
           nextSteps: [
-            "This image was saved to the user's Home workspace because no workspace was in view. If it belongs elsewhere, call move_page with targetDriveId to relocate it.",
+            target.savedTo === 'home_no_location'
+              ? "This image was saved to the user's Home workspace because no workspace was in view. If it belongs elsewhere, call move_page with targetDriveId to relocate it."
+              : "This image was saved to the user's Home workspace because the workspace in view is read-only for this user. Ask where it should go, or call move_page with targetDriveId for a workspace they can edit.",
           ],
         }),
       };

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -18,7 +18,7 @@ import { toModelOutputForReadPage, buildVisualContentMetadata } from './read-pag
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { resolveOrThrowPageId } from './page-context-defaults';
-import { resolveOrThrowDriveId } from './drive-context-defaults';
+import { resolveDriveScope } from './drive-context-defaults';
 
 const pageReadLogger = loggers.ai.child({ module: 'page-read-tools' });
 
@@ -56,11 +56,7 @@ export const pageReadTools = {
         throw new Error('User authentication required');
       }
 
-      const driveId = resolveOrThrowDriveId(driveIdArg, context as ToolExecutionContext);
-      // Echoed in the result: a defaulted scope that silently searched the wrong
-      // workspace returns an empty list, and an empty list reads as "the content
-      // doesn't exist" unless the model can see where we actually looked.
-      const scopeSource = driveIdArg ? 'explicit' : 'current_location';
+      const { driveId, scopeSource } = resolveDriveScope(driveIdArg, context as ToolExecutionContext);
 
       const normalizedParentId = parentId ? parentId : undefined;
 

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -18,6 +18,7 @@ import { toModelOutputForReadPage, buildVisualContentMetadata } from './read-pag
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { resolveOrThrowPageId } from './page-context-defaults';
+import { resolveOrThrowDriveId } from './drive-context-defaults';
 
 const pageReadLogger = loggers.ai.child({ module: 'page-read-tools' });
 
@@ -44,22 +45,29 @@ export const pageReadTools = {
     description: 'List pages at a location in a workspace. Defaults to direct children of the drive root (ls-style). Pass parentId to navigate into a folder. Set recursive: true to return the full subtree. Each result includes hasChildren so you know whether to drill in further. Pass include: "content" to batch each page\'s content into the response instead of calling read_page per page — capped at ' + MAX_CONTENT_INCLUDE_PAGES + ' pages per call.',
     inputSchema: z.object({
       driveSlug: z.string().optional().describe('The human-readable slug of the drive (for semantic understanding)'),
-      driveId: z.string().describe('The unique ID of the drive (used for operations)'),
+      driveId: z.string().optional().describe('The unique ID of the drive (used for operations). Omit to list the workspace currently in view (see LOCATION context).'),
       parentId: z.string().optional().describe('Page ID to list children of. Omit for drive root.'),
       recursive: z.boolean().optional().describe('Set true to return the full subtree instead of direct children only. Default: false.'),
       include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response instead of calling read_page per page. Content over ${MAX_CONTENT_CHARS_PER_PAGE} characters is clipped (contentClipped: true) — resume with read_page's lineStart at contentClippedAfterLine + 1. CHANNEL/TASK_LIST/FILE pages get a short summary instead of content.`),
     }),
-    execute: async ({ driveSlug, driveId, parentId, recursive = false, include }, { experimental_context: context }) => {
+    execute: async ({ driveSlug, driveId: driveIdArg, parentId, recursive = false, include }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
       }
 
+      const driveId = resolveOrThrowDriveId(driveIdArg, context as ToolExecutionContext);
+      // Echoed in the result: a defaulted scope that silently searched the wrong
+      // workspace returns an empty list, and an empty list reads as "the content
+      // doesn't exist" unless the model can see where we actually looked.
+      const scopeSource = driveIdArg ? 'explicit' : 'current_location';
+
       const normalizedParentId = parentId ? parentId : undefined;
 
       try {
         if (!await canActorAccessDrive(context as ToolExecutionContext, driveId)) {
-          return { success: false, error: `You don't have access to the "${driveSlug}" workspace` };
+          // driveSlug is absent whenever driveId was defaulted from location.
+          return { success: false, error: `You don't have access to the "${driveSlug ?? driveId}" workspace` };
         }
         const visiblePages = await getActorAccessiblePagesInDrive(context as ToolExecutionContext, driveId);
 
@@ -204,6 +212,8 @@ export const pageReadTools = {
         return {
           success: true,
           driveSlug: driveLabel,
+          driveId,
+          scopeSource,
           location,
           breadcrumb,
           pages: resultPages,

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -753,13 +753,18 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
-      // Resolve the destination drive PARENT-FIRST: an explicit parentId names
-      // the drive unambiguously and must beat any location-derived guess. Only
-      // when neither the model nor a parent supplies one do we fall back to the
-      // workspace in view. The permission gate below is unchanged either way, so
-      // a defaulted drive is authorized exactly like an explicit one.
-      const parentDriveId = parentId ? (await pageRepository.findById(parentId))?.driveId : undefined;
-      const driveId = resolveOrThrowDriveId(driveIdArg ?? parentDriveId, rawContext);
+      // Destination precedence: explicit driveId > the parent's own drive > the
+      // workspace in view. A named parent pins the drive unambiguously, so it
+      // must beat a location-derived guess; only with neither do we fall back to
+      // wherever the user is standing. The permission gate below is unchanged
+      // either way, so a defaulted drive is authorized exactly like an explicit
+      // one.
+      //
+      // The parent row is fetched ONCE here and re-used for the in-drive check
+      // below — `existsInDrive` would have asked the database the same question
+      // a second time, and tautologically so whenever driveId came from it.
+      const parent = parentId ? await pageRepository.findById(parentId) : null;
+      const driveId = resolveOrThrowDriveId(driveIdArg ?? parent?.driveId, rawContext);
 
       try {
         // Get the drive via repository seam
@@ -769,12 +774,11 @@ export const pageWriteTools = {
           throw new Error(`Drive with ID "${driveId}" not found`);
         }
 
-        // If parentId is provided, verify it exists and belongs to this drive
-        if (parentId) {
-          const parentExists = await pageRepository.existsInDrive(parentId, driveId);
-          if (!parentExists) {
-            throw new Error(`Parent page with ID "${parentId}" not found in this drive`);
-          }
+        // If parentId is provided, verify it exists and belongs to this drive.
+        // `parent` is null for a missing or trashed page, matching what
+        // existsInDrive used to reject.
+        if (parentId && parent?.driveId !== driveId) {
+          throw new Error(`Parent page with ID "${parentId}" not found in this drive`);
         }
 
         // Check permissions for page creation.

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -23,7 +23,7 @@ import { broadcastPageEvent, createPageEventPayload, broadcastDriveEvent, create
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import type { ToolExecutionContext } from '../core/types';
 import { maskIdentifier } from '@/lib/logging/mask';
-import { ensureTaskListForPage } from '@/services/api/task-sync-service';
+import { ensureTaskListForPage, syncTaskItemOnMove } from '@/services/api/task-sync-service';
 import { replaceLines } from '@/lib/editor/line-edit';
 import { insertAtAnchor } from '@/lib/editor/text-edit';
 import { resolveOrThrowPageId } from './page-context-defaults';
@@ -445,17 +445,40 @@ async function moveWithinDrive(params: {
     metadata: { newParentId, position },
   });
 
-  await applyPageMutation({
-    pageId: page.id,
-    operation: 'move',
-    updates: {
-      parentId: newParentId ?? null,
-      position: position,
-    },
-    updatedFields: ['parentId', 'position'],
-    expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
-    context: mutationContext,
+  // One transaction for the mutation AND the task-item sync, mirroring
+  // pageReorderService.reorderPage. Moving a TASK_LIST page in or out of a
+  // TASK_LIST parent adds/removes its `task_items` row; without this the AI
+  // tool left that row stale on same-drive moves while every other move path
+  // in the codebase (reorder, bulk-delete, and the cross-drive service this
+  // tool now calls) kept it correct — so the same tool was consistent only
+  // when it happened to cross a drive boundary.
+  let deferredTrigger: (() => void) | undefined;
+  await db.transaction(async (tx) => {
+    const mutResult = await applyPageMutation({
+      pageId: page.id,
+      operation: 'move',
+      updates: {
+        parentId: newParentId ?? null,
+        position: position,
+      },
+      updatedFields: ['parentId', 'position'],
+      expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
+      context: mutationContext,
+      tx,
+    });
+    // Passing our own tx makes the workflow trigger OUR responsibility to fire
+    // after commit — applyPageMutation only self-fires when it owns the tx.
+    deferredTrigger = mutResult.deferredTrigger;
+
+    await syncTaskItemOnMove(tx, {
+      movedPageId: page.id,
+      movedPageType: page.type,
+      oldParentId: page.parentId,
+      newParentId: newParentId ?? null,
+      userId: context.userId,
+    });
   });
+  deferredTrigger?.();
 
   // Broadcast page move event
   await broadcastPageEvent(

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,6 +1,9 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canActorEditPage, canActorDeletePage, canActorManageDrive, driveDeniedByAppToken } from './actor-permissions';
+import { canActorEditPage, canActorDeletePage, canActorManageDrive, driveDeniedByAppToken, driveOutsideMcpScope } from './actor-permissions';
+import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
+import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 import { isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes, getPageTypeConfig } from '@pagespace/lib/content/page-types.config';
@@ -24,6 +27,7 @@ import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { replaceLines } from '@/lib/editor/line-edit';
 import { insertAtAnchor } from '@/lib/editor/text-edit';
 import { resolveOrThrowPageId } from './page-context-defaults';
+import { resolveOrThrowDriveId } from './drive-context-defaults';
 
 const pageWriteLogger = loggers.ai.child({ module: 'page-write-tools' });
 
@@ -401,6 +405,185 @@ async function restoreDrive(
   return { id: restoredDrive.id, name: restoredDrive.name, slug: restoredDrive.slug };
 }
 
+type MovablePage = NonNullable<Awaited<ReturnType<typeof pageRepository.findById>>>;
+
+/**
+ * Same-drive move / reorder. Requires drive owner or admin — mirrors the
+ * /api/pages/reorder REST route's authorization bar for the same operation.
+ */
+async function moveWithinDrive(params: {
+  context: ToolExecutionContext;
+  page: MovablePage;
+  newParentId?: string;
+  newParentTitle?: string;
+  position: number;
+}) {
+  const { context, page, newParentId, newParentTitle, position } = params;
+
+  const canManage = await canActorManageDrive(context, page.driveId);
+  if (!canManage) {
+    throw new Error('Only drive owners and admins can move pages');
+  }
+
+  if (newParentId) {
+    // Verify the destination exists and is in the same drive
+    const parentExists = await pageRepository.existsInDrive(newParentId, page.driveId);
+    if (!parentExists) {
+      throw new Error(`Parent page with ID "${newParentId}" not found in this drive`);
+    }
+
+    // Cycle guard — the REST reorder/bulk-move paths both run this; the AI tool
+    // did not, so an agent could reparent a page under its own descendant and
+    // detach the whole subtree from the drive root.
+    const validation = await validatePageMove(page.id, newParentId);
+    if (!validation.valid) {
+      throw new Error(validation.error);
+    }
+  }
+
+  const mutationContext = await buildAiMutationContext(context, {
+    metadata: { newParentId, position },
+  });
+
+  await applyPageMutation({
+    pageId: page.id,
+    operation: 'move',
+    updates: {
+      parentId: newParentId ?? null,
+      position: position,
+    },
+    updatedFields: ['parentId', 'position'],
+    expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
+    context: mutationContext,
+  });
+
+  // Broadcast page move event
+  await broadcastPageEvent(
+    createPageEventPayload(page.driveId, page.id, 'moved', {
+      parentId: newParentId,
+      title: page.title
+    })
+  );
+
+  return {
+    success: true,
+    crossDrive: false,
+    position,
+    id: page.id,
+    pageId: page.id,
+    title: page.title,
+    type: page.type,
+    driveId: page.driveId,
+    parentId: newParentId ?? null,
+    newParentTitle: newParentTitle ?? null,
+    message: newParentId
+      ? `Successfully moved "${page.title}" to "${newParentTitle ?? 'parent folder'}" at position ${position}`
+      : `Successfully moved "${page.title}" to root at position ${position}`,
+  };
+}
+
+/**
+ * Cross-drive move. Bar mirrors POST /api/pages/bulk-move: edit access on the
+ * SOURCE page plus owner/admin on the DESTINATION drive — deliberately NOT
+ * owner/admin on the source, so this grants the agent exactly what the user can
+ * already do through the Move dialog and nothing more.
+ *
+ * The Home drive is not special-cased: relocating content the assistant filed in
+ * Home (generated images, drafts) into the workspace it belongs to is the reason
+ * this path exists. drive-guards blocks rename/trash/share/publish on Home, never
+ * move, and the REST path has always permitted it.
+ */
+async function moveAcrossDrives(params: {
+  context: ToolExecutionContext;
+  page: MovablePage;
+  targetDriveId: string;
+  newParentId?: string;
+  newParentTitle?: string;
+}) {
+  const { context, page, targetDriveId, newParentId, newParentTitle } = params;
+
+  // findById (not findByIdBasic): the model-facing message names both workspaces,
+  // and only DriveRecord carries `name`.
+  const [sourceDrive, targetDrive] = await Promise.all([
+    driveRepository.findById(page.driveId),
+    driveRepository.findById(targetDriveId),
+  ]);
+  if (!targetDrive) {
+    throw new Error(`Drive with ID "${targetDriveId}" not found`);
+  }
+
+  const result = await movePagesToDrive({
+    pageIds: [page.id],
+    targetDriveId,
+    targetParentId: newParentId ?? null,
+    userId: context.userId,
+    authorize: {
+      isDriveInScope: (driveId) => !driveOutsideMcpScope(context, driveId),
+      canAdministerDrive: (driveId) => canActorManageDrive(context, driveId),
+      canEditPage: (movedPageId) => canActorEditPage(context, movedPageId),
+    },
+    activity: {
+      isAiGenerated: true,
+      aiProvider: context.aiProvider ?? 'unknown',
+      aiModel: context.aiModel ?? 'unknown',
+      aiConversationId: context.conversationId,
+      changeGroupType: 'ai',
+      metadata: {
+        crossDriveMove: true,
+        sourceDriveId: page.driveId,
+        ...(context.parentAgentId && { parentAgentId: context.parentAgentId }),
+        ...(context.parentConversationId && { parentConversationId: context.parentConversationId }),
+        ...(context.agentChain?.length && { agentChain: context.agentChain }),
+        ...(context.requestOrigin && { requestOrigin: context.requestOrigin }),
+      },
+    },
+  });
+
+  if (!result.success) {
+    throw new Error(result.message);
+  }
+
+  // Both the source and destination trees changed — broadcasting only to the
+  // destination would leave a ghost row in the source drive's sidebar.
+  for (const driveId of result.affectedDriveIds) {
+    await broadcastPageEvent(
+      createPageEventPayload(driveId, page.id, 'moved', {
+        parentId: newParentId ?? null,
+        title: page.title,
+      })
+    );
+  }
+
+  for (const driveId of result.clearedHomePageDriveIds) {
+    void syncPublishedHomeRoot(driveId);
+  }
+
+  const moved = result.moved[0];
+  const descendants = result.descendantCount;
+  const sourceDriveName = sourceDrive?.name ?? page.driveId;
+
+  return {
+    success: true,
+    crossDrive: true,
+    id: page.id,
+    pageId: page.id,
+    title: page.title,
+    type: page.type,
+    driveId: targetDriveId,
+    driveName: targetDrive.name,
+    previousDriveId: page.driveId,
+    previousDriveName: sourceDriveName,
+    parentId: newParentId ?? null,
+    newParentTitle: newParentTitle ?? null,
+    position: moved?.position,
+    movedDescendants: descendants,
+    message:
+      `Moved "${page.title}"${descendants > 0 ? ` and ${descendants} nested page${descendants === 1 ? '' : 's'}` : ''}` +
+      ` from workspace "${sourceDriveName}" to "${targetDrive.name}"` +
+      (newParentTitle ? ` under "${newParentTitle}".` : ' at the top level.'),
+  };
+}
+
 export const pageWriteTools = {
   /**
    * Replace specific line(s) in a document
@@ -553,17 +736,26 @@ export const pageWriteTools = {
       .map((type) => `${type} (${getPageTypeConfig(type).description})`)
       .join(', ')}. Any page type can contain any other page type as children with infinite nesting. For AI_CHAT pages, use update_agent_config after creation to configure agent behavior.`,
     inputSchema: z.object({
-      driveId: z.string().describe('The unique ID of the drive to create the page in'),
+      driveId: z.string().optional().describe('The unique ID of the drive to create the page in. Omit to use the workspace currently in view (see LOCATION context) — do not guess, and never fall back to the Home drive.'),
       parentId: z.string().optional().describe('The unique ID of the parent page from list_pages - REQUIRED when creating inside any page (folder, document, channel, etc). Only omit for root-level pages in the drive.'),
       title: z.string().describe('The title of the new page'),
       type: z.enum(getCreatablePageTypes() as [string, ...string[]]).describe('The type of page to create'),
       contentMode: z.enum(['html', 'markdown']).optional().describe('Content mode for DOCUMENT pages. Defaults to html. Use markdown for markdown-native documents.'),
     }),
-    execute: async ({ driveId, parentId, title, type, contentMode }, { experimental_context: context }) => {
-      const userId = (context as ToolExecutionContext)?.userId;
+    execute: async ({ driveId: driveIdArg, parentId, title, type, contentMode }, { experimental_context: context }) => {
+      const rawContext = context as ToolExecutionContext | undefined;
+      const userId = rawContext?.userId;
       if (!userId) {
         throw new Error('User authentication required');
       }
+
+      // Resolve the destination drive PARENT-FIRST: an explicit parentId names
+      // the drive unambiguously and must beat any location-derived guess. Only
+      // when neither the model nor a parent supplies one do we fall back to the
+      // workspace in view. The permission gate below is unchanged either way, so
+      // a defaulted drive is authorized exactly like an explicit one.
+      const parentDriveId = parentId ? (await pageRepository.findById(parentId))?.driveId : undefined;
+      const driveId = resolveOrThrowDriveId(driveIdArg ?? parentDriveId, rawContext);
 
       try {
         // Get the drive via repository seam
@@ -708,9 +900,12 @@ export const pageWriteTools = {
         // this turn — same mutate-in-place pattern as switch_machine, so a
         // later tool call in this turn that omits pageId defaults to the
         // page just created, not the page the user was viewing at turn start.
-        const rawContext = context as ToolExecutionContext | undefined;
         if (rawContext) {
           rawContext.currentWorkingPage = { id: newPage.id, title: newPage.title, type: newPage.type };
+          // Drive-level twin: a follow-up tool call in this turn that omits
+          // driveId should stay in the workspace we just wrote to, not snap
+          // back to wherever the user happened to be at turn start.
+          rawContext.currentWorkingDrive = { id: drive.id };
         }
 
         return {
@@ -718,6 +913,7 @@ export const pageWriteTools = {
           id: newPage.id,
           title: newPage.title,
           type: newPage.type,
+          driveId: drive.id,
           contentMode: isDocumentPage(type as PageType) && contentMode ? contentMode : 'html',
           parentId: parentId || 'root',
           message: `Successfully created ${type.toLowerCase()} page "${title}"`,
@@ -1009,24 +1205,26 @@ export const pageWriteTools = {
   }),
 
   /**
-   * Move a page to a different parent or reorder position
+   * Move a page to a different parent, reorder position, or another drive
    */
   move_page: tool({
-    description: 'Move a page to a different parent folder or change its position within the current parent. Omit pageId to move the page currently in view.',
+    description: "Move a page — and everything nested under it — to a different parent folder, a different position, or a DIFFERENT WORKSPACE. Pass targetDriveId to relocate across workspaces: use this to move content you created in the user's personal Home workspace (a generated image, a draft plan, notes) into the shared workspace where the work actually lives. Call list_drives to get workspace IDs. Omit targetDriveId to move within the current workspace. Omit pageId to move the page currently in view. Cross-workspace moves carry the whole subtree, keep sharing grants, and append at the end of the destination folder (position is ignored).",
     inputSchema: z.object({
       title: z.string().describe('The title of the page being moved for display context'),
       pageId: z.string().optional().describe('The unique ID of the page to move. Defaults to the page currently in view if omitted.'),
+      targetDriveId: z.string().optional().describe("The workspace (drive) ID to move the page INTO. Omit to move within the page's current workspace. Get IDs from list_drives."),
       newParentTitle: z.string().optional().describe('Title of the destination folder (omit for root level)'),
-      newParentId: z.string().optional().describe('The unique ID of the new parent page (omit for root level)'),
-      position: z.number().describe('Position within the new parent (1-based, higher numbers appear later)'),
+      newParentId: z.string().optional().describe('The unique ID of the new parent page (omit for root level). For a cross-workspace move it must live in the destination workspace.'),
+      position: z.number().describe('Position within the new parent (1-based, higher numbers appear later). Ignored for cross-workspace moves, which append at the end.'),
     }),
-    execute: async ({ title, pageId: pageIdArg, newParentTitle, newParentId, position }, { experimental_context: context }) => {
-      const userId = (context as ToolExecutionContext)?.userId;
+    execute: async ({ title, pageId: pageIdArg, targetDriveId, newParentTitle, newParentId, position }, { experimental_context: context }) => {
+      const toolContext = context as ToolExecutionContext;
+      const userId = toolContext?.userId;
       if (!userId) {
         throw new Error('User authentication required');
       }
 
-      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
+      const pageId = resolveOrThrowPageId(pageIdArg, toolContext);
 
       try {
         // Get the page to move via repository seam
@@ -1036,55 +1234,32 @@ export const pageWriteTools = {
           throw new Error(`Page with ID "${pageId}" not found`);
         }
 
-        // Moving/reordering a page requires drive owner or admin — mirrors the
-        // /api/pages/reorder REST route's authorization bar for the same operation.
-        const canManage = await canActorManageDrive(context as ToolExecutionContext, page.driveId);
-        if (!canManage) {
-          throw new Error('Only drive owners and admins can move pages');
-        }
+        // Branch ONCE, up front, into two fully independent implementations with
+        // no shared authorization code: a same-drive move requires owner/admin on
+        // the page's drive, while a cross-drive move requires edit on the page plus
+        // owner/admin on the DESTINATION (mirroring /api/pages/bulk-move). Mixing
+        // the two bars in one code path is how one of them ends up unenforced.
+        //
+        // targetDriveId === page.driveId deliberately takes the same-drive bar, so
+        // a model echoing back the current workspace id can't quietly swap which
+        // authorization applies.
+        const isCrossDrive = !!targetDriveId && targetDriveId !== page.driveId;
 
-        // If newParentId is provided, verify it exists and is in the same drive
-        if (newParentId) {
-          const parentExists = await pageRepository.existsInDrive(newParentId, page.driveId);
-          if (!parentExists) {
-            throw new Error(`Parent page with ID "${newParentId}" not found in this drive`);
-          }
-        }
-
-        const mutationContext = await buildAiMutationContext(context as ToolExecutionContext, {
-          metadata: { newParentId, position },
-        });
-
-        await applyPageMutation({
-          pageId: page.id,
-          operation: 'move',
-          updates: {
-            parentId: newParentId ?? null,
-            position: position,
-          },
-          updatedFields: ['parentId', 'position'],
-          expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
-          context: mutationContext,
-        });
-
-        // Broadcast page move event
-        await broadcastPageEvent(
-          createPageEventPayload(page.driveId, page.id, 'moved', {
-            parentId: newParentId,
-            title: page.title
-          })
-        );
-
-        return {
-          success: true,
-          position,
-          id: page.id,
-          title: page.title,
-          type: page.type,
-          message: newParentId
-            ? `Successfully moved "${page.title}" to "${newParentTitle ?? 'parent folder'}" at position ${position}`
-            : `Successfully moved "${page.title}" to root at position ${position}`,
-        };
+        return isCrossDrive
+          ? await moveAcrossDrives({
+              context: toolContext,
+              page,
+              targetDriveId: targetDriveId!,
+              newParentId,
+              newParentTitle,
+            })
+          : await moveWithinDrive({
+              context: toolContext,
+              page,
+              newParentId,
+              newParentTitle,
+              position,
+            });
       } catch (error) {
         pageWriteLogger.error('Failed to move page', error instanceof Error ? error : undefined, {
           userId: maskIdentifier(userId),

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canActorEditPage, canActorDeletePage, canActorManageDrive, driveDeniedByAppToken, driveOutsideMcpScope } from './actor-permissions';
+import { canActorEditPage, canActorDeletePage, canActorManageDrive, canActorAdministerDrive, driveDeniedByAppToken, driveOutsideMcpScope } from './actor-permissions';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
 import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
 import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
@@ -519,7 +519,11 @@ async function moveAcrossDrives(params: {
     userId: context.userId,
     authorize: {
       isDriveInScope: (driveId) => !driveOutsideMcpScope(context, driveId),
-      canAdministerDrive: (driveId) => canActorManageDrive(context, driveId),
+      // canActorAdministerDrive, NOT canActorManageDrive: the latter resolves an
+      // agent actor to bare drive-membership existence, so a plain MEMBER agent
+      // would clear a destination bar that bulk-move denies to a human without
+      // OWNER/ADMIN — and pull a whole subtree in on that weaker authority.
+      canAdministerDrive: (driveId) => canActorAdministerDrive(context, driveId),
       canEditPage: (movedPageId) => canActorEditPage(context, movedPageId),
     },
     activity: {
@@ -580,7 +584,7 @@ async function moveAcrossDrives(params: {
     message:
       `Moved "${page.title}"${descendants > 0 ? ` and ${descendants} nested page${descendants === 1 ? '' : 's'}` : ''}` +
       ` from workspace "${sourceDriveName}" to "${targetDrive.name}"` +
-      (newParentTitle ? ` under "${newParentTitle}".` : ' at the top level.'),
+      (newParentId ? ` under "${newParentTitle ?? 'the destination folder'}".` : ' at the top level.'),
   };
 }
 

--- a/apps/web/src/lib/ai/tools/search-tools.ts
+++ b/apps/web/src/lib/ai/tools/search-tools.ts
@@ -5,7 +5,7 @@ import { eq, and, ne, sql, inArray, asc } from '@pagespace/db/operators'
 import { pages, drives, chatMessages } from '@pagespace/db/schema/core';
 import { getActorAccessiblePagesInDrive, canActorAccessDrive } from './actor-permissions';
 import type { ToolExecutionContext } from '../core/types';
-import { resolveOrThrowDriveId } from './drive-context-defaults';
+import { resolveDriveScope } from './drive-context-defaults';
 import { PageType } from '@pagespace/lib/utils/enums';
 
 export const searchTools = {
@@ -27,11 +27,7 @@ export const searchTools = {
         throw new Error('User authentication required');
       }
 
-      const driveId = resolveOrThrowDriveId(driveIdArg, context as ToolExecutionContext);
-      // A defaulted scope that searched the wrong workspace returns zero hits,
-      // and zero hits read as "it doesn't exist" unless the model can see where
-      // we actually looked.
-      const scopeSource = driveIdArg ? 'explicit' : 'current_location';
+      const { driveId, scopeSource } = resolveDriveScope(driveIdArg, context as ToolExecutionContext);
 
       try {
         // Validate regex pattern to prevent ReDoS attacks
@@ -319,7 +315,7 @@ export const searchTools = {
         return {
           success: true,
           driveSlug: drive.slug,
-          searchedDrive: { id: driveId, slug: drive?.slug, name: drive?.name },
+          searchedDrive: { id: driveId, name: drive.name },
           scopeSource,
           pattern,
           searchIn,
@@ -377,8 +373,7 @@ export const searchTools = {
         throw new Error('User authentication required');
       }
 
-      const driveId = resolveOrThrowDriveId(driveIdArg, context as ToolExecutionContext);
-      const scopeSource = driveIdArg ? 'explicit' : 'current_location';
+      const { driveId, scopeSource } = resolveDriveScope(driveIdArg, context as ToolExecutionContext);
 
       try {
         if (!await canActorAccessDrive(context as ToolExecutionContext, driveId)) {
@@ -484,7 +479,7 @@ export const searchTools = {
         return {
           success: true,
           driveSlug: drive.slug,
-          searchedDrive: { id: driveId, slug: drive?.slug, name: drive?.name },
+          searchedDrive: { id: driveId, name: drive.name },
           scopeSource,
           pattern,
           results,

--- a/apps/web/src/lib/ai/tools/search-tools.ts
+++ b/apps/web/src/lib/ai/tools/search-tools.ts
@@ -5,6 +5,7 @@ import { eq, and, ne, sql, inArray, asc } from '@pagespace/db/operators'
 import { pages, drives, chatMessages } from '@pagespace/db/schema/core';
 import { getActorAccessiblePagesInDrive, canActorAccessDrive } from './actor-permissions';
 import type { ToolExecutionContext } from '../core/types';
+import { resolveOrThrowDriveId } from './drive-context-defaults';
 import { PageType } from '@pagespace/lib/utils/enums';
 
 export const searchTools = {
@@ -14,17 +15,23 @@ export const searchTools = {
   regex_search: tool({
     description: 'Search page content and conversation messages using regular expression patterns. Searches both documents and conversations by default. Returns matches with IDs, titles, and context for reference. Also use to recover earlier tool results or conversation context that has been condensed or elided from the active context window.',
     inputSchema: z.object({
-      driveId: z.string().describe('The unique ID of the drive to search in'),
+      driveId: z.string().optional().describe('The unique ID of the drive to search in. Omit to search the workspace currently in view (see LOCATION context).'),
       pattern: z.string().describe('Regular expression pattern to search for (e.g., "TODO.*urgent", "\\d{4}-\\d{2}-\\d{2}", "deprecated.*API")'),
       searchIn: z.enum(['content', 'title', 'both']).default('content').describe('Where to search: content only, title only, or both'),
       maxResults: z.number().optional().default(50).describe('Maximum number of results to return'),
       contentTypes: z.array(z.enum(['documents', 'conversations'])).optional().default(['documents', 'conversations']).describe('What content to search: documents, conversations, or both'),
     }),
-    execute: async ({ driveId, pattern, searchIn, maxResults = 50, contentTypes = ['documents', 'conversations'] }, { experimental_context: context }) => {
+    execute: async ({ driveId: driveIdArg, pattern, searchIn, maxResults = 50, contentTypes = ['documents', 'conversations'] }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
       }
+
+      const driveId = resolveOrThrowDriveId(driveIdArg, context as ToolExecutionContext);
+      // A defaulted scope that searched the wrong workspace returns zero hits,
+      // and zero hits read as "it doesn't exist" unless the model can see where
+      // we actually looked.
+      const scopeSource = driveIdArg ? 'explicit' : 'current_location';
 
       try {
         // Validate regex pattern to prevent ReDoS attacks
@@ -312,6 +319,8 @@ export const searchTools = {
         return {
           success: true,
           driveSlug: drive.slug,
+          searchedDrive: { id: driveId, slug: drive?.slug, name: drive?.name },
+          scopeSource,
           pattern,
           searchIn,
           contentTypes,
@@ -354,7 +363,7 @@ export const searchTools = {
   glob_search: tool({
     description: 'Find pages using glob-style patterns for titles and paths. Useful for discovering structural patterns like "README*", "*/meeting-notes/*", or "**/*.test".',
     inputSchema: z.object({
-      driveId: z.string().describe('The unique ID of the drive to search in'),
+      driveId: z.string().optional().describe('The unique ID of the drive to search in. Omit to search the workspace currently in view (see LOCATION context).'),
       pattern: z.string().describe('Glob pattern to match page titles/paths (e.g., "**/README*", "docs/**/*.md", "meeting-*")'),
       // Derived from the canonical PageType enum: a hand-written list here
       // omitted FILE and MACHINE, so agents filtering for those page types
@@ -362,11 +371,14 @@ export const searchTools = {
       includeTypes: z.array(z.enum(PageType)).optional().describe('Filter by page types'),
       maxResults: z.number().optional().default(100).describe('Maximum number of results to return'),
     }),
-    execute: async ({ driveId, pattern, includeTypes, maxResults = 100 }, { experimental_context: context }) => {
+    execute: async ({ driveId: driveIdArg, pattern, includeTypes, maxResults = 100 }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
       }
+
+      const driveId = resolveOrThrowDriveId(driveIdArg, context as ToolExecutionContext);
+      const scopeSource = driveIdArg ? 'explicit' : 'current_location';
 
       try {
         if (!await canActorAccessDrive(context as ToolExecutionContext, driveId)) {
@@ -472,6 +484,8 @@ export const searchTools = {
         return {
           success: true,
           driveSlug: drive.slug,
+          searchedDrive: { id: driveId, slug: drive?.slug, name: drive?.name },
+          scopeSource,
           pattern,
           results,
           totalResults: results.length,

--- a/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseTabPath,
   getStaticTabMeta,
+  isDriveScopedPath,
 } from '../tab-title';
 
 describe('tab-title', () => {
@@ -555,5 +556,40 @@ describe('tab-title', () => {
 
       expect(meta!.title).toBe('Personalization');
     });
+  });
+});
+
+// isDriveScopedPath prefix-matches `drive-*`, so a future drive-level PathType
+// named something else would silently reintroduce the bug it was added to fix
+// (the assistant losing the workspace on drive sub-routes) with no compile
+// error. This sweeps every drive route shape parseTabPath can actually return
+// and asserts the predicate holds for all of them.
+describe('isDriveScopedPath', () => {
+  const DRIVE_SECTIONS = [
+    'tasks', 'activity', 'members', 'settings',
+    'trash', 'calendar', 'channels', 'files', 'workflows',
+  ];
+
+  it('holds for the bare drive route and every drive section', () => {
+    const paths = ['/dashboard/drive-1', ...DRIVE_SECTIONS.map((s) => `/dashboard/drive-1/${s}`),
+      '/dashboard/drive-1/members/invite', '/dashboard/drive-1/members/user-9'];
+    for (const path of paths) {
+      const parsed = parseTabPath(path);
+      expect({ path, scoped: isDriveScopedPath(parsed) }).toEqual({ path, scoped: true });
+    }
+  });
+
+  // A page route also carries a driveId, but callers handle it separately (it
+  // resolves to routeType 'page', which already carries the drive).
+  it('does not claim page routes, global routes, or the drive list', () => {
+    for (const path of ['/dashboard/drives', '/dashboard/tasks', '/dashboard/calendar',
+      '/dashboard/channels/c1', '/settings/account', '/dashboard']) {
+      const parsed = parseTabPath(path);
+      expect({ path, scoped: isDriveScopedPath(parsed) }).toEqual({ path, scoped: false });
+    }
+  });
+
+  it('requires a driveId, not merely a drive-shaped type', () => {
+    expect(isDriveScopedPath({ type: 'drive-tasks' })).toBe(false);
   });
 });

--- a/apps/web/src/lib/tabs/tab-title.ts
+++ b/apps/web/src/lib/tabs/tab-title.ts
@@ -72,6 +72,20 @@ const GLOBAL_DASHBOARD_ROUTES = ['tasks', 'activity', 'storage', 'trash', 'conne
 // Drive-specific special routes
 const DRIVE_SPECIAL_ROUTES = ['tasks', 'activity', 'members', 'settings', 'trash', 'calendar', 'channels', 'files', 'workflows'] as const;
 
+/**
+ * Whether a parsed route is scoped to ONE drive at the drive level — the bare
+ * `/dashboard/[driveId]` AND every `/dashboard/[driveId]/<section>` sub-route
+ * (tasks, members, settings, files, channels, workflows, calendar, trash,
+ * activity). All of them already carry `driveId`; consumers asking "which
+ * workspace is the user standing in" must not special-case only `'drive'`.
+ *
+ * Prefix-matched so a `drive-*` PathType added later is covered the day it
+ * lands. `'dashboard-drives'` (the global drive LIST) and `'page'` (a page
+ * INSIDE a drive, which callers handle separately) deliberately don't match.
+ */
+export const isDriveScopedPath = (parsed: ParsedPath): boolean =>
+  !!parsed.driveId && (parsed.type === 'drive' || parsed.type.startsWith('drive-'));
+
 export const parseTabPath = (path: string): ParsedPath => {
   const segments = path.split('/').filter(Boolean);
 

--- a/apps/web/src/lib/upload/__tests__/create-file-page.test.ts
+++ b/apps/web/src/lib/upload/__tests__/create-file-page.test.ts
@@ -174,6 +174,50 @@ describe('createImageFilePage (shell, all seams injected)', () => {
     });
   });
 
+  // targetDriveId alone used to mean "that drive's ROOT". It now means "that
+  // drive's Generated Images folder", so an image filed into a work drive lands
+  // somewhere just as tidy as one filed into Home.
+  it('routes a drive-only target through the gallery resolver for THAT drive', async () => {
+    const resolveGalleryParent = vi.fn(async () => ({ driveId: 'driveX', parentId: 'galleryX' }));
+    const out = await createImageFilePage(
+      { userId: 'u', buffer: buf, mimeType: 'image/png', title: 't', targetDriveId: 'driveX' },
+      {
+        putObject: async () => undefined,
+        resolveGalleryParent,
+        getNextPosition: async () => 1,
+        persist: async () => ({ fileWasInserted: true }),
+        checkQuota: okQuota,
+        chargeStorage: async () => {},
+      },
+    );
+    assert({
+      given: 'a target drive with no parent',
+      should: "resolve that drive's gallery folder",
+      actual: {
+        driveId: out.driveId,
+        parentId: out.parentId,
+        galleryArgs: resolveGalleryParent.mock.calls[0],
+      },
+      expected: { driveId: 'driveX', parentId: 'galleryX', galleryArgs: ['u', 'driveX'] },
+    });
+  });
+
+  it('rejects a parent with no drive, rather than guessing which drive it is in', async () => {
+    await expect(
+      createImageFilePage(
+        { userId: 'u', buffer: buf, mimeType: 'image/png', title: 't', targetParentId: 'pageY' },
+        {
+          putObject: async () => undefined,
+          resolveGalleryParent: async () => ({ driveId: 'home1', parentId: 'gallery1' }),
+          getNextPosition: async () => 1,
+          persist: async () => ({ fileWasInserted: true }),
+          checkQuota: okQuota,
+          chargeStorage: async () => {},
+        },
+      ),
+    ).rejects.toThrow('targetDriveId is required when targetParentId is provided');
+  });
+
   it('exposes the gallery folder name', () => {
     expect(GENERATED_IMAGES_FOLDER).toBe('Generated Images');
   });

--- a/apps/web/src/lib/upload/create-file-page.ts
+++ b/apps/web/src/lib/upload/create-file-page.ts
@@ -44,11 +44,16 @@ export interface CreateImageFilePageInput {
   /** Optional prompt to stamp into fileMetadata for provenance. */
   prompt?: string;
   /**
-   * Optional target location instead of the Home-drive gallery. SECURITY: the caller
-   * MUST verify the user can edit `targetDriveId`/`targetParentId` before passing them
-   * (this helper does not check drive/parent edit permissions). The generate_image tool
-   * deliberately does NOT expose these to the model — it always uses the owner's Home
-   * gallery — so untrusted, model-supplied drive ids can't reach here.
+   * Optional target location instead of the Home-drive gallery.
+   *
+   * `targetDriveId` alone files the image into THAT drive's "Generated Images"
+   * folder (find-or-create at its root); pass `targetParentId` as well to place it
+   * under an exact page. Omit both for the Home-drive gallery.
+   *
+   * SECURITY: this helper does NOT check drive/parent edit permissions. The caller
+   * MUST verify the actor can edit the target first — `generate_image` does expose
+   * these to the model and runs `canActorEditPage` on `targetParentId ?? targetDriveId`
+   * before calling here. Any new caller must do the same.
    */
   targetDriveId?: string;
   targetParentId?: string;
@@ -63,7 +68,7 @@ export interface FilePageWrite {
 export interface CreateImageFilePageDeps {
   hash?: (buffer: Buffer) => string;
   putObject?: (key: string, body: Buffer, contentType: string) => Promise<void>;
-  resolveGalleryParent?: (userId: string) => Promise<{ driveId: string; parentId: string }>;
+  resolveGalleryParent?: (userId: string, driveId?: string) => Promise<{ driveId: string; parentId: string }>;
   getNextPosition?: (driveId: string, parentId: string | null) => Promise<number>;
   /** Returns whether the content-addressed `files` row was newly inserted (charge once). */
   persist?: (write: FilePageWrite) => Promise<{ fileWasInserted: boolean }>;
@@ -151,13 +156,24 @@ export function buildImageFilePageValues(params: {
   };
 }
 
-/** Shell: find-or-create the "Generated Images" folder at the user's Home-drive root. */
-async function defaultResolveGalleryParent(userId: string): Promise<{ driveId: string; parentId: string }> {
-  const home = await getHomeDrive(userId);
-  if (!home) {
-    throw new Error(`Home drive not found for user ${userId}`);
+/**
+ * Shell: find-or-create the "Generated Images" folder at the root of `targetDriveId`,
+ * or of the user's Home drive when no drive is named. The gallery semantics travel
+ * with the drive so an image filed into a work drive lands somewhere just as tidy as
+ * one filed into Home.
+ */
+async function defaultResolveGalleryParent(
+  userId: string,
+  targetDriveId?: string,
+): Promise<{ driveId: string; parentId: string }> {
+  let driveId = targetDriveId;
+  if (!driveId) {
+    const home = await getHomeDrive(userId);
+    if (!home) {
+      throw new Error(`Home drive not found for user ${userId}`);
+    }
+    driveId = home.id;
   }
-  const driveId = home.id;
 
   const existing = await db.query.pages.findFirst({
     where: and(
@@ -212,8 +228,9 @@ async function defaultPersist(write: FilePageWrite): Promise<{ fileWasInserted: 
 
 /**
  * Persist `buffer` as a FILE page. Defaults to the user's Home-drive "Generated Images"
- * gallery; `targetDriveId`/`targetParentId` file it elsewhere (caller MUST have verified
- * edit permission — see the input type). Enforces the storage quota before writing and
+ * gallery; `targetDriveId` files it into that drive's gallery and `targetParentId` under
+ * an exact page (caller MUST have verified edit permission — see the input type).
+ * Enforces the storage quota before writing and
  * charges storage on first store. Returns the new page id (viewable at
  * `/api/files/${pageId}/view`).
  */
@@ -233,13 +250,21 @@ export async function createImageFilePage(
   const hash = (deps.hash ?? sha256Hex)(input.buffer);
   await (deps.putObject ?? putObject)(buildS3Key(hash), input.buffer, input.mimeType);
 
+  // Branch on the PARENT, not the drive: a named parent is an exact placement the
+  // caller already authorized, while a drive alone means "that drive's gallery".
   let driveId: string;
   let parentId: string | null;
-  if (input.targetDriveId) {
+  if (input.targetParentId) {
+    if (!input.targetDriveId) {
+      throw new Error('targetDriveId is required when targetParentId is provided');
+    }
     driveId = input.targetDriveId;
-    parentId = input.targetParentId ?? null;
+    parentId = input.targetParentId;
   } else {
-    const gallery = await (deps.resolveGalleryParent ?? defaultResolveGalleryParent)(input.userId);
+    const gallery = await (deps.resolveGalleryParent ?? defaultResolveGalleryParent)(
+      input.userId,
+      input.targetDriveId,
+    );
     driveId = gallery.driveId;
     parentId = gallery.parentId;
   }

--- a/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
@@ -318,6 +318,31 @@ describe('movePagesToDrive', () => {
       expect(result.success === false && result.message).toContain(String(MAX_SUBTREE_DEPTH));
     });
 
+    // Boundary: the cap exists to catch a parentId cycle, not to reject deep
+    // trees. Firing it one level early would roll back a move in which every
+    // node had already been rewritten — the worst possible moment to abort.
+    it('migrates a subtree exactly MAX_SUBTREE_DEPTH levels deep in full', async () => {
+      let level = 0;
+      txQueryPagesFindMany.mockImplementation(async () =>
+        level < MAX_SUBTREE_DEPTH ? [{ id: `deep-${level++}` }] : [],
+      );
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: true, descendantCount: MAX_SUBTREE_DEPTH });
+    });
+
+    it('rejects one level deeper than the cap', async () => {
+      let level = 0;
+      txQueryPagesFindMany.mockImplementation(async () =>
+        level < MAX_SUBTREE_DEPTH + 1 ? [{ id: `deep-${level++}` }] : [],
+      );
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: false, code: 'SUBTREE_TOO_DEEP' });
+    });
+
     it('does not walk the tree at all when the page already lives in the target drive', async () => {
       vi.mocked(db.query.pages.findMany).mockResolvedValue([
         sourcePage({ driveId: TARGET_DRIVE }),

--- a/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
@@ -395,7 +395,7 @@ describe('movePagesToDrive', () => {
 
       expect(scrubDriveScopedTaskAssociations).toHaveBeenCalledWith(
         expect.anything(),
-        { pageIds: ['page-1', 'child-1', 'grandchild-1'] },
+        { pageIds: ['page-1', 'child-1', 'grandchild-1'], targetDriveId: TARGET_DRIVE },
       );
     });
 

--- a/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Unit tests for movePagesToDrive — the shared cross-drive move implementation
+ * behind POST /api/pages/bulk-move and the AI `move_page` tool.
+ *
+ * Focus areas the route-level contract test cannot reach directly:
+ * - the authorizer contract (which question is asked, about WHICH drive, in what
+ *   order, and where it short-circuits)
+ * - the descendant cascade (batching, cycle termination, depth ceiling)
+ * - the home-page invariant, positions and activity attribution
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Mocks (before imports) ──────────────────────────────────────────────
+
+vi.mock('@pagespace/lib/pages/circular-reference-guard', () => ({
+  validatePageMove: vi.fn().mockResolvedValue({ valid: true }),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({
+    actorEmail: 'test@example.com',
+    actorDisplayName: 'Test User',
+  }),
+  logPageActivity: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/change-group', () => ({
+  createChangeGroupId: vi.fn(() => 'change-group-123'),
+}));
+
+vi.mock('@/services/api/task-sync-service', () => ({
+  syncTaskItemOnMove: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/db/db', () => {
+  const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const txUpdateSet = vi.fn().mockReturnValue({ where: txUpdateWhere });
+  const txUpdate = vi.fn().mockReturnValue({ set: txUpdateSet });
+  const txQueryPagesFindMany = vi.fn().mockResolvedValue([]);
+  const txQueryPagesFindFirst = vi.fn().mockResolvedValue(undefined);
+  const txQueryDrivesFindFirst = vi.fn().mockResolvedValue(undefined);
+  const tx = {
+    update: txUpdate,
+    query: {
+      pages: { findMany: txQueryPagesFindMany, findFirst: txQueryPagesFindFirst },
+      drives: { findFirst: txQueryDrivesFindFirst },
+    },
+  };
+  const transaction = vi.fn(async (fn: (t: unknown) => Promise<void>) => {
+    await fn(tx);
+  });
+  return {
+    db: {
+      query: {
+        drives: { findFirst: vi.fn() },
+        pages: { findFirst: vi.fn(), findMany: vi.fn() },
+      },
+      transaction,
+    },
+    __test__: {
+      txUpdate,
+      txUpdateSet,
+      txUpdateWhere,
+      txQueryPagesFindMany,
+      txQueryPagesFindFirst,
+      txQueryDrivesFindFirst,
+      transaction,
+    },
+  };
+});
+
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((a: unknown, b: unknown) => [a, b]),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ _inArray: true, col: a, values: b })),
+  desc: vi.fn((a: unknown) => a),
+  isNull: vi.fn((a: unknown) => a),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId', parentId: 'parentId', position: 'position', isTrashed: 'isTrashed' },
+  drives: { id: 'id' },
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────
+
+import { movePagesToDrive, MAX_SUBTREE_DEPTH } from '../page-cross-drive-move-service';
+import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import { logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
+// @ts-expect-error - accessing test-only export
+import { db, __test__ as dbTest } from '@pagespace/db/db';
+
+const {
+  txUpdate,
+  txUpdateSet,
+  txQueryPagesFindMany,
+  txQueryPagesFindFirst,
+  txQueryDrivesFindFirst,
+  transaction: mockTransaction,
+} = dbTest as Record<string, ReturnType<typeof vi.fn>>;
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const USER_ID = 'user_123';
+const TARGET_DRIVE = 'drive_target';
+const SOURCE_DRIVE = 'drive_source';
+
+const sourcePage = (overrides: Record<string, unknown> = {}) => ({
+  id: 'page-1',
+  title: 'Source Page',
+  type: 'DOCUMENT',
+  driveId: SOURCE_DRIVE,
+  parentId: null,
+  position: 1,
+  isTrashed: false,
+  ...overrides,
+});
+
+const makeAuthorizer = (overrides: Record<string, unknown> = {}) => ({
+  isDriveInScope: vi.fn().mockReturnValue(true),
+  canAdministerDrive: vi.fn().mockResolvedValue(true),
+  canEditPage: vi.fn().mockResolvedValue(true),
+  ...overrides,
+});
+
+const run = (
+  params: Partial<Parameters<typeof movePagesToDrive>[0]> = {},
+  authorize = makeAuthorizer(),
+) =>
+  movePagesToDrive({
+    pageIds: ['page-1'],
+    targetDriveId: TARGET_DRIVE,
+    targetParentId: null,
+    userId: USER_ID,
+    authorize: authorize as never,
+    ...params,
+  });
+
+function setupSuccessScenario() {
+  vi.mocked(db.query.drives.findFirst).mockResolvedValue({ id: TARGET_DRIVE } as never);
+  vi.mocked(db.query.pages.findMany).mockResolvedValue([sourcePage()] as never);
+  vi.mocked(db.query.pages.findFirst).mockResolvedValue({ position: 5 } as never);
+  vi.mocked(validatePageMove).mockResolvedValue({ valid: true });
+
+  const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  txUpdateSet.mockReturnValue({ where: txUpdateWhere });
+  txUpdate.mockReturnValue({ set: txUpdateSet });
+  txQueryPagesFindMany.mockResolvedValue([]);
+  txQueryPagesFindFirst.mockResolvedValue(undefined);
+  txQueryDrivesFindFirst.mockResolvedValue(undefined);
+  mockTransaction.mockImplementation(async (fn: (t: unknown) => Promise<void>) => {
+    await fn({
+      update: txUpdate,
+      query: {
+        pages: { findMany: txQueryPagesFindMany, findFirst: txQueryPagesFindFirst },
+        drives: { findFirst: txQueryDrivesFindFirst },
+      },
+    });
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('movePagesToDrive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupSuccessScenario();
+  });
+
+  // ── Authorizer contract ───────────────────────────────────────────────
+
+  describe('authorizer contract', () => {
+    it('asks canAdministerDrive exactly once, about the TARGET drive only', async () => {
+      const authorize = makeAuthorizer();
+
+      await run({}, authorize);
+
+      expect(authorize.canAdministerDrive).toHaveBeenCalledTimes(1);
+      expect(authorize.canAdministerDrive).toHaveBeenCalledWith(TARGET_DRIVE);
+      // The whole point of the chosen bar: source-drive administration is never required.
+      expect(authorize.canAdministerDrive).not.toHaveBeenCalledWith(SOURCE_DRIVE);
+    });
+
+    it('asks canEditPage once per source page, in order', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ id: 'page-1' }),
+        sourcePage({ id: 'page-2' }),
+      ] as never);
+      const authorize = makeAuthorizer();
+
+      await run({ pageIds: ['page-1', 'page-2'] }, authorize);
+
+      expect(authorize.canEditPage).toHaveBeenCalledTimes(2);
+      expect(authorize.canEditPage.mock.calls.map((c) => c[0])).toEqual(['page-1', 'page-2']);
+    });
+
+    it('fails with SOURCE_PAGE_FORBIDDEN naming the page, without opening a transaction', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ title: 'Protected Doc' }),
+      ] as never);
+      const authorize = makeAuthorizer({ canEditPage: vi.fn().mockResolvedValue(false) });
+
+      const result = await run({}, authorize);
+
+      expect(result).toMatchObject({ success: false, code: 'SOURCE_PAGE_FORBIDDEN', status: 403 });
+      expect(result.success === false && result.message).toContain('Protected Doc');
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits at the destination: canEditPage is never asked when canAdministerDrive denies', async () => {
+      const authorize = makeAuthorizer({ canAdministerDrive: vi.fn().mockResolvedValue(false) });
+
+      const result = await run({}, authorize);
+
+      expect(result).toMatchObject({ success: false, code: 'TARGET_DRIVE_FORBIDDEN', status: 403 });
+      expect(authorize.canEditPage).not.toHaveBeenCalled();
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('fails with SOURCE_DRIVE_OUT_OF_SCOPE when a source drive is outside token scope', async () => {
+      const authorize = makeAuthorizer({
+        isDriveInScope: vi.fn((driveId: string) => driveId !== SOURCE_DRIVE),
+      });
+
+      const result = await run({}, authorize);
+
+      expect(result).toMatchObject({ success: false, code: 'SOURCE_DRIVE_OUT_OF_SCOPE', status: 403 });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('fails with TARGET_DRIVE_OUT_OF_SCOPE before asking canAdministerDrive', async () => {
+      const authorize = makeAuthorizer({
+        isDriveInScope: vi.fn((driveId: string) => driveId !== TARGET_DRIVE),
+      });
+
+      const result = await run({}, authorize);
+
+      expect(result).toMatchObject({ success: false, code: 'TARGET_DRIVE_OUT_OF_SCOPE', status: 403 });
+      expect(authorize.canAdministerDrive).not.toHaveBeenCalled();
+    });
+
+    it('fails with TARGET_DRIVE_NOT_FOUND when the destination does not exist', async () => {
+      vi.mocked(db.query.drives.findFirst).mockResolvedValue(undefined as never);
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: false, code: 'TARGET_DRIVE_NOT_FOUND', status: 404 });
+    });
+
+    it('fails with TARGET_PARENT_NOT_FOUND when the parent is not in the target drive', async () => {
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue(undefined as never);
+
+      const result = await run({ targetParentId: 'nope' });
+
+      expect(result).toMatchObject({ success: false, code: 'TARGET_PARENT_NOT_FOUND', status: 404 });
+    });
+
+    it('fails with SOURCE_PAGES_NOT_FOUND when a requested page is missing', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([] as never);
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: false, code: 'SOURCE_PAGES_NOT_FOUND', status: 404 });
+    });
+
+    it('fails with CIRCULAR_REFERENCE and never opens a transaction', async () => {
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: 'target-parent', position: 3 } as never);
+      vi.mocked(validatePageMove).mockResolvedValue({
+        valid: false,
+        error: 'Cannot set parent: would create circular reference in page tree',
+      });
+
+      const result = await run({ targetParentId: 'target-parent' });
+
+      expect(result).toMatchObject({ success: false, code: 'CIRCULAR_REFERENCE', status: 400 });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Descendant cascade ────────────────────────────────────────────────
+
+  describe('descendant cascade', () => {
+    it('rewrites each level in a single batched update and counts descendants', async () => {
+      txQueryPagesFindMany
+        .mockResolvedValueOnce([{ id: 'child-1' }, { id: 'child-2' }])
+        .mockResolvedValueOnce([{ id: 'grandchild-1' }])
+        .mockResolvedValue([]);
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: true, descendantCount: 3 });
+      // 1 root move + 1 batch for level 1 + 1 batch for level 2
+      expect(txUpdate).toHaveBeenCalledTimes(3);
+    });
+
+    it('terminates on a parentId cycle, updating each node exactly once', async () => {
+      // page-1 → child-1 → page-1 (a cycle the old recursive walk would follow forever)
+      txQueryPagesFindMany
+        .mockResolvedValueOnce([{ id: 'child-1' }])
+        .mockResolvedValueOnce([{ id: 'page-1' }])
+        .mockResolvedValue([]);
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: true, descendantCount: 1 });
+      // 1 root move + 1 batch for child-1; page-1 is already in `visited`.
+      expect(txUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns SUBTREE_TOO_DEEP as a result rather than throwing out of the transaction', async () => {
+      // Every level yields one fresh node, so the walk only stops at the depth cap.
+      let counter = 0;
+      txQueryPagesFindMany.mockImplementation(async () => [{ id: `deep-${counter++}` }]);
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: false, code: 'SUBTREE_TOO_DEEP', status: 400 });
+      expect(result.success === false && result.message).toContain(String(MAX_SUBTREE_DEPTH));
+    });
+
+    it('does not walk the tree at all when the page already lives in the target drive', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ driveId: TARGET_DRIVE }),
+      ] as never);
+
+      const result = await run();
+
+      expect(result).toMatchObject({ success: true, descendantCount: 0 });
+      expect(txQueryPagesFindMany).not.toHaveBeenCalled();
+      expect(txUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-drive a source page that is a descendant of another source page', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ id: 'parent-page' }),
+        sourcePage({ id: 'child-page' }),
+      ] as never);
+      // The first cascade level returns a page that is itself a move root.
+      txQueryPagesFindMany.mockResolvedValueOnce([{ id: 'child-page' }]).mockResolvedValue([]);
+
+      const result = await run({ pageIds: ['parent-page', 'child-page'] });
+
+      expect(result).toMatchObject({ success: true, descendantCount: 0 });
+      // 2 root moves only — no cascade batch, because the sole child was a seeded root.
+      expect(txUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('includes trashed descendants (no isTrashed predicate on the walk)', async () => {
+      txQueryPagesFindMany.mockResolvedValueOnce([{ id: 'trashed-child' }]).mockResolvedValue([]);
+
+      await run();
+
+      const walkArgs = txQueryPagesFindMany.mock.calls[0][0];
+      expect(JSON.stringify(walkArgs)).not.toContain('isTrashed');
+    });
+  });
+
+  // ── Home page invariant ───────────────────────────────────────────────
+
+  describe('home page invariant', () => {
+    it('clears homePageId when the home page leaves the source drive', async () => {
+      txQueryDrivesFindFirst.mockResolvedValue({ homePageId: 'page-1' });
+      txQueryPagesFindFirst.mockResolvedValue(undefined);
+
+      const result = await run();
+
+      expect(txUpdateSet).toHaveBeenCalledWith({ homePageId: null });
+      expect(result.success === true && result.clearedHomePageDriveIds).toEqual([SOURCE_DRIVE]);
+    });
+
+    it('clears homePageId when the home page leaves as a DESCENDANT of the moved subtree', async () => {
+      // The home page is not a move root — it goes along with the cascade.
+      txQueryPagesFindMany.mockResolvedValueOnce([{ id: 'home-child' }]).mockResolvedValue([]);
+      txQueryDrivesFindFirst.mockResolvedValue({ homePageId: 'home-child' });
+      txQueryPagesFindFirst.mockResolvedValue(undefined);
+
+      const result = await run();
+
+      expect(result.success === true && result.clearedHomePageDriveIds).toEqual([SOURCE_DRIVE]);
+    });
+
+    it('leaves homePageId untouched when the home page stays put', async () => {
+      txQueryDrivesFindFirst.mockResolvedValue({ homePageId: 'page-still-here' });
+      txQueryPagesFindFirst.mockResolvedValue({ id: 'page-still-here' });
+
+      const result = await run();
+
+      expect(txUpdateSet).not.toHaveBeenCalledWith({ homePageId: null });
+      expect(result.success === true && result.clearedHomePageDriveIds).toEqual([]);
+    });
+  });
+
+  // ── Positions, result shape and activity ──────────────────────────────
+
+  describe('positions and result', () => {
+    it('appends after the last page in the target parent', async () => {
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ position: 10 } as never);
+
+      const result = await run();
+
+      expect(txUpdateSet.mock.calls[0][0].position).toBe(11);
+      expect(result.success === true && result.moved[0].position).toBe(11);
+    });
+
+    it('starts at position 1 when the target parent is empty', async () => {
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue(undefined as never);
+
+      await run();
+
+      expect(txUpdateSet.mock.calls[0][0].position).toBe(1);
+    });
+
+    it('reports every affected drive — target and all sources', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ id: 'page-1', driveId: 'drive-a' }),
+        sourcePage({ id: 'page-2', driveId: 'drive-b' }),
+      ] as never);
+
+      const result = await run({ pageIds: ['page-1', 'page-2'] });
+
+      expect(result.success === true && result.affectedDriveIds.sort()).toEqual(
+        [TARGET_DRIVE, 'drive-a', 'drive-b'].sort(),
+      );
+    });
+
+    it('returns the previous location so the caller can explain or undo the move', async () => {
+      const result = await run();
+
+      expect(result.success === true && result.moved[0]).toMatchObject({
+        id: 'page-1',
+        title: 'Source Page',
+        previousDriveId: SOURCE_DRIVE,
+        previousParentId: null,
+      });
+    });
+  });
+
+  describe('activity', () => {
+    it('logs a move per page with drive transition and one shared change group', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ id: 'page-1' }),
+        sourcePage({ id: 'page-2' }),
+      ] as never);
+
+      await run({ pageIds: ['page-1', 'page-2'] });
+
+      expect(logPageActivity).toHaveBeenCalledTimes(2);
+      expect(logPageActivity).toHaveBeenCalledWith(
+        USER_ID,
+        'move',
+        expect.objectContaining({ id: 'page-1', driveId: TARGET_DRIVE }),
+        expect.objectContaining({
+          changeGroupId: 'change-group-123',
+          updatedFields: ['driveId', 'parentId', 'position'],
+          previousValues: { driveId: SOURCE_DRIVE, parentId: null },
+          newValues: { driveId: TARGET_DRIVE, parentId: null },
+        }),
+      );
+    });
+
+    it('threads AI attribution through the shared seam', async () => {
+      await run({
+        activity: {
+          isAiGenerated: true,
+          aiProvider: 'openrouter',
+          aiModel: 'claude-opus-5',
+          aiConversationId: 'conv-1',
+          changeGroupType: 'ai',
+          metadata: { crossDriveMove: true },
+        },
+      });
+
+      expect(logPageActivity).toHaveBeenCalledWith(
+        USER_ID,
+        'move',
+        expect.anything(),
+        expect.objectContaining({
+          isAiGenerated: true,
+          aiProvider: 'openrouter',
+          aiModel: 'claude-opus-5',
+          aiConversationId: 'conv-1',
+          changeGroupType: 'ai',
+          metadata: expect.objectContaining({ crossDriveMove: true }),
+        }),
+      );
+    });
+
+    it('defaults changeGroupType to user when no activity options are given', async () => {
+      await run();
+
+      expect(logPageActivity).toHaveBeenCalledWith(
+        USER_ID,
+        'move',
+        expect.anything(),
+        expect.objectContaining({ changeGroupType: 'user' }),
+      );
+    });
+  });
+
+  describe('error propagation', () => {
+    it('lets a genuine transaction failure escape (the route maps it to a 500)', async () => {
+      mockTransaction.mockRejectedValueOnce(new Error('Database error'));
+
+      await expect(run()).rejects.toThrow('Database error');
+    });
+  });
+});

--- a/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
@@ -30,6 +30,7 @@ vi.mock('@pagespace/lib/monitoring/change-group', () => ({
 
 vi.mock('@/services/api/task-sync-service', () => ({
   syncTaskItemOnMove: vi.fn().mockResolvedValue(undefined),
+  scrubDriveScopedTaskAssociations: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@pagespace/db/db', () => {
@@ -87,6 +88,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 import { movePagesToDrive, MAX_SUBTREE_DEPTH } from '../page-cross-drive-move-service';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
 import { logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { scrubDriveScopedTaskAssociations } from '@/services/api/task-sync-service';
 // @ts-expect-error - accessing test-only export
 import { db, __test__ as dbTest } from '@pagespace/db/db';
 
@@ -377,6 +379,35 @@ describe('movePagesToDrive', () => {
 
       const walkArgs = txQueryPagesFindMany.mock.calls[0][0];
       expect(JSON.stringify(walkArgs)).not.toContain('isTrashed');
+    });
+  });
+
+  describe('drive-scoped task associations', () => {
+    // Nothing previously asserted this wiring, so removing the call would have
+    // reverted the behavior with the suite still green.
+    it('scrubs the moved roots AND every cascaded descendant', async () => {
+      txQueryPagesFindMany
+        .mockResolvedValueOnce([{ id: 'child-1' }])
+        .mockResolvedValueOnce([{ id: 'grandchild-1' }])
+        .mockResolvedValue([]);
+
+      await run();
+
+      expect(scrubDriveScopedTaskAssociations).toHaveBeenCalledWith(
+        expect.anything(),
+        { pageIds: ['page-1', 'child-1', 'grandchild-1'] },
+      );
+    });
+
+    // A same-drive bulk-move never crosses a boundary, so nothing is drive-stale.
+    it('does not scrub when the page already lives in the target drive', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ driveId: TARGET_DRIVE }),
+      ] as never);
+
+      await run();
+
+      expect(scrubDriveScopedTaskAssociations).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/services/api/__tests__/task-membership.test.ts
+++ b/apps/web/src/services/api/__tests__/task-membership.test.ts
@@ -64,6 +64,21 @@ describe('resolveTaskItemSyncAction', () => {
     expect(resolveTaskItemSyncAction(base).shouldAdd).toBe(true);
   });
 
+  // Preservation is a WITHIN-DRIVE rule. Everything the row points at is drive-scoped
+  // — agent assignees the task write paths refuse from another drive, and task_triggers
+  // cascading into drive-scoped workflows — so carrying it across a boundary would keep
+  // references the product forbids creating.
+  it('still removes on a cross-drive list-to-list move', () => {
+    expect(resolveTaskItemSyncAction({ ...base, crossDrive: true })).toEqual({
+      shouldRemove: true,
+      shouldAdd: true,
+    });
+  });
+
+  it('treats an absent crossDrive flag as a same-drive move', () => {
+    expect(resolveTaskItemSyncAction({ ...base, crossDrive: undefined }).shouldRemove).toBe(false);
+  });
+
   it('only adds when moving from a non-TASK_LIST parent into a TASK_LIST parent', () => {
     expect(
       resolveTaskItemSyncAction({ ...base, oldParentType: 'FOLDER' }),

--- a/apps/web/src/services/api/__tests__/task-membership.test.ts
+++ b/apps/web/src/services/api/__tests__/task-membership.test.ts
@@ -64,20 +64,6 @@ describe('resolveTaskItemSyncAction', () => {
     expect(resolveTaskItemSyncAction(base).shouldAdd).toBe(true);
   });
 
-  // Preservation is a WITHIN-DRIVE rule. Everything the row points at is drive-scoped
-  // — agent assignees the task write paths refuse from another drive, and task_triggers
-  // cascading into drive-scoped workflows — so carrying it across a boundary would keep
-  // references the product forbids creating.
-  it('still removes on a cross-drive list-to-list move', () => {
-    expect(resolveTaskItemSyncAction({ ...base, crossDrive: true })).toEqual({
-      shouldRemove: true,
-      shouldAdd: true,
-    });
-  });
-
-  it('treats an absent crossDrive flag as a same-drive move', () => {
-    expect(resolveTaskItemSyncAction({ ...base, crossDrive: undefined }).shouldRemove).toBe(false);
-  });
 
   it('only adds when moving from a non-TASK_LIST parent into a TASK_LIST parent', () => {
     expect(

--- a/apps/web/src/services/api/__tests__/task-membership.test.ts
+++ b/apps/web/src/services/api/__tests__/task-membership.test.ts
@@ -48,8 +48,20 @@ describe('resolveTaskItemSyncAction', () => {
     ).toEqual({ shouldRemove: false, shouldAdd: false });
   });
 
-  it('removes and adds when moving between two TASK_LIST parents', () => {
-    expect(resolveTaskItemSyncAction(base)).toEqual({ shouldRemove: true, shouldAdd: true });
+  // Previously asserted { shouldRemove: true, shouldAdd: true }. That expectation
+  // encoded silent data loss: the remove cascades task_assignees away and the
+  // re-add inserts bare defaults, so dragging a task between two lists wiped its
+  // status, priority, due date, metadata and assignees. The row is keyed by pageId
+  // and carries no list pointer, so it was valid under the new parent all along.
+  it('preserves the existing row when moving between two TASK_LIST parents', () => {
+    expect(resolveTaskItemSyncAction(base)).toEqual({ shouldRemove: false, shouldAdd: true });
+  });
+
+  // shouldAdd stays true on that path so the destination still gets its task_lists
+  // row and default status configs seeded; addTaskItemUnderParent returns early when
+  // a row already exists, so nothing is overwritten.
+  it('still signals add on a list-to-list move, so the destination list is seeded', () => {
+    expect(resolveTaskItemSyncAction(base).shouldAdd).toBe(true);
   });
 
   it('only adds when moving from a non-TASK_LIST parent into a TASK_LIST parent', () => {

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -13,6 +13,7 @@ vi.mock('@pagespace/db/schema/tasks', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ['eq', a, b]),
   and: vi.fn((...c) => ['and', ...c]),
+  asc: vi.fn((c) => ['asc', c]),
   desc: vi.fn((c) => ['desc', c]),
   inArray: vi.fn((c, v) => ['inArray', c, v]),
 }));
@@ -41,13 +42,22 @@ function makeTx(config: {
   existingItems?: Set<string>;
   existingTaskList?: boolean;
   lastPosition?: number | null;
+  /** Status carried by the preserved task_items row, and the destination's vocabulary. */
+  existingItemStatus?: string;
+  existingItemCompletedAt?: Date | null;
+  destinationStatusConfigs?: Array<{ slug: string; group: string; position: number }>;
 } = {}) {
   const {
     pageTypes = {},
     existingItems = new Set<string>(),
     existingTaskList = true,
     lastPosition = null,
+    existingItemStatus = 'pending',
+    existingItemCompletedAt = null,
+    destinationStatusConfigs = [],
   } = config;
+
+  const taskItemUpdates: Array<Record<string, unknown>> = [];
 
   const taskItemInserts: Array<Record<string, unknown>> = [];
   const taskListInserts: Array<Record<string, unknown>> = [];
@@ -81,13 +91,23 @@ function makeTx(config: {
       taskLists: { findFirst: vi.fn(async () => (existingTaskList ? { id: 'tasklist-1' } : undefined)) },
       taskItems: { findFirst: vi.fn(async (args: { where: unknown[] }) => {
         const id = args.where?.[2] as string;
-        return existingItems.has(id) ? { id: 'item-1', pageId: id } : undefined;
+        return existingItems.has(id)
+          ? { id: 'item-1', pageId: id, status: existingItemStatus, completedAt: existingItemCompletedAt }
+          : undefined;
       }) },
+      taskStatusConfigs: {
+        findFirst: vi.fn(async () =>
+          destinationStatusConfigs.find((c) => c.slug === existingItemStatus)),
+        findMany: vi.fn(async () => destinationStatusConfigs),
+      },
       pages: { findFirst: vi.fn(async () => (lastPosition === null ? undefined : { position: lastPosition })) },
     },
+    update: vi.fn(() => ({
+      set: (vals: Record<string, unknown>) => ({ where: () => { taskItemUpdates.push(vals); return Promise.resolve(); } }),
+    })),
   };
 
-  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds };
+  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates };
 }
 
 describe('seedDefaultTaskStatusConfigs', () => {
@@ -231,6 +251,62 @@ describe('syncTaskItemOnMove', () => {
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
     expect(deletedPageIds).toHaveLength(0);
     expect(taskItemInserts).toHaveLength(0);
+  });
+
+  // task_items.status is a bare slug resolved against the OWNING list's configs, so a
+  // preserved row can arrive carrying a status its new list does not define. Left alone
+  // it lands in the board's first column regardless of meaning, renders its raw slug,
+  // and drops out of status-filtered queries.
+  it('remaps a status the destination list does not define', async () => {
+    const { tx, taskItemUpdates } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'in_review',
+      destinationStatusConfigs: [
+        { slug: 'pending', group: 'todo', position: 0 },
+        { slug: 'done', group: 'done', position: 1 },
+      ],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toEqual([{ status: 'pending' }]);
+  });
+
+  // completedAt lives on the row and is list-independent, so a finished task stays
+  // finished — otherwise the checkbox and the parent's progress count disagree.
+  it('remaps a completed task into the destination\'s done group', async () => {
+    const { tx, taskItemUpdates } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'shipped',
+      existingItemCompletedAt: new Date('2026-01-01'),
+      destinationStatusConfigs: [
+        { slug: 'pending', group: 'todo', position: 0 },
+        { slug: 'complete', group: 'done', position: 1 },
+      ],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toEqual([{ status: 'complete' }]);
+  });
+
+  it('leaves a status the destination already defines untouched', async () => {
+    const { tx, taskItemUpdates } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'pending',
+      destinationStatusConfigs: [{ slug: 'pending', group: 'todo', position: 0 }],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toHaveLength(0);
+  });
+
+  // Cross-drive resets instead of preserving, so nothing survives to normalize.
+  it('removes rather than preserves on a cross-drive list-to-list move', async () => {
+    const { tx, deletedPageIds } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u', crossDrive: true });
+    expect(deletedPageIds).toEqual(['list']);
   });
 
   // ...while the destination list is still seeded, which is why shouldAdd stays true.

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -207,13 +207,41 @@ describe('syncTaskItemOnMove', () => {
     expect(deletedPageIds).toHaveLength(0);
   });
 
-  it('removes from old list and adds to new list when moving between TASK_LISTs', async () => {
+  // Previously this asserted a delete + re-insert. That was silent data loss: the
+  // delete cascades task_assignees away and the re-insert carries bare defaults, so
+  // a task dragged between two lists lost its status, priority, due date, metadata
+  // and every assignee. Membership derives from pages.parentId and the row has no
+  // list pointer, so it was valid under the new parent throughout.
+  it('backfills without deleting when moving between TASK_LISTs and no row exists', async () => {
     const { tx, taskItemInserts, deletedPageIds } = makeTx({ pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' } });
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
-    expect(deletedPageIds).toEqual(['list']);
+    expect(deletedPageIds).toHaveLength(0);
     expect(taskItemInserts).toHaveLength(1);
     expect(taskItemInserts[0]).toMatchObject({ pageId: 'list' });
     expect(taskItemInserts[0]).not.toHaveProperty('position');
+  });
+
+  // The case the old behavior destroyed: an EXISTING row survives a list-to-list
+  // move untouched — no delete, and no insert to overwrite it.
+  it('leaves an existing task_items row completely untouched on a list-to-list move', async () => {
+    const { tx, taskItemInserts, deletedPageIds } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(deletedPageIds).toHaveLength(0);
+    expect(taskItemInserts).toHaveLength(0);
+  });
+
+  // ...while the destination list is still seeded, which is why shouldAdd stays true.
+  it('still seeds the destination task list on a list-to-list move', async () => {
+    const { tx, taskListInserts } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingTaskList: false,
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskListInserts).toHaveLength(1);
   });
 
   it('only removes when moving out of a TASK_LIST into a non-TASK_LIST', async () => {

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -65,6 +65,8 @@ function makeTx(config: {
   /** task_items ids the scrub should find, and the workflow ids their triggers name. */
   scrubTaskItemIds?: string[];
   scrubWorkflowIds?: string[];
+  /** Agent each trigger workflow runs, which is set independently of the assignee. */
+  triggerAgentByWorkflow?: Record<string, string>;
   /** task_items ids the remove branch's pre-delete trigger sweep should find. */
   removeBranchTaskItemIds?: string[];
   /** Agent page referenced by each found task item, and agents already in the target drive. */
@@ -83,6 +85,7 @@ function makeTx(config: {
     lastPosition = null,
     scrubTaskItemIds = [],
     scrubWorkflowIds = [],
+    triggerAgentByWorkflow = {},
     removeBranchTaskItemIds = [],
     scrubAgentIdByItem = {},
     scrubAssigneeAgentIds = [],
@@ -111,6 +114,8 @@ function makeTx(config: {
 
   const scrubSelects: unknown[][] = [];
   const deletedTables: string[] = [];
+  const deleteConditions: Array<{ table: string; cond: unknown }> = [];
+  const workflowDriveUpdates: unknown[] = [];
 
   const tx = {
     // Dispatch on the PROJECTION SHAPE, not call order: order-based dispatch would let
@@ -127,18 +132,22 @@ function makeTx(config: {
           ? scrubTaskItemIds.map((id) => ({ id, assigneeAgentId: scrubAgentIdByItem[id] ?? null }))
         : shape === 'taskAssignees.agentPageId' ? scrubAssigneeAgentIds.map((agentPageId) => ({ agentPageId }))
         : shape === 'taskTriggers.workflowId' ? scrubWorkflowIds.map((workflowId) => ({ workflowId }))
+        : shape === 'taskTriggers.workflowId,workflows.agentPageId'
+          ? scrubWorkflowIds.map((workflowId) => ({
+              workflowId,
+              agentPageId: triggerAgentByWorkflow[workflowId] ?? 'agent-left-behind',
+            }))
         : shape === 'pages.id' ? agentsInTargetDrive.map((id) => ({ id }))
         : shape === 'taskItems.id' ? removeBranchTaskItemIds.map((id) => ({ id }))
         : null;
       if (result === null) return selectChain;
-      return {
-        from: () => ({
-          where: (cond: unknown[]) => {
-            scrubSelects.push(cond);
-            return Promise.resolve(result);
-          },
-        }),
+      const terminal = {
+        where: (cond: unknown[]) => {
+          scrubSelects.push(cond);
+          return Promise.resolve(result);
+        },
       };
+      return { from: () => ({ ...terminal, innerJoin: () => terminal }) };
     }),
     // Label by the table's OWN identity, not by which keys it happens to expose —
     // taskItems and workflows both carry `id`, and keying off that silently labelled
@@ -152,6 +161,9 @@ function makeTx(config: {
           : table === schemaTables.taskItems ? 'taskItems'
           : 'unknown';
         deletedTables.push(label);
+        // Captured so an assertion can check WHICH rows a delete targeted; discarding
+        // it let "deletes the stale workflow" pass even against a zero-row predicate.
+        deleteConditions.push({ table: label, cond });
         deletedPageIds.push(cond?.[2] as string);
         return Promise.resolve();
       },
@@ -181,12 +193,18 @@ function makeTx(config: {
       },
       pages: { findFirst: vi.fn(async () => (lastPosition === null ? undefined : { position: lastPosition })) },
     },
-    update: vi.fn(() => ({
-      set: (vals: Record<string, unknown>) => ({ where: () => { taskItemUpdates.push(vals); return Promise.resolve(); } }),
+    update: vi.fn((table: Record<string, string>) => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: (cond: unknown) => {
+          if (table === schemaTables.workflows) workflowDriveUpdates.push({ vals, cond });
+          else taskItemUpdates.push(vals);
+          return Promise.resolve();
+        },
+      }),
     })),
   };
 
-  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates, deletedTables, scrubSelects };
+  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates, deletedTables, scrubSelects, deleteConditions, workflowDriveUpdates };
 }
 
 describe('seedDefaultTaskStatusConfigs', () => {
@@ -415,7 +433,12 @@ describe('syncTaskItemOnMove', () => {
   // from slugify(name) and each list picks its own group, so "Review" can be `done` in
   // one list and `in_progress` in another. Carrying it over unchanged leaves the row's
   // group disagreeing with its own completedAt.
-  it('reconciles completedAt (not the status) when the destination defines the slug in another group', async () => {
+  // A slug the destination DOES define is left completely alone, even when its group
+  // disagrees with completedAt. Rewriting the status would reverse a deliberate regroup;
+  // rewriting completedAt would fabricate a completion time (bypassing the sub-task guard
+  // and disabling the due-date trigger) or destroy a real one nothing else records. The
+  // disagreement is already reachable inside a single list, so a move must not pay for it.
+  it('leaves a defined slug untouched even when its group disagrees with completedAt', async () => {
     const { tx, taskItemUpdates } = makeTx({
       pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
       existingItems: new Set(['list']),
@@ -427,24 +450,7 @@ describe('syncTaskItemOnMove', () => {
       ],
     });
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
-    // The status the user chose survives; the derived stamp is what gets corrected.
-    expect(taskItemUpdates).toEqual([{ completedAt: null }]);
-  });
-
-  it('stamps completedAt when the destination defines the slug as done', async () => {
-    const { tx, taskItemUpdates } = makeTx({
-      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
-      existingItems: new Set(['list']),
-      existingItemStatus: 'review',
-      destinationStatusConfigs: [
-        { slug: 'review', group: 'done', position: 0 },
-        { slug: 'todo', group: 'todo', position: 1 },
-      ],
-    });
-    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
-    expect(taskItemUpdates).toHaveLength(1);
-    expect((taskItemUpdates[0] as { completedAt: Date }).completedAt).toBeInstanceOf(Date);
-    expect(taskItemUpdates[0]).not.toHaveProperty('status');
+    expect(taskItemUpdates).toHaveLength(0);
   });
 
   // A list whose owner deleted 'pending' (permitted, via migrateToSlug) would otherwise
@@ -557,10 +563,11 @@ describe('scrubDriveScopedTaskAssociations', () => {
 
   // Finding: workflows.driveId is stamped at creation and never rewritten, so testing it
   // deleted EVERY surviving trigger. Staleness is the agent's, not the drive column's.
-  it('spares the trigger workflow when its agent moved along with the task', async () => {
-    const { tx, deletedTables } = makeTx({
+  it('spares and repoints the trigger workflow when its agent moved along', async () => {
+    const { tx, deletedTables, workflowDriveUpdates } = makeTx({
       scrubTaskItemIds: ['item-1'],
       scrubWorkflowIds: ['wf-1'],
+      triggerAgentByWorkflow: { 'wf-1': 'agent-came-along' },
       scrubAgentIdByItem: { 'item-1': 'agent-came-along' },
       agentsInTargetDrive: ['agent-came-along'],
     });
@@ -568,18 +575,42 @@ describe('scrubDriveScopedTaskAssociations', () => {
     await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
 
     expect(deletedTables).not.toContain('workflows');
+    // driveId is stamped at creation and never rewritten, so a spared workflow must be
+    // repointed or it executes against the drive the task just left.
+    expect(workflowDriveUpdates).toEqual([
+      expect.objectContaining({ vals: { driveId: 'drive-target' } }),
+    ]);
   });
 
-  it('deletes the trigger workflow when its agent stayed behind', async () => {
+  // A trigger's agent comes from workflows.agentPageId, set independently of any task
+  // assignee — keying the sweep off the assignee set let these survive a move.
+  it('deletes a stale trigger workflow even when the task has NO agent assignee', async () => {
     const { tx, deletedTables } = makeTx({
       scrubTaskItemIds: ['item-1'],
       scrubWorkflowIds: ['wf-1'],
+      triggerAgentByWorkflow: { 'wf-1': 'agent-left-behind' },
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(deletedTables).toContain('workflows');
+  });
+
+  it('deletes the trigger workflow when its agent stayed behind', async () => {
+    const { tx, deletedTables, deleteConditions } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-1'],
+      triggerAgentByWorkflow: { 'wf-1': 'agent-left-behind' },
       scrubAgentIdByItem: { 'item-1': 'agent-left-behind' },
     });
 
     await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
 
     expect(deletedTables).toContain('workflows');
+    // The predicate must actually name the doomed workflow — discarding it let this
+    // assertion pass against a delete that matched nothing.
+    const wfDelete = deleteConditions.find((d) => d.table === 'workflows');
+    expect(JSON.stringify(wfDelete?.cond)).toContain('wf-1');
   });
 
   // Human assignees, priority, dueDate and metadata are not drive-scoped, so the

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -4,16 +4,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed', position: 'pages.position', type: 'pages.type' } }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: { pageId: 'taskLists.pageId' },
-  taskItems: { pageId: 'taskItems.pageId' },
+  taskItems: { pageId: 'taskItems.pageId', id: 'taskItems.id' },
+  taskAssignees: { taskId: 'taskAssignees.taskId', agentPageId: 'taskAssignees.agentPageId' },
   taskStatusConfigs: {},
   DEFAULT_TASK_STATUSES: [
     { slug: 'pending', name: 'To Do', color: 'c', group: 'todo', position: 0 },
   ],
 }));
+vi.mock('@pagespace/db/schema/task-triggers', () => ({
+  taskTriggers: { taskItemId: 'taskTriggers.taskItemId', workflowId: 'taskTriggers.workflowId' },
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: { id: 'workflows.id' },
+}));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ['eq', a, b]),
   and: vi.fn((...c) => ['and', ...c]),
   asc: vi.fn((c) => ['asc', c]),
+  isNotNull: vi.fn((c) => ['isNotNull', c]),
   desc: vi.fn((c) => ['desc', c]),
   inArray: vi.fn((c, v) => ['inArray', c, v]),
 }));
@@ -27,6 +35,7 @@ import {
   seedDefaultTaskStatusConfigs,
   syncTaskItemOnMove,
   backfillMissingTaskItems,
+  scrubDriveScopedTaskAssociations,
 } from '../task-sync-service';
 
 /**
@@ -42,6 +51,9 @@ function makeTx(config: {
   existingItems?: Set<string>;
   existingTaskList?: boolean;
   lastPosition?: number | null;
+  /** task_items ids the scrub should find, and the workflow ids their triggers name. */
+  scrubTaskItemIds?: string[];
+  scrubWorkflowIds?: string[];
   /** Status carried by the preserved task_items row, and the destination's vocabulary. */
   existingItemStatus?: string;
   existingItemCompletedAt?: Date | null;
@@ -52,6 +64,8 @@ function makeTx(config: {
     existingItems = new Set<string>(),
     existingTaskList = true,
     lastPosition = null,
+    scrubTaskItemIds = [],
+    scrubWorkflowIds = [],
     existingItemStatus = 'pending',
     existingItemCompletedAt = null,
     destinationStatusConfigs = [],
@@ -74,9 +88,37 @@ function makeTx(config: {
     },
   };
 
+  const scrubSelects: unknown[][] = [];
+  const deletedTables: string[] = [];
+  // The scrub issues three selects in order: task_items by pageId, then task_triggers.
+  const scrubSelectResults = [
+    scrubTaskItemIds.map((id) => ({ id })),
+    scrubWorkflowIds.map((workflowId) => ({ workflowId })),
+  ];
+  let scrubSelectCall = 0;
+
   const tx = {
-    select: vi.fn(() => selectChain),
-    delete: vi.fn(() => ({ where: (cond: unknown[]) => { deletedPageIds.push(cond?.[2] as string); return Promise.resolve(); } })),
+    select: vi.fn((projection?: Record<string, unknown>) => {
+      // getPageType selects { type }; the scrub selects { id } / { workflowId }.
+      if (projection && !('type' in projection)) {
+        return {
+          from: () => ({
+            where: (cond: unknown[]) => {
+              scrubSelects.push(cond);
+              return Promise.resolve(scrubSelectResults[scrubSelectCall++] ?? []);
+            },
+          }),
+        };
+      }
+      return selectChain;
+    }),
+    delete: vi.fn((table: { pageId?: string; taskId?: string; id?: string }) => ({
+      where: (cond: unknown[]) => {
+        deletedTables.push(table?.taskId ? 'taskAssignees' : table?.id ? 'workflows' : 'taskItems');
+        deletedPageIds.push(cond?.[2] as string);
+        return Promise.resolve();
+      },
+    })),
     insert: vi.fn((table: { pageId?: string }) => ({
       values: (vals: Record<string, unknown> | Record<string, unknown>[]) => {
         const isTaskItems = table?.pageId === 'taskItems.pageId';
@@ -107,7 +149,7 @@ function makeTx(config: {
     })),
   };
 
-  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates };
+  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates, deletedTables, scrubSelects };
 }
 
 describe('seedDefaultTaskStatusConfigs', () => {
@@ -299,14 +341,49 @@ describe('syncTaskItemOnMove', () => {
     expect(taskItemUpdates).toHaveLength(0);
   });
 
-  // Cross-drive resets instead of preserving, so nothing survives to normalize.
-  it('removes rather than preserves on a cross-drive list-to-list move', async () => {
-    const { tx, deletedPageIds } = makeTx({
+  // PUT /tasks/statuses validates each config's group but never guarantees a list keeps
+  // one of each, so a naive `?? configs[0]` could drop an unfinished task onto a done
+  // slug — ticked and struck through while every completedAt-based count still calls it
+  // incomplete.
+  it('never remaps an unfinished task onto a done-group status', async () => {
+    const { tx, taskItemUpdates } = makeTx({
       pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
       existingItems: new Set(['list']),
+      existingItemStatus: 'foreign',
+      destinationStatusConfigs: [
+        { slug: 'shipped', group: 'done', position: 0 },
+        { slug: 'doing', group: 'in_progress', position: 1 },
+      ],
     });
-    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u', crossDrive: true });
-    expect(deletedPageIds).toEqual(['list']);
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toEqual([{ status: 'doing' }]);
+  });
+
+  it('keeps a completed task in a done status even when the list has no todo group', async () => {
+    const { tx, taskItemUpdates } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'foreign',
+      existingItemCompletedAt: new Date('2026-01-01'),
+      destinationStatusConfigs: [
+        { slug: 'doing', group: 'in_progress', position: 0 },
+        { slug: 'shipped', group: 'done', position: 1 },
+      ],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toEqual([{ status: 'shipped' }]);
+  });
+
+  // A list whose owner deleted 'pending' (permitted, via migrateToSlug) would otherwise
+  // get a brand-new task seeded with a status it does not define — the very defect
+  // normalizeStatusForList exists to prevent, reintroduced on the insert path.
+  it('seeds a new task with a status the destination list actually defines', async () => {
+    const { tx, taskItemInserts } = makeTx({
+      pageTypes: { old: 'FOLDER', new: 'TASK_LIST' },
+      destinationStatusConfigs: [{ slug: 'backlog', group: 'todo', position: 0 }],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemInserts[0]).toMatchObject({ status: 'backlog' });
   });
 
   // ...while the destination list is still seeded, which is why shouldAdd stays true.
@@ -332,6 +409,52 @@ describe('syncTaskItemOnMove', () => {
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: null, newParentId: 'new', userId: 'u' });
     expect(deletedPageIds).toHaveLength(0);
     expect(taskItemInserts).toHaveLength(1);
+  });
+});
+
+describe('scrubDriveScopedTaskAssociations', () => {
+  it('no-ops on an empty page list without touching the database', async () => {
+    const { tx, deletedTables } = makeTx();
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: [] });
+    expect(tx.select).not.toHaveBeenCalled();
+    expect(deletedTables).toHaveLength(0);
+  });
+
+  it('no-ops when none of the moved pages are tasks', async () => {
+    const { tx, deletedTables } = makeTx({ scrubTaskItemIds: [] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1', 'p2'] });
+    expect(deletedTables).toHaveLength(0);
+  });
+
+  // The ordering that matters: task_triggers.taskItemId cascades from task_items, so
+  // anything that removes triggers before reading them leaves the workflows rows
+  // orphaned and unreachable — the hazard disableTaskTriggers documents.
+  it('deletes the linked workflows by id, letting the cascade take the triggers', async () => {
+    const { tx, deletedTables } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-1', 'wf-2'],
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'] });
+
+    expect(deletedTables).toEqual(['workflows', 'taskAssignees']);
+  });
+
+  it('clears the agent assignee and drops agent assignee rows', async () => {
+    const { tx, taskItemUpdates, deletedTables } = makeTx({ scrubTaskItemIds: ['item-1'] });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'] });
+
+    expect(taskItemUpdates).toEqual([{ assigneeAgentId: null }]);
+    expect(deletedTables).toContain('taskAssignees');
+  });
+
+  // Human assignees, priority, dueDate and metadata are not drive-scoped, so the
+  // scrub must not be a blanket row reset.
+  it('does not delete the task_items rows themselves', async () => {
+    const { tx, deletedTables } = makeTx({ scrubTaskItemIds: ['item-1'] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'] });
+    expect(deletedTables).not.toContain('taskItems');
   });
 });
 

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed', position: 'pages.position', type: 'pages.type' } }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: { pageId: 'taskLists.pageId' },
-  taskItems: { pageId: 'taskItems.pageId', id: 'taskItems.id' },
+  taskItems: { pageId: 'taskItems.pageId', id: 'taskItems.id', assigneeAgentId: 'taskItems.assigneeAgentId', completedAt: 'taskItems.completedAt' },
   taskAssignees: { taskId: 'taskAssignees.taskId', agentPageId: 'taskAssignees.agentPageId' },
   taskStatusConfigs: {},
   DEFAULT_TASK_STATUSES: [
@@ -15,7 +15,7 @@ vi.mock('@pagespace/db/schema/task-triggers', () => ({
   taskTriggers: { taskItemId: 'taskTriggers.taskItemId', workflowId: 'taskTriggers.workflowId' },
 }));
 vi.mock('@pagespace/db/schema/workflows', () => ({
-  workflows: { id: 'workflows.id' },
+  workflows: { id: 'workflows.id', driveId: 'workflows.driveId', agentPageId: 'workflows.agentPageId' },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ['eq', a, b]),
@@ -65,6 +65,8 @@ function makeTx(config: {
   /** task_items ids the scrub should find, and the workflow ids their triggers name. */
   scrubTaskItemIds?: string[];
   scrubWorkflowIds?: string[];
+  /** task_items ids the remove branch's pre-delete trigger sweep should find. */
+  removeBranchTaskItemIds?: string[];
   /** Agent page referenced by each found task item, and agents already in the target drive. */
   scrubAgentIdByItem?: Record<string, string>;
   scrubAssigneeAgentIds?: string[];
@@ -81,6 +83,7 @@ function makeTx(config: {
     lastPosition = null,
     scrubTaskItemIds = [],
     scrubWorkflowIds = [],
+    removeBranchTaskItemIds = [],
     scrubAgentIdByItem = {},
     scrubAssigneeAgentIds = [],
     agentsInTargetDrive = [],
@@ -113,13 +116,19 @@ function makeTx(config: {
     // Dispatch on the PROJECTION SHAPE, not call order: order-based dispatch would let
     // two swapped selects — or a query against the wrong column — pass unnoticed.
     select: vi.fn((projection?: Record<string, unknown>) => {
-      const keys = projection ? Object.keys(projection).sort().join(',') : '';
+      // Keyed on the projection's VALUES, which are the table-qualified column names in
+      // these mocks. Keying on the key NAMES collided: { id: taskItems.id } and
+      // { id: pages.id } are both 'id', so a task_items-by-page lookup was
+      // indistinguishable from a pages-by-drive one and wiring them to each other
+      // passed silently.
+      const shape = projection ? Object.values(projection).sort().join(',') : '';
       const result =
-        keys === 'assigneeAgentId,id'
+        shape === 'taskItems.assigneeAgentId,taskItems.id'
           ? scrubTaskItemIds.map((id) => ({ id, assigneeAgentId: scrubAgentIdByItem[id] ?? null }))
-        : keys === 'agentPageId' ? scrubAssigneeAgentIds.map((agentPageId) => ({ agentPageId }))
-        : keys === 'workflowId' ? scrubWorkflowIds.map((workflowId) => ({ workflowId }))
-        : keys === 'id' ? agentsInTargetDrive.map((id) => ({ id }))
+        : shape === 'taskAssignees.agentPageId' ? scrubAssigneeAgentIds.map((agentPageId) => ({ agentPageId }))
+        : shape === 'taskTriggers.workflowId' ? scrubWorkflowIds.map((workflowId) => ({ workflowId }))
+        : shape === 'pages.id' ? agentsInTargetDrive.map((id) => ({ id }))
+        : shape === 'taskItems.id' ? removeBranchTaskItemIds.map((id) => ({ id }))
         : null;
       if (result === null) return selectChain;
       return {
@@ -406,7 +415,7 @@ describe('syncTaskItemOnMove', () => {
   // from slugify(name) and each list picks its own group, so "Review" can be `done` in
   // one list and `in_progress` in another. Carrying it over unchanged leaves the row's
   // group disagreeing with its own completedAt.
-  it('remaps a slug the destination defines in the WRONG group for a completed task', async () => {
+  it('reconciles completedAt (not the status) when the destination defines the slug in another group', async () => {
     const { tx, taskItemUpdates } = makeTx({
       pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
       existingItems: new Set(['list']),
@@ -418,10 +427,11 @@ describe('syncTaskItemOnMove', () => {
       ],
     });
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
-    expect(taskItemUpdates).toEqual([{ status: 'shipped' }]);
+    // The status the user chose survives; the derived stamp is what gets corrected.
+    expect(taskItemUpdates).toEqual([{ completedAt: null }]);
   });
 
-  it('remaps a slug the destination defines as done for an UNfinished task', async () => {
+  it('stamps completedAt when the destination defines the slug as done', async () => {
     const { tx, taskItemUpdates } = makeTx({
       pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
       existingItems: new Set(['list']),
@@ -432,7 +442,9 @@ describe('syncTaskItemOnMove', () => {
       ],
     });
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
-    expect(taskItemUpdates).toEqual([{ status: 'todo' }]);
+    expect(taskItemUpdates).toHaveLength(1);
+    expect((taskItemUpdates[0] as { completedAt: Date }).completedAt).toBeInstanceOf(Date);
+    expect(taskItemUpdates[0]).not.toHaveProperty('status');
   });
 
   // A list whose owner deleted 'pending' (permitted, via migrateToSlug) would otherwise
@@ -456,6 +468,20 @@ describe('syncTaskItemOnMove', () => {
     });
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
     expect(taskListInserts).toHaveLength(1);
+  });
+
+  // The remove branch must clear the trigger workflows BEFORE deleting the row:
+  // task_triggers.taskItemId cascades from task_items, so the other order strands them.
+  it('deletes trigger workflows before deleting the row it is removing', async () => {
+    const { tx, deletedTables } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'FOLDER' },
+      removeBranchTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-1'],
+    });
+
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+
+    expect(deletedTables).toEqual(['workflows', 'taskItems']);
   });
 
   it('only removes when moving out of a TASK_LIST into a non-TASK_LIST', async () => {
@@ -527,6 +553,33 @@ describe('scrubDriveScopedTaskAssociations', () => {
 
     expect(taskItemUpdates).toHaveLength(0);
     expect(deletedTables).not.toContain('taskAssignees');
+  });
+
+  // Finding: workflows.driveId is stamped at creation and never rewritten, so testing it
+  // deleted EVERY surviving trigger. Staleness is the agent's, not the drive column's.
+  it('spares the trigger workflow when its agent moved along with the task', async () => {
+    const { tx, deletedTables } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-1'],
+      scrubAgentIdByItem: { 'item-1': 'agent-came-along' },
+      agentsInTargetDrive: ['agent-came-along'],
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(deletedTables).not.toContain('workflows');
+  });
+
+  it('deletes the trigger workflow when its agent stayed behind', async () => {
+    const { tx, deletedTables } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-1'],
+      scrubAgentIdByItem: { 'item-1': 'agent-left-behind' },
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(deletedTables).toContain('workflows');
   });
 
   // Human assignees, priority, dueDate and metadata are not drive-scoped, so the

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -22,12 +22,23 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...c) => ['and', ...c]),
   asc: vi.fn((c) => ['asc', c]),
   isNotNull: vi.fn((c) => ['isNotNull', c]),
+  ne: vi.fn((a, b) => ['ne', a, b]),
   desc: vi.fn((c) => ['desc', c]),
   inArray: vi.fn((c, v) => ['inArray', c, v]),
 }));
 
 // The shells import `db` only as a type; provide a stub so the module loads.
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
+
+import { taskItems as taskItemsTable, taskAssignees as taskAssigneesTable } from '@pagespace/db/schema/tasks';
+import { workflows as workflowsTable } from '@pagespace/db/schema/workflows';
+
+/** Identity of the mocked table objects, so delete() can be labelled unambiguously. */
+const schemaTables = {
+  taskItems: taskItemsTable as unknown as Record<string, string>,
+  taskAssignees: taskAssigneesTable as unknown as Record<string, string>,
+  workflows: workflowsTable as unknown as Record<string, string>,
+};
 
 import {
   ensureTaskItemForPage,
@@ -54,6 +65,10 @@ function makeTx(config: {
   /** task_items ids the scrub should find, and the workflow ids their triggers name. */
   scrubTaskItemIds?: string[];
   scrubWorkflowIds?: string[];
+  /** Agent page referenced by each found task item, and agents already in the target drive. */
+  scrubAgentIdByItem?: Record<string, string>;
+  scrubAssigneeAgentIds?: string[];
+  agentsInTargetDrive?: string[];
   /** Status carried by the preserved task_items row, and the destination's vocabulary. */
   existingItemStatus?: string;
   existingItemCompletedAt?: Date | null;
@@ -66,6 +81,9 @@ function makeTx(config: {
     lastPosition = null,
     scrubTaskItemIds = [],
     scrubWorkflowIds = [],
+    scrubAgentIdByItem = {},
+    scrubAssigneeAgentIds = [],
+    agentsInTargetDrive = [],
     existingItemStatus = 'pending',
     existingItemCompletedAt = null,
     destinationStatusConfigs = [],
@@ -90,31 +108,41 @@ function makeTx(config: {
 
   const scrubSelects: unknown[][] = [];
   const deletedTables: string[] = [];
-  // The scrub issues three selects in order: task_items by pageId, then task_triggers.
-  const scrubSelectResults = [
-    scrubTaskItemIds.map((id) => ({ id })),
-    scrubWorkflowIds.map((workflowId) => ({ workflowId })),
-  ];
-  let scrubSelectCall = 0;
 
   const tx = {
+    // Dispatch on the PROJECTION SHAPE, not call order: order-based dispatch would let
+    // two swapped selects — or a query against the wrong column — pass unnoticed.
     select: vi.fn((projection?: Record<string, unknown>) => {
-      // getPageType selects { type }; the scrub selects { id } / { workflowId }.
-      if (projection && !('type' in projection)) {
-        return {
-          from: () => ({
-            where: (cond: unknown[]) => {
-              scrubSelects.push(cond);
-              return Promise.resolve(scrubSelectResults[scrubSelectCall++] ?? []);
-            },
-          }),
-        };
-      }
-      return selectChain;
+      const keys = projection ? Object.keys(projection).sort().join(',') : '';
+      const result =
+        keys === 'assigneeAgentId,id'
+          ? scrubTaskItemIds.map((id) => ({ id, assigneeAgentId: scrubAgentIdByItem[id] ?? null }))
+        : keys === 'agentPageId' ? scrubAssigneeAgentIds.map((agentPageId) => ({ agentPageId }))
+        : keys === 'workflowId' ? scrubWorkflowIds.map((workflowId) => ({ workflowId }))
+        : keys === 'id' ? agentsInTargetDrive.map((id) => ({ id }))
+        : null;
+      if (result === null) return selectChain;
+      return {
+        from: () => ({
+          where: (cond: unknown[]) => {
+            scrubSelects.push(cond);
+            return Promise.resolve(result);
+          },
+        }),
+      };
     }),
-    delete: vi.fn((table: { pageId?: string; taskId?: string; id?: string }) => ({
+    // Label by the table's OWN identity, not by which keys it happens to expose —
+    // taskItems and workflows both carry `id`, and keying off that silently labelled
+    // every taskItems delete as 'workflows', making the preserve-the-row assertion
+    // impossible to fail.
+    delete: vi.fn((table: Record<string, string>) => ({
       where: (cond: unknown[]) => {
-        deletedTables.push(table?.taskId ? 'taskAssignees' : table?.id ? 'workflows' : 'taskItems');
+        const label =
+          table === schemaTables.taskAssignees ? 'taskAssignees'
+          : table === schemaTables.workflows ? 'workflows'
+          : table === schemaTables.taskItems ? 'taskItems'
+          : 'unknown';
+        deletedTables.push(label);
         deletedPageIds.push(cond?.[2] as string);
         return Promise.resolve();
       },
@@ -374,6 +402,39 @@ describe('syncTaskItemOnMove', () => {
     expect(taskItemUpdates).toEqual([{ status: 'shipped' }]);
   });
 
+  // A slug match alone is not proof the status still means the same thing: slugs come
+  // from slugify(name) and each list picks its own group, so "Review" can be `done` in
+  // one list and `in_progress` in another. Carrying it over unchanged leaves the row's
+  // group disagreeing with its own completedAt.
+  it('remaps a slug the destination defines in the WRONG group for a completed task', async () => {
+    const { tx, taskItemUpdates } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'review',
+      existingItemCompletedAt: new Date('2026-01-01'),
+      destinationStatusConfigs: [
+        { slug: 'review', group: 'in_progress', position: 0 },
+        { slug: 'shipped', group: 'done', position: 1 },
+      ],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toEqual([{ status: 'shipped' }]);
+  });
+
+  it('remaps a slug the destination defines as done for an UNfinished task', async () => {
+    const { tx, taskItemUpdates } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'review',
+      destinationStatusConfigs: [
+        { slug: 'review', group: 'done', position: 0 },
+        { slug: 'todo', group: 'todo', position: 1 },
+      ],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(taskItemUpdates).toEqual([{ status: 'todo' }]);
+  });
+
   // A list whose owner deleted 'pending' (permitted, via migrateToSlug) would otherwise
   // get a brand-new task seeded with a status it does not define — the very defect
   // normalizeStatusForList exists to prevent, reintroduced on the insert path.
@@ -415,14 +476,14 @@ describe('syncTaskItemOnMove', () => {
 describe('scrubDriveScopedTaskAssociations', () => {
   it('no-ops on an empty page list without touching the database', async () => {
     const { tx, deletedTables } = makeTx();
-    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: [] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: [], targetDriveId: 'drive-target' });
     expect(tx.select).not.toHaveBeenCalled();
     expect(deletedTables).toHaveLength(0);
   });
 
   it('no-ops when none of the moved pages are tasks', async () => {
     const { tx, deletedTables } = makeTx({ scrubTaskItemIds: [] });
-    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1', 'p2'] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1', 'p2'], targetDriveId: 'drive-target' });
     expect(deletedTables).toHaveLength(0);
   });
 
@@ -433,27 +494,46 @@ describe('scrubDriveScopedTaskAssociations', () => {
     const { tx, deletedTables } = makeTx({
       scrubTaskItemIds: ['item-1'],
       scrubWorkflowIds: ['wf-1', 'wf-2'],
+      scrubAgentIdByItem: { 'item-1': 'agent-left-behind' },
     });
 
-    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
 
     expect(deletedTables).toEqual(['workflows', 'taskAssignees']);
   });
 
   it('clears the agent assignee and drops agent assignee rows', async () => {
-    const { tx, taskItemUpdates, deletedTables } = makeTx({ scrubTaskItemIds: ['item-1'] });
+    const { tx, taskItemUpdates, deletedTables } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubAgentIdByItem: { 'item-1': 'agent-left-behind' },
+    });
 
-    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
 
     expect(taskItemUpdates).toEqual([{ assigneeAgentId: null }]);
     expect(deletedTables).toContain('taskAssignees');
+  });
+
+  // Moving a project folder that carries BOTH its task list and the agent it assigns
+  // work to must not silently drop the assignment — that agent is not stale.
+  it('leaves alone an agent that moved into the target drive with the task', async () => {
+    const { tx, taskItemUpdates, deletedTables } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubAgentIdByItem: { 'item-1': 'agent-came-along' },
+      agentsInTargetDrive: ['agent-came-along'],
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(taskItemUpdates).toHaveLength(0);
+    expect(deletedTables).not.toContain('taskAssignees');
   });
 
   // Human assignees, priority, dueDate and metadata are not drive-scoped, so the
   // scrub must not be a blanket row reset.
   it('does not delete the task_items rows themselves', async () => {
     const { tx, deletedTables } = makeTx({ scrubTaskItemIds: ['item-1'] });
-    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'] });
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
     expect(deletedTables).not.toContain('taskItems');
   });
 });

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Schema tables are opaque markers in these tests; the mock tx ignores them.
-vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed', position: 'pages.position', type: 'pages.type' } }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'pages.id', driveId: 'pages.driveId', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed', position: 'pages.position', type: 'pages.type' } }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: { pageId: 'taskLists.pageId' },
   taskItems: { pageId: 'taskItems.pageId', id: 'taskItems.id', assigneeAgentId: 'taskItems.assigneeAgentId', completedAt: 'taskItems.completedAt' },
@@ -640,9 +640,51 @@ describe('scrubDriveScopedTaskAssociations', () => {
 
     await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
 
-    expect(workflowDriveUpdates).toContainEqual(
-      expect.objectContaining({ vals: { instructionPageId: null } }),
+    const clear = workflowDriveUpdates.find(
+      (u) => (u as { vals: Record<string, unknown> }).vals.instructionPageId === null,
     );
+    expect(clear).toBeDefined();
+    expect(JSON.stringify((clear as { cond: unknown }).cond)).toContain('wf-ok');
+  });
+
+  // "clear all surviving when any is stranded" would pass every single-workflow
+  // fixture; this pins that the two are decided independently.
+  it('clears only the workflow whose runbook stayed behind', async () => {
+    const { tx, workflowDriveUpdates } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-stranded', 'wf-travelled'],
+      triggerAgentByWorkflow: { 'wf-stranded': 'agent-came-along', 'wf-travelled': 'agent-came-along' },
+      agentsInTargetDrive: ['agent-came-along'],
+      instructionPageByWorkflow: { 'wf-stranded': 'runbook-left', 'wf-travelled': 'runbook-moved' },
+      pagesInTargetDrive: ['runbook-moved'],
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    const clears = workflowDriveUpdates.filter(
+      (u) => (u as { vals: Record<string, unknown> }).vals.instructionPageId === null,
+    );
+    expect(clears).toHaveLength(1);
+    expect(JSON.stringify(clears[0])).toContain('wf-stranded');
+    expect(JSON.stringify(clears[0])).not.toContain('wf-travelled');
+  });
+
+  // 7783c6618's whole effect was unasserted: dropping the shared memo left every test
+  // green. The three resolutions in one scrub must cost ONE pages lookup, not three.
+  it('resolves page residency once per scrub, not once per consumer', async () => {
+    const { tx, scrubSelects } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-ok'],
+      scrubAgentIdByItem: { 'item-1': 'agent-a' },
+      triggerAgentByWorkflow: { 'wf-ok': 'agent-a' },
+      agentsInTargetDrive: ['agent-a'],
+      instructionPageByWorkflow: { 'wf-ok': 'agent-a' },
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    const pageProbes = scrubSelects.filter((cond) => JSON.stringify(cond).includes('pages.driveId'));
+    expect(pageProbes).toHaveLength(1);
   });
 
   it('keeps an instruction page that travelled with the task', async () => {

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -15,7 +15,7 @@ vi.mock('@pagespace/db/schema/task-triggers', () => ({
   taskTriggers: { taskItemId: 'taskTriggers.taskItemId', workflowId: 'taskTriggers.workflowId' },
 }));
 vi.mock('@pagespace/db/schema/workflows', () => ({
-  workflows: { id: 'workflows.id', driveId: 'workflows.driveId', agentPageId: 'workflows.agentPageId' },
+  workflows: { id: 'workflows.id', driveId: 'workflows.driveId', agentPageId: 'workflows.agentPageId', instructionPageId: 'workflows.instructionPageId' },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ['eq', a, b]),
@@ -67,6 +67,9 @@ function makeTx(config: {
   scrubWorkflowIds?: string[];
   /** Agent each trigger workflow runs, which is set independently of the assignee. */
   triggerAgentByWorkflow?: Record<string, string>;
+  /** Runbook page each trigger workflow reads, and pages that travelled to the target. */
+  instructionPageByWorkflow?: Record<string, string>;
+  pagesInTargetDrive?: string[];
   /** task_items ids the remove branch's pre-delete trigger sweep should find. */
   removeBranchTaskItemIds?: string[];
   /** Agent page referenced by each found task item, and agents already in the target drive. */
@@ -86,6 +89,8 @@ function makeTx(config: {
     scrubTaskItemIds = [],
     scrubWorkflowIds = [],
     triggerAgentByWorkflow = {},
+    instructionPageByWorkflow = {},
+    pagesInTargetDrive = [],
     removeBranchTaskItemIds = [],
     scrubAgentIdByItem = {},
     scrubAssigneeAgentIds = [],
@@ -132,12 +137,14 @@ function makeTx(config: {
           ? scrubTaskItemIds.map((id) => ({ id, assigneeAgentId: scrubAgentIdByItem[id] ?? null }))
         : shape === 'taskAssignees.agentPageId' ? scrubAssigneeAgentIds.map((agentPageId) => ({ agentPageId }))
         : shape === 'taskTriggers.workflowId' ? scrubWorkflowIds.map((workflowId) => ({ workflowId }))
-        : shape === 'taskTriggers.workflowId,workflows.agentPageId'
+        : shape === 'taskTriggers.workflowId,workflows.agentPageId,workflows.instructionPageId'
           ? scrubWorkflowIds.map((workflowId) => ({
               workflowId,
               agentPageId: triggerAgentByWorkflow[workflowId] ?? 'agent-left-behind',
+              instructionPageId: instructionPageByWorkflow[workflowId] ?? null,
             }))
-        : shape === 'pages.id' ? agentsInTargetDrive.map((id) => ({ id }))
+        : shape === 'pages.id'
+          ? [...agentsInTargetDrive, ...pagesInTargetDrive].map((id) => ({ id }))
         : shape === 'taskItems.id' ? removeBranchTaskItemIds.map((id) => ({ id }))
         : null;
       if (result === null) return selectChain;
@@ -577,9 +584,63 @@ describe('scrubDriveScopedTaskAssociations', () => {
     expect(deletedTables).not.toContain('workflows');
     // driveId is stamped at creation and never rewritten, so a spared workflow must be
     // repointed or it executes against the drive the task just left.
-    expect(workflowDriveUpdates).toEqual([
-      expect.objectContaining({ vals: { driveId: 'drive-target' } }),
-    ]);
+    expect(workflowDriveUpdates).toHaveLength(1);
+    expect(workflowDriveUpdates[0]).toMatchObject({ vals: { driveId: 'drive-target' } });
+    // The predicate must name the workflow, not (say) its agent — an UPDATE matching
+    // zero rows would otherwise pass, exactly as it did on the delete side.
+    expect(JSON.stringify((workflowDriveUpdates[0] as { cond: unknown }).cond)).toContain('wf-1');
+  });
+
+  // The partition was only ever exercised one branch at a time; a swap would fail both
+  // single-branch tests but this pins them running together.
+  it('deletes the stale workflow and repoints the surviving one in the same move', async () => {
+    const { tx, deletedTables, workflowDriveUpdates } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-stale', 'wf-ok'],
+      triggerAgentByWorkflow: { 'wf-stale': 'agent-left-behind', 'wf-ok': 'agent-came-along' },
+      agentsInTargetDrive: ['agent-came-along'],
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(deletedTables).toContain('workflows');
+    expect(JSON.stringify(workflowDriveUpdates)).toContain('wf-ok');
+    expect(JSON.stringify(workflowDriveUpdates)).not.toContain('wf-stale');
+  });
+
+  // contextPageIds are re-filtered by driveId at fire time; instructionPageId is not —
+  // loadInstructionPage gates only on the workflow creator's membership, and that
+  // creator is a source-drive user. A runbook left behind would keep being read and its
+  // content persisted into a destination-drive agent page.
+  it('clears an instruction page that stayed behind on a surviving workflow', async () => {
+    const { tx, workflowDriveUpdates } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-ok'],
+      triggerAgentByWorkflow: { 'wf-ok': 'agent-came-along' },
+      agentsInTargetDrive: ['agent-came-along'],
+      instructionPageByWorkflow: { 'wf-ok': 'runbook-left-behind' },
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(workflowDriveUpdates).toContainEqual(
+      expect.objectContaining({ vals: { instructionPageId: null } }),
+    );
+  });
+
+  it('keeps an instruction page that travelled with the task', async () => {
+    const { tx, workflowDriveUpdates } = makeTx({
+      scrubTaskItemIds: ['item-1'],
+      scrubWorkflowIds: ['wf-ok'],
+      triggerAgentByWorkflow: { 'wf-ok': 'agent-came-along' },
+      agentsInTargetDrive: ['agent-came-along'],
+      instructionPageByWorkflow: { 'wf-ok': 'runbook-came-along' },
+      pagesInTargetDrive: ['runbook-came-along'],
+    });
+
+    await scrubDriveScopedTaskAssociations(tx as never, { pageIds: ['p1'], targetDriveId: 'drive-target' });
+
+    expect(JSON.stringify(workflowDriveUpdates)).not.toContain('instructionPageId');
   });
 
   // A trigger's agent comes from workflows.agentPageId, set independently of any task

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -120,6 +120,7 @@ function makeTx(config: {
   const scrubSelects: unknown[][] = [];
   const deletedTables: string[] = [];
   const deleteConditions: Array<{ table: string; cond: unknown }> = [];
+  const statusConfigProbes: Array<{ taskListId: string; slug: string }> = [];
   const workflowDriveUpdates: unknown[] = [];
 
   const tx = {
@@ -194,8 +195,13 @@ function makeTx(config: {
           : undefined;
       }) },
       taskStatusConfigs: {
-        findFirst: vi.fn(async () =>
-          destinationStatusConfigs.find((c) => c.slug === existingItemStatus)),
+        // where: ['and', ['eq','taskStatusConfigs.taskListId', id], ['eq','taskStatusConfigs.slug', slug]]
+        findFirst: vi.fn(async (args: { where: unknown[] }) => {
+          const listCond = args.where?.[1] as unknown[];
+          const slugCond = args.where?.[2] as unknown[];
+          statusConfigProbes.push({ taskListId: listCond?.[2] as string, slug: slugCond?.[2] as string });
+          return destinationStatusConfigs.find((c) => c.slug === slugCond?.[2]);
+        }),
         findMany: vi.fn(async () => destinationStatusConfigs),
       },
       pages: { findFirst: vi.fn(async () => (lastPosition === null ? undefined : { position: lastPosition })) },
@@ -211,7 +217,7 @@ function makeTx(config: {
     })),
   };
 
-  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates, deletedTables, scrubSelects, deleteConditions, workflowDriveUpdates };
+  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds, taskItemUpdates, deletedTables, scrubSelects, deleteConditions, workflowDriveUpdates, statusConfigProbes };
 }
 
 describe('seedDefaultTaskStatusConfigs', () => {
@@ -458,6 +464,17 @@ describe('syncTaskItemOnMove', () => {
     });
     await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
     expect(taskItemUpdates).toHaveLength(0);
+  });
+
+  it('probes the destination list for the task\'s own slug, not a hardcoded one', async () => {
+    const { tx, statusConfigProbes } = makeTx({
+      pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' },
+      existingItems: new Set(['list']),
+      existingItemStatus: 'review',
+      destinationStatusConfigs: [{ slug: 'review', group: 'todo', position: 0 }],
+    });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(statusConfigProbes).toEqual([{ taskListId: 'tasklist-1', slug: 'review' }]);
   });
 
   // A list whose owner deleted 'pending' (permitted, via migrateToSlug) would otherwise

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -32,8 +32,14 @@ import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 /**
- * Depth ceiling for the descendant cascade. Matches MAX_DEPTH in
- * circular-reference-guard so the two tree walks agree on what "too deep" means.
+ * Depth ceiling for the descendant cascade — the number of descendant LEVELS
+ * below the moved roots that will be rewritten. Chosen to match MAX_DEPTH in
+ * circular-reference-guard, which bounds the ancestor walk the same way.
+ *
+ * The guard exists to stop a parentId cycle, not to reject deep trees: it fires
+ * only when a level beyond the ceiling still has unvisited nodes, so a subtree
+ * exactly MAX_SUBTREE_DEPTH levels deep migrates in full rather than being
+ * rolled back after every one of its nodes was already written.
  */
 export const MAX_SUBTREE_DEPTH = 100;
 
@@ -144,12 +150,6 @@ async function cascadeDriveIdToDescendants(
   let total = 0;
 
   for (let depth = 0; frontier.length > 0; depth++) {
-    if (depth >= MAX_SUBTREE_DEPTH) {
-      throw new PageSubtreeTooDeepError(
-        `Page subtree exceeds ${MAX_SUBTREE_DEPTH} levels — possible circular reference`,
-      );
-    }
-
     // eslint-disable-next-line no-restricted-syntax -- level-wise tree walk, bounded by MAX_SUBTREE_DEPTH; a LIMIT would silently drop descendants and split the subtree across drives
     const children = await tx.query.pages.findMany({
       where: inArray(pages.parentId, frontier),
@@ -157,6 +157,15 @@ async function cascadeDriveIdToDescendants(
 
     const next = children.map((child) => child.id).filter((id) => !visited.has(id));
     if (next.length === 0) break;
+
+    // Checked only once a level actually HAS unvisited nodes, so a tree exactly
+    // MAX_SUBTREE_DEPTH levels deep completes instead of being rolled back with
+    // every node already rewritten.
+    if (depth >= MAX_SUBTREE_DEPTH) {
+      throw new PageSubtreeTooDeepError(
+        `Page subtree exceeds ${MAX_SUBTREE_DEPTH} levels — possible circular reference`,
+      );
+    }
 
     next.forEach((id) => visited.add(id));
     await tx.update(pages).set({ driveId: newDriveId }).where(inArray(pages.id, next));

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -27,7 +27,7 @@ import { pages, drives } from '@pagespace/db/schema/core';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
-import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
+import { syncTaskItemOnMove, scrubDriveScopedTaskAssociations } from '@/services/api/task-sync-service';
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -143,10 +143,10 @@ async function cascadeDriveIdToDescendants(
   tx: Tx,
   rootIds: string[],
   newDriveId: string,
-): Promise<number> {
+): Promise<string[]> {
   const visited = new Set(rootIds);
   let frontier = rootIds;
-  let total = 0;
+  const moved: string[] = [];
 
   for (let depth = 0; frontier.length > 0; depth++) {
     // eslint-disable-next-line no-restricted-syntax -- level-wise tree walk, bounded by MAX_SUBTREE_DEPTH; a LIMIT would silently drop descendants and split the subtree across drives
@@ -173,11 +173,11 @@ async function cascadeDriveIdToDescendants(
 
     next.forEach((id) => visited.add(id));
     await tx.update(pages).set({ driveId: newDriveId }).where(inArray(pages.id, next));
-    total += next.length;
+    moved.push(...next);
     frontier = next;
   }
 
-  return total;
+  return moved;
 }
 
 export async function movePagesToDrive(
@@ -306,9 +306,6 @@ export async function movePagesToDrive(
           oldParentId: page.parentId,
           newParentId: targetParentId,
           userId,
-          // A task's assignees, triggers and status vocabulary are all drive-scoped,
-          // so the row is reset rather than carried over a drive boundary.
-          crossDrive: page.driveId !== targetDriveId,
         });
 
         moved.push({
@@ -323,7 +320,17 @@ export async function movePagesToDrive(
       }
 
       if (cascadeRoots.length > 0) {
-        descendantCount = await cascadeDriveIdToDescendants(tx, cascadeRoots, targetDriveId);
+        const movedDescendants = await cascadeDriveIdToDescendants(tx, cascadeRoots, targetDriveId);
+        descendantCount = movedDescendants.length;
+
+        // The roots' membership change is handled by syncTaskItemOnMove above, but a
+        // descendant's parentId never changes, so no membership event fires for it even
+        // though its drive just did. Both need their drive-scoped task associations
+        // dropped, or an agent assignee / workflow trigger from the old drive survives
+        // the boundary.
+        await scrubDriveScopedTaskAssociations(tx, {
+          pageIds: [...cascadeRoots, ...movedDescendants],
+        });
       }
 
       // A drive's home page must live in that drive. Clearing here (after the

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -306,6 +306,9 @@ export async function movePagesToDrive(
           oldParentId: page.parentId,
           newParentId: targetParentId,
           userId,
+          // A task's assignees, triggers and status vocabulary are all drive-scoped,
+          // so the row is reset rather than carried over a drive boundary.
+          crossDrive: page.driveId !== targetDriveId,
         });
 
         moved.push({

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -1,0 +1,371 @@
+/**
+ * page-cross-drive-move-service — the ONE implementation of "move pages (and their
+ * subtrees) into another drive".
+ *
+ * Extracted from POST /api/pages/bulk-move so the REST route and the AI `move_page`
+ * tool share the same validation order, the same transaction, the same descendant
+ * cascade, the same home-page invariant and the same activity trail. Before this
+ * seam existed the tool simply could not move across drives, and any second
+ * implementation would have had to re-derive a dozen ordering decisions.
+ *
+ * Principal-agnostic via an INJECTED authorizer rather than a pure core plus two
+ * wrappers: the three authorization questions are interleaved with reads the
+ * service must do anyway (you cannot ask "may you administer the destination"
+ * before confirming it exists, nor "may you edit each source page" before loading
+ * the rows whose `title` the 403 message embeds). Three closures at the call site
+ * is the smallest interface that keeps ordering, short-circuiting and error copy
+ * in one place.
+ *
+ * Side effects the two callers present differently — websocket broadcast and
+ * `syncPublishedHomeRoot` — are NOT fired here. They are driven by the caller off
+ * the returned `affectedDriveIds` / `clearedHomePageDriveIds`.
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, inArray, desc, isNull } from '@pagespace/db/operators';
+import { pages, drives } from '@pagespace/db/schema/core';
+import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
+import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Depth ceiling for the descendant cascade. Matches MAX_DEPTH in
+ * circular-reference-guard so the two tree walks agree on what "too deep" means.
+ */
+export const MAX_SUBTREE_DEPTH = 100;
+
+/**
+ * The three authorization questions a cross-drive move asks, in the order the
+ * service asks them. Callers supply the primitives: the REST route closes over
+ * `canPrincipalEditPage` / its drive owner-admin block, the AI tool over
+ * `canActorEditPage` / `canActorManageDrive`. The service owns the ORDER, the
+ * failure codes and the user-facing copy — that is the drift this seam prevents.
+ */
+export interface CrossDriveMoveAuthorizer {
+  /** Deny-only MCP/app-token drive-scope ceiling. A no-op for unscoped callers. */
+  isDriveInScope(driveId: string): boolean | Promise<boolean>;
+  /** Owner/admin on the DESTINATION drive. Never asked about a source drive. */
+  canAdministerDrive(driveId: string): Promise<boolean>;
+  /** Edit access on ONE source page. Called once per source page, in order. */
+  canEditPage(pageId: string): Promise<boolean>;
+}
+
+export interface CrossDriveMoveActivity {
+  isAiGenerated?: boolean;
+  aiProvider?: string;
+  aiModel?: string;
+  aiConversationId?: string;
+  changeGroupType?: 'user' | 'ai' | 'automation' | 'system';
+  /** Merged into each activity row's metadata. */
+  metadata?: Record<string, unknown>;
+}
+
+export interface CrossDriveMoveParams {
+  pageIds: string[];
+  targetDriveId: string;
+  targetParentId: string | null;
+  /** The human behind the action, agent or not — used for activity attribution. */
+  userId: string;
+  authorize: CrossDriveMoveAuthorizer;
+  activity?: CrossDriveMoveActivity;
+}
+
+export type CrossDriveMoveFailureCode =
+  | 'TARGET_DRIVE_NOT_FOUND'
+  | 'TARGET_DRIVE_OUT_OF_SCOPE'
+  | 'TARGET_DRIVE_FORBIDDEN'
+  | 'TARGET_PARENT_NOT_FOUND'
+  | 'SOURCE_PAGES_NOT_FOUND'
+  | 'SOURCE_DRIVE_OUT_OF_SCOPE'
+  | 'SOURCE_PAGE_FORBIDDEN'
+  | 'CIRCULAR_REFERENCE'
+  | 'SUBTREE_TOO_DEEP';
+
+export interface MovedPageSummary {
+  id: string;
+  title: string | null;
+  type: string;
+  previousDriveId: string;
+  previousParentId: string | null;
+  position: number;
+}
+
+export type CrossDriveMoveResult =
+  | {
+      success: true;
+      moved: MovedPageSummary[];
+      /** How many DESCENDANT rows had their driveId rewritten. */
+      descendantCount: number;
+      /** Every drive needing a `moved` broadcast — the target plus all sources. */
+      affectedDriveIds: string[];
+      /** Drives whose homePageId was nulled; caller fires syncPublishedHomeRoot. */
+      clearedHomePageDriveIds: string[];
+    }
+  | {
+      success: false;
+      code: CrossDriveMoveFailureCode;
+      status: 400 | 403 | 404;
+      message: string;
+    };
+
+/** Internal signal: the cascade hit MAX_SUBTREE_DEPTH (almost certainly a parentId cycle). */
+class PageSubtreeTooDeepError extends Error {}
+
+function fail(
+  code: CrossDriveMoveFailureCode,
+  status: 400 | 403 | 404,
+  message: string,
+): CrossDriveMoveResult {
+  return { success: false, code, status, message };
+}
+
+/**
+ * Rewrite `driveId` on every descendant of `rootIds`, level by level.
+ *
+ * Iterative with a visited set and a depth cap, NOT recursive: `pages.parentId`
+ * carries no self-FK, so a cycle is representable — and the previous recursive
+ * version would have looped forever holding an open transaction. The visited set
+ * is seeded with the roots so a root that is itself a descendant of another root
+ * is never re-driven.
+ *
+ * Trashed descendants are deliberately included: a trashed child left behind
+ * would restore into a drive its parent has already left.
+ */
+async function cascadeDriveIdToDescendants(
+  tx: Tx,
+  rootIds: string[],
+  newDriveId: string,
+): Promise<number> {
+  const visited = new Set(rootIds);
+  let frontier = rootIds;
+  let total = 0;
+
+  for (let depth = 0; frontier.length > 0; depth++) {
+    if (depth >= MAX_SUBTREE_DEPTH) {
+      throw new PageSubtreeTooDeepError(
+        `Page subtree exceeds ${MAX_SUBTREE_DEPTH} levels — possible circular reference`,
+      );
+    }
+
+    // eslint-disable-next-line no-restricted-syntax -- level-wise tree walk, bounded by MAX_SUBTREE_DEPTH; a LIMIT would silently drop descendants and split the subtree across drives
+    const children = await tx.query.pages.findMany({
+      where: inArray(pages.parentId, frontier),
+    });
+
+    const next = children.map((child) => child.id).filter((id) => !visited.has(id));
+    if (next.length === 0) break;
+
+    next.forEach((id) => visited.add(id));
+    await tx.update(pages).set({ driveId: newDriveId }).where(inArray(pages.id, next));
+    total += next.length;
+    frontier = next;
+  }
+
+  return total;
+}
+
+export async function movePagesToDrive(
+  params: CrossDriveMoveParams,
+): Promise<CrossDriveMoveResult> {
+  const { pageIds, targetDriveId, targetParentId, userId, authorize, activity } = params;
+
+  const targetDrive = await db.query.drives.findFirst({
+    where: eq(drives.id, targetDriveId),
+  });
+  if (!targetDrive) {
+    return fail('TARGET_DRIVE_NOT_FOUND', 404, 'Target drive not found');
+  }
+
+  if (!(await authorize.isDriveInScope(targetDriveId))) {
+    return fail(
+      'TARGET_DRIVE_OUT_OF_SCOPE',
+      403,
+      'This token does not have access to the target drive',
+    );
+  }
+
+  if (!(await authorize.canAdministerDrive(targetDriveId))) {
+    return fail(
+      'TARGET_DRIVE_FORBIDDEN',
+      403,
+      'You do not have permission to move pages to this drive',
+    );
+  }
+
+  if (targetParentId) {
+    const targetParent = await db.query.pages.findFirst({
+      where: and(
+        eq(pages.id, targetParentId),
+        eq(pages.driveId, targetDriveId),
+        eq(pages.isTrashed, false),
+      ),
+    });
+    if (!targetParent) {
+      return fail('TARGET_PARENT_NOT_FOUND', 404, 'Target folder not found');
+    }
+  }
+
+  // eslint-disable-next-line no-restricted-syntax -- pre-existing unbounded findMany, not fixed by Phase 8 (PageSpace epic j44e35jwzlhr54fbmruk3k4i follow-up)
+  const sourcePages = await db.query.pages.findMany({
+    where: inArray(pages.id, pageIds),
+  });
+  if (sourcePages.length !== pageIds.length) {
+    return fail('SOURCE_PAGES_NOT_FOUND', 404, 'Some pages not found');
+  }
+
+  for (const page of sourcePages) {
+    if (!(await authorize.isDriveInScope(page.driveId))) {
+      return fail(
+        'SOURCE_DRIVE_OUT_OF_SCOPE',
+        403,
+        'This token does not have access to one or more source pages',
+      );
+    }
+  }
+
+  for (const page of sourcePages) {
+    if (!(await authorize.canEditPage(page.id))) {
+      return fail(
+        'SOURCE_PAGE_FORBIDDEN',
+        403,
+        `You do not have permission to move page: ${page.title}`,
+      );
+    }
+  }
+
+  if (targetParentId) {
+    for (const pageId of pageIds) {
+      const validation = await validatePageMove(pageId, targetParentId);
+      if (!validation.valid) {
+        return fail('CIRCULAR_REFERENCE', 400, validation.error);
+      }
+    }
+  }
+
+  const lastPage = await db.query.pages.findFirst({
+    where: and(
+      eq(pages.driveId, targetDriveId),
+      targetParentId ? eq(pages.parentId, targetParentId) : isNull(pages.parentId),
+      eq(pages.isTrashed, false),
+    ),
+    orderBy: [desc(pages.position)],
+  });
+
+  let nextPosition = (lastPage?.position || 0) + 1;
+
+  const affectedDriveIds = new Set<string>([targetDriveId]);
+  const clearedHomePageDriveIds: string[] = [];
+  const moved: MovedPageSummary[] = [];
+  let descendantCount = 0;
+
+  try {
+    await db.transaction(async (tx) => {
+      const cascadeRoots: string[] = [];
+
+      for (const page of sourcePages) {
+        affectedDriveIds.add(page.driveId);
+
+        await tx
+          .update(pages)
+          .set({
+            driveId: targetDriveId,
+            parentId: targetParentId,
+            position: nextPosition,
+            updatedAt: new Date(),
+          })
+          .where(eq(pages.id, page.id));
+
+        if (page.driveId !== targetDriveId) {
+          cascadeRoots.push(page.id);
+        }
+
+        await syncTaskItemOnMove(tx, {
+          movedPageId: page.id,
+          movedPageType: page.type,
+          oldParentId: page.parentId,
+          newParentId: targetParentId,
+          userId,
+        });
+
+        moved.push({
+          id: page.id,
+          title: page.title,
+          type: page.type,
+          previousDriveId: page.driveId,
+          previousParentId: page.parentId,
+          position: nextPosition,
+        });
+
+        nextPosition += 1;
+      }
+
+      if (cascadeRoots.length > 0) {
+        descendantCount = await cascadeDriveIdToDescendants(tx, cascadeRoots, targetDriveId);
+      }
+
+      // A drive's home page must live in that drive. Clearing here (after the
+      // moves, same transaction) also covers home pages that left as
+      // descendants of a moved subtree via the cascade above.
+      const sourceDriveIds = [...affectedDriveIds].filter((id) => id !== targetDriveId);
+      for (const sourceDriveId of sourceDriveIds) {
+        const sourceDrive = await tx.query.drives.findFirst({
+          where: eq(drives.id, sourceDriveId),
+          columns: { homePageId: true },
+        });
+        if (!sourceDrive?.homePageId) continue;
+
+        const homePageStillInDrive = await tx.query.pages.findFirst({
+          where: and(eq(pages.id, sourceDrive.homePageId), eq(pages.driveId, sourceDriveId)),
+          columns: { id: true },
+        });
+        if (!homePageStillInDrive) {
+          await tx.update(drives).set({ homePageId: null }).where(eq(drives.id, sourceDriveId));
+          clearedHomePageDriveIds.push(sourceDriveId);
+        }
+      }
+    });
+  } catch (error) {
+    if (error instanceof PageSubtreeTooDeepError) {
+      return fail('SUBTREE_TOO_DEEP', 400, error.message);
+    }
+    throw error;
+  }
+
+  const actorInfo = await getActorInfo(userId);
+  const changeGroupId = createChangeGroupId();
+  for (const page of moved) {
+    logPageActivity(
+      userId,
+      'move',
+      {
+        id: page.id,
+        title: page.title ?? undefined,
+        driveId: targetDriveId,
+      },
+      {
+        ...actorInfo,
+        changeGroupId,
+        changeGroupType: activity?.changeGroupType ?? 'user',
+        isAiGenerated: activity?.isAiGenerated,
+        aiProvider: activity?.aiProvider,
+        aiModel: activity?.aiModel,
+        aiConversationId: activity?.aiConversationId,
+        updatedFields: ['driveId', 'parentId', 'position'],
+        previousValues: { driveId: page.previousDriveId, parentId: page.previousParentId },
+        newValues: { driveId: targetDriveId, parentId: targetParentId },
+        metadata: { ...activity?.metadata },
+      },
+    );
+  }
+
+  return {
+    success: true,
+    moved,
+    descendantCount,
+    affectedDriveIds: [...affectedDriveIds],
+    clearedHomePageDriveIds,
+  };
+}

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -93,7 +93,6 @@ export type CrossDriveMoveFailureCode =
 export interface MovedPageSummary {
   id: string;
   title: string | null;
-  type: string;
   previousDriveId: string;
   previousParentId: string | null;
   position: number;
@@ -153,6 +152,11 @@ async function cascadeDriveIdToDescendants(
     // eslint-disable-next-line no-restricted-syntax -- level-wise tree walk, bounded by MAX_SUBTREE_DEPTH; a LIMIT would silently drop descendants and split the subtree across drives
     const children = await tx.query.pages.findMany({
       where: inArray(pages.parentId, frontier),
+      // ids only: this runs inside the open write transaction, and `pages`
+      // carries unbounded `content` plus several jsonb columns. Selecting whole
+      // rows would drag a whole subtree's document bodies through the wire and
+      // the heap while holding locks on the level above.
+      columns: { id: true },
     });
 
     const next = children.map((child) => child.id).filter((id) => !visited.has(id));
@@ -183,6 +187,8 @@ export async function movePagesToDrive(
 
   const targetDrive = await db.query.drives.findFirst({
     where: eq(drives.id, targetDriveId),
+    // Existence only — no column is read, and the full row carries drivePrompt.
+    columns: { id: true },
   });
   if (!targetDrive) {
     return fail('TARGET_DRIVE_NOT_FOUND', 404, 'Target drive not found');
@@ -211,6 +217,7 @@ export async function movePagesToDrive(
         eq(pages.driveId, targetDriveId),
         eq(pages.isTrashed, false),
       ),
+      columns: { id: true },
     });
     if (!targetParent) {
       return fail('TARGET_PARENT_NOT_FOUND', 404, 'Target folder not found');
@@ -220,6 +227,7 @@ export async function movePagesToDrive(
   // eslint-disable-next-line no-restricted-syntax -- pre-existing unbounded findMany, not fixed by Phase 8 (PageSpace epic j44e35jwzlhr54fbmruk3k4i follow-up)
   const sourcePages = await db.query.pages.findMany({
     where: inArray(pages.id, pageIds),
+    columns: { id: true, driveId: true, parentId: true, title: true, type: true },
   });
   if (sourcePages.length !== pageIds.length) {
     return fail('SOURCE_PAGES_NOT_FOUND', 404, 'Some pages not found');
@@ -261,6 +269,7 @@ export async function movePagesToDrive(
       eq(pages.isTrashed, false),
     ),
     orderBy: [desc(pages.position)],
+    columns: { position: true },
   });
 
   let nextPosition = (lastPage?.position || 0) + 1;
@@ -302,7 +311,6 @@ export async function movePagesToDrive(
         moved.push({
           id: page.id,
           title: page.title,
-          type: page.type,
           previousDriveId: page.driveId,
           previousParentId: page.parentId,
           position: nextPosition,

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -330,6 +330,7 @@ export async function movePagesToDrive(
         // the boundary.
         await scrubDriveScopedTaskAssociations(tx, {
           pageIds: [...cascadeRoots, ...movedDescendants],
+          targetDriveId,
         });
       }
 

--- a/apps/web/src/services/api/task-membership.ts
+++ b/apps/web/src/services/api/task-membership.ts
@@ -35,16 +35,23 @@ export interface TaskItemSyncAction {
  *
  * No-op for non-TASK_LIST pages and for pure reorders (parent unchanged).
  *
- * Moving between two TASK_LIST parents deliberately does NOT remove. The row is
- * keyed by pageId and carries no pointer to its list — membership is derived from
- * pages.parentId — so it stays valid under the new parent. Removing and re-adding
- * would destroy the user's data: addTaskItemUnderParent re-inserts bare defaults
- * (status 'pending', priority 'medium'), and task_assignees cascades on the delete,
- * so a task dragged between two lists silently lost its status, priority, due date,
- * metadata and every assignee. `shouldAdd` stays true for that case so the
- * destination list is still seeded (task_lists row + default status configs) and a
- * genuinely missing row is still backfilled — addTaskItemUnderParent returns early
- * when a row already exists, which is what preserves it.
+ * Moving between two TASK_LIST parents WITHIN A DRIVE deliberately does NOT remove.
+ * The row is keyed by pageId and carries no pointer to its list — membership is
+ * derived from pages.parentId — so it stays valid under the new parent. Removing
+ * and re-adding would destroy the user's data: addTaskItemUnderParent re-inserts
+ * bare defaults (status 'pending', priority 'medium'), and task_assignees cascades
+ * on the delete, so a task dragged between two lists silently lost its status,
+ * priority, due date, metadata and every assignee. `shouldAdd` stays true for that
+ * case so the destination list is still seeded (task_lists row + default status
+ * configs) and a genuinely missing row is still backfilled — addTaskItemUnderParent
+ * returns early when a row already exists, which is what preserves it.
+ *
+ * A CROSS-DRIVE move still removes, because the things the row points at are all
+ * drive-scoped: `assigneeAgentId` / `task_assignees.agentPageId` reference agent
+ * pages that the task write paths refuse to accept from another drive, and
+ * `task_triggers` cascade from the row into drive-scoped workflows. Carrying those
+ * across a drive boundary would preserve references the product forbids creating —
+ * e.g. a drive-A agent's title rendered to every drive-B viewer of the task.
  */
 export const resolveTaskItemSyncAction = (input: {
   movedPageType: string;
@@ -52,14 +59,16 @@ export const resolveTaskItemSyncAction = (input: {
   newParentId: string | null;
   oldParentType: string | null | undefined;
   newParentType: string | null | undefined;
+  /** True when the move crosses a drive boundary; see the note above. */
+  crossDrive?: boolean;
 }): TaskItemSyncAction => {
   if (input.movedPageType !== TASK_LIST_TYPE || input.oldParentId === input.newParentId) {
     return { shouldRemove: false, shouldAdd: false };
   }
   const landsInTaskList = input.newParentId !== null && input.newParentType === TASK_LIST_TYPE;
+  const leavesTaskList = input.oldParentId !== null && input.oldParentType === TASK_LIST_TYPE;
   return {
-    shouldRemove:
-      input.oldParentId !== null && input.oldParentType === TASK_LIST_TYPE && !landsInTaskList,
+    shouldRemove: leavesTaskList && (!landsInTaskList || input.crossDrive === true),
     shouldAdd: landsInTaskList,
   };
 };

--- a/apps/web/src/services/api/task-membership.ts
+++ b/apps/web/src/services/api/task-membership.ts
@@ -30,10 +30,21 @@ export interface TaskItemSyncAction {
 
 /**
  * Decide which `task_items` mutations a page move requires:
- * - remove the row when the page leaves a TASK_LIST parent
+ * - remove the row when the page LEAVES task-list membership entirely
  * - add the row when the page lands under a TASK_LIST parent
  *
  * No-op for non-TASK_LIST pages and for pure reorders (parent unchanged).
+ *
+ * Moving between two TASK_LIST parents deliberately does NOT remove. The row is
+ * keyed by pageId and carries no pointer to its list — membership is derived from
+ * pages.parentId — so it stays valid under the new parent. Removing and re-adding
+ * would destroy the user's data: addTaskItemUnderParent re-inserts bare defaults
+ * (status 'pending', priority 'medium'), and task_assignees cascades on the delete,
+ * so a task dragged between two lists silently lost its status, priority, due date,
+ * metadata and every assignee. `shouldAdd` stays true for that case so the
+ * destination list is still seeded (task_lists row + default status configs) and a
+ * genuinely missing row is still backfilled — addTaskItemUnderParent returns early
+ * when a row already exists, which is what preserves it.
  */
 export const resolveTaskItemSyncAction = (input: {
   movedPageType: string;
@@ -45,9 +56,11 @@ export const resolveTaskItemSyncAction = (input: {
   if (input.movedPageType !== TASK_LIST_TYPE || input.oldParentId === input.newParentId) {
     return { shouldRemove: false, shouldAdd: false };
   }
+  const landsInTaskList = input.newParentId !== null && input.newParentType === TASK_LIST_TYPE;
   return {
-    shouldRemove: input.oldParentId !== null && input.oldParentType === TASK_LIST_TYPE,
-    shouldAdd: input.newParentId !== null && input.newParentType === TASK_LIST_TYPE,
+    shouldRemove:
+      input.oldParentId !== null && input.oldParentType === TASK_LIST_TYPE && !landsInTaskList,
+    shouldAdd: landsInTaskList,
   };
 };
 

--- a/apps/web/src/services/api/task-membership.ts
+++ b/apps/web/src/services/api/task-membership.ts
@@ -46,12 +46,11 @@ export interface TaskItemSyncAction {
  * configs) and a genuinely missing row is still backfilled — addTaskItemUnderParent
  * returns early when a row already exists, which is what preserves it.
  *
- * A CROSS-DRIVE move still removes, because the things the row points at are all
- * drive-scoped: `assigneeAgentId` / `task_assignees.agentPageId` reference agent
- * pages that the task write paths refuse to accept from another drive, and
- * `task_triggers` cascade from the row into drive-scoped workflows. Carrying those
- * across a drive boundary would preserve references the product forbids creating —
- * e.g. a drive-A agent's title rendered to every drive-B viewer of the task.
+ * A CROSS-DRIVE move preserves the row too, but the caller must first scrub what IS
+ * drive-scoped — see scrubDriveScopedTaskAssociations. Deleting the row instead would
+ * throw away priority, dueDate and metadata, none of which are drive-scoped, and would
+ * only cover the moved ROOTS: a descendant's parentId never changes, so no membership
+ * event fires for it even though its drive did change.
  */
 export const resolveTaskItemSyncAction = (input: {
   movedPageType: string;
@@ -59,8 +58,6 @@ export const resolveTaskItemSyncAction = (input: {
   newParentId: string | null;
   oldParentType: string | null | undefined;
   newParentType: string | null | undefined;
-  /** True when the move crosses a drive boundary; see the note above. */
-  crossDrive?: boolean;
 }): TaskItemSyncAction => {
   if (input.movedPageType !== TASK_LIST_TYPE || input.oldParentId === input.newParentId) {
     return { shouldRemove: false, shouldAdd: false };
@@ -68,7 +65,7 @@ export const resolveTaskItemSyncAction = (input: {
   const landsInTaskList = input.newParentId !== null && input.newParentType === TASK_LIST_TYPE;
   const leavesTaskList = input.oldParentId !== null && input.oldParentType === TASK_LIST_TYPE;
   return {
-    shouldRemove: leavesTaskList && (!landsInTaskList || input.crossDrive === true),
+    shouldRemove: leavesTaskList && !landsInTaskList,
     shouldAdd: landsInTaskList,
   };
 };
@@ -76,7 +73,7 @@ export const resolveTaskItemSyncAction = (input: {
 export interface TaskItemInsert {
   readonly userId: string;
   readonly pageId: string;
-  readonly status: 'pending';
+  readonly status: string;
   readonly priority: 'medium';
 }
 
@@ -89,10 +86,18 @@ export interface TaskItemInsert {
 export const buildTaskItemInsert = (input: {
   pageId: string;
   userId: string;
+  /**
+   * Slug to seed. Defaults to 'pending' — the first of DEFAULT_TASK_STATUSES — but a
+   * list whose owner deleted that status (permitted, via migrateToSlug) does not define
+   * it, and a hardcoded seed would create exactly the orphaned-status row that
+   * normalizeStatusForList exists to prevent. Callers that know the destination's
+   * vocabulary pass its default instead.
+   */
+  status?: string;
 }): TaskItemInsert => ({
   userId: input.userId,
   pageId: input.pageId,
-  status: 'pending',
+  status: input.status ?? 'pending',
   priority: 'medium',
 });
 

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -112,15 +112,6 @@ function chunk<T>(items: T[], size: number): T[][] {
 }
 
 /**
- * Whether a status group agrees with the row's own completion stamp. `completedAt` is
- * the one completion signal that travels with the row and does not depend on any list's
- * vocabulary, so it is the arbiter when the two could disagree.
- */
-function isGroupConsistentWithCompletion(group: string, completedAt: Date | null): boolean {
-  return completedAt ? group === 'done' : group !== 'done'
-}
-
-/**
  * Keep a PRESERVED task row's status inside its new list's vocabulary.
  *
  * `task_items.status` is a bare slug with no foreign key; its meaning comes from the
@@ -132,11 +123,10 @@ function isGroupConsistentWithCompletion(group: string, completedAt: Date | null
  * queries, and (when the slug was a done one) shows unticked while `completedAt` still
  * counts it complete in the parent's progress.
  *
- * Two different repairs, depending on which side is wrong. When the destination DOES
- * define the slug, the status stands and any disagreement with `completedAt` is fixed
- * on `completedAt` — the derived field. Only when the slug is absent entirely is the
- * status itself remapped, and then `completedAt` is the intent signal, so a finished
- * task stays finished and an unfinished one stays actionable.
+ * Only the genuinely broken case is repaired: a slug the destination does not define at
+ * all. `completedAt` is the intent signal for the replacement, so a finished task stays
+ * finished and an unfinished one stays actionable. A slug the list DOES define is left
+ * untouched — see the note at the short-circuit for why neither field may be rewritten.
  */
 async function normalizeStatusForList(
   tx: Tx,
@@ -156,21 +146,18 @@ async function normalizeStatusForList(
       eq(taskStatusConfigs.slug, item.status),
     ),
   })
-  if (alreadyValid) {
-    // The slug is meaningful in this list, so the status stands. If completedAt
-    // disagrees with the config's group, completedAt is the field that drifted: it is
-    // DERIVED — the task PATCH route stamps and clears it from the group — whereas the
-    // status is what the user last chose and sees. Regrouping a status in place, or
-    // deleting one with migrateToSlug, both leave exactly this divergence behind
-    // entirely within one list, so reconciling it must not rewrite the user's choice.
-    if (!isGroupConsistentWithCompletion(alreadyValid.group, item.completedAt)) {
-      await tx
-        .update(taskItems)
-        .set({ completedAt: alreadyValid.group === 'done' ? new Date() : null })
-        .where(eq(taskItems.id, item.id))
-    }
-    return
-  }
+  // A defined slug is left completely alone, even when its group disagrees with
+  // completedAt. Both available "repairs" are worse than the disagreement:
+  //   • rewriting `status` reverses a deliberate regroup — the owner who moved "Review"
+  //     out of the done group would find every such task flung back into Done;
+  //   • rewriting `completedAt` fabricates a completion time (bypassing the sub-task
+  //     guard that makes PATCH return 422, and permanently disabling the task's
+  //     due-date trigger) or destroys a real one that nothing else records.
+  // The disagreement is not new or move-specific either: PUT /tasks/statuses regroups a
+  // config in place and DELETE+migrateToSlug re-points tasks, both leaving it inside a
+  // single list. The product already tolerates it there, so a move must not pay for it
+  // with the user's data.
+  if (alreadyValid) return
 
   const configs = await tx.query.taskStatusConfigs.findMany({
     where: eq(taskStatusConfigs.taskListId, taskListId),
@@ -287,12 +274,17 @@ export async function scrubDriveScopedTaskAssociations(
   // the assignment. Only agents left behind in the old drive are scrubbed.
   const staleAgentIds = await resolveAgentsOutsideDrive(tx, [...agentPageIds], targetDriveId)
 
-  // A trigger is stale for the same reason its assignment is: the AGENT it runs stayed
-  // behind. Testing workflows.driveId instead would delete every surviving trigger,
-  // because that column is stamped once at creation and never rewritten — after a move
-  // it always names the source drive.
+  // Trigger staleness is resolved SEPARATELY from assignment staleness. A trigger's
+  // agent comes from workflows.agentPageId, which PUT /api/tasks/:id/triggers sets
+  // without touching task_items.assigneeAgentId — a task can carry a trigger and no
+  // assignee at all, or a trigger naming a different agent than its assignee. Keying
+  // the sweep off the assignee set let exactly those workflows survive a move, still
+  // pointing at a source-drive agent, which is the leak this whole function exists to
+  // stop. Workflows whose agent came along are repointed at the new drive instead of
+  // being deleted, since their driveId is stamped once at creation and never rewritten.
+  await reconcileTaskTriggerWorkflows(tx, taskItemIds, targetDriveId)
+
   if (staleAgentIds.length === 0) return
-  await deleteTaskTriggerWorkflows(tx, taskItemIds, { onlyForAgentIds: staleAgentIds })
 
   for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
     await tx
@@ -319,30 +311,71 @@ export async function scrubDriveScopedTaskAssociations(
  * (taskItemId, triggerType) unique constraint enforces it), so deleting by id cannot
  * affect another task.
  */
-async function deleteTaskTriggerWorkflows(
-  tx: Tx,
-  taskItemIds: string[],
-  options?: { onlyForAgentIds?: string[] },
-): Promise<void> {
-  const agentIds = options?.onlyForAgentIds
-  if (agentIds && agentIds.length === 0) return
+async function deleteTaskTriggerWorkflows(tx: Tx, taskItemIds: string[]): Promise<void> {
+  for (const wfBatch of chunk(await collectTriggerWorkflowIds(tx, taskItemIds), SCRUB_CHUNK_SIZE)) {
+    await tx.delete(workflows).where(inArray(workflows.id, wfBatch))
+  }
+}
 
+/** The workflow ids backing these tasks' triggers. */
+async function collectTriggerWorkflowIds(tx: Tx, taskItemIds: string[]): Promise<string[]> {
+  const workflowIds: string[] = []
   for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
-    const triggerRows = await tx
+    const rows = await tx
       .select({ workflowId: taskTriggers.workflowId })
       .from(taskTriggers)
       .where(inArray(taskTriggers.taskItemId, batch))
-    if (triggerRows.length === 0) continue
-    const workflowIds = triggerRows.map((row) => row.workflowId)
-    for (const wfBatch of chunk(workflowIds, SCRUB_CHUNK_SIZE)) {
-      for (const agentBatch of agentIds ? chunk(agentIds, SCRUB_CHUNK_SIZE) : [null]) {
-        await tx.delete(workflows).where(
-          agentBatch
-            ? and(inArray(workflows.id, wfBatch), inArray(workflows.agentPageId, agentBatch))
-            : inArray(workflows.id, wfBatch),
-        )
-      }
+    for (const row of rows) workflowIds.push(row.workflowId)
+  }
+  return workflowIds
+}
+
+/**
+ * Bring these tasks' trigger workflows into line with the drive they now live in.
+ *
+ * A trigger's agent is `workflows.agentPageId`, set by the triggers route independently
+ * of any task assignee, so its staleness must be resolved on its own terms. A workflow
+ * whose agent stayed behind is deleted; one whose agent travelled along is still valid
+ * and is instead REPOINTED at the new drive — `workflows.driveId` is stamped once at
+ * creation and never rewritten, so leaving it would have the workflow execute against
+ * the old drive, filtering its own context pages out by driveId and telling the agent to
+ * create work back in the drive it left.
+ */
+async function reconcileTaskTriggerWorkflows(
+  tx: Tx,
+  taskItemIds: string[],
+  targetDriveId: string,
+): Promise<void> {
+  const byAgent = new Map<string, string[]>()
+  for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
+    const rows = await tx
+      .select({ workflowId: taskTriggers.workflowId, agentPageId: workflows.agentPageId })
+      .from(taskTriggers)
+      .innerJoin(workflows, eq(workflows.id, taskTriggers.workflowId))
+      .where(inArray(taskTriggers.taskItemId, batch))
+    for (const row of rows) {
+      const list = byAgent.get(row.agentPageId) ?? []
+      list.push(row.workflowId)
+      byAgent.set(row.agentPageId, list)
     }
+  }
+  if (byAgent.size === 0) return
+
+  const staleTriggerAgents = new Set(
+    await resolveAgentsOutsideDrive(tx, [...byAgent.keys()], targetDriveId),
+  )
+
+  const doomed: string[] = []
+  const surviving: string[] = []
+  for (const [agentPageId, workflowIds] of byAgent) {
+    ;(staleTriggerAgents.has(agentPageId) ? doomed : surviving).push(...workflowIds)
+  }
+
+  for (const batch of chunk(doomed, SCRUB_CHUNK_SIZE)) {
+    await tx.delete(workflows).where(inArray(workflows.id, batch))
+  }
+  for (const batch of chunk(surviving, SCRUB_CHUNK_SIZE)) {
+    await tx.update(workflows).set({ driveId: targetDriveId }).where(inArray(workflows.id, batch))
   }
 }
 

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -134,12 +134,13 @@ async function normalizeStatusForList(
 ): Promise<void> {
   const { item, taskListId } = params
 
-  // Fast path: one indexed lookup on the (taskListId, slug) unique key. A slug match
-  // alone is NOT proof the status still means what it meant — slugs come from
+  // Fast path: one indexed lookup on the (taskListId, slug) unique key.
+  //
+  // A slug match is not proof the status means the same thing — slugs come from
   // slugify(name) and each list picks its own group, so "Review" can be `done` in one
-  // list and `in_progress` in another. Carrying such a status over unchanged leaves the
-  // row's group disagreeing with its own completedAt, which is the same incoherence a
-  // missing slug produces: ticked-but-counted-incomplete, or the reverse.
+  // list and `in_progress` in another, leaving the row's group at odds with its own
+  // completedAt. That is knowingly tolerated; see below for why neither field may be
+  // rewritten to reconcile it.
   const alreadyValid = await tx.query.taskStatusConfigs.findFirst({
     where: and(
       eq(taskStatusConfigs.taskListId, taskListId),
@@ -347,9 +348,14 @@ async function reconcileTaskTriggerWorkflows(
   targetDriveId: string,
 ): Promise<void> {
   const byAgent = new Map<string, string[]>()
+  const instructionPageByWorkflow = new Map<string, string>()
   for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
     const rows = await tx
-      .select({ workflowId: taskTriggers.workflowId, agentPageId: workflows.agentPageId })
+      .select({
+        workflowId: taskTriggers.workflowId,
+        agentPageId: workflows.agentPageId,
+        instructionPageId: workflows.instructionPageId,
+      })
       .from(taskTriggers)
       .innerJoin(workflows, eq(workflows.id, taskTriggers.workflowId))
       .where(inArray(taskTriggers.taskItemId, batch))
@@ -357,6 +363,7 @@ async function reconcileTaskTriggerWorkflows(
       const list = byAgent.get(row.agentPageId) ?? []
       list.push(row.workflowId)
       byAgent.set(row.agentPageId, list)
+      if (row.instructionPageId) instructionPageByWorkflow.set(row.workflowId, row.instructionPageId)
     }
   }
   if (byAgent.size === 0) return
@@ -377,6 +384,28 @@ async function reconcileTaskTriggerWorkflows(
   for (const batch of chunk(surviving, SCRUB_CHUNK_SIZE)) {
     await tx.update(workflows).set({ driveId: targetDriveId }).where(inArray(workflows.id, batch))
   }
+
+  // contextPageIds need no repair: executeWorkflow re-filters them by the run's driveId,
+  // so repointing above already turns a left-behind page into a dropped one.
+  // instructionPageId gets no such backstop — loadInstructionPage gates only on the
+  // workflow CREATOR's membership, and that creator is a source-drive user, so a runbook
+  // left behind would keep being read and its content persisted into a destination-drive
+  // agent page for every viewer there. Cleared when its page did not travel.
+  const survivingWithInstruction = surviving.filter((id) => instructionPageByWorkflow.has(id))
+  if (survivingWithInstruction.length === 0) return
+
+  const instructionPageIds = [
+    ...new Set(survivingWithInstruction.map((id) => instructionPageByWorkflow.get(id)!)),
+  ]
+  const strandedInstructionPages = new Set(
+    await resolvePagesOutsideDrive(tx, instructionPageIds, targetDriveId),
+  )
+  const workflowsToClear = survivingWithInstruction.filter((id) =>
+    strandedInstructionPages.has(instructionPageByWorkflow.get(id)!),
+  )
+  for (const batch of chunk(workflowsToClear, SCRUB_CHUNK_SIZE)) {
+    await tx.update(workflows).set({ instructionPageId: null }).where(inArray(workflows.id, batch))
+  }
 }
 
 /** Same, addressed by page rather than task-item id (the remove branch has no id yet). */
@@ -389,23 +418,26 @@ async function deleteTaskTriggerWorkflowsForPages(tx: Tx, pageIds: string[]): Pr
   await deleteTaskTriggerWorkflows(tx, rows.map((row) => row.id))
 }
 
-/** The subset of `agentPageIds` whose pages do NOT live in `driveId`. */
-async function resolveAgentsOutsideDrive(
+/** The subset of `pageIds` that do NOT live in `driveId` — i.e. did not travel. */
+async function resolvePagesOutsideDrive(
   tx: Tx,
-  agentPageIds: string[],
+  pageIds: string[],
   driveId: string,
 ): Promise<string[]> {
-  if (agentPageIds.length === 0) return []
+  if (pageIds.length === 0) return []
   const inDrive = new Set<string>()
-  for (const batch of chunk(agentPageIds, SCRUB_CHUNK_SIZE)) {
+  for (const batch of chunk(pageIds, SCRUB_CHUNK_SIZE)) {
     const rows = await tx
       .select({ id: pages.id })
       .from(pages)
       .where(and(inArray(pages.id, batch), eq(pages.driveId, driveId)))
     for (const row of rows) inDrive.add(row.id)
   }
-  return agentPageIds.filter((id) => !inDrive.has(id))
+  return pageIds.filter((id) => !inDrive.has(id))
 }
+
+/** Agent pages that stayed behind. Same question, named for its caller. */
+const resolveAgentsOutsideDrive = resolvePagesOutsideDrive
 
 async function addTaskItemUnderParent(
   tx: Tx,

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, asc, inArray, isNotNull } from '@pagespace/db/operators'
+import { eq, ne, and, asc, inArray, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskAssignees, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
 import { taskTriggers } from '@pagespace/db/schema/task-triggers'
@@ -100,6 +100,27 @@ export async function ensureTaskListForPage(
 const STATUS_CONFIG_REMAP_LIMIT = 200
 
 /**
+ * Postgres caps a statement at 65535 bind parameters. The cascade binds one inArray per
+ * tree level, which is naturally bounded; a whole-subtree scrub is not, so it chunks.
+ */
+const SCRUB_CHUNK_SIZE = 1000
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
+  return out
+}
+
+/**
+ * Whether a status group agrees with the row's own completion stamp. `completedAt` is
+ * the one completion signal that travels with the row and does not depend on any list's
+ * vocabulary, so it is the arbiter when the two could disagree.
+ */
+function isGroupConsistentWithCompletion(group: string, completedAt: Date | null): boolean {
+  return completedAt ? group === 'done' : group !== 'done'
+}
+
+/**
  * Keep a PRESERVED task row's status inside its new list's vocabulary.
  *
  * `task_items.status` is a bare slug with no foreign key; its meaning comes from the
@@ -120,16 +141,19 @@ async function normalizeStatusForList(
 ): Promise<void> {
   const { item, taskListId } = params
 
-  // Fast path: one indexed lookup on the (taskListId, slug) unique key. The status is
-  // valid for its new list in every case except the one this function exists for, so
-  // the full vocabulary is only fetched when a remap is actually needed.
+  // Fast path: one indexed lookup on the (taskListId, slug) unique key. A slug match
+  // alone is NOT proof the status still means what it meant — slugs come from
+  // slugify(name) and each list picks its own group, so "Review" can be `done` in one
+  // list and `in_progress` in another. Carrying such a status over unchanged leaves the
+  // row's group disagreeing with its own completedAt, which is the same incoherence a
+  // missing slug produces: ticked-but-counted-incomplete, or the reverse.
   const alreadyValid = await tx.query.taskStatusConfigs.findFirst({
     where: and(
       eq(taskStatusConfigs.taskListId, taskListId),
       eq(taskStatusConfigs.slug, item.status),
     ),
   })
-  if (alreadyValid) return
+  if (alreadyValid && isGroupConsistentWithCompletion(alreadyValid.group, item.completedAt)) return
 
   const configs = await tx.query.taskStatusConfigs.findMany({
     where: eq(taskStatusConfigs.taskListId, taskListId),
@@ -139,12 +163,9 @@ async function normalizeStatusForList(
   // A list with no configs at all has no vocabulary to conform to.
   if (configs.length === 0) return
 
-  // Never fall back across the done boundary. PUT /tasks/statuses validates each
-  // config's group but does not guarantee a list retains one of each, so a plain
-  // `?? configs[0]` could drop an unfinished task onto a done-group slug (ticked and
-  // struck through while every completedAt-based count still calls it incomplete) or
-  // the reverse. Completed work stays in a done slug or, failing that, the last one;
-  // unfinished work stays in any non-done slug.
+  // Never land on the wrong side of the done boundary. (The per-group deletion guard in
+  // the statuses route means a list with any configs keeps at least one of each group,
+  // so the final `?? configs[...]` arms are defence rather than live paths.)
   const replacement = item.completedAt
     ? (configs.find((config) => config.group === 'done') ?? configs[configs.length - 1])
     : (configs.find((config) => config.group === 'todo')
@@ -163,7 +184,19 @@ async function normalizeStatusForList(
  * migrateToSlug) gets its own first todo-group slug instead, so the seed can never be a
  * status its own list does not define.
  */
-async function resolveSeedStatus(tx: Tx, taskListId: string): Promise<string> {
+async function resolveSeedStatus(
+  tx: Tx,
+  taskListId: string,
+  cache?: Map<string, string>,
+): Promise<string> {
+  const cached = cache?.get(taskListId)
+  if (cached !== undefined) return cached
+  const resolved = await resolveSeedStatusUncached(tx, taskListId)
+  cache?.set(taskListId, resolved)
+  return resolved
+}
+
+async function resolveSeedStatusUncached(tx: Tx, taskListId: string): Promise<string> {
   const defaultSlug = DEFAULT_TASK_STATUSES[0].slug
   const hasDefault = await tx.query.taskStatusConfigs.findFirst({
     where: and(
@@ -197,50 +230,136 @@ async function resolveSeedStatus(tx: Tx, taskListId: string): Promise<string> {
  *     driveId; a drive-B member completing the task would otherwise fire a drive-A
  *     agent run seeded with drive-B content.
  *
- * The workflows rows are deleted FIRST and by explicit id: `task_triggers.taskItemId`
- * cascades from `task_items`, so any approach that removes triggers first leaves the
- * workflows behind, orphaned and unreachable (the hazard task-trigger-helpers'
- * disableTaskTriggers documents). Everything runs in the caller's transaction, so a
- * failed move takes the scrub with it.
+ * Only associations that genuinely stayed behind are dropped: an agent page that moved
+ * WITH the task (a project folder carrying both its task list and its agent) is still
+ * valid in the new drive and is left alone. Everything runs in the caller's
+ * transaction, so a failed move takes the scrub with it, and every id list is chunked
+ * because a whole subtree can exceed Postgres' bind-parameter cap.
  */
 export async function scrubDriveScopedTaskAssociations(
   tx: Tx,
-  params: { pageIds: string[] },
+  params: { pageIds: string[]; targetDriveId: string },
 ): Promise<void> {
-  const { pageIds } = params
+  const { pageIds, targetDriveId } = params
   if (pageIds.length === 0) return
 
+  const taskItemIds: string[] = []
+  const agentPageIds = new Set<string>()
+  for (const batch of chunk(pageIds, SCRUB_CHUNK_SIZE)) {
+    const rows = await tx
+      .select({ id: taskItems.id, assigneeAgentId: taskItems.assigneeAgentId })
+      .from(taskItems)
+      .where(inArray(taskItems.pageId, batch))
+    for (const row of rows) {
+      taskItemIds.push(row.id)
+      if (row.assigneeAgentId) agentPageIds.add(row.assigneeAgentId)
+    }
+  }
+  if (taskItemIds.length === 0) return
+
+  for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
+    const rows = await tx
+      .select({ agentPageId: taskAssignees.agentPageId })
+      .from(taskAssignees)
+      .where(and(inArray(taskAssignees.taskId, batch), isNotNull(taskAssignees.agentPageId)))
+    for (const row of rows) if (row.agentPageId) agentPageIds.add(row.agentPageId)
+  }
+
+  // An agent that travelled WITH the task is not stale — moving a project folder that
+  // contains both a task list and the agent it assigns work to must not silently drop
+  // the assignment. Only agents left behind in the old drive are scrubbed.
+  const staleAgentIds = await resolveAgentsOutsideDrive(tx, [...agentPageIds], targetDriveId)
+
+  await deleteTaskTriggerWorkflows(tx, taskItemIds, { exceptInDriveId: targetDriveId })
+
+  if (staleAgentIds.length === 0) return
+
+  for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
+    await tx
+      .delete(taskAssignees)
+      .where(and(inArray(taskAssignees.taskId, batch), inArray(taskAssignees.agentPageId, staleAgentIds)))
+
+    await tx
+      .update(taskItems)
+      .set({ assigneeAgentId: null })
+      .where(and(inArray(taskItems.id, batch), inArray(taskItems.assigneeAgentId, staleAgentIds)))
+  }
+}
+
+/**
+ * Delete the workflows backing these tasks' triggers, by explicit id.
+ *
+ * Order is the whole point: `task_triggers.taskItemId` cascades from `task_items`, so
+ * anything that removes the task (or its triggers) first leaves the workflows behind,
+ * unreachable from any task and never cleaned up. `disableTaskTriggers` documents the
+ * same hazard for the hard-delete paths; this variant runs inside the caller's
+ * transaction so a failed move rolls the deletion back with it.
+ *
+ * A task-trigger workflow is created 1:1 with its trigger and never shared (the
+ * (taskItemId, triggerType) unique constraint enforces it), so deleting by id cannot
+ * affect another task.
+ */
+async function deleteTaskTriggerWorkflows(
+  tx: Tx,
+  taskItemIds: string[],
+  options?: { exceptInDriveId?: string },
+): Promise<void> {
+  for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
+    const triggerRows = await tx
+      .select({ workflowId: taskTriggers.workflowId })
+      .from(taskTriggers)
+      .where(inArray(taskTriggers.taskItemId, batch))
+    if (triggerRows.length === 0) continue
+    const workflowIds = triggerRows.map((row) => row.workflowId)
+    for (const wfBatch of chunk(workflowIds, SCRUB_CHUNK_SIZE)) {
+      await tx.delete(workflows).where(
+        options?.exceptInDriveId
+          ? and(inArray(workflows.id, wfBatch), ne(workflows.driveId, options.exceptInDriveId))
+          : inArray(workflows.id, wfBatch),
+      )
+    }
+  }
+}
+
+/** Same, addressed by page rather than task-item id (the remove branch has no id yet). */
+async function deleteTaskTriggerWorkflowsForPages(tx: Tx, pageIds: string[]): Promise<void> {
   const rows = await tx
     .select({ id: taskItems.id })
     .from(taskItems)
     .where(inArray(taskItems.pageId, pageIds))
   if (rows.length === 0) return
-  const taskItemIds = rows.map((row) => row.id)
+  await deleteTaskTriggerWorkflows(tx, rows.map((row) => row.id))
+}
 
-  const triggerRows = await tx
-    .select({ workflowId: taskTriggers.workflowId })
-    .from(taskTriggers)
-    .where(inArray(taskTriggers.taskItemId, taskItemIds))
-  if (triggerRows.length > 0) {
-    // Deleting the workflow cascades its task_triggers rows away.
-    await tx.delete(workflows).where(inArray(workflows.id, triggerRows.map((r) => r.workflowId)))
+/** The subset of `agentPageIds` whose pages do NOT live in `driveId`. */
+async function resolveAgentsOutsideDrive(
+  tx: Tx,
+  agentPageIds: string[],
+  driveId: string,
+): Promise<string[]> {
+  if (agentPageIds.length === 0) return []
+  const inDrive = new Set<string>()
+  for (const batch of chunk(agentPageIds, SCRUB_CHUNK_SIZE)) {
+    const rows = await tx
+      .select({ id: pages.id })
+      .from(pages)
+      .where(and(inArray(pages.id, batch), eq(pages.driveId, driveId)))
+    for (const row of rows) inDrive.add(row.id)
   }
-
-  await tx
-    .delete(taskAssignees)
-    .where(and(inArray(taskAssignees.taskId, taskItemIds), isNotNull(taskAssignees.agentPageId)))
-
-  await tx
-    .update(taskItems)
-    .set({ assigneeAgentId: null })
-    .where(inArray(taskItems.id, taskItemIds))
+  return agentPageIds.filter((id) => !inDrive.has(id))
 }
 
 async function addTaskItemUnderParent(
   tx: Tx,
-  params: { pageId: string; parentId: string; userId: string },
+  params: {
+    pageId: string;
+    parentId: string;
+    userId: string;
+    /** Shared across a backfill loop: the parent is fixed, so the seed is too. */
+    seedStatusCache?: Map<string, string>;
+  },
 ): Promise<void> {
-  const { pageId, parentId, userId } = params
+  const { pageId, parentId, userId, seedStatusCache } = params
 
   const taskList = await ensureTaskListForPage(tx, { pageId: parentId, title: 'Task List', userId })
 
@@ -256,7 +375,11 @@ async function addTaskItemUnderParent(
   // can both pass the findFirst check above, and task_items.pageId is unique — without
   // this a second insert would 500 the read. The findFirst stays as a cheap fast path.
   await tx.insert(taskItems).values(
-    buildTaskItemInsert({ pageId, userId, status: await resolveSeedStatus(tx, taskList.id) }),
+    buildTaskItemInsert({
+      pageId,
+      userId,
+      status: await resolveSeedStatus(tx, taskList.id, seedStatusCache),
+    }),
   ).onConflictDoNothing({ target: taskItems.pageId })
 }
 
@@ -311,6 +434,10 @@ export async function syncTaskItemOnMove(
   })
 
   if (action.shouldRemove) {
+    // Delete the trigger workflows BEFORE the row: task_triggers.taskItemId cascades
+    // from task_items, so dropping the row first wipes the triggers and strands their
+    // workflows rows — unreachable from any task, and never cleaned up.
+    await deleteTaskTriggerWorkflowsForPages(tx, [movedPageId])
     await tx.delete(taskItems).where(eq(taskItems.pageId, movedPageId))
   }
 
@@ -346,8 +473,11 @@ export async function backfillMissingTaskItems(
   if (missing.length === 0) return
 
   await database.transaction(async (tx) => {
+    // parentId is fixed for the whole loop, so its seed status is resolved once
+    // rather than re-queried for every missing row on this hot read path.
+    const seedStatusCache = new Map<string, string>()
     for (const pageId of missing) {
-      await addTaskItemUnderParent(tx, { pageId, parentId, userId })
+      await addTaskItemUnderParent(tx, { pageId, parentId, userId, seedStatusCache })
     }
   })
 }

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -273,7 +273,8 @@ export async function scrubDriveScopedTaskAssociations(
   // An agent that travelled WITH the task is not stale — moving a project folder that
   // contains both a task list and the agent it assigns work to must not silently drop
   // the assignment. Only agents left behind in the old drive are scrubbed.
-  const staleAgentIds = await resolveAgentsOutsideDrive(tx, [...agentPageIds], targetDriveId)
+  const residency: DriveResidency = new Map()
+  const staleAgentIds = await resolveAgentsOutsideDrive(tx, [...agentPageIds], targetDriveId, residency)
 
   // Trigger staleness is resolved SEPARATELY from assignment staleness. A trigger's
   // agent comes from workflows.agentPageId, which PUT /api/tasks/:id/triggers sets
@@ -283,7 +284,7 @@ export async function scrubDriveScopedTaskAssociations(
   // pointing at a source-drive agent, which is the leak this whole function exists to
   // stop. Workflows whose agent came along are repointed at the new drive instead of
   // being deleted, since their driveId is stamped once at creation and never rewritten.
-  await reconcileTaskTriggerWorkflows(tx, taskItemIds, targetDriveId)
+  await reconcileTaskTriggerWorkflows(tx, taskItemIds, targetDriveId, residency)
 
   if (staleAgentIds.length === 0) return
 
@@ -346,6 +347,7 @@ async function reconcileTaskTriggerWorkflows(
   tx: Tx,
   taskItemIds: string[],
   targetDriveId: string,
+  residency: DriveResidency = new Map(),
 ): Promise<void> {
   const byAgent = new Map<string, string[]>()
   const instructionPageByWorkflow = new Map<string, string>()
@@ -369,7 +371,7 @@ async function reconcileTaskTriggerWorkflows(
   if (byAgent.size === 0) return
 
   const staleTriggerAgents = new Set(
-    await resolveAgentsOutsideDrive(tx, [...byAgent.keys()], targetDriveId),
+    await resolveAgentsOutsideDrive(tx, [...byAgent.keys()], targetDriveId, residency),
   )
 
   const doomed: string[] = []
@@ -398,7 +400,7 @@ async function reconcileTaskTriggerWorkflows(
     ...new Set(survivingWithInstruction.map((id) => instructionPageByWorkflow.get(id)!)),
   ]
   const strandedInstructionPages = new Set(
-    await resolvePagesOutsideDrive(tx, instructionPageIds, targetDriveId),
+    await resolvePagesOutsideDrive(tx, instructionPageIds, targetDriveId, residency),
   )
   const workflowsToClear = survivingWithInstruction.filter((id) =>
     strandedInstructionPages.has(instructionPageByWorkflow.get(id)!),
@@ -418,22 +420,30 @@ async function deleteTaskTriggerWorkflowsForPages(tx: Tx, pageIds: string[]): Pr
   await deleteTaskTriggerWorkflows(tx, rows.map((row) => row.id))
 }
 
+/**
+ * pageId -> "did this page end up in the target drive". Shared across one scrub so the
+ * assignee agents and the trigger agents — usually the same pages — are looked up once.
+ */
+type DriveResidency = Map<string, boolean>
+
 /** The subset of `pageIds` that do NOT live in `driveId` — i.e. did not travel. */
 async function resolvePagesOutsideDrive(
   tx: Tx,
   pageIds: string[],
   driveId: string,
+  residency: DriveResidency = new Map(),
 ): Promise<string[]> {
   if (pageIds.length === 0) return []
-  const inDrive = new Set<string>()
-  for (const batch of chunk(pageIds, SCRUB_CHUNK_SIZE)) {
+  const unresolved = [...new Set(pageIds.filter((id) => !residency.has(id)))]
+  for (const batch of chunk(unresolved, SCRUB_CHUNK_SIZE)) {
     const rows = await tx
       .select({ id: pages.id })
       .from(pages)
       .where(and(inArray(pages.id, batch), eq(pages.driveId, driveId)))
-    for (const row of rows) inDrive.add(row.id)
+    const found = new Set(rows.map((row) => row.id))
+    for (const id of batch) residency.set(id, found.has(id))
   }
-  return pageIds.filter((id) => !inDrive.has(id))
+  return pageIds.filter((id) => !residency.get(id))
 }
 
 /** Agent pages that stayed behind. Same question, named for its caller. */

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, inArray } from '@pagespace/db/operators'
+import { eq, and, asc, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
 import {
@@ -90,18 +90,77 @@ export async function ensureTaskListForPage(
  * Idempotent — does nothing if the row already exists. Ensures the parent's
  * `task_lists` row and default status configs exist first.
  */
+/**
+ * Upper bound on the status vocabulary scanned when remapping. Lists carry 4 defaults
+ * and a handful of custom statuses; the cap exists to satisfy the unbounded-findMany
+ * rule, and overshooting it could only cost a remap to a different valid slug.
+ */
+const STATUS_CONFIG_REMAP_LIMIT = 200
+
+/**
+ * Keep a PRESERVED task row's status inside its new list's vocabulary.
+ *
+ * `task_items.status` is a bare slug with no foreign key; its meaning comes from the
+ * owning list's `task_status_configs`, unique per (taskListId, slug). Every write path
+ * enforces that — POST/PATCH reject an unknown slug, and deleting a config demands a
+ * migrateToSlug — so a move is the only way to produce a task whose status its list
+ * does not define. Left alone, such a task falls into the board's first column
+ * regardless of meaning, renders its raw slug as a badge, drops out of status-filtered
+ * queries, and (when the slug was a done one) shows unticked while `completedAt` still
+ * counts it complete in the parent's progress.
+ *
+ * Re-mapping uses `completedAt`, which lives on the row itself and is list-independent,
+ * so a finished task stays finished and an unfinished one stays actionable.
+ */
+async function normalizeStatusForList(
+  tx: Tx,
+  params: { item: { id: string; status: string; completedAt: Date | null }; taskListId: string },
+): Promise<void> {
+  const { item, taskListId } = params
+
+  // Fast path: one indexed lookup on the (taskListId, slug) unique key. The status is
+  // valid for its new list in every case except the one this function exists for, so
+  // the full vocabulary is only fetched when a remap is actually needed.
+  const alreadyValid = await tx.query.taskStatusConfigs.findFirst({
+    where: and(
+      eq(taskStatusConfigs.taskListId, taskListId),
+      eq(taskStatusConfigs.slug, item.status),
+    ),
+  })
+  if (alreadyValid) return
+
+  const configs = await tx.query.taskStatusConfigs.findMany({
+    where: eq(taskStatusConfigs.taskListId, taskListId),
+    orderBy: [asc(taskStatusConfigs.position)],
+    limit: STATUS_CONFIG_REMAP_LIMIT,
+  })
+  // A list with no configs at all has no vocabulary to conform to.
+  if (configs.length === 0) return
+
+  const wantedGroup = item.completedAt ? 'done' : 'todo'
+  const replacement = configs.find((config) => config.group === wantedGroup) ?? configs[0]
+
+  await tx
+    .update(taskItems)
+    .set({ status: replacement.slug })
+    .where(eq(taskItems.id, item.id))
+}
+
 async function addTaskItemUnderParent(
   tx: Tx,
   params: { pageId: string; parentId: string; userId: string },
 ): Promise<void> {
   const { pageId, parentId, userId } = params
 
-  await ensureTaskListForPage(tx, { pageId: parentId, title: 'Task List', userId })
+  const taskList = await ensureTaskListForPage(tx, { pageId: parentId, title: 'Task List', userId })
 
   const existing = await tx.query.taskItems.findFirst({
     where: eq(taskItems.pageId, pageId),
   })
-  if (existing) return
+  if (existing) {
+    await normalizeStatusForList(tx, { item: existing, taskListId: taskList.id })
+    return
+  }
 
   // ON CONFLICT DO NOTHING guards the self-heal race: concurrent GETs on a legacy list
   // can both pass the findFirst check above, and task_items.pageId is unique — without
@@ -143,9 +202,11 @@ export async function syncTaskItemOnMove(
     oldParentId: string | null;
     newParentId: string | null;
     userId: string;
+    /** True when the move crosses a drive boundary — see resolveTaskItemSyncAction. */
+    crossDrive?: boolean;
   }
 ): Promise<void> {
-  const { movedPageId, movedPageType, oldParentId, newParentId, userId } = params
+  const { movedPageId, movedPageType, oldParentId, newParentId, userId, crossDrive } = params
 
   // Cheap guards before any parent lookups.
   if (movedPageType !== TASK_LIST_TYPE || oldParentId === newParentId) return
@@ -159,6 +220,7 @@ export async function syncTaskItemOnMove(
     newParentId,
     oldParentType,
     newParentType,
+    crossDrive,
   })
 
   if (action.shouldRemove) {

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -1,7 +1,9 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, asc, inArray } from '@pagespace/db/operators'
+import { eq, and, asc, inArray, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
-import { taskLists, taskItems, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
+import { taskLists, taskItems, taskAssignees, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
+import { taskTriggers } from '@pagespace/db/schema/task-triggers'
+import { workflows } from '@pagespace/db/schema/workflows'
 import {
   TASK_LIST_TYPE,
   shouldHaveTaskItem,
@@ -137,13 +139,101 @@ async function normalizeStatusForList(
   // A list with no configs at all has no vocabulary to conform to.
   if (configs.length === 0) return
 
-  const wantedGroup = item.completedAt ? 'done' : 'todo'
-  const replacement = configs.find((config) => config.group === wantedGroup) ?? configs[0]
+  // Never fall back across the done boundary. PUT /tasks/statuses validates each
+  // config's group but does not guarantee a list retains one of each, so a plain
+  // `?? configs[0]` could drop an unfinished task onto a done-group slug (ticked and
+  // struck through while every completedAt-based count still calls it incomplete) or
+  // the reverse. Completed work stays in a done slug or, failing that, the last one;
+  // unfinished work stays in any non-done slug.
+  const replacement = item.completedAt
+    ? (configs.find((config) => config.group === 'done') ?? configs[configs.length - 1])
+    : (configs.find((config) => config.group === 'todo')
+        ?? configs.find((config) => config.group !== 'done')
+        ?? configs[0])
 
   await tx
     .update(taskItems)
     .set({ status: replacement.slug })
     .where(eq(taskItems.id, item.id))
+}
+
+/**
+ * The slug a brand-new task should start in for THIS list. Defaults to 'pending' only
+ * when the list still defines it; a list whose owner deleted that status (permitted via
+ * migrateToSlug) gets its own first todo-group slug instead, so the seed can never be a
+ * status its own list does not define.
+ */
+async function resolveSeedStatus(tx: Tx, taskListId: string): Promise<string> {
+  const defaultSlug = DEFAULT_TASK_STATUSES[0].slug
+  const hasDefault = await tx.query.taskStatusConfigs.findFirst({
+    where: and(
+      eq(taskStatusConfigs.taskListId, taskListId),
+      eq(taskStatusConfigs.slug, defaultSlug),
+    ),
+  })
+  if (hasDefault) return defaultSlug
+
+  const configs = await tx.query.taskStatusConfigs.findMany({
+    where: eq(taskStatusConfigs.taskListId, taskListId),
+    orderBy: [asc(taskStatusConfigs.position)],
+    limit: STATUS_CONFIG_REMAP_LIMIT,
+  })
+  const seed = configs.find((config) => config.group === 'todo')
+    ?? configs.find((config) => config.group !== 'done')
+    ?? configs[0]
+  return seed?.slug ?? defaultSlug
+}
+
+/**
+ * Drop the associations on a task row that are scoped to the drive it just LEFT.
+ *
+ * A cross-drive move preserves the row — priority, dueDate, metadata and human
+ * assignees are all drive-independent — but three things are not, and the task write
+ * paths actively refuse to create them across a boundary:
+ *   • `assigneeAgentId` and `task_assignees.agentPageId` name agent pages in the old
+ *     drive; left in place, a drive-A agent's title renders to every drive-B viewer and
+ *     cannot be edited away, because a PATCH re-sending that agent id now 400s.
+ *   • `task_triggers` link the task to `workflows`, which carry their own NOT NULL
+ *     driveId; a drive-B member completing the task would otherwise fire a drive-A
+ *     agent run seeded with drive-B content.
+ *
+ * The workflows rows are deleted FIRST and by explicit id: `task_triggers.taskItemId`
+ * cascades from `task_items`, so any approach that removes triggers first leaves the
+ * workflows behind, orphaned and unreachable (the hazard task-trigger-helpers'
+ * disableTaskTriggers documents). Everything runs in the caller's transaction, so a
+ * failed move takes the scrub with it.
+ */
+export async function scrubDriveScopedTaskAssociations(
+  tx: Tx,
+  params: { pageIds: string[] },
+): Promise<void> {
+  const { pageIds } = params
+  if (pageIds.length === 0) return
+
+  const rows = await tx
+    .select({ id: taskItems.id })
+    .from(taskItems)
+    .where(inArray(taskItems.pageId, pageIds))
+  if (rows.length === 0) return
+  const taskItemIds = rows.map((row) => row.id)
+
+  const triggerRows = await tx
+    .select({ workflowId: taskTriggers.workflowId })
+    .from(taskTriggers)
+    .where(inArray(taskTriggers.taskItemId, taskItemIds))
+  if (triggerRows.length > 0) {
+    // Deleting the workflow cascades its task_triggers rows away.
+    await tx.delete(workflows).where(inArray(workflows.id, triggerRows.map((r) => r.workflowId)))
+  }
+
+  await tx
+    .delete(taskAssignees)
+    .where(and(inArray(taskAssignees.taskId, taskItemIds), isNotNull(taskAssignees.agentPageId)))
+
+  await tx
+    .update(taskItems)
+    .set({ assigneeAgentId: null })
+    .where(inArray(taskItems.id, taskItemIds))
 }
 
 async function addTaskItemUnderParent(
@@ -166,7 +256,7 @@ async function addTaskItemUnderParent(
   // can both pass the findFirst check above, and task_items.pageId is unique — without
   // this a second insert would 500 the read. The findFirst stays as a cheap fast path.
   await tx.insert(taskItems).values(
-    buildTaskItemInsert({ pageId, userId }),
+    buildTaskItemInsert({ pageId, userId, status: await resolveSeedStatus(tx, taskList.id) }),
   ).onConflictDoNothing({ target: taskItems.pageId })
 }
 
@@ -202,11 +292,9 @@ export async function syncTaskItemOnMove(
     oldParentId: string | null;
     newParentId: string | null;
     userId: string;
-    /** True when the move crosses a drive boundary — see resolveTaskItemSyncAction. */
-    crossDrive?: boolean;
   }
 ): Promise<void> {
-  const { movedPageId, movedPageType, oldParentId, newParentId, userId, crossDrive } = params
+  const { movedPageId, movedPageType, oldParentId, newParentId, userId } = params
 
   // Cheap guards before any parent lookups.
   if (movedPageType !== TASK_LIST_TYPE || oldParentId === newParentId) return
@@ -220,7 +308,6 @@ export async function syncTaskItemOnMove(
     newParentId,
     oldParentType,
     newParentType,
-    crossDrive,
   })
 
   if (action.shouldRemove) {

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, ne, and, asc, inArray, isNotNull } from '@pagespace/db/operators'
+import { eq, and, asc, inArray, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskAssignees, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
 import { taskTriggers } from '@pagespace/db/schema/task-triggers'
@@ -132,8 +132,11 @@ function isGroupConsistentWithCompletion(group: string, completedAt: Date | null
  * queries, and (when the slug was a done one) shows unticked while `completedAt` still
  * counts it complete in the parent's progress.
  *
- * Re-mapping uses `completedAt`, which lives on the row itself and is list-independent,
- * so a finished task stays finished and an unfinished one stays actionable.
+ * Two different repairs, depending on which side is wrong. When the destination DOES
+ * define the slug, the status stands and any disagreement with `completedAt` is fixed
+ * on `completedAt` — the derived field. Only when the slug is absent entirely is the
+ * status itself remapped, and then `completedAt` is the intent signal, so a finished
+ * task stays finished and an unfinished one stays actionable.
  */
 async function normalizeStatusForList(
   tx: Tx,
@@ -153,7 +156,21 @@ async function normalizeStatusForList(
       eq(taskStatusConfigs.slug, item.status),
     ),
   })
-  if (alreadyValid && isGroupConsistentWithCompletion(alreadyValid.group, item.completedAt)) return
+  if (alreadyValid) {
+    // The slug is meaningful in this list, so the status stands. If completedAt
+    // disagrees with the config's group, completedAt is the field that drifted: it is
+    // DERIVED — the task PATCH route stamps and clears it from the group — whereas the
+    // status is what the user last chose and sees. Regrouping a status in place, or
+    // deleting one with migrateToSlug, both leave exactly this divergence behind
+    // entirely within one list, so reconciling it must not rewrite the user's choice.
+    if (!isGroupConsistentWithCompletion(alreadyValid.group, item.completedAt)) {
+      await tx
+        .update(taskItems)
+        .set({ completedAt: alreadyValid.group === 'done' ? new Date() : null })
+        .where(eq(taskItems.id, item.id))
+    }
+    return
+  }
 
   const configs = await tx.query.taskStatusConfigs.findMany({
     where: eq(taskStatusConfigs.taskListId, taskListId),
@@ -270,9 +287,12 @@ export async function scrubDriveScopedTaskAssociations(
   // the assignment. Only agents left behind in the old drive are scrubbed.
   const staleAgentIds = await resolveAgentsOutsideDrive(tx, [...agentPageIds], targetDriveId)
 
-  await deleteTaskTriggerWorkflows(tx, taskItemIds, { exceptInDriveId: targetDriveId })
-
+  // A trigger is stale for the same reason its assignment is: the AGENT it runs stayed
+  // behind. Testing workflows.driveId instead would delete every surviving trigger,
+  // because that column is stamped once at creation and never rewritten — after a move
+  // it always names the source drive.
   if (staleAgentIds.length === 0) return
+  await deleteTaskTriggerWorkflows(tx, taskItemIds, { onlyForAgentIds: staleAgentIds })
 
   for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
     await tx
@@ -302,8 +322,11 @@ export async function scrubDriveScopedTaskAssociations(
 async function deleteTaskTriggerWorkflows(
   tx: Tx,
   taskItemIds: string[],
-  options?: { exceptInDriveId?: string },
+  options?: { onlyForAgentIds?: string[] },
 ): Promise<void> {
+  const agentIds = options?.onlyForAgentIds
+  if (agentIds && agentIds.length === 0) return
+
   for (const batch of chunk(taskItemIds, SCRUB_CHUNK_SIZE)) {
     const triggerRows = await tx
       .select({ workflowId: taskTriggers.workflowId })
@@ -312,11 +335,13 @@ async function deleteTaskTriggerWorkflows(
     if (triggerRows.length === 0) continue
     const workflowIds = triggerRows.map((row) => row.workflowId)
     for (const wfBatch of chunk(workflowIds, SCRUB_CHUNK_SIZE)) {
-      await tx.delete(workflows).where(
-        options?.exceptInDriveId
-          ? and(inArray(workflows.id, wfBatch), ne(workflows.driveId, options.exceptInDriveId))
-          : inArray(workflows.id, wfBatch),
-      )
+      for (const agentBatch of agentIds ? chunk(agentIds, SCRUB_CHUNK_SIZE) : [null]) {
+        await tx.delete(workflows).where(
+          agentBatch
+            ? and(inArray(workflows.id, wfBatch), inArray(workflows.agentPageId, agentBatch))
+            : inArray(workflows.id, wfBatch),
+        )
+      }
     }
   }
 }

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -88,11 +88,6 @@ export async function ensureTaskListForPage(
 }
 
 /**
- * Create the `task_items` row for a page under a known TASK_LIST parent.
- * Idempotent — does nothing if the row already exists. Ensures the parent's
- * `task_lists` row and default status configs exist first.
- */
-/**
  * Upper bound on the status vocabulary scanned when remapping. Lists carry 4 defaults
  * and a handful of custom statuses; the cap exists to satisfy the unbounded-findMany
  * rule, and overshooting it could only cost a remap to a different valid slug.
@@ -426,6 +421,9 @@ async function deleteTaskTriggerWorkflowsForPages(tx: Tx, pageIds: string[]): Pr
  */
 type DriveResidency = Map<string, boolean>
 
+/** Memo key. Includes the drive so one memo can never answer for a different one. */
+const residencyKey = (driveId: string, pageId: string) => `${driveId}:${pageId}`
+
 /** The subset of `pageIds` that do NOT live in `driveId` — i.e. did not travel. */
 async function resolvePagesOutsideDrive(
   tx: Tx,
@@ -434,21 +432,29 @@ async function resolvePagesOutsideDrive(
   residency: DriveResidency = new Map(),
 ): Promise<string[]> {
   if (pageIds.length === 0) return []
-  const unresolved = [...new Set(pageIds.filter((id) => !residency.has(id)))]
+  const unresolved = [...new Set(pageIds.filter((id) => !residency.has(residencyKey(driveId, id))))]
   for (const batch of chunk(unresolved, SCRUB_CHUNK_SIZE)) {
     const rows = await tx
       .select({ id: pages.id })
       .from(pages)
       .where(and(inArray(pages.id, batch), eq(pages.driveId, driveId)))
     const found = new Set(rows.map((row) => row.id))
-    for (const id of batch) residency.set(id, found.has(id))
+    // Every id in the batch is recorded, including the ones the query did not return —
+    // that is the `false` case, and it is what keeps the lookup below total.
+    for (const id of batch) residency.set(residencyKey(driveId, id), found.has(id))
   }
-  return pageIds.filter((id) => !residency.get(id))
+  return pageIds.filter((id) => !residency.get(residencyKey(driveId, id)))
 }
 
 /** Agent pages that stayed behind. Same question, named for its caller. */
 const resolveAgentsOutsideDrive = resolvePagesOutsideDrive
 
+/**
+ * Create the `task_items` row for a page under a known TASK_LIST parent.
+ * Idempotent — does nothing if the row already exists. Ensures the parent's
+ * `task_lists` row and default status configs exist first, and brings a
+ * pre-existing row's status into the destination list's vocabulary.
+ */
 async function addTaskItemUnderParent(
   tx: Tx,
   params: {

--- a/packages/lib/src/permissions/agent-permissions.ts
+++ b/packages/lib/src/permissions/agent-permissions.ts
@@ -70,6 +70,24 @@ export async function hasAgentDriveMembership(agentPageId: string, driveId: stri
   return row.length > 0;
 }
 
+/**
+ * Whether an agent's membership in a drive carries an ADMINISTRATIVE role.
+ *
+ * Distinct from `hasAgentDriveMembership`, which answers only "is there a row"
+ * and ignores `role` entirely. Callers that gate a drive-level administrative
+ * action (e.g. accepting pages INTO a drive on a cross-drive move, where the
+ * REST equivalent demands OWNER/ADMIN) must use this instead, or a plain MEMBER
+ * agent clears a bar the same operation denies to a human.
+ */
+export async function hasAgentDriveAdminRole(agentPageId: string, driveId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ role: driveAgentMembers.role })
+    .from(driveAgentMembers)
+    .where(and(eq(driveAgentMembers.agentPageId, agentPageId), eq(driveAgentMembers.driveId, driveId)))
+    .limit(1);
+  return row?.role === 'OWNER' || row?.role === 'ADMIN';
+}
+
 export async function getAgentAccessiblePagesInDrive(
   agentPageId: string,
   driveId: string,

--- a/packages/lib/src/permissions/agent-permissions.ts
+++ b/packages/lib/src/permissions/agent-permissions.ts
@@ -80,12 +80,8 @@ export async function hasAgentDriveMembership(agentPageId: string, driveId: stri
  * agent clears a bar the same operation denies to a human.
  */
 export async function hasAgentDriveAdminRole(agentPageId: string, driveId: string): Promise<boolean> {
-  const [row] = await db
-    .select({ role: driveAgentMembers.role })
-    .from(driveAgentMembers)
-    .where(and(eq(driveAgentMembers.agentPageId, agentPageId), eq(driveAgentMembers.driveId, driveId)))
-    .limit(1);
-  return row?.role === 'OWNER' || row?.role === 'ADMIN';
+  const membership = await fetchAgentMembership(agentPageId, driveId);
+  return membership?.role === 'OWNER' || membership?.role === 'ADMIN';
 }
 
 export async function getAgentAccessiblePagesInDrive(


### PR DESCRIPTION
## Why

Content the assistant creates was getting stranded in the user's **Home** drive:

- `generate_image` **hard-coded** it — no drive/parent params at all; everything landed in a "Generated Images" folder at the Home root.
- `create_page` required an explicit `driveId` with **no fallback**, and the assistant frequently had none: `buildContextRef`'s `default:` arm collapsed every drive *sub*-route (`/dashboard/<id>/tasks`, `/members`, `/settings`, …) to `routeType: 'other'`, so `locationContext` resolved to `null`, the prompt said "operating from the dashboard", and the model guessed — usually Home.
- Once something landed there, **no agent tool could move it out**. `move_page` was same-drive only; cross-drive move existed solely in the REST/UI path (`/api/pages/bulk-move` + `MovePageDialog`).

All four pieces had to land for the loop to close: the assistant now creates in the drive the user is actually in, and when something does end up in Home it can relocate it — page plus subtree.

## What changed

**1. Shared cross-drive move service** — `apps/web/src/services/api/page-cross-drive-move-service.ts` (new)

Extracted from `bulk-move/route.ts` so the route and the AI tool share one validation order, transaction, descendant cascade, home-page invariant and activity trail. Principal-agnostic via an injected `CrossDriveMoveAuthorizer` (three closures) rather than a pure core plus wrappers — its authorization questions are interleaved with reads it must do anyway (you can't ask "may you administer the destination" before confirming it exists, nor "may you edit each source page" before loading the rows whose `title` the 403 message embeds). Failure messages are carried verbatim, so the route's responses are byte-identical.

The recursive descendant cascade became a level-wise **BFS with a visited set and a depth cap**. `pages.parentId` has no self-FK, so a cycle is representable, and the recursive version would have followed it forever *while holding an open transaction*. The cap fires only when a level beyond the ceiling still has unvisited nodes — that is what "this is a cycle" means, and it avoids aborting a legitimately deep subtree after every node was already rewritten.

**2. `move_page` gains `targetDriveId`** — `page-write-tools.ts`

Extended the existing tool rather than adding a new one: `chat/route.ts` filters against each agent's **saved** `enabledTools` array, so a new tool name would be invisible to every already-configured page agent until its owner re-saved Settings. It also avoids edits to `tool-filtering.ts`, the `CATEGORY_MAP`, three tool-call renderers, and the `WORKSPACE_TOOL_COUNT` doc-count assertions.

`execute()` branches **once, up front** into `moveWithinDrive` / `moveAcrossDrives` with zero shared authorization code. `targetDriveId === page.driveId` deliberately takes the same-drive path, so a model echoing back the current workspace id can't quietly swap which bar applies.

The destination gate is `canActorAdministerDrive` (new), **not** `canActorManageDrive`. The latter resolves an agent actor to `hasAgentDriveMembership` — bare row existence, ignoring `driveAgentMembers.role` — which would have let a plain MEMBER agent pull a subtree into a drive that `bulk-move` guards with OWNER/ADMIN for humans. `canActorManageDrive` is left untouched so no other tool's authority model shifts.

**3–4. The assistant stops guessing** — `buildContextRef.ts`, `tab-title.ts`, `drive-context-defaults.ts` (new), `types.ts`, `chat/route.ts`

`parseTabPath` already returned `driveId` for drive sub-routes; only `buildContextRef` threw it away. Those routes now resolve as `routeType: 'drive'`, inheriting the same `isPrincipalDriveMember` gate the bare drive route already passed through.

A `resolveDefaultDriveId` / `resolveOrThrowDriveId` seam mirrors the page one, adopted by `create_page` (parent-first — an explicit parent names the drive unambiguously and must beat any location guess), `list_pages`, `regex_search`, `glob_search`. The read tools echo `scopeSource`, because a defaulted scope that searched the wrong workspace returns an empty list, and an empty list reads as "it doesn't exist". Drive administration and trash tools deliberately keep requiring an explicit target. `create_page` and `create_drive` both park the agent in the workspace they wrote to for the rest of the turn.

`chat/route.ts` now normalizes **both** location sources to one `LocationContext` and builds the model prompt *and* `experimental_context` from it. Deriving the prompt from `PageContext` alone left a drive-level route telling the model "operating from the dashboard" while its tools defaulted `driveId` to that very drive — `PageContext` cannot represent a drive-level location, which is the asymmetry the new `pageContextToLocationContext` adapter exists to absorb.

**5. `generate_image` targets a drive**

Optional `driveId` / `parentId`, authorized at the **tool** layer because `create-file-page` deliberately does not check. The check runs **before** `canConsumeAI` and the provider call: after generation, a permission failure would land in the `store_failed` path — billed, unsaved, and indistinguishable from an S3 outage. Explicit targets hard-fail; an *inferred* one degrades to the Home gallery and reports **which** fallback happened (`home_no_location` vs `home_unwritable_location`) — telling a user "no workspace was in view" when the real cause is a read-only workspace sends them to fix the wrong thing.

`targetDriveId` alone now means "that drive's Generated Images folder" rather than "that drive's root".

## Reviewer notes

**Accepted authority delta — please read.** `move_page` previously required owner/admin on the page's own drive for *any* move. The cross-drive path mirrors `/api/pages/bulk-move` instead: **edit on the source page + owner/admin on the DESTINATION drive**. So a user who is merely an editor in the source drive, but administers the destination, can now move a page out of a drive they don't administer. That is parity with what `MovePageDialog` already permits — not reach beyond the user's own — but it *is* a widening of this tool specifically. There's a test named to document it rather than leaving it for review to discover.

**The Home drive is not special-cased.** `drive-guards` blocks rename/trash/share/publish on Home, never move, and the REST path has always permitted it. Moving generated images and drafts out of Home is the entire point — there's a test pinning that decision against a future "helpful" Home guard.

**Also fixed on the way past:** `move_page` never called `validatePageMove`, so an agent could reparent a page under its own descendant and detach the subtree. Both REST move paths already ran that guard.

**Known follow-ups, deliberately not in scope** (all pre-existing): descendants of a cross-drive move get no revision bump and keep a stale `stateHash`; `nextPosition` is computed once before the transaction, so concurrent moves into the same parent can collide; `pagePermissions` grants survive a cross-drive move; and a lock-order inversion between this path and `PATCH /api/pages/{id}/tasks/{taskId}` — `applyPageMutation` takes a global advisory lock before `syncTaskItemOnMove` takes `task_items` row locks, while the task PATCH route takes them in the opposite order, so a concurrent move + task edit can deadlock. Pre-existing via `pageReorderService.reorderPage`; Postgres detects it and aborts one side with a clean error rather than hanging, and fixing the ordering properly is larger than this PR; `workflows.createdBy` still names the source-drive user after a cross-drive move, so a destination-drive member completing the task runs the workflow as that creator (resolving permissions and consuming provider keys as them) — rewriting it would falsify the audit trail, so the right treatment is a product decision rather than a silent fix; and moving only an AGENT page across drives while its tasks stay behind leaves those tasks with a cross-drive assignee, which no move path currently reaches (identical on master); and a STANDALONE workflow is stranded when its agent page moves drives — the scrub only reaches workflows through `task_triggers`, so a cron workflow whose agent emigrates keeps executing against the old drive, injecting its `drivePrompt` and defaulting the agent's tools back there. Already reachable via the REST bulk-move route, so not a regression, but this PR's `move_page` tool makes it reachable by an agent.

**Also fixed, having first mis-scoped it as a follow-up:** `move_page`'s same-drive path never ran `syncTaskItemOnMove`, so moving a `TASK_LIST` page in or out of a `TASK_LIST` parent left its `task_items` row stale — while every other move path (`page-reorder-service`, `bulk-delete`, and the new cross-drive service) kept it correct. I had deferred it believing it needed a transaction threaded through `applyPageMutation`; in fact `applyPageMutation` already accepts a `tx` and `pageReorderService.reorderPage` is an exact template, including the detail that passing your own `tx` makes the deferred workflow trigger the caller's to fire after commit. Ten lines, established pattern, so there was no good reason to leave a known-stale row behind.

**And a live data-loss bug that fix uncovered:** adding `syncTaskItemOnMove` to the AI path exposed a defect in the shared `resolveTaskItemSyncAction` helper — moving a `TASK_LIST` page between two `TASK_LIST` parents returned both `shouldRemove` and `shouldAdd`, so the row was deleted and re-inserted with bare defaults while `task_assignees` cascaded away. Dragging a task from one list to another silently discarded its status, priority, due date, metadata and every assignee — **on `/api/pages/reorder`, the existing UI drag path**, not just the new agent one. The row is keyed by `pageId` and carries no list pointer (membership derives from `pages.parentId`), so it never needed replacing. `shouldRemove` is now suppressed when the page lands in another task list **within the same drive**; `shouldAdd` stays true so the destination is still seeded. Two tests that asserted the destructive behavior are corrected, and new ones pin the case it destroyed.

A follow-up review of that fix found preserving the row *unconditionally* created two new hazards, both now closed. **Cross-drive moves reset the row again**, as before: `assigneeAgentId` and `task_assignees.agentPageId` point at agent pages the task write paths refuse from another drive, and `task_triggers` cascade into drive-scoped workflows — so carrying them across a boundary preserved references the product forbids creating (a drive-A agent's title rendered to drive-B viewers, unfixable via PATCH because that now 400s). And **a preserved row's status is remapped when its new list doesn't define that slug** — `task_items.status` is a bare slug resolved per-list, so a moved task could otherwise sit in the wrong board column, render a raw slug, vanish from filtered queries, and show unticked while `completedAt` still counted it done. The remap keys off `completedAt`, so a finished task stays finished; priority, due date, metadata and assignees are untouched.

## Verification

- `bun run typecheck` — clean. `bun run lint` — no errors.
- Test sweep over `lib/ai`, `lib/upload`, `services/api`, `api/pages`, `lib/tabs`, `api/ai`: **312 files pass**, 1 fails (`activity-tools`, which issues a real Postgres query — an environment gap in this worktree, and the file is untouched by this branch).

Regression gates that held with **zero edits** — these are the proof, not decoration:

- the 44-test `bulk-move` route contract suite (the extraction gate)
- the existing `move_page` cases (same-drive path unchanged)
- every `generate_image` billing test (hold/settle invariants)
- `tool-registry-docs.test.ts` (tool count unchanged — the payoff of extending `move_page`)

New coverage includes the authorizer contract, cascade batching, cycle termination, depth-cap boundaries on **both** sides, the home-page invariant, activity attribution, agent MEMBER-vs-ADMIN on the destination, drive-defaulting across five tools, and the location adapters.

## Manual check

From `/dashboard/<workDriveId>/tasks`, ask the global assistant to generate an image — it should land in the *work* drive, not Home. Then generate one from the bare `/dashboard` root (→ Home gallery, with the relocate hint in the tool result) and ask the assistant to move it into the work drive. Confirm the page appears there, disappears from Home, and that a nested folder moved this way carries its children (check `pages.driveId` on descendants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F43ssgrQB2i1HCHEjFo2P5




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI tools now support better drive/workspace scoping when `driveId` is omitted, returning clearer scoping metadata across browse/search and read tools.
  * AI page moves (and bulk moves) are now powered by a shared cross-workspace move workflow with richer destination details and stronger validation.
  * Image generation/upload now supports optional `driveId`/`parentId` targeting, with Home fallback when no editable workspace is in view.

* **Bug Fixes**
  * Improved drive membership/admin permission enforcement, circular-move handling, descendant drive updates, and Home-page invariants.
  * Strengthened task sync behavior during moves, including safer workflow cleanup and status vocabulary remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




