### PR TITLE
Add in-app navigation bridge for canvas iframe links

### DIFF
--- a/apps/web/src/components/canvas/CanvasFrame.tsx
+++ b/apps/web/src/components/canvas/CanvasFrame.tsx
@@ -30,6 +30,29 @@ interface CanvasFrameProps {
 export const CANVAS_IFRAME_SANDBOX = 'allow-scripts allow-popups allow-popups-to-escape-sandbox';
 
 /**
+ * True if the top-level document has a currently-active (transient) user
+ * activation — i.e. a real click/keypress happened recently, not a script
+ * calling an API on its own. Used to gate `pagespace-navigate` postMessage
+ * handling: the User Activation API's "activation notification" algorithm
+ * (https://html.spec.whatwg.org/multipage/interaction.html#activation-notification)
+ * walks up through every ancestor navigable — including this cross-origin,
+ * sandboxed iframe's ancestors — on a genuine click, so a real click inside
+ * the canvas iframe DOES register here in the parent. It's the same browser
+ * mechanism that already gates the iframe's `allow-popups` (a script-only
+ * `window.open()` with no real click is blocked as a popup); this reuses it
+ * to gate the navigation bridge the same way.
+ *
+ * Browsers without `navigator.userActivation` (very old) fall back to the
+ * pre-gate (permissive) behavior — bounded residual risk, since the message
+ * is separately validated to only ever be an internal dashboard PAGE link
+ * (`isDashboardPageLink`), never an arbitrary external URL.
+ */
+function hasRecentUserActivation(): boolean {
+  if (typeof navigator === 'undefined' || !('userActivation' in navigator)) return true;
+  return Boolean(navigator.userActivation?.isActive);
+}
+
+/**
  * In-app renderer for canvas pages.
  *
  * Replaces the old Shadow-DOM approach (which could not isolate scripts and so
@@ -140,8 +163,18 @@ export function CanvasFrame({ html, title }: CanvasFrameProps) {
       // regex check (render-document.ts) is a UX nicety, not a trust
       // boundary — author JS in the sandboxed-but-scripted iframe can post
       // this message type directly, so we must not route on an unvalidated
-      // href.
-      if (e.data?.type === 'pagespace-navigate' && typeof e.data.href === 'string' && isDashboardPageLink(e.data.href)) {
+      // href. Also require a genuine, recent user gesture (see
+      // hasRecentUserActivation doc below) — without it, author JS calling
+      // `postMessage({type:'pagespace-navigate', href:'...'}, '*')` on load
+      // (no real click at all) would force-navigate the app's own tab,
+      // reopening exactly the hole `CANVAS_IFRAME_SANDBOX` deliberately
+      // closes by omitting `allow-top-navigation*`.
+      if (
+        e.data?.type === 'pagespace-navigate' &&
+        typeof e.data.href === 'string' &&
+        isDashboardPageLink(e.data.href) &&
+        hasRecentUserActivation()
+      ) {
         router.push(e.data.href);
       }
     }

--- a/apps/web/src/components/canvas/CanvasFrame.tsx
+++ b/apps/web/src/components/canvas/CanvasFrame.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import {
   extractDashboardFileViewRefs,
   rewriteDashboardFileViewLinks,
+  isDashboardPageLink,
 } from '@/lib/canvas/file-view-links';
 import { useNonce } from '@/contexts/NonceContext';
 
@@ -46,6 +48,7 @@ export const CANVAS_IFRAME_SANDBOX = 'allow-scripts allow-popups allow-popups-to
  */
 export function CanvasFrame({ html, title }: CanvasFrameProps) {
   const nonce = useNonce();
+  const router = useRouter();
   const [previewHtml, setPreviewHtml] = useState(html);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { resolvedTheme } = useTheme();
@@ -95,8 +98,11 @@ export function CanvasFrame({ html, title }: CanvasFrameProps) {
   // so default links to a new tab (works with the iframe's allow-popups).
   // injectThemeBridge: true injects a script that listens for theme messages
   // so the canvas iframe's dark/light state matches the app's current theme.
+  // navigationBridge: true injects a script that intercepts clicks on internal
+  // dashboard page links and hands them to the message handler below, so they
+  // route in-app instead of falling through to baseTarget's new-tab behavior.
   const srcDoc = useMemo(
-    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank', injectThemeBridge: true, nonce }),
+    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank', injectThemeBridge: true, navigationBridge: true, nonce }),
     [previewHtml, title, nonce],
   );
 
@@ -115,20 +121,33 @@ export function CanvasFrame({ html, title }: CanvasFrameProps) {
     );
   }, [resolvedTheme, srcDoc]);
 
-  // Respond to the iframe's initial theme request, which fires on load before
-  // the resolvedTheme effect above catches it.
+  // Respond to the iframe's initial theme request (fires on load before the
+  // resolvedTheme effect above catches it) and handle in-app navigation
+  // requests from the injected click-interceptor script (navigationBridge).
   useEffect(() => {
     function handleMessage(e: MessageEvent) {
       if (e.source !== iframeRef.current?.contentWindow) return;
-      if (e.data?.type !== 'pagespace-theme-request') return;
-      iframeRef.current?.contentWindow?.postMessage(
-        { type: 'pagespace-theme', isDark: resolvedTheme === 'dark' },
-        '*',
-      );
+
+      if (e.data?.type === 'pagespace-theme-request') {
+        iframeRef.current?.contentWindow?.postMessage(
+          { type: 'pagespace-theme', isDark: resolvedTheme === 'dark' },
+          '*',
+        );
+        return;
+      }
+
+      // Independently re-validate: the injected click-interceptor's own
+      // regex check (render-document.ts) is a UX nicety, not a trust
+      // boundary — author JS in the sandboxed-but-scripted iframe can post
+      // this message type directly, so we must not route on an unvalidated
+      // href.
+      if (e.data?.type === 'pagespace-navigate' && typeof e.data.href === 'string' && isDashboardPageLink(e.data.href)) {
+        router.push(e.data.href);
+      }
     }
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [resolvedTheme]);
+  }, [resolvedTheme, router]);
 
   return (
     <iframe

--- a/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
+++ b/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { flushSync } from 'react-dom';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
 const fetchWithAuthMock = vi.fn();
@@ -309,5 +309,77 @@ describe('CanvasFrame — navigation bridge', () => {
     }));
 
     expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  // Regression: without a user-activation gate, author JS inside the canvas
+  // iframe could postMessage `pagespace-navigate` on load (no real click at
+  // all) and force the app's own tab to navigate — reopening the exact hole
+  // CANVAS_IFRAME_SANDBOX closes by omitting allow-top-navigation*. jsdom has
+  // no navigator.userActivation at all (verified separately), so the tests
+  // above exercise the "API unsupported" fallback path; these explicitly
+  // stub the API to exercise the gate itself.
+  describe('given the User Activation API is available', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window.navigator, 'userActivation');
+
+    afterEach(() => {
+      if (originalDescriptor) {
+        Object.defineProperty(window.navigator, 'userActivation', originalDescriptor);
+      } else {
+        delete (window.navigator as { userActivation?: unknown }).userActivation;
+      }
+    });
+
+    function stubUserActivation(isActive: boolean) {
+      Object.defineProperty(window.navigator, 'userActivation', {
+        value: { isActive, hasBeenActive: isActive },
+        configurable: true,
+      });
+    }
+
+    it('given no recent user gesture (isActive: false), should NOT router.push even for a valid href', () => {
+      stubUserActivation(false);
+      const mockContentWindow = { postMessage: vi.fn() };
+
+      render(React.createElement(CanvasFrame, {
+        html: '<p>x</p>',
+        title: 'Canvas',
+      }));
+
+      const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+      Object.defineProperty(iframe, 'contentWindow', {
+        value: mockContentWindow,
+        configurable: true,
+      });
+
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1' },
+        source: mockContentWindow as unknown as MessageEventSource,
+      }));
+
+      expect(routerPushMock).not.toHaveBeenCalled();
+    });
+
+    it('given a recent user gesture (isActive: true), should router.push a valid href', () => {
+      stubUserActivation(true);
+      const mockContentWindow = { postMessage: vi.fn() };
+
+      render(React.createElement(CanvasFrame, {
+        html: '<p>x</p>',
+        title: 'Canvas',
+      }));
+
+      const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+      Object.defineProperty(iframe, 'contentWindow', {
+        value: mockContentWindow,
+        configurable: true,
+      });
+
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1' },
+        source: mockContentWindow as unknown as MessageEventSource,
+      }));
+
+      expect(routerPushMock).toHaveBeenCalledWith('/dashboard/drive-1/page-1');
+    });
   });
 });

--- a/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
+++ b/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
@@ -13,6 +13,11 @@ vi.mock('next-themes', () => ({
   useTheme: () => useThemeMock(),
 }));
 
+const routerPushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPushMock }),
+}));
+
 import { CANVAS_IFRAME_SANDBOX, CanvasFrame } from '../CanvasFrame';
 
 // React 19.2.6 production build in this sandbox doesn't export `act`;
@@ -213,5 +218,96 @@ describe('CanvasFrame — theme sync', () => {
     }));
 
     expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('CanvasFrame — navigation bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useThemeMock.mockReturnValue({ resolvedTheme: 'dark' });
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ links: [] }),
+    });
+  });
+
+  it('given navigationBridge, should pass it to renderCanvasDocument so the srcDoc contains the bridge script', () => {
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    expect(iframe.srcdoc).toContain('pagespace-navigate');
+  });
+
+  it('given a pagespace-navigate message with a valid dashboard page href from the iframe, should router.push it', () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1' },
+      source: mockContentWindow as unknown as MessageEventSource,
+    }));
+
+    expect(routerPushMock).toHaveBeenCalledWith('/dashboard/drive-1/page-1');
+  });
+
+  it('given a pagespace-navigate message with a forged/invalid href, should NOT router.push (independent re-validation)', () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-navigate', href: 'https://evil.example.com' },
+      source: mockContentWindow as unknown as MessageEventSource,
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1/view' },
+      source: mockContentWindow as unknown as MessageEventSource,
+    }));
+
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  it('given a pagespace-navigate message from a different source, should NOT router.push', () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-navigate', href: '/dashboard/drive-1/page-1' },
+      source: window,
+    }));
+
+    expect(routerPushMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
@@ -4,6 +4,7 @@ import {
   rewriteDashboardFileViewLinks,
   extractInterPageLinks,
   rewriteInterPageLinks,
+  isDashboardPageLink,
 } from '../file-view-links';
 
 describe('extractDashboardFileViewRefs', () => {
@@ -144,5 +145,34 @@ describe('rewriteInterPageLinks', () => {
     const out = rewriteInterPageLinks(html, map, SUB);
     expect(out).toContain('href="https://acme.pagespace.site/p"');
     expect(out).toContain('href="/dashboard/drive-1/priv"');
+  });
+});
+
+describe('isDashboardPageLink', () => {
+  it('given plain dashboard page links, with or without trailing slash/query/hash, should accept them', () => {
+    expect(isDashboardPageLink('/dashboard/d1/p1')).toBe(true);
+    expect(isDashboardPageLink('/dashboard/d1/p1/')).toBe(true);
+    expect(isDashboardPageLink('/dashboard/d1/p1?x=1')).toBe(true);
+    expect(isDashboardPageLink('/dashboard/d1/p1#h')).toBe(true);
+  });
+
+  it('given the /view (file-embed) form, should reject it — that is a separate embed mechanism', () => {
+    expect(isDashboardPageLink('/dashboard/d1/p1/view')).toBe(false);
+  });
+
+  it('given a same-page anchor, should reject it', () => {
+    expect(isDashboardPageLink('#foo')).toBe(false);
+  });
+
+  it('given an absolute URL to a different origin, should reject it', () => {
+    expect(isDashboardPageLink('https://evil.com/dashboard/d1/p1')).toBe(false);
+  });
+
+  it('given a single-segment dashboard path, should reject it', () => {
+    expect(isDashboardPageLink('/dashboard/d1')).toBe(false);
+  });
+
+  it('given a non-dashboard internal path, should reject it', () => {
+    expect(isDashboardPageLink('/pricing')).toBe(false);
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/render-published.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/render-published.test.ts
@@ -160,6 +160,16 @@ describe('renderPublishedPage — SEO + social passthrough', () => {
     expect(out).toContain('prefers-color-scheme');
     expect(out).toContain('pagespace-theme');
   });
+
+  // The in-app navigation bridge (CanvasFrame.tsx passing navigationBridge:
+  // true) must never reach the published artifact — published pages are
+  // top-level documents with no listening parent, so shipping the
+  // click-interceptor there would be dead weight at best. renderPublishedPage
+  // never sets the field, so this should stay true structurally, not by luck.
+  it('given a published page, should NEVER inject the navigation-bridge script', () => {
+    const out = renderPublishedPage({ html: '<a href="/dashboard/d1/p1">go</a>', pageUrl });
+    expect(out).not.toContain('pagespace-navigate');
+  });
 });
 
 describe('renderPublishedDocument', () => {

--- a/apps/web/src/lib/canvas/file-view-links.ts
+++ b/apps/web/src/lib/canvas/file-view-links.ts
@@ -108,3 +108,23 @@ export function rewriteInterPageLinks(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Dashboard page link validation (in-app navigation bridge)
+// ---------------------------------------------------------------------------
+//
+// Validates a single href STRING (not a raw-HTML search, unlike
+// INTER_PAGE_LINK_RE above) as an internal dashboard PAGE link. Used by
+// CanvasFrame.tsx to independently re-validate `href` from a
+// `pagespace-navigate` postMessage before calling router.push — the
+// injected click-interceptor script in render-document.ts is a UX nicety,
+// not a trust boundary (author JS in the sandboxed-but-scripted canvas
+// iframe can forge this message directly), so the receiving side must
+// validate on its own. Deliberately excludes the `/view` (file-embed) form,
+// which is a separate embed mechanism handled by extractDashboardFileViewRefs
+// above, not a navigation link.
+const DASHBOARD_PAGE_LINK_RE = /^\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/?(?:[?#].*)?$/;
+
+export function isDashboardPageLink(href: string): boolean {
+  return DASHBOARD_PAGE_LINK_RE.test(href);
+}
+

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -218,6 +218,18 @@ describe('renderCanvasDocument — navigation bridge', () => {
     expect(out).toContain('/^\\/dashboard\\/');
   });
 
+  // Regression: a capture-phase listener runs BEFORE the clicked element's own
+  // onclick / bubbling ancestor handlers, so an author calling preventDefault()
+  // to cancel our routing would never have a chance to (we'd have already read
+  // e.defaultPrevented as false and posted the message). The listener must be
+  // bubble-phase (no `useCapture` / no trailing `,true` in addEventListener).
+  it('given navigationBridge: true, the click listener should be registered for the BUBBLE phase, not capture', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', navigationBridge: true });
+    expect(out).toContain("document.addEventListener('click',function(e){");
+    expect(out).not.toContain(',true);');
+    expect(NAVIGATION_BRIDGE_SCRIPT).not.toContain(',true);');
+  });
+
   it('given navigationBridge: true AND a nonce, should stamp the nonce onto the navigation-bridge script too', () => {
     const out = renderCanvasDocument({ html: '<p>x</p>', navigationBridge: true, nonce: 'app-nonce==' });
     // Both injected scripts (theme + navigation) would need the nonce if both

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET, THEME_BRIDGE_SCRIPT } from '../render-document';
+import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET, THEME_BRIDGE_SCRIPT, NAVIGATION_BRIDGE_SCRIPT } from '../render-document';
 
 describe('renderCanvasDocument', () => {
   it('given any input, should return a full HTML document', () => {
@@ -196,6 +196,33 @@ describe('renderCanvasDocument — theme bridge', () => {
   // script" for the theme bridge specifically.
   it('given injectThemeBridge: true AND a nonce, should stamp the nonce onto the theme-bridge script too', () => {
     const out = renderCanvasDocument({ html: '<p>x</p>', injectThemeBridge: true, nonce: 'app-nonce==' });
+    expect(out).toContain('<script nonce="app-nonce==">(function(){');
+  });
+});
+
+describe('renderCanvasDocument — navigation bridge', () => {
+  it('given navigationBridge: true, should inject the bridge script inside <head>', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', navigationBridge: true });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain(NAVIGATION_BRIDGE_SCRIPT);
+  });
+
+  it('given no navigationBridge, should NOT inject the bridge script (covers the published-page default)', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>' });
+    expect(out).not.toContain('pagespace-navigate');
+  });
+
+  it('given navigationBridge: true, the bridge should click-intercept dashboard page links and postMessage', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', navigationBridge: true });
+    expect(out).toContain("postMessage({type:'pagespace-navigate',href:href}");
+    expect(out).toContain('/^\\/dashboard\\/');
+  });
+
+  it('given navigationBridge: true AND a nonce, should stamp the nonce onto the navigation-bridge script too', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', navigationBridge: true, nonce: 'app-nonce==' });
+    // Both injected scripts (theme + navigation) would need the nonce if both
+    // were present; here only navigationBridge is set, so exactly one stamped
+    // inline script should carry it.
     expect(out).toContain('<script nonce="app-nonce==">(function(){');
   });
 });

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -116,6 +116,23 @@ export interface RenderCanvasDocumentInput {
    */
   injectThemeBridge?: boolean;
   /**
+   * When true, injects a lightweight <script> into <head> that intercepts
+   * clicks on internal dashboard page links (`/dashboard/{driveId}/{pageId}`)
+   * and posts `{ type: 'pagespace-navigate', href }` to the parent instead of
+   * letting the click fall through to `<base target="_blank">` (a new tab).
+   * The script only decides WHETHER to ask; the parent (CanvasFrame) is the
+   * ONLY thing that actually navigates — this script never touches
+   * `history`/`location` itself, and calls `preventDefault()` only for links
+   * it recognizes and only after `postMessage` succeeds.
+   *
+   * Pass ONLY from the in-app dashboard renderer (CanvasFrame.tsx). The
+   * publish pipeline (`render-published.ts`) must NOT set this: published
+   * pages are top-level documents with no listening parent, so the script
+   * would either be dead weight or (worse) swallow clicks with no follow-up.
+   * Omitting it there keeps published HTML byte-for-byte unchanged.
+   */
+  navigationBridge?: boolean;
+  /**
    * When set, used VERBATIM as the emitted CSP `<meta>` content instead of
    * `buildBaselineCsp(formActionOrigin)`. Lets other renderers (e.g. the
    * published-document pipeline, which needs `script-src 'none'`) reuse this
@@ -191,6 +208,56 @@ export const THEME_BRIDGE_SCRIPT =
   "document.documentElement.classList.toggle('dark',e.data.isDark);}});" +
   // Request current theme from parent on load (in-app only; harmless on published)
   "try{window.parent.postMessage({type:'pagespace-theme-request'},'*');}catch(e){}" +
+  "})();</script>";
+
+/**
+ * Inline script injected when `navigationBridge` is true. Runs ONLY inside
+ * the in-app canvas iframe (see `navigationBridge` doc above).
+ *
+ * Intercepts clicks on `<a>` elements whose raw `href` attribute matches an
+ * internal dashboard PAGE link (`/dashboard/{driveId}/{pageId}`, optionally
+ * with a trailing slash / query / hash) and posts
+ * `{ type: 'pagespace-navigate', href }` to the parent so CanvasFrame can
+ * route it through the app's SPA router instead of `<base target="_blank">`
+ * opening a new tab.
+ *
+ * Deliberately narrow:
+ *  - Matches the RAW `getAttribute('href')` string, not the resolved
+ *    `a.pathname` — a `href="#section"` same-page anchor resolves its
+ *    `.pathname` to the CURRENT page's own `/dashboard/{driveId}/{pageId}`
+ *    (srcdoc iframes resolve relative URLs against the parent document),
+ *    which would false-positive match if we read `.pathname` instead.
+ *  - Requires the string to literally start with `/dashboard/` — an
+ *    author-authored absolute same-origin URL is not intercepted (falls
+ *    through to existing target="_blank" behavior).
+ *  - Explicitly excludes the `/view` (file-embed) suffix: those links are
+ *    handled by the separate file-view-token rewriting and keep their
+ *    existing behavior.
+ *  - Skips clicks with modifier keys / non-primary button, and clicks
+ *    already `defaultPrevented` by other author scripts, so ctrl/cmd/
+ *    middle-click "open in new tab" keeps working as expected.
+ *  - Only calls `preventDefault()` AFTER `postMessage` succeeds, so a link
+ *    we can't hand off is never silently swallowed.
+ *
+ * `CanvasFrame.tsx` independently re-validates `href` against the same
+ * pattern (`isDashboardPageLink` in `file-view-links.ts`) before acting on
+ * the message — this script's own check is a UX nicety, not a trust
+ * boundary, since sandboxed author JS could forge the postMessage directly.
+ */
+export const NAVIGATION_BRIDGE_SCRIPT =
+  "<script>(function(){" +
+  "var RE=/^\\/dashboard\\/([A-Za-z0-9_-]+)\\/([A-Za-z0-9_-]+)\\/?(?:[?#].*)?$/;" +
+  "document.addEventListener('click',function(e){" +
+  "if(e.defaultPrevented||e.button!==0||e.metaKey||e.ctrlKey||e.shiftKey||e.altKey)return;" +
+  "var a=e.target&&e.target.closest?e.target.closest('a[href]'):null;" +
+  "if(!a)return;" +
+  "var href=a.getAttribute('href');" +
+  "if(!href||!RE.test(href))return;" +
+  "try{" +
+  "window.parent.postMessage({type:'pagespace-navigate',href:href},'*');" +
+  "e.preventDefault();" +
+  "}catch(err){}" +
+  "},true);" +
   "})();</script>";
 
 // Re-exported for existing consumers — the implementation lives in a
@@ -322,7 +389,7 @@ function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[], no
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, nonce, cspOverride } = input;
+  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, navigationBridge, nonce, cspOverride } = input;
   const csp = cspOverride ?? buildBaselineCsp(formActionOrigin);
 
   const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts, nonce);
@@ -366,6 +433,7 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
     `<meta http-equiv="Content-Security-Policy" content="${csp}">` +
     `<style>${BASELINE_RESET}${css}</style>` +
     (injectThemeBridge ? (nonce ? stampScriptNonce(THEME_BRIDGE_SCRIPT, nonce) : THEME_BRIDGE_SCRIPT) : '') +
+    (navigationBridge ? (nonce ? stampScriptNonce(NAVIGATION_BRIDGE_SCRIPT, nonce) : NAVIGATION_BRIDGE_SCRIPT) : '') +
     '</head><body>' +
     body +
     '</body></html>'

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -235,14 +235,21 @@ export const THEME_BRIDGE_SCRIPT =
  *    existing behavior.
  *  - Skips clicks with modifier keys / non-primary button, and clicks
  *    already `defaultPrevented` by other author scripts, so ctrl/cmd/
- *    middle-click "open in new tab" keeps working as expected.
+ *    middle-click "open in new tab" keeps working as expected. The listener
+ *    is registered for the BUBBLE phase (no `useCapture`), not capture —
+ *    capture would run before the clicked element's own `onclick` (and any
+ *    bubbling ancestor handler), so an author's own `preventDefault()` call
+ *    (e.g. a canvas-internal JS router that wants to handle the click
+ *    itself) would never have a chance to run first and be observed here.
  *  - Only calls `preventDefault()` AFTER `postMessage` succeeds, so a link
  *    we can't hand off is never silently swallowed.
  *
  * `CanvasFrame.tsx` independently re-validates `href` against the same
  * pattern (`isDashboardPageLink` in `file-view-links.ts`) before acting on
- * the message — this script's own check is a UX nicety, not a trust
- * boundary, since sandboxed author JS could forge the postMessage directly.
+ * the message, AND gates on a genuine recent user gesture — this script's
+ * own checks are a UX nicety, not a trust boundary, since sandboxed author
+ * JS could forge the postMessage directly (see the gating doc comment on
+ * CanvasFrame.tsx's message handler).
  */
 export const NAVIGATION_BRIDGE_SCRIPT =
   "<script>(function(){" +
@@ -257,7 +264,7 @@ export const NAVIGATION_BRIDGE_SCRIPT =
   "window.parent.postMessage({type:'pagespace-navigate',href:href},'*');" +
   "e.preventDefault();" +
   "}catch(err){}" +
-  "},true);" +
+  "});" +
   "})();</script>";
 
 // Re-exported for existing consumers — the implementation lives in a


### PR DESCRIPTION
## Summary
- Canvas pages link to internal `/dashboard/{driveId}/{pageId}` pages, but inside the sandboxed `srcDoc` iframe these previously always opened in a new browser tab (`baseTarget: '_blank'`), since the iframe has no way to navigate its parent.
- Adds a `postMessage`-based navigation bridge, gated behind a new `navigationBridge` flag on `renderCanvasDocument` (mirrors the existing `injectThemeBridge` pattern):
  - `render-document.ts` injects a click-interceptor script that posts `{ type: 'pagespace-navigate', href }` for internal dashboard page links, skipping modifier-key clicks and the `/view` (file-embed) form.
  - `CanvasFrame.tsx` passes `navigationBridge: true` and independently re-validates the `href` via `isDashboardPageLink()` before `router.push`, since the injected script's own check is a UX nicety, not a trust boundary — sandboxed author JS could forge the postMessage directly.
  - `render-published.ts` is untouched: it never sets the flag, so published pages (never iframed by app code, no listening parent) stay byte-for-byte identical and unpublished-page links keep their existing fallback behavior.

## Security hardening (post-review)
Automated review (Codex) flagged two trust gaps in the bridge, both fixed:
- **Forced navigation without a real click**: the `pagespace-navigate` handler only validated message source + href pattern, not that a genuine click triggered it — author JS in the iframe could `postMessage` this on load and force the app's own tab to navigate, reopening the exact hole `CANVAS_IFRAME_SANDBOX` closes by omitting `allow-top-navigation*`. Fixed by gating on `navigator.userActivation.isActive`, the same mechanism the browser already uses to gate `allow-popups` against script-only `window.open()`.
- **Capture-phase interception**: the click listener ran in the capture phase, before an author's own `onclick`/bubbling handlers, so an author calling `preventDefault()` to cancel our routing never had the chance to. Switched to bubble phase.

## Test plan
- [x] Unit tests: `render-document.test.ts` (script injection gated by flag, nonce stamping, bubble-phase registration), `file-view-links.test.ts` (`isDashboardPageLink` accept/reject table), `CanvasFrame.test.ts` (valid href routes, forged/invalid href and wrong-source do not, user-activation gate blocks/allows appropriately), `render-published.test.ts` (published output never contains `pagespace-navigate`)
- [x] `bun run typecheck` clean in `packages/lib` and `apps/web`
- [x] `eslint` clean on touched files
- [x] Full `bun run --filter web build` succeeds
- [ ] Manual: click an internal canvas link in the dashboard and confirm in-app SPA navigation (no new tab); ctrl/cmd-click still opens a new tab; publish a drive and confirm the served HTML contains no `pagespace-navigate` string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7p3vTiMp7GRycDkjYY5mc
