### PR TITLE
fix(agents): show shells the agent opens or closes

### DIFF
--- a/apps/web/src/components/agents/AgentView.tsx
+++ b/apps/web/src/components/agents/AgentView.tsx
@@ -213,7 +213,19 @@ export default function AgentView({
         </TabsList>
 
         <TabsContent value={CHAT_TAB_ID} className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
-          <SessionChat agent={agent} conversationId={conversationId} context={context} isReadOnly={isReadOnly} />
+          <SessionChat
+            agent={agent}
+            conversationId={conversationId}
+            context={context}
+            isReadOnly={isReadOnly}
+            // The agent's `spawn_shell`/`kill_shell` write shell rows directly,
+            // never through this view's add/remove handlers, so nothing here
+            // learns of them: the SWR entry has no polling, no socket
+            // invalidation, and focus revalidation off. Re-reading the list when
+            // a turn ends is what makes an agent-opened shell appear as a tab —
+            // and an agent-closed one stop being one.
+            onTurnComplete={shells.mutate}
+          />
         </TabsContent>
 
         {tabs

--- a/apps/web/src/components/agents/__tests__/AgentView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentView.test.tsx
@@ -53,8 +53,15 @@ vi.mock('../useSessionShells', () => ({
   useSessionShells: () => shellsState.current,
 }));
 
+// Captures `onTurnComplete` so the wiring can be exercised: the prop is the
+// only thing that tells this view an AGENT changed the shell set, and a mock
+// that swallowed it would let the wiring be deleted with every test still green.
+const sessionChatProps = vi.hoisted(() => ({ current: {} as { onTurnComplete?: () => void } }));
 vi.mock('../chat/SessionChat', () => ({
-  default: ({ context }: { context: string }) => <div data-testid="session-chat">{context}</div>,
+  default: ({ context, onTurnComplete }: { context: string; onTurnComplete?: () => void }) => {
+    sessionChatProps.current = { onTurnComplete };
+    return <div data-testid="session-chat">{context}</div>;
+  },
 }));
 
 vi.mock('../shell/Shell', () => ({
@@ -138,6 +145,20 @@ describe('AgentView', () => {
   it('renders the chat tab with the SessionChat component in the right context', () => {
     render(<AgentView agentId="agent-1" conversationId="conv-1" context="page" />);
     expect(screen.getByTestId('session-chat')).toHaveTextContent('page');
+  });
+
+  it('should re-read the shell list when a turn ends, so agent-opened shells become tabs', async () => {
+    // `spawn_shell`/`kill_shell` write shell rows server-side and never touch
+    // this view's add/remove handlers. The SWR entry has no polling, no socket
+    // invalidation, and focus revalidation disabled — and shell socket events
+    // are connection-tagged rather than broadcast — so without this the tab
+    // simply never appears, and an agent-killed shell never goes away.
+    render(<AgentView agentId="agent-1" conversationId="conv-1" context="console" />);
+    expect(shellsState.current.mutate).not.toHaveBeenCalled();
+
+    sessionChatProps.current.onTurnComplete?.();
+
+    expect(shellsState.current.mutate).toHaveBeenCalledTimes(1);
   });
 
   it('renders a tab per shell, force-mounted, hiding the inactive one via data-state', async () => {

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -14,7 +14,7 @@
  * via props, no layout props) so a future pane grid can embed this unchanged —
  * see the design doc's "v1 = tabs, not split panes" note.
  */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ChatInput } from '@/components/ai/chat/input';
@@ -36,6 +36,18 @@ export interface SessionChatProps {
   context: 'page' | 'console';
   /** Read-only viewers get history but no send/edit/delete/retry affordances. */
   isReadOnly?: boolean;
+  /**
+   * Fired once each time a turn finishes streaming.
+   *
+   * The agent can change session state through its tools — `spawn_shell` and
+   * `kill_shell` write `agent_session_shells` server-side — and none of those
+   * writes pass through the client caches that render them. There is also no
+   * event to listen for: every shell socket event is connection-tagged rather
+   * than broadcast, by design. End-of-turn is therefore the one moment the
+   * client knows the agent may have acted, which makes it the honest place to
+   * re-read anything the agent could have changed.
+   */
+  onTurnComplete?: () => void;
 }
 
 export default function SessionChat({
@@ -43,12 +55,24 @@ export default function SessionChat({
   conversationId,
   context,
   isReadOnly = false,
+  onTurnComplete,
 }: SessionChatProps) {
   const [input, setInput] = useState('');
   const [showError, setShowError] = useState(true);
   const [undoMessageId, setUndoMessageId] = useState<string | null>(null);
 
   const chat = useAgentSessionChat({ agent, conversationId });
+
+  // Fire on the streaming → idle EDGE, not on every render where it is false:
+  // otherwise a component that re-renders while idle would re-notify forever.
+  // The ref holds the previous value rather than component state so observing
+  // the transition cannot itself cause a render.
+  const wasStreamingRef = useRef(false);
+  useEffect(() => {
+    const wasStreaming = wasStreamingRef.current;
+    wasStreamingRef.current = chat.displayIsStreaming;
+    if (wasStreaming && !chat.displayIsStreaming) onTurnComplete?.();
+  }, [chat.displayIsStreaming, onTurnComplete]);
 
   const handleSendClick = useCallback(async () => {
     const text = input;

--- a/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
+++ b/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
@@ -106,6 +106,62 @@ beforeEach(() => {
   chatState.current = baseChatState();
 });
 
+describe('SessionChat — onTurnComplete', () => {
+  it('should fire on the streaming → idle edge, once', () => {
+    const onTurnComplete = vi.fn();
+    chatState.current = baseChatState({ displayIsStreaming: true });
+    const { rerender } = render(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="console" onTurnComplete={onTurnComplete} />,
+    );
+    expect(onTurnComplete).not.toHaveBeenCalled();
+
+    chatState.current = baseChatState({ displayIsStreaming: false });
+    rerender(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="console" onTurnComplete={onTurnComplete} />,
+    );
+
+    expect(onTurnComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT fire on mount while idle — nothing has happened yet', () => {
+    // The obvious mistake is to notify whenever `displayIsStreaming` is false,
+    // which is its resting value: every consumer would then re-fetch on every
+    // render, forever, for a turn that never ran.
+    const onTurnComplete = vi.fn();
+    chatState.current = baseChatState({ displayIsStreaming: false });
+    render(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="console" onTurnComplete={onTurnComplete} />,
+    );
+    expect(onTurnComplete).not.toHaveBeenCalled();
+  });
+
+  it('should not re-fire while idle across later renders', () => {
+    const onTurnComplete = vi.fn();
+    chatState.current = baseChatState({ displayIsStreaming: true });
+    const { rerender } = render(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="console" onTurnComplete={onTurnComplete} />,
+    );
+    chatState.current = baseChatState({ displayIsStreaming: false });
+    rerender(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="console" onTurnComplete={onTurnComplete} />,
+    );
+    rerender(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="console" onTurnComplete={onTurnComplete} />,
+    );
+
+    expect(onTurnComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be optional — a surface that does not care omits it', () => {
+    chatState.current = baseChatState({ displayIsStreaming: true });
+    const { rerender } = render(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />);
+    chatState.current = baseChatState({ displayIsStreaming: false });
+    expect(() =>
+      rerender(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />),
+    ).not.toThrow();
+  });
+});
+
 describe('SessionChat', () => {
   it("renders the full messages area (ChatMessagesArea) in 'page' context", () => {
     render(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />);


### PR DESCRIPTION
Fixes #2255. Independent of #2253 — different files, merges in either order.

## The bug

`spawn_shell` and `kill_shell` write `agent_session_shells` **server-side**, never through `useSessionShells`'s `addShell`/`removeShell` — the only things that update the cache holding the tab list. That SWR entry has:

```ts
{ revalidateOnFocus: false, dedupingInterval: 5_000 }   // no polling, no socket invalidation
```

and there is no event to listen for either: every shell socket event (`shell:output`, `shell:ready`, `shell:closed`, `shell:error`) is **connection-tagged rather than broadcast**, deliberately — the rebuild plan states "No `rooms.ts` change needed."

Net effect: an agent-opened shell never appears as a tab, and an agent-closed one never disappears, until an unrelated revalidation or a remount happens to fix it.

## The fix

End-of-turn is the one moment the client knows the agent may have acted, which makes it the honest place to re-read anything the agent could have changed. `SessionChat` fires `onTurnComplete` on the streaming → idle **edge**; `AgentView` wires it to `shells.mutate`. One GET per completed turn, only while the view is mounted.

**The edge, not the level.** Notifying whenever `displayIsStreaming` is false would fire on its *resting* value — every render, forever, for a turn that never ran. The previous value lives in a ref so observing the transition cannot itself cause a render. The callback's identity is unstable (`mutate` is a fresh arrow each render), which is harmless here: the effect re-runs but only fires on a genuine transition.

## Why not the broadcast

[#2255](https://github.com/2witstudios/PageSpace/issues/2255) lists three options. A shell-lifecycle broadcast from realtime is more correct — but it is the only option that adds a room/broadcast concept to a surface built without one. This is the smallest change that fixes the reported symptom; the broadcast stays available as an upgrade.

**What this deliberately does not cover**, since a reviewer would find it and it should be stated up front: `displayIsStreaming` is **own-stream only** —

```ts
const displayIsStreaming =
  activeStream?.isOwn === true ||
  (pendingSendConversationId !== null && pendingSendConversationId === conversationId);
```

so this fires for *my* turn, not for another user's turn in a shared conversation, and not for a second browser tab of my own. Both are the broadcast case. The reported symptom — "the agent I am talking to opened a shell and no tab appeared" — is the own-turn case, which this fixes completely.

The coarseness in the other direction is deliberate and cheap: the re-read fires even when no shell tool ran.

Conversation switching is safe: `AgentsSurface` renders `<AgentView key={selectedConversationId}>`, so the edge-tracking ref resets on remount rather than carrying a stale "was streaming" across conversations.

## Validation

- `typecheck` and `lint` clean across the monorepo.
- `apps/web` agents components: **121 tests pass**.
- New tests: fires once on the edge · never on mount while idle · not again on later idle renders · optional for surfaces that don't pass it · `AgentView` actually passes it to the shells cache.
- **Mutation-verified**: deleting the `onTurnComplete={shells.mutate}` wiring fails the AgentView test and nothing else. That test captures the prop through the `SessionChat` mock, because a mock that swallowed it would let the wiring be deleted with every test still green — which is the shape of the original bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V3eqwRX5cFy3Tdu2Syoro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell lists now refresh automatically when an agent chat turn finishes.
  * Chat sessions support completion callbacks after streamed responses become idle.

* **Bug Fixes**
  * Improved synchronization between completed chat turns and the displayed shell list.

* **Tests**
  * Added coverage for callback behavior across streaming, idle, and repeated render states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
