### PR TITLE
fix(agent-sessions): CAS lifecycle stamps, atomic spawn ceiling, route error-mapping

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -18,10 +18,13 @@ const API_DIR = join(__dirname, '..');
 /**
  * Regex matching any form of security audit call used across the codebase.
  * Covers: direct securityAudit.* calls, logAuditEvent helper, logAuthEvent
- * adapter, logSecurityEvent adapter, and withAdminAuth wrapper.
+ * adapter, logSecurityEvent adapter, withAdminAuth wrapper, and the
+ * `agent-sessions/[sessionId]` family's shared not-found/denied helpers
+ * (`session-unavailable-response.ts`, review #2261/5) — both call
+ * `auditRequest` internally, one hop removed from the route file.
  */
 const AUDIT_CALL_PATTERN =
-  /securityAudit\.|logAuditEvent\(|logAuthEvent\(|logSecurityEvent\(|withAdminAuth[<(]|audit\(|auditRequest\(/;
+  /securityAudit\.|logAuditEvent\(|logAuthEvent\(|logSecurityEvent\(|withAdminAuth[<(]|audit\(|auditRequest\(|auditSessionAccessDenial\(|sessionNotFoundOrDenied\(/;
 
 /**
  * Routes explicitly exempt from audit coverage.

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/__tests__/route.test.ts
@@ -73,10 +73,11 @@ describe('GET /api/agent-sessions/[sessionId]', () => {
     expect(await response.json()).toEqual({ session: null });
   });
 
-  it('given a denial, should 403 and audit it', async () => {
+  it('given a denial, should answer { session: null } — SAME as not-found, but still audit it (review #2261/5)', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'page_access_denied' });
     const response = await get();
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ session: null });
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ eventType: 'authz.access.denied' }),
@@ -99,10 +100,10 @@ describe('POST /api/agent-sessions/[sessionId]', () => {
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
   });
 
-  it('given an access denial, should 403 BEFORE provisioning anything', async () => {
+  it('given an access denial, should 404 (SAME as not-found, review #2261/5) BEFORE provisioning anything', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
     const response = await post();
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
   });
 
@@ -163,10 +164,10 @@ describe('DELETE /api/agent-sessions/[sessionId]', () => {
     expect(mockEndSession).not.toHaveBeenCalled();
   });
 
-  it('given a denial, should 403 and never touch the session', async () => {
+  it('given a denial, should 404 (SAME as not-found, review #2261/5) and never touch the session', async () => {
     mockCheckSessionEndAccess.mockResolvedValue({ allowed: false, reason: 'not_shared' });
     const response = await del();
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockEndSession).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/__tests__/route.test.ts
@@ -44,7 +44,7 @@ vi.mock('@/lib/repositories/conversation-repository', () => ({
 }));
 
 import { POST } from '../route';
-import { ConversationUnavailableError } from '@/lib/agent-sessions/create-conversation-in-session';
+import { AgentNotInSessionDriveError, ConversationUnavailableError } from '@/lib/agent-sessions/create-conversation-in-session';
 
 const AUTH_USER = { userId: 'user-1', role: 'admin' };
 const SESSION_ID = 'ses-1';
@@ -114,10 +114,10 @@ describe('POST /api/agent-sessions/[sessionId]/conversations', () => {
     expect(mockCreateConversationInSession).not.toHaveBeenCalled();
   });
 
-  it('403s a session the requester cannot reach, and audits it', async () => {
+  it('404s a session the requester cannot reach (SAME as not-found, review #2261/5), but still audits it', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
     const response = await post({ agentPageId: 'agent-1' });
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockCreateConversationInSession).not.toHaveBeenCalled();
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
@@ -161,6 +161,12 @@ describe('POST /api/agent-sessions/[sessionId]/conversations', () => {
     const response = await post({});
     expect(response.status).toBe(502);
     expect(await response.json()).toEqual({ error: 'Could not start a conversation' });
+  });
+
+  it('400s an agent from a DIFFERENT drive than the session — a caller mistake, not a service failure (review #2261/6)', async () => {
+    mockCreateConversationInSession.mockRejectedValue(new AgentNotInSessionDriveError());
+    const response = await post({ agentPageId: 'agent-1' });
+    expect(response.status).toBe(400);
   });
 
   it('given an auth failure, should return the auth error untouched', async () => {

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/route.ts
@@ -30,25 +30,20 @@ import {
   checkSessionAccess,
   createConversationInSession,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
-import { ConversationUnavailableError, SessionFullError } from '@/lib/agent-sessions/create-conversation-in-session';
+import {
+  AgentNotInSessionDriveError,
+  ConversationUnavailableError,
+  SessionFullError,
+} from '@/lib/agent-sessions/create-conversation-in-session';
 import { sessionConversationLimitExceeded } from '@/lib/agent-sessions/quota-response';
+import { sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
-type RouteContext = { params: Promise<{ sessionId: string }> };
+const ROUTE = 'agent-sessions/[sessionId]/conversations';
 
-function denied(request: Request, userId: string, sessionId: string, reason: string): NextResponse {
-  auditRequest(request, {
-    eventType: 'authz.access.denied',
-    userId,
-    resourceType: 'agent_session',
-    resourceId: sessionId,
-    details: { reason, route: 'agent-sessions/[sessionId]/conversations' },
-    riskScore: 0.5,
-  });
-  return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
-}
+type RouteContext = { params: Promise<{ sessionId: string }> };
 
 export async function POST(request: Request, context: RouteContext) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
@@ -65,13 +60,11 @@ export async function POST(request: Request, context: RouteContext) {
     typeof body.agentPageId === 'string' && body.agentPageId.length > 0 ? body.agentPageId : null;
 
   // The session must already EXIST — a conversation joins a workspace, it
-  // never mints one (spawning a session is the collection route's act).
+  // never mints one (spawning a session is the collection route's act). Not
+  // found and denied answer THE SAME 404 (family policy, review #2261/5).
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
-    }
-    return denied(request, auth.userId, sessionId, access.reason);
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE);
   }
 
   if (agentPageId !== null) {
@@ -127,10 +120,17 @@ export async function POST(request: Request, context: RouteContext) {
         userId: auth.userId,
         resourceType: 'agent_session',
         resourceId: sessionId,
-        details: { reason: 'conversation_unavailable', conversationId, route: 'agent-sessions/[sessionId]/conversations' },
+        details: { reason: 'conversation_unavailable', conversationId, route: ROUTE },
         riskScore: 0.5,
       });
       return NextResponse.json({ error: 'That conversation id is not available' }, { status: 409 });
+    }
+    if (error instanceof AgentNotInSessionDriveError) {
+      // A caller mistake (an agent page from a DIFFERENT drive than this
+      // session), not a service failure (review #2261/6) — was falling
+      // through to the generic 502 below, which logged it as a server error
+      // and told the caller to retry a request that can never succeed.
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
     loggers.api.error(
       'Session conversation create failed',

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/diff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/diff/__tests__/route.test.ts
@@ -113,10 +113,11 @@ describe('GET /api/agent-sessions/[sessionId]/diff', () => {
     );
   });
 
-  it('given an access denial, should uniform-403 before parsing scope params, and audit', async () => {
+  it('given an access denial, should answer not_started 404 (SAME as not-found, review #2261/5) before parsing scope params, and audit', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'code_execution_denied' });
     const response = await get('?bogus=1');
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
+    expect((await response.json()).reason).toBe('not_started');
     expect(mockAuditRequest).toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/diff/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/diff/route.ts
@@ -17,7 +17,6 @@
 
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { listMachineDiffFiles, readMachineDiffPair } from '@pagespace/lib/services/sandbox/machine-diff';
 import {
@@ -35,8 +34,11 @@ import {
   resolveSessionActorContext,
   resolveSessionSandboxHandle,
 } from '@/lib/agent-sessions/session-sandbox-runtime';
+import { auditSessionAccessDenial } from '@/lib/agent-sessions/session-unavailable-response';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+const ROUTE = 'agent-sessions/[sessionId]/diff';
 
 type RouteContext = { params: Promise<{ sessionId: string }> };
 
@@ -64,21 +66,13 @@ export async function GET(request: Request, context: RouteContext) {
   const { sessionId } = await context.params;
 
   // Authorize BEFORE parsing scope/path params — a user without access gets a
-  // uniform answer and can never probe them.
+  // uniform answer and can never probe them. Not found and denied answer THE
+  // SAME (family policy, review #2261/5) — both `not_started`, never a 403
+  // that would confirm the session id is real.
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'This session has no sandbox yet', reason: 'not_started' }, { status: 404 });
-    }
-    auditRequest(request, {
-      eventType: 'authz.access.denied',
-      userId: auth.userId,
-      resourceType: 'agent_session',
-      resourceId: sessionId,
-      details: { reason: access.reason, route: 'agent-sessions/[sessionId]/diff' },
-      riskScore: 0.5,
-    });
-    return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
+    auditSessionAccessDenial(request, auth.userId, sessionId, access.reason, ROUTE);
+    return NextResponse.json({ error: 'This session has no sandbox yet', reason: 'not_started' }, { status: 404 });
   }
 
   const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/files/__tests__/route.test.ts
@@ -124,10 +124,11 @@ describe('GET /api/agent-sessions/[sessionId]/files', () => {
     expect(response.status).toBe(503);
   });
 
-  it('given an access denial, should uniform-403 BEFORE parsing any params, and audit', async () => {
+  it('given an access denial, should answer not_started 404 (SAME as not-found, review #2261/5) BEFORE parsing any params, and audit', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'page_access_denied' });
     const response = await get('?path=../escape&mode=bogus');
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual(expect.objectContaining({ reason: 'not_started' }));
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ eventType: 'authz.access.denied' }),
@@ -176,10 +177,10 @@ describe('DELETE /api/agent-sessions/[sessionId]/files', () => {
     expect(mockDeleteMachinePath).toHaveBeenCalledWith({ handle: HANDLE, path: '/workspace/clone/tmp' });
   });
 
-  it('given an access denial, should 403 and delete nothing', async () => {
+  it('given an access denial, should 404 (SAME as not-found, review #2261/5) and delete nothing', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'not_shared' });
     const response = await DELETE(jsonRequest('DELETE', { path: 'tmp' }), params);
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockDeleteMachinePath).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/files/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/files/route.ts
@@ -30,6 +30,7 @@ import { StringDecoder } from 'string_decoder';
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { auditSessionAccessDenial } from '@/lib/agent-sessions/session-unavailable-response';
 import { sanitizeFilenameForHeader } from '@pagespace/lib/utils/file-security';
 import {
   listMachineDirectory,
@@ -176,6 +177,12 @@ function resolveDenialResponse(reason: 'not_found' | 'not_started' | 'vanished')
   return NextResponse.json({ error, reason }, { status: RESOLVE_DENIAL_STATUS[reason] });
 }
 
+const ROUTE = 'agent-sessions/[sessionId]/files';
+
+/**
+ * Not found and denied answer THE SAME (family policy, review #2261/5) —
+ * both `not_started`, never a 403 that would confirm the session id is real.
+ */
 async function authorize(
   request: Request,
   userId: string,
@@ -183,18 +190,8 @@ async function authorize(
 ): Promise<NextResponse | null> {
   const access = await checkSessionAccess(userId, sessionId);
   if (access.allowed) return null;
-  if (access.reason === 'session_not_found') {
-    return NextResponse.json({ error: 'This session has no sandbox yet', reason: 'not_started' }, { status: 404 });
-  }
-  auditRequest(request, {
-    eventType: 'authz.access.denied',
-    userId,
-    resourceType: RESOURCE_TYPE,
-    resourceId: sessionId,
-    details: { reason: access.reason, route: 'agent-sessions/[sessionId]/files' },
-    riskScore: 0.5,
-  });
-  return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
+  auditSessionAccessDenial(request, userId, sessionId, access.reason, ROUTE);
+  return NextResponse.json({ error: 'This session has no sandbox yet', reason: 'not_started' }, { status: 404 });
 }
 
 function mutateFailureResponse(result: Extract<MutateMachinePathResult, { ok: false }>, notFoundMessage: string): NextResponse {

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/git-blob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/git-blob/__tests__/route.test.ts
@@ -76,10 +76,11 @@ describe('GET /api/agent-sessions/[sessionId]/git-blob', () => {
     expect((await get('?repoPath=c&ref=a')).status).toBe(400);
   });
 
-  it('given a denial, should uniform-403 before parsing ref/path, and audit', async () => {
+  it('given a denial, should answer not_started 404 (SAME as not-found, review #2261/5) before parsing ref/path, and audit', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'not_shared' });
     const response = await get('');
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
+    expect((await response.json()).reason).toBe('not_started');
     expect(mockAuditRequest).toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/git-blob/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/git-blob/route.ts
@@ -14,7 +14,6 @@
 
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { readMachineGitBlob } from '@pagespace/lib/services/sandbox/machine-git-blob';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
@@ -26,8 +25,11 @@ import {
   resolveSessionActorContext,
   resolveSessionSandboxHandle,
 } from '@/lib/agent-sessions/session-sandbox-runtime';
+import { auditSessionAccessDenial } from '@/lib/agent-sessions/session-unavailable-response';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+const ROUTE = 'agent-sessions/[sessionId]/git-blob';
 
 type RouteContext = { params: Promise<{ sessionId: string }> };
 
@@ -56,21 +58,13 @@ export async function GET(request: Request, context: RouteContext) {
   const { sessionId } = await context.params;
 
   // Authorize BEFORE parsing ref/path — a user without access can never probe
-  // ref/path handling.
+  // ref/path handling. Not found and denied answer THE SAME (family policy,
+  // review #2261/5) — both `not_started`, never a 403 that would confirm the
+  // session id is real.
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'This session has no sandbox yet', reason: 'not_started' }, { status: 404 });
-    }
-    auditRequest(request, {
-      eventType: 'authz.access.denied',
-      userId: auth.userId,
-      resourceType: 'agent_session',
-      resourceId: sessionId,
-      details: { reason: access.reason, route: 'agent-sessions/[sessionId]/git-blob' },
-      riskScore: 0.5,
-    });
-    return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
+    auditSessionAccessDenial(request, auth.userId, sessionId, access.reason, ROUTE);
+    return NextResponse.json({ error: 'This session has no sandbox yet', reason: 'not_started' }, { status: 404 });
   }
 
   const url = new URL(request.url);

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/route.ts
@@ -2,15 +2,14 @@
  * One agent session — status / ensure+provision / end.
  *
  * GET    → 200 { session: AgentSessionDTO | null }
- *   `{ session: null }` for an unknown id, NOT a 404: it is the same answer
- *   whether the session never existed or is someone else's, so a probe
+ *   `{ session: null }` whether the session never existed OR is someone
+ *   else's — never a 404 or a 403: the same answer either way, so a probe
  *   learns nothing from it. (Post-unconflation every spawned session has a
  *   row from birth; null here means the id resolves to nothing you may see.)
  *
  * POST   → 200 { session } — provision the EXISTING session's sandbox,
  *   idempotent by the session id (a re-POST resumes). No body: sessions are
- *   born through the collection route's spawn; this route never mints one, so
- *   an unknown id is a 404, not an ensure.
+ *   born through the collection route's spawn; this route never mints one.
  *
  * DELETE → 200 { ok, spriteTornDown } — end the session: instance-guarded
  *   Sprite kill, row RETAINED (re-provisionable under the same key). Gated by
@@ -19,8 +18,11 @@
  *   full decision, real capability included.
  *
  * Access decisions live in `decideAgentSessionAccess` (packages/lib) — these
- * handlers only map its verdicts onto statuses: not_found → 404 (or the
- * null-session 200 on GET), denial → 403, service failure → 502.
+ * handlers map its verdicts onto ONE not-found/denied policy for the whole
+ * `[sessionId]` family (`session-unavailable-response.ts`, review #2261/5):
+ * an unknown id and a denied one answer IDENTICALLY (the null-session 200 on
+ * GET, a uniform 404 on POST/DELETE) — service failure is the only distinct
+ * outcome, at 502.
  */
 
 import { NextResponse } from 'next/server';
@@ -28,6 +30,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { sessionQuotaExceeded } from '@/lib/agent-sessions/quota-response';
+import { auditSessionAccessDenial, sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
 import {
   checkSessionAccess,
   checkSessionEndAccess,
@@ -40,16 +43,24 @@ import {
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
+const ROUTE = 'agent-sessions/[sessionId]';
+
 type RouteContext = { params: Promise<{ sessionId: string }> };
 
-
-function denied(request: Request, userId: string, sessionId: string, reason: string): NextResponse {
+/**
+ * A denial AFTER the not-found/denied family gate has already passed — the
+ * caller already knows this session exists (the session-access check above
+ * succeeded and its row was found). This is a DIFFERENT question
+ * (`ensureAgentSessionSandbox`'s own authorization, re-checked at provision
+ * time) that leaks nothing new by staying a genuine 403.
+ */
+function provisioningDenied(request: Request, userId: string, sessionId: string, reason: string): NextResponse {
   auditRequest(request, {
     eventType: 'authz.access.denied',
     userId,
     resourceType: 'agent_session',
     resourceId: sessionId,
-    details: { reason, route: 'agent-sessions/[sessionId]' },
+    details: { reason, route: ROUTE },
     riskScore: 0.5,
   });
   return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
@@ -62,10 +73,10 @@ export async function GET(request: Request, context: RouteContext) {
 
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    // No row = no sandbox = status 'none' — the expected cold answer, not an
-    // error and not a fact worth distinguishing from "not yours to ask about".
-    if (access.reason === 'session_not_found') return NextResponse.json({ session: null });
-    return denied(request, auth.userId, sessionId, access.reason);
+    // Not found and denied answer THE SAME — null, never a 404 or a 403 —
+    // so a probe learns nothing from the difference (family policy above).
+    auditSessionAccessDenial(request, auth.userId, sessionId, access.reason, ROUTE);
+    return NextResponse.json({ session: null });
   }
 
   const row = await findSessionRecord(sessionId);
@@ -90,10 +101,7 @@ export async function POST(request: Request, context: RouteContext) {
   // start, or resume after an end.
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
-    }
-    return denied(request, auth.userId, sessionId, access.reason);
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE);
   }
 
   const existing = await findSessionRecord(sessionId);
@@ -105,11 +113,11 @@ export async function POST(request: Request, context: RouteContext) {
       // A plan-limit refusal is not an access denial — separate response and
       // separate audit event (see quotaExceeded).
       if (provisioned.denial === 'session_limit_reached') {
-        return sessionQuotaExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]', {
+        return sessionQuotaExceeded(request, auth.userId, sessionId, ROUTE, {
           reasonCode: provisioned.detail,
         });
       }
-      return denied(request, auth.userId, sessionId, provisioned.denial ?? 'denied');
+      return provisioningDenied(request, auth.userId, sessionId, provisioned.denial ?? 'denied');
     }
     loggers.api.error('Agent session provision failed', undefined, {
       sessionId,
@@ -146,10 +154,7 @@ export async function DELETE(request: Request, context: RouteContext) {
 
   const access = await checkSessionEndAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
-    }
-    return denied(request, auth.userId, sessionId, access.reason);
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE);
   }
 
   const ended = await endSession(sessionId);

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/shells/[shellId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/shells/[shellId]/__tests__/route.test.ts
@@ -86,10 +86,10 @@ describe('DELETE /api/agent-sessions/[sessionId]/shells/[shellId]', () => {
     expect(mockCheckSessionEndAccess).toHaveBeenCalledWith('user-1', SESSION_ID);
   });
 
-  it('given a denial, should 403, audit it, and kill nothing', async () => {
+  it('given a denial, should 404 (SAME as not-found, review #2261/5), audit it, and kill nothing', async () => {
     mockCheckSessionEndAccess.mockResolvedValue({ allowed: false, reason: 'not_shared' });
     const response = await del();
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockKillShellById).not.toHaveBeenCalled();
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/shells/[shellId]/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/shells/[shellId]/route.ts
@@ -18,8 +18,11 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkSessionEndAccess } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { killShellById, resolveShellById } from '@/lib/agent-sessions/session-shells-runtime';
+import { sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const ROUTE = 'agent-sessions/[sessionId]/shells/[shellId]';
 
 type RouteContext = { params: Promise<{ sessionId: string; shellId: string }> };
 
@@ -36,20 +39,12 @@ export async function DELETE(request: Request, context: RouteContext) {
     return NextResponse.json({ error: 'Shell not found' }, { status: 404 });
   }
 
+  // Not found and denied answer THE SAME 404 (family policy, review #2261/5)
+  // — "Shell not found" for both, so a caller cannot distinguish "no such
+  // shell" from "not yours".
   const access = await checkSessionEndAccess(auth.userId, resolved.shell.sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'Shell not found' }, { status: 404 });
-    }
-    auditRequest(request, {
-      eventType: 'authz.access.denied',
-      userId: auth.userId,
-      resourceType: 'agent_session',
-      resourceId: sessionId,
-      details: { reason: access.reason, route: 'agent-sessions/[sessionId]/shells/[shellId]', shellId },
-      riskScore: 0.5,
-    });
-    return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE, 'Shell not found');
   }
 
   const killed = await killShellById(shellId);

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/shells/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/shells/__tests__/route.test.ts
@@ -92,10 +92,11 @@ describe('GET /api/agent-sessions/[sessionId]/shells', () => {
     expect(mockListShells).not.toHaveBeenCalled();
   });
 
-  it('given a denial, should 403 and audit', async () => {
+  it('given a denial, should answer an EMPTY list too — SAME as not-found (review #2261/5), but still audit', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'code_execution_denied' });
     const response = await get();
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ shells: [] });
     expect(mockListShells).not.toHaveBeenCalled();
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
@@ -148,10 +149,10 @@ describe('POST /api/agent-sessions/[sessionId]/shells', () => {
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
   });
 
-  it('given an access denial, should 403 and never provision or spawn', async () => {
+  it('given an access denial, should 404 (SAME as not-found, review #2261/5) and never provision or spawn', async () => {
     mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
     const response = await post({});
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
     expect(mockSpawnShell).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/shells/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/shells/route.ts
@@ -26,24 +26,14 @@ import {
 } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { listShells, spawnShell } from '@/lib/agent-sessions/session-shells-runtime';
 import { sessionQuotaExceeded } from '@/lib/agent-sessions/quota-response';
+import { auditSessionAccessDenial, sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
+const ROUTE = 'agent-sessions/[sessionId]/shells';
+
 type RouteContext = { params: Promise<{ sessionId: string }> };
-
-
-function denied(request: Request, userId: string, sessionId: string, reason: string): NextResponse {
-  auditRequest(request, {
-    eventType: 'authz.access.denied',
-    userId,
-    resourceType: 'agent_session',
-    resourceId: sessionId,
-    details: { reason, route: 'agent-sessions/[sessionId]/shells' },
-    riskScore: 0.5,
-  });
-  return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
-}
 
 export async function GET(request: Request, context: RouteContext) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
@@ -52,11 +42,31 @@ export async function GET(request: Request, context: RouteContext) {
 
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') return NextResponse.json({ shells: [] });
-    return denied(request, auth.userId, sessionId, access.reason);
+    // Not found and denied answer THE SAME empty list (family policy, review
+    // #2261/5) — never a 403 that would tell a caller the session is real.
+    auditSessionAccessDenial(request, auth.userId, sessionId, access.reason, ROUTE);
+    return NextResponse.json({ shells: [] });
   }
 
   return NextResponse.json({ shells: await listShells(sessionId) });
+}
+
+/**
+ * A denial AFTER the not-found/denied family gate has already passed — the
+ * caller already knows this session exists. This is `ensureAgentSessionSandbox`'s
+ * OWN authorization, re-checked at provision time, and leaks nothing new by
+ * staying a genuine 403.
+ */
+function provisioningDenied(request: Request, userId: string, sessionId: string, reason: string): NextResponse {
+  auditRequest(request, {
+    eventType: 'authz.access.denied',
+    userId,
+    resourceType: 'agent_session',
+    resourceId: sessionId,
+    details: { reason, route: ROUTE },
+    riskScore: 0.5,
+  });
+  return NextResponse.json({ error: 'You do not have access to this session' }, { status: 403 });
 }
 
 const SPAWN_DENIAL_STATUS: Record<string, number> = {
@@ -96,10 +106,7 @@ export async function POST(request: Request, context: RouteContext) {
   // route, and a session is born with its first conversation, not a shell).
   const access = await checkSessionAccess(auth.userId, sessionId);
   if (!access.allowed) {
-    if (access.reason === 'session_not_found') {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
-    }
-    return denied(request, auth.userId, sessionId, access.reason);
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE);
   }
 
   const row = await findSessionRecord(sessionId);
@@ -113,11 +120,11 @@ export async function POST(request: Request, context: RouteContext) {
       // A plan-limit refusal is not an access denial — separate response and
       // separate audit event (see quotaExceeded).
       if (provisioned.denial === 'session_limit_reached') {
-        return sessionQuotaExceeded(request, auth.userId, sessionId, 'agent-sessions/[sessionId]/shells', {
+        return sessionQuotaExceeded(request, auth.userId, sessionId, ROUTE, {
           reasonCode: provisioned.detail,
         });
       }
-      return denied(request, auth.userId, sessionId, provisioned.denial ?? 'denied');
+      return provisioningDenied(request, auth.userId, sessionId, provisioned.denial ?? 'denied');
     }
     loggers.api.error('Shell spawn: session sandbox provision failed', undefined, {
       sessionId,

--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -47,6 +47,7 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
   listSessionConversationsBulk: (...args: unknown[]) => mockListSessionConversationsBulk(...args),
   countActiveSessionsForOwner: (...args: unknown[]) => mockCountActiveSessionsForOwner(...args),
+  MAX_ACTIVE_SESSIONS_PER_OWNER: 100,
   checkAccessForSubject: (...args: unknown[]) => mockCheckAccessForSubject(...args),
   createConversationInSession: (...args: unknown[]) => mockCreateConversationInSession(...args),
   endSession: (...args: unknown[]) => mockEndSession(...args),
@@ -298,5 +299,19 @@ describe('POST /api/agent-sessions — spawn ceiling (review M6/F4)', () => {
     const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
     expect(response.status).toBe(429);
     expect(mockSpawnSession).not.toHaveBeenCalled();
+  });
+
+  it('429s on the ATOMIC backstop when a concurrent spawn wins the race the pre-check missed (review #2261/2)', async () => {
+    // The pre-check above is advisory (TOCTOU-racy on its own) — spawnSession
+    // itself is the authoritative, atomically-enforced ceiling, and its
+    // refusal must reach the caller the same way the pre-check's does.
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Agent', type: 'AI_CHAT', driveId: 'drive-1' });
+    mockCanPrincipalViewPage.mockResolvedValue(true);
+    mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockSpawnSession.mockResolvedValue({ ok: false, reason: 'session_limit_reached' });
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(429);
+    expect(mockCreateConversationInSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -29,6 +29,7 @@ import {
   endSession,
   listSessions,
   listSessionConversationsBulk,
+  MAX_ACTIVE_SESSIONS_PER_OWNER,
   spawnSession,
   toAgentSessionDTO,
   type AgentSessionListFilter,
@@ -38,15 +39,6 @@ import { sessionQuotaExceeded } from '@/lib/agent-sessions/quota-response';
 
 /** Bound on the stored display label — rendered everywhere the session appears. */
 const MAX_SESSION_NAME_LENGTH = 120;
-
-/**
- * The most NOT-ENDED sessions one owner may hold. Spawn is deliberately
- * instant and free (no sandbox), which meant the live-sandbox concurrency
- * quota never applied to it — an authorized caller could mint unbounded rows
- * (review M6/F4). Matches SESSION_LIST_LIMIT: the sidebar shows at most this
- * many anyway.
- */
-const MAX_ACTIVE_SESSIONS_PER_OWNER = 100;
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -189,6 +181,13 @@ export async function POST(request: Request) {
     }
   }
 
+  // Advisory fast-path only (review #2261/2): count-then-branch here is
+  // TOCTOU-racy on its own — N concurrent POSTs could all read under the
+  // ceiling — so it exists to skip the agent lookups below for the OBVIOUS
+  // over-limit case. `spawnSession` enforces the ceiling ATOMICALLY (a
+  // per-owner advisory lock around the count-and-insert in the store), and is
+  // the authoritative check the `spawned.reason === 'session_limit_reached'`
+  // branch below maps.
   const activeCount = await countActiveSessionsForOwner(auth.userId);
   if (activeCount >= MAX_ACTIVE_SESSIONS_PER_OWNER) {
     return sessionQuotaExceeded(request, auth.userId, 'about-to-be-minted', 'agent-sessions', {
@@ -218,6 +217,13 @@ export async function POST(request: Request) {
 
   const spawned = await spawnSession({ userId: auth.userId, driveId, name });
   if (!spawned.ok) {
+    if (spawned.reason === 'session_limit_reached') {
+      // The atomic backstop caught what the pre-check above missed — a
+      // concurrent spawn landed between the pre-check and here.
+      return sessionQuotaExceeded(request, auth.userId, 'about-to-be-minted', 'agent-sessions', {
+        message: 'You have reached your active session limit — end some before starting more.',
+      });
+    }
     loggers.api.error('Agent session spawn failed', undefined, { driveId, detail: spawned.detail });
     return NextResponse.json({ error: 'Could not start a session', reason: spawned.reason }, { status: 502 });
   }

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
@@ -684,4 +684,31 @@ describe('POST session binding (sessionId in body)', () => {
     expect(response.status).toBe(409);
     expect(await response.json()).toEqual({ error: 'That conversation id is not available' });
   });
+
+  it('404s an unknown session id — a conversation joins a workspace, never mints one', async () => {
+    const runtime = await import('@/lib/agent-sessions/agent-sessions-runtime');
+    vi.mocked(runtime.checkSessionAccess).mockResolvedValue({ allowed: false, reason: 'session_not_found' });
+    const request = createRequest(mockAgentId, 'POST', { sessionId: 'ses-1' });
+    const response = await POST(request, createContext(mockAgentId));
+    expect(response.status).toBe(404);
+    expect(runtime.createConversationInSession).not.toHaveBeenCalled();
+  });
+
+  it('404s a session the requester cannot reach — SAME as not-found (review #2261/5)', async () => {
+    const runtime = await import('@/lib/agent-sessions/agent-sessions-runtime');
+    vi.mocked(runtime.checkSessionAccess).mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
+    const request = createRequest(mockAgentId, 'POST', { sessionId: 'ses-1' });
+    const response = await POST(request, createContext(mockAgentId));
+    expect(response.status).toBe(404);
+    expect(runtime.createConversationInSession).not.toHaveBeenCalled();
+  });
+
+  it('400s an agent from a DIFFERENT drive than the session — a caller mistake, not a service failure (review #2261/6)', async () => {
+    const runtime = await import('@/lib/agent-sessions/agent-sessions-runtime');
+    const { AgentNotInSessionDriveError } = await import('@/lib/agent-sessions/create-conversation-in-session');
+    vi.mocked(runtime.createConversationInSession).mockRejectedValue(new AgentNotInSessionDriveError());
+    const request = createRequest(mockAgentId, 'POST', { sessionId: 'ses-1' });
+    const response = await POST(request, createContext(mockAgentId));
+    expect(response.status).toBe(400);
+  });
 });

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server';
 import { createId, isCuid } from '@paralleldrive/cuid2';
 import { checkSessionAccess, createConversationInSession } from '@/lib/agent-sessions/agent-sessions-runtime';
-import { ConversationUnavailableError, SessionFullError } from '@/lib/agent-sessions/create-conversation-in-session';
+import {
+  AgentNotInSessionDriveError,
+  ConversationUnavailableError,
+  SessionFullError,
+} from '@/lib/agent-sessions/create-conversation-in-session';
 import { sessionConversationLimitExceeded } from '@/lib/agent-sessions/quota-response';
+import { sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalViewPage } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -207,8 +212,12 @@ export async function POST(
     if (sessionId !== null) {
       const sessionAccess = await checkSessionAccess(auth.userId, sessionId);
       if (!sessionAccess.allowed) {
-        auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'agent_session', resourceId: sessionId, details: { reason: sessionAccess.reason, method: 'POST', route: 'page-agents/conversations' }, riskScore: 0.5 });
-        return NextResponse.json({ error: 'You do not have access to this session' }, { status: sessionAccess.reason === 'session_not_found' ? 404 : 403 });
+        // Not found and denied answer THE SAME 404 — the [sessionId] family's
+        // policy (review #2261/5), applied here too since this route gates on
+        // the identical checkSessionAccess call: a 403-vs-404 split would let
+        // a caller learn whether a session id is real even when they can
+        // never touch it.
+        return sessionNotFoundOrDenied(request, auth.userId, sessionId, sessionAccess.reason, 'page-agents/conversations');
       }
     }
 
@@ -227,6 +236,12 @@ export async function POST(
           // conflict, not a service failure, and one answer for every cause.
           auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: conversationId, details: { reason: 'conversation_unavailable', method: 'POST', agentId, sessionId }, riskScore: 0.5 });
           return NextResponse.json({ error: 'That conversation id is not available' }, { status: 409 });
+        }
+        if (error instanceof AgentNotInSessionDriveError) {
+          // A caller mistake (this agent belongs to a different drive than
+          // the session), not a service failure (review #2261/6) — was
+          // falling through to the outer catch's generic 500.
+          return NextResponse.json({ error: error.message }, { status: 400 });
         }
         throw error;
       }

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -75,6 +75,16 @@ import { createConversationInSessionWith } from '@/lib/agent-sessions/create-con
 
 export { isCodeExecutionEnabled };
 
+/**
+ * The most NOT-ENDED sessions one owner may hold. Spawn is deliberately
+ * instant and free (no sandbox), which meant the live-sandbox concurrency
+ * quota never applied to it — an authorized caller could mint unbounded rows
+ * (review M6/F4). The single source of truth: `spawnSession` below passes it
+ * as `spawnAgentSession`'s REQUIRED `maxActiveSessions` dep (review
+ * #2261/2), and the route imports it for its own advisory pre-check.
+ */
+export const MAX_ACTIVE_SESSIONS_PER_OWNER = 100;
+
 // ---------------------------------------------------------------------------
 // Lazy singletons — the store reconnects to one DB pool; the host is stateless.
 // Both are built on first use so importing this module does no DB or SDK work.
@@ -264,7 +274,7 @@ export async function spawnSession(input: {
     ownerId: input.userId,
     driveId: input.driveId,
     name: input.name,
-    deps: { store, now: () => new Date() },
+    deps: { store, now: () => new Date(), maxActiveSessions: MAX_ACTIVE_SESSIONS_PER_OWNER },
   });
 }
 

--- a/apps/web/src/lib/agent-sessions/session-unavailable-response.ts
+++ b/apps/web/src/lib/agent-sessions/session-unavailable-response.ts
@@ -1,0 +1,68 @@
+/**
+ * The ONE not-found/denied policy for the `/api/agent-sessions/[sessionId]/**`
+ * route family (review #2261/5).
+ *
+ * A session that does not exist and a session this requester may not touch
+ * used to answer DIFFERENTLY across the family — `GET /[sessionId]`
+ * deliberately collapsed them into one `{ session: null }` (its own doc:
+ * "the same answer whether the session never existed or is someone else's,
+ * so a probe learns nothing from it"), while every write route (and even
+ * GET's OWN denial branch, which contradicted its neighboring comment) split
+ * them into 404 vs 403 — letting a requester learn whether a session id is
+ * REAL even when they can never touch it, exactly the enumeration the GET
+ * doc claims the family refuses.
+ *
+ * The fix is the family-wide version of what the GET doc already promised:
+ * whatever the reason (`session_not_found` or any real denial), the
+ * response the CALLER sees is identical. Only the SHAPE of "nothing here"
+ * differs per route (a null session, an empty list, a 404 error) — never
+ * whether "not yours" can be told apart from "does not exist".
+ *
+ * Real denials are still audited — this internal trail is the ONLY place the
+ * distinction survives, which is exactly right: security monitoring keeps
+ * full fidelity, the wire response does not.
+ */
+import { NextResponse } from 'next/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+/**
+ * Audit a genuine access denial. Never fired for `session_not_found` — an
+ * unknown id (a stale bookmark, a typo) is not suspicious and is the routine
+ * cold case every route in the family greets identically; auditing it would
+ * flood the security log with noise for a request that touched nothing.
+ */
+export function auditSessionAccessDenial(
+  request: Request,
+  userId: string,
+  sessionId: string,
+  reason: string,
+  route: string,
+): void {
+  if (reason === 'session_not_found') return;
+  auditRequest(request, {
+    eventType: 'authz.access.denied',
+    userId,
+    resourceType: 'agent_session',
+    resourceId: sessionId,
+    details: { reason, route },
+    riskScore: 0.5,
+  });
+}
+
+/**
+ * The shared response for routes that answer an unavailable session with an
+ * ERROR shape (as opposed to a soft empty-collection/null-session 200,
+ * which each of those routes still builds itself — see the family doc
+ * above). `not_found` and every denial reason land on this SAME 404.
+ */
+export function sessionNotFoundOrDenied(
+  request: Request,
+  userId: string,
+  sessionId: string,
+  reason: string,
+  route: string,
+  message = 'Session not found',
+): NextResponse {
+  auditSessionAccessDenial(request, userId, sessionId, reason, route);
+  return NextResponse.json({ error: message }, { status: 404 });
+}

--- a/packages/lib/src/agent-sessions/__tests__/plan-session-lifecycle.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/plan-session-lifecycle.test.ts
@@ -298,6 +298,19 @@ describe('planAgentSessionLifecycle — end (instance-guarded teardown, row reta
     });
     expect(plan.action).toBe('teardown');
   });
+
+  it('given a NORMALLY-ended row (provisioned, CONFIRMED kill — the common shape), should noop rather than re-teardown', () => {
+    // review #2261/4: teardown never clears `sandboxId` (the row outlives its
+    // Sprite on purpose), so `tornDown`/`unprovisioned` above — both
+    // `sandboxId: null` — are the UNCOMMON shape. The common one, a session
+    // that was provisioned and then normally ended, still carries its
+    // `sandboxId`; that used to fall through to `teardown` on every re-end.
+    const endedProvisioned = row({ teardownRequestedAt: NOW, spriteTornDownAt: NOW, endedAt: NOW });
+    const plan = planAgentSessionLifecycle({ row: endedProvisioned, intent: 'end', canRun: true, now: NOW });
+    if (plan.action !== 'noop') throw new Error('expected noop');
+    expect(plan.reason).toBe('already_ended');
+    expect(plan.stamps).toEqual({});
+  });
 });
 
 describe('planAgentSessionLifecycle — reprovision (heal a row whose Sprite is unusable)', () => {

--- a/packages/lib/src/agent-sessions/plan-session-lifecycle.ts
+++ b/packages/lib/src/agent-sessions/plan-session-lifecycle.ts
@@ -231,6 +231,19 @@ export function planAgentSessionLifecycle({
   // be able to end it, and so must every automated path.
   if (intent === 'end') {
     if (!row) return { action: 'noop', reason: 'no_session', stamps: {} };
+    // A CONFIRMED kill is checked BEFORE `sandboxId`, and specifically on
+    // `spriteTornDownAt` rather than the broader `isEnded` — teardown never
+    // clears `sandboxId` (the row outlives its Sprite, on purpose; see
+    // `agent-sessions-store.ts`'s schema doc), so a NORMALLY-ended session —
+    // the common shape, `sandboxId` still recorded — used to fall through to
+    // `teardown` on every re-end, re-requesting teardown and re-killing an
+    // already-confirmed-dead Sprite (review #2261/4). `isEnded` would be the
+    // WRONG guard here: it also trips on `endedAt` alone, which is exactly
+    // the crash-recovery shape below (`teardownRequestedAt`/`endedAt` stamped
+    // together on a CONFIRMED kill, so `endedAt` set with `spriteTornDownAt`
+    // still null means the kill was never confirmed) — that row must still
+    // retry teardown, not read as already-ended.
+    if (row.spriteTornDownAt !== null) return { action: 'noop', reason: 'already_ended', stamps: {} };
     if (row.sandboxId !== null) {
       return {
         action: 'teardown',
@@ -239,9 +252,9 @@ export function planAgentSessionLifecycle({
         stamps: { teardownRequestedAt: now, spriteTornDownAt: now, endedAt: now },
       };
     }
-    // No pointer left. Either it was already torn down (nothing to do) or the
-    // session never acquired a sandbox — which still ends the session.
-    if (isEnded(row)) return { action: 'noop', reason: 'already_ended', stamps: {} };
+    // No sandbox recorded: either explicitly ended already (nothing further
+    // to stamp) or never acquired one, which still ends the session.
+    if (row.endedAt !== null) return { action: 'noop', reason: 'already_ended', stamps: {} };
     return { action: 'noop', reason: 'no_sandbox', stamps: { endedAt: now } };
   }
 

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-session-sprite.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-session-sprite.test.ts
@@ -547,6 +547,35 @@ describe('ensureAgentSessionSandbox — resumed Sprite identity (ABA)', () => {
   });
 });
 
+describe('ensureAgentSessionSandbox — resume vs a concurrent end (review #2261/1 mirror)', () => {
+  it('given a concurrent end that ended the row between the read and the activity stamp, should NOT erase its teardown intent', async () => {
+    // The caller read this row (not ended) before calling ensure. Concurrently,
+    // endAgentSession ran to completion — teardown never clears `sandboxId`, so
+    // an identity CAS alone cannot catch this; only a state CAS on `endedAt`
+    // can. Without it, the resume arm's unconditional
+    // `{ endedAt: null, teardownRequestedAt: null }` stamp would silently erase
+    // the concurrent end's teardown intent.
+    const live = makeSessionRecord({ sessionKey: SESSION_KEY, sandboxId: SESSION_KEY, spriteInstanceId: 'inst-live' });
+    const store = makeAgentSessionStore([live]);
+    const host = makeSpriteHost({ seed: { [SESSION_KEY]: { instanceId: 'inst-live' } } });
+
+    store.rows.set(SESSION_ID, { ...live, teardownRequestedAt: NOW, spriteTornDownAt: NOW, endedAt: NOW });
+
+    const result = await ensureAgentSessionSandbox({
+      row: toSpriteRow(live),
+      intent: 'ensure',
+      actor,
+      deps: makeDeps({ store, host }),
+    });
+
+    expect(result).toEqual({ ok: true, sandboxId: SESSION_KEY, resumed: true });
+    const row = store.rows.get(SESSION_ID)!;
+    expect(row.endedAt).toEqual(NOW);
+    expect(row.teardownRequestedAt).toEqual(NOW);
+    expect(row.spriteTornDownAt).toEqual(NOW);
+  });
+});
+
 describe('ensureAgentSessionSandbox — attach', () => {
   const provisioned = makeSessionRecord({
     sessionKey: SESSION_KEY,

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
@@ -488,3 +488,44 @@ describe('list bounds and ordering (review M3/M4)', () => {
     expect(after).toBe(before + 1);
   });
 });
+
+describe('createIfUnderLimit — the spawn ceiling made atomic (review #2261/2)', () => {
+  it('given the owner is under the ceiling, should mint a session', async () => {
+    const result = await store.createIfUnderLimit({
+      ownerId,
+      driveId,
+      name: 'ceiling test',
+      now: new Date(),
+      maxActive: 1_000_000,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    sessionIds.push(result.session.id);
+    expect(result.session.ownerId).toBe(ownerId);
+  });
+
+  it('given the owner is AT the ceiling, should refuse without inserting', async () => {
+    const before = await store.countActive(ownerId);
+    const result = await store.createIfUnderLimit({ ownerId, driveId, name: null, now: new Date(), maxActive: before });
+    expect(result).toEqual({ ok: false, reason: 'limit_reached' });
+    expect(await store.countActive(ownerId)).toBe(before);
+  });
+
+  it('given N concurrent spawns racing the SAME ceiling, should mint EXACTLY the remaining allowance — not N (the TOCTOU a count-then-insert pre-check left open)', async () => {
+    const before = await store.countActive(ownerId);
+    const allowance = 3;
+    const maxActive = before + allowance;
+    const attempts = 10;
+
+    const results = await Promise.all(
+      Array.from({ length: attempts }, () =>
+        store.createIfUnderLimit({ ownerId, driveId, name: null, now: new Date(), maxActive }),
+      ),
+    );
+    const minted = results.filter((r): r is Extract<typeof r, { ok: true }> => r.ok);
+    for (const r of minted) sessionIds.push(r.session.id);
+
+    expect(minted).toHaveLength(allowance);
+    expect(await store.countActive(ownerId)).toBe(maxActive);
+  });
+});

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions.test.ts
@@ -30,6 +30,7 @@ function makeSpawnDeps(
   return {
     store: store.store,
     now: () => NOW,
+    maxActiveSessions: 100,
     ...over,
   };
 }
@@ -84,11 +85,29 @@ describe('spawnAgentSession', () => {
 
   it('given the store insert throwing (e.g. a dead driveId FK), should report spawn_failed', async () => {
     const store = makeAgentSessionStore();
-    store.store.create = async () => {
+    store.store.createIfUnderLimit = async () => {
       throw new Error('violates foreign key constraint');
     };
     const result = await spawnAgentSession({ ownerId: OWNER_ID, driveId: 'no-such-drive', deps: makeSpawnDeps(store) });
     expect(result).toMatchObject({ ok: false, reason: 'spawn_failed' });
+  });
+
+  it('given the owner is AT the ceiling, should report session_limit_reached — the check a future caller cannot omit (review #2261/2)', async () => {
+    const store = makeAgentSessionStore();
+    const result = await spawnAgentSession({
+      ownerId: OWNER_ID,
+      driveId: DRIVE_ID,
+      deps: makeSpawnDeps(store, { maxActiveSessions: 1 }),
+    });
+    expect(result.ok).toBe(true);
+
+    const second = await spawnAgentSession({
+      ownerId: OWNER_ID,
+      driveId: DRIVE_ID,
+      deps: makeSpawnDeps(store, { maxActiveSessions: 1 }),
+    });
+    expect(second).toEqual({ ok: false, reason: 'session_limit_reached' });
+    expect(store.rows.size).toBe(1);
   });
 });
 
@@ -240,11 +259,83 @@ describe('endAgentSession', () => {
     };
     const result = await endAgentSession({ sessionId: SESSION_ID, deps });
 
-    expect(result.ok).toBe(true);
+    // Honest reporting (review #2261/3): the CAS refused, so the caller must
+    // not be told the session ended — it is live again, on a Sprite this call
+    // never touched.
+    expect(result).toEqual({ ok: true, spriteTornDown: false });
     const row = store.rows.get(SESSION_ID)!;
     expect(row.spriteInstanceId).toBe('inst-revived');
     expect(row.spriteTornDownAt).toBeNull();
     expect(row.teardownRequestedAt).toBeNull();
+  });
+
+  it('given a concurrent ensure that PROVISIONS between the read and the stamp, should never strand endedAt on the newly-live row', async () => {
+    // The acceptance test (review #2261): concurrent end + ensure must never
+    // produce a row with endedAt set AND a live sandboxId AND no
+    // teardownRequestedAt. Our plan reads sandboxId: null and computes a
+    // never-provisioned noop; a concurrent ensure provisions in between. The
+    // CAS on that stamp must refuse, and the retry must re-plan against what
+    // the row actually is now — a real teardown, not a stale stamp.
+    const neverProvisioned = makeSessionRecord();
+    const store = makeAgentSessionStore([neverProvisioned]);
+    const host = makeSpriteHost({ seed: { [SESSION_KEY]: { instanceId: 'inst-concurrent' } } });
+    let reads = 0;
+    const deps = {
+      store: {
+        ...store.store,
+        async findById(sessionId: string) {
+          reads += 1;
+          const row = await store.store.findById(sessionId);
+          if (reads === 1) {
+            // The concurrent ensure wins the race right after our read.
+            store.rows.set(
+              SESSION_ID,
+              makeSessionRecord({
+                sessionKey: SESSION_KEY,
+                sandboxId: SESSION_KEY,
+                spriteInstanceId: 'inst-concurrent',
+              }),
+            );
+          }
+          return row;
+        },
+      },
+      host: host.host,
+      now: () => NOW,
+    };
+
+    const result = await endAgentSession({ sessionId: SESSION_ID, deps });
+
+    expect(reads).toBe(2);
+    expect(result).toEqual({ ok: true, spriteTornDown: true });
+    const row = store.rows.get(SESSION_ID)!;
+    const isTheBadState = row.endedAt !== null && row.sandboxId !== null && row.teardownRequestedAt === null;
+    expect(isTheBadState).toBe(false);
+    // It retried and genuinely tore down the newly-provisioned session.
+    expect(row.spriteTornDownAt).toEqual(NOW);
+    expect(row.endedAt).toEqual(NOW);
+    expect(host.calls.kill).toEqual([{ sandboxId: SESSION_KEY, expectedInstanceId: 'inst-concurrent' }]);
+  });
+
+  it('given a NORMALLY-ended session (provisioned, then ended — the common shape), should be idempotent without re-tearing-down', async () => {
+    // review #2261/4: `row.sandboxId !== null` used to be checked BEFORE
+    // `isEnded(row)`, and teardown never clears `sandboxId` — so this common
+    // shape (not the never-provisioned one the old test covered) fell through
+    // to the teardown branch on every re-end.
+    const endedProvisioned = makeSessionRecord({
+      sessionKey: SESSION_KEY,
+      sandboxId: SESSION_KEY,
+      spriteInstanceId: 'inst-live',
+      teardownRequestedAt: NOW,
+      spriteTornDownAt: NOW,
+      endedAt: NOW,
+    });
+    const store = makeAgentSessionStore([endedProvisioned]);
+    const host = makeSpriteHost();
+    const result = await endAgentSession({ sessionId: SESSION_ID, deps: makeEndDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, spriteTornDown: false });
+    expect(host.calls.kill).toHaveLength(0);
   });
 });
 

--- a/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
@@ -105,6 +105,24 @@ export function makeAgentSessionStore(
       return row;
     },
 
+    async createIfUnderLimit({ ownerId, driveId, name, now, maxActive }) {
+      const activeCount = [...rows.values()].filter((row) => row.ownerId === ownerId && row.endedAt === null).length;
+      if (activeCount >= maxActive) return { ok: false, reason: 'limit_reached' };
+      calls.create += 1;
+      minted += 1;
+      const row = makeSessionRecord({
+        id: `ses-minted-${minted}`,
+        ownerId,
+        driveId,
+        name,
+        storageLastBilledAt: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+      rows.set(row.id, row);
+      return { ok: true, session: row };
+    },
+
     async list(filter) {
       // Mirrors the real store: active rows only, newest activity first,
       // capped at SESSION_LIST_LIMIT (the sidebar polls this every few
@@ -164,15 +182,18 @@ export function makeAgentSessionStore(
       return true;
     },
 
-    async applyStamps({ sessionId, stamps }) {
+    async applyStamps({ sessionId, stamps, cas }) {
       const row = rows.get(sessionId);
-      if (!row) return;
+      if (!row) return true;
       // Mirrors the real store: a stamp write with nothing to write is a
       // legitimate no-op verdict, and must not bump updatedAt on a row it
       // otherwise leaves untouched.
       const columns = stampColumns(stamps);
-      if (Object.keys(columns).length === 0) return;
+      if (Object.keys(columns).length === 0) return true;
+      if (cas?.sandboxId !== undefined && (row.sandboxId ?? null) !== (cas.sandboxId ?? null)) return false;
+      if (cas?.endedAt !== undefined && (row.endedAt?.getTime() ?? null) !== (cas.endedAt?.getTime() ?? null)) return false;
       rows.set(sessionId, { ...row, ...columns, updatedAt: now() });
+      return true;
     },
 
     async requestTeardown({ sessionId, sandboxId, spriteInstanceId, at }) {

--- a/packages/lib/src/services/agent-sessions/agent-session-sprite.ts
+++ b/packages/lib/src/services/agent-sessions/agent-session-sprite.ts
@@ -355,8 +355,14 @@ export async function ensureAgentSessionSandbox({
         return { ok: false, reason: 'provision_failed', detail: 'sandbox_vanished' };
       }
       // Nothing to provision and no identity to move — only the activity stamps
-      // the verdict asked for.
-      await deps.store.applyStamps({ sessionId: row.sessionId, stamps: plan.stamps });
+      // the verdict asked for. CAS-guarded on `endedAt` still being null: these
+      // stamps (`endedAt: null, teardownRequestedAt: null`) were computed under
+      // the assumption the row was NOT ended, and a concurrent `end` that
+      // stamped it in between must not be silently erased — an unguarded write
+      // here is the mirror-image of the end path's race (review #2261/1). A
+      // refusal is not a failure: the identity being resumed is unchanged
+      // either way, only the freshness touch is skipped.
+      await deps.store.applyStamps({ sessionId: row.sessionId, stamps: plan.stamps, cas: { endedAt: null } });
       return { ok: true, sandboxId: plan.sandboxId, resumed: true };
 
     case 'adopt': {

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -94,6 +94,19 @@ export interface AgentSessionStore {
    */
   create(input: NewAgentSessionInput): Promise<AgentSessionRecord>;
   /**
+   * Mint a session row IFF this owner is under `maxActive` NOT-ENDED sessions
+   * — the spawn ceiling made STRUCTURAL rather than a pre-check (review
+   * #2261/2). A count-then-insert pre-check at the call site is TOCTOU-racy:
+   * N concurrent spawns can all read under the ceiling and all insert. This
+   * serializes the count-and-insert under a per-owner Postgres advisory lock
+   * (the same primitive `credit-gate.ts`'s billing-off ceiling uses), so two
+   * concurrent callers for the SAME owner cannot both win, while spawns for
+   * DIFFERENT owners never contend.
+   */
+  createIfUnderLimit(
+    input: NewAgentSessionInput & { maxActive: number },
+  ): Promise<{ ok: true; session: AgentSessionRecord } | { ok: false; reason: 'limit_reached' }>;
+  /**
    * ACTIVE sessions only (`endedAt IS NULL`), newest activity first
    * (`lastActiveAt DESC NULLS LAST, createdAt DESC`), capped at
    * {@link SESSION_LIST_LIMIT}. Ended rows are retained for lifecycle/billing
@@ -155,8 +168,33 @@ export interface AgentSessionStore {
     stamps: AgentSessionRowStamps;
     now: Date;
   }): Promise<boolean>;
-  /** Write a verdict's stamps with no CAS — for verdicts that change no identity (a resume's activity touch, ending a session that never provisioned). */
-  applyStamps(input: { sessionId: string; stamps: AgentSessionRowStamps }): Promise<void>;
+  /**
+   * Write a verdict's stamps — CAS-guarded whenever the verdict was planned
+   * from a read that a concurrent identity or lifecycle write could have
+   * since invalidated (review #2261/1). Two shapes of guard, matching the two
+   * ways a stale plan can corrupt the row:
+   *
+   *  - `cas.sandboxId` — for a plan computed from a `sandboxId` that could
+   *    have been claimed by a concurrent provision in between (the `end`
+   *    intent's never-provisioned noop): refuses if the row's CURRENT
+   *    `sandboxId` no longer matches, rather than stamping `endedAt` onto a
+   *    session a concurrent `ensure` just revived.
+   *  - `cas.endedAt` — for an "activity refresh" computed under the
+   *    assumption the row was NOT ended (the `resume`/`attach` arm's
+   *    `endedAt: null, teardownRequestedAt: null` stamps): refuses if the
+   *    row's CURRENT `endedAt` no longer matches, rather than silently
+   *    erasing a concurrent `end`'s teardown intent.
+   *
+   * Absent entirely for verdicts with nothing to race (an already-ended
+   * noop's empty stamps). Returns whether the write landed — `true` when no
+   * `cas` was given (nothing to have raced) or the CAS matched, `false` when
+   * a `cas` was given and refused.
+   */
+  applyStamps(input: {
+    sessionId: string;
+    stamps: AgentSessionRowStamps;
+    cas?: { sandboxId?: string | null; endedAt?: Date | null };
+  }): Promise<boolean>;
   /**
    * Record the durable teardown INTENT, BEFORE the kill. The one stamp written
    * ahead of its IO: its entire job is to survive a crash between "we decided to
@@ -320,6 +358,27 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
       return row as AgentSessionRecord;
     },
 
+    async createIfUnderLimit({ ownerId, driveId, name, now, maxActive }) {
+      return db.transaction(async (tx) => {
+        // Per-owner advisory lock, held for this transaction only — same
+        // primitive `credit-gate.ts`'s billing-off daily ceiling uses.
+        // Serializes concurrent spawns for THIS owner (so the count read
+        // below cannot go stale before the insert) without contending with
+        // any other owner's spawn at all.
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${'agent-session-spawn:' + ownerId}))`);
+        const [{ n }] = await tx
+          .select({ n: count() })
+          .from(agentSessions)
+          .where(and(eq(agentSessions.ownerId, ownerId), isNull(agentSessions.endedAt)));
+        if (n >= maxActive) return { ok: false as const, reason: 'limit_reached' as const };
+        const [row] = await tx
+          .insert(agentSessions)
+          .values({ ownerId, driveId, name, createdAt: now, updatedAt: now })
+          .returning();
+        return { ok: true as const, session: row as AgentSessionRecord };
+      });
+    },
+
     async list(filter) {
       const conditions = [];
       if (filter.ownerId !== undefined) conditions.push(eq(agentSessions.ownerId, filter.ownerId));
@@ -405,16 +464,26 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
       return updated.length > 0;
     },
 
-    async applyStamps({ sessionId, stamps }) {
+    async applyStamps({ sessionId, stamps, cas }) {
       const columns = stampColumns(stamps);
       // Nothing to write is a legitimate verdict (a noop that stamps nothing);
       // an empty `set` is a SQL error, so it is skipped rather than special-cased
       // by every caller.
-      if (Object.keys(columns).length === 0) return;
-      await db
+      if (Object.keys(columns).length === 0) return true;
+      const conditions = [eq(agentSessions.id, sessionId)];
+      if (cas?.sandboxId !== undefined) conditions.push(eqOrIsNull(agentSessions.sandboxId, cas.sandboxId));
+      if (cas?.endedAt !== undefined) conditions.push(eqOrIsNull(agentSessions.endedAt, cas.endedAt));
+      const updated = await db
         .update(agentSessions)
         .set({ ...columns, updatedAt: now() })
-        .where(eq(agentSessions.id, sessionId));
+        .where(and(...conditions))
+        .returning({ id: agentSessions.id });
+      // No guard requested: the caller accepted whatever the row currently is
+      // (there was nothing this write could have raced), so a miss (e.g. the
+      // row was deleted) is not a refusal — matches the prior unconditional
+      // behavior.
+      if (!cas) return true;
+      return updated.length > 0;
     },
 
     async requestTeardown({ sessionId, sandboxId, spriteInstanceId, at }) {

--- a/packages/lib/src/services/agent-sessions/agent-sessions.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions.ts
@@ -20,20 +20,31 @@
 
 import type { SandboxHost } from '../sandbox/sandbox-host';
 import { SandboxSpriteReplacedError } from '../sandbox/sandbox-host';
-import { planAgentSessionLifecycle } from '../../agent-sessions/plan-session-lifecycle';
+import { planAgentSessionLifecycle, type AgentSessionLifecyclePlan } from '../../agent-sessions/plan-session-lifecycle';
 import type { AgentSessionDTO } from '../../agent-sessions/contract';
 import { deriveSandboxStatus } from './session-status';
 import type { AgentSessionListFilter, AgentSessionRecord, AgentSessionStore } from './agent-sessions-store';
 
 export interface SpawnAgentSessionDeps {
-  store: Pick<AgentSessionStore, 'create'>;
+  store: Pick<AgentSessionStore, 'createIfUnderLimit'>;
   now: () => Date;
+  /**
+   * The most NOT-ENDED sessions this owner may hold. REQUIRED, mirroring
+   * `checkConcurrency` in `agent-session-sprite.ts`: the ceiling used to be a
+   * pre-check at ONE call site (the web route), which a future caller could
+   * simply forget to run. Folding it into this function's dependencies makes
+   * it a property of spawning a session at all, not a habit each call site
+   * has to remember (review #2261/2).
+   */
+  maxActiveSessions: number;
 }
 
 export type SpawnAgentSessionResult =
   | { ok: true; session: AgentSessionRecord }
   /** The drive does not exist (FK refused) or the insert failed outright. */
-  | { ok: false; reason: 'spawn_failed'; detail?: string };
+  | { ok: false; reason: 'spawn_failed'; detail?: string }
+  /** The owner is already at `maxActiveSessions` not-ended sessions. */
+  | { ok: false; reason: 'session_limit_reached' };
 
 /**
  * Spawn a session: mint the workspace row.
@@ -63,8 +74,15 @@ export async function spawnAgentSession({
   deps: SpawnAgentSessionDeps;
 }): Promise<SpawnAgentSessionResult> {
   try {
-    const session = await deps.store.create({ ownerId, driveId, name: name ?? null, now: deps.now() });
-    return { ok: true, session };
+    const result = await deps.store.createIfUnderLimit({
+      ownerId,
+      driveId,
+      name: name ?? null,
+      now: deps.now(),
+      maxActive: deps.maxActiveSessions,
+    });
+    if (!result.ok) return { ok: false, reason: 'session_limit_reached' };
+    return { ok: true, session: result.session };
   } catch (error) {
     return {
       ok: false,
@@ -85,6 +103,15 @@ export type EndAgentSessionResult =
   | { ok: false; reason: 'not_found' | 'teardown_failed'; detail?: string };
 
 /**
+ * Bounded retries for the never-provisioned-noop's CAS (see below). A stale
+ * plan re-reads and re-plans against the fresh row rather than clobbering it,
+ * so contention resolves in a handful of attempts under any realistic race;
+ * this is a backstop against pathological, sustained contention, not the
+ * normal path.
+ */
+const MAX_END_ATTEMPTS = 5;
+
+/**
  * End a session: kill its Sprite (instance-guarded) and stamp the row.
  *
  * THE ROW IS KEPT. That is the point of the whole design — a later `ensure`
@@ -103,30 +130,66 @@ export async function endAgentSession({
   sessionId: string;
   deps: EndAgentSessionDeps;
 }): Promise<EndAgentSessionResult> {
-  const row = await deps.store.findById(sessionId);
-  const now = deps.now();
-  const plan = planAgentSessionLifecycle({
-    row: row === null ? null : { ...row, sessionId: row.id },
-    intent: 'end',
-    // Ignored for `end` — the planner handles cleanup BEFORE the authorization
-    // gate. Passing `true` documents that this path deliberately does not gate.
-    canRun: true,
-    now,
-  });
+  // Bounded retry: the never-provisioned noop's plan is only valid while
+  // `sandboxId` stays null between the read and the write below. A concurrent
+  // `ensure` can provision in that window; re-reading and re-planning turns
+  // that race into a REAL teardown of the newly-live session instead of a
+  // stale `endedAt` stamp landing on it (review #2261/1).
+  for (let attempt = 0; attempt < MAX_END_ATTEMPTS; attempt += 1) {
+    const row = await deps.store.findById(sessionId);
+    const now = deps.now();
+    const plan = planAgentSessionLifecycle({
+      row: row === null ? null : { ...row, sessionId: row.id },
+      intent: 'end',
+      // Ignored for `end` — the planner handles cleanup BEFORE the authorization
+      // gate. Passing `true` documents that this path deliberately does not gate.
+      canRun: true,
+      now,
+    });
 
-  if (plan.action === 'noop') {
-    if (plan.reason === 'no_session') return { ok: false, reason: 'not_found' };
-    // Either already ended (nothing stamped) or a session that never acquired a
-    // sandbox, which still ends.
-    await deps.store.applyStamps({ sessionId, stamps: plan.stamps });
-    return { ok: true, spriteTornDown: false };
+    if (plan.action === 'noop') {
+      if (plan.reason === 'no_session') return { ok: false, reason: 'not_found' };
+      if (plan.reason === 'already_ended') {
+        // Nothing to write (plan.stamps is {}) — no race to guard against.
+        await deps.store.applyStamps({ sessionId, stamps: plan.stamps });
+        return { ok: true, spriteTornDown: false };
+      }
+      // `no_sandbox`: this plan is only valid while the row's `sandboxId`
+      // stays null. CAS-guard the `endedAt` stamp on that pointer — if a
+      // concurrent `ensure` provisioned in between, the stamp must not land on
+      // a now-live session; re-read and re-plan against what it actually is.
+      const applied = await deps.store.applyStamps({
+        sessionId,
+        stamps: plan.stamps,
+        cas: { sandboxId: null },
+      });
+      if (!applied) continue;
+      return { ok: true, spriteTornDown: false };
+    }
+
+    if (plan.action !== 'teardown') {
+      // Unreachable: `end` yields only `teardown` or `noop`.
+      return { ok: false, reason: 'teardown_failed', detail: `unexpected_lifecycle_verdict:${plan.action}` };
+    }
+
+    return endProvisionedSession({ sessionId, plan, now, deps });
   }
+  // Sustained contention exhausted every retry — a transient condition the
+  // caller can simply retry, not a genuine failure of this session.
+  return { ok: false, reason: 'teardown_failed', detail: 'concurrent_modification' };
+}
 
-  if (plan.action !== 'teardown') {
-    // Unreachable: `end` yields only `teardown` or `noop`.
-    return { ok: false, reason: 'teardown_failed', detail: `unexpected_lifecycle_verdict:${plan.action}` };
-  }
-
+async function endProvisionedSession({
+  sessionId,
+  plan,
+  now,
+  deps,
+}: {
+  sessionId: string;
+  plan: Extract<AgentSessionLifecyclePlan, { action: 'teardown' }>;
+  now: Date;
+  deps: EndAgentSessionDeps;
+}): Promise<EndAgentSessionResult> {
   // Record the teardown INTENT before the kill, so a crash in between still
   // leaves the Sprite reclaimable by the orphan reconciler. CAS-guarded on the
   // pointer we are about to kill: if a concurrent ensure has already revived
@@ -157,13 +220,17 @@ export async function endAgentSession({
   // ensure re-provisioned this session onto a live replacement between our kill
   // and now: those stamps are not ours to write, and marking that VM as torn down
   // would hide a billing Sprite from the reconciler forever.
-  await deps.store.stampSpriteTornDown({
+  const stamped = await deps.store.stampSpriteTornDown({
     sessionId,
     sandboxId: plan.sandboxId,
     spriteInstanceId: plan.expectedInstanceId,
     stamps: plan.stamps,
   });
-  return { ok: true, spriteTornDown: true };
+  // Report the CAS outcome honestly (review #2261/3): when a concurrent
+  // ensure revived this session onto a new instance, the CAS correctly
+  // refused, and the caller must not be told the session ended — it is live
+  // again, on a Sprite this call never touched.
+  return { ok: true, spriteTornDown: stamped };
 }
 
 /**


### PR DESCRIPTION
## Summary

Post-merge audit follow-up from PR #2258 (issue #2261) — session-services lifecycle + spawn-ceiling slice.

1. **CAS the end/ensure race.** `endAgentSession`'s never-provisioned noop now CAS-guards its `endedAt` stamp on `sandboxId` still being null (with a bounded retry that re-plans against the fresh row if a concurrent `ensure` won). The resume/attach arm's activity-refresh stamp now CASes on `endedAt` still being null — the mirror-image race, which could silently erase a concurrent `end`'s teardown intent. Together these close the acceptance case: concurrent `end` + `ensure` can no longer land a row with `endedAt` set, a live `sandboxId`, and no `teardownRequestedAt`.
2. **Atomic, structural spawn ceiling.** A new `AgentSessionStore.createIfUnderLimit` serializes count-then-insert under a per-owner Postgres advisory lock (same primitive `credit-gate.ts` uses), closing the TOCTOU window a pre-check left open. `spawnAgentSession` now takes `maxActiveSessions` as a **required** dep, mirroring `checkConcurrency` in `agent-session-sprite.ts` — a future caller cannot spawn without the ceiling applying.
3. **Honest `spriteTornDown`.** When a concurrent `ensure` revived the session and the teardown CAS refused, `endAgentSession` now reports `spriteTornDown: false` instead of claiming success.
4. **Already-ended re-end is a true noop.** The planner now checks `spriteTornDownAt` (not the broader `isEnded`) before `sandboxId`, since teardown never clears the pointer. Previously only the never-provisioned shape was idempotent; the common shape (provisioned, then normally ended) re-requested teardown and re-killed an already-dead Sprite on every re-end. Added the missing test for the common shape.
5. **One not-found/denied policy across the `[sessionId]` route family.** New `session-unavailable-response.ts` shared helper: an unknown session id and one the requester may not touch now answer identically everywhere (null-session 200 on GET, empty-list 200 on shells GET, uniform 404 elsewhere) instead of the previous 404-vs-403 split that let a 403 confirm a session id was real. Denials are still audited internally.
6. **`AgentNotInSessionDriveError` → 400** on both conversation-binding routes, instead of falling through to a generic 502/500.

## Test plan
- [x] `bun run typecheck` (workspace-wide via turbo build)
- [x] `bun run lint`
- [x] `bun run test:unit` (3 pre-existing failures unrelated to this change: TZ-dependent `grouping.test.ts`, wasm-dependent `shiki-js-engine-coverage.test.ts`, both untouched by this diff)
- [x] `bun run test:security` (6/50 pre-existing stale-suite failures — documented repo-memory issue, same on any branch: deleted login/signup/mobile-login route tests, DB-integration suites excluded with no DB in this env)
- [x] `cd packages/lib && bun run typecheck`
- [x] `bun run knip:check`
- [x] New unit tests for every finding (CAS races, atomic ceiling, honest report, idempotent re-end, unified route policy, 400 mapping) — all passing
- [x] New real-Postgres integration test proving the spawn ceiling holds under N concurrent callers (`createIfUnderLimit`)

Closes #2261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized unavailable or unauthorized agent-session responses to avoid revealing whether a session exists.
  * Improved conversation-creation error responses for agent/session mismatches.
  * Prevented duplicate teardown actions during concurrent session updates.
* **New Features**
  * Added an active-session limit, with clear quota responses when the limit is reached.
  * Improved handling of concurrent session creation and teardown to preserve accurate session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->