### PR TITLE
fix(agents): scope worker verbs, cap conversations, bound listings [session-tools]

### DIFF
--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/route.ts
@@ -30,7 +30,8 @@ import {
   checkSessionAccess,
   createConversationInSession,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
-import { ConversationUnavailableError } from '@/lib/agent-sessions/create-conversation-in-session';
+import { ConversationUnavailableError, SessionFullError } from '@/lib/agent-sessions/create-conversation-in-session';
+import { sessionConversationLimitExceeded } from '@/lib/agent-sessions/quota-response';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -112,6 +113,9 @@ export async function POST(request: Request, context: RouteContext) {
       sessionId,
     });
   } catch (error) {
+    if (error instanceof SessionFullError) {
+      return sessionConversationLimitExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]/conversations');
+    }
     if (error instanceof ConversationUnavailableError) {
       // The id names a conversation that cannot be claimed WITH this binding
       // (someone else's, a legacy conflict, or a different session's) — a

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createId, isCuid } from '@paralleldrive/cuid2';
 import { checkSessionAccess, createConversationInSession } from '@/lib/agent-sessions/agent-sessions-runtime';
-import { ConversationUnavailableError } from '@/lib/agent-sessions/create-conversation-in-session';
+import { ConversationUnavailableError, SessionFullError } from '@/lib/agent-sessions/create-conversation-in-session';
+import { sessionConversationLimitExceeded } from '@/lib/agent-sessions/quota-response';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalViewPage } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -217,6 +218,9 @@ export async function POST(
       try {
         await createConversationInSession({ conversationId, userId: auth.userId, agentPageId: agentId, sessionId });
       } catch (error) {
+        if (error instanceof SessionFullError) {
+          return sessionConversationLimitExceeded(request, auth.userId, sessionId, 'page-agents/conversations');
+        }
         if (error instanceof ConversationUnavailableError) {
           // The id cannot be claimed WITH this binding (someone else's row, a
           // legacy conflict, or a different session's thread) — a state

--- a/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
@@ -10,8 +10,10 @@ import {
   createConversationInSessionWith,
   ConversationUnavailableError,
   AgentNotInSessionDriveError,
+  SessionFullError,
   type CreateConversationInSessionDeps,
 } from '../create-conversation-in-session';
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
 
 const OWN_ROW = {
   userId: 'user-1',
@@ -26,6 +28,7 @@ let deps: {
   findConversation: ReturnType<typeof vi.fn>;
   findAgentDriveId: ReturnType<typeof vi.fn>;
   findSessionDriveId: ReturnType<typeof vi.fn>;
+  countActiveConversations: ReturnType<typeof vi.fn>;
 };
 
 const input = (overrides: Partial<{ agentPageId: string | null; sessionId: string }> = {}) => ({
@@ -45,6 +48,7 @@ beforeEach(() => {
     findConversation: vi.fn(async () => OWN_ROW),
     findAgentDriveId: vi.fn(async () => 'drive-1'),
     findSessionDriveId: vi.fn(async () => ({ driveId: 'drive-1' })),
+    countActiveConversations: vi.fn(async () => 0),
   };
 });
 
@@ -185,5 +189,57 @@ describe('the cross-drive gate (one binding path, review #43)', () => {
   it('a same-drive agent passes the gate and creates', async () => {
     await expect(run()).resolves.toBeUndefined();
     expect(deps.createPageConversation).toHaveBeenCalled();
+  });
+});
+
+describe('the per-session conversation cap (issue #2262 finding 2 — the HTTP binding path)', () => {
+  // This module is the ONE write path both HTTP routes
+  // (agent-sessions/[sessionId]/conversations, page-agents/[agentId]/conversations)
+  // and the session-tools spawn dep (createWorkerSession) funnel through, so a
+  // cap enforced HERE covers every conversation-minting entry point at once —
+  // including the ones that never call the pure tool-side planner.
+
+  it('refuses a NEW page conversation when the session is already at its ceiling', async () => {
+    deps.countActiveConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS);
+    deps.findConversation.mockResolvedValue(null); // no existing row — genuinely new
+    await expect(run()).rejects.toThrow(SessionFullError);
+    expect(deps.createPageConversation).not.toHaveBeenCalled();
+  });
+
+  it('refuses a NEW global conversation when the session is already at its ceiling', async () => {
+    deps.countActiveConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS);
+    deps.findConversation.mockResolvedValue(null);
+    await expect(
+      createConversationInSessionWith(deps as CreateConversationInSessionDeps, input({ agentPageId: null })),
+    ).rejects.toThrow(SessionFullError);
+    expect(deps.createGlobalConversation).not.toHaveBeenCalled();
+  });
+
+  it('allows creation with one conversation slot left', async () => {
+    deps.countActiveConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS - 1);
+    await expect(run()).resolves.toBeUndefined();
+    expect(deps.createPageConversation).toHaveBeenCalled();
+  });
+
+  it('does not look up the row at all when well under the ceiling — a retry check is only needed near capacity', async () => {
+    await run();
+    expect(deps.findConversation).not.toHaveBeenCalled();
+  });
+
+  it('lets an IDEMPOTENT RETRY of an existing conversation in THIS session through, even at the ceiling', async () => {
+    // The count reflects rows that already include this one — a retry mints
+    // nothing new, so the cap must not stand between a caller and its own
+    // already-created conversation.
+    deps.countActiveConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS);
+    deps.findConversation.mockResolvedValue(OWN_ROW); // same id, already bound HERE
+    deps.createPageConversation.mockResolvedValue('exists');
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it('still refuses a full session for an id bound to a DIFFERENT session — that is not a retry of anything here', async () => {
+    deps.countActiveConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS);
+    deps.findConversation.mockResolvedValue({ ...OWN_ROW, sessionId: 'ses-other' });
+    await expect(run()).rejects.toThrow(SessionFullError);
+    expect(deps.createPageConversation).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -18,7 +18,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, desc, eq, inArray, isNotNull } from '@pagespace/db/operators';
+import { and, count, eq, inArray, isNotNull, sql } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { driveMembers } from '@pagespace/db/schema/members';
@@ -65,6 +65,7 @@ import {
 } from '@pagespace/lib/services/agent-sessions/agent-session-access';
 import type { AgentSessionDTO } from '@pagespace/lib/agent-sessions/contract';
 import { decideAgentSessionAccess } from '@pagespace/lib/agent-sessions/decide-session-access';
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { resolveOrCreateConversation } from '@/app/api/ai/global/[id]/messages/resolve-or-create-conversation';
 import { createConversationInSessionWith } from '@/lib/agent-sessions/create-conversation-in-session';
@@ -287,6 +288,13 @@ export async function createConversationInSession(input: {
         const row = await findSessionRecord(sessionId);
         return row ? { driveId: row.driveId } : null;
       },
+      countActiveConversations: async (sessionId) => {
+        const [row] = await db
+          .select({ n: count() })
+          .from(conversations)
+          .where(and(eq(conversations.sessionId, sessionId), eq(conversations.isActive, true)));
+        return row?.n ?? 0;
+      },
     },
     input,
   );
@@ -322,16 +330,36 @@ export interface SessionConversationEntry {
 /**
  * The conversations of MANY sessions in one query, grouped by session —
  * the collection GET's shape, which previously ran one query per session
- * (review M4: 1+2N per sidebar poll). Newest activity first per
- * session; the per-session cap (100) is enforced during grouping so one hot
- * session cannot starve the others.
+ * (review M4: 1+2N per sidebar poll). Newest activity first per session,
+ * capped at {@link MAX_SESSION_CONVERSATIONS} — the same ceiling
+ * `planSpawnWorkerSession`/`createConversationInSessionWith` enforce, so a
+ * session's own listing cap and its create-time cap agree by construction.
+ *
+ * The cap is enforced IN SQL via a `ROW_NUMBER() OVER (PARTITION BY
+ * sessionId ...)` filter (issue #2262 finding 4), not the JS `bucket.length`
+ * check the previous shape used: without a query-layer bound, a single
+ * session holding far more rows than its cap pulled its ENTIRE row set into
+ * app memory before the JS loop ever discarded the excess. The window
+ * function is what keeps the per-session fairness a flat `LIMIT` would lose
+ * — one hot session's rows cannot crowd another session's out of a shared cap
+ * ordered across all of them together.
+ *
+ * DELIBERATE metadata exposure (issue #2262 finding 6): every caller with
+ * access to a session (its owner, or any member whose own conversation lives
+ * there) sees every OTHER conversation's title and agent in that session,
+ * this way — including threads it did not create. Shared-workspace semantics,
+ * not a leak: a session is one shared sandbox by design. TRANSCRIPT content
+ * is a separate, still owner-gated read (`checkSessionAccess` /
+ * `openOwnSession` in the tool layer) — this listing carries no message
+ * bodies.
  */
 export async function listSessionConversationsBulk(
   sessionIds: string[],
 ): Promise<Map<string, SessionConversationEntry[]>> {
   const grouped = new Map<string, SessionConversationEntry[]>();
   if (sessionIds.length === 0) return grouped;
-  const rows = await db
+
+  const rankedConversations = db
     .select({
       sessionId: conversations.sessionId,
       conversationId: conversations.id,
@@ -339,14 +367,29 @@ export async function listSessionConversationsBulk(
       type: conversations.type,
       contextId: conversations.contextId,
       lastMessageAt: conversations.lastMessageAt,
+      rowNumber: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${conversations.sessionId} ORDER BY ${conversations.lastMessageAt} DESC)`.as(
+        'row_number',
+      ),
     })
     .from(conversations)
     .where(and(inArray(conversations.sessionId, sessionIds), eq(conversations.isActive, true)))
-    .orderBy(desc(conversations.lastMessageAt));
+    .as('ranked_conversations');
+
+  const rows = await db
+    .select({
+      sessionId: rankedConversations.sessionId,
+      conversationId: rankedConversations.conversationId,
+      title: rankedConversations.title,
+      type: rankedConversations.type,
+      contextId: rankedConversations.contextId,
+      lastMessageAt: rankedConversations.lastMessageAt,
+    })
+    .from(rankedConversations)
+    .where(sql`${rankedConversations.rowNumber} <= ${MAX_SESSION_CONVERSATIONS}`);
+
   for (const row of rows) {
     if (row.sessionId === null) continue;
     const bucket = grouped.get(row.sessionId) ?? [];
-    if (bucket.length >= 100) continue;
     bucket.push({
       conversationId: row.conversationId,
       title: row.title,

--- a/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
+++ b/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
@@ -23,10 +23,28 @@
  * `agent-sessions-runtime.ts` only wires the production deps.
  */
 
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
+
 export class ConversationUnavailableError extends Error {
   constructor() {
     super('conversation_unavailable');
     this.name = 'ConversationUnavailableError';
+  }
+}
+
+/**
+ * The session already holds `MAX_SESSION_CONVERSATIONS` active conversations.
+ * Thrown BEFORE either creator runs (issue #2262 finding 2): this is the ONE
+ * write path both HTTP routes and the session-tools spawn dep funnel through,
+ * so the cap enforced here bounds every conversation-minting entry point —
+ * including the ones with no pure-planner preflight of their own. The tool
+ * layer's own `planSpawnWorkerSession` check against the same constant is a
+ * courtesy (a truthful denial before minting an id); this is the backstop.
+ */
+export class SessionFullError extends Error {
+  constructor() {
+    super('session_full');
+    this.name = 'SessionFullError';
   }
 }
 
@@ -80,6 +98,8 @@ export interface CreateConversationInSessionDeps {
   findAgentDriveId: (agentPageId: string) => Promise<string | null>;
   /** The session's drive (null = a global-assistant session), or null when the session is missing. */
   findSessionDriveId: (sessionId: string) => Promise<{ driveId: string | null } | null>;
+  /** ACTIVE conversations already bound to this session — the cap's input. */
+  countActiveConversations: (sessionId: string) => Promise<number>;
 }
 
 export async function createConversationInSessionWith(
@@ -100,6 +120,19 @@ export async function createConversationInSessionWith(
     title?: string | null;
   },
 ): Promise<void> {
+  const activeCount = await deps.countActiveConversations(sessionId);
+  if (activeCount >= MAX_SESSION_CONVERSATIONS) {
+    // Only a genuinely NEW conversation adds to that count — a retry of one
+    // already bound HERE does not — so before refusing, check whether this
+    // exact id already belongs to this session. A false positive here (some
+    // other mismatch that isn't really a valid retry) is caught downstream by
+    // the real idempotency check below; this is only what decides whether the
+    // cap gets a say at all.
+    const existing = await deps.findConversation(conversationId);
+    const isRetryInThisSession = existing !== null && existing.sessionId === sessionId;
+    if (!isRetryInThisSession) throw new SessionFullError();
+  }
+
   if (agentPageId === null) {
     try {
       await deps.createGlobalConversation({ conversationId, userId, sessionId, title });

--- a/apps/web/src/lib/agent-sessions/quota-response.ts
+++ b/apps/web/src/lib/agent-sessions/quota-response.ts
@@ -30,6 +30,35 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 export const SESSION_QUOTA_MESSAGE =
   "Your plan's limit for running sandboxes is already in use — stop one before starting another.";
 
+/**
+ * Human-facing copy for the PER-SESSION conversation ceiling (issue #2262
+ * finding 2) — a different quota from {@link SESSION_QUOTA_MESSAGE}'s
+ * account-wide sandbox count: this one is about how many conversations ONE
+ * session holds, and its remedy is a different session or an existing
+ * conversation, never "stop a sandbox".
+ */
+export const SESSION_CONVERSATION_LIMIT_MESSAGE =
+  'This session already holds the maximum number of conversations — continue in an existing one, or start a new session, before adding another.';
+
+/** The 429 for `SessionFullError` (`create-conversation-in-session.ts`) — kept beside its message so the two cannot drift. */
+export function sessionConversationLimitExceeded(
+  request: Request,
+  userId: string,
+  sessionId: string,
+  /** Which route refused, for the audit trail only — never shown to the caller. */
+  route: string,
+): NextResponse {
+  auditRequest(request, {
+    eventType: 'security.rate.limited',
+    userId,
+    resourceType: 'agent_session',
+    resourceId: sessionId,
+    details: { reason: 'session_conversation_limit_reached', route },
+    riskScore: 0,
+  });
+  return NextResponse.json({ error: SESSION_CONVERSATION_LIMIT_MESSAGE }, { status: 429 });
+}
+
 export function sessionQuotaExceeded(
   request: Request,
   userId: string,

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -37,9 +37,11 @@ function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
       agentPageId: CALLER_AGENT,
       name: 'worker',
       endedAt: null,
+      workspaceSessionId: WORKSPACE_ID,
     })),
     countActiveSessions: vi.fn(async () => 0),
     concurrencyLimit: vi.fn(async () => 5),
+    countSessionConversations: vi.fn(async () => 0),
     canUseAgent: vi.fn(async () => true),
     createWorkerSession: vi.fn(async () => ({ ok: true as const })),
     dispatch: vi.fn(async () => ({ ok: true as const, waited: false as const })),
@@ -282,6 +284,7 @@ describe('send_session', () => {
         agentPageId: null,
         name: '',
         endedAt: null,
+        workspaceSessionId: WORKSPACE_ID,
       })),
     });
     const tools = createSessionTools(deps);
@@ -304,6 +307,86 @@ describe('send_session', () => {
     const tools = createSessionTools(deps);
     const result = await run(tools.send_session, { sessionId: 's1', input: 'x', wait: true }, contextOptions());
     expect(result).toEqual(expect.objectContaining({ success: true, reply: 'the answer' }));
+  });
+});
+
+describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 parity with shells)', () => {
+  // The blast-radius case the shells fix (H2) never reached workers: a
+  // prompt-injected agent could aim send/read/kill_session at ANY conversation
+  // its user owns — another session's worker, another drive's thread, a plain
+  // session-less chat — and exfiltrate a private transcript or dispatch turns
+  // into a foreign sandbox. One address namespace per verb family means a
+  // worker verb resolves ONLY siblings in the caller's own session.
+  const CROSS_SESSION_ROW = {
+    sessionId: 'conv-other',
+    ownerId: USER_ID, // the caller's OWN conversation — ownership alone must not admit it
+    agentPageId: CALLER_AGENT,
+    name: 'private thread',
+    endedAt: null,
+    workspaceSessionId: 'someone-elses-workspace',
+  };
+
+  it('a conversation in ANOTHER session — even the caller\'s own — reads as nonexistent', async () => {
+    const deps = makeDeps({ findSession: vi.fn(async () => CROSS_SESSION_ROW) });
+    const tools = createSessionTools(deps);
+
+    const sent = await run(tools.send_session, { sessionId: 'conv-other', input: 'x' }, contextOptions());
+    expect(sent.success).toBe(false);
+    expect(deps.dispatch).not.toHaveBeenCalled();
+
+    const readResult = await run(tools.read_session, { sessionId: 'conv-other' }, contextOptions());
+    expect(readResult.success).toBe(false);
+    expect(deps.readTranscript).not.toHaveBeenCalled();
+
+    const killed = await run(tools.kill_session, { sessionId: 'conv-other' }, contextOptions());
+    expect(killed.success).toBe(false);
+    expect(deps.endSession).not.toHaveBeenCalled();
+  });
+
+  it('a SESSION-LESS conversation reads as nonexistent — it is not a worker anywhere', async () => {
+    const deps = makeDeps({
+      findSession: vi.fn(async () => ({ ...CROSS_SESSION_ROW, workspaceSessionId: null })),
+    });
+    const tools = createSessionTools(deps);
+    const result = await run(tools.read_session, { sessionId: 'conv-other' }, contextOptions());
+    expect(result.success).toBe(false);
+    expect(deps.readTranscript).not.toHaveBeenCalled();
+  });
+
+  it('a caller whose conversation has NO workspace cannot address any worker', async () => {
+    const deps = makeDeps({ findOwnWorkspace: vi.fn(async () => null) });
+    const tools = createSessionTools(deps);
+    const result = await run(tools.send_session, { sessionId: 's1', input: 'x' }, contextOptions());
+    expect(result.success).toBe(false);
+    expect(deps.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('a caller with no conversation at all cannot address any worker', async () => {
+    const deps = makeDeps();
+    const tools = createSessionTools(deps);
+    const result = await run(
+      tools.read_session,
+      { sessionId: 's1' },
+      contextOptions({ conversationId: undefined }),
+    );
+    expect(result.success).toBe(false);
+    expect(deps.readTranscript).not.toHaveBeenCalled();
+  });
+
+  it('the refusal reads exactly like a nonexistent session — nothing to learn from the difference', async () => {
+    const deps = makeDeps({ findSession: vi.fn(async () => CROSS_SESSION_ROW) });
+    const noRowDeps = makeDeps({ findSession: vi.fn(async () => null) });
+    const crossSession = await run(
+      createSessionTools(deps).send_session,
+      { sessionId: 'conv-other', input: 'x' },
+      contextOptions(),
+    );
+    const noRow = await run(
+      createSessionTools(noRowDeps).send_session,
+      { sessionId: 'conv-other', input: 'x' },
+      contextOptions(),
+    );
+    expect(crossSession).toEqual(noRow);
   });
 });
 

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -19,7 +19,7 @@
 
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
-import { and, eq, ne, desc } from '@pagespace/db/operators';
+import { and, count, eq, ne, desc } from '@pagespace/db/operators';
 import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { conversations, messages as globalMessages } from '@pagespace/db/schema/conversations';
 import { users } from '@pagespace/db/schema/auth';
@@ -34,6 +34,12 @@ import {
   provisionSessionSandbox,
   getAgentSessionStore,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
+import {
+  ConversationUnavailableError,
+  AgentNotInSessionDriveError,
+  SessionFullError,
+} from '@/lib/agent-sessions/create-conversation-in-session';
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import {
   getSessionShellStore,
@@ -206,7 +212,13 @@ async function dispatchThroughChatPipeline(input: {
   try {
     response = await fetch(url, { method: 'POST', headers: requestHeaders, body });
   } catch (error) {
-    return { ok: false, reason: 'failed', detail: error instanceof Error ? error.message : String(error) };
+    // A FIXED message, never the raw fetch/network error (issue #2262 finding
+    // 3) — the real cause (DNS, connection refused, TLS) is an internal detail
+    // logged server-side, not something to hand a model dispatching a turn.
+    loggers.ai.error('session dispatch: could not reach the chat pipeline', error instanceof Error ? error : undefined, {
+      sessionId: input.sessionId,
+    });
+    return { ok: false, reason: 'failed', detail: 'could not reach the chat pipeline to dispatch this turn' };
   }
 
   if (!response.ok) {
@@ -249,7 +261,21 @@ async function dispatchThroughChatPipeline(input: {
  * kill_session take), shells are the workspace's PTYs, and the sandbox status
  * is the one Sprite they all share (review H2b — the old listing enumerated
  * workspace-row ids no verb could address, and never delivered the promised
- * agent labels).
+ * agent labels). Newest first, capped at {@link MAX_SESSION_CONVERSATIONS} —
+ * the same ceiling a session's conversations are created under, so the
+ * listing can never be truncated by anything the cap didn't already permit
+ * to exist (issue #2262 finding 4 — no unbounded `db.select()` feeding model
+ * context).
+ *
+ * DELIBERATE metadata exposure (issue #2262 finding 6): this lists EVERY
+ * active conversation in the session — including siblings the CALLER did not
+ * spawn and does not own — by title and agent, to whichever member's agent
+ * asks. That is shared-workspace semantics, not a leak: a session is one
+ * shared sandbox and filesystem by design, so knowing what else is running
+ * there is the same visibility a human teammate has glancing at the sidebar.
+ * What stays owner-gated is TRANSCRIPT content — `read_session` still requires
+ * `openOwnSession`'s ownership check, so seeing a sibling listed here grants
+ * no access to what it said.
  */
 async function listSessionWorkers({
   workspaceSessionId,
@@ -272,7 +298,8 @@ async function listSessionWorkers({
       .from(conversations)
       .leftJoin(pages, eq(pages.id, conversations.contextId))
       .where(and(eq(conversations.sessionId, workspaceSessionId), eq(conversations.isActive, true)))
-      .orderBy(desc(conversations.createdAt)),
+      .orderBy(desc(conversations.createdAt))
+      .limit(MAX_SESSION_CONVERSATIONS),
     listShells(workspaceSessionId),
   ]);
 
@@ -367,7 +394,22 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
         // A worker conversation never "ends" — its session might, which the
         // dispatch surfaces as a failed run rather than a dead address.
         endedAt: null,
+        // The WORKSPACE this conversation is bound to (conversations.sessionId
+        // — the agent_sessions.id FK), or null for a session-less thread.
+        // Compared against the CALLER's own workspace in openOwnSession
+        // (issue #2262 finding 1): ownership of the row alone is not enough,
+        // because a user's own conversation in a DIFFERENT session must still
+        // refuse — exactly what shells already enforce via findOwnWorkspace.
+        workspaceSessionId: conversation.sessionId,
       };
+    },
+
+    countSessionConversations: async (workspaceSessionId) => {
+      const [row] = await db
+        .select({ n: count() })
+        .from(conversations)
+        .where(and(eq(conversations.sessionId, workspaceSessionId), eq(conversations.isActive, true)));
+      return row?.n ?? 0;
     },
 
     countActiveSessions: async (ownerId) => {
@@ -424,7 +466,20 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           title: name,
         });
       } catch (error) {
-        return { ok: false, reason: 'conversation_unavailable', detail: error instanceof Error ? error.message : String(error) };
+        // A FIXED message per known cause, never the raw driver/error string
+        // (issue #2262 finding 3): a database error's text is an internal
+        // implementation detail, not something a model should read or repeat.
+        // The real error is logged server-side for whoever debugs the denial.
+        if (error instanceof SessionFullError) {
+          return { ok: false, reason: 'session_full', detail: 'This session already has its maximum number of conversations.' };
+        }
+        if (error instanceof AgentNotInSessionDriveError) {
+          return { ok: false, reason: 'conversation_unavailable', detail: 'That agent belongs to a different drive than this session.' };
+        }
+        if (!(error instanceof ConversationUnavailableError)) {
+          loggers.ai.error('createWorkerSession: could not create the worker conversation', error instanceof Error ? error : undefined, { sessionId, callerConversationId, ownerId });
+        }
+        return { ok: false, reason: 'conversation_unavailable', detail: 'That conversation id is not available.' };
       }
       return { ok: true };
     },

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -29,15 +29,20 @@
  * no DB, no SDK, unit-tested with fakes; production wiring lives in
  * `session-tools-runtime.ts`.
  *
- * ADDRESSING RULE, stated once: a session verb only ever acts on a session the
- * CALLER OWNS, and a shell verb only ever acts on a shell of the caller's OWN
- * session. There is no cross-user (or cross-session) reach to authorize away.
+ * ADDRESSING RULE, stated once: a session verb only ever acts on a
+ * conversation the CALLER OWNS that ALSO lives in the caller's OWN workspace
+ * session, and a shell verb only ever acts on a shell of that same workspace
+ * (issue #2262 finding 1 — ownership alone is not enough: `openOwnSession`
+ * resolves the caller's workspace via `findOwnWorkspace` and compares it
+ * against the target's, exactly as `openOwnShell` already did). There is no
+ * cross-user, cross-session, or cross-drive reach to authorize away.
  */
 
 import { tool, type Tool } from 'ai';
 import { z } from 'zod';
 import {
   MAX_AGENT_DEPTH,
+  MAX_SESSION_CONVERSATIONS,
   planSpawnWorkerSession,
 } from '@pagespace/lib/agent-sessions/plan-spawn-session';
 import type { SandboxStatus, ShellDTO } from '@pagespace/lib/agent-sessions/contract';
@@ -160,6 +165,15 @@ export interface SessionToolRow {
   agentPageId: string | null;
   name: string;
   endedAt: string | null;
+  /**
+   * The WORKSPACE (agent_sessions.id) this conversation is bound to, or null
+   * for a session-less conversation. Compared against the CALLER's own
+   * workspace so a worker verb only ever reaches a sibling in the caller's own
+   * session — ownership of the row alone is not enough (issue #2262 finding
+   * 1): a user's OWN conversation in a DIFFERENT session must still refuse,
+   * exactly as shells already require via `findOwnWorkspace`.
+   */
+  workspaceSessionId: string | null;
 }
 
 export type DispatchOutcome =
@@ -209,6 +223,13 @@ export interface SessionToolsDeps {
   countActiveSessions: (ownerId: string) => Promise<number>;
   /** The owner's concurrency ceiling. */
   concurrencyLimit: (ownerId: string) => Promise<number>;
+  /**
+   * ACTIVE conversations already living in the caller's session — what a spawn
+   * actually mints, and what `MAX_SESSION_CONVERSATIONS` bounds. A required
+   * dep, not optional: the sandbox-concurrency inputs above count VMs, which a
+   * worker spawn never creates, so without this the mint is unbounded.
+   */
+  countSessionConversations: (workspaceSessionId: string) => Promise<number>;
   /**
    * Whether the CALLER may spawn a worker under this agent page — the same
    * view permission any agent consult requires. Never called for null (global).
@@ -334,12 +355,22 @@ function truncateTranscriptMessage(content: string): string {
     : `${content.slice(0, MAX_TRANSCRIPT_MESSAGE_CHARS)}\n… [truncated — this message is longer than read_session returns]`;
 }
 
-const SPAWN_DENIALS: Record<'invalid_name' | 'missing_prompt' | 'depth_exceeded' | 'concurrency_exceeded', string> = {
+const SPAWN_DENIALS: Record<
+  'invalid_name' | 'missing_prompt' | 'depth_exceeded' | 'concurrency_exceeded' | 'session_full',
+  string
+> = {
   invalid_name: 'The worker needs a usable display name (1–200 characters).',
   missing_prompt: 'A worker session must be spawned WITH work — pass a non-empty prompt.',
   depth_exceeded: `This conversation is already ${MAX_AGENT_DEPTH} agent-dispatches deep, and a chain may not go deeper. Do the work here, or report back to the agent at the top of the chain.`,
+  // Truthful about the remedy (issue #2262 finding 2): kill_session only aborts
+  // a WORKER's in-flight run in the caller's OWN session — it tears down no
+  // sandbox and frees no counted slot, so the old copy's advice to call it and
+  // retry accomplished nothing. Freeing a slot means ending a whole SESSION
+  // (its sandbox), which is a workspace-lifecycle action outside this tool
+  // family's own reach — there is no tool here to point the caller at.
   concurrency_exceeded:
-    'You are at your concurrent session limit. Kill a session you no longer need (kill_session) and retry.',
+    'You are at your concurrent sandbox limit — a different session of yours must end (its sandbox stopped) before another can start. This cannot be done from here; report the limit rather than retrying.',
+  session_full: `This session already has ${MAX_SESSION_CONVERSATIONS} conversations, its maximum. Reuse an existing worker (send_session) instead of spawning another.`,
 };
 
 const DEPTH_DENIAL = {
@@ -379,7 +410,14 @@ export function createSessionTools(deps: SessionToolsDeps): {
   read_shell: Tool;
   kill_shell: Tool;
 } {
-  /** A session verb's shared open: the row must exist and be the CALLER's own. */
+  /**
+   * A session verb's shared open: the row must exist, be the CALLER's own,
+   * AND be a sibling in the CALLER's own workspace session (issue #2262
+   * finding 1 — H2 parity: ownership alone let a worker verb reach any
+   * conversation the calling user owned, including other sessions, other
+   * drives, or session-less threads; mirrors `openOwnShell`'s workspace
+   * comparison).
+   */
   const openOwnSession = async (
     context: ToolExecutionContext | undefined,
     sessionId: string,
@@ -389,11 +427,22 @@ export function createSessionTools(deps: SessionToolsDeps): {
   > => {
     const actor = readActor(context);
     if (!actor) return { ok: false, error: NEEDS_AUTH };
+    const conversationId = context?.conversationId;
+    if (!conversationId) return { ok: false, error: NEEDS_CONVERSATION };
+    const workspace = await deps.findOwnWorkspace(conversationId);
+    if (!workspace) return { ok: false, error: notYourSession(sessionId) };
     const row = await deps.findSession(sessionId);
-    // Someone else's session and a nonexistent one read identically — there is
-    // nothing to learn from the difference and nothing the caller could do
-    // with it.
-    if (!row || row.ownerId !== actor.userId) return { ok: false, error: notYourSession(sessionId) };
+    // Someone else's session, a nonexistent one, and a session outside the
+    // caller's own workspace all read identically — there is nothing to learn
+    // from the difference and nothing the caller could do with it.
+    if (
+      !row ||
+      row.ownerId !== actor.userId ||
+      row.workspaceSessionId === null ||
+      row.workspaceSessionId !== workspace.sessionId
+    ) {
+      return { ok: false, error: notYourSession(sessionId) };
+    }
     return { ok: true, actor, row };
   };
 
@@ -450,7 +499,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
             sandbox: 'none' as const,
             workers: [],
             shells: [],
-            note: 'This conversation has no session, so there are no workers or shells. spawn_session or spawn_shell will start its session.',
+            note: 'This conversation has no session, so there are no workers or shells, and spawn_session/spawn_shell will refuse here too — sessions are not started lazily from a plain conversation.',
           };
         }
         const listing = await deps.listSessionWorkers({
@@ -471,10 +520,20 @@ export function createSessionTools(deps: SessionToolsDeps): {
         const context = readContext(options);
         const actor = readActor(context);
         if (!actor) return NEEDS_AUTH;
+        const callerConversationId = context?.conversationId;
+        if (!callerConversationId) return NEEDS_CONVERSATION;
 
-        const [activeSessionCount, concurrencyLimit] = await Promise.all([
+        // The session-level cap (issue #2262 finding 2) counts what a spawn
+        // actually mints — a conversation in THIS workspace — so it is read
+        // against the caller's own workspace, not the account-wide sandbox
+        // count above it. A caller whose conversation has no session yet
+        // reads as zero here; createWorkerSession refuses that case with its
+        // own truthful reason once the plan clears.
+        const workspace = await deps.findOwnWorkspace(callerConversationId);
+        const [activeSessionCount, concurrencyLimit, sessionConversationCount] = await Promise.all([
           deps.countActiveSessions(actor.userId),
           deps.concurrencyLimit(actor.userId),
+          workspace ? deps.countSessionConversations(workspace.sessionId) : Promise.resolve(0),
         ]);
         const plan = planSpawnWorkerSession({
           name,
@@ -483,6 +542,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
           callerDepth: readDepth(context),
           activeSessionCount,
           concurrencyLimit,
+          sessionConversationCount,
         });
         if (!plan.ok) {
           return { success: false, error: SPAWN_DENIALS[plan.reason], reason: plan.reason };
@@ -499,8 +559,6 @@ export function createSessionTools(deps: SessionToolsDeps): {
           };
         }
 
-        const callerConversationId = context?.conversationId;
-        if (!callerConversationId) return NEEDS_CONVERSATION;
         const sessionId = deps.newId();
         const created = await deps.createWorkerSession({
           sessionId,

--- a/packages/lib/src/agent-sessions/__tests__/plan-spawn-session.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/plan-spawn-session.test.ts
@@ -6,6 +6,7 @@ import {
   planSpawnWorkerSession,
   isValidShellName,
   MAX_AGENT_DEPTH,
+  MAX_SESSION_CONVERSATIONS,
   SHELL_LABEL_PREFIX,
   type PlanSpawnWorkerSessionInput,
 } from '../plan-spawn-session';
@@ -135,6 +136,7 @@ describe('planSpawnWorkerSession', () => {
       callerDepth: 0,
       activeSessionCount: 0,
       concurrencyLimit: 10,
+      sessionConversationCount: 0,
       ...overrides,
     };
   }
@@ -242,5 +244,39 @@ describe('planSpawnWorkerSession', () => {
       ok: false,
       reason: 'depth_exceeded',
     });
+  });
+
+  it('given a session already at the conversation ceiling, should reject — spawning MINTS a conversation', () => {
+    // The sandbox-concurrency inputs above count something a worker spawn never
+    // creates, so on their own they leave worker minting unbounded (issue
+    // #2262 finding 2). What a spawn actually mints is a conversation, and
+    // THIS is the input that counts it.
+    expect(planSpawnWorkerSession(input({ sessionConversationCount: MAX_SESSION_CONVERSATIONS }))).toEqual({
+      ok: false,
+      reason: 'session_full',
+    });
+    expect(
+      planSpawnWorkerSession(input({ sessionConversationCount: MAX_SESSION_CONVERSATIONS + 1 })),
+    ).toEqual({ ok: false, reason: 'session_full' });
+  });
+
+  it('given one conversation slot left, should allow', () => {
+    expect(planSpawnWorkerSession(input({ sessionConversationCount: MAX_SESSION_CONVERSATIONS - 1 })).ok).toBe(
+      true,
+    );
+  });
+
+  it('should report the account-level quota problem before the session-level one', () => {
+    expect(
+      planSpawnWorkerSession(
+        input({ activeSessionCount: 10, concurrencyLimit: 10, sessionConversationCount: MAX_SESSION_CONVERSATIONS }),
+      ),
+    ).toEqual({ ok: false, reason: 'concurrency_exceeded' });
+  });
+
+  it('should carry a conversation ceiling that matches the per-session listing cap', () => {
+    // 100 is also listSessionConversationsBulk's per-session cap: a session may
+    // never hold more conversations than its sidebar listing can show.
+    expect(MAX_SESSION_CONVERSATIONS).toBe(100);
   });
 });

--- a/packages/lib/src/agent-sessions/plan-spawn-session.ts
+++ b/packages/lib/src/agent-sessions/plan-spawn-session.ts
@@ -22,6 +22,16 @@
 /** Ported from `agent-communication-tools.ts` — the cap that stops agents recursing into each other forever. */
 export const MAX_AGENT_DEPTH = 2;
 
+/**
+ * The most ACTIVE conversations one session may hold — what a worker spawn (or
+ * an HTTP conversation-create) actually mints, and therefore the quantity its
+ * cap must count (the sandbox-concurrency inputs count VMs, which a spawn
+ * never creates — issue #2262 finding 2). 100 deliberately equals
+ * `listSessionConversationsBulk`'s per-session listing cap: a session can
+ * never hold more conversations than its sidebar listing can show.
+ */
+export const MAX_SESSION_CONVERSATIONS = 100;
+
 export const SHELL_LABEL_PREFIX = 'shell-';
 
 const MAX_SHELL_NAME_LENGTH = 100;
@@ -111,7 +121,10 @@ const MAX_SESSION_NAME_LENGTH = 200;
 
 export type PlanSpawnWorkerSessionResult =
   | { ok: true; name: string; prompt: string; agentId: string | null; childDepth: number }
-  | { ok: false; reason: 'invalid_name' | 'missing_prompt' | 'depth_exceeded' | 'concurrency_exceeded' };
+  | {
+      ok: false;
+      reason: 'invalid_name' | 'missing_prompt' | 'depth_exceeded' | 'concurrency_exceeded' | 'session_full';
+    };
 
 export interface PlanSpawnWorkerSessionInput {
   /** A free display label. Any characters; only blank or absurdly long is refused. */
@@ -126,6 +139,13 @@ export interface PlanSpawnWorkerSessionInput {
   activeSessionCount: number;
   /** The owner's tier concurrency ceiling. */
   concurrencyLimit: number;
+  /**
+   * ACTIVE conversations already living in the caller's session — the quantity
+   * a spawn actually mints, compared against `MAX_SESSION_CONVERSATIONS`.
+   * Required: without it the only spawn cap counts sandboxes, which a worker
+   * spawn never creates, and worker minting is unbounded.
+   */
+  sessionConversationCount: number;
   /** Accepted and ignored for uniqueness — worker names are free labels. Present so callers need no special case. */
   existingNames?: readonly string[];
 }
@@ -137,6 +157,7 @@ export function planSpawnWorkerSession({
   callerDepth,
   activeSessionCount,
   concurrencyLimit,
+  sessionConversationCount,
 }: PlanSpawnWorkerSessionInput): PlanSpawnWorkerSessionResult {
   const trimmedPrompt = prompt.trim();
   if (trimmedPrompt.length === 0) return { ok: false, reason: 'missing_prompt' };
@@ -150,7 +171,11 @@ export function planSpawnWorkerSession({
   // caller's bug and stays a bug at any quota, whereas a quota denial is a
   // transient condition the caller can retry.
   if (callerDepth >= MAX_AGENT_DEPTH) return { ok: false, reason: 'depth_exceeded' };
+  // Account-level ceiling before the session-level one: the account problem is
+  // the broader condition, and its remedy (a whole session ending) is different
+  // from the session-full remedy (reuse an existing worker).
   if (activeSessionCount >= concurrencyLimit) return { ok: false, reason: 'concurrency_exceeded' };
+  if (sessionConversationCount >= MAX_SESSION_CONVERSATIONS) return { ok: false, reason: 'session_full' };
 
   return { ok: true, name: trimmedName, prompt: trimmedPrompt, agentId, childDepth: callerDepth + 1 };
 }


### PR DESCRIPTION
## Summary

Full fix for issue #2262 — the six findings from the post-merge audit of PR #2258's session-tools slice (`apps/web/src/lib/ai/tools/session-tools*.ts`, `apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts`):

1. **Workspace scoping (MEDIUM, security).** `send_session`/`read_session`/`kill_session` now resolve the caller's own workspace (`findOwnWorkspace`) and require the target conversation's `sessionId` binding to match it — mirroring `openOwnShell`'s existing check. Previously ownership of the conversation row alone was sufficient, so a prompt-injected agent could reach any conversation its user owned: a different session, a different drive, or a session-less thread — and exfiltrate a transcript or dispatch turns into a foreign sandbox.
2. **Per-session conversation cap.** `planSpawnWorkerSession` takes a required `sessionConversationCount` input and enforces `MAX_SESSION_CONVERSATIONS` (100). The same cap is enforced as a backstop inside `createConversationInSessionWith` — the one write path both HTTP conversation-create routes and the tool's spawn dep funnel through — so worker minting is bounded on the tool path AND the HTTP path. New `SessionFullError` / `sessionConversationLimitExceeded` (429), with truthful denial copy (the old `concurrency_exceeded` message told callers to `kill_session`, which frees no counted slot).
3. **No raw error strings into model context.** The worker-dispatch fetch failure and worker-create catch now return fixed messages; the real error is logged server-side.
4. **SQL-bounded listings.** `listSessionWorkers` gets a `LIMIT`; `listSessionConversationsBulk` is bounded via a `ROW_NUMBER() OVER (PARTITION BY sessionId ...)` window filter (preserving per-session fairness, which a flat `LIMIT` would lose) instead of pulling the full row set into JS before capping it.
5. **Truthful guidance.** `list_sessions`' no-session note no longer claims `spawn_session`/`spawn_shell` will start a session — both refuse there too, post-unconflation.
6. **Documented exposure decision.** The shared-session metadata semantics (session members' agents see titles/activity of all conversations in the session; transcripts stay owner-gated) are now written down as deliberate, at the two query sites.

## Test plan
- [x] New tests in `session-tools.test.ts` pin: cross-session-same-owner refusal, session-less-target refusal, session-less-caller refusal — identical failure shape to a nonexistent session.
- [x] New tests in `plan-spawn-session.test.ts` pin the conversation-cap ordering (account cap before session cap) and the ceiling value.
- [x] New tests in `create-conversation-in-session.test.ts` pin the HTTP-path cap, including that an idempotent retry at the ceiling is still allowed through.
- [x] `bun run typecheck && bun run lint && bun run test:unit && bun run knip:check` all pass.
- [x] `bun run test:security` — 44/50 suites pass; the 6 failures (Session Service, Device Auth Utilities, Permissions, Login/Signup/Mobile-Login Routes) are pre-existing `test-security.sh` path/config drift unrelated to this change (confirmed unchanged vs `origin/master`, and touching none of the files in this diff).
- [x] `cd packages/lib && bun run typecheck` passes.

Closes #2262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANkaVygvTgwLNwe6y9UGtT