### PR TITLE
feat(agents): restore the per-pane agent selector in the pane bar

### DIFF
--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -41,15 +41,21 @@ import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { panesOf, isLastPane, type PaneState } from '@/stores/agent-workspace/pane-reducer';
 import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
+import { useAuth } from '@/hooks/useAuth';
+import { useConversationActiveStream } from '@/hooks/useActiveStream';
+import { AISelector } from '@/components/ai/shared';
 import EndSessionDialog from '../EndSessionDialog';
+import { useResolvedAgent } from '../useResolvedAgent';
 import SessionPanes from './SessionPanes';
 import PaneBar, { PaneSessionIdentity, PaneSplitCloseActions } from './PaneBar';
 import PanePicker, { type PickableAgent, type ReattachableShell } from './PanePicker';
-import { resolvePaneSurface } from './pane-surface';
+import { resolvePaneSurface, type PaneSurface } from './pane-surface';
+import { selectPaneAgent, type SessionConversationSummary } from './select-pane-agent';
 import PaneChat from './PaneChat';
 import Shell from '../shell/Shell';
 
@@ -77,6 +83,24 @@ export interface AgentPanesProps {
 async function shellsFetcher(url: string): Promise<{ shells: ReattachableShell[] }> {
   const response = await fetchWithAuth(url);
   if (!response.ok) throw new Error(`Failed to list shells (${response.status})`);
+  return response.json();
+}
+
+interface SessionListEntry {
+  sessionId: string;
+  conversations: SessionConversationSummary[];
+}
+
+/**
+ * The same bulk listing the sidebar polls (`AgentsSidebar`) — SWR dedupes an
+ * identical key, so mounting both costs one request, not two. No dedicated
+ * endpoint for "one session's conversations" exists, and none is needed: the
+ * pane bar selector's decision (`selectPaneAgent`) only needs to know, for
+ * THIS session, which agents already have a thread.
+ */
+async function sessionsFetcher(url: string): Promise<{ sessions: SessionListEntry[] }> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to list sessions (${response.status})`);
   return response.json();
 }
 
@@ -127,6 +151,19 @@ export default function AgentPanes({
     }
     return (shellsData?.shells ?? []).filter((shell) => !bound.has(shell.shellId));
   }, [shellsData, workspace]);
+
+  // The pane bar selector's switch decision needs to know which of the
+  // session's conversations already exist, per agent — the same list the
+  // sidebar's expansion already shows.
+  const { data: sessionsData } = useSWR(
+    driveId !== null ? `/api/agent-sessions?driveId=${encodeURIComponent(driveId)}` : '/api/agent-sessions',
+    sessionsFetcher,
+    { revalidateOnFocus: false, refreshInterval: 20_000 },
+  );
+  const sessionConversations: SessionConversationSummary[] = useMemo(
+    () => (sessionsData?.sessions ?? []).find((session) => session.sessionId === sessionId)?.conversations ?? [],
+    [sessionsData, sessionId],
+  );
 
   // Selection IS an instruction to show the conversation (review M1): on
   // mount this seeds the first pane; on a later selection within the same
@@ -273,6 +310,33 @@ export default function AgentPanes({
     [assignPane, resetPane, sessionId, paneStillExists, cleanupOrphanedConversation],
   );
 
+  // The pane bar selector's switch — focus-or-mint, decided by the pure
+  // module above. Focusing reuses the store's dedup-aware `openConversation`
+  // (the same conversation never shows in two panes at once — review M1);
+  // minting reuses `handlePickAgent`'s own path, which binds THIS pane
+  // directly, exactly as picking from the split picker already does.
+  const handleSwitchAgent = useCallback(
+    (paneId: string, currentAgentPageId: string | null, nextAgentPageId: string | null) => {
+      const decision = selectPaneAgent({
+        conversations: sessionConversations,
+        selectedAgentPageId: nextAgentPageId,
+        currentAgentPageId,
+      });
+      if (decision.action === 'noop') return;
+      if (decision.action === 'focus') {
+        openConversation(sessionId, {
+          kind: 'chat',
+          name: 'Conversation',
+          targetId: decision.conversationId,
+          agentPageId: nextAgentPageId,
+        });
+        return;
+      }
+      void handlePickAgent(paneId, nextAgentPageId);
+    },
+    [sessionConversations, sessionId, openConversation, handlePickAgent],
+  );
+
   const handlePickShell = useCallback(
     async (paneId: string) => {
       assignPane(sessionId, paneId, { kind: 'terminal', name: 'shell', targetId: null, agentPageId: null });
@@ -334,7 +398,18 @@ export default function AgentPanes({
         <PaneBar
           isActive={isActive}
           identity={
-            pane.scope ? (
+            pane.scope?.kind === 'chat' ? (
+              <ChatPaneIdentity
+                scope={pane.scope}
+                surface={surface}
+                pickableAgents={pickableAgents}
+                agentsLoading={driveId !== null && agentsLoading}
+                driveId={driveId}
+                onSelectAgent={(nextAgentPageId) =>
+                  handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)
+                }
+              />
+            ) : pane.scope ? (
               <PaneSessionIdentity name={pane.scope.name || 'pane'} />
             ) : (
               <span className="text-muted-foreground">New pane</span>
@@ -398,5 +473,59 @@ export default function AgentPanes({
         onConfirm={() => void confirmEndSession()}
       />
     </>
+  );
+}
+
+/**
+ * A chat pane's bar identity: the `/development` AISelector, restored as a
+ * first-class pane bar control (issue #2274 audit follow-up). Own component
+ * (rather than inline in `renderPane`) so its hooks — resolving the pane's
+ * agent, reading whether it's streaming — obey the rules of hooks across a
+ * pane count that changes on every split/close.
+ *
+ * `pickableAgents` is what scopes the dropdown to the session's own drive
+ * (or to nothing, for a global-assistant session — see `AISelector`'s
+ * `agents` override): the same list the split picker already offers, so a
+ * pane's selector and "Split → pick an agent" never disagree about what's
+ * choosable here.
+ */
+function ChatPaneIdentity({
+  scope,
+  surface,
+  pickableAgents,
+  agentsLoading,
+  driveId,
+  onSelectAgent,
+}: {
+  /** Always `kind: 'chat'` at the call site — `PaneScope` isn't a discriminated union, so this stays the full type. */
+  scope: PaneScope;
+  surface: PaneSurface;
+  pickableAgents: PickableAgent[];
+  agentsLoading: boolean;
+  driveId: string | null;
+  onSelectAgent: (agentPageId: string | null) => void;
+}) {
+  const { user } = useAuth();
+  const { agent } = useResolvedAgent(scope.agentPageId);
+  const conversationId = surface.surface === 'chat' ? surface.conversationId : null;
+  // The channel a stream for this conversation would be tagged with — an
+  // agent's own page id, or the user's global channel for the Assistant
+  // (`useAssistantSessionChat`'s own scoping, mirrored here).
+  const streamPageId = scope.agentPageId ?? (user?.id ? globalChannelId(user.id) : null);
+  const activeStream = useConversationActiveStream(streamPageId, conversationId);
+  // Mid-mint (the row isn't there yet) or mid-stream: switching now has
+  // nothing stable to point at, or would abandon a running send.
+  const disabled = surface.surface === 'loading' || activeStream !== undefined;
+
+  return (
+    <AISelector
+      selectedAgent={scope.agentPageId === null ? null : agent}
+      onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
+      driveId={driveId ?? undefined}
+      agents={pickableAgents}
+      agentsLoading={agentsLoading}
+      disabled={disabled}
+      className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
+    />
   );
 }

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -50,8 +50,26 @@ vi.mock('../../shell/Shell', () => ({
 
 import AgentPanes from '../AgentPanes';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 
 const jsonOk = (body: unknown) => ({ ok: true, json: async () => body });
+
+/**
+ * The default routing every test starts from: empty shells, an empty
+ * session-conversations list (`ChatPaneIdentity`'s switch-decision data), and
+ * `useResolvedAgent`'s two lookups per fixture agent (id/title come from
+ * `mockUsePageAgents` above). A test that cares about a specific route
+ * layers its own `mockImplementation` on top.
+ */
+function defaultFetchRoute(url: string): unknown {
+  if (url.includes('/shells')) return { shells: [] };
+  if (url.includes('/api/agent-sessions')) return { sessions: [] };
+  if (url === '/api/pages/agent-1') return { id: 'agent-1', title: 'Researcher', driveId: 'drive-1' };
+  if (url === '/api/pages/agent-1/agent-config') return {};
+  if (url === '/api/pages/agent-2') return { id: 'agent-2', title: 'Writer', driveId: 'drive-1' };
+  if (url === '/api/pages/agent-2/agent-config') return {};
+  return {};
+}
 
 function renderPanes(props: Partial<React.ComponentProps<typeof AgentPanes>> = {}) {
   return render(
@@ -70,6 +88,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   cuidCounter = 0;
   useAgentWorkspaceStore.setState({ workspaces: {} });
+  usePendingStreamsStore.setState({ streams: new Map() });
   mockUsePageAgents.mockReturnValue({
     allAgents: [
       { id: 'agent-1', title: 'Researcher', driveId: 'drive-1' },
@@ -77,7 +96,7 @@ beforeEach(() => {
     ],
     isLoading: false,
   });
-  mockFetchWithAuth.mockResolvedValue(jsonOk({ shells: [] }));
+  mockFetchWithAuth.mockImplementation(async (url: string) => jsonOk(defaultFetchRoute(url)));
 });
 
 describe('AgentPanes', () => {
@@ -342,6 +361,101 @@ describe('AgentPanes', () => {
       await waitFor(() =>
         expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId).not.toBe(firstPaneId),
       );
+    });
+  });
+
+  describe('the pane bar agent selector (restored /development AISelector)', () => {
+    function mockSessionConversations(
+      conversations: Array<{ conversationId: string; agentPageId: string | null; lastMessageAt?: string | null }>,
+    ) {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/api/agent-sessions')) {
+          return jsonOk({
+            sessions: [{ sessionId: 'ses-1', conversations: conversations.map((c) => ({ lastMessageAt: null, ...c })) }],
+          });
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+    }
+
+    it("shows the pane's current agent as the bar identity", async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      expect(await screen.findByRole('button', { name: /Researcher/ })).toBeInTheDocument();
+    });
+
+    it('selecting the pane\'s current agent again is a no-op', async () => {
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+      renderPanes();
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
+      );
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('button', { name: /Researcher/ }));
+      await user.click(await screen.findByRole('menuitem', { name: /Researcher/ }));
+
+      expect(mockPost).not.toHaveBeenCalled();
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].scope).toMatchObject({
+        targetId: 'conv-1',
+        agentPageId: 'agent-1',
+      });
+    });
+
+    it('switching to an agent the session already has a conversation with focuses it, without minting', async () => {
+      mockSessionConversations([
+        { conversationId: 'conv-1', agentPageId: 'agent-1' },
+        { conversationId: 'conv-existing-2', agentPageId: 'agent-2' },
+      ]);
+      renderPanes();
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
+      );
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('button', { name: /Researcher/ }));
+      await user.click(await screen.findByText('Writer'));
+
+      expect(mockPost).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].scope).toMatchObject({
+          targetId: 'conv-existing-2',
+          agentPageId: 'agent-2',
+        }),
+      );
+      expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-existing-2');
+    });
+
+    it('switching to an agent with no conversation in this session mints one, same as the split picker', async () => {
+      mockPost.mockResolvedValue({});
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+      renderPanes();
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
+      );
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('button', { name: /Researcher/ }));
+      await user.click(await screen.findByText('Writer'));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-2/conversations', {
+          conversationId: 'new-id-1',
+          sessionId: 'ses-1',
+        }),
+      );
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('new-id-1'));
+    });
+
+    it("disables the selector while the pane's chat is streaming", async () => {
+      usePendingStreamsStore.getState().addStream({
+        messageId: 'msg-1',
+        pageId: 'agent-1',
+        conversationId: 'conv-1',
+        isOwn: true,
+        triggeredBy: { userId: 'user-1', displayName: 'You' },
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      expect(await screen.findByRole('button', { name: /Researcher/ })).toBeDisabled();
     });
   });
 });

--- a/apps/web/src/components/agents/panes/__tests__/select-pane-agent.test.ts
+++ b/apps/web/src/components/agents/panes/__tests__/select-pane-agent.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The pane bar selector's switch decision as data — the rule worth pinning is
+ * that switching a pane's agent never invents a target: it either finds the
+ * session's existing conversation with that agent, or defers to a mint, and
+ * never when the pick is the pane's own current agent.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectPaneAgent, type SessionConversationSummary } from '../select-pane-agent';
+
+const conversation = (
+  conversationId: string,
+  agentPageId: string | null,
+  lastMessageAt: string | null = null,
+): SessionConversationSummary => ({ conversationId, agentPageId, lastMessageAt });
+
+describe('selectPaneAgent', () => {
+  it('given the pane is already on the picked agent, should no-op', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [conversation('conv-1', 'agent-1')],
+        selectedAgentPageId: 'agent-1',
+        currentAgentPageId: 'agent-1',
+      }),
+    ).toEqual({ action: 'noop' });
+  });
+
+  it('given the pane is already on the Global Assistant and Assistant is picked again, should no-op', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [conversation('conv-1', null)],
+        selectedAgentPageId: null,
+        currentAgentPageId: null,
+      }),
+    ).toEqual({ action: 'noop' });
+  });
+
+  it('given the session already has a conversation with the picked agent, should focus it', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [conversation('conv-1', 'agent-1'), conversation('conv-2', 'agent-2')],
+        selectedAgentPageId: 'agent-2',
+        currentAgentPageId: 'agent-1',
+      }),
+    ).toEqual({ action: 'focus', conversationId: 'conv-2' });
+  });
+
+  it('given the session has no conversation with the picked agent, should mint one', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [conversation('conv-1', 'agent-1')],
+        selectedAgentPageId: 'agent-2',
+        currentAgentPageId: 'agent-1',
+      }),
+    ).toEqual({ action: 'mint' });
+  });
+
+  it('given an empty session, should mint', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [],
+        selectedAgentPageId: 'agent-2',
+        currentAgentPageId: null,
+      }),
+    ).toEqual({ action: 'mint' });
+  });
+
+  it('given several conversations with the picked agent, should focus the most recently active one', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [
+          conversation('conv-old', 'agent-2', '2026-01-01T00:00:00.000Z'),
+          conversation('conv-new', 'agent-2', '2026-01-15T00:00:00.000Z'),
+          conversation('conv-mid', 'agent-2', '2026-01-08T00:00:00.000Z'),
+        ],
+        selectedAgentPageId: 'agent-2',
+        currentAgentPageId: 'agent-1',
+      }),
+    ).toEqual({ action: 'focus', conversationId: 'conv-new' });
+  });
+
+  it('given the picked agent has both a never-messaged and a messaged conversation, should focus the messaged one', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [
+          conversation('conv-never', 'agent-2', null),
+          conversation('conv-messaged', 'agent-2', '2026-01-01T00:00:00.000Z'),
+        ],
+        selectedAgentPageId: 'agent-2',
+        currentAgentPageId: 'agent-1',
+      }),
+    ).toEqual({ action: 'focus', conversationId: 'conv-messaged' });
+  });
+
+  it('switching from the Assistant to a drive agent with an existing thread should focus it, not mint', () => {
+    expect(
+      selectPaneAgent({
+        conversations: [conversation('conv-assistant', null), conversation('conv-agent', 'agent-1')],
+        selectedAgentPageId: 'agent-1',
+        currentAgentPageId: null,
+      }),
+    ).toEqual({ action: 'focus', conversationId: 'conv-agent' });
+  });
+});

--- a/apps/web/src/components/agents/panes/select-pane-agent.ts
+++ b/apps/web/src/components/agents/panes/select-pane-agent.ts
@@ -1,0 +1,52 @@
+/**
+ * What switching a chat pane's agent, via the pane bar's `AISelector`, means —
+ * a pure decision so the branch never lives inline in `AgentPanes`.
+ *
+ * Mirrors `useAgentWorkspaceStore`'s `openConversation` focus-or-open policy,
+ * but scoped to ONE pane's pick rather than "wherever fits": the caller
+ * already knows exactly which pane the pick came from, so there is no
+ * placement search here — only the existing-vs-mint choice, and the
+ * same-agent no-op.
+ *
+ * Switching a pane's agent never rebinds a conversation — binding is
+ * congenital and permanent (contract invariant 2). This only decides which
+ * conversation IN THE SAME SESSION the pane should point at next: an
+ * existing one (focus, via the store's dedup-aware `openConversation`, which
+ * mirrors "returning to an agent resumes its conversation as-is, it never
+ * mints a new row") or a fresh one (mint, via the picker's own path).
+ */
+
+export interface SessionConversationSummary {
+  conversationId: string;
+  agentPageId: string | null;
+  /** ISO timestamp, or null for a conversation with no messages yet. */
+  lastMessageAt: string | null;
+}
+
+export type SelectPaneAgentDecision =
+  | { action: 'noop' }
+  | { action: 'focus'; conversationId: string }
+  | { action: 'mint' };
+
+export function selectPaneAgent(params: {
+  /** This session's conversations — any agent, not just the pane's current one. */
+  conversations: readonly SessionConversationSummary[];
+  /** The agent the pane bar's dropdown was switched to. */
+  selectedAgentPageId: string | null;
+  /** The pane's agent right now. */
+  currentAgentPageId: string | null;
+}): SelectPaneAgentDecision {
+  const { conversations, selectedAgentPageId, currentAgentPageId } = params;
+
+  if (selectedAgentPageId === currentAgentPageId) return { action: 'noop' };
+
+  const matches = conversations.filter((c) => c.agentPageId === selectedAgentPageId);
+  if (matches.length === 0) return { action: 'mint' };
+
+  const mostRecent = matches.reduce((latest, candidate) => {
+    const latestAt = latest.lastMessageAt ? Date.parse(latest.lastMessageAt) : -Infinity;
+    const candidateAt = candidate.lastMessageAt ? Date.parse(candidate.lastMessageAt) : -Infinity;
+    return candidateAt > latestAt ? candidate : latest;
+  });
+  return { action: 'focus', conversationId: mostRecent.conversationId };
+}

--- a/apps/web/src/components/ai/shared/AISelector.tsx
+++ b/apps/web/src/components/ai/shared/AISelector.tsx
@@ -16,12 +16,30 @@ import { usePageAgents, type AgentSummary } from '@/hooks/page-agents';
 import { type AgentInfo } from '@/stores/page-agents';
 import { cn } from '@/lib/utils';
 
+/** A minimal, already-scoped agent — for a caller that has its own list rather than a drive to fetch. */
+export interface AISelectorAgentOption {
+  id: string;
+  title: string;
+}
+
 interface AISelectorProps {
   selectedAgent: AgentInfo | null;
   onSelectAgent: (agent: AgentInfo | null) => void;
   driveId?: string;
   disabled?: boolean;
   className?: string;
+  /**
+   * A pre-resolved, already-scoped agent list — when provided, replaces the
+   * internal cross-drive fetch entirely. `driveId` alone cannot express "no
+   * drive" (an absent `driveId` means "every drive" to `usePageAgents`), so a
+   * caller scoped to a single session — which may own no drive at all, in
+   * the global-assistant case — supplies its own list instead.
+   */
+  agents?: readonly AISelectorAgentOption[];
+  /** Loading state for `agents`, when provided. */
+  agentsLoading?: boolean;
+  /** Whether the Global Assistant is offerable. Defaults to true (existing behavior). */
+  canPickAssistant?: boolean;
 }
 
 /**
@@ -37,11 +55,20 @@ export function AISelector({
   driveId,
   disabled = false,
   className,
+  agents: agentsOverride,
+  agentsLoading = false,
+  canPickAssistant = true,
 }: AISelectorProps) {
-  const { agentsByDrive, isLoading, toAgentInfo } = usePageAgents(driveId);
+  const usingOverride = agentsOverride !== undefined;
+  const { agentsByDrive, isLoading: fetchedIsLoading, toAgentInfo } = usePageAgents(driveId, {
+    enabled: !usingOverride,
+  });
 
-  const hasAgents = agentsByDrive.some(drive => drive.agents.length > 0);
-  const showDriveLabels = !driveId && agentsByDrive.length > 1;
+  const isLoading = usingOverride ? agentsLoading : fetchedIsLoading;
+  const hasAgents = usingOverride
+    ? agentsOverride.length > 0
+    : agentsByDrive.some(drive => drive.agents.length > 0);
+  const showDriveLabels = !usingOverride && !driveId && agentsByDrive.length > 1;
 
   const handleSelectGlobal = () => {
     onSelectAgent(null);
@@ -49,6 +76,10 @@ export function AISelector({
 
   const handleSelectAgent = (agent: AgentSummary) => {
     onSelectAgent(toAgentInfo(agent));
+  };
+
+  const handleSelectOverrideAgent = (agent: AISelectorAgentOption) => {
+    onSelectAgent({ id: agent.id, title: agent.title, driveId: driveId ?? '', driveName: '' });
   };
 
   return (
@@ -69,20 +100,22 @@ export function AISelector({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="start" className="w-[280px]">
-        {/* Global Assistant - always first */}
-        <DropdownMenuItem
-          onClick={handleSelectGlobal}
-          className={cn(
-            'flex items-center gap-2 cursor-pointer',
-            !selectedAgent && 'bg-accent/50'
-          )}
-          aria-current={!selectedAgent ? 'true' : undefined}
-        >
-          <span className="font-medium">Global Assistant</span>
-          {!selectedAgent && (
-            <span className="ml-auto text-xs text-muted-foreground">Active</span>
-          )}
-        </DropdownMenuItem>
+        {/* Global Assistant - always first, when offerable */}
+        {canPickAssistant && (
+          <DropdownMenuItem
+            onClick={handleSelectGlobal}
+            className={cn(
+              'flex items-center gap-2 cursor-pointer',
+              !selectedAgent && 'bg-accent/50'
+            )}
+            aria-current={!selectedAgent ? 'true' : undefined}
+          >
+            <span className="font-medium">Global Assistant</span>
+            {!selectedAgent && (
+              <span className="ml-auto text-xs text-muted-foreground">Active</span>
+            )}
+          </DropdownMenuItem>
+        )}
 
         {/* Agents section */}
         {isLoading ? (
@@ -97,40 +130,65 @@ export function AISelector({
           <>
             <DropdownMenuSeparator />
 
-            {agentsByDrive.map((drive) => {
-              if (drive.agents.length === 0) return null;
+            {usingOverride ? (
+              <DropdownMenuGroup>
+                {agentsOverride.map((agent) => {
+                  const isSelected = selectedAgent?.id === agent.id;
 
-              return (
-                <DropdownMenuGroup key={drive.driveId}>
-                  {showDriveLabels && (
-                    <DropdownMenuLabel className="text-xs text-muted-foreground">
-                      {drive.driveName}
-                    </DropdownMenuLabel>
-                  )}
+                  return (
+                    <DropdownMenuItem
+                      key={agent.id}
+                      onClick={() => handleSelectOverrideAgent(agent)}
+                      className={cn(
+                        'flex items-center gap-2 cursor-pointer',
+                        isSelected && 'bg-accent/50'
+                      )}
+                      aria-current={isSelected ? 'true' : undefined}
+                    >
+                      <span className="truncate">{agent.title || 'Unnamed Agent'}</span>
+                      {isSelected && (
+                        <span className="ml-auto text-xs text-muted-foreground">Active</span>
+                      )}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuGroup>
+            ) : (
+              agentsByDrive.map((drive) => {
+                if (drive.agents.length === 0) return null;
 
-                  {drive.agents.map((agent) => {
-                    const isSelected = selectedAgent?.id === agent.id;
+                return (
+                  <DropdownMenuGroup key={drive.driveId}>
+                    {showDriveLabels && (
+                      <DropdownMenuLabel className="text-xs text-muted-foreground">
+                        {drive.driveName}
+                      </DropdownMenuLabel>
+                    )}
 
-                    return (
-                      <DropdownMenuItem
-                        key={agent.id}
-                        onClick={() => handleSelectAgent(agent)}
-                        className={cn(
-                          'flex items-center gap-2 cursor-pointer',
-                          isSelected && 'bg-accent/50'
-                        )}
-                        aria-current={isSelected ? 'true' : undefined}
-                      >
-                        <span className="truncate">{agent.title || 'Unnamed Agent'}</span>
-                        {isSelected && (
-                          <span className="ml-auto text-xs text-muted-foreground">Active</span>
-                        )}
-                      </DropdownMenuItem>
-                    );
-                  })}
-                </DropdownMenuGroup>
-              );
-            })}
+                    {drive.agents.map((agent) => {
+                      const isSelected = selectedAgent?.id === agent.id;
+
+                      return (
+                        <DropdownMenuItem
+                          key={agent.id}
+                          onClick={() => handleSelectAgent(agent)}
+                          className={cn(
+                            'flex items-center gap-2 cursor-pointer',
+                            isSelected && 'bg-accent/50'
+                          )}
+                          aria-current={isSelected ? 'true' : undefined}
+                        >
+                          <span className="truncate">{agent.title || 'Unnamed Agent'}</span>
+                          {isSelected && (
+                            <span className="ml-auto text-xs text-muted-foreground">Active</span>
+                          )}
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </DropdownMenuGroup>
+                );
+              })
+            )}
           </>
         ) : driveId ? (
           <>

--- a/apps/web/src/components/ai/shared/__tests__/AISelector.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/AISelector.test.tsx
@@ -119,4 +119,81 @@ describe('AISelector', () => {
       })
     );
   });
+
+  describe('agents override (session-scoped panes)', () => {
+    it('renders the supplied list instead of the internal cross-drive fetch', async () => {
+      const user = userEvent.setup();
+      render(
+        <AISelector
+          selectedAgent={null}
+          onSelectAgent={mockOnSelectAgent}
+          agents={[{ id: 'pane-agent-1', title: 'Pane Agent' }]}
+        />
+      );
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('menuitem', { name: 'Pane Agent' })).toBeInTheDocument();
+      // The fetched fixture agent ("Test Agent") must not leak in — an
+      // override means the internal drive fetch is skipped entirely.
+      expect(screen.queryByText('Test Agent')).not.toBeInTheDocument();
+    });
+
+    it('skips the internal fetch when an override is supplied', () => {
+      render(
+        <AISelector
+          selectedAgent={null}
+          onSelectAgent={mockOnSelectAgent}
+          agents={[{ id: 'pane-agent-1', title: 'Pane Agent' }]}
+        />
+      );
+
+      expect(usePageAgents).toHaveBeenCalledWith(undefined, { enabled: false });
+    });
+
+    it('shows an empty override (a global-assistant session, which owns no drive agents) as just the Assistant', async () => {
+      const user = userEvent.setup();
+      render(<AISelector selectedAgent={null} onSelectAgent={mockOnSelectAgent} agents={[]} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('menuitem', { name: /Global Assistant/ })).toBeInTheDocument();
+      expect(screen.queryByText('Test Agent')).not.toBeInTheDocument();
+    });
+
+    it('calls onSelectAgent with the picked override entry', async () => {
+      const user = userEvent.setup();
+      render(
+        <AISelector
+          selectedAgent={null}
+          onSelectAgent={mockOnSelectAgent}
+          driveId="drive_123"
+          agents={[{ id: 'pane-agent-1', title: 'Pane Agent' }]}
+        />
+      );
+
+      await user.click(screen.getByRole('button'));
+      await user.click(screen.getByRole('menuitem', { name: 'Pane Agent' }));
+
+      expect(mockOnSelectAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'pane-agent-1', title: 'Pane Agent' })
+      );
+    });
+  });
+
+  describe('canPickAssistant', () => {
+    it('hides the Global Assistant menu item when false', async () => {
+      const user = userEvent.setup();
+      render(<AISelector selectedAgent={null} onSelectAgent={mockOnSelectAgent} canPickAssistant={false} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.queryByRole('menuitem', { name: /Global Assistant/ })).not.toBeInTheDocument();
+    });
+
+    it('defaults to showing the Global Assistant menu item', async () => {
+      const user = userEvent.setup();
+      render(<AISelector selectedAgent={null} onSelectAgent={mockOnSelectAgent} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('menuitem', { name: /Global Assistant/ })).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Restores the `/development` `AISelector` as the pane bar's chat-pane identity — an audit follow-up from PR #2258/#2259 (Dev → Agents Rebuild). The old machine grid's `MachinePaneChat` hosted an `AISelector` dropdown as the pane bar's own identity (`selectedAgent={pane.selectedAgent} onSelectAgent={pane.selectAgent}`, disabled while streaming), so a pane's agent could be switched at any time. The pane-system restoration ported the grid but replaced the bar's identity with a static conversation name — the only remaining agent choice was the `PanePicker`, reachable only via Split on an *unbound* pane.

**Zero data-model impact.** Panes are local, unaddressed UI state; a session already owns many conversations with any of its drive's agents. Switching a pane's agent never rebinds a conversation — binding stays congenital and permanent — it just points the pane at a *different* conversation in the same session (minting one lazily if none exists yet), exactly the semantics the historical code documented: "returning to null resumes the conversation as-is, it never mints a new row." No schema change, no new API route.

- **`select-pane-agent.ts`** (new, pure module + test): the switch decision — no-op when the pick matches the pane's current agent, `focus` the session's most-recently-active conversation with the picked agent, or `mint` when none exists. Mirrors `useAgentWorkspaceStore`'s `openConversation` focus-or-open policy, scoped to one specific pane.
- **`AISelector.tsx`**: adds an optional pre-scoped `agents` list and a `canPickAssistant` flag, both additive and backward-compatible (existing callers — `GlobalAssistantView`, `SidebarChatTab` — are unaffected). `driveId` alone can't express "no drive at all": an absent `driveId` means "every drive" to the internal `usePageAgents` fetch, which would leak cross-drive agents into a global-assistant session's pane (a session that owns no drive to pick agents from). A session-scoped caller supplies its own already-correctly-scoped list instead.
- **`AgentPanes.tsx`**: chat panes now render the selector in the pane bar identity slot, fed by the same `pickableAgents` already computed for the split picker (so the bar and the picker never disagree about what's choosable). Switching reuses the store's dedup-aware `openConversation` for an existing thread, or the picker's own mint path (`handlePickAgent`) for a fresh one. Disabled while the pane's chat is streaming or mid-mint. The session's conversation list rides the same bulk `/api/agent-sessions` listing the sidebar already polls (SWR dedupes the shared key) — no new endpoint.

Side benefit: the bar now *displays* which agent each pane is talking to, closing the "which agent is this pane" gap the static conversation name left open.

## Test plan

- [x] `bun run typecheck` (monorepo, via turbo)
- [x] `bun run lint` (monorepo, via turbo) — only pre-existing warnings in unrelated files
- [x] `bun run test:unit` (monorepo) — all green except one pre-existing, unrelated, timezone-dependent flake (`src/lib/messages/__tests__/grouping.test.ts`, untouched by this branch)
- [x] `bun run knip:check` — within baseline
- [x] New/updated suites: `select-pane-agent.test.ts`, `AISelector.test.tsx` (agents override + `canPickAssistant`), `AgentPanes.test.tsx` (selector renders current agent, switch focuses an existing conversation, switch mints when none exists, disabled while streaming, no-op on same agent)
- [ ] Manual: `bun run dev` → Agents console Chat tab → pane bar shows the agent dropdown → switch to another drive agent → pane swaps to that agent's conversation (existing one focused if present, else a new thread appears in the sidebar under the same session); terminal pane bar unchanged; selector disabled mid-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfWmmVg3RqktRfAHtzEikF