### PR TITLE
fix(messages): broadcast DM read status and clear related notifications

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/read/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/read/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Contract tests for POST /api/channels/[pageId]/read
+ *
+ * This is the reference read-status implementation (upsert channel_read_status
+ * + broadcast inbox:read_status_changed). Stage 2 of the unread redesign adds
+ * a second responsibility: clearing the unread MENTION notifications left
+ * behind for this page (Hole C) so the nav Channels badge and bell agree with
+ * the channel's own read state.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Auth boundary --------------------------------------------------------------
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(
+    (r: unknown) => typeof r === 'object' && r !== null && 'error' in r
+  ),
+}));
+
+// --- Permissions -----------------------------------------------------------------
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+}));
+
+// --- DB seam -----------------------------------------------------------------------
+const mockFindFirst = vi.fn();
+const mockDbExecute = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { pages: { findFirst: (...args: unknown[]) => mockFindFirst(...args) } },
+    execute: (...args: unknown[]) => mockDbExecute(...args),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: Object.assign(
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings.join('?'), values })),
+    { placeholder: vi.fn() }
+  ),
+  eq: vi.fn((a, b) => ({ eq: [a, b] })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', driveId: 'driveId' },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+  },
+}));
+
+// --- Realtime broadcast ------------------------------------------------------------
+const mockBroadcastInboxEvent = vi.fn();
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastInboxEvent: (...args: unknown[]) => mockBroadcastInboxEvent(...args),
+}));
+
+// --- Notifications -------------------------------------------------------------------
+const mockMarkPageNotificationsRead = vi.fn();
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+  markPageNotificationsRead: (...args: unknown[]) => mockMarkPageNotificationsRead(...args),
+}));
+
+// --- Imports under test (must come after vi.mock blocks) ---------------------------
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import type { SessionAuthResult } from '@/lib/auth';
+
+const USER_ID = 'user_1';
+const PAGE_ID = 'page_1';
+const DRIVE_ID = 'drive_1';
+
+const sessionAuth = (userId = USER_ID): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess_test',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+function makeRequest(): Request {
+  return new Request(`http://localhost/api/channels/${PAGE_ID}/read`, { method: 'POST' });
+}
+
+const callRoute = () =>
+  POST(makeRequest(), { params: Promise.resolve({ pageId: PAGE_ID }) });
+
+describe('POST /api/channels/[pageId]/read', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    mockFindFirst.mockResolvedValue({ id: PAGE_ID, type: 'CHANNEL', driveId: DRIVE_ID });
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    mockDbExecute.mockResolvedValue(undefined);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
+    mockMarkPageNotificationsRead.mockResolvedValue(0);
+  });
+
+  it('AC4: clears unread MENTION notifications for the page and reports the count in the response', async () => {
+    mockMarkPageNotificationsRead.mockResolvedValue(3);
+
+    const res = await callRoute();
+
+    expect(res.status).toBe(200);
+    expect(mockMarkPageNotificationsRead).toHaveBeenCalledWith(USER_ID, PAGE_ID);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, notificationsMarkedRead: 3 });
+  });
+
+  it('broadcasts inbox:read_status_changed with unreadCount 0', async () => {
+    await callRoute();
+
+    expect(mockBroadcastInboxEvent).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({
+        operation: 'read_status_changed',
+        type: 'channel',
+        id: PAGE_ID,
+        driveId: DRIVE_ID,
+        unreadCount: 0,
+      })
+    );
+  });
+
+  it('returns 404 and never touches notifications when the page is not a channel', async () => {
+    mockFindFirst.mockResolvedValue({ id: PAGE_ID, type: 'DOCUMENT', driveId: DRIVE_ID });
+
+    const res = await callRoute();
+
+    expect(res.status).toBe(404);
+    expect(mockMarkPageNotificationsRead).not.toHaveBeenCalled();
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 and never touches notifications when the caller cannot view the channel', async () => {
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+    const res = await callRoute();
+
+    expect(res.status).toBe(403);
+    expect(mockMarkPageNotificationsRead).not.toHaveBeenCalled();
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/channels/[pageId]/read/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/read/route.ts
@@ -6,6 +6,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
+import { markPageNotificationsRead } from '@pagespace/lib/notifications/notifications';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
@@ -43,16 +44,22 @@ export async function POST(
     DO UPDATE SET "lastReadAt" = NOW()
   `);
 
-  // Broadcast read status change to user's inbox
-  await broadcastInboxEvent(userId, {
-    operation: 'read_status_changed',
-    type: 'channel',
-    id: pageId,
-    driveId: channel.driveId,
-    unreadCount: 0,
-  });
+  // Broadcast read status change and clear MENTION (and other) notifications
+  // tied to this page in parallel — independent writes, no dependency between
+  // them. Skipping the notification clear would leave the nav Channels badge
+  // lit even though the channel itself is read.
+  const [, notificationsMarkedRead] = await Promise.all([
+    broadcastInboxEvent(userId, {
+      operation: 'read_status_changed',
+      type: 'channel',
+      id: pageId,
+      driveId: channel.driveId,
+      unreadCount: 0,
+    }),
+    markPageNotificationsRead(userId, pageId),
+  ]);
 
-  loggers.api.debug('Channel marked as read', { channelId: pageId, userId });
+  loggers.api.debug('Channel marked as read', { channelId: pageId, userId, notificationsMarkedRead });
 
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true, notificationsMarkedRead });
 }

--- a/apps/web/src/app/api/channels/[pageId]/read/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/read/route.ts
@@ -44,20 +44,21 @@ export async function POST(
     DO UPDATE SET "lastReadAt" = NOW()
   `);
 
-  // Broadcast read status change and clear MENTION (and other) notifications
-  // tied to this page in parallel — independent writes, no dependency between
-  // them. Skipping the notification clear would leave the nav Channels badge
-  // lit even though the channel itself is read.
-  const [, notificationsMarkedRead] = await Promise.all([
-    broadcastInboxEvent(userId, {
-      operation: 'read_status_changed',
-      type: 'channel',
-      id: pageId,
-      driveId: channel.driveId,
-      unreadCount: 0,
-    }),
-    markPageNotificationsRead(userId, pageId),
-  ]);
+  // Clear MENTION notifications tied to this page BEFORE broadcasting —
+  // otherwise the nav Channels badge stays lit even though the channel
+  // itself is read. Sequenced (not parallel): a listener like
+  // useSidebarBadges revalidates /api/sidebar/badges as soon as the
+  // broadcast lands, and must observe the post-write notification state
+  // rather than racing the still-in-flight update.
+  const notificationsMarkedRead = await markPageNotificationsRead(userId, pageId);
+
+  await broadcastInboxEvent(userId, {
+    operation: 'read_status_changed',
+    type: 'channel',
+    id: pageId,
+    driveId: channel.driveId,
+    unreadCount: 0,
+  });
 
   loggers.api.debug('Channel marked as read', { channelId: pageId, userId, notificationsMarkedRead });
 

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -719,16 +719,32 @@ describe('GET /api/messages/[conversationId]', () => {
     expect(body.notificationsMarkedRead).toBe(2);
   });
 
-  it('AC3: a GET that marks nothing read broadcasts nothing and does not touch notifications', async () => {
+  it('AC3: a GET that marks nothing read broadcasts nothing (but still checks notifications)', async () => {
     mockMarkActiveMessagesRead.mockResolvedValue(0);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(0);
 
     const res = await callGet();
 
     expect(res.status).toBe(200);
     expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
-    expect(mockMarkDmConversationNotificationsRead).not.toHaveBeenCalled();
     const body = await res.json();
     expect(body.notificationsMarkedRead).toBe(0);
+  });
+
+  it('clears an orphaned NEW_DIRECT_MESSAGE notification even when no message row needed flipping, without broadcasting', async () => {
+    // Regression: a notification can be unread even when its message was
+    // already marked read by an older build (pre-Hole-E) — gating the
+    // notification clear on markedCount would leave it stuck forever.
+    mockMarkActiveMessagesRead.mockResolvedValue(0);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(1);
+
+    const res = await callGet();
+
+    expect(res.status).toBe(200);
+    expect(mockMarkDmConversationNotificationsRead).toHaveBeenCalledWith(SENDER_ID, CONVERSATION_ID);
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.notificationsMarkedRead).toBe(1);
   });
 });
 
@@ -799,16 +815,29 @@ describe('PATCH /api/messages/[conversationId] (mark-as-read)', () => {
     expect(body.notificationsMarkedRead).toBe(1);
   });
 
-  it('AC3: a PATCH that marks nothing read broadcasts nothing and does not touch notifications', async () => {
+  it('AC3: a PATCH that marks nothing read broadcasts nothing (but still checks notifications)', async () => {
     mockMarkActiveMessagesRead.mockResolvedValue(0);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(0);
 
     const res = await callPatch();
 
     expect(res.status).toBe(200);
     expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
-    expect(mockMarkDmConversationNotificationsRead).not.toHaveBeenCalled();
     const body = await res.json();
     expect(body.notificationsMarkedRead).toBe(0);
+  });
+
+  it('clears an orphaned NEW_DIRECT_MESSAGE notification even when no message row needed flipping, without broadcasting', async () => {
+    mockMarkActiveMessagesRead.mockResolvedValue(0);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(1);
+
+    const res = await callPatch();
+
+    expect(res.status).toBe(200);
+    expect(mockMarkDmConversationNotificationsRead).toHaveBeenCalledWith(SENDER_ID, CONVERSATION_ID);
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.notificationsMarkedRead).toBe(1);
   });
 });
 

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -66,9 +66,12 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 // --- Notifications -------------------------------------------------------------
 const mockCreateOrUpdateMessageNotification = vi.fn();
+const mockMarkDmConversationNotificationsRead = vi.fn();
 vi.mock('@pagespace/lib/notifications/notifications', () => ({
   createOrUpdateMessageNotification: (...args: unknown[]) =>
     mockCreateOrUpdateMessageNotification(...args),
+  markDmConversationNotificationsRead: (...args: unknown[]) =>
+    mockMarkDmConversationNotificationsRead(...args),
 }));
 
 // --- Realtime broadcast helpers ------------------------------------------------
@@ -604,11 +607,18 @@ const liveMessage = (overrides: Partial<{
 describe('GET /api/messages/[conversationId]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.INTERNAL_REALTIME_URL = 'http://realtime.test';
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
     mockFindConversationForParticipant.mockResolvedValue(mockConversation());
     mockListActiveMessages.mockResolvedValue([]);
-    mockMarkActiveMessagesRead.mockResolvedValue(undefined);
+    // Default: this GET actually flips unread rows (realistic "opening a DM
+    // with unread messages" case) — markActiveMessagesRead now reports a
+    // count, not void, so downstream broadcast/notification-clear logic can
+    // gate on it (Hole D / GET-path noise).
+    mockMarkActiveMessagesRead.mockResolvedValue(1);
     mockUpdateConversationLastRead.mockResolvedValue(undefined);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(0);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
   });
 
   it('GET_messages_filtersOutSoftDeleted_byDelegatingToListActiveMessages', async () => {
@@ -685,15 +695,53 @@ describe('GET /api/messages/[conversationId]', () => {
     expect(res.status).toBe(404);
     expect(mockListActiveMessages).not.toHaveBeenCalled();
   });
+
+  // ===== Hole D + GET-path noise (AC2, AC3) =====
+  it('AC2: broadcasts exactly one inbox:read_status_changed and clears DM notifications when the GET actually marks rows read', async () => {
+    mockMarkActiveMessagesRead.mockResolvedValue(1);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(2);
+
+    const res = await callGet();
+
+    expect(res.status).toBe(200);
+    expect(mockBroadcastInboxEvent).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastInboxEvent).toHaveBeenCalledWith(
+      SENDER_ID,
+      expect.objectContaining({
+        operation: 'read_status_changed',
+        type: 'dm',
+        id: CONVERSATION_ID,
+        unreadCount: 0,
+      })
+    );
+    expect(mockMarkDmConversationNotificationsRead).toHaveBeenCalledWith(SENDER_ID, CONVERSATION_ID);
+    const body = await res.json();
+    expect(body.notificationsMarkedRead).toBe(2);
+  });
+
+  it('AC3: a GET that marks nothing read broadcasts nothing and does not touch notifications', async () => {
+    mockMarkActiveMessagesRead.mockResolvedValue(0);
+
+    const res = await callGet();
+
+    expect(res.status).toBe(200);
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+    expect(mockMarkDmConversationNotificationsRead).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.notificationsMarkedRead).toBe(0);
+  });
 });
 
 describe('PATCH /api/messages/[conversationId] (mark-as-read)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.INTERNAL_REALTIME_URL = 'http://realtime.test';
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
     mockFindConversationForParticipant.mockResolvedValue(mockConversation());
-    mockMarkActiveMessagesRead.mockResolvedValue(undefined);
+    mockMarkActiveMessagesRead.mockResolvedValue(1);
     mockUpdateConversationLastRead.mockResolvedValue(undefined);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(0);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
   });
 
   it('PATCH_markAsRead_skipsSoftDeleted_byDelegatingToMarkActiveMessagesRead', async () => {
@@ -726,6 +774,41 @@ describe('PATCH /api/messages/[conversationId] (mark-as-read)', () => {
 
     expect(res.status).toBe(404);
     expect(mockMarkActiveMessagesRead).not.toHaveBeenCalled();
+  });
+
+  // ===== Hole D + GET-path noise mirror (AC2, AC3) =====
+  it('AC2: broadcasts exactly one inbox:read_status_changed and clears DM notifications when the PATCH actually marks rows read', async () => {
+    mockMarkActiveMessagesRead.mockResolvedValue(3);
+    mockMarkDmConversationNotificationsRead.mockResolvedValue(1);
+
+    const res = await callPatch();
+
+    expect(res.status).toBe(200);
+    expect(mockBroadcastInboxEvent).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastInboxEvent).toHaveBeenCalledWith(
+      SENDER_ID,
+      expect.objectContaining({
+        operation: 'read_status_changed',
+        type: 'dm',
+        id: CONVERSATION_ID,
+        unreadCount: 0,
+      })
+    );
+    expect(mockMarkDmConversationNotificationsRead).toHaveBeenCalledWith(SENDER_ID, CONVERSATION_ID);
+    const body = await res.json();
+    expect(body.notificationsMarkedRead).toBe(1);
+  });
+
+  it('AC3: a PATCH that marks nothing read broadcasts nothing and does not touch notifications', async () => {
+    mockMarkActiveMessagesRead.mockResolvedValue(0);
+
+    const res = await callPatch();
+
+    expect(res.status).toBe(200);
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+    expect(mockMarkDmConversationNotificationsRead).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.notificationsMarkedRead).toBe(0);
   });
 });
 

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { createOrUpdateMessageNotification } from '@pagespace/lib/notifications/notifications'
+import { createOrUpdateMessageNotification, markDmConversationNotificationsRead } from '@pagespace/lib/notifications/notifications'
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { dmMessageRepository } from '@pagespace/lib/services/dm-message-repository';
@@ -45,6 +45,32 @@ function attachmentValidationErrorResponse(
     { error: isOwnerMismatch ? 'You do not own this file' : 'File is not linked to this conversation' },
     { status: 403 }
   );
+}
+
+/**
+ * Shared by the GET side-effect and the explicit PATCH: only a call that
+ * actually flipped unread rows counts as "read" — a no-op poll/PATCH must not
+ * broadcast or touch notifications (GET-path noise). The notification clear
+ * and the inbox broadcast are independent writes, so they run in parallel.
+ */
+async function markDmConversationReadAndNotify(
+  userId: string,
+  conversationId: string,
+  markedCount: number
+): Promise<number> {
+  if (markedCount <= 0) return 0;
+
+  const [notificationsMarkedRead] = await Promise.all([
+    markDmConversationNotificationsRead(userId, conversationId),
+    broadcastInboxEvent(userId, {
+      operation: 'read_status_changed',
+      type: 'dm',
+      id: conversationId,
+      unreadCount: 0,
+    }),
+  ]);
+
+  return notificationsMarkedRead;
 }
 
 // GET /api/messages/[conversationId] - Get messages in a conversation
@@ -169,7 +195,7 @@ export async function GET(
       : conversation.participant1Id;
 
     const readAt = new Date();
-    await Promise.all([
+    const [markedCount] = await Promise.all([
       dmMessageRepository.markActiveMessagesRead({
         conversationId,
         otherUserId,
@@ -182,6 +208,8 @@ export async function GET(
       }),
     ]);
 
+    const notificationsMarkedRead = await markDmConversationReadAndNotify(userId, conversationId, markedCount);
+
     // Show oldest first in the response payload.
     messages.reverse();
 
@@ -191,7 +219,7 @@ export async function GET(
 
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'message', resourceId: conversationId });
 
-    return NextResponse.json({ messages: enriched });
+    return NextResponse.json({ messages: enriched, notificationsMarkedRead });
   } catch (error) {
     loggers.api.error('Error fetching messages:', error as Error);
     return NextResponse.json(
@@ -629,7 +657,7 @@ export async function PATCH(
       : conversation.participant1Id;
 
     const readAt = new Date();
-    await Promise.all([
+    const [markedCount] = await Promise.all([
       dmMessageRepository.markActiveMessagesRead({
         conversationId,
         otherUserId,
@@ -642,9 +670,11 @@ export async function PATCH(
       }),
     ]);
 
+    const notificationsMarkedRead = await markDmConversationReadAndNotify(userId, conversationId, markedCount);
+
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'message', resourceId: conversationId, details: { operation: 'mark_read' } });
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, notificationsMarkedRead });
   } catch (error) {
     loggers.api.error('Error marking messages as read:', error as Error);
     return NextResponse.json(

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -48,27 +48,33 @@ function attachmentValidationErrorResponse(
 }
 
 /**
- * Shared by the GET side-effect and the explicit PATCH: only a call that
- * actually flipped unread rows counts as "read" — a no-op poll/PATCH must not
- * broadcast or touch notifications (GET-path noise). The notification clear
- * and the inbox broadcast are independent writes, so they run in parallel.
+ * Shared by the GET side-effect and the explicit PATCH.
+ *
+ * The notification clear runs on every call, independent of `markedCount` — a
+ * NEW_DIRECT_MESSAGE notification can be unread even when its underlying
+ * message row was already marked read (e.g. by a build predating this fix),
+ * so gating the clear on `markedCount` would leave it orphaned forever.
+ *
+ * The inbox broadcast stays gated on `markedCount > 0` — a no-op poll must
+ * not emit socket traffic (GET-path noise) — and runs AFTER the notification
+ * write resolves, so a listener like `useSidebarBadges` that revalidates on
+ * this event observes the post-write state rather than racing it.
  */
 async function markDmConversationReadAndNotify(
   userId: string,
   conversationId: string,
   markedCount: number
 ): Promise<number> {
-  if (markedCount <= 0) return 0;
+  const notificationsMarkedRead = await markDmConversationNotificationsRead(userId, conversationId);
 
-  const [notificationsMarkedRead] = await Promise.all([
-    markDmConversationNotificationsRead(userId, conversationId),
-    broadcastInboxEvent(userId, {
+  if (markedCount > 0) {
+    await broadcastInboxEvent(userId, {
       operation: 'read_status_changed',
       type: 'dm',
       id: conversationId,
       unreadCount: 0,
-    }),
-  ]);
+    });
+  }
 
   return notificationsMarkedRead;
 }

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -25,6 +25,7 @@ import useSWR from 'swr';
 import { toast } from 'sonner';
 import { useSocket } from '@/hooks/useSocket';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { refetchNotificationsIfMarkedRead } from '@/stores/useNotificationStore';
 import { Check, MessageSquareText, X } from 'lucide-react';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
 import { ThreadOriginBadge } from '@/components/messages/ThreadOriginBadge';
@@ -160,7 +161,7 @@ export default function InboxDMPage() {
   const conversation = conversationData?.conversation;
 
   // Fetch messages
-  const { data: messagesData } = useSWR<{ messages: Message[] }>(
+  const { data: messagesData } = useSWR<{ messages: Message[]; notificationsMarkedRead?: number }>(
     conversationId ? `/api/messages/${conversationId}` : null,
     fetcher,
     {
@@ -173,6 +174,13 @@ export default function InboxDMPage() {
       setMessages(messagesData.messages);
     }
   }, [messagesData]);
+
+  // The GET above marks the conversation read server-side; when it actually
+  // cleared unread notifications, refetch so the bell/nav badge correct
+  // without a page reload (useSidebarBadges watches unreadCount for this).
+  useEffect(() => {
+    refetchNotificationsIfMarkedRead(messagesData?.notificationsMarkedRead);
+  }, [messagesData?.notificationsMarkedRead]);
 
   // Socket room join and updates
   useEffect(() => {
@@ -190,7 +198,11 @@ export default function InboxDMPage() {
         setMessages((prev) => reconcileMessage(prev, message));
 
         if (message.senderId !== user.id) {
-          patch(`/api/messages/${conversationId}`);
+          patch<{ success: boolean; notificationsMarkedRead: number }>(`/api/messages/${conversationId}`)
+            .then((res) => refetchNotificationsIfMarkedRead(res.notificationsMarkedRead))
+            .catch(() => {
+              // Silently ignore errors - marking as read is not critical
+            });
         }
       }
     };

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -31,6 +31,7 @@ import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrich
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { refetchNotificationsIfMarkedRead } from '@/stores/useNotificationStore';
 import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
 import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
@@ -188,9 +189,11 @@ function ChannelView({ page }: ChannelViewProps) {
       setNextCursor(data.nextCursor ?? null);
 
       // Mark channel as read when viewed
-      post(`/api/channels/${page.id}/read`, {}).catch(() => {
-        // Silently ignore errors - marking as read is not critical
-      });
+      post<{ success: boolean; notificationsMarkedRead: number }>(`/api/channels/${page.id}/read`, {})
+        .then((res) => refetchNotificationsIfMarkedRead(res.notificationsMarkedRead))
+        .catch(() => {
+          // Silently ignore errors - marking as read is not critical
+        });
     };
     fetchMessages();
   }, [page.id]);

--- a/apps/web/src/stores/useNotificationStore.ts
+++ b/apps/web/src/stores/useNotificationStore.ts
@@ -198,7 +198,18 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   cleanupSocketListeners: () => {
     const socket = useSocketStore.getState().getSocket();
     if (!socket) return;
-    
+
     socket.off('notification:new');
   },
 }));
+
+/**
+ * Refetches notifications when a "mark as read" API response (channel read,
+ * DM GET/PATCH) reports it actually cleared some — keeps the bell/dropdown in
+ * sync without every read-path re-deriving this same threshold check.
+ */
+export function refetchNotificationsIfMarkedRead(notificationsMarkedRead: number | undefined): void {
+  if (notificationsMarkedRead && notificationsMarkedRead > 0) {
+    void useNotificationStore.getState().fetchNotifications();
+  }
+}

--- a/packages/lib/src/notifications/__tests__/notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/notifications.test.ts
@@ -345,7 +345,7 @@ describe('markAllNotificationsAsRead', () => {
 });
 
 describe('markPageNotificationsRead', () => {
-  it('marks unread notifications for the page as read, scoped to the calling user, and returns the count', async () => {
+  it('marks unread MENTION notifications for the page as read, scoped to the calling user, and returns the count', async () => {
     const { setFn } = setupUpdateChain([{ id: 'n1' }, { id: 'n2' }]);
 
     const count = await markPageNotificationsRead('user-1', 'page-1');
@@ -357,6 +357,11 @@ describe('markPageNotificationsRead', () => {
     expect(eq).toHaveBeenCalledWith('userId', 'user-1');
     expect(eq).toHaveBeenCalledWith('pageId', 'page-1');
     expect(eq).toHaveBeenCalledWith('isRead', false);
+    // Regression guard: a page can carry PERMISSION_UPDATED/PAGE_SHARED/
+    // TASK_ASSIGNED notifications with the same pageId as a MENTION — this
+    // call must only ever touch MENTION rows, or reading a channel would
+    // silently dismiss an unrelated notification the user never saw.
+    expect(eq).toHaveBeenCalledWith('type', 'MENTION');
     expect(count).toBe(2);
   });
 
@@ -370,7 +375,7 @@ describe('markPageNotificationsRead', () => {
 });
 
 describe('markDmConversationNotificationsRead', () => {
-  it('marks unread notifications for the conversation as read, scoped to the calling user, and returns the count', async () => {
+  it('marks unread NEW_DIRECT_MESSAGE notifications for the conversation as read, scoped to the calling user, and returns the count', async () => {
     const { setFn } = setupUpdateChain([{ id: 'n1' }]);
 
     const count = await markDmConversationNotificationsRead('user-1', 'conv-1');
@@ -381,6 +386,10 @@ describe('markDmConversationNotificationsRead', () => {
     // NEW_DIRECT_MESSAGE notification for this conversation must not be touched.
     expect(eq).toHaveBeenCalledWith('userId', 'user-1');
     expect(eq).toHaveBeenCalledWith('isRead', false);
+    // Regression guard: only NEW_DIRECT_MESSAGE rows carry a conversationId
+    // in metadata today, but the type filter is explicit so a future
+    // notification type reusing that metadata shape is never swept up here.
+    expect(eq).toHaveBeenCalledWith('type', 'NEW_DIRECT_MESSAGE');
     expect(count).toBe(1);
   });
 

--- a/packages/lib/src/notifications/__tests__/notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/notifications.test.ts
@@ -21,7 +21,7 @@ vi.mock('@pagespace/db/db', () => {
 });
 
 vi.mock('@pagespace/db/schema/notifications', () => ({
-  notifications: { id: 'id', userId: 'userId', type: 'type', isRead: 'isRead', metadata: 'metadata', createdAt: 'createdAt' },
+  notifications: { id: 'id', userId: 'userId', type: 'type', isRead: 'isRead', metadata: 'metadata', createdAt: 'createdAt', pageId: 'pageId' },
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id', name: 'name', email: 'email', image: 'image' },
@@ -66,6 +66,8 @@ import {
   getUnreadCount,
   markNotificationAsRead,
   markAllNotificationsAsRead,
+  markPageNotificationsRead,
+  markDmConversationNotificationsRead,
   deleteNotification,
   createPermissionNotification,
   createDriveNotification,
@@ -76,6 +78,7 @@ import {
   markConnectionRequestActioned,
 } from '../notifications';
 import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
 import { sendPushNotification } from '../push-notifications';
 
 // ---------------------------------------------------------------------------
@@ -338,6 +341,55 @@ describe('markAllNotificationsAsRead', () => {
     await markAllNotificationsAsRead('user-1');
     expect(db.update).toHaveBeenCalled();
     expect(setFn).toHaveBeenCalledWith(expect.objectContaining({ isRead: true }));
+  });
+});
+
+describe('markPageNotificationsRead', () => {
+  it('marks unread notifications for the page as read, scoped to the calling user, and returns the count', async () => {
+    const { setFn } = setupUpdateChain([{ id: 'n1' }, { id: 'n2' }]);
+
+    const count = await markPageNotificationsRead('user-1', 'page-1');
+
+    expect(db.update).toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledWith(expect.objectContaining({ isRead: true }));
+    // AC6: scoped to the calling user, not just the page — a shared page's
+    // notifications for OTHER users must never be touched by this call.
+    expect(eq).toHaveBeenCalledWith('userId', 'user-1');
+    expect(eq).toHaveBeenCalledWith('pageId', 'page-1');
+    expect(eq).toHaveBeenCalledWith('isRead', false);
+    expect(count).toBe(2);
+  });
+
+  it('returns 0 when nothing was unread', async () => {
+    setupUpdateChain([]);
+
+    const count = await markPageNotificationsRead('user-1', 'page-1');
+
+    expect(count).toBe(0);
+  });
+});
+
+describe('markDmConversationNotificationsRead', () => {
+  it('marks unread notifications for the conversation as read, scoped to the calling user, and returns the count', async () => {
+    const { setFn } = setupUpdateChain([{ id: 'n1' }]);
+
+    const count = await markDmConversationNotificationsRead('user-1', 'conv-1');
+
+    expect(db.update).toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledWith(expect.objectContaining({ isRead: true }));
+    // AC6: scoped to the calling user — the other DM participant's own
+    // NEW_DIRECT_MESSAGE notification for this conversation must not be touched.
+    expect(eq).toHaveBeenCalledWith('userId', 'user-1');
+    expect(eq).toHaveBeenCalledWith('isRead', false);
+    expect(count).toBe(1);
+  });
+
+  it('returns 0 when nothing was unread', async () => {
+    setupUpdateChain([]);
+
+    const count = await markDmConversationNotificationsRead('user-1', 'conv-1');
+
+    expect(count).toBe(0);
   });
 });
 

--- a/packages/lib/src/notifications/notifications.ts
+++ b/packages/lib/src/notifications/notifications.ts
@@ -188,9 +188,14 @@ export async function markAllNotificationsAsRead(userId: string) {
 }
 
 /**
- * Marks a user's unread notifications for a specific page as read (e.g. MENTION
- * rows left behind after `channel_read_status` is upserted — Hole C). Scoped to
- * `userId` so one user can never mark another user's notifications read.
+ * Marks a user's unread MENTION notifications for a specific page as read
+ * (rows left behind after `channel_read_status` is upserted — Hole C). Scoped
+ * to `userId` so one user can never mark another user's notifications read.
+ *
+ * Filtered to `type: 'MENTION'`, not just `pageId` — a page can also carry
+ * PERMISSION_UPDATED/PAGE_SHARED/TASK_ASSIGNED notifications with the same
+ * `pageId` (see createPermissionNotification/createTaskAssignedNotification
+ * below), and reading a channel must not silently dismiss those.
  */
 export async function markPageNotificationsRead(userId: string, pageId: string): Promise<number> {
   const updated = await db
@@ -203,6 +208,7 @@ export async function markPageNotificationsRead(userId: string, pageId: string):
       and(
         eq(notifications.userId, userId),
         eq(notifications.pageId, pageId),
+        eq(notifications.type, 'MENTION'),
         eq(notifications.isRead, false)
       )
     )
@@ -214,11 +220,14 @@ export async function markPageNotificationsRead(userId: string, pageId: string):
 }
 
 /**
- * Marks a user's unread notifications for a specific DM conversation as read
- * (NEW_DIRECT_MESSAGE rows left behind after reading the conversation — Hole E).
- * The `conversationId` predicate mirrors `createOrUpdateMessageNotification`'s
- * lookup exactly so the write and read sides cannot drift apart. Scoped to
- * `userId` so one user can never mark another user's notifications read.
+ * Marks a user's unread NEW_DIRECT_MESSAGE notifications for a specific DM
+ * conversation as read (rows left behind after reading the conversation —
+ * Hole E). The `conversationId` predicate mirrors
+ * `createOrUpdateMessageNotification`'s lookup exactly so the write and read
+ * sides cannot drift apart. Scoped to `userId` so one user can never mark
+ * another user's notifications read, and to `type: 'NEW_DIRECT_MESSAGE'` so a
+ * future notification type that happens to store the same `conversationId`
+ * in its metadata is never swept up by this call.
  */
 export async function markDmConversationNotificationsRead(userId: string, conversationId: string): Promise<number> {
   const updated = await db
@@ -230,6 +239,7 @@ export async function markDmConversationNotificationsRead(userId: string, conver
     .where(
       and(
         eq(notifications.userId, userId),
+        eq(notifications.type, 'NEW_DIRECT_MESSAGE'),
         eq(notifications.isRead, false),
         sql`${notifications.metadata}->>'conversationId' = ${conversationId}`
       )

--- a/packages/lib/src/notifications/notifications.ts
+++ b/packages/lib/src/notifications/notifications.ts
@@ -187,6 +187,60 @@ export async function markAllNotificationsAsRead(userId: string) {
   void sendSilentBadgeUpdate(userId);
 }
 
+/**
+ * Marks a user's unread notifications for a specific page as read (e.g. MENTION
+ * rows left behind after `channel_read_status` is upserted — Hole C). Scoped to
+ * `userId` so one user can never mark another user's notifications read.
+ */
+export async function markPageNotificationsRead(userId: string, pageId: string): Promise<number> {
+  const updated = await db
+    .update(notifications)
+    .set({
+      isRead: true,
+      readAt: new Date(),
+    })
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.pageId, pageId),
+        eq(notifications.isRead, false)
+      )
+    )
+    .returning({ id: notifications.id });
+
+  void sendSilentBadgeUpdate(userId);
+
+  return updated.length;
+}
+
+/**
+ * Marks a user's unread notifications for a specific DM conversation as read
+ * (NEW_DIRECT_MESSAGE rows left behind after reading the conversation — Hole E).
+ * The `conversationId` predicate mirrors `createOrUpdateMessageNotification`'s
+ * lookup exactly so the write and read sides cannot drift apart. Scoped to
+ * `userId` so one user can never mark another user's notifications read.
+ */
+export async function markDmConversationNotificationsRead(userId: string, conversationId: string): Promise<number> {
+  const updated = await db
+    .update(notifications)
+    .set({
+      isRead: true,
+      readAt: new Date(),
+    })
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.isRead, false),
+        sql`${notifications.metadata}->>'conversationId' = ${conversationId}`
+      )
+    )
+    .returning({ id: notifications.id });
+
+  void sendSilentBadgeUpdate(userId);
+
+  return updated.length;
+}
+
 export async function markConnectionRequestActioned(
   connectionId: string,
   userId: string,

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -125,6 +125,75 @@ describe('dmMessageRepository.softDeleteMessage', () => {
   });
 });
 
+describe('dmMessageRepository.markActiveMessagesRead', () => {
+  it('flips unread active rows from the other participant and returns the count flipped (AC1)', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'msg-1', conversationId: 'conv-1', senderId: 'u-other', isActive: true, isRead: false, readAt: null },
+      { id: 'msg-2', conversationId: 'conv-1', senderId: 'u-other', isActive: true, isRead: false, readAt: null },
+    ]);
+
+    const readAt = new Date('2026-05-01T10:00:00Z');
+    const count = await dmMessageRepository.markActiveMessagesRead({
+      conversationId: 'conv-1',
+      otherUserId: 'u-other',
+      readAt,
+    });
+
+    const rows = testDbState.rows('directMessages');
+    assert({
+      given: 'two unread active DMs from the other participant',
+      should: 'flip both to isRead=true/readAt and report the count of rows it actually flipped',
+      actual: {
+        count,
+        isRead: rows.map((r) => r.isRead),
+        readAt: rows.map((r) => r.readAt),
+      },
+      expected: { count: 2, isRead: [true, true], readAt: [readAt, readAt] },
+    });
+  });
+
+  it('does not flip the caller\'s own messages, other conversations, already-read rows, or soft-deleted rows', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'own-msg', conversationId: 'conv-1', senderId: 'u-self', isActive: true, isRead: false, readAt: null },
+      { id: 'other-conv', conversationId: 'conv-2', senderId: 'u-other', isActive: true, isRead: false, readAt: null },
+      { id: 'already-read', conversationId: 'conv-1', senderId: 'u-other', isActive: true, isRead: true, readAt: new Date('2026-04-01T00:00:00Z') },
+      { id: 'soft-deleted', conversationId: 'conv-1', senderId: 'u-other', isActive: false, isRead: false, readAt: null },
+    ]);
+
+    const count = await dmMessageRepository.markActiveMessagesRead({
+      conversationId: 'conv-1',
+      otherUserId: 'u-other',
+      readAt: new Date('2026-05-01T10:00:00Z'),
+    });
+
+    assert({
+      given: 'rows that must never be flipped by this call (own message, other conversation, already read, soft-deleted)',
+      should: 'return 0 — none of them match the (conversationId, senderId=otherUserId, isRead=false, isActive=true) predicate',
+      actual: count,
+      expected: 0,
+    });
+  });
+
+  it('returns 0 when there is nothing unread to mark (GET-path noise / AC3 precondition)', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'msg-1', conversationId: 'conv-1', senderId: 'u-other', isActive: true, isRead: true, readAt: new Date('2026-04-01T00:00:00Z') },
+    ]);
+
+    const count = await dmMessageRepository.markActiveMessagesRead({
+      conversationId: 'conv-1',
+      otherUserId: 'u-other',
+      readAt: new Date('2026-05-01T10:00:00Z'),
+    });
+
+    assert({
+      given: 'a conversation with no unread rows from the other participant',
+      should: 'return 0 so the route can skip broadcasting/notification-clearing entirely',
+      actual: count,
+      expected: 0,
+    });
+  });
+});
+
 describe('dmMessageRepository.restoreDmMessage', () => {
   it('flips isActive=true and resets deletedAt; bumps parent.replyCount when the parent is still active', async () => {
     testDbState.seed('directMessages', [

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -655,8 +655,8 @@ export interface MarkMessagesReadInput {
 
 async function markActiveMessagesRead(
   input: MarkMessagesReadInput
-): Promise<void> {
-  await db
+): Promise<number> {
+  const updated = await db
     .update(directMessages)
     .set({ isRead: true, readAt: input.readAt })
     .where(
@@ -666,7 +666,10 @@ async function markActiveMessagesRead(
         eq(directMessages.isRead, false),
         eq(directMessages.isActive, true)
       )
-    );
+    )
+    .returning({ id: directMessages.id });
+
+  return updated.length;
 }
 
 export interface UpdateLastReadInput {


### PR DESCRIPTION
## Summary

This is Stage 2 of a 6-stage unread/notification-model redesign — the server side of read semantics. The client-side socket hotfix (Stage 1, #2247) and the badge/store work (Stages 3–6) are separately owned.

Fixes four holes in the DM/channel "mark as read" flow that left unread badges lit after content was actually read:

- **Hole D** — neither DM read path (`GET` side-effect on `/api/messages/[conversationId]`, nor the explicit `PATCH`) broadcast `inbox:read_status_changed`, so opening a DM never told other tabs/devices it had been read.
- **Hole C** — marking a channel read left its unread `MENTION` notifications untouched, so the nav Channels badge stayed lit.
- **Hole E** — opening a DM left its `NEW_DIRECT_MESSAGE` notifications untouched, so the bell count stayed lit.
- **GET-path noise** — the GET handler runs on every poll; broadcasting unconditionally would have spammed sockets on no-op fetches, so the broadcast gates on whether `markActiveMessagesRead` actually flipped any rows.

## Changes

- `packages/lib/src/services/dm-message-repository.ts` — `markActiveMessagesRead`: `Promise<void>` → `Promise<number>` via `.returning().length`, so callers can distinguish real work from a no-op.
- `packages/lib/src/notifications/notifications.ts` — two new user-scoped helpers: `markPageNotificationsRead` (Hole C, scoped to `type: 'MENTION'`) and `markDmConversationNotificationsRead` (Hole E, scoped to `type: 'NEW_DIRECT_MESSAGE'`, reusing the exact `metadata->>'conversationId'` predicate `createOrUpdateMessageNotification` already writes with).
- `apps/web/src/app/api/channels/[pageId]/read/route.ts` — clears the page's MENTION notifications *before* broadcasting, and returns `notificationsMarkedRead` in the response.
- `apps/web/src/app/api/messages/[conversationId]/route.ts` — GET and PATCH both clear conversation notifications unconditionally and broadcast `read_status_changed` (gated on `markedCount > 0`) via a shared `markDmConversationReadAndNotify` helper.
- `apps/web/src/stores/useNotificationStore.ts` — new `refetchNotificationsIfMarkedRead(count)` helper.
- `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx`, `.../ChannelView.tsx` — call the new helper after a read response reports work done, so the bell/nav badge self-correct without a reload (`useSidebarBadges` already watches `unreadCount` + the `read_status_changed` socket event to revalidate `/api/sidebar/badges`).

## Acceptance criteria

- **AC1** — `markActiveMessagesRead` returns the count of rows it flipped; existing callers still compile. ✅ Verified: `dm-message-repository.test.ts` (3 cases: real flip, all-excluded negative cases, zero-unread) + typecheck.
- **AC2** — Opening a DM broadcasts exactly one `inbox:read_status_changed` to `notifications:{userId}`. ✅ Verified: `messages/[conversationId]/__tests__/route.test.ts` (GET + PATCH, each asserting `toHaveBeenCalledTimes(1)` with the exact payload shape).
- **AC3** — A GET that marks nothing read broadcasts nothing. ✅ Verified: same test file, `markedCount = 0` case asserts zero broadcast calls (the notification clear itself still runs — see "Review feedback addressed" below — but never emits socket traffic on its own).
- **AC4** — Reading a channel marks its unread MENTION notifications read; nav Channels badge clears. ✅ Verified: `channels/[pageId]/read/__tests__/route.test.ts` asserts `markPageNotificationsRead` is called and its count flows into the response.
- **AC5** — Reading a DM marks its NEW_DIRECT_MESSAGE notifications read; bell count drops. ✅ Verified: same route test file, DM variant, asserts `markDmConversationNotificationsRead` call + response field.
- **AC6** — Both helpers are scoped to the calling user and cannot mark another user's notifications read. ✅ Verified: `notifications.test.ts` asserts the literal `eq('userId', ...)` predicate call for both helpers (not just a status-code check).
- **AC7** — Bell/nav badge reflect reality after reading, without a page reload. ✅ Verified: `refetchNotificationsIfMarkedRead` wired into both client read-paths; `useSidebarBadges` already revalidates off `unreadCount` changes and the `read_status_changed` socket event (chain confirmed, not re-implemented).
- **AC8** — `bun run test:unit` passes with new tests covering AC2/AC3/AC6. ✅ Full suite: 15,916 passed / 16 failed / 6 skipped. All 4 failing files are pre-existing, environment-only (no live Postgres in the sandbox; a TZ-dependent assertion) and untouched by this diff — confirmed identical failure set before and after every change in this PR.

## Review feedback addressed

Three review threads were raised (2 from Codex, 1 from CodeRabbit) and all three were real, concrete issues — fixed in `8bfcce0d5`:

1. **Notification-type scoping (CodeRabbit, major)** — `markPageNotificationsRead`/`markDmConversationNotificationsRead` originally cleared *any* unread notification sharing the `pageId`/`conversationId`, not just the intended type. Since a channel page can also carry `PERMISSION_UPDATED`/`PAGE_SHARED`/`TASK_ASSIGNED` notifications with the same `pageId`, reading a channel could have silently dismissed an unrelated notification the user never saw. Both helpers now filter on `type: 'MENTION'` / `type: 'NEW_DIRECT_MESSAGE'` respectively.
2. **Orphaned-notification gating (Codex, P2)** — the DM notification clear was gated on `markedCount > 0`, which meant a stale unread `NEW_DIRECT_MESSAGE` notification (e.g. one orphaned by the pre-fix behavior, where the message row was already marked read by an older build) would never clear. The notification clear now runs unconditionally on every GET/PATCH; only the socket broadcast stays gated on `markedCount` to avoid GET-path noise.
3. **Write-before-broadcast ordering (Codex, P2)** — an earlier `/simplify` pass had parallelized the notification write and the inbox broadcast via `Promise.all` for "efficiency," which raced them: a listener like `useSidebarBadges` revalidating off the broadcast could observe pre-write state. Both routes now await the notification write before broadcasting.

Two regression tests were added (orphaned-notification-clears-without-broadcasting, one each for GET and PATCH) plus type-predicate assertions in `notifications.test.ts`.

## Manual verification reasoning

1. Two tabs, same user, DM open in tab 1 + opened in tab 2 → tab 1's pill clears with no refresh: Hole D's broadcast now fires from the GET side-effect, and `useInboxSocket` (unchanged, already listening for `read_status_changed`) special-cases `unreadCount: 0` on the SWR cache.
2. Reading a channel with an unread @-mention clears both the nav badge and the bell: `markPageNotificationsRead` + client refetch confirmed via AC4 test + wiring.
3. A GET on a DM with nothing unread produces no socket traffic: AC3 test asserts this directly.
4. A user with a pre-existing orphaned unread DM notification (message already read, notification never cleared) gets it cleared the next time they open that conversation, even though no message row changes: covered by the new regression tests.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:unit` (full suite, pre-existing env-only failures only)
- [x] Targeted test files (187 tests across 4 files) re-verified after both the `/simplify` refactor pass and the review-feedback fixes — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWeKbVN6UtoNrQbzEyASep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marking channels and direct-message conversations as read now clears their related notifications.
  * Read actions report how many notifications were cleared, and the UI refreshes notification/badge counts without a page reload.
* **Bug Fixes**
  * Inbox read-status events are broadcast only when messages were actually marked as read.
  * Notification updates are now kept in sync after server-side “mark read” actions for both channels and DMs.
* **Tests**
  * Added/extended contract coverage for read endpoints and DM “mark as read” repository behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
