### PR TITLE
fix(web): restore live inbox updates by keying socket cache writes to consumers

### DIFF
--- a/apps/web/src/components/inbox/ChannelsCenterList.tsx
+++ b/apps/web/src/components/inbox/ChannelsCenterList.tsx
@@ -39,7 +39,7 @@ export default function ChannelsCenterList({ driveId }: ChannelsCenterListProps)
     ? `/api/inbox?type=channel&driveId=${driveId}&limit=20`
     : '/api/inbox?type=channel&limit=20';
 
-  useInboxSocket({ cacheKey: apiUrl, scope: 'channel', hasLoadedRef });
+  useInboxSocket({ cacheKey: apiUrl, scope: 'channel', driveId, hasLoadedRef });
 
   const { data, error, isLoading } = useSWR<InboxResponse>(apiUrl, fetcher, {
     refreshInterval: 0,

--- a/apps/web/src/components/inbox/ChannelsCenterList.tsx
+++ b/apps/web/src/components/inbox/ChannelsCenterList.tsx
@@ -39,13 +39,13 @@ export default function ChannelsCenterList({ driveId }: ChannelsCenterListProps)
     ? `/api/inbox?type=channel&driveId=${driveId}&limit=20`
     : '/api/inbox?type=channel&limit=20';
 
-  useInboxSocket({ driveId, hasLoadedRef });
+  useInboxSocket({ cacheKey: apiUrl, scope: 'channel', hasLoadedRef });
 
   const { data, error, isLoading } = useSWR<InboxResponse>(apiUrl, fetcher, {
     refreshInterval: 0,
     isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
-    revalidateOnFocus: false,
+    revalidateOnFocus: true,
   });
 
   // Reset state on driveId change BEFORE the data-sync effect so that an

--- a/apps/web/src/components/inbox/DMCenterList.tsx
+++ b/apps/web/src/components/inbox/DMCenterList.tsx
@@ -35,13 +35,13 @@ export default function DMCenterList() {
   const [hasLoadedMore, setHasLoadedMore] = useState(false);
   const hasLoadedRef = useRef(false);
 
-  useInboxSocket({ hasLoadedRef });
+  useInboxSocket({ cacheKey: API_URL, scope: 'dm', hasLoadedRef });
 
   const { data, error, isLoading } = useSWR<InboxResponse>(API_URL, fetcher, {
     refreshInterval: 0,
     isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
-    revalidateOnFocus: false,
+    revalidateOnFocus: true,
   });
 
   useEffect(() => {

--- a/apps/web/src/components/layout/left-sidebar/ChannelsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/ChannelsSidebar.tsx
@@ -55,7 +55,7 @@ export default function ChannelsSidebar({ className }: SidebarProps) {
     ? `/api/inbox?type=channel&driveId=${driveId}&limit=20`
     : '/api/inbox?type=channel&limit=20';
 
-  const { hasLoadedRef } = useInboxSocket({ cacheKey: apiUrl, scope: 'channel' });
+  const { hasLoadedRef } = useInboxSocket({ cacheKey: apiUrl, scope: 'channel', driveId });
 
   const { data, error } = useSWR<InboxResponse>(apiUrl, fetcher, {
     refreshInterval: 0,

--- a/apps/web/src/components/layout/left-sidebar/ChannelsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/ChannelsSidebar.tsx
@@ -55,13 +55,13 @@ export default function ChannelsSidebar({ className }: SidebarProps) {
     ? `/api/inbox?type=channel&driveId=${driveId}&limit=20`
     : '/api/inbox?type=channel&limit=20';
 
-  const { hasLoadedRef } = useInboxSocket({ driveId });
+  const { hasLoadedRef } = useInboxSocket({ cacheKey: apiUrl, scope: 'channel' });
 
   const { data, error } = useSWR<InboxResponse>(apiUrl, fetcher, {
     refreshInterval: 0,
     isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
-    revalidateOnFocus: false,
+    revalidateOnFocus: true,
   });
 
   // Reset state on driveId change BEFORE the data-sync effect so that an

--- a/apps/web/src/components/layout/left-sidebar/DMSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DMSidebar.tsx
@@ -43,13 +43,13 @@ export default function DMSidebar({ className }: SidebarProps) {
   const isSheetBreakpoint = useBreakpoint('(max-width: 1023px)');
   const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
 
-  const { hasLoadedRef } = useInboxSocket({});
+  const { hasLoadedRef } = useInboxSocket({ cacheKey: API_URL, scope: 'dm' });
 
   const { data, error } = useSWR<InboxResponse>(API_URL, fetcher, {
     refreshInterval: 0,
     isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
-    revalidateOnFocus: false,
+    revalidateOnFocus: true,
   });
 
   useEffect(() => {

--- a/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
@@ -101,19 +101,17 @@ describe('useInboxSocket', () => {
   // cacheKey it hands to useInboxSocket, checked directly against each
   // consumer's current source. This is the assertion that catches the
   // b922d5643 regression class: any divergence between the two means
-  // mutate() writes into a cache entry with no subscriber. It also fails if
-  // `driveId` is reintroduced as a useInboxSocket prop (the old, reconstructed
-  // key), since a passing pair requires cacheKey without it.
+  // mutate() writes into a cache entry with no subscriber.
   // -------------------------------------------------------------------------
   describe('consumer cache-key parity', () => {
     const CONSUMERS = [
-      { file: 'components/layout/left-sidebar/ChannelsSidebar.tsx', scope: 'channel' },
-      { file: 'components/layout/left-sidebar/DMSidebar.tsx', scope: 'dm' },
-      { file: 'components/inbox/ChannelsCenterList.tsx', scope: 'channel' },
-      { file: 'components/inbox/DMCenterList.tsx', scope: 'dm' },
+      { file: 'components/layout/left-sidebar/ChannelsSidebar.tsx', scope: 'channel', expectsDriveId: true },
+      { file: 'components/layout/left-sidebar/DMSidebar.tsx', scope: 'dm', expectsDriveId: false },
+      { file: 'components/inbox/ChannelsCenterList.tsx', scope: 'channel', expectsDriveId: true },
+      { file: 'components/inbox/DMCenterList.tsx', scope: 'dm', expectsDriveId: false },
     ] as const;
 
-    it.each(CONSUMERS)('$file passes useInboxSocket the exact key it passes to useSWR', ({ file, scope }) => {
+    it.each(CONSUMERS)('$file passes useInboxSocket the exact key it passes to useSWR', ({ file, scope, expectsDriveId }) => {
       const source = readSource(file);
 
       const swrMatch = source.match(/useSWR<InboxResponse>\(\s*([\w$]+)\s*,\s*fetcher/);
@@ -124,15 +122,21 @@ describe('useInboxSocket', () => {
       expect(socketCallMatch, `${file}: could not find a useInboxSocket({ ... }) call`).toBeTruthy();
       const socketCallArgs = socketCallMatch![1];
 
-      // The old, reconstructed-key shape passed driveId instead of cacheKey —
-      // asserting its absence is what would fail if getCacheKey were restored.
-      expect(socketCallArgs).not.toMatch(/driveId/);
-
       const cacheKeyMatch = socketCallArgs.match(/cacheKey:\s*([\w$]+)/);
       expect(cacheKeyMatch, `${file}: useInboxSocket call has no cacheKey`).toBeTruthy();
       expect(cacheKeyMatch![1]).toBe(swrKey);
 
       expect(socketCallArgs).toMatch(new RegExp(`scope:\\s*'${scope}'`));
+
+      // Channel views scoped to one drive must forward driveId, or a channel
+      // event from an unrelated drive passes the scope check, misses every
+      // item in this cache, and triggers a spurious full-revalidation
+      // refetch. DM views have no per-drive cache, so driveId must be absent.
+      if (expectsDriveId) {
+        expect(socketCallArgs, `${file}: channel view should scope by driveId`).toMatch(/driveId/);
+      } else {
+        expect(socketCallArgs, `${file}: dm view has no per-drive cache`).not.toMatch(/driveId/);
+      }
     });
 
     it('the four consumers each enable revalidateOnFocus (self-healing on missed events)', () => {
@@ -178,6 +182,53 @@ describe('useInboxSocket', () => {
 
       act(() => {
         mockSocket._trigger('inbox:channel_updated', channelPayload());
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        CHANNEL_KEY,
+        expect.any(Function),
+        { revalidate: false }
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Drive scoping: a channel event for a drive other than the one this cache
+  // is scoped to must not be treated as belonging here (flagged in PR #2247
+  // review — a drive-scoped channels view otherwise refetches on every other
+  // active drive's channel traffic, the same class of bug the scope filter
+  // above fixes, one dimension deeper).
+  // -------------------------------------------------------------------------
+  describe('drive scoping', () => {
+    it('given a driveId, a channel payload for a different drive causes zero cache writes', () => {
+      renderInboxSocket({ driveId: 'drive-a' });
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload({ driveId: 'drive-b' }));
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it('given a driveId, a channel payload for the same drive is written to the cache', () => {
+      renderInboxSocket({ driveId: 'drive-a' });
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload({ driveId: 'drive-a' }));
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        CHANNEL_KEY,
+        expect.any(Function),
+        { revalidate: false }
+      );
+    });
+
+    it('without a driveId (a cross-drive view), a channel payload for any drive is written', () => {
+      renderInboxSocket();
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload({ driveId: 'drive-a' }));
       });
 
       expect(mockMutate).toHaveBeenCalledWith(

--- a/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
@@ -318,6 +318,36 @@ describe('useInboxSocket', () => {
       expect(afterFirstHandler.items[0].unreadCount).toBe(5);
       expect(afterSecondHandler.items[0].unreadCount).toBe(5);
     });
+
+    it('two distinct messages that collide on the same millisecond timestamp still each increment (flagged in PR #2247 review)', () => {
+      // toISOString() is millisecond-precision, so two genuinely distinct
+      // messages sent in rapid succession can share an identical
+      // lastMessageAt. Distinct preview text is what tells them apart here.
+      const collidingTimestamp = '2026-07-28T13:00:00.000Z';
+      const firstPayload = dmPayload({ id: 'dm-1', lastMessageAt: collidingTimestamp, lastMessagePreview: 'first message', unreadCount: undefined });
+      const { afterFirstHandler: afterFirstMessage } = runUpdaterTwice(firstPayload, seedData);
+      expect(afterFirstMessage.items[0].unreadCount).toBe(1);
+
+      const secondPayload = dmPayload({ id: 'dm-1', lastMessageAt: collidingTimestamp, lastMessagePreview: 'second message', unreadCount: undefined });
+      const { afterFirstHandler, afterSecondHandler } = runUpdaterTwice(secondPayload, afterFirstMessage);
+
+      expect(afterFirstHandler.items[0].unreadCount).toBe(2);
+      expect(afterSecondHandler.items[0].unreadCount).toBe(2);
+      expect(afterSecondHandler.items[0].lastMessagePreview).toBe('second message');
+    });
+
+    it('a preview-less payload (e.g. an attachment-only message) still dedupes correctly across two handlers', () => {
+      // Regression guard for the previewMatches fallback: comparing
+      // payload.lastMessagePreview directly against existingItem's (instead
+      // of falling back to true when the payload has none) would make
+      // every no-preview message look like a "different" message to the
+      // second handler and double-increment it.
+      const payload = dmPayload({ id: 'dm-1', lastMessageAt: '2026-07-28T13:00:00.000Z', lastMessagePreview: undefined, unreadCount: undefined });
+      const { afterFirstHandler, afterSecondHandler } = runUpdaterTwice(payload, seedData);
+
+      expect(afterFirstHandler.items[0].unreadCount).toBe(1);
+      expect(afterSecondHandler.items[0].unreadCount).toBe(1);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
@@ -25,40 +25,26 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { createMockSocket } from '@/test/socket-mocks';
 import { useEditingStore } from '@/stores/useEditingStore';
 
 const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const readSource = (relPath: string) => readFileSync(resolve(srcRoot, relPath), 'utf8');
+const sourceCache = new Map<string, string>();
+const readSource = (relPath: string) => {
+  const cached = sourceCache.get(relPath);
+  if (cached !== undefined) return cached;
+  const content = readFileSync(resolve(srcRoot, relPath), 'utf8');
+  sourceCache.set(relPath, content);
+  return content;
+};
 
 // ---------------------------------------------------------------------------
-// Hoisted mocks shared across all tests
+// Hoisted mocks shared across all tests. `mockSocket` is built from the real
+// (unmocked) `createMockSocket`, so it must stay out of vi.hoisted — that
+// callback runs before other imports are initialized.
 // ---------------------------------------------------------------------------
-const { mockSocket, mockMutate } = vi.hoisted(() => {
-  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-
-  const mockSocket = {
-    connected: true,
-    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      if (!handlers[event]) handlers[event] = [];
-      handlers[event].push(handler);
-    }),
-    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      if (handlers[event]) {
-        handlers[event] = handlers[event].filter((h) => h !== handler);
-      }
-    }),
-    _trigger: (event: string, payload: unknown) => {
-      handlers[event]?.slice().forEach((h) => h(payload));
-    },
-    _reset: () => {
-      Object.keys(handlers).forEach((k) => { handlers[k] = []; });
-    },
-  };
-
-  const mockMutate = vi.fn();
-
-  return { mockSocket, mockMutate };
-});
+const { mockMutate } = vi.hoisted(() => ({ mockMutate: vi.fn() }));
+const mockSocket = createMockSocket();
 
 vi.mock('../useSocket', () => ({
   useSocket: () => mockSocket,
@@ -70,6 +56,17 @@ vi.mock('swr', () => ({
 
 import { useInboxSocket } from '../useInboxSocket';
 import type { InboxEventPayload } from '@/lib/websocket/socket-utils';
+
+const CHANNEL_KEY = '/api/inbox?type=channel&limit=20';
+const DM_KEY = '/api/inbox?type=dm&limit=20';
+
+const renderInboxSocket = (overrides: Partial<Parameters<typeof useInboxSocket>[0]> = {}) =>
+  renderHook(() => useInboxSocket({
+    cacheKey: CHANNEL_KEY,
+    scope: 'channel',
+    hasLoadedRef: { current: true },
+    ...overrides,
+  }));
 
 const channelPayload = (overrides: Partial<InboxEventPayload> = {}): InboxEventPayload => ({
   operation: 'channel_updated',
@@ -91,7 +88,6 @@ const dmPayload = (overrides: Partial<InboxEventPayload> = {}): InboxEventPayloa
 
 describe('useInboxSocket', () => {
   beforeEach(() => {
-    mockSocket._reset();
     vi.clearAllMocks();
     useEditingStore.setState({ activeSessions: new Map(), pendingSends: new Set() });
   });
@@ -158,8 +154,7 @@ describe('useInboxSocket', () => {
   // -------------------------------------------------------------------------
   describe('scope filtering', () => {
     it('given scope "channel", a dm-typed payload causes zero cache writes', () => {
-      const hasLoadedRef = { current: true };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+      renderInboxSocket();
 
       act(() => {
         mockSocket._trigger('inbox:dm_updated', dmPayload());
@@ -169,8 +164,7 @@ describe('useInboxSocket', () => {
     });
 
     it('given scope "dm", a channel-typed payload causes zero cache writes', () => {
-      const hasLoadedRef = { current: true };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=dm&limit=20', scope: 'dm', hasLoadedRef }));
+      renderInboxSocket({ cacheKey: DM_KEY, scope: 'dm' });
 
       act(() => {
         mockSocket._trigger('inbox:channel_updated', channelPayload());
@@ -180,15 +174,14 @@ describe('useInboxSocket', () => {
     });
 
     it('given a matching scope, the payload is written to the cache', () => {
-      const hasLoadedRef = { current: true };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+      renderInboxSocket();
 
       act(() => {
         mockSocket._trigger('inbox:channel_updated', channelPayload());
       });
 
       expect(mockMutate).toHaveBeenCalledWith(
-        '/api/inbox?type=channel&limit=20',
+        CHANNEL_KEY,
         expect.any(Function),
         { revalidate: false }
       );
@@ -200,8 +193,7 @@ describe('useInboxSocket', () => {
   // -------------------------------------------------------------------------
   describe('stale-replay on editing end', () => {
     it('replays a dropped update once editing ends, with no page reload', () => {
-      const hasLoadedRef = { current: true };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+      renderInboxSocket();
 
       act(() => {
         useEditingStore.getState().startEditing('doc-1', 'document');
@@ -220,12 +212,11 @@ describe('useInboxSocket', () => {
 
       // Editing store subscription replays via a full revalidation of the
       // same key once every editing session ends.
-      expect(mockMutate).toHaveBeenCalledWith('/api/inbox?type=channel&limit=20');
+      expect(mockMutate).toHaveBeenCalledWith(CHANNEL_KEY);
     });
 
     it('does not replay while any other editing session remains active', () => {
-      const hasLoadedRef = { current: true };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+      renderInboxSocket();
 
       act(() => {
         useEditingStore.getState().startEditing('doc-1', 'document');
@@ -247,12 +238,11 @@ describe('useInboxSocket', () => {
         useEditingStore.getState().endEditing('doc-2');
       });
 
-      expect(mockMutate).toHaveBeenCalledWith('/api/inbox?type=channel&limit=20');
+      expect(mockMutate).toHaveBeenCalledWith(CHANNEL_KEY);
     });
 
     it('does not replay when no update was dropped', () => {
-      const hasLoadedRef = { current: true };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+      renderInboxSocket();
 
       act(() => {
         useEditingStore.getState().startEditing('doc-1', 'document');
@@ -267,8 +257,7 @@ describe('useInboxSocket', () => {
 
   describe('hasLoadedRef race guard', () => {
     it('ignores events until hasLoadedRef.current is true', () => {
-      const hasLoadedRef = { current: false };
-      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+      renderInboxSocket({ hasLoadedRef: { current: false } });
 
       act(() => {
         mockSocket._trigger('inbox:channel_updated', channelPayload());

--- a/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
@@ -56,6 +56,7 @@ vi.mock('swr', () => ({
 
 import { useInboxSocket } from '../useInboxSocket';
 import type { InboxEventPayload } from '@/lib/websocket/socket-utils';
+import type { InboxResponse } from '@pagespace/lib/types';
 
 const CHANNEL_KEY = '/api/inbox?type=channel&limit=20';
 const DM_KEY = '/api/inbox?type=dm&limit=20';
@@ -240,6 +241,82 @@ describe('useInboxSocket', () => {
         expect.any(Function),
         { revalidate: false }
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Duplicate-handler idempotency: a sidebar and its matching center list
+  // (e.g. DMSidebar + DMCenterList, both mounted simultaneously on
+  // /dashboard/dms via Layout) share this exact cacheKey and each mount their
+  // own useInboxSocket, so one socket event runs this updater twice. Flagged
+  // by automated review (chatgpt-codex-connector, P1) after the driveId fix;
+  // verified empirically first (see PR #2247 discussion) that SWR's
+  // functional mutate() applies synchronously, so the second call's
+  // currentData already reflects the first call's write. Simulated here by
+  // invoking the captured updater twice in sequence, chaining the return
+  // value — exactly how two independent handlers would observe the cache.
+  // -------------------------------------------------------------------------
+  describe('duplicate-handler idempotency (shared cacheKey)', () => {
+    const seedData: InboxResponse = {
+      items: [{
+        id: 'dm-1',
+        type: 'dm',
+        name: 'Test User',
+        avatarUrl: null,
+        lastMessageAt: '2026-07-28T12:00:00.000Z',
+        lastMessagePreview: 'old message',
+        lastMessageSender: null,
+        unreadCount: 0,
+      }],
+      pagination: { hasMore: false, nextCursor: null },
+    };
+
+    const runUpdaterTwice = (payload: InboxEventPayload, currentData: InboxResponse) => {
+      // Fresh render + clean mock state each call: this simulates exactly
+      // one hook instance receiving one socket event, so the two applications
+      // below are of the *same* captured updater (standing in for two
+      // sibling hook instances), not an artifact of a stale prior render.
+      const rendered = renderInboxSocket({ cacheKey: DM_KEY, scope: 'dm' });
+      mockMutate.mockClear();
+
+      act(() => {
+        mockSocket._trigger('inbox:dm_updated', payload);
+      });
+
+      expect(mockMutate.mock.calls).toHaveLength(1);
+      const updater = mockMutate.mock.calls[0][1] as (data: InboxResponse) => InboxResponse;
+      const afterFirstHandler = updater(currentData);
+      const afterSecondHandler = updater(afterFirstHandler);
+      rendered.unmount();
+      return { afterFirstHandler, afterSecondHandler };
+    };
+
+    it('one message increments unreadCount exactly once, not twice, across two handlers', () => {
+      const payload = dmPayload({ id: 'dm-1', lastMessageAt: '2026-07-28T13:00:00.000Z', unreadCount: undefined });
+      const { afterFirstHandler, afterSecondHandler } = runUpdaterTwice(payload, seedData);
+
+      expect(afterFirstHandler.items[0].unreadCount).toBe(1);
+      expect(afterSecondHandler.items[0].unreadCount).toBe(1);
+    });
+
+    it('two distinct messages still each increment unreadCount once (guard is not overzealous)', () => {
+      const firstPayload = dmPayload({ id: 'dm-1', lastMessageAt: '2026-07-28T13:00:00.000Z', unreadCount: undefined });
+      const { afterFirstHandler: afterFirstMessage } = runUpdaterTwice(firstPayload, seedData);
+      expect(afterFirstMessage.items[0].unreadCount).toBe(1);
+
+      const secondPayload = dmPayload({ id: 'dm-1', lastMessageAt: '2026-07-28T14:00:00.000Z', unreadCount: undefined });
+      const { afterFirstHandler, afterSecondHandler } = runUpdaterTwice(secondPayload, afterFirstMessage);
+
+      expect(afterFirstHandler.items[0].unreadCount).toBe(2);
+      expect(afterSecondHandler.items[0].unreadCount).toBe(2);
+    });
+
+    it('an explicit server-provided unreadCount is naturally idempotent without the guard', () => {
+      const payload = dmPayload({ id: 'dm-1', lastMessageAt: '2026-07-28T13:00:00.000Z', unreadCount: 5 });
+      const { afterFirstHandler, afterSecondHandler } = runUpdaterTwice(payload, seedData);
+
+      expect(afterFirstHandler.items[0].unreadCount).toBe(5);
+      expect(afterSecondHandler.items[0].unreadCount).toBe(5);
     });
   });
 

--- a/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
@@ -1,0 +1,280 @@
+/**
+ * useInboxSocket regression coverage.
+ *
+ * Root cause (commit b922d5643, #1230): the hook used to reconstruct its own
+ * SWR cache key (`driveId ? ... : '/api/inbox?limit=20'`), while every
+ * consumer subscribes to SWR under a `type=`-qualified key. SWR keys by exact
+ * string value, so `mutate(cacheKey, ...)` was writing into a cache entry
+ * with zero subscribers — every socket-driven unread update was silently
+ * discarded until the page was reloaded.
+ *
+ * The fix has the hook take the consumer's literal cache key instead of
+ * rebuilding it. The most valuable regression test is therefore proving that
+ * each consumer passes `useInboxSocket` the identical expression it passes to
+ * `useSWR` — checked here directly against each consumer's source, so any
+ * future PR that changes one call site without the other fails CI instead of
+ * silently killing live updates again. Hook *behavior* against those same
+ * literal keys (scope filtering, stale-replay, the mutate() call itself) is
+ * covered separately below with the real hook and a fake socket — full DOM
+ * rendering of the sidebar/list components was deliberately avoided: it pulls
+ * in Radix ScrollArea, which loops on ref-callback resize measurement under
+ * jsdom (no real layout signal to settle on) for reasons unrelated to this fix.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEditingStore } from '@/stores/useEditingStore';
+
+const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const readSource = (relPath: string) => readFileSync(resolve(srcRoot, relPath), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks shared across all tests
+// ---------------------------------------------------------------------------
+const { mockSocket, mockMutate } = vi.hoisted(() => {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+  const mockSocket = {
+    connected: true,
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (handlers[event]) {
+        handlers[event] = handlers[event].filter((h) => h !== handler);
+      }
+    }),
+    _trigger: (event: string, payload: unknown) => {
+      handlers[event]?.slice().forEach((h) => h(payload));
+    },
+    _reset: () => {
+      Object.keys(handlers).forEach((k) => { handlers[k] = []; });
+    },
+  };
+
+  const mockMutate = vi.fn();
+
+  return { mockSocket, mockMutate };
+});
+
+vi.mock('../useSocket', () => ({
+  useSocket: () => mockSocket,
+}));
+
+vi.mock('swr', () => ({
+  useSWRConfig: () => ({ mutate: mockMutate }),
+}));
+
+import { useInboxSocket } from '../useInboxSocket';
+import type { InboxEventPayload } from '@/lib/websocket/socket-utils';
+
+const channelPayload = (overrides: Partial<InboxEventPayload> = {}): InboxEventPayload => ({
+  operation: 'channel_updated',
+  type: 'channel',
+  id: 'ch-1',
+  lastMessageAt: '2026-07-28T12:00:00.000Z',
+  unreadCount: 3,
+  ...overrides,
+});
+
+const dmPayload = (overrides: Partial<InboxEventPayload> = {}): InboxEventPayload => ({
+  operation: 'dm_updated',
+  type: 'dm',
+  id: 'dm-1',
+  lastMessageAt: '2026-07-28T12:00:00.000Z',
+  unreadCount: 2,
+  ...overrides,
+});
+
+describe('useInboxSocket', () => {
+  beforeEach(() => {
+    mockSocket._reset();
+    vi.clearAllMocks();
+    useEditingStore.setState({ activeSessions: new Map(), pendingSends: new Set() });
+  });
+
+  afterEach(() => {
+    useEditingStore.setState({ activeSessions: new Map(), pendingSends: new Set() });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC1/AC4/AC6: cache key parity between each consumer's useSWR call and the
+  // cacheKey it hands to useInboxSocket, checked directly against each
+  // consumer's current source. This is the assertion that catches the
+  // b922d5643 regression class: any divergence between the two means
+  // mutate() writes into a cache entry with no subscriber. It also fails if
+  // `driveId` is reintroduced as a useInboxSocket prop (the old, reconstructed
+  // key), since a passing pair requires cacheKey without it.
+  // -------------------------------------------------------------------------
+  describe('consumer cache-key parity', () => {
+    const CONSUMERS = [
+      { file: 'components/layout/left-sidebar/ChannelsSidebar.tsx', scope: 'channel' },
+      { file: 'components/layout/left-sidebar/DMSidebar.tsx', scope: 'dm' },
+      { file: 'components/inbox/ChannelsCenterList.tsx', scope: 'channel' },
+      { file: 'components/inbox/DMCenterList.tsx', scope: 'dm' },
+    ] as const;
+
+    it.each(CONSUMERS)('$file passes useInboxSocket the exact key it passes to useSWR', ({ file, scope }) => {
+      const source = readSource(file);
+
+      const swrMatch = source.match(/useSWR<InboxResponse>\(\s*([\w$]+)\s*,\s*fetcher/);
+      expect(swrMatch, `${file}: could not find a useSWR<InboxResponse>(key, fetcher, ...) call`).toBeTruthy();
+      const swrKey = swrMatch![1];
+
+      const socketCallMatch = source.match(/useInboxSocket\(\{([^}]*)\}\)/);
+      expect(socketCallMatch, `${file}: could not find a useInboxSocket({ ... }) call`).toBeTruthy();
+      const socketCallArgs = socketCallMatch![1];
+
+      // The old, reconstructed-key shape passed driveId instead of cacheKey —
+      // asserting its absence is what would fail if getCacheKey were restored.
+      expect(socketCallArgs).not.toMatch(/driveId/);
+
+      const cacheKeyMatch = socketCallArgs.match(/cacheKey:\s*([\w$]+)/);
+      expect(cacheKeyMatch, `${file}: useInboxSocket call has no cacheKey`).toBeTruthy();
+      expect(cacheKeyMatch![1]).toBe(swrKey);
+
+      expect(socketCallArgs).toMatch(new RegExp(`scope:\\s*'${scope}'`));
+    });
+
+    it('the four consumers each enable revalidateOnFocus (self-healing on missed events)', () => {
+      const files = CONSUMERS.map((c) => c.file);
+      for (const file of files) {
+        const source = readSource(file);
+        expect(source, `${file}: revalidateOnFocus should be true`).toMatch(/revalidateOnFocus:\s*true/);
+      }
+    });
+  });
+
+  it('the hook never re-derives an /api/inbox URL itself', () => {
+    const source = readSource('hooks/useInboxSocket.ts');
+    expect(source).not.toMatch(/\/api\/inbox/);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC2: scope filtering
+  // -------------------------------------------------------------------------
+  describe('scope filtering', () => {
+    it('given scope "channel", a dm-typed payload causes zero cache writes', () => {
+      const hasLoadedRef = { current: true };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+
+      act(() => {
+        mockSocket._trigger('inbox:dm_updated', dmPayload());
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it('given scope "dm", a channel-typed payload causes zero cache writes', () => {
+      const hasLoadedRef = { current: true };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=dm&limit=20', scope: 'dm', hasLoadedRef }));
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload());
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it('given a matching scope, the payload is written to the cache', () => {
+      const hasLoadedRef = { current: true };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload());
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        '/api/inbox?type=channel&limit=20',
+        expect.any(Function),
+        { revalidate: false }
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC3: never silently drop an event mid-edit
+  // -------------------------------------------------------------------------
+  describe('stale-replay on editing end', () => {
+    it('replays a dropped update once editing ends, with no page reload', () => {
+      const hasLoadedRef = { current: true };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+
+      act(() => {
+        useEditingStore.getState().startEditing('doc-1', 'document');
+      });
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload());
+      });
+
+      // Dropped, not written, while editing is active.
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      act(() => {
+        useEditingStore.getState().endEditing('doc-1');
+      });
+
+      // Editing store subscription replays via a full revalidation of the
+      // same key once every editing session ends.
+      expect(mockMutate).toHaveBeenCalledWith('/api/inbox?type=channel&limit=20');
+    });
+
+    it('does not replay while any other editing session remains active', () => {
+      const hasLoadedRef = { current: true };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+
+      act(() => {
+        useEditingStore.getState().startEditing('doc-1', 'document');
+        useEditingStore.getState().startEditing('doc-2', 'document');
+      });
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload());
+      });
+
+      act(() => {
+        useEditingStore.getState().endEditing('doc-1');
+      });
+
+      // doc-2 is still editing — isAnyEditing() is still true, so no replay yet.
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      act(() => {
+        useEditingStore.getState().endEditing('doc-2');
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith('/api/inbox?type=channel&limit=20');
+    });
+
+    it('does not replay when no update was dropped', () => {
+      const hasLoadedRef = { current: true };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+
+      act(() => {
+        useEditingStore.getState().startEditing('doc-1', 'document');
+      });
+      act(() => {
+        useEditingStore.getState().endEditing('doc-1');
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasLoadedRef race guard', () => {
+    it('ignores events until hasLoadedRef.current is true', () => {
+      const hasLoadedRef = { current: false };
+      renderHook(() => useInboxSocket({ cacheKey: '/api/inbox?type=channel&limit=20', scope: 'channel', hasLoadedRef }));
+
+      act(() => {
+        mockSocket._trigger('inbox:channel_updated', channelPayload());
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useInboxSocket.test.ts
@@ -118,7 +118,11 @@ describe('useInboxSocket', () => {
       expect(swrMatch, `${file}: could not find a useSWR<InboxResponse>(key, fetcher, ...) call`).toBeTruthy();
       const swrKey = swrMatch![1];
 
-      const socketCallMatch = source.match(/useInboxSocket\(\{([^}]*)\}\)/);
+      // Lazy [\s\S]*? (not [^}]*) so this still matches if the object literal
+      // is reformatted across multiple lines. It still can't handle a nested
+      // object literal inlined as one of the args (e.g. hasLoadedRef: { current:
+      // false } instead of a variable) — none of these consumers do that today.
+      const socketCallMatch = source.match(/useInboxSocket\(\{([\s\S]*?)\}\s*\)/);
       expect(socketCallMatch, `${file}: could not find a useInboxSocket({ ... }) call`).toBeTruthy();
       const socketCallArgs = socketCallMatch![1];
 

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -13,6 +13,15 @@ interface UseInboxSocketOptions {
   cacheKey: string;
   /** Item types this cache holds. Payloads of other types are ignored. */
   scope: 'dm' | 'channel' | 'all';
+  /**
+   * Set when this subscription's cache is scoped to one drive (e.g. a
+   * drive's channel list). Payloads for other drives are ignored — without
+   * this, a channel event from an unrelated drive still passes the `scope`
+   * check, fails to match any item in this drive-scoped cache, and falls
+   * through to a full-revalidation refetch for every other active drive.
+   * Omit for cross-drive views (e.g. "all channels").
+   */
+  driveId?: string;
   hasLoadedRef?: React.MutableRefObject<boolean>;
 }
 
@@ -23,11 +32,12 @@ interface UseInboxSocketOptions {
  * @param cacheKey - The exact string the consumer passes to useSWR. SWR keys by value, so
  *                   this must match verbatim or writes land in a cache entry with no subscriber.
  * @param scope - Restricts which payload types this subscription writes to its cache.
+ * @param driveId - Restricts to payloads for one drive, for drive-scoped caches.
  * @param hasLoadedRef - Optional ref to track if initial data has loaded. When provided,
  *                       socket updates will only be processed after hasLoadedRef.current is true.
  *                       This prevents socket events from racing with initial data fetches.
  */
-export function useInboxSocket({ cacheKey, scope, hasLoadedRef: externalRef }: UseInboxSocketOptions) {
+export function useInboxSocket({ cacheKey, scope, driveId, hasLoadedRef: externalRef }: UseInboxSocketOptions) {
   const socket = useSocket();
   const { mutate } = useSWRConfig();
   const internalRef = useRef(false);
@@ -43,6 +53,10 @@ export function useInboxSocket({ cacheKey, scope, hasLoadedRef: externalRef }: U
       // cache (and vice versa), finds no match, and falls through to a full
       // revalidation fallback per mounted list.
       if (scope !== 'all' && payload.type !== scope) return;
+
+      // Same reasoning for drive scope: a channel event from another drive
+      // will never match an item in this drive-scoped cache.
+      if (driveId && payload.driveId !== driveId) return;
 
       // Skip updates if we haven't loaded yet (race guard against the initial fetch).
       if (!hasLoadedRef.current) return;
@@ -126,7 +140,7 @@ export function useInboxSocket({ cacheKey, scope, hasLoadedRef: externalRef }: U
       socket.off('inbox:read_status_changed', handleInboxUpdate);
       socket.off('inbox:thread_updated', handleThreadUpdated);
     };
-  }, [socket, cacheKey, scope, mutate, hasLoadedRef]);
+  }, [socket, cacheKey, scope, driveId, mutate, hasLoadedRef]);
 
   // Replay path: an update dropped while editing was active is never lost —
   // once every editing session ends, revalidate the cache from the server.

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -22,7 +22,7 @@ interface UseInboxSocketOptions {
    * Omit for cross-drive views (e.g. "all channels").
    */
   driveId?: string;
-  hasLoadedRef?: React.MutableRefObject<boolean>;
+  hasLoadedRef?: React.RefObject<boolean>;
 }
 
 /**

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSWRConfig } from 'swr';
 import { useSocket } from './useSocket';
 import { useEditingStore } from '@/stores/useEditingStore';
@@ -9,41 +9,50 @@ import type { InboxEventPayload } from '@/lib/websocket/socket-utils';
 import type { InboxResponse } from '@pagespace/lib/types';
 
 interface UseInboxSocketOptions {
-  driveId?: string;
+  /** The exact string passed to useSWR. Must be identical — SWR keys by value. */
+  cacheKey: string;
+  /** Item types this cache holds. Payloads of other types are ignored. */
+  scope: 'dm' | 'channel' | 'all';
   hasLoadedRef?: React.MutableRefObject<boolean>;
 }
 
 /**
  * Hook that listens for inbox events (DM/channel updates) and updates the SWR cache.
- * Integrates with editing store to prevent updates during active editing sessions.
+ * Integrates with editing store to defer (not drop) updates during active editing sessions.
  *
+ * @param cacheKey - The exact string the consumer passes to useSWR. SWR keys by value, so
+ *                   this must match verbatim or writes land in a cache entry with no subscriber.
+ * @param scope - Restricts which payload types this subscription writes to its cache.
  * @param hasLoadedRef - Optional ref to track if initial data has loaded. When provided,
  *                       socket updates will only be processed after hasLoadedRef.current is true.
  *                       This prevents socket events from racing with initial data fetches.
  */
-export function useInboxSocket({ driveId, hasLoadedRef: externalRef }: UseInboxSocketOptions = {}) {
+export function useInboxSocket({ cacheKey, scope, hasLoadedRef: externalRef }: UseInboxSocketOptions) {
   const socket = useSocket();
   const { mutate } = useSWRConfig();
   const internalRef = useRef(false);
   const hasLoadedRef = externalRef ?? internalRef;
-
-  // Build the SWR cache key
-  const getCacheKey = useCallback(() => {
-    return driveId
-      ? `/api/inbox?driveId=${driveId}&limit=20`
-      : '/api/inbox?limit=20';
-  }, [driveId]);
+  const staleRef = useRef(false);
 
   useEffect(() => {
     if (!socket) return;
 
     const handleInboxUpdate = (payload: InboxEventPayload) => {
-      // Skip updates if we haven't loaded yet or if editing is active
-      if (!hasLoadedRef.current || useEditingStore.getState().isAnyEditing()) {
+      // Ignore payloads outside this subscription's scope before any other
+      // work — otherwise every DM event runs the updater against a channels
+      // cache (and vice versa), finds no match, and falls through to a full
+      // revalidation fallback per mounted list.
+      if (scope !== 'all' && payload.type !== scope) return;
+
+      // Skip updates if we haven't loaded yet (race guard against the initial fetch).
+      if (!hasLoadedRef.current) return;
+
+      if (useEditingStore.getState().isAnyEditing()) {
+        // Defer, don't drop: the editing-store subscription effect below
+        // replays this once editing ends.
+        staleRef.current = true;
         return;
       }
-
-      const cacheKey = getCacheKey();
 
       // Optimistically update the SWR cache
       mutate(
@@ -117,7 +126,19 @@ export function useInboxSocket({ driveId, hasLoadedRef: externalRef }: UseInboxS
       socket.off('inbox:read_status_changed', handleInboxUpdate);
       socket.off('inbox:thread_updated', handleThreadUpdated);
     };
-  }, [socket, getCacheKey, mutate, hasLoadedRef]);
+  }, [socket, cacheKey, scope, mutate, hasLoadedRef]);
+
+  // Replay path: an update dropped while editing was active is never lost —
+  // once every editing session ends, revalidate the cache from the server.
+  useEffect(() => {
+    const unsubscribe = useEditingStore.subscribe((state) => {
+      if (staleRef.current && !state.isAnyEditing()) {
+        staleRef.current = false;
+        mutate(cacheKey);
+      }
+    });
+    return unsubscribe;
+  }, [cacheKey, mutate]);
 
   return {
     hasLoadedRef,

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -89,13 +89,38 @@ export function useInboxSocket({ cacheKey, scope, driveId, hasLoadedRef: externa
             // independently for the same socket event. mutate()'s functional
             // updater applies synchronously, so the second call's
             // currentData already reflects the first call's write — visible
-            // here as lastMessageAt already matching the incoming payload.
-            // Without this guard, one message double-increments unreadCount
-            // (0 -> 1 -> 2). payload.unreadCount (an explicit value from the
-            // server) and read_status_changed's reset to 0 are naturally
-            // idempotent already, so only the +1 fallback needs guarding.
+            // here as lastMessageAt (+ preview, see below) already matching
+            // the incoming payload. Without this guard, one message
+            // double-increments unreadCount (0 -> 1 -> 2). payload.unreadCount
+            // (an explicit value from the server) and read_status_changed's
+            // reset to 0 are naturally idempotent already, so only the +1
+            // fallback needs guarding.
+            //
+            // The payload carries no per-message id (only the conversation's
+            // id, reused across all its messages), so lastMessageAt is the
+            // only identity signal available without a server-side payload
+            // change (out of scope here — see packages/lib/, owned by a
+            // sibling PR). lastMessageAt alone has a real, if narrow,
+            // collision risk: two distinct messages in the same conversation
+            // sent within the same millisecond serialize to an identical
+            // toISOString() value. When the payload carries preview text,
+            // also requiring it to match narrows that risk further, to two
+            // messages colliding on both timestamp and exact text. When
+            // there's no preview to compare (e.g. an attachment-only
+            // message), previewMatches falls back to true rather than
+            // comparing against existingItem's (unrelated, unchanged-by-this-
+            // payload) previous preview value, which would otherwise never
+            // match and silently defeat the guard for every no-preview
+            // message.
             const willIncrement = payload.unreadCount === undefined && payload.operation !== 'read_status_changed';
-            if (willIncrement && payload.lastMessageAt !== undefined && payload.lastMessageAt === existingItem.lastMessageAt) {
+            const previewMatches = payload.lastMessagePreview
+              ? payload.lastMessagePreview === existingItem.lastMessagePreview
+              : true;
+            const isDuplicateOfSiblingHandler = willIncrement
+              && payload.lastMessageAt !== undefined
+              && payload.lastMessageAt === existingItem.lastMessageAt
+              && previewMatches;
+            if (isDuplicateOfSiblingHandler) {
               return currentData;
             }
 

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -82,6 +82,23 @@ export function useInboxSocket({ cacheKey, scope, driveId, hasLoadedRef: externa
           if (existingIndex >= 0) {
             // Update existing item
             const existingItem = updatedItems[existingIndex];
+
+            // A sidebar and its matching center list (e.g. DMSidebar +
+            // DMCenterList on /dashboard/dms) share this exact cacheKey and
+            // each mount their own useInboxSocket, so both run this updater
+            // independently for the same socket event. mutate()'s functional
+            // updater applies synchronously, so the second call's
+            // currentData already reflects the first call's write — visible
+            // here as lastMessageAt already matching the incoming payload.
+            // Without this guard, one message double-increments unreadCount
+            // (0 -> 1 -> 2). payload.unreadCount (an explicit value from the
+            // server) and read_status_changed's reset to 0 are naturally
+            // idempotent already, so only the +1 fallback needs guarding.
+            const willIncrement = payload.unreadCount === undefined && payload.operation !== 'read_status_changed';
+            if (willIncrement && payload.lastMessageAt !== undefined && payload.lastMessageAt === existingItem.lastMessageAt) {
+              return currentData;
+            }
+
             updatedItems[existingIndex] = {
               ...existingItem,
               lastMessageAt: payload.lastMessageAt || existingItem.lastMessageAt,


### PR DESCRIPTION
## Summary

Stage 1 of the unread/notification redesign — the hotfix that unblocks every live socket update in the app. Fixes the trust-collapse bug where new messages never triggered notification bubbles until a full page reload.

**Root cause** (dead since `b922d5643`, #1230, "split inbox into Direct Messages + Channels nav tabs"): `useInboxSocket` rebuilt its own SWR cache key from `driveId` (`/api/inbox?driveId=...&limit=20`), but all four consumers (`ChannelsSidebar`, `DMSidebar`, `ChannelsCenterList`, `DMCenterList`) subscribe to SWR under a `type=`-qualified key. SWR keys by exact string value, so every `mutate(cacheKey, ...)` call landed on a cache entry with zero subscribers — every socket-driven unread update was silently discarded.

## Changes

- **AC1** — `useInboxSocket` now takes the consumer's literal `cacheKey` string instead of reconstructing it from `driveId`. No `/api/inbox` string interpolation remains in the hook.
- **AC2** — Scope filtering (`scope: 'dm' | 'channel' | 'all'`, plus an optional `driveId` — see Post-review follow-ups below): a payload outside a subscription's scope is ignored before any other work, fixing a real perf bug where every DM event previously ran the updater against the channels cache and fell through to a full-revalidation network call (and vice versa).
- **AC3** — Never silently drop an event: a `staleRef` is set when an update is dropped mid-edit, and a new editing-store subscription effect replays it (`mutate(cacheKey)`) once every editing session ends. The existing `hasLoadedRef` race guard is unchanged.
- **AC4** — All four consumers updated: each now passes the same variable to `useSWR` and `useInboxSocket({ cacheKey, scope })`; none pass `driveId` to the hook anymore.
- **AC5** — `revalidateOnFocus` flipped to `true` on all four SWR hooks, so a missed socket event self-heals on tab focus (`refreshInterval: 0` unchanged — no polling reintroduced).
- **AC6** — New `apps/web/src/hooks/__tests__/useInboxSocket.test.ts`. The key assertion checks cache-key parity directly against each consumer's current source (so a future divergence fails CI instead of silently breaking live updates again), plus scope-filtering, drive-scoping, stale-replay, and the `hasLoadedRef` guard against the real hook. Confirmed the test fails (6/13 at the time) when `useInboxSocket.ts` is reverted to the pre-fix `driveId`/`getCacheKey` shape.

## Post-review follow-ups

- **Drive-scoped channel filtering** (found by automated review, `chatgpt-codex-connector`, P2): a drive-scoped channels view (`ChannelsSidebar`/`ChannelsCenterList` with `driveId` set) only filtered by `type`, not by drive. Channel broadcasts always carry `payload.driveId` (verified against `channels/[pageId]/messages/route.ts` and `channels/[pageId]/read/route.ts`), so a channel event from any other drive the user belongs to passed the scope check, missed every item in this drive's cache, and fell through to a full-revalidation refetch — the same bug class AC2 fixes, one dimension deeper. `useInboxSocket` now takes an optional `driveId`; wired through from the two drive-scoped consumers. 3 new tests added (cross-drive ignored, same-drive written, no-driveId/global view accepts any drive).
- **Two CodeRabbit nitpicks**: `hasLoadedRef` type changed from the deprecated `React.MutableRefObject<boolean>` to `React.RefObject<boolean>` (matches this repo's existing convention — 14 other usages vs. this file's 1); widened a source-parity test regex from `[^}]*` to lazy `[\s\S]*?` (verified empirically that the specific multi-line-reflow scenario CodeRabbit described already worked correctly under the original regex — the real, narrower limitation is a nested object literal inlined as a hook argument, which none of the 4 consumers do today).
- **Double-increment on shared cacheKey** (found by automated review, `chatgpt-codex-connector`, P1): `DMSidebar`+`DMCenterList` (and `ChannelsSidebar`+`ChannelsCenterList`) mount simultaneously on their respective routes via `Layout` (sidebar is persistent chrome, center list is `children`), both subscribing `useInboxSocket` to the identical `cacheKey`. Verified empirically (a standalone repro against the real `swr` package, not the mocked test double) that SWR's functional `mutate()` applies synchronously, so a single socket event running through both hook instances' handlers double-increments `unreadCount` for one message (0 → 1 → 2). Fixed with an idempotency guard: before incrementing, check whether `payload.lastMessageAt` already equals the cached item's `lastMessageAt` — if so, an identical event was already applied by the sibling handler, so skip. 3 new tests confirm one message increments exactly once across two simulated handlers, two distinct messages each still increment once, and an explicit server-provided `unreadCount` stays idempotent without the guard needing to apply.
- **Millisecond-collision narrowing on the double-increment guard** (found by automated review, `chatgpt-codex-connector`, P2, on the fix above): `lastMessageAt` alone collides when two distinct messages in the same conversation are sent within the same millisecond (`toISOString()` is ms-precision), silently dropping the second real message's increment. No per-message id is available without a server-side payload change (out of scope, `packages/lib/`). Narrowed the guard to also require `lastMessagePreview` to match when present, with a `previewMatches` fallback to `true` when the payload has no preview (e.g. an attachment-only message) — a naive direct comparison there would never match and reintroduce the double-increment bug for every no-preview message. Verified concretely: reverted to the naive comparison (3 tests failed), then removed the preview check entirely (only the new collision test failed). 2 new tests cover both the collision fix and the no-preview regression guard. Documented residual limitation: two messages colliding on both timestamp *and* identical preview text (e.g. two captionless attachments in the same ms) would still misfire — narrower than the original gap, not fixable without a message id.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (pre-existing warnings elsewhere, none in touched files)
- `bunx vitest run --project web src/hooks/__tests__/useInboxSocket.test.ts` — 21/21 pass
- `bunx vitest run --project web src/hooks src/components/layout/left-sidebar src/components/inbox` — 663/696 pass; the 33 failures are all in `DevelopmentSidebar.test.tsx` and `useMachineDiff.test.tsx` (untouched by this PR), caused by a pre-existing gap in the root `vitest.workspace.ts` "web" project (missing the `react()` Vite plugin, so JSX in `--project web` root-level runs throws "React is not defined"). Both files pass cleanly under `apps/web`'s own `vitest.config.ts`, confirming this is an unrelated, pre-existing environment issue.
- CI (GitHub Actions `Test Suite`: Unit Tests, Lint & TypeScript Check) green on the latest commit.

**Manual E2E reasoning** (two browsers, B has channels sidebar open, A posts a plain message): B's `ChannelsSidebar` subscribes to SWR under `apiUrl` and passes that identical string as `cacheKey` to `useInboxSocket`. The `inbox:channel_updated` socket event now writes via `mutate(cacheKey, updater, { revalidate: false })` into that exact cache entry — no network round-trip — and the consumer's existing `useEffect` on `data` re-renders the bumped/incremented row. This is precisely the write path that was previously landing on an unsubscribed key.

## Scope

Touches only `apps/web/src/hooks/useInboxSocket.ts`, its four consumers, and the new test — does not touch `apps/web/src/app/api/messages/`, `apps/web/src/app/api/channels/`, or `packages/lib/` (Stage 2, owned by sibling PR #2248, confirmed no file overlap). Stages 3–6 (favicon badge, unified `useUnreadStore`, two-tier semantics, focus-aware read) are out of scope here.

https://claude.ai/code/session_01JN1m6cDa66W8cV7Yo8GhKN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time updates for channel and direct-message inboxes.
  * Prevented updates from one inbox type (or drive) from appearing in another.
  * Inbox lists now refresh when the browser window regains focus.
  * Updates received while editing are now safely replayed after editing ends.
  * Improved handling of early or duplicate socket events to avoid stale data and incorrect unread counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


