### PR TITLE
fix(canvas): show unavailable state instead of blank Settings panel

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -27,6 +27,11 @@ interface PublishControlsProps {
    *  (a save just completed) and the page is published, the control marks itself
    *  stale so the user sees the Update button without a page reload. */
   contentDirty?: boolean;
+  /** 'header' (default): rendered among other populated header buttons, so
+   *  staying silent when unavailable is fine. 'panel': rendered as the sole
+   *  content of a dedicated tab/panel, where silence would leave a blank tab —
+   *  render an explanatory message instead. */
+  variant?: 'header' | 'panel';
 }
 
 /** Author-supplied SEO overrides for a published page. */
@@ -83,7 +88,7 @@ const readError = async (res: Response): Promise<string> => {
   }
 };
 
-const PublishControls = ({ pageId, contentDirty }: PublishControlsProps) => {
+const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishControlsProps) => {
   const params = useParams<{ driveId?: string }>();
   const driveId = params?.driveId;
   const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
@@ -208,9 +213,18 @@ const PublishControls = ({ pageId, contentDirty }: PublishControlsProps) => {
     return <span className="px-4 py-2 text-sm text-muted-foreground">Loading…</span>;
   }
 
-  // Publishing isn't configured on this deployment (e.g. no PUBLISH_BUCKET) —
-  // hide the control entirely rather than show a button that only returns 503.
+  // Publishing isn't configured on this deployment (e.g. no PUBLISH_BUCKET), or
+  // this viewer lacks permission to publish. In the header (among other
+  // populated buttons) staying silent is fine; in a standalone panel (the
+  // canvas Settings tab) silence would leave the tab blank, so explain instead.
   if (!state.available) {
+    if (variant === 'panel') {
+      return (
+        <p className="text-sm text-muted-foreground">
+          Publishing isn&apos;t available for this page.
+        </p>
+      );
+    }
     return null;
   }
 

--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -99,7 +99,7 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
   // publishing as genuinely unavailable. Keeping these separate stops a blip
   // from rendering the same "isn't available" message as a real, durable
   // unavailability signal.
-  const [loadError, setLoadError] = useState(false);
+  const [hasLoadError, setHasLoadError] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const prevDirtyRef = useRef<boolean | undefined>(undefined);
@@ -107,7 +107,7 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
   useEffect(() => {
     let cancelled = false;
     setIsLoading(true);
-    setLoadError(false);
+    setHasLoadError(false);
     (async () => {
       try {
         const res = await fetchWithAuth(`/api/pages/${pageId}/publish`);
@@ -116,7 +116,7 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
           // 403 means the viewer definitively lacks permission to publish —
           // a genuine unavailability signal, not a failed request. Anything
           // else (5xx, etc.) is a real load failure.
-          if (res.status !== 403) setLoadError(true);
+          if (res.status !== 403) setHasLoadError(true);
           setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
           return;
         }
@@ -132,7 +132,7 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
         }
       } catch {
         if (!cancelled) {
-          setLoadError(true);
+          setHasLoadError(true);
           setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
         }
       } finally {
@@ -231,15 +231,15 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
 
   // Publishing isn't configured on this deployment (e.g. no PUBLISH_BUCKET), or
   // this viewer lacks permission to publish (a definitive 403 — see
-  // `loadError` above for the transient-failure case, handled separately). In
-  // the header (among other populated buttons) staying silent is fine; in a
-  // standalone panel (the canvas Settings tab) silence would leave the tab
+  // `hasLoadError` above for the transient-failure case, handled separately).
+  // In the header (among other populated buttons) staying silent is fine; in
+  // a standalone panel (the canvas Settings tab) silence would leave the tab
   // blank, so explain instead.
   if (!state.available) {
     if (variant === 'panel') {
       return (
         <p className="text-sm text-muted-foreground">
-          {loadError
+          {hasLoadError
             ? "Couldn't load publishing status. Try again shortly."
             : "Publishing isn't available for this page."}
         </p>

--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -51,9 +51,26 @@ interface PublishState {
   available: boolean;
   isStale: boolean;
   settings: PublishSettings;
+  // True only for a transient failure to load status (network error, 5xx) —
+  // distinct from `!available`, which means the status request succeeded (or
+  // definitively 403'd for a read-only viewer) and reported publishing as
+  // genuinely unavailable. Keeping these separate stops a blip from rendering
+  // the same "isn't available" message as a real, durable unavailability
+  // signal. Lives alongside `available` (rather than as its own useState) so
+  // every status-fetch outcome sets both fields in one atomic update.
+  hasLoadError: boolean;
 }
 
 const EMPTY_SETTINGS: PublishSettings = { title: '', description: '', ogImageUrl: '', noindex: false };
+
+const EMPTY_STATE: PublishState = {
+  published: false,
+  url: null,
+  available: false,
+  isStale: false,
+  settings: EMPTY_SETTINGS,
+  hasLoadError: false,
+};
 
 /** PublishSettings plus a transient "picked an uploaded file" alternative to
  *  pasting a URL — resolved server-side, never persisted as its own field. */
@@ -91,15 +108,8 @@ const readError = async (res: Response): Promise<string> => {
 const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishControlsProps) => {
   const params = useParams<{ driveId?: string }>();
   const driveId = params?.driveId;
-  const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
+  const [state, setState] = useState<PublishState>(EMPTY_STATE);
   const [isLoading, setIsLoading] = useState(true);
-  // True only for a transient failure to load status (network error, 5xx) —
-  // distinct from `!state.available`, which means the status request
-  // succeeded (or definitively 403'd for a read-only viewer) and reported
-  // publishing as genuinely unavailable. Keeping these separate stops a blip
-  // from rendering the same "isn't available" message as a real, durable
-  // unavailability signal.
-  const [hasLoadError, setHasLoadError] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const prevDirtyRef = useRef<boolean | undefined>(undefined);
@@ -107,7 +117,6 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
   useEffect(() => {
     let cancelled = false;
     setIsLoading(true);
-    setHasLoadError(false);
     (async () => {
       try {
         const res = await fetchWithAuth(`/api/pages/${pageId}/publish`);
@@ -116,8 +125,7 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
           // 403 means the viewer definitively lacks permission to publish —
           // a genuine unavailability signal, not a failed request. Anything
           // else (5xx, etc.) is a real load failure.
-          if (res.status !== 403) setHasLoadError(true);
-          setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
+          setState({ ...EMPTY_STATE, hasLoadError: res.status !== 403 });
           return;
         }
         const data = (await res.json()) as PublishStatusResponse;
@@ -128,12 +136,12 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
             available: data.available ?? false,
             isStale: data.isStale ?? false,
             settings: settingsFromResponse(data),
+            hasLoadError: false,
           });
         }
       } catch {
         if (!cancelled) {
-          setHasLoadError(true);
-          setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
+          setState({ ...EMPTY_STATE, hasLoadError: true });
         }
       } finally {
         if (!cancelled) setIsLoading(false);
@@ -231,15 +239,15 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
 
   // Publishing isn't configured on this deployment (e.g. no PUBLISH_BUCKET), or
   // this viewer lacks permission to publish (a definitive 403 — see
-  // `hasLoadError` above for the transient-failure case, handled separately).
-  // In the header (among other populated buttons) staying silent is fine; in
-  // a standalone panel (the canvas Settings tab) silence would leave the tab
-  // blank, so explain instead.
+  // `hasLoadError` on PublishState for the transient-failure case, handled
+  // separately). In the header (among other populated buttons) staying silent
+  // is fine; in a standalone panel (the canvas Settings tab) silence would
+  // leave the tab blank, so explain instead.
   if (!state.available) {
     if (variant === 'panel') {
       return (
         <p className="text-sm text-muted-foreground">
-          {hasLoadError
+          {state.hasLoadError
             ? "Couldn't load publishing status. Try again shortly."
             : "Publishing isn't available for this page."}
         </p>

--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -93,6 +93,13 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
   const driveId = params?.driveId;
   const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
   const [isLoading, setIsLoading] = useState(true);
+  // True only for a transient failure to load status (network error, 5xx) —
+  // distinct from `!state.available`, which means the status request
+  // succeeded (or definitively 403'd for a read-only viewer) and reported
+  // publishing as genuinely unavailable. Keeping these separate stops a blip
+  // from rendering the same "isn't available" message as a real, durable
+  // unavailability signal.
+  const [loadError, setLoadError] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const prevDirtyRef = useRef<boolean | undefined>(undefined);
@@ -100,11 +107,17 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
   useEffect(() => {
     let cancelled = false;
     setIsLoading(true);
+    setLoadError(false);
     (async () => {
       try {
         const res = await fetchWithAuth(`/api/pages/${pageId}/publish`);
         if (!res.ok) {
-          if (!cancelled) setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
+          if (cancelled) return;
+          // 403 means the viewer definitively lacks permission to publish —
+          // a genuine unavailability signal, not a failed request. Anything
+          // else (5xx, etc.) is a real load failure.
+          if (res.status !== 403) setLoadError(true);
+          setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
           return;
         }
         const data = (await res.json()) as PublishStatusResponse;
@@ -118,7 +131,10 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
           });
         }
       } catch {
-        if (!cancelled) setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
+        if (!cancelled) {
+          setLoadError(true);
+          setState({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
+        }
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -214,14 +230,18 @@ const PublishControls = ({ pageId, contentDirty, variant = 'header' }: PublishCo
   }
 
   // Publishing isn't configured on this deployment (e.g. no PUBLISH_BUCKET), or
-  // this viewer lacks permission to publish. In the header (among other
-  // populated buttons) staying silent is fine; in a standalone panel (the
-  // canvas Settings tab) silence would leave the tab blank, so explain instead.
+  // this viewer lacks permission to publish (a definitive 403 — see
+  // `loadError` above for the transient-failure case, handled separately). In
+  // the header (among other populated buttons) staying silent is fine; in a
+  // standalone panel (the canvas Settings tab) silence would leave the tab
+  // blank, so explain instead.
   if (!state.available) {
     if (variant === 'panel') {
       return (
         <p className="text-sm text-muted-foreground">
-          Publishing isn&apos;t available for this page.
+          {loadError
+            ? "Couldn't load publishing status. Try again shortly."
+            : "Publishing isn't available for this page."}
         </p>
       );
     }

--- a/apps/web/src/components/layout/middle-content/content-header/__tests__/PublishControls.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/__tests__/PublishControls.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// ============================================================================
+// Smoke tests for PublishControls' unavailable-state branching.
+//
+// Validates that:
+//   1. A successful response reporting `available: false` (unconfigured,
+//      disabled, or a read-only viewer's 403) shows the "isn't available"
+//      panel message — a durable, expected state.
+//   2. A transient load failure (5xx, network error) shows a distinct
+//      "couldn't load" message instead of the same durable-sounding text.
+//   3. The 'header' variant (default) stays silent (renders null) in both
+//      cases, preserving its existing behavior among other header buttons.
+// ============================================================================
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(() => ({ driveId: 'drive_xyz' })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import PublishControls from '../PublishControls';
+
+const mockFetchWithAuth = vi.mocked(fetchWithAuth);
+
+describe('PublishControls unavailable states', () => {
+  it('given a read-only viewer (403), panel variant shows the durable unavailable message', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'You do not have permission to view this page' }),
+    } as Response);
+
+    render(<PublishControls pageId="page_1" variant="panel" />);
+
+    expect(await screen.findByText("Publishing isn't available for this page.")).toBeInTheDocument();
+  });
+
+  it('given publishing unconfigured (200, available: false), panel variant shows the durable unavailable message', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ published: false, available: false }),
+    } as Response);
+
+    render(<PublishControls pageId="page_1" variant="panel" />);
+
+    expect(await screen.findByText("Publishing isn't available for this page.")).toBeInTheDocument();
+  });
+
+  it('given a server error (500), panel variant shows a distinct load-failure message', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Failed to read publish status' }),
+    } as Response);
+
+    render(<PublishControls pageId="page_1" variant="panel" />);
+
+    expect(await screen.findByText("Couldn't load publishing status. Try again shortly.")).toBeInTheDocument();
+    expect(screen.queryByText("Publishing isn't available for this page.")).not.toBeInTheDocument();
+  });
+
+  it('given a network error, panel variant shows a distinct load-failure message', async () => {
+    mockFetchWithAuth.mockRejectedValue(new Error('network down'));
+
+    render(<PublishControls pageId="page_1" variant="panel" />);
+
+    expect(await screen.findByText("Couldn't load publishing status. Try again shortly.")).toBeInTheDocument();
+  });
+
+  it('given a read-only viewer (403), header variant (default) renders nothing', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'You do not have permission to view this page' }),
+    } as Response);
+
+    const { container } = render(<PublishControls pageId="page_1" />);
+
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('given a server error (500), header variant (default) renders nothing', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Failed to read publish status' }),
+    } as Response);
+
+    const { container } = render(<PublishControls pageId="page_1" />);
+
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/apps/web/src/components/layout/middle-content/content-header/__tests__/PublishControls.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/__tests__/PublishControls.test.tsx
@@ -1,16 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import { assert } from '@/stores/__tests__/riteway';
 
 // ============================================================================
 // Smoke tests for PublishControls' unavailable-state branching.
 //
 // Validates that:
-//   1. A successful response reporting `available: false` (unconfigured,
-//      disabled, or a read-only viewer's 403) shows the "isn't available"
-//      panel message — a durable, expected state.
+//   1. A definitive unavailability signal (a read-only viewer's 403, or a
+//      successful response reporting `available: false`) shows the panel
+//      variant's durable "isn't available" message.
 //   2. A transient load failure (5xx, network error) shows a distinct
 //      "couldn't load" message instead of the same durable-sounding text.
-//   3. The 'header' variant (default) stays silent (renders null) in both
+//   3. The 'header' variant (default) stays silent (renders nothing) in both
 //      cases, preserving its existing behavior among other header buttons.
 // ============================================================================
 
@@ -34,75 +35,105 @@ import PublishControls from '../PublishControls';
 
 const mockFetchWithAuth = vi.mocked(fetchWithAuth);
 
-describe('PublishControls unavailable states', () => {
-  it('given a read-only viewer (403), panel variant shows the durable unavailable message', async () => {
-    mockFetchWithAuth.mockResolvedValue({
-      ok: false,
-      status: 403,
-      json: async () => ({ error: 'You do not have permission to view this page' }),
-    } as Response);
+const make403Response = () =>
+  ({
+    ok: false,
+    status: 403,
+    json: async () => ({ error: 'You do not have permission to view this page' }),
+  }) as Response;
+
+const make500Response = () =>
+  ({
+    ok: false,
+    status: 500,
+    json: async () => ({ error: 'Failed to read publish status' }),
+  }) as Response;
+
+const makeUnavailableResponse = () =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ published: false, available: false }),
+  }) as Response;
+
+describe('PublishControls — unavailable-state branching', () => {
+  it('given a read-only viewer (403), panel variant should show the durable unavailable message', async () => {
+    mockFetchWithAuth.mockResolvedValue(make403Response());
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
-    expect(await screen.findByText("Publishing isn't available for this page.")).toBeInTheDocument();
+    const message = await screen.findByText("Publishing isn't available for this page.");
+    assert({
+      given: 'a read-only viewer whose status request 403s',
+      should: 'show the durable unavailable message in the panel variant',
+      actual: message !== null,
+      expected: true,
+    });
   });
 
-  it('given publishing unconfigured (200, available: false), panel variant shows the durable unavailable message', async () => {
-    mockFetchWithAuth.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ published: false, available: false }),
-    } as Response);
+  it('given publishing unconfigured (200, available: false), panel variant should show the durable unavailable message', async () => {
+    mockFetchWithAuth.mockResolvedValue(makeUnavailableResponse());
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
-    expect(await screen.findByText("Publishing isn't available for this page.")).toBeInTheDocument();
+    const message = await screen.findByText("Publishing isn't available for this page.");
+    assert({
+      given: 'a successful response explicitly reporting available: false',
+      should: 'show the durable unavailable message in the panel variant',
+      actual: message !== null,
+      expected: true,
+    });
   });
 
-  it('given a server error (500), panel variant shows a distinct load-failure message', async () => {
-    mockFetchWithAuth.mockResolvedValue({
-      ok: false,
-      status: 500,
-      json: async () => ({ error: 'Failed to read publish status' }),
-    } as Response);
+  it('given a server error (500), panel variant should show a distinct load-failure message', async () => {
+    mockFetchWithAuth.mockResolvedValue(make500Response());
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
-    expect(await screen.findByText("Couldn't load publishing status. Try again shortly.")).toBeInTheDocument();
-    expect(screen.queryByText("Publishing isn't available for this page.")).not.toBeInTheDocument();
+    const message = await screen.findByText("Couldn't load publishing status. Try again shortly.");
+    assert({
+      given: 'a 500 from the status endpoint',
+      should: 'show a load-failure message, not the durable unavailable message',
+      actual: [message !== null, screen.queryByText("Publishing isn't available for this page.")],
+      expected: [true, null],
+    });
   });
 
-  it('given a network error, panel variant shows a distinct load-failure message', async () => {
+  it('given a network error, panel variant should show a distinct load-failure message', async () => {
     mockFetchWithAuth.mockRejectedValue(new Error('network down'));
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
-    expect(await screen.findByText("Couldn't load publishing status. Try again shortly.")).toBeInTheDocument();
+    const message = await screen.findByText("Couldn't load publishing status. Try again shortly.");
+    assert({
+      given: 'a network error while loading status',
+      should: 'show the load-failure message in the panel variant',
+      actual: message !== null,
+      expected: true,
+    });
   });
 
-  it('given a read-only viewer (403), header variant (default) renders nothing', async () => {
-    mockFetchWithAuth.mockResolvedValue({
-      ok: false,
-      status: 403,
-      json: async () => ({ error: 'You do not have permission to view this page' }),
-    } as Response);
+  it('given a read-only viewer (403), header variant (default) should render nothing', async () => {
+    mockFetchWithAuth.mockResolvedValue(make403Response());
 
     const { container } = render(<PublishControls pageId="page_1" />);
-
-    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    await waitFor(() => assert({
+      given: 'a read-only viewer whose status request 403s',
+      should: 'render nothing in the default header variant',
+      actual: container.textContent,
+      expected: '',
+    }));
   });
 
-  it('given a server error (500), header variant (default) renders nothing', async () => {
-    mockFetchWithAuth.mockResolvedValue({
-      ok: false,
-      status: 500,
-      json: async () => ({ error: 'Failed to read publish status' }),
-    } as Response);
+  it('given a server error (500), header variant (default) should render nothing', async () => {
+    mockFetchWithAuth.mockResolvedValue(make500Response());
 
     const { container } = render(<PublishControls pageId="page_1" />);
-
-    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    await waitFor(() => assert({
+      given: 'a 500 from the status endpoint',
+      should: 'render nothing in the default header variant (stays silent on transient failures too)',
+      actual: container.textContent,
+      expected: '',
+    }));
   });
 });

--- a/apps/web/src/components/layout/middle-content/content-header/__tests__/PublishControls.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/__tests__/PublishControls.test.tsx
@@ -35,30 +35,14 @@ import PublishControls from '../PublishControls';
 
 const mockFetchWithAuth = vi.mocked(fetchWithAuth);
 
-const make403Response = () =>
-  ({
-    ok: false,
-    status: 403,
-    json: async () => ({ error: 'You do not have permission to view this page' }),
-  }) as Response;
-
-const make500Response = () =>
-  ({
-    ok: false,
-    status: 500,
-    json: async () => ({ error: 'Failed to read publish status' }),
-  }) as Response;
-
-const makeUnavailableResponse = () =>
-  ({
-    ok: true,
-    status: 200,
-    json: async () => ({ published: false, available: false }),
-  }) as Response;
+const makeStatusResponse = ({ status = 200, body = {} }: { status?: number; body?: unknown } = {}) =>
+  ({ ok: status < 400, status, json: async () => body }) as Response;
 
 describe('PublishControls — unavailable-state branching', () => {
   it('given a read-only viewer (403), panel variant should show the durable unavailable message', async () => {
-    mockFetchWithAuth.mockResolvedValue(make403Response());
+    mockFetchWithAuth.mockResolvedValue(
+      makeStatusResponse({ status: 403, body: { error: 'You do not have permission to view this page' } })
+    );
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
@@ -72,7 +56,7 @@ describe('PublishControls — unavailable-state branching', () => {
   });
 
   it('given publishing unconfigured (200, available: false), panel variant should show the durable unavailable message', async () => {
-    mockFetchWithAuth.mockResolvedValue(makeUnavailableResponse());
+    mockFetchWithAuth.mockResolvedValue(makeStatusResponse({ body: { published: false, available: false } }));
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
@@ -86,7 +70,9 @@ describe('PublishControls — unavailable-state branching', () => {
   });
 
   it('given a server error (500), panel variant should show a distinct load-failure message', async () => {
-    mockFetchWithAuth.mockResolvedValue(make500Response());
+    mockFetchWithAuth.mockResolvedValue(
+      makeStatusResponse({ status: 500, body: { error: 'Failed to read publish status' } })
+    );
 
     render(<PublishControls pageId="page_1" variant="panel" />);
 
@@ -114,7 +100,9 @@ describe('PublishControls — unavailable-state branching', () => {
   });
 
   it('given a read-only viewer (403), header variant (default) should render nothing', async () => {
-    mockFetchWithAuth.mockResolvedValue(make403Response());
+    mockFetchWithAuth.mockResolvedValue(
+      makeStatusResponse({ status: 403, body: { error: 'You do not have permission to view this page' } })
+    );
 
     const { container } = render(<PublishControls pageId="page_1" />);
     await waitFor(() => assert({
@@ -126,7 +114,9 @@ describe('PublishControls — unavailable-state branching', () => {
   });
 
   it('given a server error (500), header variant (default) should render nothing', async () => {
-    mockFetchWithAuth.mockResolvedValue(make500Response());
+    mockFetchWithAuth.mockResolvedValue(
+      makeStatusResponse({ status: 500, body: { error: 'Failed to read publish status' } })
+    );
 
     const { container } = render(<PublishControls pageId="page_1" />);
     await waitFor(() => assert({

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -217,7 +217,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
       )}
       {activeTab === 'settings' && (
         <div className="flex-1 min-h-0 overflow-y-auto p-4">
-          <PublishControls pageId={pageId} contentDirty={documentState?.isDirty || false} />
+          <PublishControls pageId={pageId} contentDirty={documentState?.isDirty || false} variant="panel" />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Fixes an unresolved review finding from #2250 ([comment](https://github.com/2witstudios/PageSpace/pull/2250#discussion_r3671500213)) that was left open when that PR merged.

- `PublishControls` returns `null` when publishing is unconfigured, disabled, or unavailable to a read-only viewer (403 from the publish-status endpoint). In the content header that's harmless — one fewer button among several others — but PR #2250 moved canvas publish controls into a dedicated, always-selectable "Settings" tab, where `PublishControls` is the sole content. Selecting Settings in the unavailable case produced a blank panel with no explanation and no way to tell what happened.
- Added a `variant?: 'header' | 'panel'` prop to `PublishControls`: the `'header'` variant (default) keeps the existing silent `null` behavior; the `'panel'` variant (used by `CanvasPageView`'s Settings tab) renders an explanatory message instead.
- **Review follow-up** (both CodeRabbit and Codex independently flagged the same issue): the original fix collapsed transient load failures (5xx, network errors) into the same message as a genuine, durable "publishing unavailable" signal. Added a separate `hasLoadError` state so the panel now distinguishes:
  - Genuine unavailability (a definitive 403, or a successful response explicitly reporting `available: false`) → `"Publishing isn't available for this page."`
  - A transient load failure (5xx / network error) → `"Couldn't load publishing status. Try again shortly."`
- Self-review pass: renamed `loadError` → `hasLoadError` to match this file's existing `is*`/`has*` boolean naming (`isLoading`, `isBusy`, `isStale`), and rewrote the new test file to use the `given/should/actual/expected` `assert()` helper from `stores/__tests__/riteway`, matching the established convention in the sibling `ShareDialog.test.tsx` (same directory) rather than raw `expect()` assertions.
- **`/simplify` pass** (4 parallel review agents — reuse, simplification, efficiency, altitude): reuse/efficiency/altitude came back clean (the `variant` prop and local 403-classification logic match established codebase idioms — checked against `PageWebhooksDialog.tsx` and others). Simplification flagged that `hasLoadError` was a second, easy-to-desync `useState` alongside the `PublishState` object — folded it into `PublishState` itself so every fetch-outcome branch sets both fields atomically in one `setState` call, added an `EMPTY_STATE` constant to replace a 3x-duplicated empty-state literal, and consolidated the test file's three response-factory functions into one parametrized `makeStatusResponse(overrides)`, matching the precedent in `BackupDiffPreview.test.tsx`. No behavior change — same 16 tests pass.

## Test plan
- [x] `bun run typecheck` (web) — passes
- [x] `bun run lint` (web) — passes (only pre-existing, unrelated warnings)
- [x] `bun run knip:check` — no new issues
- [x] New unit tests in `PublishControls.test.tsx` (6 cases: durable-unavailable vs load-error, for both variants) — all pass
- [ ] Manually verify in the dev app:
  - [ ] Read-only viewer on a canvas page → Settings tab shows the durable unavailable message, not a blank panel
  - [ ] Publishing disabled/unconfigured (`CANVAS_PUBLISHING_DISABLED=true` or no `PUBLISH_BUCKET`) → same durable message
  - [ ] A transient 5xx/network blip while loading status → shows the distinct "couldn't load" message, not the durable one
  - [ ] Editor with publishing available → Settings tab still shows the normal Publish/published controls, unchanged
  - [ ] Non-canvas publishable page (e.g. Document) with publishing unavailable → header still shows nothing extra, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgEDGrDoiYZnXwsY5Jg53g

