### PR TITLE
fix(billing): unify sandbox payer on the SESSION; retire page-keyed payer helper

### DIFF
--- a/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
@@ -1721,6 +1721,10 @@ describe('buildShellHandlers', () => {
       const call = billing.trackUsage.mock.calls[0][0];
       expect(call).toMatchObject({ payerId: 'owner-1', holdId: 'hold-1' });
       expect(call.pageId).toBeUndefined();
+      // First-class attribution: no drive to group under, but the session id
+      // still rides top-level (never JSON-forensics-only).
+      expect(call.driveId).toBeUndefined();
+      expect(call.sessionId).toBe('conv-1');
     });
 
     it('on natural shell exit, settles the hold to the real connected-window seconds and never releases it separately', async () => {
@@ -1737,6 +1741,9 @@ describe('buildShellHandlers', () => {
       // No pageId: a session is drive-scoped, not page-anchored — usage has no page grouping.
       expect(call).toMatchObject({ payerId: 'owner-1', holdId: 'hold-1' });
       expect((call as { pageId?: string }).pageId).toBeUndefined();
+      // First-class drive/session attribution (Terminal Epic 3 usage-breakdown fix).
+      expect(call.driveId).toBe('drive-1');
+      expect(call.sessionId).toBe('conv-1');
       expect(call.activeSeconds).toBeCloseTo(7, 0);
       expect(billing.releaseHold).not.toHaveBeenCalled();
       expect(sessionMap.getByKey('shell:shl-1')).toBeUndefined();
@@ -1752,7 +1759,7 @@ describe('buildShellHandlers', () => {
 
       // The 30-min detached window spans heartbeat settles plus the reap's tail —
       // however it is sliced, the settled seconds must sum to the whole window and
-      // every slice must carry the payer/page attribution.
+      // every slice must carry the payer/drive/session attribution.
       const calls = billing.trackUsage.mock.calls.map((c) => c[0]);
       expect(calls.length).toBeGreaterThanOrEqual(1);
       expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo(DETACHED_IDLE_MS / 1000, 0);
@@ -1760,6 +1767,8 @@ describe('buildShellHandlers', () => {
         expect(call.payerId).toBe('owner-1');
         // No page grouping: a session is drive-scoped, not page-anchored.
         expect(call.pageId).toBeUndefined();
+        expect(call.driveId).toBe('drive-1');
+        expect(call.sessionId).toBe('conv-1');
       }
       expect(calls[0].holdId).toBe('hold-1');
       expect(billing.releaseHold).not.toHaveBeenCalled();
@@ -1780,6 +1789,8 @@ describe('buildShellHandlers', () => {
         const first = billing.trackUsage.mock.calls[0][0];
         expect(first).toMatchObject({ payerId: 'owner-1', holdId: 'hold-1' });
         expect((first as { pageId?: string }).pageId).toBeUndefined();
+        expect(first.driveId).toBe('drive-1');
+        expect(first.sessionId).toBe('conv-1');
         expect(first.activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
         // The session survives the heartbeat with a fresh hold in place.
         expect(shell.kill).not.toHaveBeenCalled();

--- a/apps/realtime/src/terminal/shell-handler.ts
+++ b/apps/realtime/src/terminal/shell-handler.ts
@@ -64,7 +64,7 @@ export type ShellSandboxResult =
   | {
       ok: true;
       shellId: string;
-      /** ≡ the conversation id of the owning session. */
+      /** The owning session's id (`agent_sessions.id`) — no conversation involved, a shell is a PTY, not a chat thread. */
       sessionId: string;
       sandboxId: string;
       /** The working directory for a FRESH session — always `SANDBOX_ROOT` (`/workspace`). */
@@ -358,7 +358,13 @@ function endShellSession(
   if (deps.billing && session.payerId && session.connectedAt !== undefined) {
     const activeSeconds = Math.max(0, (Date.now() - session.connectedAt) / 1000);
     void deps.billing
-      .trackUsage({ payerId: session.payerId, holdId: session.holdId, activeSeconds, pageId: session.pageId })
+      .trackUsage({
+        payerId: session.payerId,
+        holdId: session.holdId,
+        activeSeconds,
+        driveId: session.driveId,
+        sessionId: session.agentSessionId,
+      })
       .catch((error) => {
         loggers.realtime.error('Shell session billing settle failed', error instanceof Error ? error : new Error(String(error)), {
           sessionKey,
@@ -562,7 +568,13 @@ async function settleAccruedWindow(
   session.holdId = undefined;
   const activeSeconds = Math.max(0, (session.connectedAt - windowStart) / 1000);
   try {
-    await billing.trackUsage({ payerId, holdId, activeSeconds, pageId: session.pageId });
+    await billing.trackUsage({
+      payerId,
+      holdId,
+      activeSeconds,
+      driveId: session.driveId,
+      sessionId: session.agentSessionId,
+    });
   } catch (error) {
     loggers.realtime.error('Shell heartbeat settle failed', error instanceof Error ? error : new Error(String(error)), {
       sessionKey,
@@ -579,7 +591,13 @@ async function settleAccruedWindow(
       // the same fire-and-forget guarantee the end-settle itself has. If it
       // also fails, the hold expires via TTL and the window is lost.
       void billing
-        .trackUsage({ payerId, holdId, activeSeconds, pageId: session.pageId })
+        .trackUsage({
+          payerId,
+          holdId,
+          activeSeconds,
+          driveId: session.driveId,
+          sessionId: session.agentSessionId,
+        })
         .catch(() => {});
     }
     return true;
@@ -1074,10 +1092,12 @@ export async function ensureShellSession(
       payerId: access.payerId,
       holdId,
       connectedAt,
-      // No pageId: a session is a drive-level workspace, not page-anchored —
-      // usage attributes to the payer (drive owner, or the session's own owner
-      // for a global-assistant session) with no page grouping.
-      pageId: undefined,
+      // First-class attribution (Terminal Epic 3 usage-breakdown fix): the
+      // session's own drive (already resolved onto the access verdict) and its
+      // own agent_sessions.id (resolved onto the sandbox result) — no page
+      // grouping, since a session is drive-level, not page-anchored.
+      driveId: access.driveId ?? undefined,
+      agentSessionId: sandbox.sessionId,
       shellId: sandbox.shellId,
       // The creator is viewer #1, registered in the literal — BEFORE
       // `openShell` — so output arriving between the shell opening and

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -109,8 +109,15 @@ export type TerminalSession = {
   payerId?: string;
   holdId?: string;
   connectedAt?: number;
-  /** The Terminal page this session is for — the usage-breakdown's per-machine attribution key. */
-  pageId?: string;
+  /**
+   * First-class billing attribution (Terminal Epic 3 usage-breakdown fix) —
+   * the agent-session's own drive (undefined for a global-assistant session)
+   * and its own `agent_sessions.id`, so the usage breakdown can group shell
+   * runtime spend by drive/session without JSON forensics. A session is
+   * drive-level, not page-anchored, so there is no `pageId` to attribute to.
+   */
+  driveId?: string;
+  agentSessionId?: string;
   /**
    * The `machine_agent_terminals` row this PTY belongs to (issue #2205's
    * cold-tail persist). Known ONLY on the create path

--- a/apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts
@@ -50,6 +50,7 @@ describe('/api/cron/reconcile-machine-storage', () => {
       charged: 2,
       skipped: 1,
       failed: 0,
+      chargedButUnadvanced: 0,
       staleMeasurements: 1,
       totalCostDollars: 0.001234,
     });
@@ -76,10 +77,10 @@ describe('/api/cron/reconcile-machine-storage', () => {
         eventType: 'data.write',
         resourceType: 'cron_job',
         resourceId: 'reconcile_machine_storage',
-        details: expect.objectContaining({ processed: 3, charged: 2, skipped: 1, failed: 0, staleMeasurements: 1 }),
+        details: expect.objectContaining({ processed: 3, charged: 2, skipped: 1, failed: 0, chargedButUnadvanced: 0, staleMeasurements: 1 }),
       }),
     );
-    expect(body).toMatchObject({ success: true, processed: 3, charged: 2, skipped: 1, failed: 0, staleMeasurements: 1 });
+    expect(body).toMatchObject({ success: true, processed: 3, charged: 2, skipped: 1, failed: 0, chargedButUnadvanced: 0, staleMeasurements: 1 });
   });
 
   it('given the advisory lock is held by another run, should no-op WITHOUT auditing and report lock_busy', async () => {

--- a/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: Request) {
     }
 
     console.log(
-      `[Cron] Terminal storage reconcile: processed ${run.processed}, charged ${run.charged}, skipped ${run.skipped}, failed ${run.failed}, stale ${run.staleMeasurements}, total $${run.totalCostDollars.toFixed(6)}`,
+      `[Cron] Terminal storage reconcile: processed ${run.processed}, charged ${run.charged}, skipped ${run.skipped}, failed ${run.failed}, chargedButUnadvanced ${run.chargedButUnadvanced}, stale ${run.staleMeasurements}, total $${run.totalCostDollars.toFixed(6)}`,
     );
 
     audit({
@@ -67,6 +67,7 @@ export async function GET(request: Request) {
         charged: run.charged,
         skipped: run.skipped,
         failed: run.failed,
+        chargedButUnadvanced: run.chargedButUnadvanced,
         staleMeasurements: run.staleMeasurements,
         totalCostDollars: run.totalCostDollars,
       },
@@ -78,6 +79,7 @@ export async function GET(request: Request) {
       charged: run.charged,
       skipped: run.skipped,
       failed: run.failed,
+      chargedButUnadvanced: run.chargedButUnadvanced,
       staleMeasurements: run.staleMeasurements,
       totalCostDollars: run.totalCostDollars,
       timestamp: new Date().toISOString(),

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -408,6 +408,104 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
   });
 });
 
+// Billing attribution resolve (issue #2260): a CHEAP session-row read (no
+// provisioning) so `withMachineBilling` can resolve the payer from the
+// SESSION's own driveId/ownerId before gating — never from the caller's
+// surface drive/tenant.
+describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
+  function makeSessionRecord(overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord {
+    const now = new Date('2026-06-01T00:00:00Z');
+    return {
+      id: 'ses-1',
+      ownerId: 'u1',
+      driveId: 'd1',
+      name: null,
+      sessionKey: null,
+      sandboxId: null,
+      spriteInstanceId: null,
+      egressPolicyToken: null,
+      teardownRequestedAt: null,
+      spriteTornDownAt: null,
+      storageLastBilledAt: now,
+      storageMeasuredBytes: null,
+      storageMeasuredAt: null,
+      lastActiveAt: null,
+      endedAt: null,
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves the session's own driveId/ownerId — NOT ctx.tenantId/ctx.driveId, which may be a different drive entirely", async () => {
+    mockFindSessionForConversation.mockResolvedValue(
+      makeSessionRecord({ id: 'shared-session-1', driveId: 'session-own-drive', ownerId: 'session-own-owner' }),
+    );
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'surface-tenant-should-never-be-used',
+      driveId: 'surface-drive-should-never-be-used',
+      conversationId: 'conv-1',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toEqual({ sessionId: 'shared-session-1', driveId: 'session-own-drive', ownerId: 'session-own-owner' });
+    expect(mockFindSessionForConversation).toHaveBeenCalledWith('conv-1');
+  });
+
+  it('given a global-assistant session (null driveId), resolves driveId null and the session ownerId', async () => {
+    mockFindSessionForConversation.mockResolvedValue(makeSessionRecord({ driveId: null, ownerId: 'global-owner-1' }));
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-1',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toEqual({ sessionId: 'ses-1', driveId: null, ownerId: 'global-owner-1' });
+  });
+
+  it('given no conversationId, resolves null WITHOUT touching the session runtime', async () => {
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: undefined as unknown as string,
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toBeNull();
+    expect(mockFindSessionForConversation).not.toHaveBeenCalled();
+  });
+
+  it('given a conversation with no session yet, resolves null', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-legacy',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
 describe('buildSandboxTools', () => {
   it('should return exactly the four session tools', () => {
     expect(Object.keys(buildSandboxTools()).sort()).toEqual(['bash', 'editFile', 'readFile', 'writeFile']);

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -9,12 +9,15 @@
  * (`@fly/sprites` is ESM/node24-only).
  *
  * THE HANDLE SOURCE: `acquireSandbox` lazily ensures the conversation's agent
- * session row and its Sprite from `conversationId` alone — the session id IS
- * the conversation id (contract.ts invariant 1), and this is one of the two
- * sanctioned first-touch provisioning sites (the other is a shell open). It
- * runs through the SAME `ensureSession`/`provisionSessionSandbox` path the API
- * routes and the realtime bridge use, so the CAS in `agent-session-sprite.ts`
- * actually serializes every concurrent provisioner.
+ * session row and its Sprite from `conversationId` alone — resolving
+ * `conversations.sessionId` to the session row it's bound to, NOT treating the
+ * conversation id as a session id (contract.ts invariant 1: a session hosts
+ * MANY conversations, and post-unconflation the two are different id
+ * namespaces). This is one of the two sanctioned first-touch provisioning
+ * sites (the other is a shell open). It runs through the SAME
+ * `ensureSession`/`provisionSessionSandbox` path the API routes and the
+ * realtime bridge use, so the CAS in `agent-session-sprite.ts` actually
+ * serializes every concurrent provisioner.
  */
 
 import type { Tool } from 'ai';
@@ -154,9 +157,13 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         // The session the sandbox belongs to — what every post-run hook
         // (storage measurement, activity feed) is keyed by.
         sessionId: row.id,
-        // The billing/attribution key: the session's agent page when it has
-        // one. A global-assistant session has none; the payer resolution's
-        // tenant fallback covers it.
+        // The CALLER's surface agent page (the conversation this run came
+        // through) — purely descriptive per-agent attribution for the usage
+        // breakdown, never a billing/payer key. A session hosts MANY
+        // conversations (with any of the drive's agents, or the global
+        // assistant) and has no agent page of its own; the payer is resolved
+        // from the session's own driveId/ownerId (`resolveBillingSession`
+        // below), never from this field.
         pageId: input.agentPageId,
       };
     },
@@ -208,9 +215,21 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       }),
     now: () => new Date(),
     logger: loggers.ai,
-    // Meter this run's active-runtime cost against the session's payer (the
-    // agent page's drive owner, or the acting tenant for a global session).
+    // Meter this run's active-runtime cost against the SESSION's payer (its
+    // own drive owner, or the session's own owner for a global-assistant
+    // session) — never the caller's surface drive/agent page.
     billing: defaultSandboxBillingDeps,
+    // Cheap billing-attribution resolve (`withMachineBilling` calls this
+    // BEFORE gating, so a credit-exhausted payer is denied without waking a
+    // hibernating sandbox): the same session row `acquireSandbox` above
+    // resolves via `conversations.sessionId`, read again here rather than
+    // threaded through the acquire result — this runs BEFORE the sandbox is
+    // provisioned, so there is nothing from `acquireSandbox` to thread yet.
+    resolveBillingSession: async (ctx) => {
+      if (!ctx.conversationId) return null;
+      const row = await findSessionForConversation(ctx.conversationId);
+      return row ? { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId } : null;
+    },
     // Sprites Platform Alignment 5-2: checkpoint the sandbox filesystem before
     // an agent bash batch runs (fail-open, at most once per turn — see
     // checkpoint-policy.ts). State is in-process, keyed by sandboxId; a

--- a/apps/web/src/lib/subscription/usage-breakdown-query.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown-query.ts
@@ -20,8 +20,8 @@ import { aggregateUsageBreakdown, resolveUsageWindow, type UsageBreakdown } from
  * "recent usage" view.
  *
  * `byAgentSession` needs no separate drive-ownership filter: `creditLedger.userId` IS
- * the PAYER (`resolveSandboxPayerId` in sandbox-payer.ts always resolves to the
- * backing page's drive owner, falling back to the acting tenant only when
+ * the PAYER (`resolveSessionPayerId` in sandbox-payer.ts always resolves to the
+ * session's own drive owner, falling back to the session's own owner only when
  * unresolvable), so every row this query returns for `userId` is already scoped to
  * a session they own or a run they footed the bill for directly.
  */

--- a/packages/lib/src/billing/__tests__/sandbox-payer.test.ts
+++ b/packages/lib/src/billing/__tests__/sandbox-payer.test.ts
@@ -4,112 +4,66 @@ const mockDb = vi.hoisted(() => ({ select: vi.fn() }));
 vi.mock('@pagespace/db/db', () => ({ db: mockDb }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn((a, b) => ({ op: 'eq', a, b })) }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'pages.id', driveId: 'pages.driveId' },
   drives: { id: 'drives.id', ownerId: 'drives.ownerId' },
 }));
 
-import { resolveSandboxPayerId, resolveAgentSessionPayerId, lookupPageOwnerId } from '../sandbox-payer';
+import { resolveSessionPayerId, lookupDriveOwnerId } from '../sandbox-payer';
 
-describe('resolveSandboxPayerId', () => {
-  it('falls back to tenantId when there is no backing agent page (e.g. a global-assistant run)', async () => {
+describe('resolveSessionPayerId', () => {
+  it('bills the session owner directly for a global-assistant session (driveId null), with no lookup', async () => {
     const lookup = vi.fn();
     await expect(
-      resolveSandboxPayerId({ tenantId: 'owner-1', lookupPageOwnerId: lookup }),
+      resolveSessionPayerId({ driveId: null, ownerId: 'owner-1', lookupDriveOwnerId: lookup }),
     ).resolves.toBe('owner-1');
     expect(lookup).not.toHaveBeenCalled();
   });
 
-  it("resolves to the referenced page's ACTUAL owner, not the acting tenantId", async () => {
-    const lookup = vi.fn(async () => 'real-owner');
+  it("resolves to the session's ACTUAL drive owner when driveId is set — never the caller's surface tenant", async () => {
+    const lookup = vi.fn(async () => 'real-drive-owner');
     await expect(
-      resolveSandboxPayerId({
-        tenantId: 'acting-user',
-        agentPageId: 'terminal-page-1',
-        lookupPageOwnerId: lookup,
-      }),
-    ).resolves.toBe('real-owner');
-    expect(lookup).toHaveBeenCalledWith('terminal-page-1');
+      resolveSessionPayerId({ driveId: 'session-drive-1', ownerId: 'session-owner-1', lookupDriveOwnerId: lookup }),
+    ).resolves.toBe('real-drive-owner');
+    expect(lookup).toHaveBeenCalledWith('session-drive-1');
   });
 
-  it('falls back to tenantId when the page/drive lookup finds no owner (orphaned page)', async () => {
+  it('falls back to the session ownerId when the drive lookup finds no owner (a stale read mid-delete)', async () => {
     const lookup = vi.fn(async () => null);
     await expect(
-      resolveSandboxPayerId({
-        tenantId: 'owner-1',
-        agentPageId: 'gone',
-        lookupPageOwnerId: lookup,
-      }),
+      resolveSessionPayerId({ driveId: 'vanished-drive', ownerId: 'owner-1', lookupDriveOwnerId: lookup }),
     ).resolves.toBe('owner-1');
   });
 
-  it('is not a passthrough — a resolved owner beats a different tenantId', async () => {
+  it('is not a passthrough — a resolved drive owner beats a different session ownerId', async () => {
     const lookup = vi.fn(async () => 'other-owner');
-    const a = await resolveSandboxPayerId({ tenantId: 'a', agentPageId: 'p', lookupPageOwnerId: lookup });
-    const b = await resolveSandboxPayerId({ tenantId: 'b', agentPageId: 'p', lookupPageOwnerId: lookup });
+    const a = await resolveSessionPayerId({ driveId: 'd', ownerId: 'a', lookupDriveOwnerId: lookup });
+    const b = await resolveSessionPayerId({ driveId: 'd', ownerId: 'b', lookupDriveOwnerId: lookup });
     expect(a).toBe('other-owner');
     expect(b).toBe('other-owner');
   });
 });
 
-describe('resolveAgentSessionPayerId', () => {
-  it('bills the session owner directly for a global-assistant session (null agentPageId)', async () => {
-    const lookup = vi.fn();
-    await expect(
-      resolveAgentSessionPayerId({ ownerId: 'owner-1', agentPageId: null, lookupPageOwnerId: lookup }),
-    ).resolves.toBe('owner-1');
-    expect(lookup).not.toHaveBeenCalled();
-  });
-
-  it("resolves to the agent page's ACTUAL page owner when agentPageId is set", async () => {
-    const lookup = vi.fn(async () => 'real-owner');
-    await expect(
-      resolveAgentSessionPayerId({ ownerId: 'owner-1', agentPageId: 'agent-page-1', lookupPageOwnerId: lookup }),
-    ).resolves.toBe('real-owner');
-    expect(lookup).toHaveBeenCalledWith('agent-page-1');
-  });
-
-  it('falls back to the session ownerId when the agent page/drive lookup finds no owner (orphaned page)', async () => {
-    const lookup = vi.fn(async () => null);
-    await expect(
-      resolveAgentSessionPayerId({ ownerId: 'owner-1', agentPageId: 'gone', lookupPageOwnerId: lookup }),
-    ).resolves.toBe('owner-1');
-  });
-
-  it('is not a passthrough — a resolved owner beats a different ownerId', async () => {
-    const lookup = vi.fn(async () => 'other-owner');
-    const a = await resolveAgentSessionPayerId({ ownerId: 'a', agentPageId: 'p', lookupPageOwnerId: lookup });
-    const b = await resolveAgentSessionPayerId({ ownerId: 'b', agentPageId: 'p', lookupPageOwnerId: lookup });
-    expect(a).toBe('other-owner');
-    expect(b).toBe('other-owner');
-  });
-});
-
-describe('lookupPageOwnerId (real pages -> drives join)', () => {
+describe('lookupDriveOwnerId (real drives read)', () => {
   beforeEach(() => mockDb.select.mockReset());
 
-  it('joins pages -> drives and returns the drive ownerId', async () => {
+  it("returns the drive's ownerId", async () => {
     mockDb.select.mockReturnValue({
       from: () => ({
-        leftJoin: () => ({
-          where: () => ({
-            limit: async () => [{ ownerId: 'owner-42' }],
-          }),
+        where: () => ({
+          limit: async () => [{ ownerId: 'owner-42' }],
         }),
       }),
     });
-    await expect(lookupPageOwnerId('page-1')).resolves.toBe('owner-42');
+    await expect(lookupDriveOwnerId('drive-1')).resolves.toBe('owner-42');
   });
 
-  it('returns null when the page has no row', async () => {
+  it('returns null when the drive has no row', async () => {
     mockDb.select.mockReturnValue({
       from: () => ({
-        leftJoin: () => ({
-          where: () => ({
-            limit: async () => [],
-          }),
+        where: () => ({
+          limit: async () => [],
         }),
       }),
     });
-    await expect(lookupPageOwnerId('missing')).resolves.toBeNull();
+    await expect(lookupDriveOwnerId('missing')).resolves.toBeNull();
   });
 });

--- a/packages/lib/src/billing/sandbox-payer.ts
+++ b/packages/lib/src/billing/sandbox-payer.ts
@@ -1,98 +1,46 @@
 /**
- * resolveSandboxPayerId — the ONE seam that names who pays for a sandbox's
- * active runtime (and, via the idle-storage cron, its persistent storage).
+ * resolveSessionPayerId — the ONE seam that names who pays for a sandbox's
+ * active runtime, and (via the storage reconcile) its persistent storage.
  *
- * Every sandbox acquisition path (agent tool runs via
- * `createResolveSandboxActorContext`, interactive PTY sessions via
- * `makeTerminalCheckAuth`) resolves `tenantId` to the ACTING drive's
- * `ownerId` — correct when the sandbox is anchored to the agent's own page in
- * its own drive, but an agent page can be shared into a DIFFERENT drive than
- * the acting tenant's (page-permission-based, not per-drive). In that case
- * `tenantId` is the ACTOR's drive owner, not the referenced page's — so this
- * resolves the referenced page's own drive owner and bills THAT account,
- * falling back to `tenantId` only when there's no backing page (e.g. a
- * global-assistant run with no agent page) or the page's owner can't be
- * resolved (orphaned page).
+ * A session is a drive-level workspace (contract.ts invariant 1): its bill
+ * lands on the drive's owner when it has one, or on the session's own
+ * `ownerId` for a user-scoped global-assistant session (`driveId` null) — the
+ * SAME attribution rule `storageBillingTarget`
+ * (`services/sandbox/sandbox-storage-attribution.ts`) decides for storage.
+ * This is the charge-time twin of that rule: where the storage reconcile
+ * SKIPS a row whose drive owner can't be resolved (a stale read mid-delete,
+ * self-corrects next run), a live runtime charge has already happened and
+ * needs a payer NOW, so it falls back to the session's own `ownerId` instead.
  *
- * `lookupPageOwnerId` is injected (not a direct DB import) so this stays a
- * pure, independently-testable seam; `lookupPageOwnerId` below is the one real
- * implementation every caller wires in, so the pages→drives join is written
- * exactly once.
+ * Deliberately keyed on the session's OWN `driveId`/`ownerId`, never on the
+ * caller's surface drive or the conversation's agent page — a session hosts
+ * MANY conversations (possibly with agents from a different drive than the
+ * one the caller happens to be chatting from), and the payer must not depend
+ * on which conversation the request came through.
+ *
+ * `lookupDriveOwnerId` is injected (not a direct DB import) so this stays a
+ * pure, independently-testable seam.
  */
-export interface ResolveSandboxPayerInput {
-  /** Fallback payer — the ACTING drive's owner, as resolved by every current sandbox-acquisition path. */
-  tenantId: string;
-  /** The active sandbox's backing agent page id; undefined when there's no backing page. */
-  agentPageId?: string;
-  /** Resolves a page's owning drive's `ownerId`; null when the page/drive can't be found. */
-  lookupPageOwnerId: (pageId: string) => Promise<string | null>;
-}
-
-export async function resolveSandboxPayerId(input: ResolveSandboxPayerInput): Promise<string> {
-  if (!input.agentPageId) return input.tenantId;
-  const ownerId = await input.lookupPageOwnerId(input.agentPageId);
-  return ownerId ?? input.tenantId;
-}
-
-/**
- * resolveAgentSessionPayerId — the agent-sessions twin of `resolveSandboxPayerId`
- * above, and the ONLY place the nullable-`agentPageId` payer invariant is
- * handled (Phase 7, billing/storage re-point). Do not re-derive this fallback
- * elsewhere.
- *
- * An `agent_sessions` row's `agentPageId` is nullable — null means a
- * global-assistant session with no backing page at all, not an orphaned
- * reference. So the fallback here is the row's own `ownerId` (always present),
- * never a caller-supplied tenantId: unlike a sandbox acquisition (which can be
- * addressed from a different drive than the acting tenant), a session's owner
- * IS its payer of last resort by construction.
- *
- * When `agentPageId` IS set, resolution is identical to
- * `resolveSandboxPayerId`: look up the page's owning drive's owner, falling
- * back to `ownerId` if that lookup fails (e.g. an orphaned page) rather than
- * leaving the session unbillable.
- */
-export interface ResolveAgentSessionPayerInput {
-  /** The session's own owner — the fallback payer, and the ONLY payer for a null-`agentPageId` (global-assistant) session. */
+export interface ResolveSessionPayerInput {
+  /** The session's own drive; null for a user-scoped global-assistant session. */
+  driveId: string | null;
+  /** The session's own owner — the fallback payer, and the ONLY payer when `driveId` is null. */
   ownerId: string;
-  /** The session's backing agent page; null for a global-assistant session. */
-  agentPageId: string | null;
-  /** Resolves a page's owning drive's `ownerId`; null when the page/drive can't be found. */
-  lookupPageOwnerId: (pageId: string) => Promise<string | null>;
+  /** Resolves a drive's `ownerId`; null when it can't be resolved (e.g. a stale read of a drive mid-delete). */
+  lookupDriveOwnerId: (driveId: string) => Promise<string | null>;
 }
 
-export async function resolveAgentSessionPayerId(input: ResolveAgentSessionPayerInput): Promise<string> {
-  if (!input.agentPageId) return input.ownerId;
-  const ownerId = await input.lookupPageOwnerId(input.agentPageId);
+export async function resolveSessionPayerId(input: ResolveSessionPayerInput): Promise<string> {
+  if (!input.driveId) return input.ownerId;
+  const ownerId = await input.lookupDriveOwnerId(input.driveId);
   return ownerId ?? input.ownerId;
 }
 
 /**
- * Real DB-backed page→drive-owner lookup — the ONE place this join is
- * written. `leftJoin` (not `innerJoin`) so a page whose drive vanished (should
- * never happen given the cascade FK, but defends against a stale read) resolves
- * to `null` rather than silently dropping the row.
- */
-export async function lookupPageOwnerId(pageId: string): Promise<string | null> {
-  const { db } = await import('@pagespace/db/db');
-  const { eq } = await import('@pagespace/db/operators');
-  const { pages, drives } = await import('@pagespace/db/schema/core');
-
-  const [row] = await db
-    .select({ ownerId: drives.ownerId })
-    .from(pages)
-    .leftJoin(drives, eq(pages.driveId, drives.id))
-    .where(eq(pages.id, pageId))
-    .limit(1);
-
-  return row?.ownerId ?? null;
-}
-
-/**
  * Real DB-backed drive→owner lookup — the ONE place this read is written for
- * billing. A session is a drive-level workspace, so its storage bills the
- * drive's owner; null when the drive cannot be found (a stale read mid-delete
- * — the storage reconcile skips rather than misattributing).
+ * billing. A session is a drive-level workspace, so its runtime/storage bills
+ * the drive's owner; null when the drive cannot be found (a stale read mid-delete
+ * — callers fall back to the session's own owner, or skip, per their own policy).
  */
 export async function lookupDriveOwnerId(driveId: string): Promise<string | null> {
   const { db } = await import('@pagespace/db/db');

--- a/packages/lib/src/logging/logger-database.ts
+++ b/packages/lib/src/logging/logger-database.ts
@@ -204,6 +204,8 @@ export async function writeAiUsage(usage: {
   messageId?: string;
   pageId?: string;
   driveId?: string;
+  /** The `agent_sessions.id` this usage attributes to — terminal runtime/storage charges only. */
+  sessionId?: string;
   success?: boolean;
   error?: string;
   source?: string;
@@ -241,6 +243,7 @@ export async function writeAiUsage(usage: {
       messageId: usage.messageId,
       pageId: usage.pageId,
       driveId: usage.driveId,
+      sessionId: usage.sessionId,
       success: usage.success,
       error: usage.error,
       source: usage.source,

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -815,6 +815,13 @@ export interface AIUsageData {
   messageId?: string;
   pageId?: string;
   driveId?: string;
+  /**
+   * The `agent_sessions.id` this usage attributes to (Terminal Epic 3 first-class
+   * attribution) — set by the sandbox runtime/storage charge streams so the
+   * usage breakdown can group terminal spend by session without JSON forensics.
+   * Absent for every non-terminal source.
+   */
+  sessionId?: string;
   success?: boolean;
   error?: string;
   metadata?: Record<string, unknown>;
@@ -960,6 +967,7 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
         messageId: data.messageId,
         pageId: data.pageId,
         driveId: data.driveId,
+        sessionId: data.sessionId,
         success,
         error: data.error,
         source: normalizeUsageSource(data.source),

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-billing.test.ts
@@ -39,42 +39,40 @@ beforeEach(() => {
   mockTrackUsage.mockReset();
 });
 
-function mockPageOwnerRow(row: { ownerId: string } | undefined) {
+function mockDriveOwnerRow(row: { ownerId: string } | undefined) {
   mockDb.select.mockReturnValue({
     from: () => ({
-      leftJoin: () => ({
-        where: () => ({
-          limit: async () => (row ? [row] : []),
-        }),
+      where: () => ({
+        limit: async () => (row ? [row] : []),
       }),
     }),
   });
 }
 
 describe('defaultSandboxBillingDeps.resolvePayerId', () => {
-  it('falls back to tenantId when there is no agentPageId (no DB lookup performed)', async () => {
-    const result = await defaultSandboxBillingDeps.resolvePayerId({ tenantId: 'owner-1' });
+  it('bills the session ownerId directly for a global-assistant session (driveId null), with no DB lookup', async () => {
+    const result = await defaultSandboxBillingDeps.resolvePayerId({ driveId: null, ownerId: 'owner-1' });
     expect(result).toBe('owner-1');
     expect(mockDb.select).not.toHaveBeenCalled();
   });
 
-  it("resolves to the referenced agent page's ACTUAL drive owner via the pages -> drives join, not the acting tenantId", async () => {
-    mockPageOwnerRow({ ownerId: 'real-owner' });
+  it("resolves to the SESSION's ACTUAL drive owner via a direct drives read — never the session's own ownerId when a real owner resolves", async () => {
+    mockDriveOwnerRow({ ownerId: 'real-owner' });
 
     const result = await defaultSandboxBillingDeps.resolvePayerId({
-      tenantId: 'acting-user',
-      agentPageId: 'other-terminal-page',
+      driveId: 'session-drive-1',
+      ownerId: 'session-owner-1',
     });
 
     expect(result).toBe('real-owner');
   });
 
-  it('falls back to tenantId when the referenced page/drive cannot be resolved', async () => {
-    mockPageOwnerRow(undefined);
+  it('falls back to the session ownerId when the drive cannot be resolved (a stale read mid-delete)', async () => {
+    mockDriveOwnerRow(undefined);
 
     const result = await defaultSandboxBillingDeps.resolvePayerId({
-      tenantId: 'owner-1',
-      agentPageId: 'orphaned-page',
+      driveId: 'vanished-drive',
+      ownerId: 'owner-1',
     });
 
     expect(result).toBe('owner-1');
@@ -188,6 +186,20 @@ describe('defaultSandboxBillingDeps.trackUsage', () => {
     });
     const call = mockTrackUsage.mock.calls[0][0];
     expect(call.pageId).toBe('terminal-page-1');
+  });
+
+  it('forwards driveId/sessionId to AIMonitoring.trackUsage as first-class attribution (Terminal Epic 3 usage-breakdown fix)', async () => {
+    mockTrackUsage.mockResolvedValue(undefined);
+    await defaultSandboxBillingDeps.trackUsage({
+      payerId: 'owner-1',
+      holdId: 'hold-1',
+      activeSeconds: 60,
+      driveId: 'drive-1',
+      sessionId: 'session-1',
+    });
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.driveId).toBe('drive-1');
+    expect(call.sessionId).toBe('session-1');
   });
 
   it("passes MACHINE_MARKUP_BPS as markupBpsOverride so the settle path floors at terminal's own rate, not the shared AI MARKUP_BPS", async () => {

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.test.ts
@@ -19,7 +19,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 vi.mock('@pagespace/db/schema/agent-sessions', () => ({
   agentSessions: {
     id: 'agent_sessions.id',
-    driveId: 'agent_sessions.agentPageId',
+    driveId: 'agent_sessions.driveId',
     ownerId: 'agent_sessions.ownerId',
     sandboxId: 'agent_sessions.sandboxId',
     spriteTornDownAt: 'agent_sessions.spriteTornDownAt',
@@ -147,9 +147,12 @@ describe('defaultReconcileSandboxStorageDeps.chargeStorage', () => {
       providerCostDollars: 0.05,
       success: true,
       costSource: 'list_price',
+      // First-class attribution — top-level columns, not just metadata forensics.
+      driveId: 'drive-1',
+      sessionId: 'session-1',
     });
     expect(call.holdId).toBeUndefined();
-    expect(call.metadata).toMatchObject({ type: 'terminal_storage', driveId: 'drive-1', sessionId: 'session-1', gbMonths: 0.2 });
+    expect(call.metadata).toMatchObject({ type: 'terminal_storage', gbMonths: 0.2 });
   });
 
   it("passes MACHINE_MARKUP_BPS as markupBpsOverride", async () => {
@@ -177,9 +180,24 @@ describe('defaultReconcileSandboxStorageDeps.chargeStorage', () => {
       gbMonths: 0.2,
     });
 
-    // The drive and session ride in metadata for forensics instead.
+    // The drive and session ride as first-class top-level columns instead.
     expect(mockTrackUsage.mock.calls[0][0].pageId).toBeUndefined();
-    expect(mockTrackUsage.mock.calls[0][0].metadata).toMatchObject({ driveId: 'drive-1', sessionId: 'session-1' });
+    expect(mockTrackUsage.mock.calls[0][0]).toMatchObject({ driveId: 'drive-1', sessionId: 'session-1' });
+  });
+
+  it('given a global-assistant session (no drive), forwards driveId as undefined rather than null', async () => {
+    mockTrackUsage.mockResolvedValue(undefined);
+
+    await defaultReconcileSandboxStorageDeps.chargeStorage({
+      payerId: 'owner-1',
+      driveId: undefined,
+      sessionId: 'session-1',
+      costDollars: 0.05,
+      gbMonths: 0.2,
+    });
+
+    expect(mockTrackUsage.mock.calls[0][0].driveId).toBeUndefined();
+    expect(mockTrackUsage.mock.calls[0][0].sessionId).toBe('session-1');
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-reconcile.test.ts
@@ -172,8 +172,8 @@ describe('reconcileSandboxStorage', () => {
     const result = await reconcileSandboxStorage(deps);
 
     assert({
-      given: 'an agent-session Sprite with a backing agent page and a measured 1GB footprint',
-      should: 'charge its agent page — the key the usage breakdown groups on',
+      given: 'an agent-session Sprite with a backing drive and a measured 1GB footprint',
+      should: 'charge its drive — the key the usage breakdown groups on',
       actual: { charged: result.charged, driveId: chargeCalls[0]?.driveId },
       expected: { charged: 1, driveId: 'drive-1' },
     });
@@ -195,7 +195,7 @@ describe('reconcileSandboxStorage', () => {
     expect(chargeCalls[0]).toMatchObject({ payerId: 'owner-of-drive-9', driveId: 'drive-9' });
   });
 
-  it('bills a global-assistant session (null agentPageId) straight to its ownerId, with no page lookup and no pageId on the charge', async () => {
+  it('bills a global-assistant session (null driveId) straight to its ownerId, with no drive lookup and no driveId on the charge', async () => {
     const lookup = vi.fn(async () => 'should-not-be-called');
     const { deps, chargeCalls } = makeDeps({
       listAgentSessionSprites: async () => [agentSession({ driveId: null, ownerId: 'global-owner-1' })],
@@ -206,8 +206,8 @@ describe('reconcileSandboxStorage', () => {
 
     expect(lookup).not.toHaveBeenCalled();
     assert({
-      given: 'a global-assistant agent-session Sprite (no backing page)',
-      should: 'charge the session ownerId directly, with pageId omitted from the charge',
+      given: 'a global-assistant agent-session Sprite (no backing drive)',
+      should: 'charge the session ownerId directly, with driveId omitted from the charge',
       actual: { charged: result.charged, payerId: chargeCalls[0]?.payerId, driveId: chargeCalls[0]?.driveId },
       expected: { charged: 1, payerId: 'global-owner-1', driveId: undefined },
     });
@@ -241,20 +241,44 @@ describe('reconcileSandboxStorage', () => {
     expect(agentSessionAdvanceCalls).toEqual([]);
   });
 
-  it('reports a session failure distinguishably rather than aborting the batch', async () => {
-    const { deps, chargeCalls } = makeDeps({
+  it('given chargeStorage succeeds but the FOLLOWING watermark advance throws, counts the money as charged (never under-reported) and flags the row distinguishably', async () => {
+    const { deps, chargeCalls, agentSessionAdvanceCalls } = makeDeps({
       listAgentSessionSprites: async () => [agentSession({ sessionId: 'boom' }), agentSession({ sessionId: 'fine' })],
-      advanceAgentSessionWatermark: async ({ sessionId }) => {
-        if (sessionId === 'boom') throw new Error('watermark write failed');
+      advanceAgentSessionWatermark: async (input) => {
+        if (input.sessionId === 'boom') throw new Error('watermark write failed');
+        agentSessionAdvanceCalls.push(input);
       },
     });
 
     const result = await reconcileSandboxStorage(deps);
 
-    // 'boom' is charged (chargeStorage succeeds) but its advance throws before
-    // `charged` increments — counted as failed, not charged.
-    expect(result).toMatchObject({ processed: 2, charged: 1, failed: 1 });
+    // Both rows' money actually moved (chargeStorage succeeded for both) — so
+    // BOTH count toward `charged`/`totalCostDollars`, regardless of the
+    // watermark outcome. 'boom's failed advance is its own distinct signal
+    // (`chargedButUnadvanced`), not folded into `failed` (which would imply
+    // nothing was billed).
+    expect(result).toMatchObject({ processed: 2, charged: 2, failed: 0, chargedButUnadvanced: 1 });
+    expect(result.totalCostDollars).toBeGreaterThan(0);
     expect(chargeCalls).toHaveLength(2);
+    // Only 'fine' successfully advanced — 'boom' will be billed again next run.
+    expect(agentSessionAdvanceCalls.map((c) => c.sessionId)).toEqual(['fine']);
+  });
+
+  it('given chargeStorage ITSELF throws, bills nothing for that row (no double-count) and never attempts its watermark advance', async () => {
+    const { deps, chargeCalls, agentSessionAdvanceCalls } = makeDeps({
+      listAgentSessionSprites: async () => [agentSession({ sessionId: 'boom' }), agentSession({ sessionId: 'fine' })],
+      chargeStorage: async (input) => {
+        if (input.sessionId === 'boom') throw new Error('credit ledger unreachable');
+        chargeCalls.push(input);
+      },
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    expect(result).toMatchObject({ processed: 2, charged: 1, failed: 1, chargedButUnadvanced: 0 });
+    expect(chargeCalls).toHaveLength(1);
+    expect(chargeCalls[0].sessionId).toBe('fine');
+    expect(agentSessionAdvanceCalls.map((c) => c.sessionId)).toEqual(['fine']);
   });
 
   it('given a stale measurement on an idle session, still bills the last measured value and flags it stale', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -155,6 +155,30 @@ describe('runBashInSandbox', () => {
     expect(slots.released).toBe(1);
   });
 
+  it("given a conversation with no session (a legacy pre-session thread), should log the denial at WARN — not ERROR — since it's an expected refusal, not an infra fault", async () => {
+    const warnings: Array<[string, Record<string, unknown> | undefined]> = [];
+    const errors: Array<[string, unknown]> = [];
+    const { deps, slots } = makeDeps({
+      acquireSandbox: async () => ({ ok: false, reason: 'no_session' }),
+      logger: {
+        warn: (message, metadata) => {
+          warnings.push([message, metadata]);
+        },
+        error: (message, error) => {
+          errors.push([message, error]);
+        },
+      },
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'no_session' });
+    expect(slots.released).toBe(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0][0]).toBe('Sandbox access denied');
+    expect(errors).toHaveLength(0);
+  });
+
   it('given an authz denial from acquire and a throwing logger, should still release the slot and map the reason', async () => {
     const { deps, slots } = makeDeps({
       acquireSandbox: async () => ({ ok: false, reason: 'insufficient_role' }),
@@ -1087,19 +1111,19 @@ function makeMutableClock(startMs: number) {
 
 function makeBilling(over: Partial<SandboxRunDeps['billing']> = {}): {
   billing: NonNullable<SandboxRunDeps['billing']>;
-  resolvePayerIdCalls: Array<{ tenantId: string; agentPageId?: string }>;
+  resolvePayerIdCalls: Array<{ driveId: string | null; ownerId: string }>;
   gateCalls: Array<{ payerId: string }>;
-  trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string }>;
+  trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string; driveId?: string; sessionId?: string }>;
   releaseHoldCalls: string[];
 } {
-  const resolvePayerIdCalls: Array<{ tenantId: string; agentPageId?: string }> = [];
+  const resolvePayerIdCalls: Array<{ driveId: string | null; ownerId: string }> = [];
   const gateCalls: Array<{ payerId: string }> = [];
-  const trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string }> = [];
+  const trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string; driveId?: string; sessionId?: string }> = [];
   const releaseHoldCalls: string[] = [];
   const billing: NonNullable<SandboxRunDeps['billing']> = {
     resolvePayerId: async (input) => {
       resolvePayerIdCalls.push(input);
-      return input.tenantId;
+      return input.ownerId;
     },
     gate: async (input) => {
       gateCalls.push(input);
@@ -1116,6 +1140,24 @@ function makeBilling(over: Partial<SandboxRunDeps['billing']> = {}): {
   return { billing, resolvePayerIdCalls, gateCalls, trackUsageCalls, releaseHoldCalls };
 }
 
+/**
+ * The billing seam's session resolve (`resolveBillingSession`) — a fake
+ * mirroring `sandbox-tools-runtime.ts`'s real wiring, which reads the
+ * ACQUIRED session's own driveId/ownerId (never `ctx.tenantId`/`ctx.driveId`,
+ * the caller's surface facts). Defaults to a session whose facts happen to
+ * equal the ctx's (the common single-conversation-drive case); tests proving
+ * the session/surface DIVERGE override this explicitly instead of ctx.
+ */
+function makeBillingSession(
+  over: Partial<{ sessionId: string; driveId: string | null; ownerId: string }> = {},
+): NonNullable<SandboxRunDeps['resolveBillingSession']> {
+  return async (ctx) => ({
+    sessionId: over.sessionId ?? 'ws-1',
+    driveId: over.driveId !== undefined ? over.driveId : (ctx.driveId ?? null),
+    ownerId: over.ownerId ?? ctx.tenantId,
+  });
+}
+
 describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
   it('given no billing deps, runs unmetered (no gate, no trackUsage, no releaseHold)', async () => {
     const { deps } = makeDeps();
@@ -1123,10 +1165,25 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(result).toMatchObject({ success: true });
   });
 
-  it('places a hold BEFORE the machine is acquired, keyed to the resolved payerId', async () => {
+  it('given billing but no resolveBillingSession dep (or one that resolves null — a legacy pre-session conversation), runs unmetered and lets acquire surface the denial', async () => {
+    const { billing, gateCalls, trackUsageCalls } = makeBilling();
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: async () => null,
+      acquireSandbox: async () => ({ ok: false, reason: 'no_session' }),
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'no_session' });
+    expect(gateCalls).toEqual([]);
+    expect(trackUsageCalls).toEqual([]);
+  });
+
+  it('places a hold BEFORE the machine is acquired, keyed to the payer resolved from the SESSION', async () => {
     const { billing, gateCalls } = makeBilling();
-    const { deps } = makeDeps({ billing });
-    await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ tenantId: 'owner-42' }), deps });
+    const { deps } = makeDeps({ billing, resolveBillingSession: makeBillingSession({ ownerId: 'owner-42' }) });
+    await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
     expect(gateCalls).toEqual([{ payerId: 'owner-42' }]);
   });
 
@@ -1139,12 +1196,19 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
       },
     });
     const { billing, trackUsageCalls, releaseHoldCalls } = makeBilling();
-    const { deps } = makeDeps({ billing, reconnect: async () => sandbox, now: clock.now });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession({ ownerId: 'owner-42', driveId: 'd1', sessionId: 'ws-1' }),
+      reconnect: async () => sandbox,
+      now: clock.now,
+    });
 
-    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ tenantId: 'owner-42' }), deps });
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
 
     expect(result).toMatchObject({ success: true });
-    expect(trackUsageCalls).toEqual([{ payerId: 'owner-42', holdId: 'hold-1', activeSeconds: 5 }]);
+    expect(trackUsageCalls).toEqual([
+      { payerId: 'owner-42', holdId: 'hold-1', activeSeconds: 5, pageId: undefined, driveId: 'd1', sessionId: 'ws-1' },
+    ]);
     expect(releaseHoldCalls).toEqual([]);
   });
 
@@ -1155,6 +1219,7 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     });
     const { deps } = makeDeps({
       billing,
+      resolveBillingSession: makeBillingSession(),
       acquireSandbox: async () => {
         acquireCalls += 1;
         return { ok: true, sandboxId: 'sbx-1', resumed: false, sessionId: 'ws-1' };
@@ -1172,7 +1237,7 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
       },
     });
     const { billing, trackUsageCalls, releaseHoldCalls } = makeBilling();
-    const { deps } = makeDeps({ billing, reconnect: async () => sandbox });
+    const { deps } = makeDeps({ billing, resolveBillingSession: makeBillingSession(), reconnect: async () => sandbox });
 
     const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
 
@@ -1185,6 +1250,7 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     const { billing, trackUsageCalls, releaseHoldCalls } = makeBilling();
     const { deps } = makeDeps({
       billing,
+      resolveBillingSession: makeBillingSession(),
       quota: { acquireSlot: () => false, releaseSlot: () => {} },
     });
 
@@ -1195,9 +1261,12 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(releaseHoldCalls).toEqual(['hold-1']);
   });
 
-  it("resolves agentPageId from ctx.agentPageId and forwards both to billing.resolvePayerId", async () => {
+  it("resolves the payer from the SESSION's driveId/ownerId — never ctx.tenantId/ctx.agentPageId", async () => {
     const { billing, resolvePayerIdCalls } = makeBilling();
-    const { deps } = makeDeps({ billing });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession({ driveId: 'session-drive-1', ownerId: 'session-owner-1' }),
+    });
 
     await runBashInSandbox({
       command: 'echo hi',
@@ -1205,10 +1274,10 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
       deps,
     });
 
-    expect(resolvePayerIdCalls).toEqual([{ tenantId: 'owner-1', agentPageId: 'own-agent-page' }]);
+    expect(resolvePayerIdCalls).toEqual([{ driveId: 'session-drive-1', ownerId: 'session-owner-1' }]);
   });
 
-  it("forwards the resolved agentPageId as pageId to trackUsage, so usage-breakdown can attribute cost to the right agent page", async () => {
+  it("forwards ctx.agentPageId as pageId to trackUsage (purely descriptive per-agent attribution), so usage-breakdown can attribute cost to the right agent page", async () => {
     const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
     const sandbox = makeSandbox({
       runCommand: async () => {
@@ -1217,7 +1286,12 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
       },
     });
     const { billing, trackUsageCalls } = makeBilling();
-    const { deps } = makeDeps({ billing, reconnect: async () => sandbox, now: clock.now });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession({ ownerId: 'acting-user', driveId: 'd1', sessionId: 'ws-1' }),
+      reconnect: async () => sandbox,
+      now: clock.now,
+    });
 
     await runBashInSandbox({
       command: 'echo hi',
@@ -1229,11 +1303,11 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     });
 
     expect(trackUsageCalls).toEqual([
-      { payerId: 'acting-user', holdId: 'hold-1', activeSeconds: 3, pageId: 'other-terminal-page' },
+      { payerId: 'acting-user', holdId: 'hold-1', activeSeconds: 3, pageId: 'other-terminal-page', driveId: 'd1', sessionId: 'ws-1' },
     ]);
   });
 
-  it("gates and settles usage against the PAYER resolvePayerId returns, not the raw tenantId, when they differ (owner-pays for a page owned by someone else)", async () => {
+  it("gates and settles usage against the PAYER resolvePayerId returns, not the session's raw ownerId, when they differ (owner-pays for a drive owned by someone else)", async () => {
     const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
     const sandbox = makeSandbox({
       runCommand: async () => {
@@ -1244,7 +1318,12 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     const { billing, gateCalls, trackUsageCalls } = makeBilling({
       resolvePayerId: async () => 'real-owner-99',
     });
-    const { deps } = makeDeps({ billing, reconnect: async () => sandbox, now: clock.now });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession({ ownerId: 'session-owner', driveId: 'd1', sessionId: 'ws-1' }),
+      reconnect: async () => sandbox,
+      now: clock.now,
+    });
 
     const result = await runBashInSandbox({
       command: 'echo hi',
@@ -1258,7 +1337,73 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(result).toMatchObject({ success: true });
     expect(gateCalls).toEqual([{ payerId: 'real-owner-99' }]);
     expect(trackUsageCalls).toEqual([
-      { payerId: 'real-owner-99', holdId: 'hold-1', activeSeconds: 2, pageId: 'other-terminal-page' },
+      { payerId: 'real-owner-99', holdId: 'hold-1', activeSeconds: 2, pageId: 'other-terminal-page', driveId: 'd1', sessionId: 'ws-1' },
+    ]);
+  });
+
+  // KEY ACCEPTANCE TEST (issue #2260): a session whose driveId differs from the
+  // caller's SURFACE drive must bill the SESSION's payer, not the surface's.
+  // Fails on master's `withMachineBilling` (which resolved payerId from
+  // `ctx.tenantId`/`ctx.agentPageId` — the caller's client-influenceable
+  // surface — via `resolveSandboxPayerId`, ignoring the session entirely).
+  it("bills the SESSION's payer, not the caller's surface drive/tenant, when a session hosts a conversation from a DIFFERENT drive than the one it was spawned in", async () => {
+    const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
+    const sandbox = makeSandbox({
+      runCommand: async () => {
+        clock.advance(4000);
+        return { exitCode: 0, stdout: 'ok', stderr: '' };
+      },
+    });
+    const resolvePayerIdCalls: Array<{ driveId: string | null; ownerId: string }> = [];
+    const { billing, gateCalls, trackUsageCalls } = makeBilling({
+      // Mirrors the real resolveSessionPayerId rule: drive owner when set.
+      resolvePayerId: async (input) => {
+        resolvePayerIdCalls.push(input);
+        return input.driveId ? `owner-of-${input.driveId}` : 'unreachable';
+      },
+    });
+    const { deps } = makeDeps({
+      billing,
+      // The SESSION's own facts — a DIFFERENT drive than the surface the agent
+      // is chatting through (ctx below), and a different owner entirely. This
+      // is exactly the R0 scenario: one session hosts many conversations,
+      // possibly from agents in other drives.
+      resolveBillingSession: async () => ({
+        sessionId: 'shared-session-1',
+        driveId: 'session-own-drive',
+        ownerId: 'session-own-owner',
+      }),
+      reconnect: async () => sandbox,
+      now: clock.now,
+    });
+
+    const result = await runBashInSandbox({
+      command: 'echo hi',
+      ctx: makeCtx({
+        // The SURFACE the caller happens to be chatting from — deliberately
+        // DIFFERENT from the session's own drive/owner above.
+        tenantId: 'surface-tenant-should-never-be-billed',
+        driveId: 'surface-drive-should-never-be-billed',
+        agentPageId: 'surface-agent-page',
+      }),
+      deps,
+    });
+
+    expect(result).toMatchObject({ success: true });
+    // The payer was resolved from the SESSION's driveId, never the surface's.
+    expect(resolvePayerIdCalls).toEqual([{ driveId: 'session-own-drive', ownerId: 'session-own-owner' }]);
+    expect(gateCalls).toEqual([{ payerId: 'owner-of-session-own-drive' }]);
+    expect(trackUsageCalls).toEqual([
+      {
+        payerId: 'owner-of-session-own-drive',
+        holdId: 'hold-1',
+        activeSeconds: 4,
+        // Still descriptive of which surface agent page the call came
+        // through — just never the PAYER source.
+        pageId: 'surface-agent-page',
+        driveId: 'session-own-drive',
+        sessionId: 'shared-session-1',
+      },
     ]);
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-billing.ts
+++ b/packages/lib/src/services/sandbox/sandbox-billing.ts
@@ -17,7 +17,7 @@ import {
   MACHINE_MAX_INFLIGHT,
   MACHINE_MARKUP_BPS,
 } from '../../billing/credit-pricing';
-import { resolveSandboxPayerId, lookupPageOwnerId } from '../../billing/sandbox-payer';
+import { resolveSessionPayerId, lookupDriveOwnerId } from '../../billing/sandbox-payer';
 import { AIMonitoring } from '../../monitoring/ai-monitoring';
 import { calculateMachineCostDollars } from '../../monitoring/machine-pricing';
 import { toSubscriptionTier, type SubscriptionTier } from '../../billing/subscription-tiers';
@@ -40,24 +40,14 @@ async function resolvePayerTier(payerId: string): Promise<SubscriptionTier> {
 }
 
 export const defaultSandboxBillingDeps: SandboxBillingDeps = {
-  // PHASE 8 NOTE: `agentPageId` here is `ctx.agentPageId` directly
-  // (`tool-runners.ts`'s `withMachineBilling` — `activeMachine`/
-  // `resolveMachinePageId` were deleted along with the Machine page type, so
-  // there is no second source `agentPageId` could ever diverge from).
-  // `resolveSandboxPayerId` therefore resolves correctly BY CONSTRUCTION, not
-  // coincidentally: an agent page set → its owning drive's owner; unset (a
-  // global-assistant session) → falls through to `tenantId`, which
-  // `sandbox-tools-runtime.ts`'s actor-context resolver sets to `userId` for a
-  // driveless global session — and `userId` and the session's `ownerId`
-  // coincide there, since a global-assistant conversation is single-user by
-  // construction. `resolveAgentSessionPayerId` (`billing/sandbox-payer.ts`) is
-  // the `agent_sessions`-row-aware twin of this fallback (used by the storage
-  // reconcile in `sandbox-storage-billing.ts`); re-pointing THIS runtime seam
-  // to it would need `SandboxBillingDeps`/`ToolExecutionContext` to carry the
-  // session's real `ownerId` end-to-end for no behavioral difference given the
-  // invariant above, so it stays as `resolveSandboxPayerId` here.
-  async resolvePayerId({ tenantId, agentPageId }) {
-    return resolveSandboxPayerId({ tenantId, agentPageId, lookupPageOwnerId });
+  // Resolves from the ACQUIRED SESSION's own driveId/ownerId (never the
+  // caller's surface drive or agent page) — `resolveSessionPayerId` is the
+  // same drive-owner-else-session-owner rule `storageBillingTarget` applies
+  // for the storage charge stream, so both streams bill one payer for one
+  // session regardless of which conversation/drive the caller happened to be
+  // in when the run started.
+  async resolvePayerId({ driveId, ownerId }) {
+    return resolveSessionPayerId({ driveId, ownerId, lookupDriveOwnerId });
   },
 
   async gate({ payerId }) {
@@ -78,15 +68,22 @@ export const defaultSandboxBillingDeps: SandboxBillingDeps = {
     return { allowed: result.allowed, holdId: result.holdId, reason: result.allowed ? undefined : result.reason };
   },
 
-  async trackUsage({ payerId, holdId, activeSeconds, pageId }) {
+  async trackUsage({ payerId, holdId, activeSeconds, pageId, driveId, sessionId }) {
     await AIMonitoring.trackUsage({
       userId: payerId,
       provider: 'sprites',
       model: 'terminal-machine',
       source: 'terminal',
-      // The machine's identifying page (resolveMachinePageId's output) — the ONE
-      // attribution field the usage-breakdown's per-machine view groups on.
+      // The referenced agent page — purely descriptive per-agent grouping,
+      // never the payer source (resolved from the session by `resolvePayerId`
+      // above).
       pageId,
+      // First-class drive/session attribution (Terminal Epic 3 usage-breakdown
+      // fix) — the SAME session driveId/ownerId the payer was resolved from,
+      // so the breakdown can group runtime spend by session/drive without
+      // JSON forensics, consistently with the storage charge stream.
+      driveId,
+      sessionId,
       providerCostDollars: calculateMachineCostDollars({ activeSeconds }),
       // Active-window duration (ms), matching the quantity that was billed —
       // not a request-latency figure, since there is no single "request" here.

--- a/packages/lib/src/services/sandbox/sandbox-storage-attribution.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-attribution.ts
@@ -11,10 +11,11 @@
  * drive-level workspace, so the bill lands on the DRIVE's owner (`driveId`
  * set), or on the session's own `ownerId` for a user-scoped global-assistant
  * session (`driveId` null) — the payer of last resort, with no lookup at all
- * (mirrors `resolveAgentSessionPayerId` in `billing/sandbox-payer.ts`, which
- * applies the same rule at charge time with one deliberate difference — it
+ * (mirrors `resolveSessionPayerId` in `billing/sandbox-payer.ts`, which
+ * applies the same rule at charge time — both the runtime and storage charge
+ * streams bill one payer for one session — with one deliberate difference: it
  * falls back to the session owner on a failed drive lookup, where the storage
- * reconcile skips).
+ * reconcile skips instead).
  */
 
 /** A billable agent-session Sprite. */
@@ -31,8 +32,9 @@ export interface StorageSubject {
  * Who ultimately gets billed for a subject's storage. A drive-scoped session
  * bills its drive's owner; a global-assistant session (null `driveId`) has no
  * drive, so billing falls straight through to its `ownerId` with no lookup at
- * all (mirrors `resolveAgentSessionPayerId` in `billing/sandbox-payer.ts`,
- * which the storage reconcile's IO composition uses for the `ownerId` case).
+ * all (mirrors `resolveSessionPayerId` in `billing/sandbox-payer.ts`, which
+ * the storage reconcile's IO composition uses for the `ownerId` case, and
+ * which the runtime billing seam now uses for the SAME session-level rule).
  */
 export function storageBillingTarget(subject: StorageSubject): { driveId: string } | { ownerId: string } {
   return subject.driveId ? { driveId: subject.driveId } : { ownerId: subject.ownerId };

--- a/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
@@ -69,9 +69,14 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
       source: 'terminal',
       // No pageId: a session is a drive-level workspace, not page-anchored, so
       // there is no page to group its storage under. `trackUsage` treats a
-      // missing pageId as unattributed-to-a-page, not an error; the drive and
-      // session ride in metadata for forensics.
+      // missing pageId as unattributed-to-a-page, not an error.
       pageId: undefined,
+      // First-class drive/session attribution (Terminal Epic 3 usage-breakdown
+      // fix) — top-level columns the breakdown can group/filter on directly,
+      // not just freeform metadata forensics. `driveId` undefined for a
+      // global-assistant session (mirrors `pageId`'s "unattributed" reading).
+      driveId,
+      sessionId,
       providerCostDollars: costDollars,
       // Not a wall-clock duration (this is a background storage charge, not a
       // single timed run) — 0 mirrors the shape of every other non-timed
@@ -84,7 +89,7 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
       // Same 1.5x substrate floor as active-runtime billing (machine-billing.ts),
       // independent of the shared AI MARKUP_BPS default.
       markupBpsOverride: MACHINE_MARKUP_BPS,
-      metadata: { type: 'terminal_storage', driveId, sessionId, gbMonths },
+      metadata: { type: 'terminal_storage', gbMonths },
     });
   },
 

--- a/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
@@ -168,11 +168,20 @@ export interface ReconcileSandboxStorageDeps {
 
 export interface ReconcileSandboxStorageResult {
   processed: number;
+  /** Rows where `chargeStorage` SUCCEEDED — the money moved, regardless of whether the watermark then advanced. Always reflected in `totalCostDollars`. */
   charged: number;
   /** Rows with a positive accrual whose owner could not be resolved — left unbilled (watermark untouched) for a future run to retry. */
   skipped: number;
-  /** Rows where `chargeStorage`/`advanceWatermark` threw — isolated so one bad row doesn't abort the batch; see module doc on the residual double-bill risk this leaves for a future run to retry. */
+  /** Rows where `chargeStorage` ITSELF threw — nothing was billed, isolated so one bad row doesn't abort the batch. */
   failed: number;
+  /**
+   * Rows where `chargeStorage` succeeded but the FOLLOWING `advanceAgentSessionWatermark`
+   * threw — the money already moved (counted in `charged`/`totalCostDollars`), but the
+   * watermark did not advance, so this row's window WILL be billed again on the next run
+   * (see module doc on the double-bill risk this leaves). Distinct from `failed`, where
+   * nothing was charged at all.
+   */
+  chargedButUnadvanced: number;
   /**
    * Rows billed from a MEASURED footprint whose measurement is older than
    * {@link STALE_MEASUREMENT_MS} while the sandbox is not currently awake —
@@ -182,6 +191,7 @@ export interface ReconcileSandboxStorageResult {
    * (see `skipped` is unrelated; never-measured simply bill 0).
    */
   staleMeasurements: number;
+  /** Total money actually moved this run — accumulated the moment `chargeStorage` succeeds, never gated on the watermark advance that follows it. */
   totalCostDollars: number;
 }
 
@@ -194,6 +204,7 @@ export async function reconcileSandboxStorage(
   let charged = 0;
   let skipped = 0;
   let failed = 0;
+  let chargedButUnadvanced = 0;
   let staleMeasurements = 0;
   let totalCostDollars = 0;
 
@@ -205,6 +216,11 @@ export async function reconcileSandboxStorage(
     // the one place this fork exists).
     const target = storageBillingTarget(subject);
     const attributionDriveId = 'driveId' in target ? target.driveId : undefined;
+
+    // Everything up to (but NOT including) the charge itself: pure accrual
+    // computation plus the owner lookup. A throw anywhere in here means
+    // nothing was billed, so it counts as `failed` exactly like before.
+    let resolved: { ownerId: string; costDollars: number; gbMonths: number } | undefined;
     try {
       const elapsedMs = now.getTime() - session.storageLastBilledAt.getTime();
       const lastMeasuredGB = session.measuredBytes === null ? null : bytesToGB(session.measuredBytes);
@@ -259,23 +275,61 @@ export async function reconcileSandboxStorage(
         continue;
       }
 
-      await deps.chargeStorage({ payerId: ownerId, driveId: attributionDriveId, sessionId: session.sessionId, costDollars, gbMonths });
-      await deps.advanceAgentSessionWatermark({ sessionId: session.sessionId, billedThrough: now });
-      totalCostDollars += costDollars;
-      charged += 1;
+      resolved = { ownerId, costDollars, gbMonths };
     } catch (error) {
-      // Isolated per-row: one session's charge/advance failure must not drop
-      // every other session in this run from being billed. Left unresolved: if
-      // chargeStorage already committed before advanceWatermark threw, this
-      // row's window bills again next run (see module doc).
       failed += 1;
       loggers.ai.error(
         'Sandbox storage reconcile failed for session',
         error instanceof Error ? error : new Error(String(error)),
         { driveId: attributionDriveId, sessionId: session.sessionId },
       );
+      continue;
+    }
+    if (!resolved) continue;
+
+    // The charge itself — isolated from the watermark advance below so the
+    // two outcomes ("nothing was billed" vs "billed, but the watermark write
+    // failed") are never conflated. Real money moves the moment this
+    // resolves, so `charged`/`totalCostDollars` reflect it immediately,
+    // regardless of what happens next.
+    try {
+      await deps.chargeStorage({
+        payerId: resolved.ownerId,
+        driveId: attributionDriveId,
+        sessionId: session.sessionId,
+        costDollars: resolved.costDollars,
+        gbMonths: resolved.gbMonths,
+      });
+    } catch (error) {
+      // Isolated per-row: one session's charge failure must not drop every
+      // other session in this run from being billed. Nothing was moved, so
+      // this is a genuine failure — the accrual is retried next run.
+      failed += 1;
+      loggers.ai.error(
+        'Sandbox storage reconcile: chargeStorage failed for session',
+        error instanceof Error ? error : new Error(String(error)),
+        { driveId: attributionDriveId, sessionId: session.sessionId },
+      );
+      continue;
+    }
+    totalCostDollars += resolved.costDollars;
+    charged += 1;
+
+    try {
+      await deps.advanceAgentSessionWatermark({ sessionId: session.sessionId, billedThrough: now });
+    } catch (error) {
+      // The charge already committed (counted above) — only the watermark
+      // write failed, so this row's window WILL be billed again on the next
+      // run (see module doc on the double-bill risk). Distinguishable from a
+      // real charge failure: `chargedButUnadvanced`, not `failed`.
+      chargedButUnadvanced += 1;
+      loggers.ai.error(
+        'Sandbox storage reconcile: watermark advance failed after a successful charge — this window will be re-billed next run',
+        error instanceof Error ? error : new Error(String(error)),
+        { driveId: attributionDriveId, sessionId: session.sessionId },
+      );
     }
   }
 
-  return { processed: sessions.length, charged, skipped, failed, staleMeasurements, totalCostDollars };
+  return { processed: sessions.length, charged, skipped, failed, chargedButUnadvanced, staleMeasurements, totalCostDollars };
 }

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -90,16 +90,28 @@ export interface SandboxQuotaDeps {
  */
 export interface SandboxBillingDeps {
   /**
-   * Resolves who pays for THIS run (Terminal Epic 3 owner-pays) — the
-   * referenced agent page's actual owner when resolvable, else the acting
-   * tenantId. The one seam payer resolution goes through; see
-   * `sandbox-payer.ts`'s `resolveSandboxPayerId`.
+   * Resolves who pays for THIS run (Terminal Epic 3 owner-pays) — from the
+   * ACQUIRED SESSION's own `driveId`/`ownerId` (drive owner when it has one,
+   * else the session's own owner), never the caller's surface drive or agent
+   * page. The one seam payer resolution goes through; see `sandbox-payer.ts`'s
+   * `resolveSessionPayerId` — the same rule `storageBillingTarget` applies for
+   * storage attribution.
    */
-  resolvePayerId: (input: { tenantId: string; agentPageId?: string }) => Promise<string>;
+  resolvePayerId: (input: { driveId: string | null; ownerId: string }) => Promise<string>;
   /** Places a flat-estimate hold for this payer before the machine run begins. */
   gate: (input: { payerId: string }) => Promise<{ allowed: boolean; holdId?: string; reason?: string }>;
   /** Settles the hold to the real active-window cost. Only called on a successful run. */
-  trackUsage: (input: { payerId: string; holdId?: string; activeSeconds: number; pageId?: string }) => Promise<void>;
+  trackUsage: (input: {
+    payerId: string;
+    holdId?: string;
+    activeSeconds: number;
+    /** The referenced agent page, for the per-agent usage-breakdown grouping — purely descriptive, never the payer source. */
+    pageId?: string;
+    /** The session's own drive — first-class attribution so the usage breakdown can group terminal spend by drive without JSON forensics. Undefined for a global-assistant session. */
+    driveId?: string;
+    /** The `agent_sessions.id` this run belongs to — first-class attribution, mirroring `driveId`. */
+    sessionId?: string;
+  }) => Promise<void>;
   /** Releases a hold without billing. Called on every exit that never reaches `trackUsage`. */
   releaseHold: (holdId: string) => Promise<void>;
 }
@@ -111,7 +123,9 @@ export interface SandboxBillingDeps {
  */
 export interface ShellActivityNotification {
   /**
-   * The session whose sandbox the agent acted on — ≡ its conversation id.
+   * The session whose sandbox the agent acted on — `agent_sessions.id`, NOT
+   * the conversation id (post-unconflation the two are different namespaces:
+   * one session hosts many conversations).
    *
    * This replaces the old `(tenantId, driveId, pageId)` machine tuple, which
    * had no successor and, worse, could not address a global-assistant session
@@ -161,9 +175,12 @@ export interface AcquireSandboxRequest {
   requestOrigin?: 'user' | 'agent';
   agentPageId?: string;
   /**
-   * The conversation this run belongs to — which IS the agent-session id
-   * (contract.ts invariant 1). The session-anchored `acquireSandbox`
-   * implementation folds the Sprite key off it.
+   * The conversation this run belongs to — NOT the agent-session id
+   * (contract.ts invariant 1: a session hosts MANY conversations, and the two
+   * are different id namespaces post-unconflation). The session-anchored
+   * `acquireSandbox` implementation resolves this conversation's session row
+   * (`conversations.sessionId`) and folds the Sprite key off THAT row's own
+   * id, never off this one.
    */
   conversationId?: string;
 }
@@ -221,6 +238,24 @@ export interface SandboxRunDeps {
    */
   billing?: SandboxBillingDeps;
   /**
+   * Cheap resolve of the CALLER's session identity for billing attribution — a
+   * read of the session row only (`agent_sessions.driveId`/`ownerId`/`id`), no
+   * sandbox provisioning. Called BEFORE the gate whenever `billing` is set, so
+   * a credit-exhausted payer is denied without ever waking a hibernating
+   * sandbox — the same fail-fast property the old (surface-derived, ctx-only)
+   * payer resolution had, now backed by a real (if cheap) session read instead
+   * of trusting client-influenceable context. `null` = the conversation has no
+   * session yet (a legacy pre-session thread): `withMachineBilling` skips
+   * gating entirely and calls straight through to `run()`, which surfaces the
+   * ordinary `no_session` denial via `openSession`. Required whenever
+   * `billing` is set; never called otherwise.
+   */
+  resolveBillingSession?: (ctx: SandboxActorContext) => Promise<{
+    sessionId: string;
+    driveId: string | null;
+    ownerId: string;
+  } | null>;
+  /**
    * Optional opportunistic storage-measurement seam (Sprites Platform Alignment
    * 6-1): while this sprite is ALREADY awake for this real op, capture its used
    * storage bytes (throttled, best-effort) so the storage reconcile can bill
@@ -270,6 +305,10 @@ export function safeLogWarn(
 const AUTHZ_DENY_REASONS = new Set([
   'no_drive_access', 'insufficient_role', 'no_agent_access', 'app_admin_required', 'kill_switch_off', 'no_machine',
   'machine_runtime_exceeded', 'session_limit_reached',
+  // A legacy conversation that predates sessions has no working context to run
+  // in — an expected refusal (not an infra fault), so it belongs here rather
+  // than paging on-call for every pre-session thread an agent tool touches.
+  'no_session',
 ]);
 
 
@@ -455,8 +494,24 @@ async function withMachineBilling<S>(
   const billing = deps.billing;
   if (!billing) return run();
 
-  const agentPageId = ctx.agentPageId;
-  const payerId = await billing.resolvePayerId({ tenantId: ctx.tenantId, agentPageId });
+  // Resolve the CALLER's session for billing attribution — a cheap session-row
+  // read (no sandbox provisioning), so a credit-exhausted payer is denied
+  // before any sandbox work happens: the same fail-fast property the old
+  // surface-derived resolution had, now backed by the SESSION's own
+  // driveId/ownerId instead of the caller's (client-influenceable) surface
+  // drive/agent page — a session hosts MANY conversations, and its drive can
+  // differ from the one the caller happens to be chatting from.
+  //
+  // `null` = no session yet for this conversation (a legacy pre-session
+  // thread): nothing to gate against, so fall through unmetered and let
+  // `run()` surface the ordinary `no_session` denial via `openSession`.
+  const billingSession = deps.resolveBillingSession ? await deps.resolveBillingSession(ctx) : null;
+  if (!billingSession) return run();
+
+  const payerId = await billing.resolvePayerId({
+    driveId: billingSession.driveId,
+    ownerId: billingSession.ownerId,
+  });
   const gate = await billing.gate({ payerId });
   if (!gate.allowed) return fail('credit_exhausted');
 
@@ -468,7 +523,16 @@ async function withMachineBilling<S>(
     if (result.success) {
       handedOff = true;
       const activeSeconds = Math.max(0, (deps.now().getTime() - startedAt) / 1000);
-      await billing.trackUsage({ payerId, holdId, activeSeconds, pageId: agentPageId });
+      await billing.trackUsage({
+        payerId,
+        holdId,
+        activeSeconds,
+        // Purely descriptive (which agent page this run was for) — never the
+        // payer source, which is resolved from the session above.
+        pageId: ctx.agentPageId,
+        driveId: billingSession.driveId ?? undefined,
+        sessionId: billingSession.sessionId,
+      });
     }
     return result;
   } finally {


### PR DESCRIPTION
## Summary

Follow-up from the post-merge audit of #2258 (billing slice, [issue #2260](https://github.com/2witstudios/PageSpace/issues/2260)). One sandbox was billing through two different payer-resolution rules depending on charge type — runtime billing resolved from the caller's client-influenceable surface (`ctx.tenantId`/`ctx.agentPageId`), storage billing already resolved from the session's own `driveId`/`ownerId`. The M5 fix (session un-conflation) made those diverge for real: one session can host conversations from a different drive than the one it was spawned in.

- **Unify payer resolution on the session** (`withMachineBilling` in `tool-runners.ts`): added a cheap `resolveBillingSession` seam (session-row read, no provisioning) so the payer resolves from the ACQUIRED session's `driveId`/`ownerId` before gating — preserving the "credit-exhausted never wakes the sandbox" property. `SandboxBillingDeps.resolvePayerId` now takes `{driveId, ownerId}` instead of `{tenantId, agentPageId}`.
- **One rule, written once**: added `resolveSessionPayerId` (`packages/lib/src/billing/sandbox-payer.ts`) — drive owner else session owner, the same rule `storageBillingTarget` already applied for storage. Deleted `resolveSandboxPayerId`, `lookupPageOwnerId`, and the dead `resolveAgentSessionPayerId` (the wrong-shaped page-keyed twin), and fixed the now-false "resolves correctly BY CONSTRUCTION" comments this invalidated across `sandbox-billing.ts`, `sandbox-storage-attribution.ts`, `sandbox-storage-reconcile.ts`, and `usage-breakdown-query.ts`.
- **`no_session` added to `AUTHZ_DENY_REASONS`** so the expected "conversation predates sessions" refusal logs at warn, not error.
- **Reconcile totals accounting fix**: a `chargeStorage` success followed by a throwing `advanceAgentSessionWatermark` now counts toward `charged`/`totalCostDollars` (the money DID move) with a new `chargedButUnadvanced` counter, instead of silently under-reporting it as `failed`.
- **First-class drive/session attribution on `trackUsage`** (Terminal Epic 3 usage-breakdown fix): added a `sessionId` field alongside the existing `driveId` on `AIUsageData`/`writeAiUsage`/`ai_usage_logs`. `sandbox-storage-billing.ts`'s `chargeStorage` now passes `driveId`/`sessionId` top-level (previously JSON-forensics-only in metadata). The realtime shell-handler's three `trackUsage` call sites now pass the session's real `driveId`/`agentSessionId` instead of a permanently-undefined `pageId`.

  **Note for #2265**: the new `sessionId` field on `AIUsageData`/`writeAiUsage` is the seam to consume for realtime shell-usage attribution — it's self-contained in `packages/lib` (schema column already existed, just unused).

- Corrected stale conversation≡session comments (`tool-runners.ts`, `sandbox-tools-runtime.ts`, `shell-handler.ts`'s `ShellSandboxResult`) and test-hygiene copy-paste leftovers.

**Key acceptance test** (`tool-runners.test.ts`): a session whose `driveId` differs from the caller's surface drive bills the SESSION's payer for the runtime stream — fails on master's `withMachineBilling`, passes after this fix. The storage stream already had equivalent coverage in `sandbox-storage-reconcile.test.ts`.

## Test plan

- [x] `bun run typecheck` (root) — 16/16 tasks pass
- [x] `bun run lint` (root) — 14/14 tasks pass
- [x] `cd packages/lib && bun run typecheck` — clean
- [x] `bun run knip:check` — 4 issues, all within baseline (no new dead exports)
- [x] `bun run test:unit` — lib: 8632 passed / 11 skipped, 0 failed. web: 15057 passed, 1 failed (`grouping.test.ts` midnight/TZ test — pre-existing, documented env-only flake, unrelated file untouched by this diff)
- [x] `bun run test:security` — 44/50 suites pass; the 6 failures (Session Service, Device Auth Utilities, Permissions, Login Route, Signup Route, Mobile Login) are pre-existing stale suites unrelated to this change (deleted routes / excluded configs)
- [x] New/updated tests: `packages/lib/src/billing/__tests__/sandbox-payer.test.ts`, `packages/lib/src/services/sandbox/__tests__/{tool-runners,sandbox-billing,sandbox-storage-billing,sandbox-storage-reconcile}.test.ts`, `apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts`, `apps/realtime/src/terminal/__tests__/shell-handler.test.ts`, `apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts`

Closes #2260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExHmbFs9zbegha2bQDuL2b