### PR TITLE
fix(security): degrade to conservative in-memory rate limiting when Postgres is down in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **A database outage no longer takes the whole platform down with it** — when Postgres
+  became unreachable (as in the recent OOM stalls), the rate limiter denied every request
+  platform-wide, turning a database incident into a total outage. Production now degrades to
+  a conservative per-instance in-memory limit at half the configured threshold: legitimate
+  users keep working, attackers face a *stricter* limit than usual, and nothing ever fails
+  open. A 30-second circuit breaker stops requests from waiting on the stalled database
+  (a single probe rechecks it each cooldown), the fallback's memory is hard-capped so an
+  identifier flood can't exhaust the process, and distributed enforcement resumes
+  automatically the moment Postgres recovers.
+
 - **A machine-bound agent addressing its own project's default checkout as `branch: "main"`/`"master"` is no longer silently denied** —
   a bound conversation's `target` only ever resolved against explicitly created branch worktrees, so a model reasoning in ordinary
   git terms (where "main" means "my own checkout") got refused with a generic scope error even when addressing itself. The system

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.integration.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.integration.test.ts
@@ -150,22 +150,29 @@ describe('distributed-rate-limit integration (Postgres)', () => {
     expect(atBoundary.allowed).toBe(false);
   }, 10_000); // bucket alignment + 1 window + DB round-trips can exceed default 5s
 
-  it('fails closed in production when DB is unavailable', async () => {
+  it('enforces a conservative in-memory limit in production when DB is unavailable', async () => {
     if (!dbAvailable) return;
 
     process.env.NODE_ENV = 'production';
     const cfg: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
-    const key = TEST_KEY_PREFIX + 'fail-closed';
+    const key = TEST_KEY_PREFIX + 'pg-down-fallback';
 
     vi.spyOn(db, 'insert').mockImplementation(() => {
       throw new Error('DB unavailable');
     });
 
-    const result = await checkDistributedRateLimit(key, cfg);
+    // Conservative threshold is floor(5/2) = 2 per instance: availability is
+    // preserved for legitimate users, but the limit still binds — and tighter
+    // than the configured one.
+    const first = await checkDistributedRateLimit(key, cfg);
+    expect(first.allowed).toBe(true);
 
-    expect(result.allowed).toBe(false);
-    expect(result.retryAfter).toBe(60);
-    expect(result.attemptsRemaining).toBe(0);
+    const second = await checkDistributedRateLimit(key, cfg);
+    expect(second.allowed).toBe(true);
+
+    const third = await checkDistributedRateLimit(key, cfg);
+    expect(third.allowed).toBe(false);
+    expect(third.retryAfter).toBeGreaterThan(0);
   });
 
   it('concurrent increments against the same bucket are atomic (final count === N)', async () => {

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -49,6 +49,8 @@ import {
   conservativeFallbackMaxAttempts,
   conservativeFallbackConfig,
   conservativeFallbackCheck,
+  sweepExpiredInMemoryAttempts,
+  MAX_IN_MEMORY_ATTEMPT_ENTRIES,
   DISTRIBUTED_RATE_LIMITS,
   type RateLimitConfig,
 } from '../distributed-rate-limit';
@@ -625,6 +627,82 @@ describe('distributed-rate-limit', () => {
       const afterExpiry = await checkDistributedRateLimit('expiry-test', config);
       expect(afterExpiry.allowed).toBe(true);
     });
+  });
+
+  describe('in-memory fallback memory bounds', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      mockInsertThrows(drizzleWrappedPgError());
+    });
+
+    it('sweeps entries once their window has fully elapsed, not on a fixed 25h cutoff', async () => {
+      const t0 = 1_000_000;
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+      try {
+        const config: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
+        await checkDistributedRateLimit('sweep-a', config);
+        await checkDistributedRateLimit('sweep-b', config);
+        await checkDistributedRateLimit('sweep-c', config);
+
+        expect(sweepExpiredInMemoryAttempts(t0 + 59_999)).toBe(0);
+        expect(sweepExpiredInMemoryAttempts(t0 + 60_000)).toBe(3);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('does not sweep an actively blocked entry before its block expires', async () => {
+      const t0 = 1_000_000;
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+      try {
+        // maxAttempts 2 → conservative threshold 1; second check trips the
+        // 10-minute block, which outlives the 1s window.
+        const config: RateLimitConfig = {
+          maxAttempts: 2,
+          windowMs: 1_000,
+          blockDurationMs: 600_000,
+        };
+        await checkDistributedRateLimit('sweep-blocked', config);
+        const blocked = await checkDistributedRateLimit('sweep-blocked', config);
+        expect(blocked.allowed).toBe(false);
+
+        // Window has elapsed but the block is live — evicting now would reset
+        // the counter and void the block.
+        expect(sweepExpiredInMemoryAttempts(t0 + 1_000)).toBe(0);
+        nowSpy.mockReturnValue(t0 + 1_000);
+        const stillBlocked = await checkDistributedRateLimit('sweep-blocked', config);
+        expect(stillBlocked.allowed).toBe(false);
+
+        expect(sweepExpiredInMemoryAttempts(t0 + 600_000)).toBe(1);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('caps distinct tracked identifiers, evicting oldest-first under identifier flood', async () => {
+      const config: RateLimitConfig = { maxAttempts: 4, windowMs: 60_000 };
+
+      for (let i = 0; i < MAX_IN_MEMORY_ATTEMPT_ENTRIES; i++) {
+        await checkDistributedRateLimit(`flood:${i}`, config);
+      }
+
+      // A new identifier past the cap is still admitted and enforced (not
+      // denied, not unlimited) — the oldest entry is evicted to make room.
+      const overCap = await checkDistributedRateLimit('flood:new', config);
+      expect(overCap.allowed).toBe(true);
+
+      // flood:0 was evicted, so its counter restarted: conservative threshold
+      // is floor(4/2) = 2, and a fresh first attempt reports 1 remaining. Had
+      // it survived the flood, this second attempt would report 0.
+      const evicted = await checkDistributedRateLimit('flood:0', config);
+      expect(evicted.allowed).toBe(true);
+      expect(evicted.attemptsRemaining).toBe(1);
+
+      // A recent identifier kept its counter: second attempt → 0 remaining.
+      const retained = await checkDistributedRateLimit(`flood:${MAX_IN_MEMORY_ATTEMPT_ENTRIES - 1}`, config);
+      expect(retained.allowed).toBe(true);
+      expect(retained.attemptsRemaining).toBe(0);
+    }, 30_000);
   });
 
   describe('conservativeFallbackMaxAttempts (pure)', () => {

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -363,6 +363,14 @@ describe('distributed-rate-limit', () => {
             expect(loggers.api.info).toHaveBeenCalledWith(
               'Distributed rate limiting enabled (Postgres)'
             );
+
+            // The successful probe fully closed the circuit (and released any
+            // half-open claim): the next request still goes to Postgres.
+            const probes = insertMock.mock.calls.length;
+            mockInsertReturning(2);
+            const next = await checkDistributedRateLimit('prod-recovery', testConfig);
+            expect(next.allowed).toBe(true);
+            expect(insertMock.mock.calls.length).toBe(probes + 1);
           } finally {
             nowSpy.mockRestore();
           }
@@ -380,6 +388,47 @@ describe('distributed-rate-limit', () => {
           expect(insertMock.mock.calls.length).toBe(probesAfterOpen);
           expect(second.allowed).toBe(true);
           expect(other.allowed).toBe(true);
+        });
+
+        it('serializes the half-open probe: concurrent requests do not stampede Postgres', async () => {
+          const t0 = 10_000_000;
+          const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+          try {
+            await checkDistributedRateLimit('herd', testConfig); // opens circuit
+
+            nowSpy.mockReturnValue(t0 + 31_000);
+            // Async-rejecting insert models the OOM-stalled pool: the probe
+            // hangs on its await instead of failing synchronously, so the
+            // other concurrent requests arrive while it is still in flight.
+            insertMock.mockImplementation(() => ({
+              values: () => ({
+                onConflictDoUpdate: () => ({
+                  returning: () => Promise.reject(drizzleWrappedPgError()),
+                }),
+              }),
+            }));
+            const probesBefore = insertMock.mock.calls.length;
+            const results = await Promise.all([
+              checkDistributedRateLimit('herd', testConfig),
+              checkDistributedRateLimit('herd', testConfig),
+              checkDistributedRateLimit('herd', testConfig),
+            ]);
+
+            // Exactly ONE request performed the half-open probe; the rest were
+            // served by the fallback without touching the stalled pool.
+            expect(insertMock.mock.calls.length).toBe(probesBefore + 1);
+            for (const r of results) {
+              expect(typeof r.allowed).toBe('boolean');
+            }
+
+            // The failed probe released its claim: after another cooldown the
+            // next request probes again rather than deadlocking on the flag.
+            nowSpy.mockReturnValue(t0 + 62_000);
+            await checkDistributedRateLimit('herd', testConfig);
+            expect(insertMock.mock.calls.length).toBe(probesBefore + 2);
+          } finally {
+            nowSpy.mockRestore();
+          }
         });
 
         it('re-probes once after the cooldown and re-opens on continued failure', async () => {

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -495,6 +495,41 @@ describe('distributed-rate-limit', () => {
           }
         });
 
+        it('a stale success from before the circuit opened does not close it', async () => {
+          // Two requests are in flight together while the circuit is closed.
+          // The failing one opens the circuit; the SLOWER success from the
+          // same batch must not clear the fresh cooldown — intermittent
+          // stalls produce exactly this interleaving, and a stale success
+          // would re-expose Postgres to the full request stream instead of
+          // the single half-open probe.
+          let resolveSlow!: (rows: { count: number }[]) => void;
+          const slowRows = new Promise<{ count: number }[]>((r) => {
+            resolveSlow = r;
+          });
+          insertMock
+            .mockImplementationOnce(() => ({
+              values: () => ({
+                onConflictDoUpdate: () => ({ returning: () => slowRows }),
+              }),
+            }))
+            .mockImplementationOnce(() => {
+              throw drizzleWrappedPgError();
+            });
+
+          const slowCheck = checkDistributedRateLimit('stale-a', testConfig); // in flight
+          const failed = await checkDistributedRateLimit('stale-b', testConfig); // opens circuit
+          expect(failed.allowed).toBe(true); // served by the fallback
+
+          resolveSlow([{ count: 1 }]);
+          const slow = await slowCheck; // stale success lands after the open
+          expect(slow.allowed).toBe(true);
+
+          // The circuit must still be open: the next request short-circuits.
+          const probes = insertMock.mock.calls.length;
+          await checkDistributedRateLimit('stale-c', testConfig);
+          expect(insertMock.mock.calls.length).toBe(probes);
+        });
+
         it('re-probes once after the cooldown and re-opens on continued failure', async () => {
           const t0 = 10_000_000;
           const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -679,6 +679,70 @@ describe('distributed-rate-limit', () => {
       }
     });
 
+    it('does not evict an actively blocked entry to admit new identifiers', async () => {
+      // maxAttempts 2 → conservative threshold 1; second check trips a long block.
+      const config: RateLimitConfig = {
+        maxAttempts: 2,
+        windowMs: 60_000,
+        blockDurationMs: 600_000,
+      };
+      await checkDistributedRateLimit('evict-victim', config);
+      const blocked = await checkDistributedRateLimit('evict-victim', config);
+      expect(blocked.allowed).toBe(false);
+
+      // The blocked entry is the oldest in the map. Flooding past the cap must
+      // not evict it — otherwise an attacker could flush their own block by
+      // spraying fresh identifiers.
+      for (let i = 0; i < MAX_IN_MEMORY_ATTEMPT_ENTRIES; i++) {
+        await checkDistributedRateLimit(`evict-flood:${i}`, config);
+      }
+
+      const still = await checkDistributedRateLimit('evict-victim', config);
+      expect(still.allowed).toBe(false);
+    }, 30_000);
+
+    it('denies everything when configured maxAttempts is 0, even in the fallback', async () => {
+      // PG-up semantics for maxAttempts 0 are "always deny" (count 1 > 0); the
+      // fallback must never be looser than the configured limit.
+      const config: RateLimitConfig = { maxAttempts: 0, windowMs: 60_000 };
+      const result = await checkDistributedRateLimit('zero-config', config);
+      expect(result.allowed).toBe(false);
+    });
+
+    it('re-arms the cleanup sweep when traffic resumes after shutdown', async () => {
+      vi.useFakeTimers();
+      try {
+        shutdownRateLimiting();
+        await checkDistributedRateLimit('rearm', { maxAttempts: 5, windowMs: 50 });
+        // One interval tick later the expired entry must already be gone —
+        // i.e. the insert re-armed the sweep the shutdown had cleared.
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+        expect(sweepExpiredInMemoryAttempts(Date.now())).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('characterizes bounded overage across a flapping outage (accepted trade-off)', async () => {
+      // Distributed and in-memory counters are disjoint by design: warming the
+      // in-memory map on every successful PG check would churn the capped store
+      // for all traffic. Worst case when PG flaps mid-window is configured +
+      // conservative threshold (~1.5x) per instance — bounded, and strictly
+      // tighter than the pre-fallback alternative of an unbounded bypass.
+      const config: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
+      mockInsertReturning(5);
+      const atLimit = await checkDistributedRateLimit('flap', config);
+      expect(atLimit.allowed).toBe(true);
+
+      mockInsertThrows(drizzleWrappedPgError());
+      const r1 = await checkDistributedRateLimit('flap', config);
+      const r2 = await checkDistributedRateLimit('flap', config);
+      const r3 = await checkDistributedRateLimit('flap', config);
+      expect(r1.allowed).toBe(true);
+      expect(r2.allowed).toBe(true);
+      expect(r3.allowed).toBe(false);
+    });
+
     it('caps distinct tracked identifiers, evicting oldest-first under identifier flood', async () => {
       const config: RateLimitConfig = { maxAttempts: 4, windowMs: 60_000 };
 

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -46,9 +46,23 @@ import {
   getDistributedRateLimitStatus,
   initializeDistributedRateLimiting,
   shutdownRateLimiting,
+  conservativeFallbackMaxAttempts,
+  conservativeFallbackConfig,
+  conservativeFallbackCheck,
   DISTRIBUTED_RATE_LIMITS,
   type RateLimitConfig,
 } from '../distributed-rate-limit';
+
+// Drizzle wraps driver errors: the pg fields (code, etc.) live on error.cause,
+// not the top-level error. Throw the wrapper shape the real code sees so tests
+// don't pass against a convenient flat error the production path never gets.
+function drizzleWrappedPgError(pgMessage = 'connection refused'): Error {
+  const cause = Object.assign(new Error(pgMessage), { code: 'ECONNREFUSED' });
+  return Object.assign(
+    new Error('Failed query: insert into "rate_limit_buckets" ...'),
+    { cause },
+  );
+}
 
 // Build a chainable mock for db.insert(...).values(...).onConflictDoUpdate(...).returning()
 function mockInsertReturning(count: number) {
@@ -274,34 +288,75 @@ describe('distributed-rate-limit', () => {
         expect(blocked.retryAfter).toBeGreaterThan(0);
       });
 
-      it('denies requests in production when DB unavailable (fail-closed)', async () => {
-        process.env.NODE_ENV = 'production';
-        mockInsertThrows(new Error('DB down'));
+      // testConfig.maxAttempts is 5 → conservative fallback threshold is
+      // floor(5/2) = 2 per instance.
+      describe('in production (conservative in-memory fallback)', () => {
+        beforeEach(() => {
+          process.env.NODE_ENV = 'production';
+          mockInsertThrows(drizzleWrappedPgError());
+        });
 
-        const { loggers } = await import('../../logging/logger-config');
-        const result = await checkDistributedRateLimit('prod-fallback', testConfig);
+        it('allows initial requests instead of denying everything', async () => {
+          const result = await checkDistributedRateLimit('prod-fallback', testConfig);
 
-        expect(result.allowed).toBe(false);
-        expect(result.retryAfter).toBe(60);
-        expect(result.attemptsRemaining).toBe(0);
-        expect(loggers.api.error).toHaveBeenCalledWith(
-          'Postgres unavailable in production - DENYING request (fail-closed)',
-          expect.any(Object)
-        );
-      });
+          expect(result.allowed).toBe(true);
+          expect(result.attemptsRemaining).toBe(1);
+        });
 
-      it('truncates long identifiers in the fail-closed log (safety)', async () => {
-        process.env.NODE_ENV = 'production';
-        mockInsertThrows(new Error('DB down'));
+        it('denies requests past the conservative threshold', async () => {
+          await checkDistributedRateLimit('prod-threshold', testConfig);
+          await checkDistributedRateLimit('prod-threshold', testConfig);
+          const blocked = await checkDistributedRateLimit('prod-threshold', testConfig);
 
-        const { loggers } = await import('../../logging/logger-config');
-        const longId = 'x'.repeat(50);
-        await checkDistributedRateLimit(longId, testConfig);
+          expect(blocked.allowed).toBe(false);
+          expect(blocked.retryAfter).toBeGreaterThan(0);
+        });
 
-        expect(loggers.api.error).toHaveBeenCalledWith(
-          'Postgres unavailable in production - DENYING request (fail-closed)',
-          expect.objectContaining({ identifier: expect.stringContaining('...') })
-        );
+        it('logs a WARN with the RATE_LIMIT_PG_FALLBACK marker and truncated identifier', async () => {
+          const { loggers } = await import('../../logging/logger-config');
+          const longId = 'x'.repeat(50);
+          await checkDistributedRateLimit(longId, testConfig);
+
+          expect(loggers.api.warn).toHaveBeenCalledWith(
+            expect.stringContaining('RATE_LIMIT_PG_FALLBACK'),
+            expect.objectContaining({ identifier: expect.stringContaining('...') })
+          );
+          expect(loggers.api.error).not.toHaveBeenCalled();
+        });
+
+        it('preserves window semantics: fallback counts expire after windowMs', async () => {
+          // maxAttempts 2 → conservative threshold 1.
+          const config: RateLimitConfig = { maxAttempts: 2, windowMs: 50 };
+
+          await checkDistributedRateLimit('prod-expiry', config);
+          const blocked = await checkDistributedRateLimit('prod-expiry', config);
+          expect(blocked.allowed).toBe(false);
+
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
+          const afterExpiry = await checkDistributedRateLimit('prod-expiry', config);
+          expect(afterExpiry.allowed).toBe(true);
+        });
+
+        it('resumes distributed enforcement after Postgres recovers, ignoring fallback counts', async () => {
+          const { loggers } = await import('../../logging/logger-config');
+
+          // Exhaust the conservative in-memory threshold during the outage.
+          await checkDistributedRateLimit('prod-recovery', testConfig);
+          await checkDistributedRateLimit('prod-recovery', testConfig);
+          const blocked = await checkDistributedRateLimit('prod-recovery', testConfig);
+          expect(blocked.allowed).toBe(false);
+
+          // Postgres comes back: the distributed count (1) is authoritative and
+          // the in-memory outage counts must not bleed into the decision.
+          mockInsertReturning(1);
+          const recovered = await checkDistributedRateLimit('prod-recovery', testConfig);
+          expect(recovered.allowed).toBe(true);
+          expect(recovered.attemptsRemaining).toBe(4);
+          expect(loggers.api.info).toHaveBeenCalledWith(
+            'Distributed rate limiting enabled (Postgres)'
+          );
+        });
       });
     });
   });
@@ -358,13 +413,27 @@ describe('distributed-rate-limit', () => {
       expect(status.attemptsRemaining).toBe(5);
     });
 
-    it('reports blocked in production when DB unavailable (fail-closed)', async () => {
+    it('reports conservative in-memory status in production when DB unavailable', async () => {
       process.env.NODE_ENV = 'production';
-      mockSelectThrows(new Error('DB down'));
+      mockSelectThrows(drizzleWrappedPgError());
 
+      // No attempts recorded → not blocked; remaining reflects the conservative
+      // threshold (floor(5/2) = 2), not the configured 5.
       const status = await getDistributedRateLimitStatus('prod-status', testConfig);
+      expect(status.blocked).toBe(false);
+      expect(status.attemptsRemaining).toBe(2);
+    });
+
+    it('reports blocked in production once fallback attempts reach the conservative threshold', async () => {
+      process.env.NODE_ENV = 'production';
+      mockInsertThrows(drizzleWrappedPgError());
+      mockSelectThrows(drizzleWrappedPgError());
+
+      await checkDistributedRateLimit('prod-status-blocked', testConfig);
+      await checkDistributedRateLimit('prod-status-blocked', testConfig);
+
+      const status = await getDistributedRateLimitStatus('prod-status-blocked', testConfig);
       expect(status.blocked).toBe(true);
-      expect(status.retryAfter).toBe(60);
       expect(status.attemptsRemaining).toBe(0);
     });
 
@@ -555,6 +624,74 @@ describe('distributed-rate-limit', () => {
 
       const afterExpiry = await checkDistributedRateLimit('expiry-test', config);
       expect(afterExpiry.allowed).toBe(true);
+    });
+  });
+
+  describe('conservativeFallbackMaxAttempts (pure)', () => {
+    it('halves the configured limit, rounding down', () => {
+      expect(conservativeFallbackMaxAttempts(5)).toBe(2);
+      expect(conservativeFallbackMaxAttempts(100)).toBe(50);
+    });
+
+    it('floors at 1 so legitimate users are never denied outright', () => {
+      expect(conservativeFallbackMaxAttempts(1)).toBe(1);
+      expect(conservativeFallbackMaxAttempts(2)).toBe(1);
+      expect(conservativeFallbackMaxAttempts(3)).toBe(1);
+    });
+
+    it('never exceeds the configured limit, even at degenerate values', () => {
+      expect(conservativeFallbackMaxAttempts(0)).toBe(0);
+    });
+  });
+
+  describe('conservativeFallbackConfig (pure)', () => {
+    it('reduces only maxAttempts, preserving window and block semantics', () => {
+      const config: RateLimitConfig = {
+        maxAttempts: 10,
+        windowMs: 60_000,
+        blockDurationMs: 30_000,
+        progressiveDelay: true,
+      };
+
+      expect(conservativeFallbackConfig(config)).toEqual({
+        maxAttempts: 5,
+        windowMs: 60_000,
+        blockDurationMs: 30_000,
+        progressiveDelay: true,
+      });
+    });
+  });
+
+  describe('conservativeFallbackCheck', () => {
+    const config: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
+
+    it('enforces the conservative threshold via the injected checker', () => {
+      const memCheck = vi.fn().mockReturnValue({ allowed: true, attemptsRemaining: 1 });
+
+      const result = conservativeFallbackCheck('inject-key', config, memCheck);
+
+      expect(memCheck).toHaveBeenCalledWith('inject-key', {
+        maxAttempts: 2,
+        windowMs: 60_000,
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('fails closed (never open) when the in-memory check itself throws', async () => {
+      const { loggers } = await import('../../logging/logger-config');
+      const memCheck = vi.fn(() => {
+        throw new Error('map corrupted');
+      });
+
+      const result = conservativeFallbackCheck('broken-key', config, memCheck);
+
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfter).toBe(60);
+      expect(result.attemptsRemaining).toBe(0);
+      expect(loggers.api.error).toHaveBeenCalledWith(
+        'Postgres unavailable in production - DENYING request (fail-closed)',
+        expect.any(Object)
+      );
     });
   });
 });

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -50,6 +50,7 @@ import {
   conservativeFallbackConfig,
   conservativeFallbackCheck,
   sweepExpiredInMemoryAttempts,
+  countAuthFailure,
   MAX_IN_MEMORY_ATTEMPT_ENTRIES,
   DISTRIBUTED_RATE_LIMITS,
   type RateLimitConfig,
@@ -342,22 +343,61 @@ describe('distributed-rate-limit', () => {
 
         it('resumes distributed enforcement after Postgres recovers, ignoring fallback counts', async () => {
           const { loggers } = await import('../../logging/logger-config');
+          const t0 = 10_000_000;
+          const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+          try {
+            // Exhaust the conservative in-memory threshold during the outage.
+            await checkDistributedRateLimit('prod-recovery', testConfig);
+            await checkDistributedRateLimit('prod-recovery', testConfig);
+            const blocked = await checkDistributedRateLimit('prod-recovery', testConfig);
+            expect(blocked.allowed).toBe(false);
 
-          // Exhaust the conservative in-memory threshold during the outage.
-          await checkDistributedRateLimit('prod-recovery', testConfig);
-          await checkDistributedRateLimit('prod-recovery', testConfig);
-          const blocked = await checkDistributedRateLimit('prod-recovery', testConfig);
-          expect(blocked.allowed).toBe(false);
+            // The probe cooldown elapses and Postgres is healthy again: the
+            // distributed count (1) is authoritative — outage-time in-memory
+            // counts (already blocked!) must not bleed into the decision.
+            nowSpy.mockReturnValue(t0 + 31_000);
+            mockInsertReturning(1);
+            const recovered = await checkDistributedRateLimit('prod-recovery', testConfig);
+            expect(recovered.allowed).toBe(true);
+            expect(recovered.attemptsRemaining).toBe(4);
+            expect(loggers.api.info).toHaveBeenCalledWith(
+              'Distributed rate limiting enabled (Postgres)'
+            );
+          } finally {
+            nowSpy.mockRestore();
+          }
+        });
 
-          // Postgres comes back: the distributed count (1) is authoritative and
-          // the in-memory outage counts must not bleed into the decision.
-          mockInsertReturning(1);
-          const recovered = await checkDistributedRateLimit('prod-recovery', testConfig);
-          expect(recovered.allowed).toBe(true);
-          expect(recovered.attemptsRemaining).toBe(4);
-          expect(loggers.api.info).toHaveBeenCalledWith(
-            'Distributed rate limiting enabled (Postgres)'
-          );
+        it('short-circuits Postgres probes while the outage cooldown is active', async () => {
+          await checkDistributedRateLimit('breaker-a', testConfig); // probe fails → circuit opens
+          const probesAfterOpen = insertMock.mock.calls.length;
+
+          const second = await checkDistributedRateLimit('breaker-a', testConfig);
+          const other = await checkDistributedRateLimit('breaker-b', testConfig);
+
+          // No further Postgres work while the circuit is open — the stalled
+          // pool must not accumulate probes — yet limits are still enforced.
+          expect(insertMock.mock.calls.length).toBe(probesAfterOpen);
+          expect(second.allowed).toBe(true);
+          expect(other.allowed).toBe(true);
+        });
+
+        it('re-probes once after the cooldown and re-opens on continued failure', async () => {
+          const t0 = 10_000_000;
+          const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+          try {
+            await checkDistributedRateLimit('breaker-reopen', testConfig); // opens circuit
+            const callsWhileOpen = insertMock.mock.calls.length;
+
+            nowSpy.mockReturnValue(t0 + 31_000);
+            await checkDistributedRateLimit('breaker-reopen', testConfig); // half-open probe fails
+            expect(insertMock.mock.calls.length).toBe(callsWhileOpen + 1);
+
+            await checkDistributedRateLimit('breaker-reopen', testConfig); // circuit re-opened
+            expect(insertMock.mock.calls.length).toBe(callsWhileOpen + 1);
+          } finally {
+            nowSpy.mockRestore();
+          }
         });
       });
     });
@@ -375,6 +415,22 @@ describe('distributed-rate-limit', () => {
         throw new Error('DB down');
       });
       await expect(resetDistributedRateLimit('fail-reset')).resolves.toBeUndefined();
+    });
+
+    it('skips the Postgres delete while the outage cooldown is active', async () => {
+      process.env.NODE_ENV = 'production';
+      mockInsertThrows(drizzleWrappedPgError());
+      const config: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
+      await checkDistributedRateLimit('reset-breaker', config); // opens circuit
+
+      deleteMock.mockClear();
+      await resetDistributedRateLimit('reset-breaker');
+      expect(deleteMock).not.toHaveBeenCalled();
+
+      // The in-memory side was still cleared: next check starts a fresh
+      // conservative window (first of 2 → 1 remaining).
+      const after = await checkDistributedRateLimit('reset-breaker', config);
+      expect(after.attemptsRemaining).toBe(1);
     });
   });
 
@@ -471,6 +527,19 @@ describe('distributed-rate-limit', () => {
       expect(status.retryAfter).toBeLessThanOrEqual(10);
     });
 
+    it('short-circuits status probes while the outage cooldown is active', async () => {
+      process.env.NODE_ENV = 'production';
+      mockInsertThrows(drizzleWrappedPgError());
+      await checkDistributedRateLimit('status-breaker', testConfig); // opens circuit
+
+      selectMock.mockClear();
+      const status = await getDistributedRateLimitStatus('status-breaker', testConfig);
+      expect(selectMock).not.toHaveBeenCalled();
+      // 1 of the conservative 2 attempts consumed during the outage.
+      expect(status.blocked).toBe(false);
+      expect(status.attemptsRemaining).toBe(1);
+    });
+
     it('includes weighted contribution from previous bucket', async () => {
       // Pin to bucket boundary: prevWeight = 1, effective = 1 + 10*1 = 11 → blocked.
       const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(60_000);
@@ -484,6 +553,22 @@ describe('distributed-rate-limit', () => {
       } finally {
         nowSpy.mockRestore();
       }
+    });
+  });
+
+  describe('countAuthFailure under outage cooldown', () => {
+    it('returns 0 without probing Postgres while the cooldown is active', async () => {
+      process.env.NODE_ENV = 'production';
+      mockInsertThrows(drizzleWrappedPgError());
+      await checkDistributedRateLimit('authfail-breaker', {
+        maxAttempts: 5,
+        windowMs: 60_000,
+      }); // opens circuit
+
+      const probes = insertMock.mock.calls.length;
+      const count = await countAuthFailure('user@example.com', 60_000);
+      expect(count).toBe(0);
+      expect(insertMock.mock.calls.length).toBe(probes);
     });
   });
 
@@ -680,11 +765,15 @@ describe('distributed-rate-limit', () => {
     });
 
     it('does not evict an actively blocked entry to admit new identifiers', async () => {
-      // maxAttempts 2 → conservative threshold 1; second check trips a long block.
+      // maxAttempts 2 → conservative threshold 1; second check trips the block.
+      // blockDurationMs equals windowMs deliberately: this is the
+      // FORM_SUBMISSION shape, where a blocked entry does NOT outlive newer
+      // window entries — eviction policies that merely prefer later-expiring
+      // entries still sacrifice this block.
       const config: RateLimitConfig = {
         maxAttempts: 2,
         windowMs: 60_000,
-        blockDurationMs: 600_000,
+        blockDurationMs: 60_000,
       };
       await checkDistributedRateLimit('evict-victim', config);
       const blocked = await checkDistributedRateLimit('evict-victim', config);
@@ -743,29 +832,76 @@ describe('distributed-rate-limit', () => {
       expect(r3.allowed).toBe(false);
     });
 
-    it('caps distinct tracked identifiers, evicting oldest-first under identifier flood', async () => {
+    it('denies previously unseen identifiers at capacity instead of evicting active counters', async () => {
       const config: RateLimitConfig = { maxAttempts: 4, windowMs: 60_000 };
 
       for (let i = 0; i < MAX_IN_MEMORY_ATTEMPT_ENTRIES; i++) {
         await checkDistributedRateLimit(`flood:${i}`, config);
       }
 
-      // A new identifier past the cap is still admitted and enforced (not
-      // denied, not unlimited) — the oldest entry is evicted to make room.
+      // Every tracked window is still active, so there is no safe slot: the
+      // unseen identifier is conservatively denied rather than resetting
+      // someone else's active limit (never fail open, never sacrifice a
+      // victim's counter to an identifier-rotation flood).
       const overCap = await checkDistributedRateLimit('flood:new', config);
-      expect(overCap.allowed).toBe(true);
+      expect(overCap.allowed).toBe(false);
+      expect(overCap.retryAfter).toBeGreaterThan(0);
 
-      // flood:0 was evicted, so its counter restarted: conservative threshold
-      // is floor(4/2) = 2, and a fresh first attempt reports 1 remaining. Had
-      // it survived the flood, this second attempt would report 0.
-      const evicted = await checkDistributedRateLimit('flood:0', config);
-      expect(evicted.allowed).toBe(true);
-      expect(evicted.attemptsRemaining).toBe(1);
+      // Existing counters were preserved: flood:0 is on its second attempt of
+      // the conservative threshold floor(4/2) = 2 → 0 remaining, not a fresh
+      // window.
+      const oldest = await checkDistributedRateLimit('flood:0', config);
+      expect(oldest.allowed).toBe(true);
+      expect(oldest.attemptsRemaining).toBe(0);
+    }, 30_000);
 
-      // A recent identifier kept its counter: second attempt → 0 remaining.
-      const retained = await checkDistributedRateLimit(`flood:${MAX_IN_MEMORY_ATTEMPT_ENTRIES - 1}`, config);
-      expect(retained.allowed).toBe(true);
-      expect(retained.attemptsRemaining).toBe(0);
+    it('reclaims expired entries at capacity instead of denying new identifiers', async () => {
+      const t0 = 10_000_000;
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+      try {
+        const config: RateLimitConfig = { maxAttempts: 4, windowMs: 60_000 };
+        for (let i = 0; i < MAX_IN_MEMORY_ATTEMPT_ENTRIES; i++) {
+          await checkDistributedRateLimit(`stale:${i}`, config);
+        }
+
+        // Every tracked window has elapsed: capacity is reclaimable, so a new
+        // identifier must be admitted, not denied.
+        nowSpy.mockReturnValue(t0 + 61_000);
+        const fresh = await checkDistributedRateLimit('stale:new', config);
+        expect(fresh.allowed).toBe(true);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    }, 30_000);
+
+    it('reclaims expired capacity beyond the bounded scan via a throttled full sweep', async () => {
+      const t0 = 10_000_000;
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+      try {
+        const longConfig: RateLimitConfig = { maxAttempts: 4, windowMs: 3_600_000 };
+        const shortConfig: RateLimitConfig = { maxAttempts: 4, windowMs: 60_000 };
+
+        // The oldest entries are long-lived and still active; everything
+        // behind them is expired but out of reach of the bounded scan.
+        for (let i = 0; i < 20; i++) {
+          await checkDistributedRateLimit(`long:${i}`, longConfig);
+        }
+        for (let i = 0; i < MAX_IN_MEMORY_ATTEMPT_ENTRIES - 20; i++) {
+          await checkDistributedRateLimit(`short:${i}`, shortConfig);
+        }
+
+        nowSpy.mockReturnValue(t0 + 61_000);
+        const fresh = await checkDistributedRateLimit('short:new', shortConfig);
+        expect(fresh.allowed).toBe(true);
+
+        // The long-lived active counters survived reclamation: second attempt
+        // on an existing window → 0 of the conservative 2 remaining.
+        const long0 = await checkDistributedRateLimit('long:0', longConfig);
+        expect(long0.allowed).toBe(true);
+        expect(long0.attemptsRemaining).toBe(0);
+      } finally {
+        nowSpy.mockRestore();
+      }
     }, 30_000);
   });
 

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -402,6 +402,38 @@ describe('distributed-rate-limit', () => {
           expect(other.allowed).toBe(true);
         });
 
+        it('a shorter block expiring does not reset the still-active window', async () => {
+          const t0 = 10_000_000;
+          const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+          try {
+            // The OAUTH_DEVICE_POLL shape: window far longer than the block.
+            // maxAttempts 4 → conservative threshold 2.
+            const config: RateLimitConfig = {
+              maxAttempts: 4,
+              windowMs: 300_000,
+              blockDurationMs: 60_000,
+            };
+            await checkDistributedRateLimit('farm', config);
+            await checkDistributedRateLimit('farm', config);
+            const blocked = await checkDistributedRateLimit('farm', config);
+            expect(blocked.allowed).toBe(false);
+
+            // The 1-min block expires while the 5-min window is still live:
+            // the counter must persist — a full reset would compound to ~5x
+            // the allowance per window (above even the configured limit).
+            nowSpy.mockReturnValue(t0 + 61_000);
+            const afterBlock = await checkDistributedRateLimit('farm', config);
+            expect(afterBlock.allowed).toBe(false);
+
+            // Once the WINDOW itself ends, a fresh allowance is correct.
+            nowSpy.mockReturnValue(t0 + 301_000);
+            const afterWindow = await checkDistributedRateLimit('farm', config);
+            expect(afterWindow.allowed).toBe(true);
+          } finally {
+            nowSpy.mockRestore();
+          }
+        });
+
         it('serializes the half-open probe: concurrent requests do not stampede Postgres', async () => {
           const t0 = 10_000_000;
           const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -51,6 +51,8 @@ import {
   conservativeFallbackCheck,
   sweepExpiredInMemoryAttempts,
   countAuthFailure,
+  boundedIdentifier,
+  isPgUnavailabilityError,
   MAX_IN_MEMORY_ATTEMPT_ENTRIES,
   DISTRIBUTED_RATE_LIMITS,
   type RateLimitConfig,
@@ -61,6 +63,16 @@ import {
 // don't pass against a convenient flat error the production path never gets.
 function drizzleWrappedPgError(pgMessage = 'connection refused'): Error {
   const cause = Object.assign(new Error(pgMessage), { code: 'ECONNREFUSED' });
+  return Object.assign(
+    new Error('Failed query: insert into "rate_limit_buckets" ...'),
+    { cause },
+  );
+}
+
+// Same wrapper shape, but with a server-returned SQLSTATE instead of a
+// driver-level errno — the server answered, it is not down.
+function drizzleWrappedSqlstateError(sqlstate: string, message: string): Error {
+  const cause = Object.assign(new Error(message), { code: sqlstate });
   return Object.assign(
     new Error('Failed query: insert into "rate_limit_buckets" ...'),
     { cause },
@@ -426,6 +438,58 @@ describe('distributed-rate-limit', () => {
             nowSpy.mockReturnValue(t0 + 62_000);
             await checkDistributedRateLimit('herd', testConfig);
             expect(insertMock.mock.calls.length).toBe(probesBefore + 2);
+          } finally {
+            nowSpy.mockRestore();
+          }
+        });
+
+        it('does not open the circuit for data errors the server actively returned', async () => {
+          // A hostile payload (e.g. an oversized OAuth client_id blowing the
+          // B-tree entry limit) fails only ITS insert, with a server-returned
+          // SQLSTATE. The server is alive — the process-wide circuit must not
+          // open, or the payload becomes a lever to degrade every instance to
+          // the conservative fallback while Postgres is healthy.
+          mockInsertThrows(
+            drizzleWrappedSqlstateError('54000', 'index row size exceeds maximum')
+          );
+          const first = await checkDistributedRateLimit('data-error', testConfig);
+          expect(first.allowed).toBe(true); // this request still gets limited via fallback
+
+          const probes = insertMock.mock.calls.length;
+          await checkDistributedRateLimit('data-error-b', testConfig);
+          expect(insertMock.mock.calls.length).toBe(probes + 1); // still probing Postgres
+        });
+
+        it('opens the circuit for connection-class SQLSTATE errors', async () => {
+          mockInsertThrows(drizzleWrappedSqlstateError('08006', 'connection failure'));
+          await checkDistributedRateLimit('conn-error', testConfig);
+
+          const probes = insertMock.mock.calls.length;
+          await checkDistributedRateLimit('conn-error-b', testConfig);
+          expect(insertMock.mock.calls.length).toBe(probes); // circuit open, no probe
+        });
+
+        it('throttles the fallback WARN to once per interval with a suppression count', async () => {
+          const { loggers } = await import('../../logging/logger-config');
+          const t0 = 10_000_000;
+          const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0);
+          try {
+            await checkDistributedRateLimit('warn-a', testConfig);
+            await checkDistributedRateLimit('warn-b', testConfig);
+            await checkDistributedRateLimit('warn-c', testConfig);
+            const markerWarns = vi
+              .mocked(loggers.api.warn)
+              .mock.calls.filter((c) => String(c[0]).includes('RATE_LIMIT_PG_FALLBACK'));
+            expect(markerWarns.length).toBe(1);
+
+            // Next interval: one WARN, carrying how many were suppressed.
+            nowSpy.mockReturnValue(t0 + 31_000);
+            await checkDistributedRateLimit('warn-d', testConfig);
+            const after = vi
+              .mocked(loggers.api.warn)
+              .mock.calls.filter((c) => String(c[0]).includes('RATE_LIMIT_PG_FALLBACK'));
+            expect(after.length).toBe(2);
+            expect(after[1][1]).toMatchObject({ suppressedSinceLastWarn: 2 });
           } finally {
             nowSpy.mockRestore();
           }
@@ -952,6 +1016,61 @@ describe('distributed-rate-limit', () => {
         nowSpy.mockRestore();
       }
     }, 30_000);
+
+    it('bounds oversized identifiers by hashing before storing them as map keys', async () => {
+      // Unbounded attacker-supplied identifiers (e.g. 10KB OAuth client_ids)
+      // would defeat the entry cap's memory bound. Keys longer than the bound
+      // are hashed — not truncated — so distinct identifiers stay distinct.
+      const config: RateLimitConfig = { maxAttempts: 4, windowMs: 60_000 };
+      const longId = 'x'.repeat(10_000) + 'suffix-a';
+
+      const first = await checkDistributedRateLimit(longId, config);
+      expect(first.attemptsRemaining).toBe(1);
+
+      // The stored key IS the bounded form: presenting the bounded form
+      // directly shares the oversized original's counter.
+      const { createHash } = await import('crypto');
+      const boundedForm = `h:${createHash('sha256').update(longId).digest('hex')}`;
+      const second = await checkDistributedRateLimit(boundedForm, config);
+      expect(second.attemptsRemaining).toBe(0);
+
+      // A different oversized identifier with the same prefix keeps its own
+      // counter (would collide under truncation).
+      const otherLong = 'x'.repeat(10_000) + 'suffix-b';
+      const fresh = await checkDistributedRateLimit(otherLong, config);
+      expect(fresh.attemptsRemaining).toBe(1);
+    });
+  });
+
+  describe('boundedIdentifier (pure)', () => {
+    it('returns identifiers within the bound unchanged', () => {
+      expect(boundedIdentifier('login:203.0.113.7')).toBe('login:203.0.113.7');
+      expect(boundedIdentifier('x'.repeat(128))).toBe('x'.repeat(128));
+    });
+
+    it('hashes oversized identifiers to fixed-length, distinct, stable keys', () => {
+      const a = boundedIdentifier('x'.repeat(200) + 'a');
+      const b = boundedIdentifier('x'.repeat(200) + 'b');
+      expect(a).not.toBe(b);
+      expect(a.length).toBeLessThanOrEqual(80);
+      expect(boundedIdentifier('x'.repeat(200) + 'a')).toBe(a);
+    });
+  });
+
+  describe('isPgUnavailabilityError (pure)', () => {
+    it('treats driver-level network errors and connection/resource/shutdown SQLSTATEs as outages', () => {
+      expect(isPgUnavailabilityError(drizzleWrappedPgError())).toBe(true); // ECONNREFUSED
+      expect(isPgUnavailabilityError(drizzleWrappedSqlstateError('08006', 'connection failure'))).toBe(true);
+      expect(isPgUnavailabilityError(drizzleWrappedSqlstateError('53300', 'too many connections'))).toBe(true);
+      expect(isPgUnavailabilityError(drizzleWrappedSqlstateError('57P01', 'terminating connection'))).toBe(true);
+      expect(isPgUnavailabilityError(new Error('socket hang up'))).toBe(true); // no code at all
+    });
+
+    it('treats server-returned data/logic errors as NOT outages', () => {
+      expect(isPgUnavailabilityError(drizzleWrappedSqlstateError('54000', 'index row size exceeds maximum'))).toBe(false);
+      expect(isPgUnavailabilityError(drizzleWrappedSqlstateError('22001', 'value too long'))).toBe(false);
+      expect(isPgUnavailabilityError(drizzleWrappedSqlstateError('42P01', 'relation does not exist'))).toBe(false);
+    });
   });
 
   describe('conservativeFallbackMaxAttempts (pure)', () => {

--- a/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
+++ b/packages/lib/src/security/__tests__/distributed-rate-limit.test.ts
@@ -565,20 +565,41 @@ describe('distributed-rate-limit', () => {
       await expect(resetDistributedRateLimit('fail-reset')).resolves.toBeUndefined();
     });
 
-    it('skips the Postgres delete while the outage cooldown is active', async () => {
+    it('attempts the Postgres delete even while the outage cooldown is active', async () => {
+      // Resets REFUND a consumed limit (e.g. EXPORT_DATA's 1-per-24h after a
+      // failed export). Skipping the delete while the circuit is open would
+      // leave the Postgres row intact and 429 the caller for the rest of the
+      // window once Postgres recovers. Resets are low-volume, so they are
+      // deliberately not breaker-gated.
       process.env.NODE_ENV = 'production';
       mockInsertThrows(drizzleWrappedPgError());
       const config: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
       await checkDistributedRateLimit('reset-breaker', config); // opens circuit
 
       deleteMock.mockClear();
+      mockDeleteResolves();
       await resetDistributedRateLimit('reset-breaker');
-      expect(deleteMock).not.toHaveBeenCalled();
+      expect(deleteMock).toHaveBeenCalled();
 
-      // The in-memory side was still cleared: next check starts a fresh
-      // conservative window (first of 2 → 1 remaining).
+      // The in-memory side was also cleared: next fallback check starts a
+      // fresh conservative window (first of 2 → 1 remaining).
       const after = await checkDistributedRateLimit('reset-breaker', config);
       expect(after.attemptsRemaining).toBe(1);
+    });
+
+    it('a successful reset delete closes the circuit as evidence of recovery', async () => {
+      process.env.NODE_ENV = 'production';
+      mockInsertThrows(drizzleWrappedPgError());
+      const config: RateLimitConfig = { maxAttempts: 5, windowMs: 60_000 };
+      await checkDistributedRateLimit('reset-recovery', config); // opens circuit
+
+      mockDeleteResolves();
+      await resetDistributedRateLimit('reset-recovery'); // delete succeeds → PG is back
+
+      mockInsertReturning(1);
+      const next = await checkDistributedRateLimit('reset-recovery-2', config);
+      expect(next.allowed).toBe(true);
+      expect(next.attemptsRemaining).toBe(4); // distributed path, not fallback
     });
   });
 

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -86,6 +86,12 @@ export function boundedIdentifier(identifier: string): string {
   if (identifier.length <= MAX_IDENTIFIER_KEY_LENGTH) {
     return identifier;
   }
+  // sha256 is deliberate and correct here despite identifiers possibly
+  // deriving from credentials (CodeQL js/insufficient-password-hash flags
+  // this): the digest is an in-memory Map KEY for rate-limit counting — never
+  // persisted, never used to verify anything — and the alternative stored the
+  // RAW identifier, which is strictly worse. A slow password KDF would itself
+  // be a DoS vector on this per-request hot path.
   return `h:${createHash('sha256').update(identifier).digest('hex')}`;
 }
 
@@ -662,17 +668,23 @@ export async function checkDistributedRateLimit(
  * Reset rate limit for an identifier (e.g., after successful auth).
  */
 export async function resetDistributedRateLimit(identifier: string): Promise<void> {
-  if (pgGateAllowsDb(Date.now())) {
-    const admittedEpoch = pgCircuitEpoch;
-    try {
-      await db.delete(rateLimitBuckets).where(eq(rateLimitBuckets.key, identifier));
-      closePgCircuitIfCurrent(admittedEpoch);
-    } catch (error) {
-      loggers.api.debug('Postgres rate limit reset failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      recordPgFailure(error, Date.now());
-    }
+  // Deliberately NOT gated by the circuit breaker: a reset REFUNDS a consumed
+  // limit (e.g. EXPORT_DATA's single attempt per 24h after a failed export),
+  // so silently skipping the delete while the circuit is open would leave the
+  // Postgres row intact and 429 the caller for the rest of the window once
+  // Postgres recovers. Resets are low-volume cold paths (post-auth-success,
+  // failure refunds) that cannot stampede a stalled pool the way hot check
+  // paths can; a failed delete keeps the pre-breaker best-effort semantics
+  // and re-arms the breaker, while a success doubles as recovery evidence.
+  const admittedEpoch = pgCircuitEpoch;
+  try {
+    await db.delete(rateLimitBuckets).where(eq(rateLimitBuckets.key, identifier));
+    closePgCircuitIfCurrent(admittedEpoch);
+  } catch (error) {
+    loggers.api.debug('Postgres rate limit reset failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    recordPgFailure(error, Date.now());
   }
 
   inMemoryResetRateLimit(identifier);

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -36,6 +36,7 @@
  * @see packages/lib/src/auth/rate-limit-utils.ts for the in-memory-only version
  */
 
+import { createHash } from 'crypto';
 import { db } from '@pagespace/db/db';
 import { sql, eq, lt } from '@pagespace/db/operators';
 import { rateLimitBuckets } from '@pagespace/db/schema/rate-limit-buckets';
@@ -73,6 +74,20 @@ interface InMemoryAttempt {
 
 const inMemoryAttempts = new Map<string, InMemoryAttempt>();
 let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
+
+// Longest identifier stored verbatim as a Map key. Unauthenticated callers
+// control identifier content (e.g. OAuth client_id), so without a byte bound
+// the 50k entry cap is not a memory bound — 10KB identifiers at the cap are
+// ~500MB. Oversized identifiers are HASHED, not truncated: distinct inputs
+// stay distinct, and equal inputs keep sharing one counter.
+export const MAX_IDENTIFIER_KEY_LENGTH = 128;
+
+export function boundedIdentifier(identifier: string): string {
+  if (identifier.length <= MAX_IDENTIFIER_KEY_LENGTH) {
+    return identifier;
+  }
+  return `h:${createHash('sha256').update(identifier).digest('hex')}`;
+}
 
 /**
  * Hard cap on distinct identifiers tracked in memory (~250 bytes/entry →
@@ -166,6 +181,8 @@ export function shutdownRateLimiting(): void {
   }
   inMemoryAttempts.clear();
   lastInlineSweepAt = 0;
+  lastFallbackWarnAt = 0;
+  suppressedFallbackWarns = 0;
   closePgCircuit();
 }
 
@@ -189,8 +206,9 @@ function inMemoryCheckRateLimit(
     };
   }
 
+  const key = boundedIdentifier(identifier);
   const now = Date.now();
-  let attempt = inMemoryAttempts.get(identifier);
+  let attempt = inMemoryAttempts.get(key);
 
   if (!attempt) {
     if (
@@ -214,7 +232,7 @@ function inMemoryCheckRateLimit(
       lastAttempt: now,
       expiresAt: now + config.windowMs,
     };
-    inMemoryAttempts.set(identifier, attempt);
+    inMemoryAttempts.set(key, attempt);
     return { allowed: true, attemptsRemaining: config.maxAttempts - 1 };
   }
 
@@ -267,7 +285,7 @@ function inMemoryCheckRateLimit(
 }
 
 function inMemoryResetRateLimit(identifier: string): void {
-  inMemoryAttempts.delete(identifier);
+  inMemoryAttempts.delete(boundedIdentifier(identifier));
 }
 
 function inMemoryGetRateLimitStatus(
@@ -275,7 +293,7 @@ function inMemoryGetRateLimitStatus(
   config: RateLimitConfig
 ): { blocked: boolean; retryAfter?: number; attemptsRemaining?: number } {
   const now = Date.now();
-  const attempt = inMemoryAttempts.get(identifier);
+  const attempt = inMemoryAttempts.get(boundedIdentifier(identifier));
 
   if (!attempt) {
     return { blocked: false, attemptsRemaining: config.maxAttempts };
@@ -349,6 +367,57 @@ function closePgCircuit(): void {
   pgProbeInFlight = false;
 }
 
+/**
+ * Distinguish "Postgres is unreachable/overloaded" from "Postgres actively
+ * rejected this query". Only the former may open the process-wide circuit:
+ * per-query errors can be attacker-crafted (an oversized identifier blowing
+ * the index entry limit fails only that insert, with SQLSTATE 54000), and
+ * treating them as outages would let a single hostile request degrade every
+ * instance to the conservative fallback while the database is healthy.
+ *
+ * Rule, walking the drizzle wrapper's cause chain: an errno-style network
+ * code (ECONNREFUSED, ETIMEDOUT, ...) is an outage. A 5-char SQLSTATE in
+ * class 08 (connection), 53 (insufficient resources) or 57 (operator
+ * intervention/shutdown) is an outage; any other SQLSTATE means the server
+ * was alive enough to answer — not an outage. No code anywhere means no
+ * server response (socket errors, generic timeouts) — treat as an outage,
+ * since payload-triggerable failures always come back with a SQLSTATE.
+ */
+export function isPgUnavailabilityError(error: unknown): boolean {
+  const OUTAGE_SQLSTATE_CLASSES = new Set(['08', '53', '57']);
+  let sawServerSqlstate = false;
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current instanceof Error; depth++) {
+    const code = (current as Error & { code?: unknown }).code;
+    if (typeof code === 'string') {
+      if (/^E[A-Z_]+$/.test(code)) {
+        return true; // errno-style driver/network failure
+      }
+      if (/^[0-9A-Z]{5}$/.test(code)) {
+        if (OUTAGE_SQLSTATE_CLASSES.has(code.slice(0, 2))) {
+          return true;
+        }
+        sawServerSqlstate = true;
+      }
+    }
+    current = current.cause;
+  }
+  return !sawServerSqlstate;
+}
+
+/**
+ * Record a failed Postgres attempt from a request path: open the circuit for
+ * genuine unavailability, otherwise just release any half-open probe claim so
+ * a server-returned per-query error never trips the breaker.
+ */
+function recordPgFailure(error: unknown, now: number): void {
+  if (isPgUnavailabilityError(error)) {
+    openPgCircuit(now);
+  } else {
+    pgProbeInFlight = false;
+  }
+}
+
 // Fail-closed response when DB is unavailable in production.
 function failClosedResponse(config: RateLimitConfig): RateLimitResult {
   return {
@@ -387,6 +456,14 @@ export function conservativeFallbackConfig(config: RateLimitConfig): RateLimitCo
  *
  * `memCheck` is injectable for tests; production callers use the default.
  */
+// During an outage every rate-limited request routes through the fallback;
+// an unthrottled per-request WARN would flood logging during the very
+// incident the breaker mitigates. One WARN per interval, carrying how many
+// occurrences were suppressed since the last emit.
+const FALLBACK_WARN_INTERVAL_MS = 30_000;
+let lastFallbackWarnAt = 0;
+let suppressedFallbackWarns = 0;
+
 export function conservativeFallbackCheck(
   identifier: string,
   config: RateLimitConfig,
@@ -397,10 +474,21 @@ export function conservativeFallbackCheck(
 
   try {
     const result = memCheck(identifier, conservativeFallbackConfig(config));
-    loggers.api.warn(
-      'RATE_LIMIT_PG_FALLBACK: Postgres unavailable in production - enforcing conservative per-instance in-memory limit',
-      { identifier: logId, allowed: result.allowed },
-    );
+    const now = Date.now();
+    if (lastFallbackWarnAt === 0 || now - lastFallbackWarnAt >= FALLBACK_WARN_INTERVAL_MS) {
+      loggers.api.warn(
+        'RATE_LIMIT_PG_FALLBACK: Postgres unavailable in production - enforcing conservative per-instance in-memory limit',
+        {
+          identifier: logId,
+          allowed: result.allowed,
+          suppressedSinceLastWarn: suppressedFallbackWarns,
+        },
+      );
+      lastFallbackWarnAt = now;
+      suppressedFallbackWarns = 0;
+    } else {
+      suppressedFallbackWarns++;
+    }
     return result;
   } catch {
     loggers.api.error('Postgres unavailable in production - DENYING request (fail-closed)', {
@@ -542,7 +630,7 @@ export async function checkDistributedRateLimit(
     postgresAvailableLogged = false;
 
     if (process.env.NODE_ENV === 'production') {
-      openPgCircuit(Date.now());
+      recordPgFailure(error, Date.now());
       return conservativeFallbackCheck(identifier, config);
     }
 
@@ -562,7 +650,7 @@ export async function resetDistributedRateLimit(identifier: string): Promise<voi
       loggers.api.debug('Postgres rate limit reset failed', {
         error: error instanceof Error ? error.message : String(error),
       });
-      openPgCircuit(Date.now());
+      recordPgFailure(error, Date.now());
     }
   }
 
@@ -635,9 +723,9 @@ export async function getDistributedRateLimitStatus(
         Math.ceil(config.maxAttempts - effectiveCount),
       ),
     };
-  } catch {
+  } catch (error) {
     if (process.env.NODE_ENV === 'production') {
-      openPgCircuit(Date.now());
+      recordPgFailure(error, Date.now());
       return conservativeFallbackStatus(identifier, config);
     }
 
@@ -701,7 +789,7 @@ export async function countAuthFailure(identifier: string, windowMs: number): Pr
     loggers.api.warn('countAuthFailure failed', {
       error: error instanceof Error ? error.message : String(error),
     });
-    openPgCircuit(Date.now());
+    recordPgFailure(error, Date.now());
     return 0;
   }
 }

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -312,21 +312,41 @@ let postgresAvailableLogged = false;
 // connection/statement timeouts (seconds each) before falling back — adding
 // user-facing latency and piling more work onto the struggling database.
 // While the circuit is open, request paths skip Postgres entirely and use the
-// conservative in-memory fallback; once the cooldown elapses, the next request
-// probes Postgres (half-open) and either closes the circuit or re-opens it.
+// conservative in-memory fallback; once the cooldown elapses, exactly ONE
+// request claims the half-open probe (the claim is atomic — single-threaded
+// event loop) and either closes the circuit or re-opens it. Concurrent
+// requests during the probe stay on the fallback, so an expiring cooldown
+// cannot stampede the stalled pool every 30 seconds.
 const PG_PROBE_COOLDOWN_MS = 30_000;
 let pgUnhealthyUntil = 0;
+let pgProbeInFlight = false;
 
-function pgCircuitOpen(now: number): boolean {
-  return process.env.NODE_ENV === 'production' && now < pgUnhealthyUntil;
+/**
+ * Gate for every request-path Postgres attempt. Returns true when the caller
+ * may touch the database — either the circuit is closed, or the caller just
+ * claimed the single half-open probe. A claimant MUST end its attempt in
+ * closePgCircuit() (success) or openPgCircuit() (failure); both release the
+ * claim.
+ */
+function pgGateAllowsDb(now: number): boolean {
+  if (process.env.NODE_ENV !== 'production' || pgUnhealthyUntil === 0) {
+    return true;
+  }
+  if (now < pgUnhealthyUntil || pgProbeInFlight) {
+    return false;
+  }
+  pgProbeInFlight = true;
+  return true;
 }
 
 function openPgCircuit(now: number): void {
   pgUnhealthyUntil = now + PG_PROBE_COOLDOWN_MS;
+  pgProbeInFlight = false;
 }
 
 function closePgCircuit(): void {
   pgUnhealthyUntil = 0;
+  pgProbeInFlight = false;
 }
 
 // Fail-closed response when DB is unavailable in production.
@@ -438,7 +458,7 @@ export async function checkDistributedRateLimit(
 ): Promise<RateLimitResult> {
   const now = Date.now();
 
-  if (pgCircuitOpen(now)) {
+  if (!pgGateAllowsDb(now)) {
     return conservativeFallbackCheck(identifier, config);
   }
 
@@ -534,9 +554,10 @@ export async function checkDistributedRateLimit(
  * Reset rate limit for an identifier (e.g., after successful auth).
  */
 export async function resetDistributedRateLimit(identifier: string): Promise<void> {
-  if (!pgCircuitOpen(Date.now())) {
+  if (pgGateAllowsDb(Date.now())) {
     try {
       await db.delete(rateLimitBuckets).where(eq(rateLimitBuckets.key, identifier));
+      closePgCircuit();
     } catch (error) {
       loggers.api.debug('Postgres rate limit reset failed', {
         error: error instanceof Error ? error.message : String(error),
@@ -561,7 +582,7 @@ export async function getDistributedRateLimitStatus(
 ): Promise<{ blocked: boolean; retryAfter?: number; attemptsRemaining?: number }> {
   const now = Date.now();
 
-  if (pgCircuitOpen(now)) {
+  if (!pgGateAllowsDb(now)) {
     return conservativeFallbackStatus(identifier, config);
   }
 
@@ -586,6 +607,7 @@ export async function getDistributedRateLimitStatus(
         .limit(1),
     ]);
 
+    closePgCircuit();
     const currCount = currRows[0]?.count ?? 0;
     const prevCount = prevRows[0]?.count ?? 0;
     const effectiveCount = computeEffectiveCount(
@@ -656,7 +678,7 @@ function conservativeFallbackStatus(
 export async function countAuthFailure(identifier: string, windowMs: number): Promise<number> {
   const now = Date.now();
 
-  if (pgCircuitOpen(now)) {
+  if (!pgGateAllowsDb(now)) {
     return 0;
   }
 
@@ -673,6 +695,7 @@ export async function countAuthFailure(identifier: string, windowMs: number): Pr
         set: { count: sql`${rateLimitBuckets.count} + 1` },
       })
       .returning({ count: rateLimitBuckets.count });
+    closePgCircuit();
     return rows[0]?.count ?? 0;
   } catch (error) {
     loggers.api.warn('countAuthFailure failed', {

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -249,10 +249,16 @@ function inMemoryCheckRateLimit(
     };
   }
 
-  if (
-    (attempt.blockedUntil && now >= attempt.blockedUntil) ||
-    now - attempt.firstAttempt > config.windowMs
-  ) {
+  // An expired block only lifts the block — the window counter persists. A
+  // full reset here would let a config with blockDurationMs < windowMs (e.g.
+  // OAUTH_DEVICE_POLL: 5min window, 1min block) hand out a fresh allowance
+  // every block period, compounding past even the configured per-window
+  // limit. Postgres-side buckets likewise outlive any block.
+  if (attempt.blockedUntil && now >= attempt.blockedUntil) {
+    delete attempt.blockedUntil;
+  }
+
+  if (now - attempt.firstAttempt > config.windowMs) {
     attempt.count = 1;
     attempt.firstAttempt = now;
     attempt.lastAttempt = now;

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -29,7 +29,9 @@
  *   instance enforces a CONSERVATIVE in-memory limit (half the configured
  *   threshold) so a DB outage neither becomes a total platform outage
  *   (fail-closed shared fate) nor a rate-limit bypass (fail-open). Only if
- *   the in-memory check itself fails does the request fail closed.
+ *   the in-memory check itself fails does the request fail closed. The
+ *   in-memory store is bounded (per-entry expiry sweep + hard identifier cap)
+ *   so an identifier flood during the outage cannot OOM the process.
  *
  * @see packages/lib/src/auth/rate-limit-utils.ts for the in-memory-only version
  */
@@ -65,27 +67,53 @@ interface InMemoryAttempt {
   firstAttempt: number;
   lastAttempt: number;
   blockedUntil?: number;
+  /** When this entry is dead weight: end of its window or of any active block. */
+  expiresAt: number;
 }
 
 const inMemoryAttempts = new Map<string, InMemoryAttempt>();
 let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
 
 /**
+ * Hard cap on distinct identifiers tracked in memory (~250 bytes/entry →
+ * ~12 MB worst case). The store is production-reachable during a Postgres
+ * outage, where an attacker can spray arbitrary identifiers (emails, client
+ * IDs) at unauthenticated endpoints; without a cap that turns the DB incident
+ * into an application OOM. When full, the oldest-inserted entry is evicted
+ * (FIFO): resetting a stale counter early slightly loosens limiting under an
+ * active identifier flood, but identifier rotation already defeats
+ * per-identifier limits, whereas unbounded growth defeats the availability
+ * goal of the fallback itself.
+ */
+export const MAX_IN_MEMORY_ATTEMPT_ENTRIES = 50_000;
+
+/**
+ * Delete entries whose window AND any block have fully elapsed. Never evicts
+ * an actively blocked entry — that would reset its counter and void the block.
+ * Exported for tests; production runs it on the cleanup interval.
+ */
+export function sweepExpiredInMemoryAttempts(now: number = Date.now()): number {
+  let evicted = 0;
+  for (const [key, attempt] of inMemoryAttempts.entries()) {
+    if (now >= attempt.expiresAt) {
+      inMemoryAttempts.delete(key);
+      evicted++;
+    }
+  }
+  return evicted;
+}
+
+/**
  * Start the cleanup interval for in-memory rate limiting.
- * Uses 25-hour cutoff to match longest rate limit window (EXPORT_DATA 24h) with buffer.
+ * Evicts by per-entry expiry (window/block end), so a 1-minute API bucket is
+ * reclaimed in minutes while the 24h EXPORT_DATA bucket still survives its
+ * full window.
  */
 function startCleanupInterval(): void {
   if (cleanupIntervalId) return;
 
   cleanupIntervalId = setInterval(() => {
-    const now = Date.now();
-    const cutoff = now - 25 * 60 * 60 * 1000;
-
-    for (const [key, attempt] of inMemoryAttempts.entries()) {
-      if (attempt.lastAttempt < cutoff) {
-        inMemoryAttempts.delete(key);
-      }
-    }
+    sweepExpiredInMemoryAttempts();
   }, 5 * 60 * 1000);
 }
 
@@ -115,7 +143,20 @@ function inMemoryCheckRateLimit(
   let attempt = inMemoryAttempts.get(identifier);
 
   if (!attempt) {
-    attempt = { count: 1, firstAttempt: now, lastAttempt: now };
+    if (inMemoryAttempts.size >= MAX_IN_MEMORY_ATTEMPT_ENTRIES) {
+      // Map iteration is insertion-ordered; drop the oldest entry to admit
+      // the new one (see MAX_IN_MEMORY_ATTEMPT_ENTRIES for the trade-off).
+      const oldest = inMemoryAttempts.keys().next();
+      if (!oldest.done) {
+        inMemoryAttempts.delete(oldest.value);
+      }
+    }
+    attempt = {
+      count: 1,
+      firstAttempt: now,
+      lastAttempt: now,
+      expiresAt: now + config.windowMs,
+    };
     inMemoryAttempts.set(identifier, attempt);
     return { allowed: true, attemptsRemaining: config.maxAttempts - 1 };
   }
@@ -127,18 +168,14 @@ function inMemoryCheckRateLimit(
     };
   }
 
-  if (attempt.blockedUntil && now >= attempt.blockedUntil) {
+  if (
+    (attempt.blockedUntil && now >= attempt.blockedUntil) ||
+    now - attempt.firstAttempt > config.windowMs
+  ) {
     attempt.count = 1;
     attempt.firstAttempt = now;
     attempt.lastAttempt = now;
-    delete attempt.blockedUntil;
-    return { allowed: true, attemptsRemaining: config.maxAttempts - 1 };
-  }
-
-  if (now - attempt.firstAttempt > config.windowMs) {
-    attempt.count = 1;
-    attempt.firstAttempt = now;
-    attempt.lastAttempt = now;
+    attempt.expiresAt = now + config.windowMs;
     delete attempt.blockedUntil;
     return { allowed: true, attemptsRemaining: config.maxAttempts - 1 };
   }
@@ -164,6 +201,7 @@ function inMemoryCheckRateLimit(
   }
 
   attempt.blockedUntil = now + blockDuration;
+  attempt.expiresAt = Math.max(attempt.expiresAt, attempt.blockedUntil);
 
   return {
     allowed: false,

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -25,7 +25,11 @@
  * - Works across multiple server instances (Postgres is the source of truth)
  * - Progressive blocking for repeated violations (computed at call time)
  * - Graceful fallback to in-memory in development when DB is unreachable
- * - Fail-closed in production: deny with Retry-After when DB is unreachable
+ * - Degraded-but-enforcing in production: when the DB is unreachable, each
+ *   instance enforces a CONSERVATIVE in-memory limit (half the configured
+ *   threshold) so a DB outage neither becomes a total platform outage
+ *   (fail-closed shared fate) nor a rate-limit bypass (fail-open). Only if
+ *   the in-memory check itself fails does the request fail closed.
  *
  * @see packages/lib/src/auth/rate-limit-utils.ts for the in-memory-only version
  */
@@ -214,6 +218,58 @@ function failClosedResponse(config: RateLimitConfig): RateLimitResult {
   };
 }
 
+/**
+ * Conservative per-instance threshold used while Postgres is unreachable in
+ * production. Half the configured limit (floor 1): the in-memory fallback is
+ * per-instance, so with N instances an attacker spraying evenly could reach
+ * N × this value — halving claws back headroom against that multiplier while
+ * still letting legitimate users through. Never exceeds the configured limit
+ * (a degenerate configured 0 stays 0).
+ */
+export function conservativeFallbackMaxAttempts(maxAttempts: number): number {
+  return Math.min(maxAttempts, Math.max(1, Math.floor(maxAttempts / 2)));
+}
+
+/**
+ * Same window/block semantics as the caller's config, with only maxAttempts
+ * reduced to the conservative per-instance threshold.
+ */
+export function conservativeFallbackConfig(config: RateLimitConfig): RateLimitConfig {
+  return { ...config, maxAttempts: conservativeFallbackMaxAttempts(config.maxAttempts) };
+}
+
+/**
+ * Production fallback when Postgres is unreachable: enforce the conservative
+ * in-memory limit instead of denying every request (a fail-closed check that
+ * shares fate with the primary DB turns a DB stall into a total platform
+ * outage). Limits stay at or below configured — never fail open. If the
+ * in-memory check itself throws, we genuinely cannot limit, so fail closed.
+ *
+ * `memCheck` is injectable for tests; production callers use the default.
+ */
+export function conservativeFallbackCheck(
+  identifier: string,
+  config: RateLimitConfig,
+  memCheck: (identifier: string, config: RateLimitConfig) => RateLimitResult = inMemoryCheckRateLimit,
+): RateLimitResult {
+  const safeId = String(identifier ?? '').slice(0, 20);
+  const logId = safeId.length >= 20 ? `${safeId}...` : safeId;
+
+  try {
+    const result = memCheck(identifier, conservativeFallbackConfig(config));
+    loggers.api.warn(
+      'RATE_LIMIT_PG_FALLBACK: Postgres unavailable in production - enforcing conservative per-instance in-memory limit',
+      { identifier: logId, allowed: result.allowed },
+    );
+    return result;
+  } catch {
+    loggers.api.error('Postgres unavailable in production - DENYING request (fail-closed)', {
+      identifier: logId,
+    });
+    return failClosedResponse(config);
+  }
+}
+
 // Bucket-aligned window_start for the current time.
 function currentWindowStart(windowMs: number, now: number = Date.now()): Date {
   return new Date(Math.floor(now / windowMs) * windowMs);
@@ -335,12 +391,12 @@ export async function checkDistributedRateLimit(
       error: error instanceof Error ? error.message : String(error),
     });
 
+    // Re-arm the mode log so recovery ("Distributed rate limiting enabled")
+    // is visible in logs after an outage.
+    postgresAvailableLogged = false;
+
     if (process.env.NODE_ENV === 'production') {
-      const safeId = String(identifier ?? '').slice(0, 20);
-      loggers.api.error('Postgres unavailable in production - DENYING request (fail-closed)', {
-        identifier: safeId.length >= 20 ? `${safeId}...` : safeId,
-      });
-      return failClosedResponse(config);
+      return conservativeFallbackCheck(identifier, config);
     }
 
     return inMemoryCheckRateLimit(identifier, config);
@@ -364,8 +420,10 @@ export async function resetDistributedRateLimit(identifier: string): Promise<voi
 
 /**
  * Get rate limit status without incrementing.
- * In production, fails closed (reports blocked) when DB is unavailable to avoid
- * returning potentially stale in-memory status in distributed deployments.
+ * In production, when the DB is unavailable this reports the same conservative
+ * per-instance in-memory state the check path enforces during the outage, so
+ * status and enforcement agree; it fails closed (reports blocked) only if the
+ * in-memory read itself throws.
  */
 export async function getDistributedRateLimitStatus(
   identifier: string,
@@ -422,11 +480,15 @@ export async function getDistributedRateLimitStatus(
     };
   } catch {
     if (process.env.NODE_ENV === 'production') {
-      return {
-        blocked: true,
-        retryAfter: Math.ceil(config.windowMs / 1000),
-        attemptsRemaining: 0,
-      };
+      try {
+        return inMemoryGetRateLimitStatus(identifier, conservativeFallbackConfig(config));
+      } catch {
+        return {
+          blocked: true,
+          retryAfter: Math.ceil(config.windowMs / 1000),
+          attemptsRemaining: 0,
+        };
+      }
     }
 
     return inMemoryGetRateLimitStatus(identifier, config);

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -79,47 +79,46 @@ let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
  * ~12 MB worst case). The store is production-reachable during a Postgres
  * outage, where an attacker can spray arbitrary identifiers (emails, client
  * IDs) at unauthenticated endpoints; without a cap that turns the DB incident
- * into an application OOM. When full, the entry closest to expiry among the
- * oldest-inserted few is evicted: resetting a stale counter early slightly
- * loosens limiting under an active identifier flood, but identifier rotation
- * already defeats per-identifier limits, whereas unbounded growth defeats the
- * availability goal of the fallback itself.
+ * into an application OOM. At capacity, only EXPIRED entries are reclaimed;
+ * if every tracked window is still active, previously unseen identifiers are
+ * conservatively denied instead — evicting an active entry would let an
+ * attacker rotating identifiers reset a victim's counter or flush their own
+ * block. Denial at capacity only occurs under an extreme identifier flood and
+ * self-heals as tracked windows expire.
  */
 export const MAX_IN_MEMORY_ATTEMPT_ENTRIES = 50_000;
 
-// How many of the oldest entries to consider when the store is full. Bounds
-// eviction cost per insert while still strongly preferring window-only entries
-// (near expiry) over actively blocked ones (expiry extended to block end) —
-// evicting a live block would let an attacker flush their own block by
-// spraying fresh identifiers.
+// How many of the oldest entries (Map iteration is insertion-ordered, so
+// expired entries cluster at the old end) to scan for a reclaimable slot on
+// each at-capacity insert. Bounds per-request cost during a flood.
 const EVICTION_SCAN_LIMIT = 16;
 
+// A full-map sweep from the insert path is O(cap); allow at most one per
+// second so a flood cannot turn every request into a 50k-entry scan.
+const INLINE_SWEEP_MIN_INTERVAL_MS = 1_000;
+let lastInlineSweepAt = 0;
+
 /**
- * Evict one entry to admit a new identifier when the store is at capacity.
- * Scans the oldest EVICTION_SCAN_LIMIT entries (Map iteration is
- * insertion-ordered) and deletes the one closest to expiry; anything already
- * expired wins immediately. Blocks survive because their expiresAt extends to
- * the block end, sorting them behind ordinary window entries.
+ * Try to free a slot for a new identifier when the store is at capacity.
+ * Reclaims expired entries only — active counters and blocks are never
+ * sacrificed. Cheap bounded scan of the oldest entries first, then at most
+ * one throttled full sweep. Returns whether a slot was freed.
  */
-function evictForCapacity(now: number): void {
-  let victimKey: string | undefined;
-  let victimExpiry = Infinity;
+function tryReclaimCapacity(now: number): boolean {
   let scanned = 0;
   for (const [key, attempt] of inMemoryAttempts.entries()) {
     if (scanned >= EVICTION_SCAN_LIMIT) break;
     scanned++;
     if (now >= attempt.expiresAt) {
-      victimKey = key;
-      break;
-    }
-    if (attempt.expiresAt < victimExpiry) {
-      victimExpiry = attempt.expiresAt;
-      victimKey = key;
+      inMemoryAttempts.delete(key);
+      return true;
     }
   }
-  if (victimKey !== undefined) {
-    inMemoryAttempts.delete(victimKey);
+  if (now - lastInlineSweepAt >= INLINE_SWEEP_MIN_INTERVAL_MS) {
+    lastInlineSweepAt = now;
+    return sweepExpiredInMemoryAttempts(now) > 0;
   }
+  return false;
 }
 
 /**
@@ -166,6 +165,8 @@ export function shutdownRateLimiting(): void {
     cleanupIntervalId = null;
   }
   inMemoryAttempts.clear();
+  lastInlineSweepAt = 0;
+  closePgCircuit();
 }
 
 // Auto-start cleanup on module load
@@ -192,8 +193,17 @@ function inMemoryCheckRateLimit(
   let attempt = inMemoryAttempts.get(identifier);
 
   if (!attempt) {
-    if (inMemoryAttempts.size >= MAX_IN_MEMORY_ATTEMPT_ENTRIES) {
-      evictForCapacity(now);
+    if (
+      inMemoryAttempts.size >= MAX_IN_MEMORY_ATTEMPT_ENTRIES &&
+      !tryReclaimCapacity(now)
+    ) {
+      // Full of active windows/blocks: deny the unseen identifier rather than
+      // resetting someone else's active limit (see MAX_IN_MEMORY_ATTEMPT_ENTRIES).
+      return {
+        allowed: false,
+        retryAfter: Math.ceil(config.windowMs / 1000),
+        attemptsRemaining: 0,
+      };
     }
     // Re-arm the expiry sweep if a shutdown cleared it and traffic resumed —
     // without this, only the capacity cap would bound the store afterwards.
@@ -293,6 +303,31 @@ function inMemoryGetRateLimitStatus(
 // =============================================================================
 
 let postgresAvailableLogged = false;
+
+// -----------------------------------------------------------------------------
+// Postgres circuit breaker (production only)
+// -----------------------------------------------------------------------------
+// The outage this module defends against is an OOM-STALLED Postgres, not a
+// fast-rejecting one: without a breaker, every request waits out the pool's
+// connection/statement timeouts (seconds each) before falling back — adding
+// user-facing latency and piling more work onto the struggling database.
+// While the circuit is open, request paths skip Postgres entirely and use the
+// conservative in-memory fallback; once the cooldown elapses, the next request
+// probes Postgres (half-open) and either closes the circuit or re-opens it.
+const PG_PROBE_COOLDOWN_MS = 30_000;
+let pgUnhealthyUntil = 0;
+
+function pgCircuitOpen(now: number): boolean {
+  return process.env.NODE_ENV === 'production' && now < pgUnhealthyUntil;
+}
+
+function openPgCircuit(now: number): void {
+  pgUnhealthyUntil = now + PG_PROBE_COOLDOWN_MS;
+}
+
+function closePgCircuit(): void {
+  pgUnhealthyUntil = 0;
+}
 
 // Fail-closed response when DB is unavailable in production.
 function failClosedResponse(config: RateLimitConfig): RateLimitResult {
@@ -402,6 +437,11 @@ export async function checkDistributedRateLimit(
   config: RateLimitConfig
 ): Promise<RateLimitResult> {
   const now = Date.now();
+
+  if (pgCircuitOpen(now)) {
+    return conservativeFallbackCheck(identifier, config);
+  }
+
   const windowStart = currentWindowStart(config.windowMs, now);
   const prevWindowStart = new Date(windowStart.getTime() - config.windowMs);
   // expires_at covers 2 windows so the previous bucket survives long enough
@@ -442,6 +482,7 @@ export async function checkDistributedRateLimit(
       config.windowMs,
     );
 
+    closePgCircuit();
     if (!postgresAvailableLogged) {
       loggers.api.info('Distributed rate limiting enabled (Postgres)');
       postgresAvailableLogged = true;
@@ -481,6 +522,7 @@ export async function checkDistributedRateLimit(
     postgresAvailableLogged = false;
 
     if (process.env.NODE_ENV === 'production') {
+      openPgCircuit(Date.now());
       return conservativeFallbackCheck(identifier, config);
     }
 
@@ -492,12 +534,15 @@ export async function checkDistributedRateLimit(
  * Reset rate limit for an identifier (e.g., after successful auth).
  */
 export async function resetDistributedRateLimit(identifier: string): Promise<void> {
-  try {
-    await db.delete(rateLimitBuckets).where(eq(rateLimitBuckets.key, identifier));
-  } catch (error) {
-    loggers.api.debug('Postgres rate limit reset failed', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  if (!pgCircuitOpen(Date.now())) {
+    try {
+      await db.delete(rateLimitBuckets).where(eq(rateLimitBuckets.key, identifier));
+    } catch (error) {
+      loggers.api.debug('Postgres rate limit reset failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      openPgCircuit(Date.now());
+    }
   }
 
   inMemoryResetRateLimit(identifier);
@@ -515,6 +560,11 @@ export async function getDistributedRateLimitStatus(
   config: RateLimitConfig
 ): Promise<{ blocked: boolean; retryAfter?: number; attemptsRemaining?: number }> {
   const now = Date.now();
+
+  if (pgCircuitOpen(now)) {
+    return conservativeFallbackStatus(identifier, config);
+  }
+
   const windowStart = currentWindowStart(config.windowMs, now);
   const prevWindowStart = new Date(windowStart.getTime() - config.windowMs);
 
@@ -565,18 +615,31 @@ export async function getDistributedRateLimitStatus(
     };
   } catch {
     if (process.env.NODE_ENV === 'production') {
-      try {
-        return inMemoryGetRateLimitStatus(identifier, conservativeFallbackConfig(config));
-      } catch {
-        return {
-          blocked: true,
-          retryAfter: Math.ceil(config.windowMs / 1000),
-          attemptsRemaining: 0,
-        };
-      }
+      openPgCircuit(Date.now());
+      return conservativeFallbackStatus(identifier, config);
     }
 
     return inMemoryGetRateLimitStatus(identifier, config);
+  }
+}
+
+/**
+ * Read-only counterpart of conservativeFallbackCheck: reports the state of the
+ * conservative in-memory bucket while Postgres is unreachable, failing closed
+ * (blocked) only if the in-memory read itself throws.
+ */
+function conservativeFallbackStatus(
+  identifier: string,
+  config: RateLimitConfig,
+): { blocked: boolean; retryAfter?: number; attemptsRemaining?: number } {
+  try {
+    return inMemoryGetRateLimitStatus(identifier, conservativeFallbackConfig(config));
+  } catch {
+    return {
+      blocked: true,
+      retryAfter: Math.ceil(config.windowMs / 1000),
+      attemptsRemaining: 0,
+    };
   }
 }
 
@@ -586,11 +649,17 @@ export async function getDistributedRateLimitStatus(
  * `authfail:` key prefix so the count survives restarts and spans replicas
  * (#977) — feeding the pure auth-anomaly detector.
  *
- * Best-effort: returns 0 on DB error, so the caller treats an unknown count as
- * "no anomaly" rather than failing the auth request.
+ * Best-effort: returns 0 on DB error (and immediately while the Postgres
+ * circuit is open), so the caller treats an unknown count as "no anomaly"
+ * rather than failing — or stalling — the auth request.
  */
 export async function countAuthFailure(identifier: string, windowMs: number): Promise<number> {
   const now = Date.now();
+
+  if (pgCircuitOpen(now)) {
+    return 0;
+  }
+
   const windowStart = currentWindowStart(windowMs, now);
   const expiresAt = new Date(windowStart.getTime() + 2 * windowMs);
   const key = `authfail:${identifier}`;
@@ -609,6 +678,7 @@ export async function countAuthFailure(identifier: string, windowMs: number): Pr
     loggers.api.warn('countAuthFailure failed', {
       error: error instanceof Error ? error.message : String(error),
     });
+    openPgCircuit(Date.now());
     return 0;
   }
 }

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -400,7 +400,8 @@ export function isPgUnavailabilityError(error: unknown): boolean {
         sawServerSqlstate = true;
       }
     }
-    current = current.cause;
+    // Error.cause is untyped under this package's typecheck lib target.
+    current = (current as Error & { cause?: unknown }).cause;
   }
   return !sawServerSqlstate;
 }

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -338,6 +338,11 @@ let postgresAvailableLogged = false;
 const PG_PROBE_COOLDOWN_MS = 30_000;
 let pgUnhealthyUntil = 0;
 let pgProbeInFlight = false;
+// Bumped every time the circuit opens. A success may only close the circuit
+// if no open happened after that request was admitted — otherwise a slow
+// success dispatched BEFORE the failure would clear the fresh cooldown and
+// re-expose the unhealthy database to the full request stream.
+let pgCircuitEpoch = 0;
 
 /**
  * Gate for every request-path Postgres attempt. Returns true when the caller
@@ -360,11 +365,24 @@ function pgGateAllowsDb(now: number): boolean {
 function openPgCircuit(now: number): void {
   pgUnhealthyUntil = now + PG_PROBE_COOLDOWN_MS;
   pgProbeInFlight = false;
+  pgCircuitEpoch++;
 }
 
+// Unconditional close — reserved for full state resets (shutdown).
 function closePgCircuit(): void {
   pgUnhealthyUntil = 0;
   pgProbeInFlight = false;
+}
+
+/**
+ * Close the circuit after a successful Postgres operation, but only if the
+ * circuit has not been (re)opened since the caller was admitted — a stale
+ * success from before a failure must not cancel the failure's cooldown.
+ */
+function closePgCircuitIfCurrent(admittedEpoch: number): void {
+  if (admittedEpoch === pgCircuitEpoch) {
+    closePgCircuit();
+  }
 }
 
 /**
@@ -550,6 +568,7 @@ export async function checkDistributedRateLimit(
   if (!pgGateAllowsDb(now)) {
     return conservativeFallbackCheck(identifier, config);
   }
+  const admittedEpoch = pgCircuitEpoch;
 
   const windowStart = currentWindowStart(config.windowMs, now);
   const prevWindowStart = new Date(windowStart.getTime() - config.windowMs);
@@ -591,7 +610,7 @@ export async function checkDistributedRateLimit(
       config.windowMs,
     );
 
-    closePgCircuit();
+    closePgCircuitIfCurrent(admittedEpoch);
     if (!postgresAvailableLogged) {
       loggers.api.info('Distributed rate limiting enabled (Postgres)');
       postgresAvailableLogged = true;
@@ -644,9 +663,10 @@ export async function checkDistributedRateLimit(
  */
 export async function resetDistributedRateLimit(identifier: string): Promise<void> {
   if (pgGateAllowsDb(Date.now())) {
+    const admittedEpoch = pgCircuitEpoch;
     try {
       await db.delete(rateLimitBuckets).where(eq(rateLimitBuckets.key, identifier));
-      closePgCircuit();
+      closePgCircuitIfCurrent(admittedEpoch);
     } catch (error) {
       loggers.api.debug('Postgres rate limit reset failed', {
         error: error instanceof Error ? error.message : String(error),
@@ -674,6 +694,7 @@ export async function getDistributedRateLimitStatus(
   if (!pgGateAllowsDb(now)) {
     return conservativeFallbackStatus(identifier, config);
   }
+  const admittedEpoch = pgCircuitEpoch;
 
   const windowStart = currentWindowStart(config.windowMs, now);
   const prevWindowStart = new Date(windowStart.getTime() - config.windowMs);
@@ -696,7 +717,7 @@ export async function getDistributedRateLimitStatus(
         .limit(1),
     ]);
 
-    closePgCircuit();
+    closePgCircuitIfCurrent(admittedEpoch);
     const currCount = currRows[0]?.count ?? 0;
     const prevCount = prevRows[0]?.count ?? 0;
     const effectiveCount = computeEffectiveCount(
@@ -770,6 +791,7 @@ export async function countAuthFailure(identifier: string, windowMs: number): Pr
   if (!pgGateAllowsDb(now)) {
     return 0;
   }
+  const admittedEpoch = pgCircuitEpoch;
 
   const windowStart = currentWindowStart(windowMs, now);
   const expiresAt = new Date(windowStart.getTime() + 2 * windowMs);
@@ -784,7 +806,7 @@ export async function countAuthFailure(identifier: string, windowMs: number): Pr
         set: { count: sql`${rateLimitBuckets.count} + 1` },
       })
       .returning({ count: rateLimitBuckets.count });
-    closePgCircuit();
+    closePgCircuitIfCurrent(admittedEpoch);
     return rows[0]?.count ?? 0;
   } catch (error) {
     loggers.api.warn('countAuthFailure failed', {

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -79,13 +79,48 @@ let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
  * ~12 MB worst case). The store is production-reachable during a Postgres
  * outage, where an attacker can spray arbitrary identifiers (emails, client
  * IDs) at unauthenticated endpoints; without a cap that turns the DB incident
- * into an application OOM. When full, the oldest-inserted entry is evicted
- * (FIFO): resetting a stale counter early slightly loosens limiting under an
- * active identifier flood, but identifier rotation already defeats
- * per-identifier limits, whereas unbounded growth defeats the availability
- * goal of the fallback itself.
+ * into an application OOM. When full, the entry closest to expiry among the
+ * oldest-inserted few is evicted: resetting a stale counter early slightly
+ * loosens limiting under an active identifier flood, but identifier rotation
+ * already defeats per-identifier limits, whereas unbounded growth defeats the
+ * availability goal of the fallback itself.
  */
 export const MAX_IN_MEMORY_ATTEMPT_ENTRIES = 50_000;
+
+// How many of the oldest entries to consider when the store is full. Bounds
+// eviction cost per insert while still strongly preferring window-only entries
+// (near expiry) over actively blocked ones (expiry extended to block end) —
+// evicting a live block would let an attacker flush their own block by
+// spraying fresh identifiers.
+const EVICTION_SCAN_LIMIT = 16;
+
+/**
+ * Evict one entry to admit a new identifier when the store is at capacity.
+ * Scans the oldest EVICTION_SCAN_LIMIT entries (Map iteration is
+ * insertion-ordered) and deletes the one closest to expiry; anything already
+ * expired wins immediately. Blocks survive because their expiresAt extends to
+ * the block end, sorting them behind ordinary window entries.
+ */
+function evictForCapacity(now: number): void {
+  let victimKey: string | undefined;
+  let victimExpiry = Infinity;
+  let scanned = 0;
+  for (const [key, attempt] of inMemoryAttempts.entries()) {
+    if (scanned >= EVICTION_SCAN_LIMIT) break;
+    scanned++;
+    if (now >= attempt.expiresAt) {
+      victimKey = key;
+      break;
+    }
+    if (attempt.expiresAt < victimExpiry) {
+      victimExpiry = attempt.expiresAt;
+      victimKey = key;
+    }
+  }
+  if (victimKey !== undefined) {
+    inMemoryAttempts.delete(victimKey);
+  }
+}
 
 /**
  * Delete entries whose window AND any block have fully elapsed. Never evicts
@@ -115,6 +150,9 @@ function startCleanupInterval(): void {
   cleanupIntervalId = setInterval(() => {
     sweepExpiredInMemoryAttempts();
   }, 5 * 60 * 1000);
+
+  // Don't let the sweep keep the process alive (no-op outside Node).
+  (cleanupIntervalId as { unref?: () => unknown }).unref?.();
 }
 
 /**
@@ -139,18 +177,27 @@ function inMemoryCheckRateLimit(
   identifier: string,
   config: RateLimitConfig
 ): RateLimitResult {
+  // Match PG-up semantics for a degenerate zero/negative limit: with PG up,
+  // the first attempt already exceeds maxAttempts 0, so everything is denied.
+  // The fallback must never be looser than the configured limit.
+  if (config.maxAttempts < 1) {
+    return {
+      allowed: false,
+      retryAfter: Math.ceil(config.windowMs / 1000),
+      attemptsRemaining: 0,
+    };
+  }
+
   const now = Date.now();
   let attempt = inMemoryAttempts.get(identifier);
 
   if (!attempt) {
     if (inMemoryAttempts.size >= MAX_IN_MEMORY_ATTEMPT_ENTRIES) {
-      // Map iteration is insertion-ordered; drop the oldest entry to admit
-      // the new one (see MAX_IN_MEMORY_ATTEMPT_ENTRIES for the trade-off).
-      const oldest = inMemoryAttempts.keys().next();
-      if (!oldest.done) {
-        inMemoryAttempts.delete(oldest.value);
-      }
+      evictForCapacity(now);
     }
+    // Re-arm the expiry sweep if a shutdown cleared it and traffic resumed —
+    // without this, only the capacity cap would bound the store afterwards.
+    startCleanupInterval();
     attempt = {
       count: 1,
       firstAttempt: now,


### PR DESCRIPTION
## Why

Production Postgres OOM-stalled four times (latest Jul 28, ~18:11 UTC). During the stall, `checkDistributedRateLimit` failed closed and denied **every** request — the rate-limit control shared fate with the same Postgres the runaway query killed, turning a DB outage into a total platform outage.

Fail-closed remains correct as a security decision (DB pressure must never grant a rate-limit bypass); the fix removes the shared fate without ever failing open.

## What

- **Production DB-outage path now enforces a conservative per-instance in-memory bucket** instead of denying everything: effective `maxAttempts = min(configured, max(1, floor(configured / 2)))` — half the configured limit, floor 1, never above configured. Halving claws back headroom against the per-instance multiplier (N instances × per-instance bucket); window/block/progressive semantics are unchanged (reuses the existing dev in-memory limiter).
- **Logging:** fallback activation logs a greppable `RATE_LIMIT_PG_FALLBACK` WARN. The exact ERROR line `Postgres unavailable in production - DENYING request (fail-closed)` is kept for the residual path where the in-memory check itself throws (verified nothing in infra/deploy greps the old marker — only the unit tests consumed it).
- **Recovery:** first successful Postgres check resumes distributed enforcement immediately (distributed counts authoritative; outage-time in-memory counts self-expire via existing window lifecycle) and re-logs "Distributed rate limiting enabled (Postgres)".
- **Status path** (`getDistributedRateLimitStatus`) reports the same conservative in-memory state during an outage so status and enforcement agree; fails closed only if the in-memory read throws.
- **Never fail open:** any unrecognized failure still limits; `failClosedResponse` remains for the genuinely-cannot-limit path.
- New logic is in pure, exported, fully-branch-covered helpers (`conservativeFallbackMaxAttempts`, `conservativeFallbackConfig`, `conservativeFallbackCheck` with injectable checker).
- **Bounded fallback store** (review follow-up, d0bb272): entries carry `expiresAt` (window end or active-block end) and the 5-min sweep evicts on that per-entry expiry instead of a flat 25h cutoff; an active block is never swept early. A `MAX_IN_MEMORY_ATTEMPT_ENTRIES = 50_000` hard cap (~12 MB worst case) bounds the store, so a distinct-identifier flood during the outage cannot OOM the process.
- **Hardening from adversarial self-review** (c05574f): `maxAttempts < 1` denies outright in the fallback, matching PG-up semantics. The sweep re-arms on insert after `shutdownRateLimiting()`, and the interval is `unref()`d. Documented + characterization-tested accepted trade-off: a flapping outage can admit up to configured + conservative (~1.5×) per instance per window, since distributed and in-memory counters are deliberately disjoint.
- **Circuit breaker** (review rounds 2–3, 1cb185c + d8f882e): the incident scenario is an OOM-*stalled* Postgres, so without a breaker every request waits out the pool's 10–15s timeouts before falling back. A production-only 30s breaker short-circuits check/status/reset/`countAuthFailure` straight to the fallback while open; when the cooldown expires, exactly ONE request claims the half-open probe (atomic claim on the event loop) while concurrent requests stay on the fallback — no thundering herd against the stalled pool. Any successful DB op closes the circuit; a failed probe re-arms the cooldown. CHANGELOG.md entry added under [Unreleased].
- **Capacity = expired-only reclamation + conservative denial** (review round 2, 1cb185c): at the 50k cap, only expired entries are reclaimed (bounded oldest-first scan, then ≤1 full sweep/sec). If every tracked window is active, previously unseen identifiers are denied rather than evicting a victim's counter or an attacker's own block — identifier-rotation floods can no longer flush anyone's active limit (including the FORM_SUBMISSION shape where block duration equals the window).
- **Round 5** (76efb48): circuit closing is epoch-guarded — a slow success dispatched before a concurrent failure can no longer cancel the fresh cooldown (stale successes don't flap the breaker under intermittent stalls).
- **Round 7** (a6ce9d1): an expired block no longer resets a still-active window — the counter persists until the window ends (matching PG bucket semantics), so configs with block < window (OAUTH_DEVICE_POLL) can't be farmed for ~5× the allowance during an outage.
- **Round 6** (92be226): `resetDistributedRateLimit` bypasses the breaker — resets refund consumed limits (EXPORT_DATA 1/24h), are low-volume cold paths, and a skipped delete would 429 the caller for the rest of the window after recovery; a successful delete closes the circuit as recovery evidence. CodeQL's `js/insufficient-password-hash` on `boundedIdentifier` dismissed as false positive (in-memory key derivation, not credential storage; rationale in-code and on alert #272).
- **Round 4 hardening** (381c2b8): the circuit opens only for genuine unavailability (`isPgUnavailabilityError`: errno network codes, SQLSTATE classes 08/53/57, or no server response) — a server-returned data error like SQLSTATE 54000 from an attacker-sized identifier limits that one request via the fallback without tripping the process-wide breaker. Identifiers >128 chars are sha256-hashed before use as Map keys (hashed, not truncated), restoring the cap's real memory bound (~20MB). The `RATE_LIMIT_PG_FALLBACK` WARN is throttled to once per 30s with a `suppressedSinceLastWarn` count.

## Behavior

| Scenario | Before | After |
|---|---|---|
| PG up | distributed sliding-window limits | unchanged |
| PG down, legitimate user | **denied (outage)** | allowed up to half the configured limit per instance |
| PG down, attacker | denied | denied past the conservative (stricter) threshold; no bypass |
| PG down + in-memory check broken | denied | denied (fail-closed, ERROR logged) |

## Tests

TDD: RED commit (9b97c92) specifies the fallback behavior — prod NODE_ENV + drizzle-wrapped PG errors (`error.cause` carries pg fields) → first requests allowed, past-threshold denied, WARN marker, recovery, residual fail-closed. GREEN commit (7cf5042) implements it. Memory bounds follow the same pattern: a RED commit specifying expiry-sweep boundaries, blocked-entry retention, and a 50k-identifier flood with oldest-first eviction, then GREEN (d0bb272). `cd packages/lib && bunx vitest run src/security/`: **289 passed (11 files)**.

Local typecheck/lint skipped due to machine contention with sibling worktrees — relying on CI per @2witstudios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnZVYRyAsK9dyZWnXK8YJS
