### PR TITLE
fix(realtime): hoist cross-tier tenant/membership resolution; dead-code sweep; retire machine vocabulary

### DIFF
--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -272,6 +272,10 @@ vi.mock('../terminal/shell-handler', () => ({
     onResize: vi.fn(),
     onDisconnect: vi.fn(),
   }),
+  // Real implementation (pure, no deps) — the `shell:connect` success-path
+  // tests below assert index.ts looks the just-registered session up under
+  // this SAME composed key.
+  composeSocketKey: (socketId: string, connectionId: string) => `${socketId}\u0000${connectionId}`,
 }));
 
 // Captures the deps object index.ts builds for the shell-IO bridge, so the

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -8,10 +8,10 @@ import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyBroadcastSignature } from '@pagespace/lib/auth/broadcast-auth';
 import * as dotenv from 'dotenv';
 import { db } from '@pagespace/db/db';
-import { and, eq, isNotNull, or } from '@pagespace/db/operators';
+import { and, eq, or } from '@pagespace/db/operators';
 import { dmConversations } from '@pagespace/db/schema/social';
 import { users } from '@pagespace/db/schema/auth';
-import { driveMembers, userProfiles } from '@pagespace/db/schema/members';
+import { userProfiles } from '@pagespace/db/schema/members';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { canRunCode, isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { checkAgentSessionConcurrency } from '@pagespace/lib/services/sandbox/quota';
@@ -27,7 +27,7 @@ import {
 } from '@pagespace/lib/services/sandbox/containment';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { defaultSandboxBillingDeps } from '@pagespace/lib/services/sandbox/sandbox-billing';
-import { checkMachineRuntimeGuardrail, recordMachineActivity, acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
+import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
 import { createSpritesSandboxClient, createSpriteHandleCache, type SpritesSdk } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { createSpriteSandboxHost } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-sandbox-host';
 import {
@@ -42,6 +42,7 @@ import { openPtyShell } from './terminal/sprites-shell';
 import { getRealtimeSpritesSdk } from './terminal/realtime-sprites-client';
 import {
   buildShellHandlers,
+  composeSocketKey,
   connectFailureMessage,
   ensureShellSession,
   armIdleReap as armShellIdleReap,
@@ -53,13 +54,17 @@ import { deriveShellSessionKey } from './terminal/shell-session-key';
 import { handleShellReadRequest, handleShellSendRequest } from './terminal/shell-io';
 import { handleShellActivityRequest } from './terminal/shell-activity';
 import { checkAgentSessionAccess } from '@pagespace/lib/services/agent-sessions/agent-session-access';
+import {
+  resolveSessionTenantId,
+  resolveDriveMembership,
+  canRunCodeForSession,
+} from '@pagespace/lib/services/agent-sessions/agent-session-tenant';
 import { resolveSessionShellById } from '@pagespace/lib/services/agent-sessions/session-shells';
 import { createDbSessionShellStore } from '@pagespace/lib/services/agent-sessions/session-shells-store';
 import { createDbAgentSessionStore } from '@pagespace/lib/services/agent-sessions/agent-sessions-store';
 import { ensureAgentSessionSandbox } from '@pagespace/lib/services/agent-sessions/agent-session-sprite';
 import { resolveSandboxNetworkOptions } from '@pagespace/lib/services/sandbox/network-options';
 import { getConfiguredEgressIpTag } from '@pagespace/lib/services/sandbox/egress-ip';
-import { conversations } from '@pagespace/db/schema/conversations';
 import {
   validatePageId,
   validateDriveId,
@@ -121,24 +126,6 @@ export async function resolveActorEmail(rawEmail: string | null | undefined): Pr
   return rawEmail ? await decryptField(rawEmail) : '';
 }
 
-/**
- * A page's CURRENT driveId + that drive's owner (the `tenantId` convention the
- * Sprite session-key derivation uses) — shared by every call site below that
- * needs "which drive owns this agent page, and who pays" without risking a
- * stale cross-drive lookup.
- */
-type DriveOwnerContextResult =
-  | { ok: true; driveId: string; tenantId: string }
-  | { ok: false; reason: 'page_not_found' | 'drive_not_found' };
-
-async function resolveDriveOwnerContext(pageId: string): Promise<DriveOwnerContextResult> {
-  const [pageRow] = await db.select({ driveId: pages.driveId }).from(pages).where(eq(pages.id, pageId)).limit(1);
-  if (!pageRow) return { ok: false, reason: 'page_not_found' };
-  const [driveRow] = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, pageRow.driveId)).limit(1);
-  if (!driveRow) return { ok: false, reason: 'drive_not_found' };
-  return { ok: true, driveId: pageRow.driveId, tenantId: driveRow.ownerId };
-}
-
 // ---------------------------------------------------------------------------
 // shell:* family — the PTY bridge re-keyed onto agent sessions (Phase 3).
 //
@@ -165,9 +152,11 @@ async function resolveOwnerTier(ownerId: string) {
  * Ensure (create/resume/adopt) the session's ONE shared sandbox — the
  * `ensureSessionSandbox` seam of `buildShellCheckAuth`, backed by the shared
  * packages/lib provisioner and NEVER a realtime-local one. `tenantId` (the
- * Sprite-key fold's tenant and the billing account) is the agent page's drive
- * owner, falling back to the session's own owner for a global-assistant
- * session — the same `agentPageId ?? ownerId` attribution rule billing uses.
+ * Sprite-key fold's tenant and the billing account) is the session's own
+ * DRIVE owner, falling back to the session's own owner for a global-assistant
+ * session — resolved through `resolveSessionTenantId`, the SAME shared lib
+ * function the web tier's `provisionSessionSandbox` calls, so a vanished
+ * drive fails closed identically on both tiers.
  */
 async function ensureShellSessionSandbox({ sessionId, userId }: { sessionId: string; userId: string }): Promise<
   { ok: true; sandboxId: string } | { ok: false; reason: string }
@@ -176,17 +165,9 @@ async function ensureShellSessionSandbox({ sessionId, userId }: { sessionId: str
   const row = await store.findById(sessionId);
   if (!row) return { ok: false, reason: 'session_not_found' };
 
-  // tenantId (the Sprite-key fold's tenant and the billing account) is the
-  // session's DRIVE owner, falling back to the session's own owner for a
-  // user-scoped global-assistant session — the drive is a fact of the row now.
-  let tenantId: string;
-  if (row.driveId === null) {
-    tenantId = row.ownerId;
-  } else {
-    const [drive] = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, row.driveId)).limit(1);
-    if (!drive) return { ok: false, reason: 'drive_not_found' };
-    tenantId = drive.ownerId;
-  }
+  const tenant = await resolveSessionTenantId(row);
+  if (!tenant.ok) return { ok: false, reason: tenant.reason };
+  const tenantId = tenant.tenantId;
 
   const sdk = createSpriteHandleCache(await getRealtimeSpritesSdk());
   const host = createSpriteSandboxHost({ sdk, client: createSpritesSandboxClient({ sdk }) });
@@ -199,7 +180,7 @@ async function ensureShellSessionSandbox({ sessionId, userId }: { sessionId: str
       store,
       host,
       substrate: { kind: 'sprite' },
-      options: resolveSandboxNetworkOptions({ surface: 'machine', egressIpTag: getConfiguredEgressIpTag() }),
+      options: resolveSandboxNetworkOptions({ surface: 'session', egressIpTag: getConfiguredEgressIpTag() }),
       secret: getSandboxSessionSecret(),
       // SECURITY: the centralized code-execution gate, applied inside the
       // shared provisioner before any Sprite is provisioned OR handed back —
@@ -316,25 +297,8 @@ const shellCheckAuth = buildShellCheckAuth({
         // The row was just read; hand the wrapper the same subject rather than
         // paying a second lookup for the identical answer.
         findSession: async () => subject,
-        resolveDriveMembership: async ({ userId, driveId }) => {
-          const [drive] = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, driveId)).limit(1);
-          if (!drive) return 'none';
-          if (drive.ownerId === userId) return 'owner';
-          const [membership] = await db
-            .select({ id: driveMembers.id })
-            .from(driveMembers)
-            .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId), isNotNull(driveMembers.acceptedAt)))
-            .limit(1);
-          return membership ? 'member' : 'none';
-        },
-        canRunCode: async ({ userId, driveId }) => {
-          const verdict = await canRunCode({
-            userId,
-            driveId: driveId ?? undefined,
-            requestOrigin: 'user',
-          });
-          return verdict.ok;
-        },
+        resolveDriveMembership,
+        canRunCode: canRunCodeForSession,
       },
     });
     return decision.allowed ? { allowed: true, session: subject } : decision;
@@ -1501,8 +1465,8 @@ io.on('connection', (socket: AuthSocket) => {
   // Shell PTY handlers (shell:* family): a named PTY inside its
   // agent session's ONE shared sandbox, addressed by `{shellId}` alone. Billing
   // meters every connection's active-runtime cost against the session's payer
-  // (agent page's drive owner, or the session owner for a global-assistant
-  // session).
+  // (the session's own DRIVE owner, or the session owner for a
+  // global-assistant session or a vanished drive).
   const shellHandlers = buildShellHandlers({
     ...shellSessionDeps,
     socket: socket as unknown as ShellSocketLike,
@@ -1518,7 +1482,7 @@ io.on('connection', (socket: AuthSocket) => {
       // Same `connectionId ?? socket.id` fallback `onConnect` itself uses —
       // several panes share this socket, each under its own connectionId, so a
       // bare `socket.id` lookup would only ever find whichever pane sent none.
-      const session = agentTerminalSessionMap.getBySocket(`${socket.id}\u0000${payloadConnectionId ?? socket.id}`);
+      const session = agentTerminalSessionMap.getBySocket(composeSocketKey(socket.id, payloadConnectionId ?? socket.id));
       if (session) {
         loggers.realtime.info('Shell session opened', { userId: user?.id, sessionKey: session.sessionKey, sandboxId: session.sandboxId });
       }

--- a/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
@@ -1696,10 +1696,10 @@ describe('buildShellHandlers', () => {
       expect(sessionMap.getByKey('shell:shl-1')).toBeUndefined();
     });
 
-    it('given a GLOBAL-ASSISTANT session (no agent page), settles usage with no pageId so it attributes to the owner alone', async () => {
+    it('given a GLOBAL-ASSISTANT session (no drive), settles usage with a null driveId so it attributes to the owner alone', async () => {
       // driveId is nullable by design: a global-assistant conversation has
-      // no agent page to attribute against, and the payer falls back to the
-      // session owner. Attaching someone else's pageId here would misattribute
+      // no drive to attribute against, and the payer falls back to the
+      // session owner. Attaching someone else's driveId here would misattribute
       // the usage on the billing dashboard.
       const globalCheckAuth = vi.fn(async () => makeAuthSuccess({ driveId: null }));
       const billing = makeBilling();

--- a/apps/realtime/src/terminal/shell-access.ts
+++ b/apps/realtime/src/terminal/shell-access.ts
@@ -60,9 +60,10 @@ export interface ShellCheckAuthDeps {
   checkSessionAccess: (input: { requesterId: string; sessionId: string }) => Promise<ShellSessionAccessResult>;
   /**
    * Who pays for this session's runtime, and which drive an audit row lands
-   * under. Payer = the agent page's drive owner, falling back to the session's
-   * own owner when there is no page (a global-assistant session) or the page's
-   * owner cannot be resolved — the drive-owner ?? session-owner attribution rule.
+   * under. Payer = the session's own DRIVE owner, falling back to the
+   * session's own owner when there is no drive (a global-assistant session)
+   * or the drive has vanished — the drive-owner ?? session-owner attribution
+   * rule.
    */
   resolvePayer: (session: AgentSessionAccessSubject) => Promise<{ payerId: string; driveId: string | null }>;
   /** The requester's tier (slot accounting) + email (audit), or undefined when the row is missing. */

--- a/apps/realtime/src/terminal/shell-handler.ts
+++ b/apps/realtime/src/terminal/shell-handler.ts
@@ -1424,6 +1424,19 @@ export function connectFailureMessage(failure: Extract<EnsureShellSessionResult,
   }
 }
 
+/**
+ * The key a session is filed under on its VIEWER side: a socket's own
+ * server-assigned id, namespaced by the client-minted `connectionId` it
+ * multiplexes (several panes share one socket). Exported so `index.ts`'s
+ * `shell:connect` handler can look up the just-registered session by the
+ * SAME key `onConnect` files it under, without re-spelling the format
+ * inline — see `buildShellHandlers`'s internal `socketKey` (below) for why
+ * the namespacing exists.
+ */
+export function composeSocketKey(socketId: string, connectionId: string): string {
+  return `${socketId}\u0000${connectionId}`;
+}
+
 export function buildShellHandlers({
   sessionMap,
   openShell,
@@ -1499,25 +1512,11 @@ export function buildShellHandlers({
   }
 
   /**
-   * The key a session is filed under on its VIEWER side.
-   *
-   * `connectionId` is a UUID the CLIENT mints, and the session map is one
-   * shared, server-wide instance — so filing by the bare id lets one client's
-   * chosen string address ANOTHER client's session. Two sockets picking the
-   * same id (a buggy client, or a hostile one: it is validated only as a
-   * non-empty string) then collide inside the map, where `setNew` silently
-   * overwrites the socket entry of a session that is still running. That
-   * session is then unreachable: no viewer, no armed reap, so its PTY, its
-   * concurrency slot and its billing heartbeat run for the life of the process
-   * — billed to the SESSION's payer, not the caller's. Worse, the first
-   * socket's later disconnect resolves to the SECOND socket's session and
-   * reaps it, killing a shell someone else is watching.
-   *
-   * Namespacing by the server-assigned socket id makes that collision
-   * unrepresentable rather than merely detected: a client can only ever name
-   * its own connections.
+   * The key a session is filed under on its VIEWER side — see
+   * `composeSocketKey`'s doc for why this is namespaced by the socket id
+   * rather than the bare, client-minted `connectionId`.
    */
-  const socketKey = (connectionId: string) => `${socket.id}\u0000${connectionId}`;
+  const socketKey = (connectionId: string) => composeSocketKey(socket.id, connectionId);
 
   function disconnectConnection(connectionId: string) {
     const session = sessionMap.getBySocket(socketKey(connectionId));

--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -2,9 +2,9 @@
  * useAgentSessionChat Hook Tests — Phase 6.
  *
  * The ONE chat's state for a fixed agent + fixed conversation (no dual-mode
- * selector, no pendingPrompt — those are the machine pane's concerns, not an
- * AgentView's). Behavior under test, derived from useMachinePaneChat's
- * default-mode coverage:
+ * selector, no pendingPrompt — those are pane-picker concerns, not this
+ * hook's). Consumed by `SessionChat.tsx`, one chat pane inside an agent
+ * session's pane grid. Behavior under test:
  *
  * - loads the conversation into the shared cache keyed by (agentId, conversationId)
  * - sends { chatId: agentId, conversationId, ...agent config } through useChat
@@ -12,8 +12,7 @@
  * - renders from the shared conversation cache
  * - error cause is forwarded
  *
- * Template: useMachinePaneChat.test.ts (renderHook, auth-fetch mocked, real
- * swr, real conversation-messages store).
+ * renderHook, auth-fetch mocked, real swr, real conversation-messages store.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';

--- a/apps/web/src/components/agents/shell/XtermTerminal.tsx
+++ b/apps/web/src/components/agents/shell/XtermTerminal.tsx
@@ -385,10 +385,11 @@ export default function XtermTerminal({ socket, shellId, initialInput, onInitial
           useEditingStore.getState().endEditing(shellId);
         };
 
-        // The tracking row for this shell must already exist — adding a shell
-        // (`useSessionShells.addShell()`) reserves it before this component is
-        // ever bound to it, so connecting here only ever attaches to (or
-        // resumes) an already-known session.
+        // The tracking row for this shell must already exist — the pane picker's
+        // `POST /api/agent-sessions/{sessionId}/shells` (`AgentPanes.tsx`'s
+        // `handlePickShell`) reserves it before this component is ever bound to
+        // it, so connecting here only ever attaches to (or resumes) an
+        // already-known session.
         //
         // Bind now if the socket is up; otherwise the `connect` handler does the
         // first bind when it comes up. (Emitting while down would only sit in

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -18,10 +18,8 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, count, eq, inArray, isNotNull, sql } from '@pagespace/db/operators';
-import { drives } from '@pagespace/db/schema/core';
+import { and, count, eq, inArray, sql } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
-import { driveMembers } from '@pagespace/db/schema/members';
 import { users } from '@pagespace/db/schema/auth';
 import { checkAgentSessionConcurrency } from '@pagespace/lib/services/sandbox/quota';
 import {
@@ -63,6 +61,11 @@ import {
   type AgentSessionAccessCheck,
   type AgentSessionAccessDeps,
 } from '@pagespace/lib/services/agent-sessions/agent-session-access';
+import {
+  resolveSessionTenantId,
+  resolveDriveMembership,
+  canRunCodeForSession,
+} from '@pagespace/lib/services/agent-sessions/agent-session-tenant';
 import type { AgentSessionDTO } from '@pagespace/lib/agent-sessions/contract';
 import { decideAgentSessionAccess } from '@pagespace/lib/agent-sessions/decide-session-access';
 import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
@@ -119,24 +122,6 @@ export function getSandboxHost(): Promise<SandboxHost> {
 // Row-fact lookups (null-plumbing only)
 // ---------------------------------------------------------------------------
 
-/**
- * The tenant a session's Sprite key folds under: the agent page's drive OWNER
- * for a page-anchored session, the session owner themself for a global one
- * (the user is their own isolation boundary — same rule as
- * `resolveSandboxActorContext`).
- */
-export async function resolveSessionTenantId(session: {
-  driveId: string | null;
-  ownerId: string;
-}): Promise<string> {
-  if (session.driveId === null) return session.ownerId;
-  const drive = await db.query.drives.findFirst({
-    where: eq(drives.id, session.driveId),
-    columns: { ownerId: true },
-  });
-  return drive?.ownerId ?? session.ownerId;
-}
-
 /** The owner's not-ended session count — the spawn ceiling's input (store.countActive). */
 export async function countActiveSessionsForOwner(ownerId: string): Promise<number> {
   return (await getAgentSessionStore()).countActive(ownerId);
@@ -150,30 +135,6 @@ export async function findSessionRecord(sessionId: string): Promise<AgentSession
 // Access
 // ---------------------------------------------------------------------------
 
-/**
- * The requester's relationship to a drive: its owner, an accepted member, or
- * neither. The ONE membership read both access checks share.
- */
-export async function resolveDriveMembership({
-  userId,
-  driveId,
-}: {
-  userId: string;
-  driveId: string;
-}): Promise<'owner' | 'member' | 'none'> {
-  const drive = await db.query.drives.findFirst({
-    where: eq(drives.id, driveId),
-    columns: { ownerId: true },
-  });
-  if (!drive) return 'none';
-  if (drive.ownerId === userId) return 'owner';
-  const membership = await db.query.driveMembers.findFirst({
-    where: and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId), isNotNull(driveMembers.acceptedAt)),
-    columns: { id: true },
-  });
-  return membership ? 'member' : 'none';
-}
-
 function buildAccessDeps(): AgentSessionAccessDeps {
   return {
     findSession: async (sessionId) => {
@@ -182,14 +143,7 @@ function buildAccessDeps(): AgentSessionAccessDeps {
       return { sessionId: row.id, ownerId: row.ownerId, driveId: row.driveId };
     },
     resolveDriveMembership,
-    canRunCode: async ({ userId, driveId }) => {
-      const result = await canRunCode({
-        userId,
-        driveId: driveId ?? undefined,
-        requestOrigin: 'user',
-      });
-      return result.ok;
-    },
+    canRunCode: canRunCodeForSession,
   };
 }
 
@@ -410,21 +364,28 @@ export async function provisionSessionSandbox(
   row: AgentSessionRecord,
   requesterId: string,
 ): Promise<EnsureAgentSessionSandboxResult> {
-  const [store, host, tenantId] = await Promise.all([
+  const [store, host, tenant] = await Promise.all([
     getAgentSessionStore(),
     getSandboxHost(),
     resolveSessionTenantId(row),
   ]);
+  // Fail CLOSED on a vanished drive — never fall back to the session owner.
+  // That fallback would fold the Sprite key under a DIFFERENT tenant than the
+  // one this session's key already folded under on a prior provision,
+  // splitting one session across two Sprite identities (audit #2265 finding 1).
+  if (!tenant.ok) {
+    return { ok: false, reason: 'provision_failed', detail: tenant.reason };
+  }
 
   return ensureAgentSessionSandbox({
     row: { ...row, sessionId: row.id },
     intent: 'ensure',
-    actor: { userId: requesterId, tenantId },
+    actor: { userId: requesterId, tenantId: tenant.tenantId },
     deps: {
       store,
       host,
       substrate: { kind: 'sprite' },
-      options: resolveSandboxNetworkOptions({ surface: 'machine', egressIpTag: getConfiguredEgressIpTag() }),
+      options: resolveSandboxNetworkOptions({ surface: 'session', egressIpTag: getConfiguredEgressIpTag() }),
       secret: getSandboxSessionSecret(),
       authorize: canRunCode,
       checkFullEgressEnablement: async () =>

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -9,14 +9,14 @@ const {
   mockFindSessionForConversation,
   mockProvisionSessionSandbox,
   mockMeasureWarmSessionStorage,
-  mockCheckMachineRuntimeGuardrail,
-  mockRecordMachineActivity,
+  mockCheckSessionRuntimeGuardrail,
+  mockRecordSessionActivity,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
   mockMeasureWarmSessionStorage: vi.fn(async () => {}),
-  mockCheckMachineRuntimeGuardrail: vi.fn(),
-  mockRecordMachineActivity: vi.fn(),
+  mockCheckSessionRuntimeGuardrail: vi.fn(),
+  mockRecordSessionActivity: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
@@ -32,8 +32,8 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
 vi.mock('@pagespace/lib/services/sandbox/quota', () => ({
   acquireCodeExecutionSlot: vi.fn(() => true),
   releaseCodeExecutionSlot: vi.fn(),
-  checkMachineRuntimeGuardrail: mockCheckMachineRuntimeGuardrail,
-  recordMachineActivity: mockRecordMachineActivity,
+  checkSessionRuntimeGuardrail: mockCheckSessionRuntimeGuardrail,
+  recordSessionActivity: mockRecordSessionActivity,
 }));
 vi.mock('@pagespace/lib/services/sandbox/sandbox-billing', () => ({
   defaultSandboxBillingDeps: {
@@ -286,7 +286,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckMachineRuntimeGuardrail.mockReturnValue({ allowed: true });
+    mockCheckSessionRuntimeGuardrail.mockReturnValue({ allowed: true });
     mockFindSessionForConversation.mockResolvedValue(sessionRecord);
     mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sbx-1', resumed: false, sessionId: 'ws-1' });
   });
@@ -312,21 +312,21 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     expect(result).toEqual({ ok: false, reason: 'provision_failed', cause: 'missing_conversation_id' });
     expect(mockFindSessionForConversation).not.toHaveBeenCalled();
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
-    expect(mockCheckMachineRuntimeGuardrail).not.toHaveBeenCalled();
+    expect(mockCheckSessionRuntimeGuardrail).not.toHaveBeenCalled();
   });
 
   it('given the runtime guardrail denies, should short-circuit BEFORE provisioning — keyed by the SESSION id', async () => {
-    mockCheckMachineRuntimeGuardrail.mockReturnValue({ allowed: false, reason: 'machine_runtime_exceeded' });
+    mockCheckSessionRuntimeGuardrail.mockReturnValue({ allowed: false, reason: 'session_runtime_exceeded' });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput());
-    expect(result).toEqual({ ok: false, reason: 'machine_runtime_exceeded' });
+    expect(result).toEqual({ ok: false, reason: 'session_runtime_exceeded' });
     // One runtime budget per WORKSPACE, however many threads work in it.
-    expect(mockCheckMachineRuntimeGuardrail).toHaveBeenCalledWith({
-      machineKey: 'ses-1',
+    expect(mockCheckSessionRuntimeGuardrail).toHaveBeenCalledWith({
+      sessionId: 'ses-1',
       now: expect.any(Number),
     });
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
-    expect(mockRecordMachineActivity).not.toHaveBeenCalled();
+    expect(mockRecordSessionActivity).not.toHaveBeenCalled();
   });
 
   it('given a conversation with NO session, should DENY — never lazily mint a per-thread environment', async () => {
@@ -337,7 +337,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     const result = await deps.acquireSandbox(baseInput());
     expect(result).toEqual({ ok: false, reason: 'no_session' });
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
-    expect(mockRecordMachineActivity).not.toHaveBeenCalled();
+    expect(mockRecordSessionActivity).not.toHaveBeenCalled();
   });
 
   it('given two conversations bound to ONE session, both should acquire the SAME sandbox', async () => {
@@ -363,7 +363,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput());
     expect(result).toEqual({ ok: false, reason: 'no_drive_access' });
-    expect(mockRecordMachineActivity).not.toHaveBeenCalled();
+    expect(mockRecordSessionActivity).not.toHaveBeenCalled();
   });
 
   it('given provisioning is denied for any other reason, should map to provision_failed with the denial as the cause', async () => {
@@ -394,8 +394,8 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: true, sessionId: 'ses-1', pageId: 'agent-1' });
     expect(mockFindSessionForConversation).toHaveBeenCalledWith('conv-1');
     expect(mockProvisionSessionSandbox).toHaveBeenCalledWith(sessionRecord, 'u1');
-    expect(mockRecordMachineActivity).toHaveBeenCalledWith({
-      machineKey: 'ses-1',
+    expect(mockRecordSessionActivity).toHaveBeenCalledWith({
+      sessionId: 'ses-1',
       now: expect.any(Number),
     });
   });

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -41,8 +41,8 @@ import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-
 import {
   acquireCodeExecutionSlot,
   releaseCodeExecutionSlot,
-  checkMachineRuntimeGuardrail,
-  recordMachineActivity,
+  checkSessionRuntimeGuardrail,
+  recordSessionActivity,
 } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import { gateSandboxToolCall } from '@pagespace/lib/services/sandbox/tool-gate';
@@ -133,7 +133,7 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       // The per-sandbox continuous-runtime backstop, keyed by the SESSION id —
       // one budget per workspace, however many threads work in it.
       const nowMs = Date.now();
-      const guardrail = checkMachineRuntimeGuardrail({ machineKey: row.id, now: nowMs });
+      const guardrail = checkSessionRuntimeGuardrail({ sessionId: row.id, now: nowMs });
       if (!guardrail.allowed) return { ok: false, reason: guardrail.reason };
 
       const provisioned = await provisionSessionSandbox(row, input.userId);
@@ -148,7 +148,7 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         return { ok: false, reason: 'provision_failed', cause: provisioned.detail ?? provisioned.reason };
       }
 
-      recordMachineActivity({ machineKey: row.id, now: nowMs });
+      recordSessionActivity({ sessionId: row.id, now: nowMs });
 
       return {
         ok: true,

--- a/knip.json
+++ b/knip.json
@@ -398,6 +398,7 @@
         "src/security/url-validator.ts",
         "src/services/agent-sessions/agent-session-access.ts",
         "src/services/agent-sessions/agent-session-sprite.ts",
+        "src/services/agent-sessions/agent-session-tenant.ts",
         "src/services/agent-sessions/agent-sessions-store.ts",
         "src/services/agent-sessions/agent-sessions.ts",
         "src/services/agent-sessions/session-scrollback.ts",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -677,6 +677,11 @@
       "import": "./dist/services/agent-sessions/agent-session-sprite.js",
       "require": "./dist/services/agent-sessions/agent-session-sprite.js"
     },
+    "./services/agent-sessions/agent-session-tenant": {
+      "types": "./dist/services/agent-sessions/agent-session-tenant.d.ts",
+      "import": "./dist/services/agent-sessions/agent-session-tenant.js",
+      "require": "./dist/services/agent-sessions/agent-session-tenant.js"
+    },
     "./services/agent-sessions/agent-sessions": {
       "types": "./dist/services/agent-sessions/agent-sessions.d.ts",
       "import": "./dist/services/agent-sessions/agent-sessions.js",

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-session-tenant.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-session-tenant.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The tenant/membership gather both tiers (web routes, the realtime shell
+ * bridge) call through — the shared fix for the fail-open/fail-closed
+ * divergence (audit #2265 finding 1): a vanished drive must deny, never fall
+ * back to the session owner, on EITHER tier.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockDriveFindFirst = vi.hoisted(() => vi.fn());
+const mockDriveMemberFindFirst = vi.hoisted(() => vi.fn());
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      drives: { findFirst: mockDriveFindFirst },
+      driveMembers: { findFirst: mockDriveMemberFindFirst },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a, b) => ({ op: 'eq', a, b })),
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  isNotNull: vi.fn((a) => ({ op: 'isNotNull', a })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'drives.id', ownerId: 'drives.ownerId' } }));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: { id: 'driveMembers.id', driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt' },
+}));
+
+const mockCanRunCode = vi.hoisted(() => vi.fn());
+vi.mock('../../sandbox/can-run-code', () => ({ canRunCode: mockCanRunCode }));
+
+import { resolveSessionTenantId, resolveDriveMembership, canRunCodeForSession } from '../agent-session-tenant';
+
+beforeEach(() => {
+  mockDriveFindFirst.mockReset();
+  mockDriveMemberFindFirst.mockReset();
+  mockCanRunCode.mockReset();
+});
+
+describe('resolveSessionTenantId', () => {
+  it('given a global-assistant session (no drive), should resolve the session owner without a DB read', async () => {
+    const result = await resolveSessionTenantId({ driveId: null, ownerId: 'owner-1' });
+    expect(result).toEqual({ ok: true, tenantId: 'owner-1' });
+    expect(mockDriveFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('given a drive-scoped session whose drive exists, should resolve the DRIVE owner', async () => {
+    mockDriveFindFirst.mockResolvedValue({ ownerId: 'drive-owner-1' });
+    const result = await resolveSessionTenantId({ driveId: 'drive-1', ownerId: 'owner-1' });
+    expect(result).toEqual({ ok: true, tenantId: 'drive-owner-1' });
+  });
+
+  it('given a VANISHED drive, should fail CLOSED — never fall back to the session owner', async () => {
+    mockDriveFindFirst.mockResolvedValue(undefined);
+    const result = await resolveSessionTenantId({ driveId: 'gone-drive', ownerId: 'owner-1' });
+    expect(result).toEqual({ ok: false, reason: 'drive_not_found' });
+  });
+});
+
+describe('resolveDriveMembership', () => {
+  it('given a vanished drive, should answer none', async () => {
+    mockDriveFindFirst.mockResolvedValue(undefined);
+    const result = await resolveDriveMembership({ userId: 'user-1', driveId: 'gone-drive' });
+    expect(result).toBe('none');
+    expect(mockDriveMemberFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('given the requester IS the drive owner, should answer owner without a membership read', async () => {
+    mockDriveFindFirst.mockResolvedValue({ ownerId: 'user-1' });
+    const result = await resolveDriveMembership({ userId: 'user-1', driveId: 'drive-1' });
+    expect(result).toBe('owner');
+    expect(mockDriveMemberFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('given an accepted member who is not the owner, should answer member', async () => {
+    mockDriveFindFirst.mockResolvedValue({ ownerId: 'someone-else' });
+    mockDriveMemberFindFirst.mockResolvedValue({ id: 'membership-1' });
+    const result = await resolveDriveMembership({ userId: 'user-1', driveId: 'drive-1' });
+    expect(result).toBe('member');
+  });
+
+  it('given no accepted membership row, should answer none', async () => {
+    mockDriveFindFirst.mockResolvedValue({ ownerId: 'someone-else' });
+    mockDriveMemberFindFirst.mockResolvedValue(undefined);
+    const result = await resolveDriveMembership({ userId: 'user-1', driveId: 'drive-1' });
+    expect(result).toBe('none');
+  });
+});
+
+describe('canRunCodeForSession', () => {
+  it('given a drive-scoped session, should pass the driveId through as-is', async () => {
+    mockCanRunCode.mockResolvedValue({ ok: true });
+    await canRunCodeForSession({ userId: 'user-1', driveId: 'drive-1' });
+    expect(mockCanRunCode).toHaveBeenCalledWith({ userId: 'user-1', driveId: 'drive-1', requestOrigin: 'user' });
+  });
+
+  it('given a global-assistant session (null driveId), should pass undefined, not null', async () => {
+    mockCanRunCode.mockResolvedValue({ ok: true });
+    await canRunCodeForSession({ userId: 'user-1', driveId: null });
+    expect(mockCanRunCode).toHaveBeenCalledWith({ userId: 'user-1', driveId: undefined, requestOrigin: 'user' });
+  });
+
+  it('given the capability check refuses, should reduce to false', async () => {
+    mockCanRunCode.mockResolvedValue({ ok: false, reason: 'kill_switch_off' });
+    const result = await canRunCodeForSession({ userId: 'user-1', driveId: 'drive-1' });
+    expect(result).toBe(false);
+  });
+});

--- a/packages/lib/src/services/agent-sessions/agent-session-tenant.ts
+++ b/packages/lib/src/services/agent-sessions/agent-session-tenant.ts
@@ -1,0 +1,83 @@
+/**
+ * The tenant/membership FACTS a session's Sprite-key fold and its access
+ * decision both need — gathered ONCE so a change to either rule cannot land
+ * on one tier (web routes, the realtime shell bridge) and miss the other.
+ *
+ * `resolveSessionTenantId` folds the Sprite key's tenant: the agent session's
+ * drive OWNER for a drive-scoped session, the session's own owner for a
+ * global-assistant one. A drive that no longer exists is NOT the global case
+ * — it fails closed (`drive_not_found`) rather than silently falling back to
+ * the session owner, which would mint a Sprite under a DIFFERENT tenant than
+ * the one this session's key already folded under, splitting one session
+ * across two Sprite identities.
+ *
+ * `resolveDriveMembership` is the requester's relationship to a drive (owner,
+ * accepted member, or neither) — the ONE membership read
+ * `checkAgentSessionAccess`'s gather calls for a drive-scoped session.
+ * `canRunCodeForSession` reduces the centralized `canRunCode` capability check
+ * to the boolean the access decider consumes.
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, isNotNull } from '@pagespace/db/operators';
+import { drives } from '@pagespace/db/schema/core';
+import { driveMembers } from '@pagespace/db/schema/members';
+import { canRunCode } from '../sandbox/can-run-code';
+import type { DriveMembership } from '../../agent-sessions/decide-session-access';
+
+export type ResolveSessionTenantIdResult =
+  | { ok: true; tenantId: string }
+  | { ok: false; reason: 'drive_not_found' };
+
+/**
+ * The tenant a session's Sprite key folds under. Fails CLOSED on a vanished
+ * drive row rather than falling back to the session owner — see module doc.
+ */
+export async function resolveSessionTenantId(session: {
+  driveId: string | null;
+  ownerId: string;
+}): Promise<ResolveSessionTenantIdResult> {
+  if (session.driveId === null) return { ok: true, tenantId: session.ownerId };
+  const drive = await db.query.drives.findFirst({
+    where: eq(drives.id, session.driveId),
+    columns: { ownerId: true },
+  });
+  if (!drive) return { ok: false, reason: 'drive_not_found' };
+  return { ok: true, tenantId: drive.ownerId };
+}
+
+/**
+ * The requester's relationship to a drive: its owner, an accepted member, or
+ * neither. The ONE membership read both access checks (main + end) share.
+ */
+export async function resolveDriveMembership({
+  userId,
+  driveId,
+}: {
+  userId: string;
+  driveId: string;
+}): Promise<DriveMembership> {
+  const drive = await db.query.drives.findFirst({
+    where: eq(drives.id, driveId),
+    columns: { ownerId: true },
+  });
+  if (!drive) return 'none';
+  if (drive.ownerId === userId) return 'owner';
+  const membership = await db.query.driveMembers.findFirst({
+    where: and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId), isNotNull(driveMembers.acceptedAt)),
+    columns: { id: true },
+  });
+  return membership ? 'member' : 'none';
+}
+
+/** The centralized `canRunCode` capability check, reduced to the boolean the access decider consumes. */
+export async function canRunCodeForSession({
+  userId,
+  driveId,
+}: {
+  userId: string;
+  driveId: string | null;
+}): Promise<boolean> {
+  const result = await canRunCode({ userId, driveId: driveId ?? undefined, requestOrigin: 'user' });
+  return result.ok;
+}

--- a/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
@@ -169,7 +169,7 @@ describe('checkpoint state (in-process, per sandbox)', () => {
 
   // Efficiency finding from code review: this in-process Map has no
   // symmetric acquire/release, so it needs an opportunistic sweep (mirroring
-  // quota.ts's machineActivityByKey) or it grows by one entry per distinct
+  // quota.ts's sessionActivityByKey) or it grows by one entry per distinct
   // sandboxId ever seen for the life of the process.
   it('opportunistically evicts entries older than the TTL when a later checkpoint is recorded', () => {
     resetCheckpointState();

--- a/packages/lib/src/services/sandbox/__tests__/egress-ip.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress-ip.test.ts
@@ -17,11 +17,11 @@ describe('resolveEgressIpTag', () => {
   });
 
   it('given an empty/whitespace tag, should treat it as unset (degraded)', () => {
-    expect(resolveEgressIpTag({ surface: 'machine', configuredTag: '   ' }).dedicated).toBe(false);
+    expect(resolveEgressIpTag({ surface: 'session', configuredTag: '   ' }).dedicated).toBe(false);
   });
 
   it('a configured tag is trimmed', () => {
-    expect(resolveEgressIpTag({ surface: 'machine', configuredTag: '  t1  ' })).toEqual({
+    expect(resolveEgressIpTag({ surface: 'session', configuredTag: '  t1  ' })).toEqual({
       tag: 't1',
       dedicated: true,
     });

--- a/packages/lib/src/services/sandbox/__tests__/network-options.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/network-options.test.ts
@@ -9,16 +9,16 @@ describe('resolveSandboxNetworkOptions', () => {
     expect(options.egressMode).toBe('open');
   });
 
-  it('given surface: machine, should resolve OPEN egress identically (one source of truth)', () => {
+  it('given surface: session, should resolve OPEN egress identically (one source of truth)', () => {
     const agent = resolveSandboxNetworkOptions({ surface: 'agent' });
-    const machine = resolveSandboxNetworkOptions({ surface: 'machine' });
-    expect(machine.egressMode).toBe('open');
-    expect(machine.egressMode).toBe(agent.egressMode);
+    const session = resolveSandboxNetworkOptions({ surface: 'session' });
+    expect(session.egressMode).toBe('open');
+    expect(session.egressMode).toBe(agent.egressMode);
   });
 
   it('given either surface, should carry the standard resource caps', () => {
     expect(resolveSandboxNetworkOptions({ surface: 'agent' }).caps).toEqual(SANDBOX_RESOURCE_CAPS);
-    expect(resolveSandboxNetworkOptions({ surface: 'machine' }).caps).toEqual(SANDBOX_RESOURCE_CAPS);
+    expect(resolveSandboxNetworkOptions({ surface: 'session' }).caps).toEqual(SANDBOX_RESOURCE_CAPS);
   });
 
   it('given a configured egress-IP tag, should carry it on the options (dedicated attribution)', () => {

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -7,12 +7,12 @@ import {
   resetCodeExecutionConcurrency,
   checkCodeExecutionQuota,
   checkAgentSessionConcurrency,
-  checkMachineRuntimeGuardrail,
-  recordMachineActivity,
-  resetMachineRuntimeGuardrail,
-  getMachineMaxActiveSeconds,
-  machineActivityMapSize,
-  MACHINE_ACTIVITY_GRACE_MS,
+  checkSessionRuntimeGuardrail,
+  recordSessionActivity,
+  resetSessionRuntimeGuardrail,
+  getSessionMaxActiveSeconds,
+  sessionActivityMapSize,
+  SESSION_ACTIVITY_GRACE_MS,
   type CodeExecutionQuotaDeps,
 } from '../quota';
 
@@ -198,106 +198,106 @@ describe('checkAgentSessionConcurrency', () => {
   });
 });
 
-describe('machine runtime guardrail', () => {
-  const ORIGINAL_ENV = process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS;
+describe('session runtime guardrail', () => {
+  const ORIGINAL_ENV = process.env.TERMINAL_SESSION_MAX_ACTIVE_SECONDS;
 
   beforeEach(() => {
-    resetMachineRuntimeGuardrail();
+    resetSessionRuntimeGuardrail();
   });
 
   afterEach(() => {
     if (ORIGINAL_ENV === undefined) {
-      delete process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS;
+      delete process.env.TERMINAL_SESSION_MAX_ACTIVE_SECONDS;
     } else {
-      process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = ORIGINAL_ENV;
+      process.env.TERMINAL_SESSION_MAX_ACTIVE_SECONDS = ORIGINAL_ENV;
     }
   });
 
-  it('given a fresh machine with no recorded activity, should allow', () => {
-    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm1', now: 1_000, maxActiveSeconds: 60 });
+  it('given a fresh session with no recorded activity, should allow', () => {
+    const decision = checkSessionRuntimeGuardrail({ sessionId: 'ses-1', now: 1_000, maxActiveSeconds: 60 });
     expect(decision).toEqual({ allowed: true });
   });
 
   it('given continuous activity under the cap, should allow', () => {
-    recordMachineActivity({ machineKey: 'm1', now: 0 });
-    recordMachineActivity({ machineKey: 'm1', now: 30_000 });
-    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm1', now: 59_000, maxActiveSeconds: 60 });
+    recordSessionActivity({ sessionId: 'ses-1', now: 0 });
+    recordSessionActivity({ sessionId: 'ses-1', now: 30_000 });
+    const decision = checkSessionRuntimeGuardrail({ sessionId: 'ses-1', now: 59_000, maxActiveSeconds: 60 });
     expect(decision).toEqual({ allowed: true });
   });
 
-  it('given continuous activity that crosses the cap, should deny machine_runtime_exceeded', () => {
-    recordMachineActivity({ machineKey: 'm1', now: 0 });
-    recordMachineActivity({ machineKey: 'm1', now: 30_000 });
-    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm1', now: 61_000, maxActiveSeconds: 60 });
-    expect(decision).toEqual({ allowed: false, reason: 'machine_runtime_exceeded' });
+  it('given continuous activity that crosses the cap, should deny session_runtime_exceeded', () => {
+    recordSessionActivity({ sessionId: 'ses-1', now: 0 });
+    recordSessionActivity({ sessionId: 'ses-1', now: 30_000 });
+    const decision = checkSessionRuntimeGuardrail({ sessionId: 'ses-1', now: 61_000, maxActiveSeconds: 60 });
+    expect(decision).toEqual({ allowed: false, reason: 'session_runtime_exceeded' });
   });
 
   it('given a gap longer than the grace window, should reset the continuous-activity clock', () => {
-    recordMachineActivity({ machineKey: 'm1', now: 0 });
+    recordSessionActivity({ sessionId: 'ses-1', now: 0 });
     // Exceed the cap, but only after a long idle gap — the clock should have reset.
-    const idleGapEnd = MACHINE_ACTIVITY_GRACE_MS + 1;
-    recordMachineActivity({ machineKey: 'm1', now: idleGapEnd });
-    const decision = checkMachineRuntimeGuardrail({
-      machineKey: 'm1',
+    const idleGapEnd = SESSION_ACTIVITY_GRACE_MS + 1;
+    recordSessionActivity({ sessionId: 'ses-1', now: idleGapEnd });
+    const decision = checkSessionRuntimeGuardrail({
+      sessionId: 'ses-1',
       now: idleGapEnd + 60_000,
       maxActiveSeconds: 60,
     });
     // 60s since the reset at idleGapEnd — right at the cap, not yet over it.
-    expect(decision).toEqual({ allowed: false, reason: 'machine_runtime_exceeded' });
+    expect(decision).toEqual({ allowed: false, reason: 'session_runtime_exceeded' });
 
     // A fresh key never touched near the deadline stays under budget.
-    const freshDecision = checkMachineRuntimeGuardrail({
-      machineKey: 'm1',
+    const freshDecision = checkSessionRuntimeGuardrail({
+      sessionId: 'ses-1',
       now: idleGapEnd + 1,
       maxActiveSeconds: 60,
     });
     expect(freshDecision).toEqual({ allowed: true });
   });
 
-  it('given activity on one machine, should track another machine independently', () => {
-    recordMachineActivity({ machineKey: 'm1', now: 0 });
-    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm2', now: 61_000, maxActiveSeconds: 60 });
+  it('given activity on one session, should track another session independently', () => {
+    recordSessionActivity({ sessionId: 'ses-1', now: 0 });
+    const decision = checkSessionRuntimeGuardrail({ sessionId: 'ses-2', now: 61_000, maxActiveSeconds: 60 });
     expect(decision).toEqual({ allowed: true });
   });
 
   it('given no env override, should default to 4 hours', () => {
-    delete process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS;
-    expect(getMachineMaxActiveSeconds()).toBe(4 * 60 * 60);
+    delete process.env.TERMINAL_SESSION_MAX_ACTIVE_SECONDS;
+    expect(getSessionMaxActiveSeconds()).toBe(4 * 60 * 60);
   });
 
   it('given a valid env override, should use it', () => {
-    process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = '120';
-    expect(getMachineMaxActiveSeconds()).toBe(120);
+    process.env.TERMINAL_SESSION_MAX_ACTIVE_SECONDS = '120';
+    expect(getSessionMaxActiveSeconds()).toBe(120);
   });
 
   it('given an invalid env override, should fall back to the default', () => {
-    process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = 'not-a-number';
-    expect(getMachineMaxActiveSeconds()).toBe(4 * 60 * 60);
+    process.env.TERMINAL_SESSION_MAX_ACTIVE_SECONDS = 'not-a-number';
+    expect(getSessionMaxActiveSeconds()).toBe(4 * 60 * 60);
   });
 
-  it('given a machine that has gone idle past the grace window, should evict its entry (bounded memory)', () => {
-    recordMachineActivity({ machineKey: 'stale-machine', now: 0 });
-    expect(machineActivityMapSize()).toBe(1);
+  it('given a session that has gone idle past the grace window, should evict its entry (bounded memory)', () => {
+    recordSessionActivity({ sessionId: 'stale-session', now: 0 });
+    expect(sessionActivityMapSize()).toBe(1);
 
-    // A later acquisition on a DIFFERENT machine, well past the first
-    // machine's grace window, should sweep the stale entry rather than
+    // A later acquisition on a DIFFERENT session, well past the first
+    // session's grace window, should sweep the stale entry rather than
     // accumulating it forever.
-    const now = MACHINE_ACTIVITY_GRACE_MS + 1;
-    recordMachineActivity({ machineKey: 'other-machine', now });
+    const now = SESSION_ACTIVITY_GRACE_MS + 1;
+    recordSessionActivity({ sessionId: 'other-session', now });
 
-    expect(machineActivityMapSize()).toBe(1);
+    expect(sessionActivityMapSize()).toBe(1);
   });
 
-  it('given many machines that all go idle, should not grow unbounded across acquisitions', () => {
+  it('given many sessions that all go idle, should not grow unbounded across acquisitions', () => {
     for (let i = 0; i < 50; i++) {
-      recordMachineActivity({ machineKey: `machine-${i}`, now: 0 });
+      recordSessionActivity({ sessionId: `session-${i}`, now: 0 });
     }
-    expect(machineActivityMapSize()).toBe(50);
+    expect(sessionActivityMapSize()).toBe(50);
 
     // One more acquisition, long after all 50 went idle, should sweep them all.
-    recordMachineActivity({ machineKey: 'fresh-machine', now: MACHINE_ACTIVITY_GRACE_MS + 1 });
+    recordSessionActivity({ sessionId: 'fresh-session', now: SESSION_ACTIVITY_GRACE_MS + 1 });
 
-    expect(machineActivityMapSize()).toBe(1);
+    expect(sessionActivityMapSize()).toBe(1);
   });
 });
 

--- a/packages/lib/src/services/sandbox/checkpoint-policy.ts
+++ b/packages/lib/src/services/sandbox/checkpoint-policy.ts
@@ -113,7 +113,7 @@ const stateBySandboxId = new Map<string, CheckpointState>();
 /**
  * How long a sandbox's checkpoint bookkeeping may sit unused before an
  * opportunistic sweep reclaims it — mirrors `quota.ts`'s
- * `evictStaleMachineActivity`/`MACHINE_ACTIVITY_GRACE_MS` pattern (this map
+ * `evictStaleSessionActivity`/`SESSION_ACTIVITY_GRACE_MS` pattern (this map
  * has no symmetric acquire/release either, so eviction has to be
  * opportunistic). Sandboxes are long-lived and reused across many turns, so
  * this is deliberately generous — the only failure mode of evicting too

--- a/packages/lib/src/services/sandbox/network-options.ts
+++ b/packages/lib/src/services/sandbox/network-options.ts
@@ -21,7 +21,7 @@ import type { SandboxCreateOptions } from './sandbox-options';
 import { resolveEgressIpTag } from './egress-ip';
 
 /** The two sandbox surfaces that share the network posture. */
-export type SandboxSurface = 'agent' | 'machine';
+export type SandboxSurface = 'agent' | 'session';
 
 /**
  * Resolve the create-time network options for a sandbox surface. Both surfaces get

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -160,112 +160,112 @@ export async function checkAgentSessionConcurrency({
 }
 
 /**
- * Per-machine active-runtime guardrail (Terminal Epic 1 T1.5).
+ * Per-session active-runtime guardrail (Terminal Epic 1 T1.5).
  *
  * A pulled-forward, minimal cost backstop ahead of Epic 3's full usage
- * metering: an agent that keeps a persistent machine continuously busy
- * (back-to-back tool calls, no idle gaps) is capped at a configurable
+ * metering: an agent that keeps a persistent session's sandbox continuously
+ * busy (back-to-back tool calls, no idle gaps) is capped at a configurable
  * wall-clock duration instead of running unbounded. This tracks CONTINUOUS
- * activity per machine, not lifetime usage — a gap longer than the grace
- * window resets the clock, so a machine that goes idle (naturally, or via
+ * activity per session, not lifetime usage — a gap longer than the grace
+ * window resets the clock, so a session that goes idle (naturally, or via
  * Sprite hibernation) recovers full budget rather than being capped forever.
  *
  * Deliberately separate from the per-user concurrency semaphore above: that
  * bounds how many runs a USER has in flight; this bounds how long a single
- * MACHINE has been kept continuously active, regardless of which user/agent
- * is driving it.
+ * SESSION's sandbox has been kept continuously active, regardless of which
+ * user/agent is driving it.
  */
 
-const MACHINE_MAX_ACTIVE_SECONDS_ENV = 'TERMINAL_MACHINE_MAX_ACTIVE_SECONDS';
-const DEFAULT_MACHINE_MAX_ACTIVE_SECONDS = 4 * 60 * 60; // 4 hours
+const SESSION_MAX_ACTIVE_SECONDS_ENV = 'TERMINAL_SESSION_MAX_ACTIVE_SECONDS';
+const DEFAULT_SESSION_MAX_ACTIVE_SECONDS = 4 * 60 * 60; // 4 hours
 /** A gap longer than this between calls resets the continuous-activity clock. */
-export const MACHINE_ACTIVITY_GRACE_MS = 5 * 60 * 1000;
+export const SESSION_ACTIVITY_GRACE_MS = 5 * 60 * 1000;
 
-export function getMachineMaxActiveSeconds(): number {
-  const raw = process.env[MACHINE_MAX_ACTIVE_SECONDS_ENV];
+export function getSessionMaxActiveSeconds(): number {
+  const raw = process.env[SESSION_MAX_ACTIVE_SECONDS_ENV];
   const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MACHINE_MAX_ACTIVE_SECONDS;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_MAX_ACTIVE_SECONDS;
 }
 
-interface MachineActivityState {
+interface SessionActivityState {
   firstActiveAt: number;
   lastActiveAt: number;
 }
 
-const machineActivityByKey = new Map<string, MachineActivityState>();
+const sessionActivityByKey = new Map<string, SessionActivityState>();
 
-export type MachineRuntimeGuardrailReason = 'machine_runtime_exceeded';
+export type SessionRuntimeGuardrailReason = 'session_runtime_exceeded';
 
-export type MachineRuntimeGuardrailDecision =
+export type SessionRuntimeGuardrailDecision =
   | { allowed: true }
-  | { allowed: false; reason: MachineRuntimeGuardrailReason };
+  | { allowed: false; reason: SessionRuntimeGuardrailReason };
 
 /**
  * Drop entries whose gap has already exceeded the grace window: once that's
- * true, `checkMachineRuntimeGuardrail` treats the key as if it had no state
+ * true, `checkSessionRuntimeGuardrail` treats the key as if it had no state
  * anyway, so the entry is pure dead weight. Without this, every distinct
- * machine ever acquired would occupy an entry for the life of the process —
+ * session ever acquired would occupy an entry for the life of the process —
  * unlike the per-user semaphore above, this map has no symmetric
  * acquire/release to hook a delete into, so eviction has to be opportunistic.
  */
-function evictStaleMachineActivity(now: number): void {
-  for (const [key, state] of machineActivityByKey) {
-    if (now - state.lastActiveAt > MACHINE_ACTIVITY_GRACE_MS) {
-      machineActivityByKey.delete(key);
+function evictStaleSessionActivity(now: number): void {
+  for (const [key, state] of sessionActivityByKey) {
+    if (now - state.lastActiveAt > SESSION_ACTIVITY_GRACE_MS) {
+      sessionActivityByKey.delete(key);
     }
   }
 }
 
 /**
- * Advisory check: has this machine been continuously active (no gap longer
- * than `MACHINE_ACTIVITY_GRACE_MS`) for at least `maxActiveSeconds`? Pure
- * read — does not itself record activity; callers must also call
- * `recordMachineActivity` on every acquisition (allowed or not) so a stalled
+ * Advisory check: has this session's sandbox been continuously active (no gap
+ * longer than `SESSION_ACTIVITY_GRACE_MS`) for at least `maxActiveSeconds`?
+ * Pure read — does not itself record activity; callers must also call
+ * `recordSessionActivity` on every acquisition (allowed or not) so a stalled
  * caller who never records still reflects real elapsed time.
  */
-export function checkMachineRuntimeGuardrail({
-  machineKey,
+export function checkSessionRuntimeGuardrail({
+  sessionId,
   now,
-  maxActiveSeconds = getMachineMaxActiveSeconds(),
+  maxActiveSeconds = getSessionMaxActiveSeconds(),
 }: {
-  machineKey: string;
+  sessionId: string;
   now: number;
   maxActiveSeconds?: number;
-}): MachineRuntimeGuardrailDecision {
-  const state = machineActivityByKey.get(machineKey);
-  if (state && now - state.lastActiveAt <= MACHINE_ACTIVITY_GRACE_MS) {
+}): SessionRuntimeGuardrailDecision {
+  const state = sessionActivityByKey.get(sessionId);
+  if (state && now - state.lastActiveAt <= SESSION_ACTIVITY_GRACE_MS) {
     const activeMs = now - state.firstActiveAt;
     if (activeMs >= maxActiveSeconds * 1000) {
-      return { allowed: false, reason: 'machine_runtime_exceeded' };
+      return { allowed: false, reason: 'session_runtime_exceeded' };
     }
   }
   return { allowed: true };
 }
 
 /**
- * Record that this machine was just active. Starts (or continues) the
- * continuous-activity window; a gap longer than the grace period starts a
- * fresh window instead of extending the old one.
+ * Record that this session's sandbox was just active. Starts (or continues)
+ * the continuous-activity window; a gap longer than the grace period starts
+ * a fresh window instead of extending the old one.
  */
-export function recordMachineActivity({ machineKey, now }: { machineKey: string; now: number }): void {
+export function recordSessionActivity({ sessionId, now }: { sessionId: string; now: number }): void {
   // Opportunistic sweep: every acquisition is a natural checkpoint to reclaim
-  // any OTHER machine's entry that has gone idle, keeping the map bounded by
-  // currently (or recently) active machines rather than every machine ever seen.
-  evictStaleMachineActivity(now);
-  const state = machineActivityByKey.get(machineKey);
-  if (!state || now - state.lastActiveAt > MACHINE_ACTIVITY_GRACE_MS) {
-    machineActivityByKey.set(machineKey, { firstActiveAt: now, lastActiveAt: now });
+  // any OTHER session's entry that has gone idle, keeping the map bounded by
+  // currently (or recently) active sessions rather than every session ever seen.
+  evictStaleSessionActivity(now);
+  const state = sessionActivityByKey.get(sessionId);
+  if (!state || now - state.lastActiveAt > SESSION_ACTIVITY_GRACE_MS) {
+    sessionActivityByKey.set(sessionId, { firstActiveAt: now, lastActiveAt: now });
   } else {
     state.lastActiveAt = now;
   }
 }
 
-/** Clear all machine-runtime guardrail state. Test-only seam. */
-export function resetMachineRuntimeGuardrail(): void {
-  machineActivityByKey.clear();
+/** Clear all session-runtime guardrail state. Test-only seam. */
+export function resetSessionRuntimeGuardrail(): void {
+  sessionActivityByKey.clear();
 }
 
 /** Current guardrail map size — test-only seam for verifying eviction bounds memory. */
-export function machineActivityMapSize(): number {
-  return machineActivityByKey.size;
+export function sessionActivityMapSize(): number {
+  return sessionActivityByKey.size;
 }

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -100,7 +100,13 @@ export interface SandboxBillingDeps {
   resolvePayerId: (input: { driveId: string | null; ownerId: string }) => Promise<string>;
   /** Places a flat-estimate hold for this payer before the machine run begins. */
   gate: (input: { payerId: string }) => Promise<{ allowed: boolean; holdId?: string; reason?: string }>;
-  /** Settles the hold to the real active-window cost. Only called on a successful run. */
+  /**
+   * Settles the hold to the real active-window cost. Only called on a
+   * successful run. `pageId` is the AI-tool-runner path's calling-surface
+   * agent page; `driveId` is the realtime shell bridge's session-level
+   * attribution (a session is drive-scoped, not page-anchored) — a caller
+   * sets whichever one its own model has, never both.
+   */
   trackUsage: (input: {
     payerId: string;
     holdId?: string;
@@ -151,7 +157,7 @@ export interface ShellActivityNotification {
  * `getState`/`recordCheckpoint` are the bookkeeping the pure `shouldCheckpoint`
  * policy (`checkpoint-policy.ts`) needs to enforce "at most once per turn" +
  * the rapid-batch throttle; production wires them to an in-process Map keyed
- * by sandboxId (mirrors `quota.ts`'s `machineActivityByKey` — no persistence,
+ * by sandboxId (mirrors `quota.ts`'s `sessionActivityByKey` — no persistence,
  * no reaper). `createCheckpoint` is the actual SDK call against a live,
  * already-awake sandbox handle.
  */
@@ -304,7 +310,7 @@ export function safeLogWarn(
 // noise that trains the on-call to ignore this logger.
 const AUTHZ_DENY_REASONS = new Set([
   'no_drive_access', 'insufficient_role', 'no_agent_access', 'app_admin_required', 'kill_switch_off', 'no_machine',
-  'machine_runtime_exceeded', 'session_limit_reached',
+  'session_runtime_exceeded', 'session_limit_reached',
   // A legacy conversation that predates sessions has no working context to run
   // in — an expected refusal (not an infra fault), so it belongs here rather
   // than paging on-call for every pre-session thread an agent tool touches.
@@ -319,7 +325,7 @@ export type SandboxToolDenialReason =
   | 'insufficient_role'
   | 'no_agent_access'
   | 'no_machine'
-  | 'machine_runtime_exceeded'
+  | 'session_runtime_exceeded'
   | 'credit_exhausted'
   | 'concurrency_limit'
   | 'session_limit_reached'
@@ -360,8 +366,8 @@ export const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   insufficient_role: 'Running code requires drive owner or admin access.',
   no_agent_access: 'This agent is not permitted to run code in this drive.',
   no_machine: 'No machine is configured for this run.',
-  machine_runtime_exceeded:
-    'This machine has been running continuously for too long. Wait for it to go idle, or switch to a different machine.',
+  session_runtime_exceeded:
+    "This session's sandbox has been running continuously for too long. Wait for it to go idle, or switch to a different session.",
   credit_exhausted: 'Insufficient credits to run this machine.',
   concurrency_limit: 'Too many concurrent runs. Wait for a run to finish and retry.',
   // A different limit from `concurrency_limit`, and the distinction is the


### PR DESCRIPTION
## Summary
Follow-up from the post-merge audit of PR #2258 (realtime + cross-tier consistency slice). Fixes all 7 findings in #2265:

- **Fail-closed tenant resolution (finding 1)**: hoisted `resolveSessionTenantId` into `packages/lib/src/services/agent-sessions/agent-session-tenant.ts`, imported by both `apps/realtime/src/index.ts` and `apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts`. Kills the web tier's fail-open `drive?.ownerId ?? session.ownerId` fallback — a vanished drive now denies on both tiers via the same function.
- **One membership-gathering implementation (finding 2)**: `resolveDriveMembership` + the `canRunCode` reduction also live in the new module, replacing the copy-pasted DB queries in both tiers.
- **Dead code (finding 3)**: removed unused `checkMachineRuntimeGuardrail`/`recordMachineActivity` imports, the dead `conversations` schema import, and the unused `resolveDriveOwnerContext` helper + type from `apps/realtime/src/index.ts`.
- **Stale doc comments (finding 4)**: fixed the tenantId docblock in `index.ts`, the payer prose in `shell-access.ts`, `XtermTerminal.tsx`'s reference to a deleted method, and `useAgentSessionChat.test.ts`'s header referencing deleted modules.
- **Dead `pageId` plumbing (finding 5)**: ~~deleted `TerminalSession.pageId`...~~ **UPDATE:** PR #2273 (billing payer unification, issue #2260) merged to master mid-review and fully addressed this independently — it deleted `TerminalSession.pageId`, added `driveId`/`agentSessionId` fields, and threaded them through all three `trackUsage` call sites plus the first-class `driveId`/`sessionId` columns on `AIMonitoring.trackUsage`. After rebasing onto master, this branch's own (less complete) version of the same fix was dropped entirely in favor of #2273's — confirmed via `git diff origin/master...HEAD -- apps/realtime/src/terminal/terminal-session-map.ts packages/lib/src/services/sandbox/sandbox-billing.ts` showing **zero diff** against master. Finding 5 is fully satisfied by master; nothing left for this PR to do there.
- **`composeSocketKey` export (finding 6)**: exported from `shell-handler.ts`; `index.ts` now calls it instead of re-spelling the socket-key format inline.
- **Machine → session vocabulary (finding 7)**: `SandboxSurface`'s `'machine'` value and every `quota.ts` guardrail identifier (`checkMachineRuntimeGuardrail` → `checkSessionRuntimeGuardrail`, `recordMachineActivity` → `recordSessionActivity`, `MACHINE_ACTIVITY_GRACE_MS` → `SESSION_ACTIVITY_GRACE_MS`, etc.) renamed, touching both tiers' call sites and tests. `machine_sprite_reclaims` table name deliberately untouched (migration-documented).

Issue #2260's PR (#2273) merged with a more complete billing-attribution fix than finding 5 anticipated, so this branch defers to it entirely rather than duplicating.

**Rebase note:** this branch was rebased onto master twice during review to pick up PR #2273 (billing payer unification) and PRs #2269/#2268 (session-tools scoping, pane lifecycle) as they landed. All five overlapping files (`shell-handler.ts`, `terminal-session-map.ts`, `shell-handler.test.ts`, `sandbox-tools-runtime.ts`, `tool-runners.ts`) plus `agent-sessions-runtime.ts` (overlap with #2269's bounded `listSessionConversationsBulk`) were reconciled by hand — master's versions won wherever there was real overlap; this PR's renames/hoists/dead-code deletions sit cleanly on top.

## Test plan
- [x] New `agent-session-tenant.test.ts` pins fail-closed-on-vanished-drive for `resolveSessionTenantId`, plus `resolveDriveMembership`/`canRunCodeForSession`
- [x] `apps/realtime` full suite passes
- [x] `apps/web` sandbox-tools-runtime + agent-sessions route tests pass
- [x] `packages/lib` full suite passes
- [x] `bun run typecheck`, `bun run lint`, `bun run knip:check` all pass (monorepo + per-package for realtime/web/lib)
- [x] `cd packages/lib && bun run typecheck` passes
- [x] `bun run test:unit` — 15122/15129 pass; the 1 failure (`grouping.test.ts` midnight-crossing) is a pre-existing TZ-env issue in a file this branch never touches
- [x] `bun run test:security` — 44/50 suites pass; the 6 failures are pre-existing stale references in `scripts/test-security.sh` (test files deleted in #861, and vitest-config-excluded files), confirmed via `git log --diff-filter=D`, unrelated to this branch

Closes #2265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrdwiwAmX57oXSpiBcmAF