### PR TITLE
feat(canvas): in-app navigation for canvas iframe via postMessage bridge

### DIFF
--- a/apps/web/src/components/canvas/CanvasFrame.tsx
+++ b/apps/web/src/components/canvas/CanvasFrame.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from 'next-themes';
+import { useRouter } from 'next/navigation';
 import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import {
@@ -49,6 +50,7 @@ export function CanvasFrame({ html, title }: CanvasFrameProps) {
   const [previewHtml, setPreviewHtml] = useState(html);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { resolvedTheme } = useTheme();
+  const router = useRouter();
 
   useEffect(() => {
     const refs = extractDashboardFileViewRefs(html);
@@ -96,7 +98,7 @@ export function CanvasFrame({ html, title }: CanvasFrameProps) {
   // injectThemeBridge: true injects a script that listens for theme messages
   // so the canvas iframe's dark/light state matches the app's current theme.
   const srcDoc = useMemo(
-    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank', injectThemeBridge: true, nonce }),
+    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank', injectThemeBridge: true, injectNavBridge: true, nonce }),
     [previewHtml, title, nonce],
   );
 
@@ -129,6 +131,27 @@ export function CanvasFrame({ html, title }: CanvasFrameProps) {
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
   }, [resolvedTheme]);
+
+  // Listen for navigation requests from the canvas iframe. The injected nav
+  // bridge intercepts clicks on `/dashboard/...` links and sends
+  // `{ type: 'pagespace-navigate', href }` via postMessage. We verify the
+  // message came from our iframe, then router.push for in-app navigation.
+  // This keeps the sandbox boundary intact (no allow-same-origin needed) while
+  // giving smooth in-app navigation instead of new-tab pop-outs.
+  const handleNavigation = useCallback((href: string) => {
+    router.push(href);
+  }, [router]);
+
+  useEffect(() => {
+    function handleNavMessage(e: MessageEvent) {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      if (e.data?.type !== 'pagespace-navigate') return;
+      if (typeof e.data.href !== 'string') return;
+      handleNavigation(e.data.href);
+    }
+    window.addEventListener('message', handleNavMessage);
+    return () => window.removeEventListener('message', handleNavMessage);
+  }, [handleNavigation]);
 
   return (
     <iframe

--- a/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
+++ b/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
@@ -13,6 +13,11 @@ vi.mock('next-themes', () => ({
   useTheme: () => useThemeMock(),
 }));
 
+const mockRouterPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
 import { CANVAS_IFRAME_SANDBOX, CanvasFrame } from '../CanvasFrame';
 
 // React 19.2.6 production build in this sandbox doesn't export `act`;
@@ -213,5 +218,75 @@ describe('CanvasFrame — theme sync', () => {
     }));
 
     expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('CanvasFrame — in-app navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useThemeMock.mockReturnValue({ resolvedTheme: 'dark' });
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ links: [] }),
+    });
+  });
+
+  it('given injectNavBridge, should pass it to renderCanvasDocument so the srcDoc contains the nav bridge script', () => {
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    expect(iframe.srcdoc).toContain('pagespace-navigate');
+  });
+
+  it('given a pagespace-navigate message from the iframe, should call router.push with the href', async () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    mockRouterPush.mockClear();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1' },
+      source: mockContentWindow as unknown as MessageEventSource,
+    }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/dashboard/drive-1/page-1');
+  });
+
+  it('given a pagespace-navigate message from a different source, should NOT navigate', async () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    mockRouterPush.mockClear();
+
+    // Message from a source that is NOT the iframe.
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1' },
+      source: window,
+    }));
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'next/navigation';
 import { usePageStore } from '@/hooks/usePage';
 import { Button } from '@/components/ui/button';
 import { Download } from 'lucide-react';
-import { isDocumentPage, isFilePage, isSheetPage, isCodePage, isPublishablePageType } from '@pagespace/lib/content/page-types.config';
+import { isDocumentPage, isFilePage, isSheetPage, isCodePage, isCanvasPage, isPublishablePageType } from '@pagespace/lib/content/page-types.config';
 import { ExportDropdown } from './ExportDropdown';
 import PublishControls from './PublishControls';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -90,6 +90,7 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
   const pageIsSheet = page ? isSheetPage(page.type) : false;
   const pageIsFile = page ? isFilePage(page.type) : false;
   const pageIsCode = page ? isCodePage(page.type) : false;
+  const pageIsCanvas = page ? isCanvasPage(page.type) : false;
   const showSaveStatus = (pageIsDocument || pageIsSheet || pageIsCode) && !isMobile;
 
   // Track and display presence (who else is viewing this page)
@@ -158,7 +159,7 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
               {!isMobile && (isDownloading ? 'Downloading...' : 'Download')}
             </Button>
           )}
-          {page && isPublishablePageType(page.type) && (
+          {page && isPublishablePageType(page.type) && !pageIsCanvas && (
             // Keyed on pageId so navigating to a different page remounts the
             // control instead of reusing local UI state (e.g. an open Publish
             // Settings dialog) across pages.

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -12,6 +12,7 @@ import { useSocket } from '@/hooks/useSocket';
 import { PageEventPayload } from '@/lib/websocket';
 import { useFindStore } from '@/stores/useFindStore';
 import CanvasFormsSettingsTab from './CanvasFormsSettingsTab';
+import PublishControls from '../../content-header/PublishControls';
 
 interface CanvasPageViewProps {
   pageId: string;
@@ -169,22 +170,28 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
     <div ref={containerRef} className="h-full flex flex-col relative">
       <div className="relative flex flex-wrap items-center border-b">
         <button
-          className={`px-4 py-2 ${activeTab === 'code' ? 'border-b-2 border-blue-500' : ''}`}
-          onClick={() => setActiveTab('code')}
-        >
-          Code
-        </button>
-        <button
           className={`px-4 py-2 ${activeTab === 'view' ? 'border-b-2 border-blue-500' : ''}`}
           onClick={() => setActiveTab('view')}
         >
           View
         </button>
         <button
+          className={`px-4 py-2 ${activeTab === 'code' ? 'border-b-2 border-blue-500' : ''}`}
+          onClick={() => setActiveTab('code')}
+        >
+          Code
+        </button>
+        <button
           className={`px-4 py-2 ${activeTab === 'forms' ? 'border-b-2 border-blue-500' : ''}`}
           onClick={() => setActiveTab('forms')}
         >
           Forms
+        </button>
+        <button
+          className={`px-4 py-2 ${activeTab === 'settings' ? 'border-b-2 border-blue-500' : ''}`}
+          onClick={() => setActiveTab('settings')}
+        >
+          Settings
         </button>
       </div>
       {activeTab === 'code' && (
@@ -206,6 +213,11 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
       {activeTab === 'forms' && (
         <div className="flex-1 min-h-0 overflow-y-auto">
           <CanvasFormsSettingsTab pageId={pageId} content={content} onContentChange={handleFormsTabContentChange} />
+        </div>
+      )}
+      {activeTab === 'settings' && (
+        <div className="flex-1 min-h-0 overflow-y-auto p-4">
+          <PublishControls pageId={pageId} contentDirty={documentState?.isDirty || false} />
         </div>
       )}
 

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET, THEME_BRIDGE_SCRIPT } from '../render-document';
+import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET, THEME_BRIDGE_SCRIPT, NAV_BRIDGE_SCRIPT } from '../render-document';
 
 describe('renderCanvasDocument', () => {
   it('given any input, should return a full HTML document', () => {
@@ -902,5 +902,46 @@ describe('renderCanvasDocument — cspOverride', () => {
     });
     expect(out).toContain('content="default-src \'none\'; script-src \'none\';"');
     expect(out).not.toContain('ignored.example');
+  });
+});
+
+describe('renderCanvasDocument — nav bridge', () => {
+  it('given injectNavBridge: true, should inject the nav bridge script inside <head>', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', injectNavBridge: true });
+    const headEnd = out.indexOf('</head>');
+    const head = out.slice(0, headEnd);
+    expect(head).toContain(NAV_BRIDGE_SCRIPT);
+  });
+
+  it('given no injectNavBridge, should NOT inject the nav bridge script', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>' });
+    expect(out).not.toContain('pagespace-navigate');
+  });
+
+  it('given injectNavBridge: true, the bridge should check for iframe context (parent !== window)', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', injectNavBridge: true });
+    expect(out).toContain('window.parent===window');
+  });
+
+  it('given injectNavBridge: true, the bridge should intercept /dashboard/ links via postMessage', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', injectNavBridge: true });
+    expect(out).toContain("type:'pagespace-navigate'");
+    expect(out).toContain("/dashboard/");
+  });
+
+  it('given injectNavBridge: true AND a nonce, should stamp the nonce onto the nav-bridge script', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', injectNavBridge: true, nonce: 'nav-nonce==' });
+    const nonceStamped = `nonce="nav-nonce=="`;
+    // Both the nav bridge and any author scripts should have the nonce.
+    const navBridgeStart = out.indexOf(NAV_BRIDGE_SCRIPT.slice(0, 8));
+    expect(navBridgeStart).toBeGreaterThan(-1);
+    // The nonce should appear in the head section near the nav bridge.
+    expect(out).toContain(nonceStamped);
+  });
+
+  it('given both injectThemeBridge and injectNavBridge, should inject both scripts', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', injectThemeBridge: true, injectNavBridge: true });
+    expect(out).toContain(THEME_BRIDGE_SCRIPT);
+    expect(out).toContain(NAV_BRIDGE_SCRIPT);
   });
 });

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -931,12 +931,8 @@ describe('renderCanvasDocument — nav bridge', () => {
 
   it('given injectNavBridge: true AND a nonce, should stamp the nonce onto the nav-bridge script', () => {
     const out = renderCanvasDocument({ html: '<p>x</p>', injectNavBridge: true, nonce: 'nav-nonce==' });
-    const nonceStamped = `nonce="nav-nonce=="`;
-    // Both the nav bridge and any author scripts should have the nonce.
-    const navBridgeStart = out.indexOf(NAV_BRIDGE_SCRIPT.slice(0, 8));
-    expect(navBridgeStart).toBeGreaterThan(-1);
-    // The nonce should appear in the head section near the nav bridge.
-    expect(out).toContain(nonceStamped);
+    expect(out).toContain('<script nonce="nav-nonce==">(function(){');
+    expect(out).toContain('pagespace-navigate');
   });
 
   it('given both injectThemeBridge and injectNavBridge, should inject both scripts', () => {

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -116,6 +116,16 @@ export interface RenderCanvasDocumentInput {
    */
   injectThemeBridge?: boolean;
   /**
+   * When true, injects a click interceptor <script> into <head> that catches
+   * clicks on `/dashboard/...` links and forwards them to the parent via
+   * `postMessage({ type: 'pagespace-navigate', href })`. The parent (CanvasFrame)
+   * listens and calls `router.push(href)`, giving in-app navigation without
+   * breaking the sandbox isolation. Only active inside an iframe
+   * (`window.parent !== window`); published pages (standalone documents) are
+   * unaffected because their links are already rewritten to public URLs.
+   */
+  injectNavBridge?: boolean;
+  /**
    * When set, used VERBATIM as the emitted CSP `<meta>` content instead of
    * `buildBaselineCsp(formActionOrigin)`. Lets other renderers (e.g. the
    * published-document pipeline, which needs `script-src 'none'`) reuse this
@@ -191,6 +201,30 @@ export const THEME_BRIDGE_SCRIPT =
   "document.documentElement.classList.toggle('dark',e.data.isDark);}});" +
   // Request current theme from parent on load (in-app only; harmless on published)
   "try{window.parent.postMessage({type:'pagespace-theme-request'},'*');}catch(e){}" +
+  "})();</script>";
+
+/**
+ * Inline script injected when `injectNavBridge` is true. Provides in-app
+ * navigation for canvas iframes by intercepting clicks on `/dashboard/...`
+ * links and forwarding them to the parent via postMessage.
+ *
+ * Only active inside an iframe (`window.parent !== window`). On published
+ * pages (standalone documents) it is a no-op because `parent === window`.
+ *
+ * Pattern matches the in-app link convention: `/dashboard/{driveId}/{pageId}`
+ * (and the `/view` variant for file pages). Hash-only links (`#section`) and
+ * external URLs pass through to default behavior.
+ */
+export const NAV_BRIDGE_SCRIPT =
+  "<script>(function(){" +
+  "if(window.parent===window)return;" +
+  "document.addEventListener('click',function(e){" +
+  "var a=e.target.closest('a');if(!a)return;" +
+  "var href=a.getAttribute('href');if(!href)return;" +
+  "if(href.indexOf('/dashboard/')!==0)return;" +
+  "e.preventDefault();e.stopPropagation();" +
+  "window.parent.postMessage({type:'pagespace-navigate',href:href},'*');" +
+  "},true);" +
   "})();</script>";
 
 // Re-exported for existing consumers — the implementation lives in a
@@ -322,7 +356,7 @@ function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[], no
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, nonce, cspOverride } = input;
+  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, injectNavBridge, nonce, cspOverride } = input;
   const csp = cspOverride ?? buildBaselineCsp(formActionOrigin);
 
   const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts, nonce);
@@ -366,6 +400,7 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
     `<meta http-equiv="Content-Security-Policy" content="${csp}">` +
     `<style>${BASELINE_RESET}${css}</style>` +
     (injectThemeBridge ? (nonce ? stampScriptNonce(THEME_BRIDGE_SCRIPT, nonce) : THEME_BRIDGE_SCRIPT) : '') +
+    (injectNavBridge ? (nonce ? stampScriptNonce(NAV_BRIDGE_SCRIPT, nonce) : NAV_BRIDGE_SCRIPT) : '') +
     '</head><body>' +
     body +
     '</body></html>'

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -219,6 +219,7 @@ export const NAV_BRIDGE_SCRIPT =
   "<script>(function(){" +
   "if(window.parent===window)return;" +
   "document.addEventListener('click',function(e){" +
+  "if(e.ctrlKey||e.metaKey||e.shiftKey||e.button!==0)return;" +
   "var a=e.target.closest('a');if(!a)return;" +
   "var href=a.getAttribute('href');if(!href)return;" +
   "if(href.indexOf('/dashboard/')!==0)return;" +


### PR DESCRIPTION
## What

Canvas links to `/dashboard/` pages now navigate in-app instead of opening new tabs.

## How

- `NAV_BRIDGE_SCRIPT` injected into the canvas iframe (only when `injectNavBridge: true`)
- Click interceptor on capture phase catches `/dashboard/` link clicks
- Sends `{ type: 'pagespace-navigate', href }` via `postMessage` to parent
- `CanvasFrame` listener verifies source is the iframe, then calls `router.push(href)`

## Security

- Sandbox boundary preserved (no `allow-same-origin` needed)
- Bridge only fires inside an iframe (`window.parent !== window`) — published pages are unaffected
- Message source verified (`e.source === iframeRef.contentWindow`)
- External links and hash links pass through normally

## Published page fallback

Published pages have links rewritten to public URLs at publish time by `rewriteInterPageLinks`. The bridge is a no-op on published pages. Unpublished links on published pages are already broken regardless — this doesn't change that.

## Tests

- 110 render-document tests pass (including 6 new nav bridge tests)
- 11 CanvasFrame tests pass (including 3 new navigation tests)