### PR TITLE
fix(agents): auth-loading capability race, quota-vs-capability surfacing, sidebar polish

### DIFF
--- a/apps/web/src/app/api/agent-sessions/[sessionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/__tests__/route.test.ts
@@ -106,10 +106,26 @@ describe('POST /api/agent-sessions/[sessionId]', () => {
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
   });
 
-  it('given a PLAN-LIMIT refusal, should 429 — not the 403 an authorization failure gets', async () => {
-    mockProvisionSessionSandbox.mockResolvedValue({ ok: false, reason: 'denied', denial: 'session_limit_reached' });
+  it('given a PLAN-LIMIT refusal, should 429 with the human sentence — not the provisioner\'s diagnostic enum', async () => {
+    // `detail: 'concurrency_limit'` is the REAL shape `checkAgentSessionConcurrency`
+    // returns — a diagnostic enum, not a sentence. It must reach the audit row
+    // and never the response body (PR #2253's live P1).
+    mockProvisionSessionSandbox.mockResolvedValue({
+      ok: false,
+      reason: 'denied',
+      denial: 'session_limit_reached',
+      detail: 'concurrency_limit',
+    });
     const response = await post();
     expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.error).not.toContain('concurrency_limit');
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({ reasonCode: 'concurrency_limit' }),
+      }),
+    );
   });
 
   it('given a provisioning denial, should 403 with the audit trail', async () => {

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/route.ts
@@ -105,7 +105,9 @@ export async function POST(request: Request, context: RouteContext) {
       // A plan-limit refusal is not an access denial — separate response and
       // separate audit event (see quotaExceeded).
       if (provisioned.denial === 'session_limit_reached') {
-        return sessionQuotaExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]', provisioned.detail);
+        return sessionQuotaExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]', {
+          reasonCode: provisioned.detail,
+        });
       }
       return denied(request, auth.userId, sessionId, provisioned.denial ?? 'denied');
     }

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/shells/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/shells/__tests__/route.test.ts
@@ -189,16 +189,25 @@ describe('POST /api/agent-sessions/[sessionId]/shells', () => {
     // their ceiling is not filed as data-access forensics), and the route tag,
     // which became a PARAMETER when the duplicated helper was extracted and can
     // therefore now be passed wrong.
+    //
+    // `detail: 'concurrency_limit'` here is the REAL shape `checkAgentSessionConcurrency`
+    // returns (packages/lib/src/services/sandbox/quota.ts) — a diagnostic enum,
+    // not a sentence. A mock without it (as this test previously had) hid the P1
+    // where that enum was rendered verbatim as `body.error` (PR #2253).
     mockProvisionSessionSandbox.mockResolvedValue({
       ok: false,
       reason: 'denied',
       denial: 'session_limit_reached',
+      detail: 'concurrency_limit',
     });
 
     const response = await post({});
 
     expect(response.status).toBe(429);
-    expect((await response.json()).error).toContain('sandbox');
+    const body = await response.json();
+    expect(body.error).toContain('sandbox');
+    // The diagnostic enum must never leak into what the user reads.
+    expect(body.error).not.toContain('concurrency_limit');
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -206,6 +215,8 @@ describe('POST /api/agent-sessions/[sessionId]/shells', () => {
         details: expect.objectContaining({
           reason: 'session_limit_reached',
           route: 'agent-sessions/[sessionId]/shells',
+          // ...but IS still recorded, for diagnosis — just in the audit row.
+          reasonCode: 'concurrency_limit',
         }),
       }),
     );

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/shells/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/shells/route.ts
@@ -113,7 +113,9 @@ export async function POST(request: Request, context: RouteContext) {
       // A plan-limit refusal is not an access denial — separate response and
       // separate audit event (see quotaExceeded).
       if (provisioned.denial === 'session_limit_reached') {
-        return sessionQuotaExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]/shells', provisioned.detail);
+        return sessionQuotaExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]/shells', {
+          reasonCode: provisioned.detail,
+        });
       }
       return denied(request, auth.userId, sessionId, provisioned.denial ?? 'denied');
     }

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -191,13 +191,9 @@ export async function POST(request: Request) {
 
   const activeCount = await countActiveSessionsForOwner(auth.userId);
   if (activeCount >= MAX_ACTIVE_SESSIONS_PER_OWNER) {
-    return sessionQuotaExceeded(
-      request,
-      auth.userId,
-      'about-to-be-minted',
-      'agent-sessions',
-      `You have ${activeCount} active sessions — end some before starting more.`,
-    );
+    return sessionQuotaExceeded(request, auth.userId, 'about-to-be-minted', 'agent-sessions', {
+      message: `You have ${activeCount} active sessions — end some before starting more.`,
+    });
   }
 
   const access = await checkAccessForSubject(auth.userId, {

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -69,7 +69,7 @@ export interface AgentPageViewProps {
 }
 
 export default function AgentPageView({ page }: AgentPageViewProps) {
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
   // The same gate every session surface uses — the server still decides
   // (drive membership + code-execution) on every spawn.
   const canUseSessions = user?.role === 'admin';
@@ -77,6 +77,10 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   const { resolved: initialResolved } = useResolvedConversation(page.id, {
     driveId: page.driveId,
     canUseSessions,
+    // A hard refresh starts `user` (and so `canUseSessions`) undefined/false
+    // before the role loads — resolving then would mint the agent's first
+    // conversation as permanently session-less. Wait it out.
+    authLoading,
   });
   const [override, setOverride] = useState<ResolvedConversation | null>(null);
   // The conversation on screen: the user's own switching (history select, new,

--- a/apps/web/src/components/agents/__tests__/spawn-refusal.test.ts
+++ b/apps/web/src/components/agents/__tests__/spawn-refusal.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The spawn-refusal classification — the pure decision behind the page's
+ * fallback to a plain conversation. What matters: a QUOTA refusal (429) is the
+ * one the user must HEAR about (they hold the capability and merely ran out of
+ * allowance — silence reads as a permissions problem), while every other
+ * refusal is the by-design silent degrade ("no workspace for you" is never
+ * "no conversation").
+ */
+import { describe, it, expect } from 'vitest';
+
+import { classifySpawnRefusal } from '../spawn-refusal';
+
+describe('classifySpawnRefusal', () => {
+  it("a 429 is a QUOTA refusal, carrying the server's own message", () => {
+    const refusal = classifySpawnRefusal(429, 'You have 100 active sessions — end some before starting more.');
+    expect(refusal.kind).toBe('quota');
+    expect(refusal.message).toBe('You have 100 active sessions — end some before starting more.');
+  });
+
+  it('a 429 with no readable body still explains itself', () => {
+    const refusal = classifySpawnRefusal(429, null);
+    expect(refusal.kind).toBe('quota');
+    expect(refusal.message.length).toBeGreaterThan(0);
+  });
+
+  it('a 403 is a capability refusal — the silent degrade', () => {
+    const refusal = classifySpawnRefusal(403, 'Insufficient permissions to use this agent');
+    expect(refusal.kind).toBe('capability');
+    expect(refusal.message).toBe('Insufficient permissions to use this agent');
+  });
+
+  it('an unexpected failure (5xx) counts as capability, never quota', () => {
+    // "Could not have a workspace right now" and "not allowed one" degrade the
+    // same way; only the allowance case earns the interruption.
+    expect(classifySpawnRefusal(502, null).kind).toBe('capability');
+    expect(classifySpawnRefusal(500, 'Could not start a session').kind).toBe('capability');
+  });
+});

--- a/apps/web/src/components/agents/__tests__/usePermissionsCheck.test.ts
+++ b/apps/web/src/components/agents/__tests__/usePermissionsCheck.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The agent page's read-only gate. Fail-open to editable is the documented
+ * intent (the server enforces regardless) — so the property worth pinning is
+ * that fail-open holds PER PAGE: one page's read-only verdict must never leak
+ * onto the next page when that page's own check errors out.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockFetchWithAuth = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+}));
+
+import { usePermissionsCheck } from '../usePermissionsCheck';
+
+const respondCanEdit = (canEdit: boolean) =>
+  mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ canEdit }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePermissionsCheck', () => {
+  it('reports read-only when the viewer cannot edit the page', async () => {
+    respondCanEdit(false);
+    const { result } = renderHook(() => usePermissionsCheck('page-1', 'user-1'));
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('reports editable when the viewer can edit', async () => {
+    respondCanEdit(true);
+    const { result } = renderHook(() => usePermissionsCheck('page-1', 'user-1'));
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/pages/page-1/permissions/check'));
+    expect(result.current).toBe(false);
+  });
+
+  it('fails open to editable when the check errors', async () => {
+    mockFetchWithAuth.mockRejectedValue(new Error('down'));
+    const { result } = renderHook(() => usePermissionsCheck('page-1', 'user-1'));
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+
+  it("a page change starts from editable again — the previous page's verdict must not leak", async () => {
+    respondCanEdit(false);
+    const { result, rerender } = renderHook(
+      ({ pageId }) => usePermissionsCheck(pageId, 'user-1'),
+      { initialProps: { pageId: 'page-1' } },
+    );
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // The NEXT page's check errors: fail-open must win, not the stale `true`.
+    mockFetchWithAuth.mockRejectedValue(new Error('down'));
+    rerender({ pageId: 'page-2' });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('makes no check without a user, and stays editable', () => {
+    const { result } = renderHook(() => usePermissionsCheck('page-1', undefined));
+    expect(result.current).toBe(false);
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/agents/__tests__/useResolvedConversation.test.ts
+++ b/apps/web/src/components/agents/__tests__/useResolvedConversation.test.ts
@@ -2,9 +2,12 @@
  * The page's conversation resolution, now session-aware: resolution carries
  * `{conversationId, sessionId}` because the Chat tab renders a session-bound
  * thread as a pane grid and a plain one as the plain chat. What matters most:
- * the CAPABILITY SPLIT (session users spawn, everyone else creates plain) and
- * the FALLBACK (a refused spawn degrades to a plain conversation — the page
- * must never fail to open over a workspace it merely could not have).
+ * the CAPABILITY SPLIT (session users spawn, everyone else creates plain), the
+ * FALLBACK (a refused spawn degrades to a plain conversation — the page must
+ * never fail to open over a workspace it merely could not have), the
+ * AUTH-LOADING GATE (a hard refresh must never mint a permanently
+ * session-less first conversation while the role is still unknown), and the
+ * QUOTA-vs-CAPABILITY split in how a refusal is surfaced.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -20,15 +23,30 @@ vi.mock('@/hooks/conversationMessagesActions', () => ({
 }));
 
 const mockPost = vi.hoisted(() => vi.fn());
+const { MockApiRequestError } = vi.hoisted(() => ({
+  MockApiRequestError: class MockApiRequestError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'ApiRequestError';
+      this.status = status;
+    }
+  },
+}));
 vi.mock('@/lib/auth/auth-fetch', () => ({
   post: (...args: unknown[]) => mockPost(...args),
   fetchWithAuth: vi.fn(),
+  ApiRequestError: MockApiRequestError,
 }));
 
-import { useResolvedConversation, createPageConversation } from '../useResolvedConversation';
+const mockToastError = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({ toast: { error: mockToastError } }));
 
-const OPTS = { driveId: 'drive-1', canUseSessions: false };
-const SESSION_OPTS = { driveId: 'drive-1', canUseSessions: true };
+import { useResolvedConversation, createPageConversation } from '../useResolvedConversation';
+import { ApiRequestError } from '@/lib/auth/auth-fetch';
+
+const OPTS = { driveId: 'drive-1', canUseSessions: false, authLoading: false };
+const SESSION_OPTS = { driveId: 'drive-1', canUseSessions: true, authLoading: false };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -100,6 +118,83 @@ describe('useResolvedConversation', () => {
     await waitFor(() => expect(result.current.resolved).not.toBeNull());
     expect(result.current.resolved?.sessionId).toBeNull();
     expect(agentConversations.createAgentConversation).toHaveBeenCalled();
+  });
+
+  it('a CAPABILITY refusal (403) falls back silently — no toast', async () => {
+    agentConversations.fetchMostRecentAgentConversation.mockResolvedValue(null);
+    mockPost.mockRejectedValue(new ApiRequestError('Insufficient permissions to use this agent', 403));
+
+    const { result } = renderHook(() => useResolvedConversation('agent-1', SESSION_OPTS));
+
+    await waitFor(() => expect(result.current.resolved).not.toBeNull());
+    expect(result.current.resolved?.sessionId).toBeNull();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it('a QUOTA refusal (429) surfaces distinctly from the silent capability degrade', async () => {
+    // The caller HAS the capability and simply ran out of allowance — worth
+    // interrupting them for, unlike every other refusal.
+    agentConversations.fetchMostRecentAgentConversation.mockResolvedValue(null);
+    mockPost.mockRejectedValue(
+      new ApiRequestError('You have 100 active sessions — end some before starting more.', 429),
+    );
+
+    const { result } = renderHook(() => useResolvedConversation('agent-1', SESSION_OPTS));
+
+    await waitFor(() => expect(result.current.resolved).not.toBeNull());
+    expect(result.current.resolved?.sessionId).toBeNull();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Workspace unavailable — plain chat',
+      expect.objectContaining({ description: expect.stringContaining('100 active sessions') }),
+    );
+  });
+
+  it('while auth is still loading, resolution WAITS — then creates WITH the session capability once it resolves', async () => {
+    // Key acceptance case: a hard refresh must never mint an admin's first
+    // conversation session-less just because the role hasn't loaded yet.
+    agentConversations.fetchMostRecentAgentConversation.mockResolvedValue(null);
+    mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, conversationId: 'conv-new' });
+
+    const { result, rerender } = renderHook(
+      ({ authLoading, canUseSessions }: { authLoading: boolean; canUseSessions: boolean }) =>
+        useResolvedConversation('agent-1', { driveId: 'drive-1', canUseSessions, authLoading }),
+      { initialProps: { authLoading: true, canUseSessions: false } },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(agentConversations.fetchMostRecentAgentConversation).not.toHaveBeenCalled();
+
+    // Auth settles: the caller now knows the admin role.
+    rerender({ authLoading: false, canUseSessions: true });
+
+    await waitFor(() => expect(result.current.resolved?.sessionId).toBe('ses-new'));
+    expect(result.current.resolved?.conversationId).toBe('conv-new');
+    expect(agentConversations.createAgentConversation).not.toHaveBeenCalled();
+  });
+
+  it('a later authLoading blip does not re-resolve an already-settled agent', async () => {
+    agentConversations.fetchMostRecentAgentConversation.mockResolvedValue({
+      id: 'conv-recent',
+      sessionId: 'ses-1',
+    });
+
+    const { result, rerender } = renderHook(
+      ({ authLoading }: { authLoading: boolean }) =>
+        useResolvedConversation('agent-1', { ...OPTS, authLoading }),
+      { initialProps: { authLoading: false } },
+    );
+
+    await waitFor(() => expect(result.current.resolved?.conversationId).toBe('conv-recent'));
+    expect(agentConversations.fetchMostRecentAgentConversation).toHaveBeenCalledTimes(1);
+
+    // A token-refresh-shaped loading blip, for the SAME agent, must not
+    // restart resolution and clobber the conversation the user is in.
+    rerender({ authLoading: true });
+    rerender({ authLoading: false });
+
+    expect(agentConversations.fetchMostRecentAgentConversation).toHaveBeenCalledTimes(1);
+    expect(result.current.resolved?.conversationId).toBe('conv-recent');
   });
 
   it('reports isLoading true until resolution settles', async () => {

--- a/apps/web/src/components/agents/spawn-refusal.ts
+++ b/apps/web/src/components/agents/spawn-refusal.ts
@@ -1,0 +1,34 @@
+/**
+ * Classifies why a session spawn was refused, so the caller can treat the two
+ * cases differently:
+ *
+ * - **quota** (429): the caller HAS the capability and simply ran out of
+ *   allowance — worth interrupting them for, since it's actionable ("end a
+ *   session").
+ * - **capability** (everything else — 403 membership/role, 5xx, network): the
+ *   by-design silent degrade. A session owns a sandbox, and a user (or a
+ *   moment — e.g. a role that hasn't loaded yet) without that surface must
+ *   still be able to chat, without a refusal toast on every visit.
+ *
+ * Pure and side-effect free so the split is unit-testable without mocking
+ * fetch or toast.
+ */
+
+export type SpawnRefusalKind = 'quota' | 'capability';
+
+export interface SpawnRefusal {
+  kind: SpawnRefusalKind;
+  message: string;
+}
+
+const DEFAULT_QUOTA_MESSAGE =
+  "Your plan's limit for running sandboxes is already in use — stop one before starting another.";
+const DEFAULT_CAPABILITY_MESSAGE = 'Workspace unavailable — continuing with a plain chat.';
+
+export function classifySpawnRefusal(status: number | undefined, message: string | null | undefined): SpawnRefusal {
+  const trimmed = message?.trim();
+  if (status === 429) {
+    return { kind: 'quota', message: trimmed && trimmed.length > 0 ? trimmed : DEFAULT_QUOTA_MESSAGE };
+  }
+  return { kind: 'capability', message: trimmed && trimmed.length > 0 ? trimmed : DEFAULT_CAPABILITY_MESSAGE };
+}

--- a/apps/web/src/components/agents/usePermissionsCheck.ts
+++ b/apps/web/src/components/agents/usePermissionsCheck.ts
@@ -12,6 +12,11 @@ export function usePermissionsCheck(pageId: string, userId: string | undefined):
   const [isReadOnly, setIsReadOnly] = useState(false);
 
   useEffect(() => {
+    // Fail-open for THIS page from the start — a previous page's `true` must
+    // never survive into a page whose own check hasn't answered yet (or
+    // errors out), since that reads as this page being read-only when it was
+    // simply never checked.
+    setIsReadOnly(false);
     if (!userId) return;
     let cancelled = false;
     (async () => {

--- a/apps/web/src/components/agents/useResolvedConversation.ts
+++ b/apps/web/src/components/agents/useResolvedConversation.ts
@@ -22,13 +22,21 @@
  * Only the INITIAL value: once resolved, the caller owns switching
  * conversations (history select, new, delete) as plain local state — this
  * hook never re-resolves for an agentId it has already settled.
+ *
+ * `authLoading` gates the FIRST resolve: on a hard refresh `useAuth` starts
+ * out loading, so `canUseSessions` reads as false before the role is known.
+ * Resolving anyway would mint a fresh agent's first conversation as a PLAIN
+ * one — and thread→session binding is congenital and permanent, so that
+ * conversation could never gain a grid afterward. Waiting costs nothing: the
+ * caller is already rendering its own loading state for an unresolved auth.
  */
 import { useEffect, useRef, useState } from 'react';
 import { createId } from '@paralleldrive/cuid2';
 import { fetchMostRecentAgentConversation, createAgentConversation } from '@/lib/ai/shared/agent-conversations';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
-import { post } from '@/lib/auth/auth-fetch';
+import { post, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
+import { classifySpawnRefusal } from './spawn-refusal';
 
 export interface ResolvedConversation {
   conversationId: string;
@@ -83,8 +91,16 @@ export async function createPageConversation({
     } catch (error) {
       // The role gate is a cheap client-side approximation; the server's
       // access decision (drive membership + code-execution) is the truth.
-      // A refusal means "no workspace for you", not "no conversation".
+      // A refusal means "no workspace for you", not "no conversation" — but
+      // QUOTA is worth interrupting the user for (they have the capability
+      // and simply ran out of allowance); every other refusal degrades
+      // silently, the same as a role that hasn't loaded yet.
+      const status = error instanceof ApiRequestError ? error.status : undefined;
+      const refusal = classifySpawnRefusal(status, error instanceof Error ? error.message : null);
       console.warn('Session spawn refused; falling back to a plain conversation:', error);
+      if (refusal.kind === 'quota') {
+        toast.error('Workspace unavailable — plain chat', { description: refusal.message });
+      }
     }
   }
 
@@ -96,7 +112,7 @@ export async function createPageConversation({
 
 export function useResolvedConversation(
   agentId: string,
-  { driveId, canUseSessions }: { driveId: string; canUseSessions: boolean },
+  { driveId, canUseSessions, authLoading }: { driveId: string; canUseSessions: boolean; authLoading: boolean },
 ): UseResolvedConversationResult {
   const [resolved, setResolved] = useState<ResolvedConversation | null>(null);
   const resolvingAgentIdRef = useRef<string | null>(null);
@@ -106,8 +122,25 @@ export function useResolvedConversation(
   canUseSessionsRef.current = canUseSessions;
   const driveIdRef = useRef(driveId);
   driveIdRef.current = driveId;
+  // The agentId resolution has already been KICKED OFF for. `authLoading` is
+  // in the effect's deps only so a still-loading mount can wait for it once —
+  // not so every later loading blip (token refresh, forced reload) restarts
+  // resolution and clobbers a conversation the user is already typing into.
+  const startedForAgentIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    // `user` (and so `canUseSessions`) is undefined/false while auth is still
+    // loading. Resolving now would mint a fresh agent's first conversation as
+    // a PLAIN one — and thread→session binding is congenital and permanent,
+    // so a hard refresh could never give it a grid afterward. Wait it out;
+    // the ref above already guarantees the capability read at resolve time is
+    // the settled one.
+    if (authLoading) return;
+    // Already started (or finished) for this exact agent — a later
+    // authLoading flip is not a reason to redo it.
+    if (startedForAgentIdRef.current === agentId) return;
+    startedForAgentIdRef.current = agentId;
+
     resolvingAgentIdRef.current = agentId;
     setResolved(null);
 
@@ -149,7 +182,7 @@ export function useResolvedConversation(
       }
     };
     void resolve();
-  }, [agentId]);
+  }, [agentId, authLoading]);
 
   return { resolved, isLoading: resolved === null };
 }

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -23,6 +23,7 @@ import { usePageAgents, type DriveWithAgents } from '@/hooks/page-agents/usePage
 import { useAgentSurfaceStore, SHEET_BREAKPOINT_QUERY } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+import { groupSessionsByDrive, ASSISTANT_GROUP_KEY } from './session-groups';
 
 /**
  * The Agents console's left sidebar: **Drive → Session → conversations.**
@@ -222,23 +223,17 @@ function SessionList({
   // fetch, though: an offer to spawn under a spinner would remount mid-click.
   const showEmptyAssistantGroup = !driveId && canSpawn && !isLoading && !(hasError && sessions.length === 0);
 
-  // Group by drive in global mode (Assistant first — it is the user's own);
-  // a single implicit group in drive mode.
+  // Group by drive in global mode (Assistant first — it is the user's own,
+  // sorted there deterministically rather than by fetch order); a single
+  // implicit group in drive mode.
   const groups = useMemo(() => {
     if (driveId) return sessions.length > 0 || notice === null ? [{ driveId, sessions }] : [];
-    const byDrive = new Map<string, SessionListEntry[]>(
-      showEmptyAssistantGroup ? [['global', []]] : [],
-    );
-    for (const session of sessions) {
-      const key = session.driveId ?? 'global';
-      byDrive.set(key, [...(byDrive.get(key) ?? []), session]);
-    }
-    return [...byDrive.entries()].map(([id, list]) => ({ driveId: id, sessions: list }));
+    return groupSessionsByDrive(sessions, { seedEmptyAssistantGroup: showEmptyAssistantGroup });
   }, [driveId, sessions, notice, showEmptyAssistantGroup]);
 
   const driveTitle = useCallback(
     (id: string) => {
-      if (id === 'global') return 'Assistant';
+      if (id === ASSISTANT_GROUP_KEY) return 'Assistant';
       return agentsByDrive.find((entry) => entry.driveId === id)?.driveName ?? id;
     },
     [agentsByDrive],
@@ -255,7 +250,7 @@ function SessionList({
             <SessionRow key={session.sessionId} session={session} onChanged={onChanged} />
           ))}
           <NewSessionRow
-            driveId={group.driveId === 'global' ? null : group.driveId}
+            driveId={group.driveId === ASSISTANT_GROUP_KEY ? null : group.driveId}
             agentsByDrive={agentsByDrive}
             onSpawned={onChanged}
           />
@@ -374,7 +369,17 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
           {expanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
         </button>
         <button type="button" className="flex min-w-0 flex-1 items-center gap-1.5 text-left" onClick={openSession}>
-          {isRunning && <span aria-label="Sandbox running" className="size-1.5 shrink-0 rounded-full bg-emerald-500" />}
+          {isRunning && (
+            // `role="img"` gives the span an accessible-name-bearing role — a
+            // plain `<span aria-label>` is not announced by most screen
+            // readers, since aria-label is only honoured on elements with a
+            // role that supports naming.
+            <span
+              role="img"
+              aria-label="Sandbox running"
+              className="size-1.5 shrink-0 rounded-full bg-emerald-500"
+            />
+          )}
           <span className="truncate">{session.name || 'Session'}</span>
         </button>
         <button

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -283,6 +283,15 @@ describe('AgentsSidebar', () => {
       await screen.findByText('api refactor');
       expect(screen.queryByLabelText('Sandbox running')).toBeNull();
     });
+
+    test('is announced as an image with its name — a plain span aria-label is not announced by most screen readers', async () => {
+      renderSidebar();
+      await screen.findByText('api refactor');
+      // getByRole('img', {name}) only matches elements a screen reader would
+      // actually announce as a named object — the bar a bare aria-label span
+      // fails.
+      expect(screen.getByRole('img', { name: 'Sandbox running' })).toBeDefined();
+    });
   });
 
   describe('new conversation in a session', () => {
@@ -424,6 +433,29 @@ describe('AgentsSidebar', () => {
       await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-a'));
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-a');
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBeNull();
+    });
+
+    test('the Assistant group sorts first even when a drive session arrives before it in the fetch', async () => {
+      // Assistant first because it's the user's own — not because
+      // `showEmptyAssistantGroup` happened to seed the Map before this drive
+      // session was iterated. Here there's no empty-group seed at all: an
+      // assistant session is already present, ahead of the map-insertion-order
+      // bug this pins.
+      respondWithSessions([
+        SESSION,
+        {
+          ...SESSION,
+          sessionId: 'ses-g',
+          driveId: null,
+          name: 'assistant session',
+          conversations: [{ conversationId: 'conv-g', title: 'Thread', agentPageId: null }],
+        },
+      ]);
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      const headers = screen.getAllByText(/^(Alpha|Assistant)$/);
+      expect(headers.map((el) => el.textContent)).toEqual(['Assistant', 'Alpha']);
     });
 
     test('a new conversation in an assistant session goes through the session-centric creator', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/session-groups.test.ts
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/session-groups.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The global console's drive grouping — a pure decision, kept out of the
+ * component. The property worth pinning: the ASSISTANT group is
+ * deterministically first because it is the user's own, not because a seeded
+ * Map entry happened to be inserted before the fetch results.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { groupSessionsByDrive, ASSISTANT_GROUP_KEY } from '../session-groups';
+
+const session = (sessionId: string, driveId: string | null) => ({ sessionId, driveId });
+
+describe('groupSessionsByDrive', () => {
+  it('puts the Assistant group first regardless of fetch order', () => {
+    const groups = groupSessionsByDrive(
+      [session('s1', 'drive-1'), session('s2', null), session('s3', 'drive-2')],
+      { seedEmptyAssistantGroup: false },
+    );
+    expect(groups.map((group) => group.driveId)).toEqual([ASSISTANT_GROUP_KEY, 'drive-1', 'drive-2']);
+  });
+
+  it("keeps the server's listing order within each group, and between drives", () => {
+    const groups = groupSessionsByDrive(
+      [session('s1', 'drive-2'), session('s2', 'drive-1'), session('s3', 'drive-2')],
+      { seedEmptyAssistantGroup: false },
+    );
+    expect(groups.map((group) => group.driveId)).toEqual(['drive-2', 'drive-1']);
+    expect(groups[0].sessions.map((entry) => entry.sessionId)).toEqual(['s1', 's3']);
+  });
+
+  it('seeds an empty Assistant group when asked — the affordance to start one IS the group', () => {
+    const groups = groupSessionsByDrive([session('s1', 'drive-1')], { seedEmptyAssistantGroup: true });
+    expect(groups.map((group) => group.driveId)).toEqual([ASSISTANT_GROUP_KEY, 'drive-1']);
+    expect(groups[0].sessions).toEqual([]);
+  });
+
+  it('shows no Assistant group when there are no assistant sessions and no seed', () => {
+    const groups = groupSessionsByDrive([session('s1', 'drive-1')], { seedEmptyAssistantGroup: false });
+    expect(groups.map((group) => group.driveId)).toEqual(['drive-1']);
+  });
+
+  it('an empty listing with the seed still yields exactly the Assistant group', () => {
+    const groups = groupSessionsByDrive([], { seedEmptyAssistantGroup: true });
+    expect(groups).toEqual([{ driveId: ASSISTANT_GROUP_KEY, sessions: [] }]);
+  });
+});

--- a/apps/web/src/components/layout/left-sidebar/session-groups.ts
+++ b/apps/web/src/components/layout/left-sidebar/session-groups.ts
@@ -1,0 +1,40 @@
+/**
+ * Groups the global console's sessions by drive, for the sidebar's tree.
+ * Pure and side-effect free — the one branching decision (where the Assistant
+ * group sorts) belongs here, not inline in the component render.
+ *
+ * The Assistant group (the user's own, driveId `null`) is always FIRST,
+ * regardless of where its sessions land in the fetch response — sorted
+ * explicitly rather than relying on Map insertion order, which only put it
+ * first when `showEmptyAssistantGroup` happened to seed the Map before any
+ * drive session was iterated.
+ */
+
+export const ASSISTANT_GROUP_KEY = 'global';
+
+export interface DriveGroup<T> {
+  driveId: string;
+  sessions: T[];
+}
+
+export function groupSessionsByDrive<T extends { driveId: string | null }>(
+  sessions: T[],
+  { seedEmptyAssistantGroup }: { seedEmptyAssistantGroup: boolean },
+): DriveGroup<T>[] {
+  const byDrive = new Map<string, T[]>(seedEmptyAssistantGroup ? [[ASSISTANT_GROUP_KEY, []]] : []);
+  for (const session of sessions) {
+    const key = session.driveId ?? ASSISTANT_GROUP_KEY;
+    byDrive.set(key, [...(byDrive.get(key) ?? []), session]);
+  }
+
+  // A stable sort: the Assistant group moves to the front, and every other
+  // group keeps the server's original ordering relative to the others.
+  const entries = [...byDrive.entries()];
+  entries.sort(([a], [b]) => {
+    if (a === ASSISTANT_GROUP_KEY) return -1;
+    if (b === ASSISTANT_GROUP_KEY) return 1;
+    return 0;
+  });
+
+  return entries.map(([driveId, list]) => ({ driveId, sessions: list }));
+}

--- a/apps/web/src/lib/agent-sessions/__tests__/quota-response.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/quota-response.test.ts
@@ -12,8 +12,18 @@
  * perfectly well to whoever wrote it. Only a reader who knows the convention
  * would catch it, and conventions with no test decay.
  */
-import { describe, it, expect } from 'vitest';
-import { SESSION_QUOTA_MESSAGE } from '../quota-response';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  SESSION_QUOTA_MESSAGE,
+  SESSION_CONVERSATION_LIMIT_MESSAGE,
+  sessionQuotaExceeded,
+  sessionConversationLimitExceeded,
+} from '../quota-response';
+
+const mockAuditRequest = vi.hoisted(() => vi.fn());
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
 
 describe('SESSION_QUOTA_MESSAGE', () => {
   it('should not use the backend vocabulary a human never sees', () => {
@@ -25,5 +35,112 @@ describe('SESSION_QUOTA_MESSAGE', () => {
     // this one clears by stopping a sandbox, never by waiting.
     expect(SESSION_QUOTA_MESSAGE.toLowerCase()).toContain('sandbox');
     expect(SESSION_QUOTA_MESSAGE.toLowerCase()).toMatch(/stop|end/);
+  });
+});
+
+describe('sessionQuotaExceeded', () => {
+  const request = new Request('https://example.test/api/agent-sessions/ses-1');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("a provisioner's raw diagnostic code NEVER reaches the response body — the human sentence does", async () => {
+    // Mutation check: this is the live P1 PR #2253 caught — the provisioner's
+    // denial always sets a diagnostic enum (`quota.reason`, e.g.
+    // 'concurrency_limit'), so restoring the old `detail ?? SESSION_QUOTA_MESSAGE`
+    // shape (feeding that enum straight into `error`) makes this assertion fail:
+    // the body would read 'concurrency_limit' instead of the sandbox sentence.
+    const response = sessionQuotaExceeded(request, 'user-1', 'ses-1', 'agent-sessions/[sessionId]', {
+      reasonCode: 'concurrency_limit',
+    });
+
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.error).toBe(SESSION_QUOTA_MESSAGE);
+    expect(body.error).not.toContain('concurrency_limit');
+  });
+
+  it('records the diagnostic code in the audit row, not the response', () => {
+    sessionQuotaExceeded(request, 'user-1', 'ses-1', 'agent-sessions/[sessionId]', {
+      reasonCode: 'concurrency_limit',
+    });
+
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        eventType: 'security.rate.limited',
+        details: expect.objectContaining({
+          reason: 'session_limit_reached',
+          route: 'agent-sessions/[sessionId]',
+          reasonCode: 'concurrency_limit',
+        }),
+      }),
+    );
+  });
+
+  it('an already-human message override (e.g. a live count) is used verbatim — not replaced by the generic sentence', async () => {
+    const response = sessionQuotaExceeded(request, 'user-1', 'about-to-be-minted', 'agent-sessions', {
+      message: 'You have 100 active sessions — end some before starting more.',
+    });
+
+    const body = await response.json();
+    expect(body.error).toBe('You have 100 active sessions — end some before starting more.');
+  });
+
+  it('with neither reasonCode nor message, falls back to the generic sentence and audits no reason code', () => {
+    const response = sessionQuotaExceeded(request, 'user-1', 'ses-1', 'agent-sessions/[sessionId]');
+
+    return response.json().then((body) => {
+      expect(body.error).toBe(SESSION_QUOTA_MESSAGE);
+      const [, details] = mockAuditRequest.mock.calls[0];
+      expect(details.details).not.toHaveProperty('reasonCode');
+    });
+  });
+});
+
+describe('sessionConversationLimitExceeded', () => {
+  // The PER-SESSION conversation ceiling (`SessionFullError`, PR #2269) — a
+  // second quota refusal added to this file alongside the sandbox-count one
+  // above. It takes no `detail`/`reasonCode` parameter at all today, so there
+  // is currently no path for a diagnostic enum to reach its body — this pins
+  // that shape so it can't regress the same way `sessionQuotaExceeded` did:
+  // the body is ALWAYS the fixed human sentence, never anything computed or
+  // passed through from a caller.
+  const request = new Request('https://example.test/api/agent-sessions/ses-1/conversations');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('always answers with the fixed human sentence — there is no parameter that could leak a diagnostic code', async () => {
+    const response = sessionConversationLimitExceeded(
+      request,
+      'user-1',
+      'ses-1',
+      'agent-sessions/[sessionId]/conversations',
+    );
+
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.error).toBe(SESSION_CONVERSATION_LIMIT_MESSAGE);
+    // Guards against ever widening the signature to accept a raw code and
+    // splicing it into the body the way the sandbox-quota path once did.
+    expect(sessionConversationLimitExceeded.length).toBeLessThanOrEqual(4);
+  });
+
+  it('records the conversation-limit reason in the audit row, distinct from the sandbox-quota reason', () => {
+    sessionConversationLimitExceeded(request, 'user-1', 'ses-1', 'agent-sessions/[sessionId]/conversations');
+
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        eventType: 'security.rate.limited',
+        details: expect.objectContaining({
+          reason: 'session_conversation_limit_reached',
+          route: 'agent-sessions/[sessionId]/conversations',
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/src/lib/agent-sessions/quota-response.ts
+++ b/apps/web/src/lib/agent-sessions/quota-response.ts
@@ -22,6 +22,16 @@
  *    agents, conversations and sandboxes. It matches what the socket surface
  *    prints into the terminal pane for the identical refusal — one event should
  *    not read three different ways depending on which layer said no.
+ *
+ * `reasonCode` vs `message` are deliberately two separate parameters, not one
+ * overloaded `detail` string (a live P1 the un-restored PR #2253 caught): the
+ * provisioner's denial carries a DIAGNOSTIC enum (`quota.reason`, e.g.
+ * `'concurrency_limit'`) that is always set whenever the denial fires — so a
+ * single `detail ?? SESSION_QUOTA_MESSAGE` never falls through to the human
+ * sentence and the caller sees the bare enum code rendered as their error
+ * message. `reasonCode` goes ONLY into the audit row; the response body is
+ * always the human sentence unless a caller hands `message` an already-human
+ * string it computed itself (the active-session-count refusal below does).
  */
 import { NextResponse } from 'next/server';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -65,16 +75,24 @@ export function sessionQuotaExceeded(
   sessionId: string,
   /** Which route refused, for the audit trail only — never shown to the caller. */
   route: string,
-  /** A more specific message from the provisioner, when it had one. */
-  detail?: string,
+  options?: {
+    /** A diagnostic enum from the provisioner (e.g. `'concurrency_limit'`) — audit-only, NEVER the response body. */
+    reasonCode?: string;
+    /** An already-human-worded override (e.g. one that names a live count). Falls back to SESSION_QUOTA_MESSAGE. */
+    message?: string;
+  },
 ): NextResponse {
   auditRequest(request, {
     eventType: 'security.rate.limited',
     userId,
     resourceType: 'agent_session',
     resourceId: sessionId,
-    details: { reason: 'session_limit_reached', route },
+    details: {
+      reason: 'session_limit_reached',
+      route,
+      ...(options?.reasonCode ? { reasonCode: options.reasonCode } : {}),
+    },
     riskScore: 0,
   });
-  return NextResponse.json({ error: detail ?? SESSION_QUOTA_MESSAGE }, { status: 429 });
+  return NextResponse.json({ error: options?.message ?? SESSION_QUOTA_MESSAGE }, { status: 429 });
 }

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -21,6 +21,22 @@ export interface SessionRefreshResult {
   shouldLogout: boolean;
 }
 
+/**
+ * Thrown by `fetchJSON`/`post`/etc. on a non-2xx response. A plain `Error`
+ * loses the status code the moment it's thrown, which callers need to tell a
+ * quota refusal (429) apart from a capability one (403) — `instanceof Error`
+ * still holds for every existing catch site.
+ */
+export class ApiRequestError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.status = status;
+  }
+}
+
 class AuthFetch {
   private isRefreshing = false;
   private refreshQueue: QueuedRequest[] = [];
@@ -1147,11 +1163,11 @@ class AuthFetch {
       // Try to parse JSON error response and extract error message
       try {
         const json = JSON.parse(text);
-        throw new Error(json.error || json.message || text);
+        throw new ApiRequestError(json.error || json.message || text, response.status);
       } catch (parseError) {
         // If parsing fails, it's not JSON - use the raw text
         if (parseError instanceof SyntaxError) {
-          throw new Error(text);
+          throw new ApiRequestError(text, response.status);
         }
         // Re-throw if it's our Error from above
         throw parseError;


### PR DESCRIPTION
## Summary

Fixes issue #2264 — the follow-up audit findings from PR #2258 (agent-session un-conflation + pane restore) — plus a live P1 the point guard surfaced from stale PR #2253's quota-delivery path.

**#2264 findings:**
- **`useResolvedConversation.ts`** — first resolution now gates on `authLoading === false`. On a hard refresh, `useAuth` starts out loading, so `canUseSessions` reads `false` before the role is known; resolving anyway would mint a fresh agent's first conversation as permanently session-less (thread→session binding is congenital and permanent — it could never gain a grid afterward). A `startedForAgentId` ref ensures this only waits out the *first* load: a later auth-loading blip (token refresh) never restarts resolution and clobbers a conversation the user is already typing into.
- Spawn refusals are now split into **quota** (429 — worth interrupting the user for, since they have the capability and simply ran out of allowance) vs **capability** (everything else — the existing silent degrade to a plain conversation). New `spawn-refusal.ts` pure module (`classifySpawnRefusal`) plus `ApiRequestError` in `auth-fetch.ts` to carry the HTTP status code through the thrown error (previously lost).
- **`usePermissionsCheck.ts`** — resets `isReadOnly` at the start of every effect run, so a page change no longer inherits the previous page's read-only verdict when the new page's own check errors out.
- **`AgentsSidebar.tsx`** — extracted `session-groups.ts` (`groupSessionsByDrive`): the Assistant group now sorts first *deterministically* instead of depending on `Map` insertion order during the sessions fetch. The running-sandbox status dot gets `role="img"` so it's actually announced by screen readers (a bare `aria-label` span is not).

**Scope addition #1 (mid-task, from the point guard) — live P1 from stale PR #2253:**
- `apps/web/src/lib/agent-sessions/quota-response.ts` answered every 429 with `{ error: detail ?? SESSION_QUOTA_MESSAGE }`, where `detail` was overloaded: sometimes a computed human sentence, sometimes the provisioner's raw diagnostic enum (`quota.reason`, e.g. `'concurrency_limit'`) — which is *always* set on a denial, so the enum always won and users saw `concurrency_limit` rendered verbatim as their error message; the human sentence was unreachable on that path. Split into `{ reasonCode, message }`: `reasonCode` goes only into the audit row, the response body is always human-worded (falls back to `SESSION_QUOTA_MESSAGE` unless a caller — the active-session-count refusal — hands a message it already computed itself). Added a mutation-check test (verified it fails if `detail ??`-style logic is restored) plus updated the two route tests that were mocking an unrealistically detail-less shape.
- Addresses the quota-delivery half of PR #2253.
- Verified the new UI's 429 consumers already catch and toast the rejection: `AgentPanes.tsx`'s `handlePickShell` and `AgentsSidebar.tsx`'s spawn/newConversation/endSession all have proper try/catch + `toast.error`, so there's no repeat of the deleted `AgentView.tsx`'s `handleAddShell` bug (try/finally with no catch → unhandled rejection, silent spinner).

**Scope addition #2 (rebase reconciliation) — PR #2269 also landed on `quota-response.ts`:**
- PR #2269 (session-tools) merged to master and added a second refusal helper to the same file, `sessionConversationLimitExceeded` (the per-session conversation ceiling, `SessionFullError`). It takes no `detail`/`reasonCode` parameter and always answers with a fixed `SESSION_CONVERSATION_LIMIT_MESSAGE`, so it never had the enum-leak bug — but I extended the test file to pin that shape explicitly (asserting the body is always the fixed sentence, and the audit row carries the distinct `session_conversation_limit_reached` reason), so it can't regress the same way `sessionQuotaExceeded` did.

## Coordination notes

- `useResolvedConversation` now takes an `authLoading` param. `AgentPageView.tsx` is owned by the pane-system agent (issue #2263, `components/agents/panes/**`), so it got the smallest possible touch: destructuring `isLoading` from `useAuth` and passing it through to the hook call.
- This branch was rebased TWICE mid-task as sibling PRs landed on master: PR #2269 (session-tools, added `sessionConversationLimitExceeded` to `quota-response.ts` — reconciled above) and PR #2268 (pane lifecycle, issue #2263 — extracted `EndSessionDialog` from `AgentsSidebar.tsx`, added a `sessionId`-reuse path to `createPageConversation` in `useResolvedConversation.ts`, and touched `AgentPageView.tsx`'s `newConversation` callback). Both rebases resolved without textual conflicts; I manually re-verified every touched file's post-rebase diff was semantically correct (not just non-conflicting) before re-running the full gate suite. None of my `useResolvedConversation.ts` changes were made redundant by master's version — the two sets of changes are orthogonal (my authLoading gate vs. master's session-reuse-on-delete path).

## Test plan
- [x] `bun run typecheck` — 16/16 packages pass
- [x] `bun run lint` — 14/14 pass
- [x] `bun run test:unit` — all green except the pre-existing `grouping.test.ts` midnight/TZ failure (confirmed passes under `TZ=UTC`; unrelated file, untouched by this branch)
- [x] `bun run knip:check` — within baseline
- [x] `bun run test:security` — Security Audit Route Coverage passes; the 6 pre-existing failures are stale test-security.sh paths (nonexistent `login.test.ts`/`signup.test.ts`/`mobile-login.test.ts`) and DB-integration tests excluded by `packages/lib/vitest.config.ts` — unrelated to any file this branch touches
- [x] Manually reverted the quota-response.ts fix and confirmed the mutation-check test fails (catches the regression)
- [x] Post-rebase: re-ran all directly-touched test suites (agents, sidebar, agent-sessions routes, panes, agent-workspace store) plus the full gate suite — all green modulo the two pre-existing failures above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZ55BHXrze46tyZDA9eNhU