### PR TITLE
fix(agents): confirmed, server-first pane-close lifecycle

### DIFF
--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -60,6 +60,7 @@ import {
 import { useResolvedAgent } from './useResolvedAgent';
 import SessionChat from './chat/SessionChat';
 import AgentPanes from './panes/AgentPanes';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import type { TreePage } from '@/hooks/usePageTree';
 import type { AgentConfig } from '@/lib/ai/shared/chat-types';
 
@@ -119,16 +120,20 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
     isProviderConfigured,
   } = useProviderSettings({ pageId: page.id });
 
-  const newConversation = useCallback(async () => {
-    const created = await createPageConversation({
-      agentId: page.id,
-      driveId: page.driveId,
-      canUseSessions,
-    });
-    setOverride(created);
-    setActiveTab('chat');
-    return created;
-  }, [page.id, page.driveId, canUseSessions]);
+  const newConversation = useCallback(
+    async (reuseSessionId?: string | null) => {
+      const created = await createPageConversation({
+        agentId: page.id,
+        driveId: page.driveId,
+        canUseSessions,
+        sessionId: reuseSessionId ?? null,
+      });
+      setOverride(created);
+      setActiveTab('chat');
+      return created;
+    },
+    [page.id, page.driveId, canUseSessions],
+  );
 
   const {
     conversations,
@@ -142,7 +147,26 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
     // can be looked up for its session.
     enabled: activeTab === 'history' || activeTab === 'chat',
     onConversationDelete: () => {
-      void newConversation();
+      // `onConversationDelete` only fires for the CURRENT conversation, so
+      // `current` here is exactly the deleted thread. If it was session-bound,
+      // mint the replacement INTO that session — never spawn a new one, which
+      // would abandon a live session (issue #2263, finding 4) — and prune the
+      // pane that was showing the now-deleted id, wherever it lives in the
+      // grid (not necessarily the active pane: the grid's own selection and
+      // this page's `current` are independent state).
+      const deletedConversationId = current?.conversationId ?? null;
+      const sessionId = current?.sessionId ?? null;
+      void (async () => {
+        const created = await newConversation(sessionId);
+        if (sessionId && deletedConversationId) {
+          useAgentWorkspaceStore.getState().replaceConversation(sessionId, deletedConversationId, {
+            kind: 'chat',
+            name: 'New conversation',
+            targetId: created.conversationId,
+            agentPageId: page.id,
+          });
+        }
+      })();
     },
   });
 

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -5,6 +5,7 @@ import { Bot } from 'lucide-react';
 import useSWR from 'swr';
 
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import AgentPanes from './panes/AgentPanes';
 
@@ -55,6 +56,19 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
   // The session's own drive wins; the surface's drive covers the in-flight
   // window (they agree in drive mode, and global mode has nothing better).
   const sessionDriveId = sessionData?.session?.driveId ?? storeDriveId;
+
+  // The server is the authority on whether the selected session still
+  // exists. `session: null` means it doesn't (ended elsewhere, reaped,
+  // never existed) — forget its persisted grid rather than let a dead
+  // workspace sit in `localStorage` forever, and back out of it the same way
+  // a deep link to nothing does (issue #2263, finding 6: GC on the one
+  // signal this surface already has, rather than a new sweep).
+  useEffect(() => {
+    if (selectedSessionId && sessionData && sessionData.session === null) {
+      useAgentWorkspaceStore.getState().forgetWorkspace(selectedSessionId);
+      selectSession(null);
+    }
+  }, [selectedSessionId, sessionData, selectSession]);
 
   // Deep link, refresh, and Back are the same operation: read the URL. `popstate`
   // needs nothing beyond re-reading it, because the browser has already restored

--- a/apps/web/src/components/agents/EndSessionDialog.tsx
+++ b/apps/web/src/components/agents/EndSessionDialog.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * The one confirm dialog for ending a session — shared by the sidebar's "End
+ * session" control and the pane grid's last-pane close, so the two paths that
+ * both tear down the same sandbox ask the user the same question (issue
+ * #2263, finding 2: closing the last pane used to skip this entirely, while
+ * the sidebar's identical act already required it).
+ */
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+export interface EndSessionDialogProps {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  /** Display label, when the caller has one — "this session" otherwise (never an address). */
+  sessionName?: string | null;
+  /** Disables both actions while the DELETE is in flight. */
+  isEnding: boolean;
+  onConfirm(): void;
+}
+
+export default function EndSessionDialog({ open, onOpenChange, sessionName, isEnding, onConfirm }: EndSessionDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>End {sessionName ? `“${sessionName}”` : 'this session'}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Its sandbox is stopped and its shells close. Conversations stay in each agent&apos;s history.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isEnding}>Cancel</AlertDialogCancel>
+          <AlertDialogAction disabled={isEnding} onClick={onConfirm}>
+            End session
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -84,9 +84,16 @@ const conversationsState = vi.hoisted(() => ({
     deleteConversation: vi.fn(async () => {}),
     refreshConversations: vi.fn(),
   },
+  // Captured so tests can trigger `onConversationDelete` directly — the real
+  // hook fires it when the deleted id is the current conversation; this mock
+  // stands in for the hook's own logic, not the callback wiring under test.
+  lastOnConversationDelete: null as (() => void) | null,
 }));
 vi.mock('@/lib/ai/shared/hooks/useConversations', () => ({
-  useConversations: () => conversationsState.current,
+  useConversations: (opts: { onConversationDelete?: () => void }) => {
+    conversationsState.lastOnConversationDelete = opts.onConversationDelete ?? null;
+    return conversationsState.current;
+  },
 }));
 
 vi.mock('@/components/ai/page-agents', () => ({
@@ -95,12 +102,17 @@ vi.mock('@/components/ai/page-agents', () => ({
   ),
   PageAgentHistoryTab: ({
     onSelectConversation,
+    onCreateNew,
   }: {
     onSelectConversation: (id: string) => void;
+    onCreateNew: () => void;
   }) => (
     <div data-testid="history-tab">
       <button data-testid="history-select-conv-2" onClick={() => onSelectConversation('conv-2')}>
         conv-2
+      </button>
+      <button data-testid="history-create-new" onClick={onCreateNew}>
+        New
       </button>
     </div>
   ),
@@ -115,6 +127,7 @@ vi.mock('@/components/shared/PageWebhooksDialog', () => ({
 }));
 
 import AgentPageView from '../AgentPageView';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 
 function pageFixture(): TreePage {
   return {
@@ -144,6 +157,8 @@ beforeEach(() => {
     deleteConversation: vi.fn(async () => {}),
     refreshConversations: vi.fn(),
   };
+  conversationsState.lastOnConversationDelete = null;
+  useAgentWorkspaceStore.setState({ workspaces: {} });
   mockFetchWithAuth.mockImplementation(async (url: string) => {
     if (url.endsWith('/permissions/check')) return jsonResponse({ canEdit: true });
     if (url.endsWith('/agent-config'))
@@ -309,5 +324,84 @@ describe('AgentPageView', () => {
     expect(screen.queryByTestId('sandbox-status-chip')).not.toBeInTheDocument();
     expect(screen.queryByText(/add shell/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Conversation history')).not.toBeInTheDocument();
+  });
+
+  describe('deleting the current conversation (issue #2263, finding 4)', () => {
+    it('when session-bound, mints the replacement INTO that session — never a new one', async () => {
+      resolveTo({ conversationId: 'conv-1', sessionId: 'ses-1' });
+      mockCreatePageConversation.mockResolvedValue({ conversationId: 'conv-2', sessionId: 'ses-1' });
+      render(<AgentPageView page={pageFixture()} />);
+      await waitFor(() => expect(screen.getByTestId('agent-panes')).toBeInTheDocument());
+
+      conversationsState.lastOnConversationDelete?.();
+
+      await waitFor(() =>
+        expect(mockCreatePageConversation).toHaveBeenCalledWith(
+          expect.objectContaining({ agentId: 'agent-1', sessionId: 'ses-1' }),
+        ),
+      );
+      await waitFor(() => expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-1/conv-2'));
+    });
+
+    it('prunes the pane that was showing the deleted conversation, wherever it lived in the grid', async () => {
+      resolveTo({ conversationId: 'conv-1', sessionId: 'ses-1' });
+      mockCreatePageConversation.mockResolvedValue({ conversationId: 'conv-2', sessionId: 'ses-1' });
+      render(<AgentPageView page={pageFixture()} />);
+      await waitFor(() => expect(screen.getByTestId('agent-panes')).toBeInTheDocument());
+
+      // A split grid where the deleted conversation is NOT the active pane —
+      // pruning must target the pane actually showing it, not "the active one".
+      useAgentWorkspaceStore.getState().ensureWorkspace('ses-1', {
+        kind: 'chat',
+        name: 'Conversation',
+        targetId: 'conv-1',
+        agentPageId: 'agent-1',
+      });
+      const originalPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId;
+      useAgentWorkspaceStore.getState().splitRight('ses-1', originalPaneId);
+      useAgentWorkspaceStore.getState().selectPane('ses-1', originalPaneId);
+
+      conversationsState.lastOnConversationDelete?.();
+
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === originalPaneId);
+        expect(pane?.scope?.targetId).toBe('conv-2');
+      });
+    });
+
+    it('when NOT session-bound, falls back to the plain new-conversation path unaffected', async () => {
+      resolveTo({ conversationId: 'conv-1', sessionId: null });
+      mockCreatePageConversation.mockResolvedValue({ conversationId: 'conv-2', sessionId: null });
+      render(<AgentPageView page={pageFixture()} />);
+      await waitFor(() => expect(screen.getByTestId('plain-chat')).toHaveTextContent('conv-1'));
+
+      conversationsState.lastOnConversationDelete?.();
+
+      await waitFor(() =>
+        expect(mockCreatePageConversation).toHaveBeenCalledWith(
+          expect.objectContaining({ agentId: 'agent-1', sessionId: null }),
+        ),
+      );
+      await waitFor(() => expect(screen.getByTestId('plain-chat')).toHaveTextContent('conv-2'));
+    });
+
+    it('the History tab "New" button is unaffected — it always spawns a fresh session, never reuses', async () => {
+      resolveTo({ conversationId: 'conv-1', sessionId: 'ses-1' });
+      mockCreatePageConversation.mockResolvedValue({ conversationId: 'conv-3', sessionId: 'ses-new' });
+      render(<AgentPageView page={pageFixture()} />);
+      await waitFor(() => expect(screen.getByTestId('agent-panes')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByRole('tab', { name: /history/i }));
+      await userEvent.click(await screen.findByTestId('history-create-new'));
+
+      await waitFor(() =>
+        expect(mockCreatePageConversation).toHaveBeenCalledWith(
+          expect.objectContaining({ agentId: 'agent-1', sessionId: null }),
+        ),
+      );
+    });
   });
 });

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -36,9 +36,12 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 
 import AgentsSurface from '../AgentsSurface';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 
 beforeEach(() => {
-  mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ session: null }) });
+  // A selected session exists by default — the tests that care about a GONE
+  // session (finding 6's GC) set their own `{ session: null }` response.
+  mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ session: { driveId: null } }) });
   window.history.replaceState({}, '', '/dashboard/agents');
   useAgentSurfaceStore.setState({
     driveId: null,
@@ -125,6 +128,46 @@ describe('AgentsSurface', () => {
     window.history.replaceState({}, '', '/dashboard/agents?session=ses-1&c=conv-1');
     render(<AgentsSurface />);
     expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-1/conv-1/no-agent');
+  });
+});
+
+describe('GC when the server says the session is gone (issue #2263, finding 6)', () => {
+  beforeEach(() => {
+    useAgentWorkspaceStore.setState({ workspaces: {} });
+  });
+
+  it('forgets the persisted grid and backs out to the empty state', async () => {
+    mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ session: null }) });
+    useAgentWorkspaceStore.getState().ensureWorkspace('ses-gone', {
+      kind: 'chat',
+      name: 'x',
+      targetId: 'conv-1',
+      agentPageId: 'agent-1',
+    });
+    window.history.replaceState({}, '', '/dashboard/agents?session=ses-gone&c=conv-1&agent=agent-1');
+
+    render(<AgentsSurface />);
+
+    await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBeNull());
+    expect(useAgentWorkspaceStore.getState().workspaces['ses-gone']).toBeUndefined();
+    expect(screen.getByText('Select a session')).toBeDefined();
+  });
+
+  it('a session the server confirms exists is left untouched', async () => {
+    mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ session: { driveId: null } }) });
+    useAgentWorkspaceStore.getState().ensureWorkspace('ses-live', {
+      kind: 'chat',
+      name: 'x',
+      targetId: 'conv-1',
+      agentPageId: 'agent-1',
+    });
+    window.history.replaceState({}, '', '/dashboard/agents?session=ses-live&c=conv-1&agent=agent-1');
+
+    render(<AgentsSurface />);
+
+    await waitFor(() => expect(screen.getByTestId('agent-panes')).toBeInTheDocument());
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-live');
+    expect(useAgentWorkspaceStore.getState().workspaces['ses-live']).toBeDefined();
   });
 });
 

--- a/apps/web/src/components/agents/__tests__/useResolvedConversation.test.ts
+++ b/apps/web/src/components/agents/__tests__/useResolvedConversation.test.ts
@@ -138,4 +138,42 @@ describe('createPageConversation', () => {
     });
     expect(created).toEqual({ conversationId: 'conv-x', sessionId: 'ses-x' });
   });
+
+  describe('given a sessionId to reuse (issue #2263, finding 4)', () => {
+    // Deleting the CURRENT conversation must mint its replacement INTO the
+    // same session — never spawn a new one, which would abandon a live
+    // session (contradicting "a session is never empty") and leave the old
+    // session's quota burned for nothing.
+    it('mints the replacement into that session via the session-scoped route, never /api/agent-sessions', async () => {
+      mockPost.mockResolvedValue(undefined);
+      const created = await createPageConversation({
+        agentId: 'agent-1',
+        driveId: 'drive-1',
+        canUseSessions: true,
+        sessionId: 'ses-existing',
+      });
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [url, body] = mockPost.mock.calls[0];
+      expect(url).toBe('/api/ai/page-agents/agent-1/conversations');
+      expect(body).toMatchObject({ sessionId: 'ses-existing' });
+      expect(created.sessionId).toBe('ses-existing');
+      expect(created.conversationId).toBe(body.conversationId);
+    });
+
+    it('takes priority over canUseSessions — reuse is never downgraded to a fresh spawn', async () => {
+      mockPost.mockResolvedValue(undefined);
+      await createPageConversation({
+        agentId: 'agent-1',
+        driveId: 'drive-1',
+        canUseSessions: false,
+        sessionId: 'ses-existing',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/ai/page-agents/agent-1/conversations',
+        expect.objectContaining({ sessionId: 'ses-existing' }),
+      );
+    });
+  });
 });

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -9,7 +9,8 @@
  * ```
  * SessionPanes (layout only, surfaces injected)
  *  └─ pane: PaneBar (identity + split/close) over
- *      picker   → PanePicker      (unbound — choose an agent or a shell)
+ *      picker   → PanePicker      (unbound — choose an agent, a shell, or
+ *                                  reattach one already running)
  *      chat     → PaneChat        (a conversation IN this session)
  *      terminal → Shell           (a PTY on this session's sandbox)
  *      loading  → spinner         (bound, row not minted yet — never a
@@ -17,27 +18,37 @@
  * ```
  *
  * The container owns ALL the IO a pick triggers — minting a conversation into
- * THIS session, opening a shell on THIS session — and writes the resulting
- * `PaneScope` back through `assignPane`. Sandbox identity is never threaded
- * anywhere: every conversation and shell here resolves the session's one
- * sandbox by construction (the Sprite key folds the session id).
+ * THIS session, opening or reattaching a shell on THIS session — and writes
+ * the resulting `PaneScope` back through `assignPane`. Sandbox identity is
+ * never threaded anywhere: every conversation and shell here resolves the
+ * session's one sandbox by construction (the Sprite key folds the session
+ * id).
  *
- * Closing the LAST pane ends the session: the store intercepts it and answers
- * `'session-ended'`, and this container performs the teardown IO (DELETE the
- * session) and tells its host, which owns what the empty state looks like.
+ * Closing the LAST pane ends the session — confirmed, server-first, and
+ * rollback-safe (issue #2263, finding 1): the grid never drops locally until
+ * the DELETE succeeds, so a failure (a lost capability, a network blip)
+ * leaves the user exactly where they were, on the live session, instead of
+ * minting a second one behind their back. The confirm dialog is the same one
+ * the sidebar's identical "End session" act already required (finding 2).
+ * Closing a TERMINAL pane also kills its shell (finding 3) — a closed tab is
+ * a DELETE, not an orphan — and the picker offers to reattach any shell this
+ * session already has that isn't currently shown anywhere.
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createId } from '@paralleldrive/cuid2';
 import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { post, del } from '@/lib/auth/auth-fetch';
+import useSWR from 'swr';
+import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
-import type { PaneState } from '@/stores/agent-workspace/pane-reducer';
+import { panesOf, isLastPane, type PaneState } from '@/stores/agent-workspace/pane-reducer';
 import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
+import EndSessionDialog from '../EndSessionDialog';
 import SessionPanes from './SessionPanes';
 import PaneBar, { PaneSessionIdentity, PaneSplitCloseActions } from './PaneBar';
-import PanePicker, { type PickableAgent } from './PanePicker';
+import PanePicker, { type PickableAgent, type ReattachableShell } from './PanePicker';
 import { resolvePaneSurface } from './pane-surface';
 import PaneChat from './PaneChat';
 import Shell from '../shell/Shell';
@@ -63,6 +74,12 @@ export interface AgentPanesProps {
   isReadOnly?: boolean;
 }
 
+async function shellsFetcher(url: string): Promise<{ shells: ReattachableShell[] }> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to list shells (${response.status})`);
+  return response.json();
+}
+
 export default function AgentPanes({
   sessionId,
   driveId,
@@ -71,25 +88,46 @@ export default function AgentPanes({
   chatContext = 'console',
   isReadOnly = false,
 }: AgentPanesProps) {
-  const workspaces = useAgentWorkspaceStore((state) => state.workspaces);
+  const workspace = useAgentWorkspaceStore((state) => state.workspaces[sessionId]);
   const openConversation = useAgentWorkspaceStore((state) => state.openConversation);
   const splitRight = useAgentWorkspaceStore((state) => state.splitRight);
   const splitDown = useAgentWorkspaceStore((state) => state.splitDown);
   const closePane = useAgentWorkspaceStore((state) => state.closePane);
   const selectPane = useAgentWorkspaceStore((state) => state.selectPane);
   const assignPane = useAgentWorkspaceStore((state) => state.assignPane);
-  const dismissPicker = useAgentWorkspaceStore((state) => state.dismissPicker);
+  const resetPane = useAgentWorkspaceStore((state) => state.resetPane);
 
   // The picker's agent list — the session's drive only. A global-assistant
   // session offers no drive agents (there is no drive to list).
   const { allAgents, isLoading: agentsLoading } = usePageAgents(driveId ?? undefined, {
     enabled: driveId !== null,
   });
-  const pickableAgents: PickableAgent[] = (allAgents ?? [])
-    .filter((agent) => agent.driveId === driveId)
-    .map((agent) => ({ id: agent.id, title: agent.title ?? 'Agent' }));
+  const pickableAgents: PickableAgent[] = useMemo(
+    () =>
+      (allAgents ?? [])
+        .filter((agent) => agent.driveId === driveId)
+        .map((agent) => ({ id: agent.id, title: agent.title ?? 'Agent' })),
+    [allAgents, driveId],
+  );
 
-  const workspace = workspaces[sessionId];
+  // This session's shells, so the picker can offer to REATTACH one instead of
+  // only spawning new — otherwise closing a terminal pane orphans its shell
+  // with no way back short of the sidebar's (now-stale) count.
+  const { data: shellsData } = useSWR(
+    `/api/agent-sessions/${encodeURIComponent(sessionId)}/shells`,
+    shellsFetcher,
+    { revalidateOnFocus: false, refreshInterval: 15_000 },
+  );
+  const reattachableShells: ReattachableShell[] = useMemo(() => {
+    const bound = new Set<string>();
+    if (workspace) {
+      for (const pane of panesOf(workspace)) {
+        if (pane.scope?.kind === 'terminal' && pane.scope.targetId) bound.add(pane.scope.targetId);
+      }
+    }
+    return (shellsData?.shells ?? []).filter((shell) => !bound.has(shell.shellId));
+  }, [shellsData, workspace]);
+
   // Selection IS an instruction to show the conversation (review M1): on
   // mount this seeds the first pane; on a later selection within the same
   // session it focuses the pane already showing the thread, or opens it in a
@@ -105,25 +143,96 @@ export default function AgentPanes({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, initialConversation.conversationId, openConversation]);
 
-  const handleClosePane = useCallback(
-    async (paneId: string) => {
-      const verdict = closePane(sessionId, paneId);
-      if (verdict !== 'session-ended') return;
-      // Emptying the session ends it — one act, per the lifecycle invariant.
-      try {
-        await del(`/api/agent-sessions/${encodeURIComponent(sessionId)}`);
-      } catch (error) {
-        // The grid is already gone locally; the sandbox teardown failing is
-        // worth saying because it keeps billing until the reclaim path runs.
-        console.error('Failed to end session:', error);
-        toast.error('Could not stop the sandbox', {
-          description: error instanceof Error ? error.message : 'It will be cleaned up automatically.',
-        });
-      }
-      onSessionEnded?.();
+  // Ending the session: peeked, confirmed, and gated on the server (findings
+  // 1 + 2). `pendingEndClose` carries the pane and its scope from the PEEK,
+  // taken before any IO or mutation — so cancelling, or the DELETE failing,
+  // leaves nothing to roll back.
+  const [pendingEndClose, setPendingEndClose] = useState<{ paneId: string; scope: PaneScope | null } | null>(null);
+  const [endingSession, setEndingSession] = useState(false);
+
+  const closeShell = useCallback(
+    (shellId: string) => {
+      void del(`/api/agent-sessions/${encodeURIComponent(sessionId)}/shells/${encodeURIComponent(shellId)}`).catch(
+        (error) => {
+          console.error('Failed to close shell:', error);
+          toast.error('Could not close the shell', {
+            description: error instanceof Error ? error.message : 'It may still be running.',
+          });
+        },
+      );
     },
-    [closePane, sessionId, onSessionEnded],
+    [sessionId],
   );
+
+  const closeTerminalShell = useCallback(
+    (scope: PaneScope | null) => {
+      if (scope?.kind === 'terminal' && scope.targetId) closeShell(scope.targetId);
+    },
+    [closeShell],
+  );
+
+  const handleClosePane = useCallback(
+    (paneId: string) => {
+      if (!workspace) return;
+      const pane = panesOf(workspace).find((p) => p.id === paneId);
+      if (isLastPane(workspace, paneId)) {
+        // Emptying the session ends it — ask first, same as the sidebar's
+        // identical act, and don't touch the grid until the user confirms.
+        setPendingEndClose({ paneId, scope: pane?.scope ?? null });
+        return;
+      }
+      closePane(sessionId, paneId);
+      closeTerminalShell(pane?.scope ?? null);
+    },
+    [workspace, closePane, sessionId, closeTerminalShell],
+  );
+
+  const confirmEndSession = useCallback(async () => {
+    if (!pendingEndClose) return;
+    setEndingSession(true);
+    try {
+      await del(`/api/agent-sessions/${encodeURIComponent(sessionId)}`);
+    } catch (error) {
+      // Nothing was mutated locally, so there is nothing to restore — the
+      // grid the user is looking at is still exactly the live session.
+      console.error('Failed to end session:', error);
+      toast.error('Could not end the session', {
+        description: error instanceof Error ? error.message : 'Please try again.',
+      });
+      setEndingSession(false);
+      return;
+    }
+    // Server-confirmed: NOW the grid comes down, same as any other last-pane
+    // close, and its terminal (if any) is cleaned up alongside it.
+    closePane(sessionId, pendingEndClose.paneId);
+    closeTerminalShell(pendingEndClose.scope);
+    setEndingSession(false);
+    setPendingEndClose(null);
+    onSessionEnded?.();
+  }, [pendingEndClose, sessionId, closePane, closeTerminalShell, onSessionEnded]);
+
+  const paneStillExists = useCallback(
+    (paneId: string) => {
+      const current = useAgentWorkspaceStore.getState().workspaces[sessionId];
+      return current ? panesOf(current).some((pane) => pane.id === paneId) : false;
+    },
+    [sessionId],
+  );
+
+  const cleanupOrphanedConversation = useCallback(async (agentPageId: string | null, conversationId: string) => {
+    // Best-effort: the pane that wanted this is already gone, so a failure
+    // here just leaves a harmless unbound row rather than blocking anything
+    // the user can see.
+    try {
+      const url =
+        agentPageId === null
+          ? `/api/ai/global/${encodeURIComponent(conversationId)}`
+          : `/api/ai/page-agents/${encodeURIComponent(agentPageId)}/conversations/${encodeURIComponent(conversationId)}`;
+      await del(url);
+    } catch (error) {
+      console.error('Failed to clean up an orphaned conversation:', error);
+    }
+  }, []);
 
   const handlePickAgent = useCallback(
     async (paneId: string, agentPageId: string | null) => {
@@ -144,18 +253,24 @@ export default function AgentPanes({
             sessionId,
           });
         }
+        if (!paneStillExists(paneId)) {
+          // The pane closed mid-mint. The row was already created
+          // server-side (the request was already in the air) — clean it up
+          // rather than leaving an orphaned, unbound thread in the session's
+          // history.
+          void cleanupOrphanedConversation(agentPageId, conversationId);
+          return;
+        }
         assignPane(sessionId, paneId, { kind: 'chat', name: 'New conversation', targetId: conversationId, agentPageId });
       } catch (error) {
         console.error('Failed to start a conversation in this pane:', error);
         toast.error('Could not start a conversation', {
           description: error instanceof Error ? error.message : 'Please try again.',
         });
-        // Back to the picker — a pane stuck on `loading` forever is a dead pane.
-        assignPane(sessionId, paneId, { kind: 'chat', name: '', targetId: null, agentPageId: null });
-        dismissPicker(sessionId, paneId);
+        resetPane(sessionId, paneId);
       }
     },
-    [assignPane, dismissPicker, sessionId],
+    [assignPane, resetPane, sessionId, paneStillExists, cleanupOrphanedConversation],
   );
 
   const handlePickShell = useCallback(
@@ -166,17 +281,30 @@ export default function AgentPanes({
           `/api/agent-sessions/${encodeURIComponent(sessionId)}/shells`,
           {},
         );
+        if (!paneStillExists(paneId)) {
+          // Same staleness rule as a conversation mint: the row exists
+          // server-side already, so close it rather than leave it running
+          // unattached.
+          closeShell(shell.shellId);
+          return;
+        }
         assignPane(sessionId, paneId, { kind: 'terminal', name: shell.name, targetId: shell.shellId, agentPageId: null });
       } catch (error) {
         console.error('Failed to open a shell in this pane:', error);
         toast.error('Could not open a shell', {
           description: error instanceof Error ? error.message : 'Please try again.',
         });
-        assignPane(sessionId, paneId, { kind: 'chat', name: '', targetId: null, agentPageId: null });
-        dismissPicker(sessionId, paneId);
+        resetPane(sessionId, paneId);
       }
     },
-    [assignPane, dismissPicker, sessionId],
+    [assignPane, resetPane, sessionId, paneStillExists, closeShell],
+  );
+
+  const handleReattachShell = useCallback(
+    (paneId: string, shellId: string, name: string) => {
+      assignPane(sessionId, paneId, { kind: 'terminal', name, targetId: shellId, agentPageId: null });
+    },
+    [assignPane, sessionId],
   );
 
   if (!workspace) {
@@ -189,18 +317,19 @@ export default function AgentPanes({
   }
 
   const renderPane = ({ pane, isActive, canSplit }: { pane: PaneState; isActive: boolean; canSplit: boolean }) => {
-    // An unbound pane (scope null) OR a bound-but-unresolved CHAT pane with no
-    // target and no agent renders the picker (the error-recovery reset above
-    // produces the latter shape).
     const surface = resolvePaneSurface(pane.scope);
-    const showPicker =
-      surface.surface === 'picker' ||
-      (surface.surface === 'loading' && pane.scope?.kind === 'chat' && pane.scope.agentPageId === null && pane.scope.name === '');
+    // Unbound (scope null) is the only picker shape now — `resetPane` is the
+    // one path back to it, so there is no longer a bound-but-empty sentinel
+    // to also treat as one (issue #2263, finding 5).
+    const showPicker = surface.surface === 'picker';
 
     return (
       <div
         className="group/pane flex h-full min-h-0 flex-col"
         onClick={() => selectPane(sessionId, pane.id)}
+        // Tabbing into any control inside a pane (the chat input, a close
+        // button) must activate it too — a click is not the only way in.
+        onFocusCapture={() => selectPane(sessionId, pane.id)}
       >
         <PaneBar
           isActive={isActive}
@@ -217,7 +346,7 @@ export default function AgentPanes({
               canClose
               onSplitRight={() => splitRight(sessionId, pane.id)}
               onSplitDown={() => splitDown(sessionId, pane.id)}
-              onClose={() => void handleClosePane(pane.id)}
+              onClose={() => handleClosePane(pane.id)}
             />
           }
         />
@@ -226,12 +355,17 @@ export default function AgentPanes({
             <PanePicker
               agents={pickableAgents}
               isLoading={driveId !== null && agentsLoading}
+              existingShells={reattachableShells}
               // The assistant identity path is live (AssistantSessionChat), so
               // every session can host an assistant thread beside its agents.
+              // Hardcoded true rather than reading a prop — flagged in issue
+              // #2263 (finding 8) as a product decision to confirm; left
+              // unchanged here.
               canPickAssistant
               autoFocus={workspace.pendingPickerPaneId === pane.id}
               onPickAgent={(agentPageId) => void handlePickAgent(pane.id, agentPageId)}
               onPickShell={() => void handlePickShell(pane.id)}
+              onReattachShell={(shellId, name) => handleReattachShell(pane.id, shellId, name)}
             />
           ) : surface.surface === 'loading' ? (
             <div className="flex h-full items-center justify-center">
@@ -252,5 +386,17 @@ export default function AgentPanes({
     );
   };
 
-  return <SessionPanes workspace={workspace} onSelectPane={(paneId) => selectPane(sessionId, paneId)} renderPane={renderPane} />;
+  return (
+    <>
+      <SessionPanes workspace={workspace} onSelectPane={(paneId) => selectPane(sessionId, paneId)} renderPane={renderPane} />
+      <EndSessionDialog
+        open={pendingEndClose !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingEndClose(null);
+        }}
+        isEnding={endingSession}
+        onConfirm={() => void confirmEndSession()}
+      />
+    </>
+  );
 }

--- a/apps/web/src/components/agents/panes/PaneBar.tsx
+++ b/apps/web/src/components/agents/panes/PaneBar.tsx
@@ -111,8 +111,9 @@ export function PaneSplitCloseActions({
             onClick={guarded(onSplitRight)}
             className="size-6 text-muted-foreground hover:text-foreground"
             title="Split right"
+            aria-label="Split right"
           >
-            <SquareSplitHorizontal className="size-3.5" />
+            <SquareSplitHorizontal className="size-3.5" aria-hidden="true" />
           </Button>
           <Button
             variant="ghost"
@@ -120,8 +121,9 @@ export function PaneSplitCloseActions({
             onClick={guarded(onSplitDown)}
             className="size-6 text-muted-foreground hover:text-foreground"
             title="Split down"
+            aria-label="Split down"
           >
-            <SquareSplitVertical className="size-3.5" />
+            <SquareSplitVertical className="size-3.5" aria-hidden="true" />
           </Button>
         </>
       )}
@@ -132,8 +134,9 @@ export function PaneSplitCloseActions({
           onClick={guarded(onClose)}
           className="size-6 text-muted-foreground hover:text-destructive"
           title="Close pane"
+          aria-label="Close pane"
         >
-          <X className="size-3.5" />
+          <X className="size-3.5" aria-hidden="true" />
         </Button>
       )}
     </>

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -23,10 +23,23 @@ export interface PickableAgent {
   title: string;
 }
 
+/** A shell already open in this session but not currently shown in any pane. */
+export interface ReattachableShell {
+  shellId: string;
+  name: string;
+}
+
 export interface PanePickerProps {
   agents: readonly PickableAgent[];
   /** No agents resolved yet — distinct from "this drive has none". */
   isLoading?: boolean;
+  /**
+   * Shells this session already has running, not bound to any pane right
+   * now — offered above "Shell" so reopening one is a click rather than a
+   * dead end (issue #2263, finding 3: closing a terminal pane used to have
+   * no way back to it short of the sidebar's stale count).
+   */
+  existingShells?: readonly ReattachableShell[];
   /**
    * Takes focus on mount. A split sets this on the pane it just made, so the
    * user lands in the picker rather than a blank rectangle with a control to go
@@ -44,6 +57,8 @@ export interface PanePickerProps {
   /** `null` starts a global-assistant conversation, which has no agent page. */
   onPickAgent(agentPageId: string | null): void;
   onPickShell(): void;
+  /** Bind this pane to an already-running shell instead of spawning a new one. */
+  onReattachShell?(shellId: string, name: string): void;
 }
 
 export default function PanePicker({
@@ -51,8 +66,10 @@ export default function PanePicker({
   isLoading = false,
   autoFocus = false,
   canPickAssistant = false,
+  existingShells = [],
   onPickAgent,
   onPickShell,
+  onReattachShell,
 }: PanePickerProps) {
   const firstRef = useRef<HTMLButtonElement>(null);
 
@@ -93,6 +110,28 @@ export default function PanePicker({
           </Button>
         )}
       </div>
+
+      {/* Shells this session already has, not shown anywhere right now — above
+          the drive's agents since reattaching an existing thing outranks
+          spawning a new one. */}
+      {existingShells.length > 0 && (
+        <div className="flex min-h-0 flex-col gap-1">
+          <p className="shrink-0 pt-1 text-xs font-medium text-muted-foreground">Reattach a shell</p>
+          {existingShells.map((shell) => (
+            <Button
+              key={shell.shellId}
+              variant="ghost"
+              size="sm"
+              className="h-8 justify-start gap-2 px-2"
+              onClick={() => onReattachShell?.(shell.shellId, shell.name)}
+              data-testid={`reattach-shell-${shell.shellId}`}
+            >
+              <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <span className="truncate">{shell.name}</span>
+            </Button>
+          ))}
+        </div>
+      )}
 
       {/* The agents of this drive. Listed BELOW the two fixed choices rather than
           merged with them: this list is unbounded, and a drive with forty agents

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * AgentPanes — the container's own IO: minting conversations/shells into a
+ * session, and the pane-close lifecycle (issue #2263).
+ *
+ * The properties worth pinning hardest: **closing the last pane is
+ * confirmed and server-first** — no grid mutation happens until the DELETE
+ * succeeds, so a failed teardown leaves the user exactly where they were
+ * rather than spawning a second session behind their back; **a terminal pane
+ * close kills its shell**; and **a pane closed mid-mint doesn't resurrect**
+ * once its POST resolves. Leaf renderers (`PaneChat`, `Shell`) are mocked —
+ * this suite is the container's wiring, not their internals. The real store
+ * and the real pane-reducer run underneath, same as `AgentsSidebar.test.tsx`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SWRConfig } from 'swr';
+
+const mockPost = vi.fn();
+const mockDel = vi.fn();
+const mockFetchWithAuth = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+  post: (...args: unknown[]) => mockPost(...args),
+  del: (...args: unknown[]) => mockDel(...args),
+}));
+
+let cuidCounter = 0;
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: () => `new-id-${++cuidCounter}`,
+}));
+
+const mockUsePageAgents = vi.fn(() => ({
+  allAgents: [
+    { id: 'agent-1', title: 'Researcher', driveId: 'drive-1' },
+    { id: 'agent-2', title: 'Writer', driveId: 'drive-1' },
+  ],
+  isLoading: false,
+}));
+vi.mock('@/hooks/page-agents/usePageAgents', () => ({
+  usePageAgents: () => mockUsePageAgents(),
+}));
+
+vi.mock('../PaneChat', () => ({
+  default: ({ conversationId }: { conversationId: string }) => <div data-testid="pane-chat">{conversationId}</div>,
+}));
+vi.mock('../../shell/Shell', () => ({
+  default: ({ shellId }: { shellId: string }) => <div data-testid="pane-shell">{shellId}</div>,
+}));
+
+import AgentPanes from '../AgentPanes';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+
+const jsonOk = (body: unknown) => ({ ok: true, json: async () => body });
+
+function renderPanes(props: Partial<React.ComponentProps<typeof AgentPanes>> = {}) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <AgentPanes
+        sessionId="ses-1"
+        driveId="drive-1"
+        initialConversation={{ conversationId: 'conv-1', agentPageId: 'agent-1', name: 'Conversation' }}
+        {...props}
+      />
+    </SWRConfig>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cuidCounter = 0;
+  useAgentWorkspaceStore.setState({ workspaces: {} });
+  mockUsePageAgents.mockReturnValue({
+    allAgents: [
+      { id: 'agent-1', title: 'Researcher', driveId: 'drive-1' },
+      { id: 'agent-2', title: 'Writer', driveId: 'drive-1' },
+    ],
+    isLoading: false,
+  });
+  mockFetchWithAuth.mockResolvedValue(jsonOk({ shells: [] }));
+});
+
+describe('AgentPanes', () => {
+  it('seeds the grid on its first conversation and renders the chat pane', async () => {
+    renderPanes();
+    await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+  });
+
+  describe('closing a NON-last pane', () => {
+    it('closes locally with no confirm dialog and no session DELETE', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = Object.values(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes)[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      const user = userEvent.setup();
+      const closeButtons = screen.getAllByLabelText('Close pane');
+      await user.click(closeButtons[0]);
+
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      expect(mockDel).not.toHaveBeenCalled();
+    });
+
+    it('closing a terminal pane kills its shell', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const workspace = useAgentWorkspaceStore.getState().workspaces['ses-1'];
+      const chatPaneId = workspace.columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', chatPaneId));
+      const termPaneId = Object.values(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns)
+        .flatMap((c) => c.panes)
+        .find((p) => p.id !== chatPaneId)!.id;
+      act(() =>
+        useAgentWorkspaceStore
+          .getState()
+          .assignPane('ses-1', termPaneId, { kind: 'terminal', name: 'shell-1', targetId: 'shell-9', agentPageId: null }),
+      );
+
+      mockDel.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      await waitFor(() => expect(screen.getByTestId('pane-shell')).toBeInTheDocument());
+      const closeButtons = screen.getAllByLabelText('Close pane');
+      // The terminal pane's own close button — bar order follows column order.
+      await user.click(closeButtons[closeButtons.length - 1]);
+
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/shells/shell-9'),
+      );
+    });
+  });
+
+  describe('closing the LAST pane (findings 1 + 2)', () => {
+    it('asks for confirmation rather than closing immediately', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+
+      expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+      expect(mockDel).not.toHaveBeenCalled();
+      // Nothing was mutated yet — the grid is still exactly what it was.
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+    });
+
+    it('cancelling leaves the session and the grid untouched', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+      const dialog = await screen.findByRole('alertdialog');
+
+      await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      expect(mockDel).not.toHaveBeenCalled();
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+
+    it('confirming DELETEs the session, THEN drops the grid and reports it ended', async () => {
+      mockDel.mockResolvedValue(undefined);
+      const onSessionEnded = vi.fn();
+      renderPanes({ onSessionEnded });
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+      const dialog = await screen.findByRole('alertdialog');
+
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
+      await waitFor(() => expect(onSessionEnded).toHaveBeenCalledTimes(1));
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeUndefined();
+    });
+
+    it('a failed DELETE leaves the grid exactly as it was — no rollback needed because nothing moved', async () => {
+      mockDel.mockRejectedValue(new Error('sandbox teardown failed'));
+      const onSessionEnded = vi.fn();
+      renderPanes({ onSessionEnded });
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+      const dialog = await screen.findByRole('alertdialog');
+
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
+      expect(onSessionEnded).not.toHaveBeenCalled();
+      // The session is still live locally — no second session gets minted
+      // because nothing here ever creates one.
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+      expect(screen.getByTestId('pane-chat')).toBeInTheDocument();
+    });
+  });
+
+  describe('picking an agent (mint lifecycle)', () => {
+    it('mints a conversation into the session and binds the pane', async () => {
+      mockPost.mockResolvedValue({});
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId('pick-agent-agent-2'));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-2/conversations', {
+          conversationId: 'new-id-1',
+          sessionId: 'ses-1',
+        }),
+      );
+      await waitFor(() => expect(screen.getAllByTestId('pane-chat')).toHaveLength(2));
+    });
+
+    it('a failed mint resets the pane back to the picker, not a dead sentinel scope', async () => {
+      mockPost.mockRejectedValue(new Error('quota exceeded'));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId('pick-agent-agent-2'));
+
+      await waitFor(() => {
+        const newPane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id !== paneId)!;
+        expect(newPane.scope).toBeNull();
+      });
+      expect(await screen.findAllByTestId('pane-picker')).toHaveLength(1);
+    });
+
+    it('a pane closed mid-mint does not resurrect once the POST resolves, and the orphaned row is cleaned up', async () => {
+      let resolvePost!: (value: unknown) => void;
+      mockPost.mockReturnValue(new Promise((resolve) => (resolvePost = resolve)));
+      mockDel.mockResolvedValue(undefined);
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId('pick-agent-agent-2'));
+      const mintingPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+
+      // The user closes the still-minting pane before the network resolves.
+      act(() => {
+        useAgentWorkspaceStore.getState().closePane('ses-1', mintingPaneId);
+      });
+      expect(
+        useAgentWorkspaceStore.getState().workspaces['ses-1'].columns.flatMap((c) => c.panes),
+      ).toHaveLength(1);
+
+      resolvePost({});
+
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/ai/page-agents/agent-2/conversations/new-id-1'),
+      );
+      // Still just the one pane — the resolved mint did not resurrect it.
+      expect(
+        useAgentWorkspaceStore.getState().workspaces['ses-1'].columns.flatMap((c) => c.panes),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('picking a shell', () => {
+    it('opens a shell in the session and binds the pane to it', async () => {
+      mockPost.mockResolvedValue({ shell: { shellId: 'shell-9', name: 'shell-1' } });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId('pick-shell'));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions/ses-1/shells', {}),
+      );
+      await waitFor(() => expect(screen.getByTestId('pane-shell')).toHaveTextContent('shell-9'));
+    });
+  });
+
+  describe('reattaching an existing shell (finding 3)', () => {
+    it('offers a shell not currently shown in any pane, and binds it with no POST', async () => {
+      mockFetchWithAuth.mockResolvedValue(jsonOk({ shells: [{ shellId: 'shell-old', name: 'build' }] }));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId('reattach-shell-shell-old'));
+
+      expect(mockPost).not.toHaveBeenCalled();
+      await waitFor(() => expect(screen.getByTestId('pane-shell')).toHaveTextContent('shell-old'));
+    });
+
+    it('does not offer a shell already bound to a pane in this grid', async () => {
+      mockFetchWithAuth.mockResolvedValue(jsonOk({ shells: [{ shellId: 'shell-bound', name: 'build' }] }));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const chatPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', chatPaneId));
+      const termPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== chatPaneId)!.id;
+      act(() =>
+        useAgentWorkspaceStore
+          .getState()
+          .assignPane('ses-1', termPaneId, { kind: 'terminal', name: 'build', targetId: 'shell-bound', agentPageId: null }),
+      );
+
+      act(() => useAgentWorkspaceStore.getState().splitDown('ses-1', termPaneId));
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('reattach-shell-shell-bound')).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('keyboard activation (finding 7)', () => {
+    it('focusing a control inside a pane activates it, not only a click', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      // The split focused the new pane; move active back to the first so the
+      // test can prove a FOCUS (not a click) moves it again.
+      act(() => useAgentWorkspaceStore.getState().selectPane('ses-1', firstPaneId));
+
+      const closeButtons = screen.getAllByLabelText('Close pane');
+      act(() => closeButtons[closeButtons.length - 1].focus());
+
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId).not.toBe(firstPaneId),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/agents/panes/__tests__/PanePicker.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/PanePicker.test.tsx
@@ -83,4 +83,44 @@ describe('PanePicker', () => {
     expect(screen.getByTestId('pick-shell')).toBeInTheDocument();
     expect(screen.getByTestId('pick-global-assistant')).toBeInTheDocument();
   });
+
+  describe('reattaching an existing shell (issue #2263, finding 3)', () => {
+    const shells = [
+      { shellId: 'shell-1', name: 'build' },
+      { shellId: 'shell-2', name: 'server' },
+    ];
+
+    it('offers each existing shell as a reattach choice', () => {
+      render(<PanePicker agents={agents} existingShells={shells} onPickAgent={vi.fn()} onPickShell={vi.fn()} />);
+      expect(screen.getByTestId('reattach-shell-shell-1')).toBeInTheDocument();
+      expect(screen.getByText('build')).toBeInTheDocument();
+      expect(screen.getByTestId('reattach-shell-shell-2')).toBeInTheDocument();
+      expect(screen.getByText('server')).toBeInTheDocument();
+    });
+
+    it('reports the reattached shell by id and name', async () => {
+      const onReattachShell = vi.fn();
+      render(
+        <PanePicker
+          agents={agents}
+          existingShells={shells}
+          onPickAgent={vi.fn()}
+          onPickShell={vi.fn()}
+          onReattachShell={onReattachShell}
+        />,
+      );
+      await userEvent.click(screen.getByTestId('reattach-shell-shell-2'));
+      expect(onReattachShell).toHaveBeenCalledWith('shell-2', 'server');
+    });
+
+    it('renders no reattach section when there is nothing to reattach', () => {
+      render(<PanePicker agents={agents} existingShells={[]} onPickAgent={vi.fn()} onPickShell={vi.fn()} />);
+      expect(screen.queryByText(/reattach/i)).not.toBeInTheDocument();
+    });
+
+    it('omits the section entirely when the prop is not passed — sidebar callers unaffected', () => {
+      render(<PanePicker agents={agents} onPickAgent={vi.fn()} onPickShell={vi.fn()} />);
+      expect(screen.queryByText(/reattach/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/components/agents/panes/__tests__/pane-surface.test.ts
+++ b/apps/web/src/components/agents/panes/__tests__/pane-surface.test.ts
@@ -65,4 +65,15 @@ describe('resolvePaneSurface', () => {
     const surfaces = [chat('conv-1'), chat(null), chat('conv-1', null)].map(resolvePaneSurface);
     expect(surfaces.some((s) => s.surface === 'terminal')).toBe(false);
   });
+
+  it('given a scope with a kind neither validation nor the type system caught, should hold rather than mount a PTY', () => {
+    // The concrete bug (issue #2263, finding 6): the old branch was a
+    // chat-or-else ternary, so ANY non-'chat' kind — including one that
+    // slipped past `paneScopeSchema` (a stale persisted value, a corrupted
+    // store) — fell into the terminal branch. Persist-time validation is the
+    // primary defense; this is the second one, because a pane resolver that
+    // trusts its input is exactly the hazard this module exists to rule out.
+    const corrupted = { kind: 'legacy-ssh', name: 'x', targetId: 'row-1', agentPageId: null } as unknown as PaneScope;
+    expect(resolvePaneSurface(corrupted)).toEqual({ surface: 'loading' });
+  });
 });

--- a/apps/web/src/components/agents/panes/pane-surface.ts
+++ b/apps/web/src/components/agents/panes/pane-surface.ts
@@ -35,7 +35,13 @@ export function resolvePaneSurface(scope: PaneScope | null): PaneSurface {
   // — and, more importantly, from opening a PTY stream it would have to close.
   if (scope.targetId === null) return { surface: 'loading' };
 
-  return scope.kind === 'chat'
-    ? { surface: 'chat', conversationId: scope.targetId, agentPageId: scope.agentPageId }
-    : { surface: 'terminal', shellId: scope.targetId };
+  if (scope.kind === 'chat') return { surface: 'chat', conversationId: scope.targetId, agentPageId: scope.agentPageId };
+  if (scope.kind === 'terminal') return { surface: 'terminal', shellId: scope.targetId };
+
+  // A `kind` this module has never heard of — a stale persisted value that
+  // predates a schema change, or a corrupted store slipping past
+  // `paneScopeSchema` — must never fall through to a live PTY. The old
+  // `scope.kind === 'chat' ? chat : terminal` ternary treated "not chat" as
+  // "therefore terminal," which is exactly backwards for an unknown value.
+  return { surface: 'loading' };
 }

--- a/apps/web/src/components/agents/useResolvedConversation.ts
+++ b/apps/web/src/components/agents/useResolvedConversation.ts
@@ -51,11 +51,27 @@ export async function createPageConversation({
   agentId,
   driveId,
   canUseSessions,
+  sessionId,
 }: {
   agentId: string;
   driveId: string;
   canUseSessions: boolean;
+  /**
+   * Mint the replacement INTO this session rather than spawning a new one —
+   * set when the conversation being replaced was itself session-bound
+   * (deleting the current conversation must never abandon its session).
+   * Takes priority over `canUseSessions`: reuse is never downgraded to a
+   * fresh spawn.
+   */
+  sessionId?: string | null;
 }): Promise<ResolvedConversation> {
+  if (sessionId) {
+    const conversationId = createId();
+    conversationMessagesActions.seedConversation(conversationId);
+    await post(`/api/ai/page-agents/${encodeURIComponent(agentId)}/conversations`, { conversationId, sessionId });
+    return { conversationId, sessionId };
+  }
+
   if (canUseSessions) {
     try {
       const created = await post<{ session: { sessionId: string }; conversationId: string }>(

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -6,16 +6,7 @@ import { Bot, ChevronDown, ChevronRight, CircleStop, MessageSquarePlus, Plus, Sq
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import EndSessionDialog from '@/components/agents/EndSessionDialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn, isElectron } from '@/lib/utils';
 import type { SidebarProps } from './index';
@@ -404,23 +395,13 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
         </button>
       </div>
 
-      <AlertDialog open={confirmingEnd} onOpenChange={setConfirmingEnd}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>End {session.name ? `“${session.name}”` : 'this session'}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Its sandbox is stopped and its shells close. Conversations stay in each
-              agent&apos;s history.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={ending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction disabled={ending} onClick={() => void endSession()}>
-              End session
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <EndSessionDialog
+        open={confirmingEnd}
+        onOpenChange={setConfirmingEnd}
+        sessionName={session.name}
+        isEnding={ending}
+        onConfirm={() => void endSession()}
+      />
 
       {expanded && (
         <div className="ml-5 space-y-0.5 border-l border-border pl-2">

--- a/apps/web/src/stores/agent-workspace/__tests__/pane-reducer.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/pane-reducer.test.ts
@@ -8,10 +8,13 @@ import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
 import {
   newWorkspace,
   assignPane,
+  assignPaneShowing,
   dismissPicker,
   splitRight,
   splitDown,
   closePane,
+  isLastPane,
+  resetPane,
   selectPane,
   panesOf,
   paneShowing,
@@ -213,5 +216,61 @@ describe('panesOf / paneShowing', () => {
     const state = splitRight(base(), 'pane-1', 'col-2', 'pane-2');
     expect(panesOf(state)[1].scope).toBeNull();
     expect(paneShowing(state, 'conv-1')?.id).toBe('pane-1');
+  });
+});
+
+describe('isLastPane', () => {
+  it('given the only pane in the grid, should say so', () => {
+    expect(isLastPane(base(), 'pane-1')).toBe(true);
+  });
+
+  it('given one of several panes, should say no', () => {
+    const state = splitRight(base(), 'pane-1', 'col-2', 'pane-2');
+    expect(isLastPane(state, 'pane-1')).toBe(false);
+    expect(isLastPane(state, 'pane-2')).toBe(false);
+  });
+
+  it('given an unresolvable pane, should say no rather than throw', () => {
+    expect(isLastPane(base(), 'ghost')).toBe(false);
+  });
+});
+
+describe('resetPane', () => {
+  it('should unbind the pane back to null scope', () => {
+    const state = resetPane(base(), 'pane-1');
+    expect(state.columns[0].panes[0].scope).toBeNull();
+  });
+
+  it('should focus the reset pane\'s picker, same as a fresh split', () => {
+    const state = resetPane(base(), 'pane-1');
+    expect(state.pendingPickerPaneId).toBe('pane-1');
+  });
+
+  it('given an unresolvable pane, should no-op', () => {
+    const state = base();
+    expect(resetPane(state, 'ghost')).toBe(state);
+  });
+
+  it('should leave sibling panes untouched', () => {
+    let state = splitRight(base(), 'pane-1', 'col-2', 'pane-2');
+    state = assignPane(state, 'pane-2', terminalScope('shell-9'));
+    state = resetPane(state, 'pane-1');
+    expect(panesOf(state).find((p) => p.id === 'pane-2')?.scope).toEqual(terminalScope('shell-9'));
+  });
+});
+
+describe('assignPaneShowing', () => {
+  it('should assign the pane currently showing the old target to a new scope', () => {
+    let state = splitRight(base(), 'pane-1', 'col-2', 'pane-2');
+    state = assignPane(state, 'pane-2', chatScope('conv-2', 'agent-2'));
+
+    state = assignPaneShowing(state, 'conv-2', chatScope('conv-3', 'agent-3'));
+
+    expect(panesOf(state).find((p) => p.id === 'pane-2')?.scope).toEqual(chatScope('conv-3', 'agent-3'));
+  });
+
+  it('given a target shown nowhere, should no-op — nothing stale to prune', () => {
+    const state = base();
+    expect(assignPaneShowing(state, 'never-shown', chatScope('conv-9'))).toBe(state);
   });
 });

--- a/apps/web/src/stores/agent-workspace/__tests__/persisted-workspace.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/persisted-workspace.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Rehydration is the one boundary in this store that reads untyped data —
+ * everything past this module can trust a `WorkspaceState` is what it claims
+ * to be. These tests exist to keep that true across storage corruption, not
+ * just the happy path.
+ */
+import { describe, it, expect } from 'vitest';
+import { newWorkspace } from '../pane-reducer';
+import { validatePersistedWorkspaces } from '../persisted-workspace';
+
+function validWorkspace(sessionId: string) {
+  return newWorkspace({
+    sessionId,
+    paneId: 'pane-1',
+    columnId: 'col-1',
+    scope: { kind: 'chat', name: 'Planning', targetId: 'conv-1', agentPageId: 'agent-1' },
+  });
+}
+
+describe('validatePersistedWorkspaces', () => {
+  it('keeps a grid that matches the shape exactly', () => {
+    const result = validatePersistedWorkspaces({ workspaces: { 'ses-1': validWorkspace('ses-1') } });
+    expect(result['ses-1']).toEqual(validWorkspace('ses-1'));
+  });
+
+  it('keeps several valid grids side by side', () => {
+    const result = validatePersistedWorkspaces({
+      workspaces: { 'ses-1': validWorkspace('ses-1'), 'ses-2': validWorkspace('ses-2') },
+    });
+    expect(Object.keys(result).sort()).toEqual(['ses-1', 'ses-2']);
+  });
+
+  it('drops a grid whose pane scope has a kind paneScopeSchema does not recognize', () => {
+    const corrupt = validWorkspace('ses-1');
+    corrupt.columns[0].panes[0].scope = { kind: 'legacy-ssh', name: 'x', targetId: 'row-1', agentPageId: null } as never;
+    const result = validatePersistedWorkspaces({ workspaces: { 'ses-1': corrupt } });
+    expect(result['ses-1']).toBeUndefined();
+  });
+
+  it('keeps a valid neighbor when only one grid is corrupt', () => {
+    const corrupt = validWorkspace('ses-bad');
+    corrupt.activePaneId = '';
+    const result = validatePersistedWorkspaces({
+      workspaces: { 'ses-bad': corrupt, 'ses-good': validWorkspace('ses-good') },
+    });
+    expect(result['ses-bad']).toBeUndefined();
+    expect(result['ses-good']).toBeDefined();
+  });
+
+  it('drops a grid with an empty column list', () => {
+    const corrupt = { ...validWorkspace('ses-1'), columns: [] };
+    const result = validatePersistedWorkspaces({ workspaces: { 'ses-1': corrupt } });
+    expect(result['ses-1']).toBeUndefined();
+  });
+
+  it('given a scope of null (an unbound pane), keeps the grid', () => {
+    const withPicker = validWorkspace('ses-1');
+    withPicker.columns[0].panes[0].scope = null;
+    const result = validatePersistedWorkspaces({ workspaces: { 'ses-1': withPicker } });
+    expect(result['ses-1']).toEqual(withPicker);
+  });
+
+  it('given no workspaces key at all, returns an empty map rather than throwing', () => {
+    expect(validatePersistedWorkspaces({})).toEqual({});
+  });
+
+  it('given garbage (not an object), returns an empty map', () => {
+    expect(validatePersistedWorkspaces(null)).toEqual({});
+    expect(validatePersistedWorkspaces('corrupted-string')).toEqual({});
+    expect(validatePersistedWorkspaces(undefined)).toEqual({});
+  });
+
+  it('given a workspaces value that is not itself an object, returns an empty map', () => {
+    expect(validatePersistedWorkspaces({ workspaces: 'nope' })).toEqual({});
+  });
+});

--- a/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
@@ -112,6 +112,59 @@ describe('transitions', () => {
   });
 });
 
+describe('resetPane', () => {
+  beforeEach(() => {
+    store().ensureWorkspace('ses-1', scope());
+  });
+
+  it('should unbind the pane so it renders the picker again', () => {
+    store().resetPane('ses-1', grid().activePaneId);
+    expect(panesOf(grid())[0].scope).toBeNull();
+  });
+
+  it('should no-op against a grid that is gone', () => {
+    store().forgetWorkspace('ses-1');
+    expect(() => store().resetPane('ses-1', 'pane-1')).not.toThrow();
+    expect(store().workspaces['ses-1']).toBeUndefined();
+  });
+});
+
+describe('replaceConversation — pruning the pane a deleted conversation left behind', () => {
+  const replacement: PaneScope = { kind: 'chat', name: 'New conversation', targetId: 'conv-new', agentPageId: 'agent-1' };
+
+  it('should assign the pane that was showing the deleted conversation to its replacement', () => {
+    store().ensureWorkspace('ses-1', scope());
+    const paneId = grid().activePaneId;
+
+    store().replaceConversation('ses-1', 'conv-1', replacement);
+
+    expect(panesOf(grid()).find((p) => p.id === paneId)?.scope).toEqual(replacement);
+  });
+
+  it('should target the pane holding the OLD id even when it is not the active pane', () => {
+    store().ensureWorkspace('ses-1', scope());
+    const original = grid().activePaneId;
+    store().splitRight('ses-1', original);
+    // The split moved active focus to the new pane; the deleted conversation
+    // is still in the ORIGINAL one.
+    expect(grid().activePaneId).not.toBe(original);
+
+    store().replaceConversation('ses-1', 'conv-1', replacement);
+
+    expect(panesOf(grid()).find((p) => p.id === original)?.scope).toEqual(replacement);
+  });
+
+  it('given a conversation shown nowhere, should no-op', () => {
+    store().ensureWorkspace('ses-1', scope());
+    expect(() => store().replaceConversation('ses-1', 'never-shown', replacement)).not.toThrow();
+    expect(panesOf(grid())[0].scope).toEqual(scope());
+  });
+
+  it('should no-op against a grid that is gone', () => {
+    expect(() => store().replaceConversation('never-existed', 'conv-1', replacement)).not.toThrow();
+  });
+});
+
 describe('a transition aimed at a grid that is gone', () => {
   it('should no-op rather than throw or fabricate one', () => {
     // A close can land after the conversation was deleted and its grid
@@ -199,5 +252,57 @@ describe('openConversation — selection means SHOW it (review M1)', () => {
     expect(panes).toHaveLength(2);
     expect(panes.filter((p) => p.scope?.kind === 'terminal')).toHaveLength(1);
     expect(panes.find((p) => p.scope?.targetId === 'conv-2')).toBeDefined();
+  });
+
+  it('never clobbers a pane whose mint is still in flight (review low-batch #1)', () => {
+    // The active pane is bound to a KIND but has no row yet (the picker just
+    // chose it, the POST hasn't resolved) — picking a DIFFERENT conversation
+    // from history in the meantime must not land on top of it, or the mint's
+    // own success callback later overwrites the user's newer selection.
+    store().openConversation('ses-1', conv('conv-1'));
+    const inFlightPane = panesOf(grid())[0];
+    store().assignPane('ses-1', inFlightPane.id, {
+      kind: 'chat',
+      name: 'New conversation',
+      targetId: null,
+      agentPageId: 'agent-2',
+    });
+
+    store().openConversation('ses-1', conv('conv-2'));
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === inFlightPane.id)?.scope?.targetId).toBeNull();
+    expect(panes.find((p) => p.scope?.targetId === 'conv-2')).toBeDefined();
+  });
+});
+
+describe('persistence', () => {
+  it('is versioned, so a future shape change can migrate rather than silently misreading old storage', () => {
+    expect(useAgentWorkspaceStore.persist.getOptions().version).toBe(1);
+  });
+
+  it('drops a corrupted grid on rehydrate rather than letting it reach the store', async () => {
+    const storage = useAgentWorkspaceStore.persist.getOptions().storage;
+    expect(storage).toBeDefined();
+    await storage!.setItem('agent-workspace-storage', {
+      state: {
+        workspaces: {
+          'ses-corrupt': { id: 'ses-corrupt', columns: [], activePaneId: '', pendingPickerPaneId: null },
+          'ses-1': {
+            id: 'ses-1',
+            columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: scope() }] }],
+            activePaneId: 'pane-1',
+            pendingPickerPaneId: null,
+          },
+        },
+      },
+      version: 1,
+    });
+
+    await useAgentWorkspaceStore.persist.rehydrate();
+
+    expect(store().workspaces['ses-corrupt']).toBeUndefined();
+    expect(store().workspaces['ses-1']).toBeDefined();
   });
 });

--- a/apps/web/src/stores/agent-workspace/pane-reducer.ts
+++ b/apps/web/src/stores/agent-workspace/pane-reducer.ts
@@ -173,6 +173,51 @@ export function selectPane(state: WorkspaceState, id: string): WorkspaceState {
   return { ...state, activePaneId: id };
 }
 
+/**
+ * Whether closing this pane would empty the grid. The container needs this
+ * BEFORE it decides anything — show a confirm dialog, gate the close on a
+ * server round-trip — and `closePane` itself only answers it by no-oping
+ * (it cannot delete its own container), which is too late for a caller that
+ * has to decide what to do *before* committing to the close.
+ */
+export function isLastPane(state: WorkspaceState, id: string): boolean {
+  if (!findPaneLocation(state, id)) return false;
+  return panesOf(state).length <= 1;
+}
+
+/**
+ * Unbind a pane back to the picker — the first-class shape for "this mint
+ * failed, start over here." Distinct from ever writing a scope whose fields
+ * lie about what it is: an earlier version overloaded `name === ''` on a
+ * still-bound chat scope as an unbound sentinel, on a field the contract
+ * documents as "never an address" (any future empty-named chat scope would
+ * have silently become a picker). Focuses the pane's picker on the next
+ * render, the same courtesy a fresh split gets.
+ */
+export function resetPane(state: WorkspaceState, id: string): WorkspaceState {
+  if (!findPaneLocation(state, id)) return state;
+  return {
+    ...state,
+    columns: state.columns.map((column) => ({
+      ...column,
+      panes: column.panes.map((pane) => (pane.id === id ? { ...pane, scope: null } : pane)),
+    })),
+    pendingPickerPaneId: id,
+  };
+}
+
+/**
+ * Assign whichever pane is showing `oldTargetId` to a new scope — used when
+ * the row it addressed was deleted and replaced, so the pane the user was
+ * looking at follows the replacement instead of dangling on a dead id. A
+ * target shown nowhere is a no-op: there is nothing stale to prune.
+ */
+export function assignPaneShowing(state: WorkspaceState, oldTargetId: string, newScope: PaneScope): WorkspaceState {
+  const pane = paneShowing(state, oldTargetId);
+  if (!pane) return state;
+  return assignPane(state, pane.id, newScope);
+}
+
 /** Every pane, flattened in visual order (left-to-right, top-to-bottom). */
 export function panesOf(state: WorkspaceState): PaneState[] {
   return state.columns.flatMap((column) => column.panes);

--- a/apps/web/src/stores/agent-workspace/persisted-workspace.ts
+++ b/apps/web/src/stores/agent-workspace/persisted-workspace.ts
@@ -1,0 +1,58 @@
+/**
+ * Validates `localStorage`-rehydrated workspace state before it ever reaches
+ * the store.
+ *
+ * `JSON.parse` on rehydration is untyped by construction — a previous schema
+ * version, a browser extension, or plain storage corruption can all write
+ * something the cast would have accepted and this app never would. Every
+ * grid is validated with `paneScopeSchema` on the way in, and a grid that
+ * fails is DROPPED wholesale rather than repaired: a half-valid layout is not
+ * a layout worth keeping, and the session it names is still reachable from
+ * its sidebar row (the grid just reopens on that session's first
+ * conversation, same as a session with no persisted layout at all).
+ *
+ * This is the primary defense against a corrupt `kind` reaching
+ * `resolvePaneSurface`; that module's own fallback (finding 6) is the second
+ * one, for state this module never saw (a test, a future caller).
+ */
+import { z } from 'zod';
+import { paneScopeSchema } from '@pagespace/lib/agent-sessions/contract';
+import type { WorkspaceState } from './pane-reducer';
+
+const paneStateSchema = z.object({
+  id: z.string().min(1),
+  scope: paneScopeSchema.nullable(),
+});
+
+const columnStateSchema = z.object({
+  id: z.string().min(1),
+  panes: z.array(paneStateSchema).min(1),
+});
+
+const workspaceStateSchema = z.object({
+  id: z.string().min(1),
+  columns: z.array(columnStateSchema).min(1),
+  activePaneId: z.string().min(1),
+  pendingPickerPaneId: z.string().nullable(),
+});
+
+function isValidWorkspace(value: unknown): value is WorkspaceState {
+  return workspaceStateSchema.safeParse(value).success;
+}
+
+/**
+ * `persist`'s `merge` hook: `persisted` is whatever `JSON.parse`d value the
+ * storage held (or `undefined`/garbage on a cold or foreign key). Returns
+ * only the grids that pass validation, keyed by session id.
+ */
+export function validatePersistedWorkspaces(persisted: unknown): Record<string, WorkspaceState> {
+  if (persisted === null || typeof persisted !== 'object') return {};
+  const candidate = (persisted as { workspaces?: unknown }).workspaces;
+  if (candidate === null || typeof candidate !== 'object') return {};
+
+  const result: Record<string, WorkspaceState> = {};
+  for (const [sessionId, workspace] of Object.entries(candidate as Record<string, unknown>)) {
+    if (isValidWorkspace(workspace)) result[sessionId] = workspace;
+  }
+  return result;
+}

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -6,13 +6,18 @@ import {
   paneShowing,
   panesOf,
   assignPane as assignPaneIn,
+  assignPaneShowing as assignPaneShowingIn,
   dismissPicker as dismissPickerIn,
   splitRight as splitRightIn,
   splitDown as splitDownIn,
   closePane as closePaneIn,
+  isLastPane,
+  resetPane as resetPaneIn,
   selectPane as selectPaneIn,
+  type PaneState,
   type WorkspaceState,
 } from './pane-reducer';
+import { validatePersistedWorkspaces } from './persisted-workspace';
 
 /**
  * Where each session's pane layout lives.
@@ -64,7 +69,16 @@ interface AgentWorkspaceState {
   closePane(sessionId: string, paneId: string): 'closed' | 'session-ended' | 'noop';
   selectPane(sessionId: string, paneId: string): void;
   assignPane(sessionId: string, paneId: string, scope: PaneScope): void;
+  /** Unbind a pane back to the picker — a failed mint, first-class rather than a sentinel scope. */
+  resetPane(sessionId: string, paneId: string): void;
   dismissPicker(sessionId: string, paneId: string): void;
+  /**
+   * Point whichever pane is showing `oldConversationId` at its replacement.
+   * Used when the current conversation is deleted and re-minted into the
+   * SAME session (`AgentPageView`'s delete flow) — a no-op if the deleted
+   * conversation was not showing in any pane.
+   */
+  replaceConversation(sessionId: string, oldConversationId: string, newScope: PaneScope): void;
   /** Drop a session's grid entirely (the session was ended elsewhere). */
   forgetWorkspace(sessionId: string): void;
 }
@@ -138,10 +152,14 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
         }
         const panes = panesOf(workspace);
         const active = panes.find((pane) => pane.id === workspace.activePaneId);
-        const replaceable =
-          active && active.scope?.kind !== 'terminal'
-            ? active
-            : panes.find((pane) => pane.scope?.kind !== 'terminal');
+        // Replaceable = unbound (picker), or bound to a resolved, non-terminal
+        // row. A pane whose mint is still in flight (`targetId === null`) is
+        // EXCLUDED even though its kind isn't terminal: landing a different
+        // selection there now means the mint's own success callback later
+        // overwrites it with the stale pick (review low-batch #1).
+        const isReplaceable = (pane: PaneState) =>
+          pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null);
+        const replaceable = active && isReplaceable(active) ? active : panes.find(isReplaceable);
         if (replaceable) {
           state.assignPane(sessionId, replaceable.id, scope);
           return;
@@ -175,9 +193,8 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
       closePane: (sessionId, paneId) => {
         const current = useAgentWorkspaceStore.getState().workspaces[sessionId];
         if (!current) return 'noop';
-        const paneExists = panesOf(current).some((pane) => pane.id === paneId);
-        if (!paneExists) return 'noop';
-        if (panesOf(current).length <= 1) {
+        if (!panesOf(current).some((pane) => pane.id === paneId)) return 'noop';
+        if (isLastPane(current, paneId)) {
           // The LAST pane: emptying a session ends it. The reducer no-ops on
           // this by design (it cannot delete its own container); the store is
           // the container, so the interception lives here — the old
@@ -198,8 +215,17 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
       assignPane: (sessionId, paneId, scope) =>
         set((state) => updateWorkspace(state, sessionId, (w) => assignPaneIn(w, paneId, scope)) ?? {}),
 
+      resetPane: (sessionId, paneId) =>
+        set((state) => updateWorkspace(state, sessionId, (w) => resetPaneIn(w, paneId)) ?? {}),
+
       dismissPicker: (sessionId, paneId) =>
         set((state) => updateWorkspace(state, sessionId, (w) => dismissPickerIn(w, paneId)) ?? {}),
+
+      replaceConversation: (sessionId, oldConversationId, newScope) =>
+        set(
+          (state) =>
+            updateWorkspace(state, sessionId, (w) => assignPaneShowingIn(w, oldConversationId, newScope)) ?? {},
+        ),
 
       forgetWorkspace: (sessionId) =>
         set((state) => {
@@ -208,6 +234,17 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
           return { workspaces: rest };
         }),
     }),
-    { name: 'agent-workspace-storage' },
+    {
+      name: 'agent-workspace-storage',
+      // Bumped when the persisted grid shape changes; paired with `merge`
+      // below so a stale or corrupted grid is dropped on rehydrate rather
+      // than trusted — see `validatePersistedWorkspaces`.
+      version: 1,
+      partialize: (state) => ({ workspaces: state.workspaces }),
+      merge: (persisted, current) => ({
+        ...current,
+        workspaces: validatePersistedWorkspaces(persisted),
+      }),
+    },
   ),
 );


### PR DESCRIPTION
## Summary
Full fix for the pane-system lifecycle audit follow-up (issue #2263), covering `apps/web/src/components/agents/**` and `apps/web/src/stores/agent-workspace/**`:

1. **HIGH** — Last-pane close is now peeked, confirmed, and gated on the session DELETE succeeding *before* any local grid mutation. A failed teardown leaves the user on the live session instead of silently minting a second one.
2. Reuses the sidebar's `AlertDialog` (extracted to `EndSessionDialog`) for the identical "end session" act, via a pure `isLastPane` peek.
3. Closing a terminal pane now DELETEs its shell; `PanePicker` offers to reattach any shell the session already has that isn't currently shown in any pane — un-deadending the sidebar's shell count too.
4. Deleting the current conversation mints its replacement INTO the same session (`createConversationInSession` path) instead of spawning a new one, and prunes whichever pane was showing the deleted id via a new `assignPaneShowing`/`replaceConversation` — not just "the active pane" (grid selection and the page's `current` can drift independently).
5. First-class pane reset (`resetPane`, `scope: null`) replaces the `name === ''` sentinel that overloaded a field the contract documents as "never an address."
6. Persisted workspaces are now zod-validated on rehydrate (`persisted-workspace.ts`), the persist store is versioned, and grids are GC'd when the server confirms a session is gone; `resolvePaneSurface` no longer falls through an unrecognized `kind` into a live PTY.
7. Low batch: mint-in-flight panes excluded from `openConversation`'s replace-target search; a pane closed mid-mint no longer resurrects once its POST resolves (the orphaned row is cleaned up instead); `PaneBar` controls get `aria-label` + `aria-hidden` icons; pane activation has a keyboard path (`onFocusCapture`); narrowed the workspace store selector; memoized `pickableAgents`.
8. `canPickAssistant` left unchanged (flagged as a product decision in the issue) — comment added pointing at #2263.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (pre-existing unrelated warnings only)
- [x] `bun run test:unit` — all pass except one pre-existing TZ-dependent test (`grouping.test.ts`, unrelated file, confirmed identical on master)
- [x] `bun run knip:check` — within baseline
- [x] New/updated test files: `pane-reducer.test.ts`, `useAgentWorkspaceStore.test.ts`, `persisted-workspace.test.ts` (new), `pane-surface.test.ts`, `AgentPanes.test.tsx` (new, 14 tests covering the close/mint lifecycle), `PanePicker.test.tsx`, `AgentPageView.test.tsx`, `AgentsSurface.test.tsx`, `useResolvedConversation.test.ts`, `AgentsSidebar.test.tsx` (regression-checked after `EndSessionDialog` extraction)

Closes #2263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9CEVT7cMs3mCKTTXCgyd9