### PR TITLE
fix(agent-sessions): quota refusal delivery + storage-measurement generation CAS

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -285,9 +285,11 @@ async function measureWarmSessionStorageOnResume(sessionId: string, sandboxId: s
     await refreshSessionStorageMeasurement({
       handle: { exec: (args) => sandbox.runCommand(args) },
       sessionId,
-      // The generation read above, before the walk — a re-provision mid-`du`
-      // moves the row on and the stale write is dropped (see the web tier).
-      spriteInstanceId: row.spriteInstanceId ?? null,
+      // The FETCHED sandbox's own generation, not the row's: the CAS has to
+      // describe the disk that was walked (see the web tier). Here the two
+      // usually agree — the sandbox is fetched right after the row — but
+      // "usually" is exactly what a CAS is for.
+      spriteInstanceId: sandbox.spriteInstanceId ?? null,
       lastMeasuredAt: row.storageMeasuredAt ?? null,
       now: new Date(),
       persist: async ({ spriteInstanceId, measuredBytes, measuredAt }) => {

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -225,12 +225,14 @@ async function ensureShellSessionSandbox({ sessionId, userId }: { sessionId: str
         await refreshSessionStorageMeasurement({
           handle,
           sessionId,
+          // The generation just minted, for the writer's CAS (see the web tier).
+          spriteInstanceId: handle.spriteInstanceId ?? null,
           // Null for the same reason as the web tier: this fires on the create
           // arm, whose own stamps reset the measurement columns.
           lastMeasuredAt: null,
           now: new Date(),
-          persist: async ({ measuredBytes, measuredAt }) => {
-            await store.recordStorageMeasurement({ sessionId, measuredBytes, measuredAt });
+          persist: async ({ spriteInstanceId, measuredBytes, measuredAt }) => {
+            await store.recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt });
           },
         });
       },
@@ -283,10 +285,13 @@ async function measureWarmSessionStorageOnResume(sessionId: string, sandboxId: s
     await refreshSessionStorageMeasurement({
       handle: { exec: (args) => sandbox.runCommand(args) },
       sessionId,
+      // The generation read above, before the walk — a re-provision mid-`du`
+      // moves the row on and the stale write is dropped (see the web tier).
+      spriteInstanceId: row.spriteInstanceId ?? null,
       lastMeasuredAt: row.storageMeasuredAt ?? null,
       now: new Date(),
-      persist: async ({ measuredBytes, measuredAt }) => {
-        await store.recordStorageMeasurement({ sessionId, measuredBytes, measuredAt });
+      persist: async ({ spriteInstanceId, measuredBytes, measuredAt }) => {
+        await store.recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt });
       },
     });
   } catch {

--- a/apps/web/src/components/agents/AgentView.tsx
+++ b/apps/web/src/components/agents/AgentView.tsx
@@ -23,6 +23,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { AlertCircle, Bot, ExternalLink, Loader2, Plus, X } from 'lucide-react';
+import { toast } from 'sonner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { useResolvedAgent } from './useResolvedAgent';
@@ -79,6 +80,17 @@ export default function AgentView({
     try {
       const shell = await shells.addShell();
       if (shell) setActiveTab(`shell:${shell.shellId}`);
+    } catch (error) {
+      // The refusal this most often carries is the plan's sandbox limit, whose
+      // 429 body is written to be read by a human. Without this catch the
+      // rejection escaped an onClick handler as an unhandled rejection: the
+      // spinner stopped, no tab appeared, and the message explaining why —
+      // and naming the one action that clears it — reached nothing. A limit
+      // the product enforces but never states is indistinguishable from a bug.
+      console.error('Failed to add shell:', error);
+      toast.error('Could not add a shell', {
+        description: error instanceof Error ? error.message : 'Please try again.',
+      });
     } finally {
       setIsAddingShell(false);
     }
@@ -86,7 +98,17 @@ export default function AgentView({
 
   const handleCloseShell = useCallback(
     async (shellId: string) => {
-      await shells.removeShell(shellId);
+      try {
+        await shells.removeShell(shellId);
+      } catch (error) {
+        // Closing is optimistic — the tab is already gone from the UI, so a
+        // failure silently RESTORES it via SWR rollback. Saying so beats a tab
+        // that reappears for no stated reason.
+        console.error('Failed to close shell:', error);
+        toast.error('Could not close that shell', {
+          description: error instanceof Error ? error.message : 'Please try again.',
+        });
+      }
     },
     [shells],
   );

--- a/apps/web/src/components/agents/__tests__/AgentView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentView.test.tsx
@@ -25,6 +25,9 @@ vi.mock('../useResolvedAgent', () => ({
   useResolvedAgent: () => resolvedAgent.current,
 }));
 
+const toastMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+vi.mock('sonner', () => ({ toast: toastMock }));
+
 const sessionState = vi.hoisted(() => ({
   current: {
     session: null,
@@ -103,6 +106,8 @@ beforeEach(() => {
     removeShell: vi.fn(async () => {}),
     mutate: vi.fn(),
   };
+  toastMock.error.mockClear();
+  toastMock.success.mockClear();
 });
 
 describe('AgentView', () => {
@@ -163,6 +168,60 @@ describe('AgentView', () => {
     fireEvent.click(screen.getByRole('button', { name: /Add shell/ }));
 
     await waitFor(() => expect(shellsState.current.addShell).toHaveBeenCalled());
+  });
+
+  it('given the server refuses to add a shell, should tell the user why instead of failing silently', async () => {
+    // The refusal this most often carries is the plan's sandbox limit. `post()`
+    // rethrows the 429 body's `error` as the Error message, so the sentence the
+    // API wrote for a human is already in hand — it just had nowhere to go: the
+    // handler was try/finally with no catch, so the rejection escaped an onClick
+    // as an unhandled rejection and the user got a spinner that stopped and no
+    // tab. A limit the product enforces but never states reads as a bug.
+    shellsState.current.addShell = vi.fn(async () => {
+      throw new Error("Your plan's limit for running sandboxes is already in use — stop one before starting another.");
+    });
+    render(<AgentView agentId="agent-1" conversationId="conv-1" context="console" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add shell/ }));
+
+    await waitFor(() =>
+      expect(toastMock.error).toHaveBeenCalledWith('Could not add a shell', {
+        description: "Your plan's limit for running sandboxes is already in use — stop one before starting another.",
+      }),
+    );
+  });
+
+  it('given adding a shell fails, should re-enable the button rather than latch it disabled', async () => {
+    shellsState.current.addShell = vi.fn(async () => {
+      throw new Error('nope');
+    });
+    render(<AgentView agentId="agent-1" conversationId="conv-1" context="console" />);
+    const button = screen.getByRole('button', { name: /Add shell/ });
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(toastMock.error).toHaveBeenCalled());
+    // The `finally` must survive the new catch: a permanently disabled button
+    // would strand the user even after the condition that refused them clears.
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it('given closing a shell fails, should say so — the tab silently comes back', async () => {
+    // Removal is optimistic with `rollbackOnError`, so a failure restores the
+    // tab. Unexplained, that reads as a click that did not register.
+    shellsState.current.shells = [shellFixture({ shellId: 'shell-a', name: 'shell-a' })];
+    shellsState.current.removeShell = vi.fn(async () => {
+      throw new Error('sandbox unreachable');
+    });
+    render(<AgentView agentId="agent-1" conversationId="conv-1" context="console" />);
+
+    fireEvent.click(screen.getByLabelText('Close shell-a'));
+
+    await waitFor(() =>
+      expect(toastMock.error).toHaveBeenCalledWith('Could not close that shell', {
+        description: 'sandbox unreachable',
+      }),
+    );
   });
 
   it('shows Starting on the chip while the first shell provisions the sandbox', async () => {

--- a/apps/web/src/lib/agent-sessions/__tests__/quota-response.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/quota-response.test.ts
@@ -12,8 +12,46 @@
  * perfectly well to whoever wrote it. Only a reader who knows the convention
  * would catch it, and conventions with no test decay.
  */
-import { describe, it, expect } from 'vitest';
-import { SESSION_QUOTA_MESSAGE } from '../quota-response';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { SESSION_QUOTA_MESSAGE, sessionQuotaExceeded } from '../quota-response';
+
+/**
+ * The tests above pin the COPY. These pin the PATH to it — the gap that let the
+ * copy be right and unreachable at the same time.
+ */
+describe('sessionQuotaExceeded', () => {
+  const call = (detail?: string) =>
+    sessionQuotaExceeded(new Request('https://x.test/api'), 'user_1', 'ses_1', 'route/under/test', detail);
+
+  it('should answer 429, not an authorization status', async () => {
+    expect(call().status).toBe(429);
+  });
+
+  it('should send the human sentence to the caller even when the provisioner names a code', async () => {
+    // The regression: `detail` is ALWAYS set (`quota.reason` === 'concurrency_limit'),
+    // so a `detail ?? SESSION_QUOTA_MESSAGE` body rendered the enum into the product.
+    const body = await call('concurrency_limit').json();
+    expect(body.error).toBe(SESSION_QUOTA_MESSAGE);
+  });
+
+  it('should never leak a provisioner code to the caller, whatever it says', async () => {
+    const body = await call('some_internal_reason_code').json();
+    expect(JSON.stringify(body)).not.toContain('some_internal_reason_code');
+  });
+
+  it('should keep the code in the audit trail, where diagnostics belong', () => {
+    vi.mocked(auditRequest).mockClear();
+    call('concurrency_limit');
+    expect(vi.mocked(auditRequest).mock.calls[0][1]).toMatchObject({
+      eventType: 'security.rate.limited',
+      details: { reason: 'session_limit_reached', route: 'route/under/test', detail: 'concurrency_limit' },
+    });
+  });
+});
 
 describe('SESSION_QUOTA_MESSAGE', () => {
   it('should not use the backend vocabulary a human never sees', () => {

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -394,7 +394,15 @@ export async function provisionSessionSandbox(
  */
 export async function measureWarmSessionStorage(input: {
   sessionId: string;
-  attach: () => Promise<{ exec: SandboxHandle['exec'] } | null>;
+  /**
+   * Returns the sandbox to measure AND its own generation id. Both, because the
+   * two can disagree: this path is fed by a sandbox the tool run ALREADY
+   * acquired, so by the time the row is read below the session may have been
+   * torn down and re-provisioned — the row would say B while the handle in hand
+   * is still A. CASing on the row's value would then let A's bytes land on B
+   * under a CAS that "succeeded", which is the bug the CAS exists to stop.
+   */
+  attach: () => Promise<{ exec: SandboxHandle['exec']; spriteInstanceId: string | null } | null>;
 }): Promise<void> {
   try {
     const store = await getAgentSessionStore();
@@ -413,11 +421,11 @@ export async function measureWarmSessionStorage(input: {
     await refreshSessionStorageMeasurement({
       handle,
       sessionId: input.sessionId,
-      // The generation observed at the top of this function, before the `du`.
-      // If a teardown + re-provision lands while the walk runs, the row's
-      // instance moves on and the write is dropped rather than billing the new
-      // Sprite for the old one's disk.
-      spriteInstanceId: row.spriteInstanceId ?? null,
+      // The MEASURED handle's own generation, never the row's. The row is read
+      // for the throttle; the CAS has to describe the disk the `du` actually
+      // walked, or a handle captured before a re-provision would persist the
+      // old generation's bytes under the new generation's id.
+      spriteInstanceId: handle.spriteInstanceId,
       lastMeasuredAt: row.storageMeasuredAt ?? null,
       now: new Date(),
       persist: (measurement) => store.recordStorageMeasurement(measurement),

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -359,6 +359,9 @@ export async function provisionSessionSandbox(
         await refreshSessionStorageMeasurement({
           handle,
           sessionId,
+          // The generation just minted — the CAS target for the write. Taken
+          // from the handle, not the row: this is the VM the `du` runs on.
+          spriteInstanceId: handle.spriteInstanceId ?? null,
           // NULL, not the row's value: this callback only fires on the `create`
           // arm, where the same operation resets the measurement columns (a new
           // Sprite generation is an empty filesystem). Passing the pre-provision
@@ -410,6 +413,11 @@ export async function measureWarmSessionStorage(input: {
     await refreshSessionStorageMeasurement({
       handle,
       sessionId: input.sessionId,
+      // The generation observed at the top of this function, before the `du`.
+      // If a teardown + re-provision lands while the walk runs, the row's
+      // instance moves on and the write is dropped rather than billing the new
+      // Sprite for the old one's disk.
+      spriteInstanceId: row.spriteInstanceId ?? null,
       lastMeasuredAt: row.storageMeasuredAt ?? null,
       now: new Date(),
       persist: (measurement) => store.recordStorageMeasurement(measurement),

--- a/apps/web/src/lib/agent-sessions/quota-response.ts
+++ b/apps/web/src/lib/agent-sessions/quota-response.ts
@@ -36,7 +36,19 @@ export function sessionQuotaExceeded(
   sessionId: string,
   /** Which route refused, for the audit trail only — never shown to the caller. */
   route: string,
-  /** A more specific message from the provisioner, when it had one. */
+  /**
+   * The provisioner's DIAGNOSTIC CODE for the refusal (`'concurrency_limit'`),
+   * recorded in the audit trail and never shown to the caller.
+   *
+   * It used to be the response body — `{ error: detail ?? SESSION_QUOTA_MESSAGE }`
+   * — on the reading that a provisioner would supply something "more specific".
+   * It supplies `quota.reason`, an enum, and always: so the `??` never fell
+   * through, both human strings on this path were unreachable, and a user who hit
+   * their plan limit got `{"error":"concurrency_limit"}` rendered into the
+   * product. The socket surface printed the real sentence for the same refusal —
+   * the exact three-ways-to-say-one-thing this module exists to prevent, hidden
+   * because the copy had a test and the PATH to it did not.
+   */
   detail?: string,
 ): NextResponse {
   auditRequest(request, {
@@ -44,8 +56,8 @@ export function sessionQuotaExceeded(
     userId,
     resourceType: 'agent_session',
     resourceId: sessionId,
-    details: { reason: 'session_limit_reached', route },
+    details: { reason: 'session_limit_reached', route, detail },
     riskScore: 0,
   });
-  return NextResponse.json({ error: detail ?? SESSION_QUOTA_MESSAGE }, { status: 429 });
+  return NextResponse.json({ error: SESSION_QUOTA_MESSAGE }, { status: 429 });
 }

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -306,6 +306,31 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     expect(typeof deps.notifyShellActivity).toBe('function');
   });
 
+  it('should measure against the ACQUIRED sandbox\'s generation, not whatever the row says later', async () => {
+    // The storage CAS is only as good as the id handed to it. This seam is fed
+    // the sandbox the tool run ALREADY acquired, and the measurement is
+    // fire-and-forget — so between acquiring it and persisting, the session can
+    // be torn down and re-provisioned. Reading the instance from the session row
+    // at persist time would then name generation B while `du` walked A's disk,
+    // and the CAS would "succeed" against B with A's bytes: the exact write the
+    // CAS exists to reject, waved through by its own guard.
+    const deps = buildRealSandboxRunDeps();
+    expect(typeof deps.measureStorage).toBe('function');
+
+    const sandbox = {
+      spriteInstanceId: 'instance-A',
+      runCommand: vi.fn(async () => ({ exitCode: 0, stdout: '1\t/workspace', stderr: '' })),
+    };
+    await deps.measureStorage!({ sandbox: sandbox as never, sessionId: 'conv-1' });
+
+    const [call] = mockMeasureWarmSessionStorage.mock.calls as unknown as [
+      [{ sessionId: string; attach: () => Promise<{ spriteInstanceId: string | null } | null> }],
+    ];
+    expect(call[0].sessionId).toBe('conv-1');
+    const attached = await call[0].attach();
+    expect(attached?.spriteInstanceId).toBe('instance-A');
+  });
+
   it('given no conversationId, should fail as provision_failed/missing_conversation_id without touching the session runtime', async () => {
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ conversationId: undefined }));

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -180,7 +180,15 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         sessionId,
         // The exec client exposes `runCommand`; the measurement seam speaks the
         // host's `exec`. One adapter here beats widening either contract.
-        attach: async () => ({ exec: (args) => sandbox.runCommand(args) }),
+        //
+        // `spriteInstanceId` comes off THIS sandbox — the one the tool run
+        // acquired and just used — because that is the disk `du` will walk.
+        // Reading it from the session row instead would name whatever generation
+        // is current at persist time, which is not necessarily this one.
+        attach: async () => ({
+          exec: (args) => sandbox.runCommand(args),
+          spriteInstanceId: sandbox.spriteInstanceId,
+        }),
       }),
     notifyShellActivity: (input) => notifyShellAgentActivity(input),
     // Injection seam (DEFENSE-IN-DEPTH, fail-open): screen untrusted tool output

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-session-sprite.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-session-sprite.test.ts
@@ -823,7 +823,11 @@ describe('ensureAgentSessionSandbox — concurrency ceiling', () => {
       actor: { userId: OWNER_ID, tenantId: TENANT_ID },
       deps: makeDeps(
         { store, host },
-        { checkConcurrency: async () => ({ allowed: false, reason: 'live agent-session limit reached' }) },
+        // The real `checkAgentSessionConcurrency` answers with a CODE, not prose
+        // — the fixture said otherwise, and a fixture that misstates its
+        // supplier is how `detail` came to be treated as user copy and rendered
+        // into the product as `{"error":"concurrency_limit"}`.
+        { checkConcurrency: async () => ({ allowed: false, reason: 'concurrency_limit' }) },
       ),
     });
 

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
@@ -48,7 +48,9 @@ let store: Awaited<ReturnType<typeof createDbAgentSessionStore>>;
 
 /** A conversation row (the FK/PK target) plus its session row. */
 async function seedSession(
-  over: Partial<{ sandboxId: string; spriteInstanceId: string; spriteTornDownAt: Date; endedAt: Date }> = {},
+  // `spriteInstanceId` is explicitly nullable: a driver that reports no
+  // generation id is a real case the storage CAS has to answer for.
+  over: Partial<{ sandboxId: string; spriteInstanceId: string | null; spriteTornDownAt: Date; endedAt: Date }> = {},
 ) {
   const conversationId = createId();
   conversationIds.push(conversationId);
@@ -265,7 +267,12 @@ describe('recordStorageMeasurement', () => {
     const conversationId = await seedSession({ sandboxId: 'sbx-1', spriteInstanceId: 'i' });
     const measuredAt = new Date();
 
-    await store.recordStorageMeasurement({ sessionId: conversationId, measuredBytes: 4096, measuredAt });
+    await store.recordStorageMeasurement({
+      sessionId: conversationId,
+      spriteInstanceId: 'i',
+      measuredBytes: 4096,
+      measuredAt,
+    });
 
     const [row] = await db.select().from(agentSessions).where(eq(agentSessions.conversationId, conversationId));
     expect(Number(row.storageMeasuredBytes)).toBe(4096);
@@ -279,10 +286,80 @@ describe('recordStorageMeasurement', () => {
       spriteTornDownAt: new Date(),
     });
 
-    await store.recordStorageMeasurement({ sessionId: conversationId, measuredBytes: 999, measuredAt: new Date() });
+    await store.recordStorageMeasurement({
+      sessionId: conversationId,
+      spriteInstanceId: 'i',
+      measuredBytes: 999,
+      measuredAt: new Date(),
+    });
 
     const [row] = await db.select().from(agentSessions).where(eq(agentSessions.conversationId, conversationId));
     expect(row.storageMeasuredBytes).toBeNull();
+  });
+
+  it('given the Sprite generation moved on mid-measurement, should DROP the stale write', async () => {
+    // The window the liveness guard cannot close, because a re-provision REVIVES
+    // the row: measure generation A (fire-and-forget) → A torn down → B minted,
+    // which clears `spriteTornDownAt` and nulls the measurement columns → A's
+    // `du` finally lands. Guarded only on liveness it finds a live row and
+    // writes A's bytes onto B, with a fresh `storageMeasuredAt` that suppresses
+    // B's own measurement for the whole throttle window while the reconcile
+    // bills B's interval against A's disk.
+    //
+    // The name cannot arbitrate this: `sandboxId` is HMAC-derived from the
+    // session, so A and B share it. Only the instance id differs.
+    const conversationId = await seedSession({ sandboxId: 'sbx-stable-name', spriteInstanceId: 'instance-A' });
+
+    await db
+      .update(agentSessions)
+      .set({ spriteInstanceId: 'instance-B', spriteTornDownAt: null, storageMeasuredBytes: null, storageMeasuredAt: null })
+      .where(eq(agentSessions.conversationId, conversationId));
+
+    await store.recordStorageMeasurement({
+      sessionId: conversationId,
+      spriteInstanceId: 'instance-A',
+      measuredBytes: 5_000_000,
+      measuredAt: new Date(),
+    });
+
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.conversationId, conversationId));
+    expect(row.storageMeasuredBytes).toBeNull();
+    // The timestamp matters as much as the bytes: a stale one silences the next
+    // real measurement without ever having recorded a real number.
+    expect(row.storageMeasuredAt).toBeNull();
+  });
+
+  it('given the same generation still on the row, should persist despite an identical sandbox NAME', async () => {
+    // The other half: the CAS must not reject a legitimate measurement just
+    // because the name is reused. Same name, same instance → this is the disk
+    // that was measured.
+    const conversationId = await seedSession({ sandboxId: 'sbx-stable-name', spriteInstanceId: 'instance-B' });
+
+    await store.recordStorageMeasurement({
+      sessionId: conversationId,
+      spriteInstanceId: 'instance-B',
+      measuredBytes: 777,
+      measuredAt: new Date(),
+    });
+
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.conversationId, conversationId));
+    expect(Number(row.storageMeasuredBytes)).toBe(777);
+  });
+
+  it('given a driver that reports no instance id, should still persist against a null row', async () => {
+    // Degrades to the liveness guard rather than never persisting — the most a
+    // caller can know when the platform gives it no generation id.
+    const conversationId = await seedSession({ sandboxId: 'sbx-no-instance', spriteInstanceId: null });
+
+    await store.recordStorageMeasurement({
+      sessionId: conversationId,
+      spriteInstanceId: null,
+      measuredBytes: 321,
+      measuredAt: new Date(),
+    });
+
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.conversationId, conversationId));
+    expect(Number(row.storageMeasuredBytes)).toBe(321);
   });
 });
 

--- a/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
@@ -106,11 +106,16 @@ export function makeAgentSessionStore(seed: AgentSessionRecord[] = []): FakeAgen
       ).length;
     },
 
-    async recordStorageMeasurement({ sessionId, measuredBytes, measuredAt }) {
+    async recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt }) {
       const row = rows.get(sessionId);
       // Mirrors the real store's live-row guard: a measurement landing after
       // teardown describes a filesystem that no longer exists.
       if (!row || row.spriteTornDownAt !== null) return;
+      // ...and its generation CAS. A fake that accepts writes the real store
+      // rejects makes every test using it agree with a bug: the liveness guard
+      // alone passes a stale measurement onto the NEXT generation, because
+      // re-provisioning clears `spriteTornDownAt`.
+      if ((row.spriteInstanceId ?? null) !== (spriteInstanceId ?? null)) return;
       row.storageMeasuredBytes = measuredBytes;
       row.storageMeasuredAt = measuredAt;
     },

--- a/packages/lib/src/services/agent-sessions/agent-session-sprite.ts
+++ b/packages/lib/src/services/agent-sessions/agent-session-sprite.ts
@@ -426,9 +426,13 @@ export async function ensureAgentSessionSandbox({
           ok: false,
           reason: 'denied',
           denial: 'session_limit_reached',
-          detail:
-            quota.reason ??
-            'live agent-session limit reached for your plan — end an existing session before starting another',
+          // A diagnostic CODE, never user copy. The prose that used to sit here
+          // was unreachable (`quota.reason` is always set) and, worse, it taught
+          // every caller that `detail` was a human sentence — which is how it
+          // ended up rendered into the product as `{"error":"concurrency_limit"}`.
+          // The one user-facing string for this refusal lives at the edge, in
+          // `SESSION_QUOTA_MESSAGE`; this layer says only what happened.
+          detail: quota.reason ?? 'concurrency_limit',
         };
       }
 

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -94,17 +94,37 @@ export interface AgentSessionStore {
   countLive(ownerId: string): Promise<number>;
   /**
    * Persist an opportunistic storage measurement (see
-   * `services/sandbox/sandbox-storage-measure.ts`). Separate from
-   * `updateSpriteIdentity` because it is a pure billing observation, not a
-   * lifecycle transition: it carries no CAS and must never disturb identity or
-   * teardown stamps.
+   * `services/sandbox/sandbox-storage-measure.ts`). Not a lifecycle transition —
+   * a pure billing observation that must never disturb identity or teardown
+   * stamps — but it IS generation-scoped, so it carries a CAS of its own.
    *
-   * Guarded on the row still being live (`spriteTornDownAt IS NULL`): a
-   * measurement that lands after teardown describes a filesystem that no longer
-   * exists, and writing it would bill the next generation against a dead disk.
+   * The CAS is on `spriteInstanceId`, the id of the VM actually measured, and it
+   * has to be: `sandboxId` is the HMAC-derived NAME, identical across every
+   * generation of one session, so it cannot tell A from B. `SandboxHandle` says
+   * this outright — "anything that must act on THIS VM (a kill, a CAS against a
+   * tracking row) keys on this".
+   *
+   * A liveness guard alone (`spriteTornDownAt IS NULL`) does NOT cover it. The
+   * measurement is fire-and-forget, so a `du` against generation A can still be
+   * in flight when A is torn down and B provisioned — and B's own stamps clear
+   * `spriteTornDownAt` AND null the measurement columns
+   * (`plan-session-lifecycle.ts`), so the late write finds a live row, lands A's
+   * bytes on B, and stamps a fresh `storageMeasuredAt` that suppresses B's real
+   * measurement for the whole throttle window. The reconcile then bills B's
+   * interval against A's disk. The teardown-only guard is the one case where the
+   * row is never revived.
+   *
+   * A stale write is DROPPED, not retried: the next wake re-measures, and a
+   * billing observation is worth less than a wrong one.
    */
   recordStorageMeasurement(input: {
     sessionId: string;
+    /**
+     * The instance actually measured. Null when the driver reports none — then
+     * the row's own null matches and the CAS degrades to the liveness guard,
+     * which is the most any caller can know without a generation id.
+     */
+    spriteInstanceId: string | null;
     measuredBytes: number;
     measuredAt: Date;
   }): Promise<void>;
@@ -315,7 +335,7 @@ export async function createDbAgentSessionStore(): Promise<AgentSessionStore> {
       return row?.n ?? 0;
     },
 
-    async recordStorageMeasurement({ sessionId, measuredBytes, measuredAt }) {
+    async recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt }) {
       await db
         .update(agentSessions)
         .set({ storageMeasuredBytes: measuredBytes, storageMeasuredAt: measuredAt })
@@ -323,6 +343,10 @@ export async function createDbAgentSessionStore(): Promise<AgentSessionStore> {
           and(
             eq(agentSessions.conversationId, sessionId),
             isNull(agentSessions.spriteTornDownAt),
+            // CAS on the generation measured. `eqOrIsNull` so a driver that
+            // reports no instance id still matches its own null row rather than
+            // never persisting — plain `eq` never matches null in SQL.
+            eqOrIsNull(agentSessions.spriteInstanceId, spriteInstanceId),
           ),
         );
     },

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-measure.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-measure.test.ts
@@ -67,19 +67,30 @@ describe('shouldRefreshMeasurement', () => {
 
 describe('refreshSessionStorageMeasurement', () => {
   it('given a never-measured session, should run du on the workspace and persist the bytes', async () => {
-    const persisted: Array<{ sessionId: string; measuredBytes: number; measuredAt: Date }> = [];
+    const persisted: Array<{
+      sessionId: string;
+      spriteInstanceId: string | null;
+      measuredBytes: number;
+      measuredAt: Date;
+    }> = [];
     const { handle, calls } = fakeHandle({ stdout: '2048\t/workspace\n' });
 
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async (m) => { persisted.push(m); },
     });
 
     expect(result).toEqual({ measured: true, bytes: 2048 });
-    expect(persisted).toEqual([{ sessionId: 'conv_1', measuredBytes: 2048, measuredAt: NOW }]);
+    // The instance travels WITH the bytes: the write is fire-and-forget, so the
+    // writer needs to know which generation's disk this number describes before
+    // it commits to a row that may have moved on.
+    expect(persisted).toEqual([
+      { sessionId: 'conv_1', spriteInstanceId: 'instance-A', measuredBytes: 2048, measuredAt: NOW },
+    ]);
     // -B1 (allocated bytes, not apparent size) and -x (don't cross mounts) are
     // the whole reason this bills what was written rather than the allocation.
     expect(calls[0]).toEqual({ cmd: 'du', args: ['-sxB1', '--', SESSION_STORAGE_MEASURE_PATH] });
@@ -90,6 +101,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: new Date(NOW.getTime() - 5),
       now: NOW,
       throttleMs: 60_000,
@@ -104,6 +116,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async () => { throw new Error('must not persist'); },
@@ -117,6 +130,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async (m) => { persisted.push(m.measuredBytes); },
@@ -130,6 +144,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async () => { throw new Error('must not persist'); },

--- a/packages/lib/src/services/sandbox/sandbox-storage-measure.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-measure.ts
@@ -95,6 +95,13 @@ export function shouldRefreshMeasurement(input: {
 export type PersistSessionStorageMeasurement = (input: {
   /** The `agent_sessions` PK (≡ conversationId) whose row receives the measurement. */
   sessionId: string;
+  /**
+   * The Sprite INSTANCE these bytes were read from, for the writer to CAS on.
+   * Carried because the measurement is fire-and-forget: it can land after its
+   * generation is gone and a new one has taken the row, and `sessionId` alone
+   * cannot tell the writer which disk the number describes.
+   */
+  spriteInstanceId: string | null;
   measuredBytes: number;
   measuredAt: Date;
 }) => Promise<void>;
@@ -103,6 +110,8 @@ export interface RefreshSessionStorageMeasurementInput {
   /** An ALREADY-AWAKE sandbox handle (real work just happened on it) — measurement never provisions or wakes. */
   handle: Pick<SandboxHandle, 'exec'>;
   sessionId: string;
+  /** The instance being measured, passed straight through to `persist` for its CAS. */
+  spriteInstanceId: string | null;
   /** Last persisted measurement time for this session (null = never measured). */
   lastMeasuredAt: Date | null;
   now: Date;
@@ -153,6 +162,11 @@ export async function refreshSessionStorageMeasurement(
   const bytes = parseDuBytes(run.stdout);
   if (bytes === null) return { measured: false };
 
-  await input.persist({ sessionId: input.sessionId, measuredBytes: bytes, measuredAt: input.now });
+  await input.persist({
+    sessionId: input.sessionId,
+    spriteInstanceId: input.spriteInstanceId,
+    measuredBytes: bytes,
+    measuredAt: input.now,
+  });
   return { measured: true, bytes };
 }


### PR DESCRIPTION
Follow-up to #2249, which **merged at 14:47 UTC today** while a review pass was still running. These fixes were verified after the merge, so they never landed with it. All are on code #2249 introduced.

Two of the three are **P1s reported by Codex** on post-merge re-reviews — the second confirmed and reproduced against real Postgres, the third a defect Codex found in my fix for the second.

---

## 1. The plan-limit refusal reached the user as an enum code

`sessionQuotaExceeded` answered `{ error: detail ?? SESSION_QUOTA_MESSAGE }`. `detail` is `quota.reason` — `'concurrency_limit'`, and **always set** — so the `??` never fell through: both human strings on that path were unreachable and a user over their sandbox limit received

```json
{"error":"concurrency_limit"}
```

rendered straight into the product, while the socket surface printed the real sentence for the identical refusal. That is the "one event should not read three different ways depending on which layer said no" the module was extracted to prevent.

Compounding it, `handleAddShell` was `try/finally` with **no `catch`**, so the 429 rejected out of an onClick as an unhandled rejection — spinner stopped, no tab, nothing said. A limit the product enforces but never states is indistinguishable from a bug.

- `detail` is now what it always was: a diagnostic code, recorded in the audit row, never in the body.
- The provisioner's dead prose fallback becomes a code, so no caller can read `detail` as user copy again.
- Both shell handlers surface failures via the toast convention already used in this directory.

The copy had a test; the path to it did not. Added: the body is the human sentence whatever code the provisioner names, the code still reaches the audit trail, the button re-enables after failure, and both handlers report rather than swallow. **Mutation-verified** — restoring `detail ??` fails two of them.

## 2. [P1] Storage measurements could bill the next Sprite generation for the previous one's disk

`recordStorageMeasurement` wrote on `(conversationId, spriteTornDownAt IS NULL)` — no generation guard, in a store where every other write CASes.

The measurement is fire-and-forget, so a `du` against generation A can still be running when A is torn down and B provisioned. B's own stamps clear `spriteTornDownAt` **and** null the measurement columns (`plan-session-lifecycle.ts:218`), so A's late write finds a live, freshly-reset row: it lands A's bytes on B and stamps a fresh `storageMeasuredAt` that suppresses B's real measurement for the whole throttle window while the reconcile bills B's interval against A's disk.

The guard has to be `spriteInstanceId`, **not** `sandboxId` — the name is HMAC-derived from the session and is identical across generations, so a CAS on it would have looked like a fix and caught nothing. `SandboxHandle` already states the rule: *"anything that must act on THIS VM (a kill, a CAS against a tracking row) keys on this."*

The interface comment claimed this protection ("would bill the next generation against a dead disk") while the predicate delivered it only for the never-revived case.

- CAS on `spriteInstanceId`, via `eqOrIsNull` so a driver reporting no instance id still matches its own null row.
- The instance travels with the bytes through the pure measure module to all four call sites (web create + warm, realtime create + resume). Making the field required is what surfaced them — two realtime callers were destructuring `{measuredBytes, measuredAt}` and would have dropped it silently.
- The in-memory fake honours the CAS: a fake that accepts writes the real store rejects makes every test using it agree with the bug.

## 3. The CAS was reading its generation from the wrong place

Codex, reviewing commit 2 — and correct. A CAS is only as good as the id handed to it, and I handed it the row's.

`measureWarmSessionStorage` read `spriteInstanceId` off the session row. But this path is fed a sandbox the tool run **already acquired**, and the measurement is fire-and-forget — so between capturing that handle and reading the row, the session can be torn down and re-provisioned. The row then names generation B while `du` walks A's disk, and the CAS *succeeds* against B carrying A's bytes and A's throttle timestamp: the exact write the CAS was added to reject, waved through by its own guard.

I had considered this window in commit 2 and called it a residual. It isn't residual on this path — the handle is captured *before* the row read, so the mismatch is the normal ordering, not a rare interleaving. A guard that is wrong in the common case is worse than none, because it reads as covered.

`ExecutableSandbox extends SandboxHandle`, so the acquired sandbox already knows its own generation — no contract widening, just carrying what was there:

- `attach()` returns `{ exec, spriteInstanceId }`; the CAS uses the handle's id — the identity of the disk actually measured.
- The row is still read, but only for the throttle, which is all it can honestly say about a handle it did not produce.
- Same correction on the realtime resume path.

All five measurement call sites now source the id from a handle; none from a row. Create-arm ordering re-checked: `updateSpriteIdentity` is confirmed (`recorded === true`) *before* measurement fires, so tightening the predicate does not drop the baseline measurement.

## Validation

- `typecheck`, `lint` clean across the monorepo.
- `packages/lib` agent-sessions + sandbox: 928 tests. `apps/realtime`: 937. `apps/web` agent-sessions + agents + tools: 1530 passing (1 unrelated pre-existing failure, `activity-tools`, which needs a test DB and fails on `Failed query` in any local env).
- Integration suite run against **real Postgres** (throwaway instance, all 235 migrations applied): 19 tests, including three new CAS cases — stale generation dropped (bytes *and* timestamp), same generation persists despite a reused NAME, null-instance driver still persists.
- **Mutation-verified, both fixes**: restoring `detail ??` fails two quota tests; removing the CAS predicate fails the stale-generation case; pinning the supplied instance id to null fails the seam test. Each fails that test and nothing else.

The timestamp assertion is the one worth keeping: a stale `storageMeasuredAt` silences the next real measurement for a full window without ever recording a real number, so dropping only the bytes would leave half the bug.

## Review coverage

Stated explicitly because #2249 taught the lesson: a green bot check is not evidence of review.

- **Codex** has reviewed HEAD (`9a0d8f634`) — no issues. Its two findings on earlier commits are fixed and left open for verification.
- **CodeRabbit** reviewed commits 1–2 with no actionable comments, then reviewed commit 3 on request — "Review finished", no findings.

## Still open from the Codex re-review (not in this PR)

Two findings against merged code, now filed so they outlive this PR:

1. **[P1] → #2254** `0234_phase8_teardown_machines_world.sql` — the four rescue `INSERT`s use `ON CONFLICT DO NOTHING`, while the 0209/0219/0229 triggers use `DO UPDATE SET spriteInstanceId = COALESCE(...)` precisely because *"a newer generation took this name; the pointer must chase the VM that is actually alive now."* If the outbox already held that `sandboxId` from an older generation, the rescue keeps the stale instance id while the migration drops the current generation's tracking row; `agent-session-orphan-reconcile-runtime.ts:132` then returns `{ok: true}` on `SandboxSpriteReplacedError`, deleting the outbox row and orphaning a live Sprite. **This migration is already on master**, so the fix is not an edit to it — needs a decision between a corrective migration and hardening the reconciler's replaced-instance handling for outbox rows, which is where the host's own comment says the safe behaviour is to keep the pointer.
2. **[P2] → #2255** `useSessionShells.ts` — agent-invoked `spawn_shell`/`kill_shell` mutate shell rows without touching this SWR cache, which has no polling or socket invalidation and disables focus revalidation, so agent-created shells never appear as tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V3eqwRX5cFy3Tdu2Syoro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage measurement accuracy by preventing stale data from older sandbox instances from overwriting current session data.
  * Added clearer, user-friendly quota error messages while preserving diagnostic details for internal auditing.
  * Added error notifications when adding or closing agent shells fails.
  * Ensured the “Add shell” action becomes available again after an error.

* **Tests**
  * Expanded coverage for quota messaging, shell operation errors, and storage measurement safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
