### PR TITLE
Move canvas settings into tab bar (View/Code/Forms/Settings)

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'next/navigation';
 import { usePageStore } from '@/hooks/usePage';
 import { Button } from '@/components/ui/button';
 import { Download } from 'lucide-react';
-import { isDocumentPage, isFilePage, isSheetPage, isCodePage, isPublishablePageType } from '@pagespace/lib/content/page-types.config';
+import { isDocumentPage, isFilePage, isSheetPage, isCodePage, isCanvasPage, isPublishablePageType } from '@pagespace/lib/content/page-types.config';
 import { ExportDropdown } from './ExportDropdown';
 import PublishControls from './PublishControls';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -90,6 +90,7 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
   const pageIsSheet = page ? isSheetPage(page.type) : false;
   const pageIsFile = page ? isFilePage(page.type) : false;
   const pageIsCode = page ? isCodePage(page.type) : false;
+  const pageIsCanvas = page ? isCanvasPage(page.type) : false;
   const showSaveStatus = (pageIsDocument || pageIsSheet || pageIsCode) && !isMobile;
 
   // Track and display presence (who else is viewing this page)
@@ -158,7 +159,7 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
               {!isMobile && (isDownloading ? 'Downloading...' : 'Download')}
             </Button>
           )}
-          {page && isPublishablePageType(page.type) && (
+          {page && isPublishablePageType(page.type) && !pageIsCanvas && (
             // Keyed on pageId so navigating to a different page remounts the
             // control instead of reusing local UI state (e.g. an open Publish
             // Settings dialog) across pages.

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -12,6 +12,7 @@ import { useSocket } from '@/hooks/useSocket';
 import { PageEventPayload } from '@/lib/websocket';
 import { useFindStore } from '@/stores/useFindStore';
 import CanvasFormsSettingsTab from './CanvasFormsSettingsTab';
+import PublishControls from '../../content-header/PublishControls';
 
 interface CanvasPageViewProps {
   pageId: string;
@@ -169,22 +170,28 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
     <div ref={containerRef} className="h-full flex flex-col relative">
       <div className="relative flex flex-wrap items-center border-b">
         <button
-          className={`px-4 py-2 ${activeTab === 'code' ? 'border-b-2 border-blue-500' : ''}`}
-          onClick={() => setActiveTab('code')}
-        >
-          Code
-        </button>
-        <button
           className={`px-4 py-2 ${activeTab === 'view' ? 'border-b-2 border-blue-500' : ''}`}
           onClick={() => setActiveTab('view')}
         >
           View
         </button>
         <button
+          className={`px-4 py-2 ${activeTab === 'code' ? 'border-b-2 border-blue-500' : ''}`}
+          onClick={() => setActiveTab('code')}
+        >
+          Code
+        </button>
+        <button
           className={`px-4 py-2 ${activeTab === 'forms' ? 'border-b-2 border-blue-500' : ''}`}
           onClick={() => setActiveTab('forms')}
         >
           Forms
+        </button>
+        <button
+          className={`px-4 py-2 ${activeTab === 'settings' ? 'border-b-2 border-blue-500' : ''}`}
+          onClick={() => setActiveTab('settings')}
+        >
+          Settings
         </button>
       </div>
       {activeTab === 'code' && (
@@ -206,6 +213,11 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
       {activeTab === 'forms' && (
         <div className="flex-1 min-h-0 overflow-y-auto">
           <CanvasFormsSettingsTab pageId={pageId} content={content} onContentChange={handleFormsTabContentChange} />
+        </div>
+      )}
+      {activeTab === 'settings' && (
+        <div className="flex-1 min-h-0 overflow-y-auto p-4">
+          <PublishControls pageId={pageId} contentDirty={documentState?.isDirty || false} />
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Canvas pages now have a dedicated **Settings** tab in the tab bar, and the tab order is **View / Code / Forms / Settings**.

Previously, publish controls (Publish, Settings dialog, URL, Copy link, Unpublish) rendered in the content header for all publishable page types. For canvas pages, that cluttered the header. Now the entire `PublishControls` component renders inside the Settings tab instead.

## Changes

- **`CanvasPageView.tsx`**: 
  - Reordered tabs to View → Code → Forms → Settings
  - Added Settings tab that renders `PublishControls` inline (passes `pageId` and `contentDirty`)
- **`content-header/index.tsx`**: 
  - `PublishControls` no longer renders in the header for canvas pages (the `!pageIsCanvas` guard)
  - Non-canvas publishable types (documents, sheets, etc.) are unaffected

## Verification

- ESLint passes on both changed files
- Full typecheck OOMs in sandbox (pre-existing limitation), but changes are type-safe: `PublishControls` accepts `{ pageId: string; contentDirty?: boolean }`, `isCanvasPage` is already exported from `page-types.config`

## Test plan

- [ ] Open a canvas page — tabs should read View / Code / Forms / Settings
- [ ] Settings tab shows publish controls (Publish button or URL + Update/Settings/Copy/Unpublish)
- [ ] Content header for canvas pages should NOT show publish controls
- [ ] Open a document page — publish controls should still appear in the header as before