### PR TITLE
fix(agent-sessions): storage-measurement generation CAS + reclaim-outbox instance chase

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -205,12 +205,14 @@ async function ensureShellSessionSandbox({ sessionId, userId }: { sessionId: str
         await refreshSessionStorageMeasurement({
           handle,
           sessionId,
+          // The generation just minted, for the writer's CAS (see the web tier).
+          spriteInstanceId: handle.spriteInstanceId ?? null,
           // Null for the same reason as the web tier: this fires on the create
           // arm, whose own stamps reset the measurement columns.
           lastMeasuredAt: null,
           now: new Date(),
-          persist: async ({ measuredBytes, measuredAt }) => {
-            await store.recordStorageMeasurement({ sessionId, measuredBytes, measuredAt });
+          persist: async ({ spriteInstanceId, measuredBytes, measuredAt }) => {
+            await store.recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt });
           },
         });
       },
@@ -263,10 +265,15 @@ async function measureWarmSessionStorageOnResume(sessionId: string, sandboxId: s
     await refreshSessionStorageMeasurement({
       handle: { exec: (args) => sandbox.runCommand(args) },
       sessionId,
+      // The FETCHED sandbox's own generation, not the row's: the CAS has to
+      // describe the disk that was walked (see the web tier). Here the two
+      // usually agree — the sandbox is fetched right after the row — but
+      // "usually" is exactly what a CAS is for.
+      spriteInstanceId: sandbox.spriteInstanceId ?? null,
       lastMeasuredAt: row.storageMeasuredAt ?? null,
       now: new Date(),
-      persist: async ({ measuredBytes, measuredAt }) => {
-        await store.recordStorageMeasurement({ sessionId, measuredBytes, measuredAt });
+      persist: async ({ spriteInstanceId, measuredBytes, measuredAt }) => {
+        await store.recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt });
       },
     });
   } catch {

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-session-orphan-reconcile-runtime.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-session-orphan-reconcile-runtime.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockKill = vi.fn();
 const mockStampSpriteTornDown = vi.fn();
+const mockEnqueueReclaim = vi.fn();
 const mockSelect = vi.fn();
 
 vi.mock('@pagespace/db/db', () => ({
@@ -26,6 +27,7 @@ vi.mock('./../agent-sessions-runtime', () => ({
   getSandboxHost: async () => ({ kill: (...args: unknown[]) => mockKill(...args) }),
   getAgentSessionStore: async () => ({
     stampSpriteTornDown: (...args: unknown[]) => mockStampSpriteTornDown(...args),
+    enqueueReclaim: (...args: unknown[]) => mockEnqueueReclaim(...args),
     findById: async () => null,
   }),
 }));
@@ -67,11 +69,16 @@ describe('killSprite', () => {
     expect(mockKill).toHaveBeenCalledWith({ sandboxId: 'sbx-1', expectedInstanceId: 'i-1' });
   });
 
-  it('given the name now holds a DIFFERENT VM, should treat it as success rather than retry forever', async () => {
-    // Our target is already gone — the outcome we wanted. The newcomer has its
-    // own tracking row, so releasing ours never orphans it.
+  it('given the name now holds a DIFFERENT VM, should report the replacement rather than collapsing to success', async () => {
+    // #2254: which VM the replacement means "gone" for is a per-row-kind
+    // decision the PURE module makes, not this binding — collapsing straight to
+    // `{ ok: true }` here is what let a `reclaim` row's replaced-instance
+    // refusal delete its outbox pointer and orphan the live VM.
     mockKill.mockRejectedValueOnce(new SandboxSpriteReplacedError('sbx-1', 'i-old', 'i-new'));
-    expect(await deps.killSprite({ sandboxId: 'sbx-1', spriteInstanceId: 'i-old' })).toEqual({ ok: true });
+    expect(await deps.killSprite({ sandboxId: 'sbx-1', spriteInstanceId: 'i-old' })).toEqual({
+      ok: 'replaced',
+      actualInstanceId: 'i-new',
+    });
   });
 
   it('given a genuine kill failure, should report it so the row stays queued for a later tick', async () => {
@@ -110,6 +117,18 @@ describe('markSessionTornDown', () => {
     expect(
       await deps.markSessionTornDown({ sessionId: 'conv-1', sandboxId: 'sbx-1', spriteInstanceId: 'i-1' }),
     ).toBe(false);
+  });
+});
+
+describe('chaseReclaimInstance', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should re-point the outbox row at the live instance via the store upsert, not delete it', async () => {
+    mockEnqueueReclaim.mockResolvedValueOnce(undefined);
+
+    await deps.chaseReclaimInstance({ sandboxId: 'sbx-1', actualInstanceId: 'i-new' });
+
+    expect(mockEnqueueReclaim).toHaveBeenCalledWith({ sandboxId: 'sbx-1', spriteInstanceId: 'i-new' });
   });
 });
 

--- a/apps/web/src/lib/agent-sessions/agent-session-orphan-reconcile-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-session-orphan-reconcile-runtime.ts
@@ -126,10 +126,18 @@ export const defaultReconcileAgentSessionOrphanSpritesDeps: ReconcileOrphanSprit
       await host.kill({ sandboxId, expectedInstanceId: spriteInstanceId ?? undefined });
       return { ok: true };
     } catch (error) {
-      // A DIFFERENT VM holds this name now — our target is already gone,
-      // exactly the outcome we wanted. The newcomer has its OWN fresh
-      // tracking row, so releasing ours never orphans it.
-      if (error instanceof SandboxSpriteReplacedError) return { ok: true };
+      // A DIFFERENT VM holds this name now — our target is already gone, but
+      // what that MEANS depends on which row this is (#2254), and this binding
+      // doesn't know that — the pure module does (`row.kind`). Report the
+      // replacement rather than collapsing it to success here: for a session
+      // row that reads as "confirmed gone" (its own identity CAS protects a
+      // live replacement), but for a `reclaim` row — whose outbox entry is the
+      // LAST pointer to whatever VM exists under this name — treating it as
+      // success would delete the only pointer to a Sprite still alive under
+      // `actualInstanceId`.
+      if (error instanceof SandboxSpriteReplacedError) {
+        return { ok: 'replaced', actualInstanceId: error.actualInstanceId };
+      }
       return { ok: false, error };
     }
   },
@@ -159,5 +167,14 @@ export const defaultReconcileAgentSessionOrphanSpritesDeps: ReconcileOrphanSprit
         lastError: error instanceof Error ? error.message : String(error),
       })
       .where(eq(machineSpriteReclaims.sandboxId, sandboxId));
+  },
+
+  async chaseReclaimInstance({ sandboxId, actualInstanceId }) {
+    // Reuses the store's own upsert rather than a second write path — its
+    // `ON CONFLICT DO UPDATE ... COALESCE` is exactly the trigger-mirroring
+    // chase this needs, and the row already exists (we are reconciling it), so
+    // this always takes the UPDATE branch.
+    const store = await getAgentSessionStore();
+    await store.enqueueReclaim({ sandboxId, spriteInstanceId: actualInstanceId });
   },
 };

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -425,6 +425,9 @@ export async function provisionSessionSandbox(
         await refreshSessionStorageMeasurement({
           handle,
           sessionId,
+          // The generation just minted — the CAS target for the write. Taken
+          // from the handle, not the row: this is the VM the `du` runs on.
+          spriteInstanceId: handle.spriteInstanceId ?? null,
           // NULL, not the row's value: this callback only fires on the `create`
           // arm, where the same operation resets the measurement columns (a new
           // Sprite generation is an empty filesystem). Passing the pre-provision
@@ -457,7 +460,15 @@ export async function provisionSessionSandbox(
  */
 export async function measureWarmSessionStorage(input: {
   sessionId: string;
-  attach: () => Promise<{ exec: SandboxHandle['exec'] } | null>;
+  /**
+   * Returns the sandbox to measure AND its own generation id. Both, because the
+   * two can disagree: this path is fed by a sandbox the tool run ALREADY
+   * acquired, so by the time the row is read below the session may have been
+   * torn down and re-provisioned — the row would say B while the handle in hand
+   * is still A. CASing on the row's value would then let A's bytes land on B
+   * under a CAS that "succeeded", which is the bug the CAS exists to stop.
+   */
+  attach: () => Promise<{ exec: SandboxHandle['exec']; spriteInstanceId: string | null } | null>;
 }): Promise<void> {
   try {
     const store = await getAgentSessionStore();
@@ -476,6 +487,11 @@ export async function measureWarmSessionStorage(input: {
     await refreshSessionStorageMeasurement({
       handle,
       sessionId: input.sessionId,
+      // The MEASURED handle's own generation, never the row's. The row is read
+      // for the throttle; the CAS has to describe the disk the `du` actually
+      // walked, or a handle captured before a re-provision would persist the
+      // old generation's bytes under the new generation's id.
+      spriteInstanceId: handle.spriteInstanceId,
       lastMeasuredAt: row.storageMeasuredAt ?? null,
       now: new Date(),
       persist: (measurement) => store.recordStorageMeasurement(measurement),

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -306,6 +306,31 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     expect(typeof deps.notifyShellActivity).toBe('function');
   });
 
+  it('should measure against the ACQUIRED sandbox\'s generation, not whatever the row says later', async () => {
+    // The storage CAS is only as good as the id handed to it. This seam is fed
+    // the sandbox the tool run ALREADY acquired, and the measurement is
+    // fire-and-forget — so between acquiring it and persisting, the session can
+    // be torn down and re-provisioned. Reading the instance from the session row
+    // at persist time would then name generation B while `du` walked A's disk,
+    // and the CAS would "succeed" against B with A's bytes: the exact write the
+    // CAS exists to reject, waved through by its own guard.
+    const deps = buildRealSandboxRunDeps();
+    expect(typeof deps.measureStorage).toBe('function');
+
+    const sandbox = {
+      spriteInstanceId: 'instance-A',
+      runCommand: vi.fn(async () => ({ exitCode: 0, stdout: '1\t/workspace', stderr: '' })),
+    };
+    await deps.measureStorage!({ sandbox: sandbox as never, sessionId: 'conv-1' });
+
+    const [call] = mockMeasureWarmSessionStorage.mock.calls as unknown as [
+      [{ sessionId: string; attach: () => Promise<{ spriteInstanceId: string | null } | null> }],
+    ];
+    expect(call[0].sessionId).toBe('conv-1');
+    const attached = await call[0].attach();
+    expect(attached?.spriteInstanceId).toBe('instance-A');
+  });
+
   it('given no conversationId, should fail as provision_failed/missing_conversation_id without touching the session runtime', async () => {
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ conversationId: undefined }));

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -192,7 +192,15 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         sessionId,
         // The exec client exposes `runCommand`; the measurement seam speaks the
         // host's `exec`. One adapter here beats widening either contract.
-        attach: async () => ({ exec: (args) => sandbox.runCommand(args) }),
+        //
+        // `spriteInstanceId` comes off THIS sandbox — the one the tool run
+        // acquired and just used — because that is the disk `du` will walk.
+        // Reading it from the session row instead would name whatever generation
+        // is current at persist time, which is not necessarily this one.
+        attach: async () => ({
+          exec: (args) => sandbox.runCommand(args),
+          spriteInstanceId: sandbox.spriteInstanceId,
+        }),
       }),
     notifyShellActivity: (input) => notifyShellAgentActivity(input),
     // Injection seam (DEFENSE-IN-DEPTH, fail-open): screen untrusted tool output

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
@@ -293,27 +293,97 @@ describe('countLive', () => {
 
 describe('recordStorageMeasurement', () => {
   it('given a live row, should persist the measurement', async () => {
-    const conversationId = await seedSession({ sandboxId: 'sbx-1', spriteInstanceId: 'i' });
+    const sessionId = await seedSession({ sandboxId: 'sbx-1', spriteInstanceId: 'i' });
     const measuredAt = new Date();
 
-    await store.recordStorageMeasurement({ sessionId: conversationId, measuredBytes: 4096, measuredAt });
+    await store.recordStorageMeasurement({ sessionId, spriteInstanceId: 'i', measuredBytes: 4096, measuredAt });
 
-    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, conversationId));
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, sessionId));
     expect(Number(row.storageMeasuredBytes)).toBe(4096);
     expect(row.storageMeasuredAt).not.toBeNull();
   });
 
   it('given a TORN-DOWN row, should not write — that filesystem no longer exists', async () => {
-    const conversationId = await seedSession({
+    const sessionId = await seedSession({
       sandboxId: 'sbx-1',
       spriteInstanceId: 'i',
       spriteTornDownAt: new Date(),
     });
 
-    await store.recordStorageMeasurement({ sessionId: conversationId, measuredBytes: 999, measuredAt: new Date() });
+    await store.recordStorageMeasurement({
+      sessionId,
+      spriteInstanceId: 'i',
+      measuredBytes: 999,
+      measuredAt: new Date(),
+    });
 
-    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, conversationId));
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, sessionId));
     expect(row.storageMeasuredBytes).toBeNull();
+  });
+
+  it('given the Sprite generation moved on mid-measurement, should DROP the stale write', async () => {
+    // The window the liveness guard cannot close, because a re-provision REVIVES
+    // the row: measure generation A (fire-and-forget) → A torn down → B minted,
+    // which clears `spriteTornDownAt` and nulls the measurement columns → A's
+    // `du` finally lands. Guarded only on liveness it finds a live row and
+    // writes A's bytes onto B, with a fresh `storageMeasuredAt` that suppresses
+    // B's own measurement for the whole throttle window while the reconcile
+    // bills B's interval against A's disk.
+    //
+    // The name cannot arbitrate this: `sandboxId` is HMAC-derived from the
+    // session, so A and B share it. Only the instance id differs.
+    const sessionId = await seedSession({ sandboxId: 'sbx-stable-name', spriteInstanceId: 'instance-A' });
+
+    await db
+      .update(agentSessions)
+      .set({ spriteInstanceId: 'instance-B', spriteTornDownAt: null, storageMeasuredBytes: null, storageMeasuredAt: null })
+      .where(eq(agentSessions.id, sessionId));
+
+    await store.recordStorageMeasurement({
+      sessionId,
+      spriteInstanceId: 'instance-A',
+      measuredBytes: 5_000_000,
+      measuredAt: new Date(),
+    });
+
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, sessionId));
+    expect(row.storageMeasuredBytes).toBeNull();
+    // The timestamp matters as much as the bytes: a stale one silences the next
+    // real measurement without ever having recorded a real number.
+    expect(row.storageMeasuredAt).toBeNull();
+  });
+
+  it('given the same generation still on the row, should persist despite an identical sandbox NAME', async () => {
+    // The other half: the CAS must not reject a legitimate measurement just
+    // because the name is reused. Same name, same instance → this is the disk
+    // that was measured.
+    const sessionId = await seedSession({ sandboxId: 'sbx-stable-name', spriteInstanceId: 'instance-B' });
+
+    await store.recordStorageMeasurement({
+      sessionId,
+      spriteInstanceId: 'instance-B',
+      measuredBytes: 777,
+      measuredAt: new Date(),
+    });
+
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, sessionId));
+    expect(Number(row.storageMeasuredBytes)).toBe(777);
+  });
+
+  it('given a driver that reports no instance id, should still persist against a null row', async () => {
+    // Degrades to the liveness guard rather than never persisting — the most a
+    // caller can know when the platform gives it no generation id.
+    const sessionId = await seedSession({ sandboxId: 'sbx-no-instance', spriteInstanceId: null });
+
+    await store.recordStorageMeasurement({
+      sessionId,
+      spriteInstanceId: null,
+      measuredBytes: 321,
+      measuredAt: new Date(),
+    });
+
+    const [row] = await db.select().from(agentSessions).where(eq(agentSessions.id, sessionId));
+    expect(Number(row.storageMeasuredBytes)).toBe(321);
   });
 });
 

--- a/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
@@ -153,11 +153,16 @@ export function makeAgentSessionStore(
       ).length;
     },
 
-    async recordStorageMeasurement({ sessionId, measuredBytes, measuredAt }) {
+    async recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt }) {
       const row = rows.get(sessionId);
       // Mirrors the real store's live-row guard: a measurement landing after
       // teardown describes a filesystem that no longer exists.
       if (!row || row.spriteTornDownAt !== null) return;
+      // ...and its generation CAS. A fake that accepts writes the real store
+      // rejects makes every test using it agree with a bug: the liveness guard
+      // alone passes a stale measurement onto the NEXT generation, because
+      // re-provisioning clears `spriteTornDownAt`.
+      if ((row.spriteInstanceId ?? null) !== (spriteInstanceId ?? null)) return;
       row.storageMeasuredBytes = measuredBytes;
       row.storageMeasuredAt = measuredAt;
     },

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -133,17 +133,37 @@ export interface AgentSessionStore {
   countLive(ownerId: string): Promise<number>;
   /**
    * Persist an opportunistic storage measurement (see
-   * `services/sandbox/sandbox-storage-measure.ts`). Separate from
-   * `updateSpriteIdentity` because it is a pure billing observation, not a
-   * lifecycle transition: it carries no CAS and must never disturb identity or
-   * teardown stamps.
+   * `services/sandbox/sandbox-storage-measure.ts`). Not a lifecycle transition —
+   * a pure billing observation that must never disturb identity or teardown
+   * stamps — but it IS generation-scoped, so it carries a CAS of its own.
    *
-   * Guarded on the row still being live (`spriteTornDownAt IS NULL`): a
-   * measurement that lands after teardown describes a filesystem that no longer
-   * exists, and writing it would bill the next generation against a dead disk.
+   * The CAS is on `spriteInstanceId`, the id of the VM actually measured, and it
+   * has to be: `sandboxId` is the HMAC-derived NAME, identical across every
+   * generation of one session, so it cannot tell A from B. `SandboxHandle` says
+   * this outright — "anything that must act on THIS VM (a kill, a CAS against a
+   * tracking row) keys on this".
+   *
+   * A liveness guard alone (`spriteTornDownAt IS NULL`) does NOT cover it. The
+   * measurement is fire-and-forget, so a `du` against generation A can still be
+   * in flight when A is torn down and B provisioned — and B's own stamps clear
+   * `spriteTornDownAt` AND null the measurement columns
+   * (`plan-session-lifecycle.ts`), so the late write finds a live row, lands A's
+   * bytes on B, and stamps a fresh `storageMeasuredAt` that suppresses B's real
+   * measurement for the whole throttle window. The reconcile then bills B's
+   * interval against A's disk. The teardown-only guard is the one case where the
+   * row is never revived.
+   *
+   * A stale write is DROPPED, not retried: the next wake re-measures, and a
+   * billing observation is worth less than a wrong one.
    */
   recordStorageMeasurement(input: {
     sessionId: string;
+    /**
+     * The instance actually measured. Null when the driver reports none — then
+     * the row's own null matches and the CAS degrades to the liveness guard,
+     * which is the most any caller can know without a generation id.
+     */
+    spriteInstanceId: string | null;
     measuredBytes: number;
     measuredAt: Date;
   }): Promise<void>;
@@ -426,7 +446,7 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
       return row?.n ?? 0;
     },
 
-    async recordStorageMeasurement({ sessionId, measuredBytes, measuredAt }) {
+    async recordStorageMeasurement({ sessionId, spriteInstanceId, measuredBytes, measuredAt }) {
       await db
         .update(agentSessions)
         .set({ storageMeasuredBytes: measuredBytes, storageMeasuredAt: measuredAt })
@@ -434,6 +454,10 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
           and(
             eq(agentSessions.id, sessionId),
             isNull(agentSessions.spriteTornDownAt),
+            // CAS on the generation measured. `eqOrIsNull` so a driver that
+            // reports no instance id still matches its own null row rather than
+            // never persisting — plain `eq` never matches null in SQL.
+            eqOrIsNull(agentSessions.spriteInstanceId, spriteInstanceId),
           ),
         );
     },

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-measure.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-measure.test.ts
@@ -67,19 +67,30 @@ describe('shouldRefreshMeasurement', () => {
 
 describe('refreshSessionStorageMeasurement', () => {
   it('given a never-measured session, should run du on the workspace and persist the bytes', async () => {
-    const persisted: Array<{ sessionId: string; measuredBytes: number; measuredAt: Date }> = [];
+    const persisted: Array<{
+      sessionId: string;
+      spriteInstanceId: string | null;
+      measuredBytes: number;
+      measuredAt: Date;
+    }> = [];
     const { handle, calls } = fakeHandle({ stdout: '2048\t/workspace\n' });
 
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async (m) => { persisted.push(m); },
     });
 
     expect(result).toEqual({ measured: true, bytes: 2048 });
-    expect(persisted).toEqual([{ sessionId: 'conv_1', measuredBytes: 2048, measuredAt: NOW }]);
+    // The instance travels WITH the bytes: the write is fire-and-forget, so the
+    // writer needs to know which generation's disk this number describes before
+    // it commits to a row that may have moved on.
+    expect(persisted).toEqual([
+      { sessionId: 'conv_1', spriteInstanceId: 'instance-A', measuredBytes: 2048, measuredAt: NOW },
+    ]);
     // -B1 (allocated bytes, not apparent size) and -x (don't cross mounts) are
     // the whole reason this bills what was written rather than the allocation.
     expect(calls[0]).toEqual({ cmd: 'du', args: ['-sxB1', '--', SESSION_STORAGE_MEASURE_PATH] });
@@ -90,6 +101,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: new Date(NOW.getTime() - 5),
       now: NOW,
       throttleMs: 60_000,
@@ -104,6 +116,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async () => { throw new Error('must not persist'); },
@@ -117,6 +130,7 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async (m) => { persisted.push(m.measuredBytes); },
@@ -130,10 +144,29 @@ describe('refreshSessionStorageMeasurement', () => {
     const result = await refreshSessionStorageMeasurement({
       handle,
       sessionId: 'conv_1',
+      spriteInstanceId: 'instance-A',
       lastMeasuredAt: null,
       now: NOW,
       persist: async () => { throw new Error('must not persist'); },
     });
     expect(result).toEqual({ measured: false });
+  });
+
+  it('given a null instance id (driver reported none), should still pass it through to persist', async () => {
+    const persisted: Array<{ spriteInstanceId: string | null }> = [];
+    const { handle } = fakeHandle({ stdout: '512\t/workspace\n' });
+
+    await refreshSessionStorageMeasurement({
+      handle,
+      sessionId: 'conv_1',
+      spriteInstanceId: null,
+      lastMeasuredAt: null,
+      now: NOW,
+      persist: async (m) => { persisted.push(m); },
+    });
+
+    expect(persisted).toEqual([
+      { sessionId: 'conv_1', spriteInstanceId: null, measuredBytes: 512, measuredAt: NOW },
+    ]);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/sprite-orphan-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sprite-orphan-reconcile.test.ts
@@ -19,11 +19,13 @@ function makeDeps(over: Partial<ReconcileOrphanSpritesDeps> = {}): {
   stampedSessions: string[];
   releasedReclaims: string[];
   notedFailures: string[];
+  chasedInstances: Array<{ sandboxId: string; actualInstanceId: string }>;
 } {
   const killed: string[] = [];
   const stampedSessions: string[] = [];
   const releasedReclaims: string[] = [];
   const notedFailures: string[] = [];
+  const chasedInstances: Array<{ sandboxId: string; actualInstanceId: string }> = [];
   const deps: ReconcileOrphanSpritesDeps = {
     listOrphanCandidates: async () => ({ rows: [], capped: false }),
     isTeardownStillRequested: async () => true,
@@ -41,9 +43,12 @@ function makeDeps(over: Partial<ReconcileOrphanSpritesDeps> = {}): {
     noteReclaimFailure: async ({ sandboxId }) => {
       notedFailures.push(sandboxId);
     },
+    chaseReclaimInstance: async ({ sandboxId, actualInstanceId }) => {
+      chasedInstances.push({ sandboxId, actualInstanceId });
+    },
     ...over,
   };
-  return { deps, killed, stampedSessions, releasedReclaims, notedFailures };
+  return { deps, killed, stampedSessions, releasedReclaims, notedFailures, chasedInstances };
 }
 
 const sessionRow: SpriteOrphanRow = {
@@ -105,6 +110,40 @@ describe('reconcileOrphanSprites — the reclaim outbox (a pointer whose row is 
     expect(result).toEqual({ processed: 1, capped: false, incomplete: false, torndown: 0, skipped: 0, failed: 1 });
     expect(releasedReclaims).toEqual([]); // and the pointer survives
   });
+
+  it('#2254: given the name now holds a DIFFERENT VM, should CHASE the pointer rather than releasing it', async () => {
+    // The outbox row is the LAST pointer to whatever VM exists under this name
+    // — unlike an `agent-session` row, there is no live row's own CAS left to
+    // protect a replacement. A stale outbox instance (e.g. from the 0234
+    // rescue's `ON CONFLICT DO NOTHING`) must never read as "confirmed killed":
+    // that would delete the only pointer to a Sprite that is still alive.
+    const { deps, killed, releasedReclaims, chasedInstances } = makeDeps({
+      listOrphanCandidates: async () => ({ rows: [reclaimRow], capped: false }),
+      killSprite: async () => ({ ok: 'replaced', actualInstanceId: 'inst-live-now' }),
+    });
+
+    const result = await reconcileOrphanSprites(deps);
+
+    expect(result).toEqual({ processed: 1, capped: false, incomplete: false, torndown: 0, skipped: 1, failed: 0 });
+    expect(killed).toEqual([]); // killSprite itself is stubbed, but the point is nothing was RELEASED
+    expect(releasedReclaims).toEqual([]);
+    expect(chasedInstances).toEqual([{ sandboxId: 'pgs-ses-orphaned', actualInstanceId: 'inst-live-now' }]);
+  });
+
+  it('#2254: given the chase write itself fails, should still leave the pointer in place', async () => {
+    const { deps, releasedReclaims } = makeDeps({
+      listOrphanCandidates: async () => ({ rows: [reclaimRow], capped: false }),
+      killSprite: async () => ({ ok: 'replaced', actualInstanceId: 'inst-live-now' }),
+      chaseReclaimInstance: async () => {
+        throw new Error('db write failed');
+      },
+    });
+
+    const result = await reconcileOrphanSprites(deps);
+
+    expect(result).toMatchObject({ torndown: 0, skipped: 1, failed: 0 });
+    expect(releasedReclaims).toEqual([]);
+  });
 });
 
 describe('reconcileOrphanSprites — agent-session rows whose teardown never confirmed', () => {
@@ -141,6 +180,23 @@ describe('reconcileOrphanSprites — agent-session rows whose teardown never con
     expect(killSprite).toHaveBeenCalledTimes(1);
     expect(killSprite).toHaveBeenCalledWith({ sandboxId: 'pgs-ses-1', spriteInstanceId: 'inst-1' });
     expect(stampedSessions).toEqual(['conv-1']);
+  });
+
+  it('#2254: given the name now holds a DIFFERENT VM, should still treat it as confirmed-gone — the row\'s own CAS protects a live replacement', async () => {
+    // Unlike a `reclaim` row, an `agent-session` row is not the last pointer:
+    // `markSessionTornDown`'s own instance CAS already refuses to mark a live
+    // replacement dead, so a replaced-instance kill can be handled exactly like
+    // a confirmed one here.
+    const { deps, stampedSessions, chasedInstances } = makeDeps({
+      listOrphanCandidates: async () => ({ rows: [sessionRow], capped: false }),
+      killSprite: async () => ({ ok: 'replaced', actualInstanceId: 'inst-new' }),
+    });
+
+    const result = await reconcileOrphanSprites(deps);
+
+    expect(result).toEqual({ processed: 1, capped: false, incomplete: false, torndown: 1, skipped: 0, failed: 0 });
+    expect(stampedSessions).toEqual(['conv-1']);
+    expect(chasedInstances).toEqual([]); // chasing is only meaningful for a reclaim row
   });
 
   it('counts a CAS lost to a concurrent re-provision as skipped, not torn down', async () => {

--- a/packages/lib/src/services/sandbox/sandbox-storage-measure.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-measure.ts
@@ -95,6 +95,13 @@ export function shouldRefreshMeasurement(input: {
 export type PersistSessionStorageMeasurement = (input: {
   /** The `agent_sessions` PK (the workspace row id) whose row receives the measurement. */
   sessionId: string;
+  /**
+   * The Sprite INSTANCE these bytes were read from, for the writer to CAS on.
+   * Carried because the measurement is fire-and-forget: it can land after its
+   * generation is gone and a new one has taken the row, and `sessionId` alone
+   * cannot tell the writer which disk the number describes.
+   */
+  spriteInstanceId: string | null;
   measuredBytes: number;
   measuredAt: Date;
 }) => Promise<void>;
@@ -103,6 +110,8 @@ export interface RefreshSessionStorageMeasurementInput {
   /** An ALREADY-AWAKE sandbox handle (real work just happened on it) — measurement never provisions or wakes. */
   handle: Pick<SandboxHandle, 'exec'>;
   sessionId: string;
+  /** The instance being measured, passed straight through to `persist` for its CAS. */
+  spriteInstanceId: string | null;
   /** Last persisted measurement time for this session (null = never measured). */
   lastMeasuredAt: Date | null;
   now: Date;
@@ -153,6 +162,11 @@ export async function refreshSessionStorageMeasurement(
   const bytes = parseDuBytes(run.stdout);
   if (bytes === null) return { measured: false };
 
-  await input.persist({ sessionId: input.sessionId, measuredBytes: bytes, measuredAt: input.now });
+  await input.persist({
+    sessionId: input.sessionId,
+    spriteInstanceId: input.spriteInstanceId,
+    measuredBytes: bytes,
+    measuredAt: input.now,
+  });
   return { measured: true, bytes };
 }

--- a/packages/lib/src/services/sandbox/sprite-orphan-reconcile.ts
+++ b/packages/lib/src/services/sandbox/sprite-orphan-reconcile.ts
@@ -124,7 +124,20 @@ export interface ReconcileOrphanSpritesDeps {
   killSprite: (input: {
     sandboxId: string;
     spriteInstanceId: string | null;
-  }) => Promise<{ ok: true } | { ok: false; error: unknown }>;
+  }) => Promise<
+    | { ok: true }
+    | { ok: false; error: unknown }
+    /**
+     * A DIFFERENT VM holds this name now — our target is already gone, but what
+     * that MEANS depends on `row.kind` (see #2254). For an `agent-session` row
+     * the session's own identity CAS still protects a live replacement, so this
+     * is handled exactly like `ok: true`. For a `reclaim` row the outbox entry
+     * is the LAST pointer to whatever VM exists here — there is no row left to
+     * protect it — so treating this as "confirmed gone" would delete the only
+     * pointer to a Sprite that is still alive under `actualInstanceId`.
+     */
+    | { ok: 'replaced'; actualInstanceId: string }
+  >;
   /** CAS-stamp `spriteTornDownAt` on the session row (never delete it — it is re-provisionable identity): only if the row still points at the INSTANCE we killed. Reports whether it actually wrote. */
   markSessionTornDown: (input: {
     sessionId: string;
@@ -135,6 +148,15 @@ export interface ReconcileOrphanSpritesDeps {
   releaseReclaim: (sandboxId: string) => Promise<void>;
   /** Record a failed kill against its outbox row (attempts/lastError) so a Sprite that cannot be killed becomes visible rather than silently retried forever. */
   noteReclaimFailure: (input: { sandboxId: string; error: unknown }) => Promise<void>;
+  /**
+   * Re-point a `reclaim` outbox row at the instance actually alive now, after a
+   * kill refused with `SandboxSpriteReplacedError` — never release the row for
+   * this case, only chase it. Mirrors the AFTER-DELETE trigger's own
+   * `ON CONFLICT DO UPDATE ... COALESCE` (0209/0219/0229 migration comments):
+   * "a newer generation took this name; the pointer must chase the VM that is
+   * actually alive now, not the one a stale row remembers." Idempotent.
+   */
+  chaseReclaimInstance: (input: { sandboxId: string; actualInstanceId: string }) => Promise<void>;
 }
 
 export interface ReconcileOrphanSpritesResult {
@@ -185,6 +207,25 @@ export async function reconcileOrphanSprites(
         sandboxId: row.sandboxId,
         spriteInstanceId: row.spriteInstanceId,
       });
+
+      if (killed.ok === 'replaced' && row.kind === 'reclaim') {
+        // The outbox is the LAST pointer to whatever VM exists under this name.
+        // A replaced-instance refusal here must never read as "done" (#2254):
+        // chase the pointer at the live instance and retry next tick, rather
+        // than confirming a kill that never touched the VM actually running.
+        try {
+          await deps.chaseReclaimInstance({ sandboxId: row.sandboxId, actualInstanceId: killed.actualInstanceId });
+        } catch (chaseError) {
+          loggers.ai.error(
+            'Failed to chase a replaced outbox Sprite instance; stale pointer retained for retry',
+            chaseError instanceof Error ? chaseError : new Error(String(chaseError)),
+            { sandboxId: row.sandboxId, actualInstanceId: killed.actualInstanceId },
+          );
+        }
+        skipped += 1;
+        continue;
+      }
+
       if (!killed.ok) {
         // Leave the row EXACTLY as it is: it is the only pointer to this
         // sandboxId. The next run retries it.


### PR DESCRIPTION
## Summary

Wave-2 of the post-#2258 audit: re-lands the generation-CAS half of #2253 (pre-restore, cannot merge as-is) onto current master's session-keyed model, and fixes #2254.

**1. Storage-measurement generation CAS (#2253 fix 2)**

`recordStorageMeasurement` writes now CAS on `spriteInstanceId` (not `sandboxId` — that name is HMAC-derived from the session and identical across generations) via `eqOrIsNull`, so a driver reporting no instance id still matches its own null row. Without this, a `du` against a torn-down generation that completes after re-provisioning could land its bytes and `storageMeasuredAt` on the new generation's row, silencing the new generation's real measurement for a full throttle window while the reconcile bills its interval against the wrong disk.

The field is now **required** through `refreshSessionStorageMeasurement`/`PersistSessionStorageMeasurement` so a call site can't silently drop it, threaded to all four call sites: web create + warm (`agent-sessions-runtime.ts`, `sandbox-tools-runtime.ts`), realtime create + resume (`apps/realtime/src/index.ts`). The in-memory store fake honours the same CAS as the real store.

**2. Handle-sourced generation id (#2253 fix 3)**

Every measurement call site now sources `spriteInstanceId` from the **acquired sandbox handle** — the identity of the disk actually measured — never from a re-read of the session row, which can name a different generation than the one `du` walked (the row is read only for the throttle check).

**3. Issue #2254 — reclaim-outbox stale instance pointer**

`agent-session-orphan-reconcile-runtime.ts` treated `SandboxSpriteReplacedError` as `{ ok: true }` unconditionally, deleting the outbox row — but for a `reclaim` row (whose outbox entry is the *last* pointer to whatever VM exists under that name), a stale instance id there orphans the live replacement forever.

`killSprite` now reports a replaced instance distinctly (`{ ok: 'replaced', actualInstanceId }`) instead of collapsing it to success. The pure `reconcileOrphanSprites` loop decides per `row.kind`:
- `reclaim` rows: chase the pointer at the live instance via `chaseReclaimInstance` (reuses the store's own `enqueueReclaim` upsert — the same `ON CONFLICT DO UPDATE ... COALESCE` the 0209/0219/0229 triggers use) and retry next tick, rather than releasing.
- `agent-session` rows: unaffected — the row's own identity CAS in `markSessionTornDown` already protects a live replacement, so a replaced instance still counts as confirmed-gone.

Closes #2254. PR #2253 can now be closed (superseded by this PR, adapted to the current session-keyed model).

## Test plan
- [x] New/updated tests pin: stale-generation write dropped (bytes AND timestamp), same-generation persists despite reused name, null-instance driver persists, outbox replaced-instance chases instead of orphaning (plus an agent-session-row replaced-instance case, still confirmed-gone).
- [x] `bun run typecheck && bun run lint && bun run test:unit && bun run knip:check` — clean (one pre-existing, unrelated TZ-environment test failure in `messages/grouping.test.ts`, present on master, untouched by this diff).
- [x] `cd packages/lib && bun run typecheck` — clean.
- [x] `bun run test:security` — 44/50 suites pass; the same 6 pre-existing failures as master (deleted Login/Signup/Mobile-Login routes, excluded Session Service/Device Auth/Permissions suites — a documented script gap, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrK6Xpi8fu6jtyLxNqnTAt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage measurements now remain associated with the correct sandbox instance, preventing stale or misattributed usage data.
  * Measurements from inactive sessions or replaced sandbox instances are safely ignored.
  * Orphan cleanup now follows reclaim records to replacement sandbox instances instead of incorrectly releasing them.
  * Reconciliation handles replacement and failed updates more safely, reducing the risk of incorrect cleanup actions.

* **Tests**
  * Expanded coverage for storage measurement safeguards and orphan reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->