### PR TITLE
fix(agents): close two pane-selector mint races flagged in #2276 review

### DIFF
--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -155,19 +155,34 @@ export default function AgentPanes({
   // The pane bar selector's switch decision needs to know which of the
   // session's conversations already exist, per agent — the same list the
   // sidebar's expansion already shows.
-  const {
-    data: sessionsData,
-    isLoading: sessionConversationsLoading,
-    mutate: mutateSessionConversations,
-  } = useSWR(
+  const { data: sessionsData, mutate: mutateSessionConversations } = useSWR(
     driveId !== null ? `/api/agent-sessions?driveId=${encodeURIComponent(driveId)}` : '/api/agent-sessions',
     sessionsFetcher,
     { revalidateOnFocus: false, refreshInterval: 20_000 },
   );
-  const sessionConversations: SessionConversationSummary[] = useMemo(
-    () => (sessionsData?.sessions ?? []).find((session) => session.sessionId === sessionId)?.conversations ?? [],
+  // THIS session's own entry, looked up once and reused for both the
+  // conversation list and the readiness check below — a session that
+  // hasn't appeared here yet is not the same fact as an empty list.
+  const currentSessionConversationsEntry = useMemo(
+    () => (sessionsData?.sessions ?? []).find((session) => session.sessionId === sessionId),
     [sessionsData, sessionId],
   );
+  const sessionConversations: SessionConversationSummary[] = useMemo(
+    () => currentSessionConversationsEntry?.conversations ?? [],
+    [currentSessionConversationsEntry],
+  );
+  // Ready only once THIS session's entry has actually appeared in the
+  // cache — not merely once a fetch has settled. Two ways "settled" lies:
+  // an initial-fetch ERROR leaves `sessionsData` undefined forever with
+  // SWR's `isLoading` already back to false (SWR only tracks the fetch's
+  // own pending state, not "do we have usable data"); and a cache that was
+  // already warm from BEFORE this session was spawned (this SWR key is
+  // shared across every session in the drive) answers with real data that
+  // simply has no row for a session this new yet. Both leave
+  // `sessionConversations` reading as `[]` — indistinguishable from "no
+  // thread exists" — so the entry's actual presence, not a loading flag, is
+  // the fact the switch decision needs.
+  const sessionKnownToConversationsCache = currentSessionConversationsEntry !== undefined;
 
   // A successful mint writes straight into the pane store, but the switch
   // DECISION reads `sessionConversations` from this SWR cache, which only
@@ -436,7 +451,7 @@ export default function AgentPanes({
                 surface={surface}
                 pickableAgents={pickableAgents}
                 agentsLoading={driveId !== null && agentsLoading}
-                conversationsLoading={sessionConversationsLoading}
+                conversationsReady={sessionKnownToConversationsCache}
                 driveId={driveId}
                 onSelectAgent={(nextAgentPageId) =>
                   handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)
@@ -527,7 +542,7 @@ function ChatPaneIdentity({
   surface,
   pickableAgents,
   agentsLoading,
-  conversationsLoading,
+  conversationsReady,
   driveId,
   onSelectAgent,
 }: {
@@ -537,13 +552,13 @@ function ChatPaneIdentity({
   pickableAgents: PickableAgent[];
   agentsLoading: boolean;
   /**
-   * Still on the FIRST fetch of the session's conversation list. Before that
-   * list has ever loaded, `selectPaneAgent` sees an empty array — indistinguishable
-   * from "no conversation with this agent exists yet" — and a switch to an
-   * agent that already HAS a thread would wrongly mint a duplicate instead of
-   * focusing it. Disabled here rather than raced.
+   * Whether THIS session's entry has appeared in the switch decision's own
+   * data (`sessionConversations`). Before it has, that list reads as `[]` —
+   * indistinguishable from "no conversation with this agent exists yet" —
+   * and a switch to an agent that already HAS a thread would wrongly mint a
+   * duplicate instead of focusing it. Disabled here rather than raced.
    */
-  conversationsLoading: boolean;
+  conversationsReady: boolean;
   driveId: string | null;
   onSelectAgent: (agentPageId: string | null) => void;
 }) {
@@ -556,9 +571,9 @@ function ChatPaneIdentity({
   const streamPageId = scope.agentPageId ?? (user?.id ? globalChannelId(user.id) : null);
   const activeStream = useConversationActiveStream(streamPageId, conversationId);
   // Mid-mint (the row isn't there yet), mid-stream, or the switch decision's
-  // own data hasn't loaded yet: none of these have anything safe to switch
-  // against.
-  const disabled = surface.surface === 'loading' || activeStream !== undefined || conversationsLoading;
+  // own data doesn't know this session yet: none of these have anything
+  // safe to switch against.
+  const disabled = surface.surface === 'loading' || activeStream !== undefined || !conversationsReady;
 
   return (
     <AISelector

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -155,7 +155,11 @@ export default function AgentPanes({
   // The pane bar selector's switch decision needs to know which of the
   // session's conversations already exist, per agent — the same list the
   // sidebar's expansion already shows.
-  const { data: sessionsData } = useSWR(
+  const {
+    data: sessionsData,
+    isLoading: sessionConversationsLoading,
+    mutate: mutateSessionConversations,
+  } = useSWR(
     driveId !== null ? `/api/agent-sessions?driveId=${encodeURIComponent(driveId)}` : '/api/agent-sessions',
     sessionsFetcher,
     { revalidateOnFocus: false, refreshInterval: 20_000 },
@@ -163,6 +167,33 @@ export default function AgentPanes({
   const sessionConversations: SessionConversationSummary[] = useMemo(
     () => (sessionsData?.sessions ?? []).find((session) => session.sessionId === sessionId)?.conversations ?? [],
     [sessionsData, sessionId],
+  );
+
+  // A successful mint writes straight into the pane store, but the switch
+  // DECISION reads `sessionConversations` from this SWR cache, which only
+  // catches up on its next 20s poll. Left alone, switching away from a
+  // freshly-minted agent and back to it inside that window re-runs
+  // `selectPaneAgent` against a list that still doesn't know the mint
+  // happened — a second `mint` for the same agent, a duplicate conversation.
+  // Writing the new row in here, locally, closes that window without
+  // waiting on the network.
+  const recordMintedConversation = useCallback(
+    (conversationId: string, agentPageId: string | null) => {
+      void mutateSessionConversations((current) => {
+        if (!current) return current;
+        return {
+          sessions: current.sessions.map((session) =>
+            session.sessionId === sessionId
+              ? {
+                  ...session,
+                  conversations: [{ conversationId, agentPageId, lastMessageAt: null }, ...session.conversations],
+                }
+              : session,
+          ),
+        };
+      }, { revalidate: false });
+    },
+    [mutateSessionConversations, sessionId],
   );
 
   // Selection IS an instruction to show the conversation (review M1): on
@@ -299,6 +330,7 @@ export default function AgentPanes({
           return;
         }
         assignPane(sessionId, paneId, { kind: 'chat', name: 'New conversation', targetId: conversationId, agentPageId });
+        recordMintedConversation(conversationId, agentPageId);
       } catch (error) {
         console.error('Failed to start a conversation in this pane:', error);
         toast.error('Could not start a conversation', {
@@ -307,7 +339,7 @@ export default function AgentPanes({
         resetPane(sessionId, paneId);
       }
     },
-    [assignPane, resetPane, sessionId, paneStillExists, cleanupOrphanedConversation],
+    [assignPane, resetPane, sessionId, paneStillExists, cleanupOrphanedConversation, recordMintedConversation],
   );
 
   // The pane bar selector's switch — focus-or-mint, decided by the pure
@@ -404,6 +436,7 @@ export default function AgentPanes({
                 surface={surface}
                 pickableAgents={pickableAgents}
                 agentsLoading={driveId !== null && agentsLoading}
+                conversationsLoading={sessionConversationsLoading}
                 driveId={driveId}
                 onSelectAgent={(nextAgentPageId) =>
                   handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)
@@ -494,6 +527,7 @@ function ChatPaneIdentity({
   surface,
   pickableAgents,
   agentsLoading,
+  conversationsLoading,
   driveId,
   onSelectAgent,
 }: {
@@ -502,6 +536,14 @@ function ChatPaneIdentity({
   surface: PaneSurface;
   pickableAgents: PickableAgent[];
   agentsLoading: boolean;
+  /**
+   * Still on the FIRST fetch of the session's conversation list. Before that
+   * list has ever loaded, `selectPaneAgent` sees an empty array — indistinguishable
+   * from "no conversation with this agent exists yet" — and a switch to an
+   * agent that already HAS a thread would wrongly mint a duplicate instead of
+   * focusing it. Disabled here rather than raced.
+   */
+  conversationsLoading: boolean;
   driveId: string | null;
   onSelectAgent: (agentPageId: string | null) => void;
 }) {
@@ -513,9 +555,10 @@ function ChatPaneIdentity({
   // (`useAssistantSessionChat`'s own scoping, mirrored here).
   const streamPageId = scope.agentPageId ?? (user?.id ? globalChannelId(user.id) : null);
   const activeStream = useConversationActiveStream(streamPageId, conversationId);
-  // Mid-mint (the row isn't there yet) or mid-stream: switching now has
-  // nothing stable to point at, or would abandon a running send.
-  const disabled = surface.surface === 'loading' || activeStream !== undefined;
+  // Mid-mint (the row isn't there yet), mid-stream, or the switch decision's
+  // own data hasn't loaded yet: none of these have anything safe to switch
+  // against.
+  const disabled = surface.surface === 'loading' || activeStream !== undefined || conversationsLoading;
 
   return (
     <AISelector

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -378,7 +378,7 @@ describe('AgentPanes', () => {
       });
     }
 
-    /** Every interactive test needs the switch-decision data loaded first — see the disabled-while-loading test below for why. */
+    /** Every interactive test needs THIS session's entry present in the switch-decision data first — see the readiness tests below for why. */
     async function findEnabledSelector(name: RegExp) {
       const button = await screen.findByRole('button', { name });
       await waitFor(() => expect(button).not.toBeDisabled());
@@ -391,12 +391,12 @@ describe('AgentPanes', () => {
       expect(await screen.findByRole('button', { name: /Researcher/ })).toBeInTheDocument();
     });
 
-    it('is disabled until the session conversation list — the switch decision\'s own data — has loaded at least once', async () => {
+    it("is disabled until THIS session's entry appears in the switch decision's own data", async () => {
       let resolveSessions!: () => void;
       mockFetchWithAuth.mockImplementation(async (url: string) => {
         if (url.includes('/api/agent-sessions')) {
           return new Promise((resolve) => {
-            resolveSessions = () => resolve(jsonOk({ sessions: [] }));
+            resolveSessions = () => resolve(jsonOk({ sessions: [{ sessionId: 'ses-1', conversations: [] }] }));
           });
         }
         return jsonOk(defaultFetchRoute(url));
@@ -409,6 +409,41 @@ describe('AgentPanes', () => {
 
       resolveSessions();
       await waitFor(() => expect(button).not.toBeDisabled());
+    });
+
+    it('stays disabled when the initial sessions fetch fails outright (SWR isLoading goes false with no data)', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/api/agent-sessions')) return { ok: false, status: 500, json: async () => ({}) };
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const button = await screen.findByRole('button', { name: /Researcher/ });
+      // Give SWR's failed fetch time to settle (isLoading -> false) — the
+      // gate must not key off that; it must still see no data for THIS
+      // session and stay disabled.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(button).toBeDisabled();
+    });
+
+    it('stays disabled when the shared drive-level cache is already warm but does not yet list THIS session (a session spawned after the last successful fetch)', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/api/agent-sessions')) {
+          // Warm cache, real data, but for a DIFFERENT session — exactly
+          // what a shared per-drive SWR key can already hold when a brand
+          // new session opens.
+          return jsonOk({ sessions: [{ sessionId: 'some-other-session', conversations: [] }] });
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
+      );
+
+      expect(await screen.findByRole('button', { name: /Researcher/ })).toBeDisabled();
     });
 
     it('selecting the pane\'s current agent again is a no-op', async () => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -378,20 +378,44 @@ describe('AgentPanes', () => {
       });
     }
 
+    /** Every interactive test needs the switch-decision data loaded first — see the disabled-while-loading test below for why. */
+    async function findEnabledSelector(name: RegExp) {
+      const button = await screen.findByRole('button', { name });
+      await waitFor(() => expect(button).not.toBeDisabled());
+      return button;
+    }
+
     it("shows the pane's current agent as the bar identity", async () => {
       renderPanes();
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
       expect(await screen.findByRole('button', { name: /Researcher/ })).toBeInTheDocument();
     });
 
+    it('is disabled until the session conversation list — the switch decision\'s own data — has loaded at least once', async () => {
+      let resolveSessions!: () => void;
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/api/agent-sessions')) {
+          return new Promise((resolve) => {
+            resolveSessions = () => resolve(jsonOk({ sessions: [] }));
+          });
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const button = await screen.findByRole('button', { name: /Researcher/ });
+      expect(button).toBeDisabled();
+
+      resolveSessions();
+      await waitFor(() => expect(button).not.toBeDisabled());
+    });
+
     it('selecting the pane\'s current agent again is a no-op', async () => {
       mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
       renderPanes();
-      await waitFor(() =>
-        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
-      );
       const user = userEvent.setup();
-      await user.click(await screen.findByRole('button', { name: /Researcher/ }));
+      await user.click(await findEnabledSelector(/Researcher/));
       await user.click(await screen.findByRole('menuitem', { name: /Researcher/ }));
 
       expect(mockPost).not.toHaveBeenCalled();
@@ -407,11 +431,8 @@ describe('AgentPanes', () => {
         { conversationId: 'conv-existing-2', agentPageId: 'agent-2' },
       ]);
       renderPanes();
-      await waitFor(() =>
-        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
-      );
       const user = userEvent.setup();
-      await user.click(await screen.findByRole('button', { name: /Researcher/ }));
+      await user.click(await findEnabledSelector(/Researcher/));
       await user.click(await screen.findByText('Writer'));
 
       expect(mockPost).not.toHaveBeenCalled();
@@ -428,11 +449,8 @@ describe('AgentPanes', () => {
       mockPost.mockResolvedValue({});
       mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
       renderPanes();
-      await waitFor(() =>
-        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
-      );
       const user = userEvent.setup();
-      await user.click(await screen.findByRole('button', { name: /Researcher/ }));
+      await user.click(await findEnabledSelector(/Researcher/));
       await user.click(await screen.findByText('Writer'));
 
       await waitFor(() =>
@@ -444,7 +462,45 @@ describe('AgentPanes', () => {
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('new-id-1'));
     });
 
+    it('records the freshly minted conversation locally, so switching straight back to it focuses rather than mints again', async () => {
+      mockPost.mockResolvedValue({});
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+      renderPanes();
+      const user = userEvent.setup();
+      await user.click(await findEnabledSelector(/Researcher/));
+      await user.click(await screen.findByText('Writer'));
+      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('new-id-1'));
+
+      // Switch back to the ORIGINAL agent, then forward to the one just
+      // minted — all inside the SWR poll's 20s window, with the sessions
+      // endpoint still answering its ORIGINAL (pre-mint) fixture. Without a
+      // local record of the mint, this reaches `selectPaneAgent` with a list
+      // that still doesn't know agent-2 has a thread — a second mint.
+      await user.click(await findEnabledSelector(/Writer/));
+      await user.click(await screen.findByRole('menuitem', { name: /Researcher/ }));
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].scope).toMatchObject({
+          targetId: 'conv-1',
+        }),
+      );
+
+      await user.click(await findEnabledSelector(/Researcher/));
+      await user.click(await screen.findByRole('menuitem', { name: /Writer/ }));
+
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].scope).toMatchObject({
+          targetId: 'new-id-1',
+          agentPageId: 'agent-2',
+        }),
+      );
+      // Exactly the one mint from the first switch — the second forward
+      // switch focused the recorded conversation instead of minting again.
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+
     it("disables the selector while the pane's chat is streaming", async () => {
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
       usePendingStreamsStore.getState().addStream({
         messageId: 'msg-1',
         pageId: 'agent-1',
@@ -454,6 +510,11 @@ describe('AgentPanes', () => {
       });
       renderPanes();
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      // Let the (now-loaded) conversation list rule itself out as the cause,
+      // isolating the assertion to the streaming guard.
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(expect.stringContaining('/api/agent-sessions?driveId=drive-1')),
+      );
 
       expect(await screen.findByRole('button', { name: /Researcher/ })).toBeDisabled();
     });

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -534,6 +534,43 @@ describe('AgentPanes', () => {
       expect(mockPost).toHaveBeenCalledTimes(1);
     });
 
+    it('records a freshly minted GLOBAL ASSISTANT conversation locally too (agentPageId: null), so switching back focuses rather than re-mints', async () => {
+      mockPost.mockResolvedValue({});
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+      renderPanes();
+      const user = userEvent.setup();
+      await user.click(await findEnabledSelector(/Researcher/));
+      await user.click(await screen.findByRole('menuitem', { name: 'Global Assistant' }));
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations', {
+          conversationId: 'new-id-1',
+        }),
+      );
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('new-id-1'));
+
+      // Same race as the named-agent case, for the null-agentPageId branch:
+      // switch away then back inside the poll window, sessions fixture
+      // never updated.
+      await user.click(await findEnabledSelector(/Global Assistant/));
+      await user.click(await screen.findByRole('menuitem', { name: /Researcher/ }));
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].scope).toMatchObject({
+          targetId: 'conv-1',
+        }),
+      );
+
+      await user.click(await findEnabledSelector(/Researcher/));
+      await user.click(await screen.findByRole('menuitem', { name: /Global Assistant/ }));
+
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].scope).toMatchObject({
+          targetId: 'new-id-1',
+          agentPageId: null,
+        }),
+      );
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+
     it("disables the selector while the pane's chat is streaming", async () => {
       mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
       usePendingStreamsStore.getState().addStream({

--- a/tasks/reviews/pu-pane-agent-selector-followup.md
+++ b/tasks/reviews/pu-pane-agent-selector-followup.md
@@ -85,11 +85,9 @@ something happen," it asks the one question the switch decision actually depends
   mints from different panes in the same session in quick succession both land, neither overwrites the
   other. No test added (would require reaching into SWR's internal mutate queue to observe ordering);
   reasoned through the SWR contract instead.
-- [ ] **minor, not actioned** · test coverage gap · No test exercises `recordMintedConversation` for a
-  `null` (Global Assistant) `agentPageId` specifically — the function is parameterized identically for
-  both cases and the existing agent-2 test exercises the same code path, so this is symmetric-logic
-  coverage rather than a distinct branch. Flagging so it isn't silently forgotten if
-  `recordMintedConversation` ever grows agent-specific branching.
+- [x] **minor, fixed** · test coverage gap · No test exercised `recordMintedConversation` for a `null`
+  (Global Assistant) `agentPageId`. Cheap and directly in-scope, so added rather than left noted:
+  "records a freshly minted GLOBAL ASSISTANT conversation locally too."
 - [ ] **not a defect** · perpetual-disable-on-a-permanently-denied-fetch · If `/api/agent-sessions`
   ever answers with a durable, non-recovering failure for this session specifically (not the transient
   case the new test covers — that one still resolves via SWR's retry/poll), the selector stays
@@ -99,8 +97,8 @@ something happen," it asks the one question the switch decision actually depends
   (same shape). No action.
 
 **Verdict: 2 blockers-in-practice found and fixed across two review rounds / 0 majors remaining /
-0 minors actioned / 1 minor noted-not-actioned / 2 nits verified.** Both original Codex findings from
-#2276 are now fixed with a gate that doesn't share their own failure mode, each covered by a
-regression test that fails on revert (traced by hand). No security-relevant surface touched
+1 minor fixed / 2 nits verified.** Both original Codex findings from #2276 are now fixed with a gate
+that doesn't share their own failure mode, each covered by a regression test that fails on revert
+(traced by hand). No security-relevant surface touched
 (client-side SWR cache + a disabled boolean; no new network requests, no auth/permission code, no user
 input handling). Merge-ready.

--- a/tasks/reviews/pu-pane-agent-selector-followup.md
+++ b/tasks/reviews/pu-pane-agent-selector-followup.md
@@ -1,17 +1,17 @@
 # Code Review — `pu/pane-agent-selector-followup` (PR #2278)
 
 Reviewed 2026-07-30 against `origin/master` (merge-base `e672903788e87ad64b1204aea2b7fe7fa6e5dd10`, the
-merge commit for #2276). 2 files changed, 121 insertions / 17 deletions, both in
-`apps/web/src/components/agents/panes/`.
+merge commit for #2276). Two review rounds on this branch itself (see "Second round" below) — this log
+reflects the FINAL state, not the intermediate one.
 
 Scope: a narrow follow-up to PR #2276 (restore the per-pane agent selector). #2276 merged before its
 Codex review finished; both findings it raised were real, so they land here instead of a push to the
 already-merged branch.
 
-Gates run locally, all green:
+Gates run locally, all green (final state):
 - `bun run typecheck` (apps/web, `tsc --noEmit` — clean `.next/types` rebuild) ✅
 - `bun run lint` (apps/web) ✅ — only pre-existing warnings in unrelated files
-- `bun x vitest run` on `select-pane-agent.test.ts`, `AISelector.test.tsx`, `AgentPanes.test.tsx` — 38/38 ✅
+- `bun x vitest run` on `select-pane-agent.test.ts`, `AISelector.test.tsx`, `AgentPanes.test.tsx` — 40/40 ✅
 - `bun run knip:check` ✅ within baseline
 
 The PageSpace board was not consulted for this review: `pagespace whoami` resolves to an unrelated
@@ -22,50 +22,85 @@ here per the review skill's no-board fallback, matching this repo's existing con
 
 ## What changed and why
 
-Two staleness races in the pane bar selector's switch decision (`selectPaneAgent`, unchanged — the
-data feeding it was the bug):
+Both Codex findings from #2276 share one root cause: `selectPaneAgent`'s switch decision reads
+`sessionConversations` (an SWR-backed list, `selectPaneAgent` itself unchanged throughout), which can
+legitimately lag what has actually happened — not loaded yet, not yet revalidated after a mint this
+tab just made, or (see second round below) present but not yet covering THIS session.
 
-1. **Cold-mount race** (Codex, [#2276 discussion_r3683989069](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989069)):
-   before the session's conversation list (`sessionConversations`, SWR-backed) loads even once, it
-   reads as `[]` — indistinguishable from "no thread yet." If the agent-picker's OWN list
-   (`pickableAgents`, a separate faster fetch) was already warm, a user could switch agents before the
-   conversation list caught up, and picking an agent that already had a thread would wrongly `mint` a
-   duplicate. Fixed: `sessionConversationsLoading` (SWR's own `isLoading`) folds into the selector's
-   existing `disabled` condition.
-2. **Post-mint staleness** (Codex, [#2276 discussion_r3683989078](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989078)):
+1. **Cold-mount race** (Codex, [#2276 r3683989069](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989069)):
+   before the list loads even once, it reads as `[]` — indistinguishable from "no thread yet." If the
+   agent-picker's own list was already warm, a user could switch before the conversation list caught
+   up and mint a duplicate for an agent that already had a thread.
+2. **Post-mint staleness** (Codex, [#2276 r3683989078](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989078)):
    a successful mint wrote straight into the pane store, but `sessionConversations` only caught up on
-   its next 20s SWR poll. Switching away from the freshly-minted agent and back within that window
-   re-ran the decision against a list that still didn't know the mint happened — a second mint. Fixed:
-   `recordMintedConversation` writes the new row into the SWR cache locally (`mutate(fn, {revalidate:
-   false})`) right after a successful mint, correctly reconciled by the next real poll rather than
-   racing it.
+   its next 20s SWR poll — switching away and back within that window minted a second duplicate.
+   Fixed by `recordMintedConversation`: writes the new row into the SWR cache locally
+   (`mutate(fn, {revalidate: false})`) right after a successful mint, reconciled by the next real poll.
+
+## First-round fix, and what was wrong with it
+
+The first push gated the selector on SWR's own `isLoading` flag. **This was an incomplete fix that my
+own self-review (recorded in this file's first version) explicitly rated "not a defect" and declined
+to act on — that call was wrong.** Two follow-up review passes caught what it missed:
+
+- **CodeRabbit (major)**: SWR's `isLoading` becomes `false` once a fetch *settles*, including on
+  ERROR — not once real data exists. An initial-fetch failure leaves `sessionsData` `undefined`
+  forever while `isLoading` reads `false`, silently re-opening finding 1.
+- **Codex, second pass (P1)**: the SWR key is a *shared, per-drive* cache, already warm from before a
+  brand-new session was spawned. `isLoading` (or even `sessionsData !== undefined`, CodeRabbit's own
+  suggested fix) reads "ready" the instant ANY data exists for that drive — even if the array has no
+  entry for the session that just opened. Same symptom as finding 1, dressed differently.
+
+Both share the actual bug: a *loading flag* is a proxy for "did a fetch resolve," not for "do we have
+the one fact the decision needs" (whether THIS session's row is in the cache). Proxies for readiness
+are exactly the class of bug this whole PR exists to fix in the first place — using one to gate the
+fix was the same mistake at one remove.
+
+## Second-round fix
+
+Replaced the `isLoading`-based gate with presence: `sessionKnownToConversationsCache` — does the
+session's own entry exist in `sessionsData.sessions`, looked up once via `currentSessionConversationsEntry`
+and reused for both the conversation list and the readiness check. This single condition subsumes
+every case above (cold mount, fetch error, warm-but-incomplete cache) because it doesn't ask "did
+something happen," it asks the one question the switch decision actually depends on.
 
 ## Findings
 
-- [x] **nit** · `AgentPanes.tsx:332-333` (verified, no code change needed) · Confirmed
-  `recordMintedConversation` is called ONLY after the `paneStillExists` early-return for a pane closed
-  mid-mint — an orphaned mint (cleaned up server-side via `cleanupOrphanedConversation`) is correctly
-  never recorded into `sessionConversations`. Traced the exact statement order to rule out a
-  false-positive record of a conversation about to be deleted.
-- [x] **nit** · concurrent-mint composition (verified, no code change needed) · `mutateSessionConversations`
-  uses a functional updater (`(current) => {...}`), which SWR serializes against its own cache rather
-  than a stale closure — two mints from different panes in the same session in quick succession both
-  land, neither overwrites the other. No test added (would require reaching into SWR's internal
-  mutate queue to observe ordering); reasoned through the SWR contract instead.
+- [x] **major, fixed** · `AgentPanes.tsx` (first-round `sessionConversationsLoading`) · `isLoading`
+  reads `false` after an error with `sessionsData` still `undefined` — selector wrongly re-enables,
+  reopening the exact race the gate exists to close. Fixed by keying readiness off cache presence
+  instead of a loading flag (see above). New test: "stays disabled when the initial sessions fetch
+  fails outright."
+- [x] **P1, fixed** · `AgentPanes.tsx` (first-round gate, any loading/undefined-based formulation) ·
+  A brand-new session can be absent from an already-warm, per-drive-shared SWR cache — no loading-flag
+  formulation catches this, only checking for the session's actual presence does. Fixed by the same
+  presence-based gate. New test: "stays disabled when the shared drive-level cache is already warm but
+  does not yet list THIS session."
+- [x] **nit** · `AgentPanes.tsx` (`recordMintedConversation` call site) · Confirmed it is called ONLY
+  after the `paneStillExists` early-return for a pane closed mid-mint — an orphaned mint (cleaned up
+  server-side) is correctly never recorded into `sessionConversations`. Traced the exact statement
+  order to rule out a false-positive record of a conversation about to be deleted.
+- [x] **nit** · concurrent-mint composition · `mutateSessionConversations` uses a functional updater
+  (`(current) => {...}`), which SWR serializes against its own cache rather than a stale closure — two
+  mints from different panes in the same session in quick succession both land, neither overwrites the
+  other. No test added (would require reaching into SWR's internal mutate queue to observe ordering);
+  reasoned through the SWR contract instead.
 - [ ] **minor, not actioned** · test coverage gap · No test exercises `recordMintedConversation` for a
   `null` (Global Assistant) `agentPageId` specifically — the function is parameterized identically for
   both cases and the existing agent-2 test exercises the same code path, so this is symmetric-logic
-  coverage rather than a distinct branch. Left out of scope for this narrowly-targeted fix; flagging so
-  it isn't silently forgotten if `recordMintedConversation` ever grows agent-specific branching.
-- [ ] **not a defect** · perpetual-disable-on-hang · If the `/api/agent-sessions` fetch never settles
-  (a true network hang, no timeout anywhere in this stack), `sessionConversationsLoading` stays `true`
-  forever and the selector never enables. This matches the existing, unrelated `agentsLoading` gate on
-  `PanePicker` (same shape, same lack of a timeout) — not a regression this PR introduces, and there is
-  no established timeout convention elsewhere in this codebase to diverge toward. No action.
+  coverage rather than a distinct branch. Flagging so it isn't silently forgotten if
+  `recordMintedConversation` ever grows agent-specific branching.
+- [ ] **not a defect** · perpetual-disable-on-a-permanently-denied-fetch · If `/api/agent-sessions`
+  ever answers with a durable, non-recovering failure for this session specifically (not the transient
+  case the new test covers — that one still resolves via SWR's retry/poll), the selector stays
+  disabled indefinitely. `AgentPanes` only renders behind the same admin + session-membership gate the
+  fetch itself checks, so this session's own entry SHOULD always be reachable for a user who can see
+  this component at all. Consistent with the existing, unrelated `agentsLoading` gate on `PanePicker`
+  (same shape). No action.
 
-**Verdict: 0 blockers / 0 majors / 0 minors actioned / 1 minor noted-not-actioned / 2 nits verified.**
-Both Codex findings from #2276 are correctly and narrowly fixed, with a regression test per fix that
-would fail on a revert (traced by hand: removing `recordMintedConversation`'s call site makes the new
-switch-back-then-forward test fail on `mockPost` call count). No security-relevant surface touched
+**Verdict: 2 blockers-in-practice found and fixed across two review rounds / 0 majors remaining /
+0 minors actioned / 1 minor noted-not-actioned / 2 nits verified.** Both original Codex findings from
+#2276 are now fixed with a gate that doesn't share their own failure mode, each covered by a
+regression test that fails on revert (traced by hand). No security-relevant surface touched
 (client-side SWR cache + a disabled boolean; no new network requests, no auth/permission code, no user
 input handling). Merge-ready.

--- a/tasks/reviews/pu-pane-agent-selector-followup.md
+++ b/tasks/reviews/pu-pane-agent-selector-followup.md
@@ -1,0 +1,71 @@
+# Code Review — `pu/pane-agent-selector-followup` (PR #2278)
+
+Reviewed 2026-07-30 against `origin/master` (merge-base `e672903788e87ad64b1204aea2b7fe7fa6e5dd10`, the
+merge commit for #2276). 2 files changed, 121 insertions / 17 deletions, both in
+`apps/web/src/components/agents/panes/`.
+
+Scope: a narrow follow-up to PR #2276 (restore the per-pane agent selector). #2276 merged before its
+Codex review finished; both findings it raised were real, so they land here instead of a push to the
+already-merged branch.
+
+Gates run locally, all green:
+- `bun run typecheck` (apps/web, `tsc --noEmit` — clean `.next/types` rebuild) ✅
+- `bun run lint` (apps/web) ✅ — only pre-existing warnings in unrelated files
+- `bun x vitest run` on `select-pane-agent.test.ts`, `AISelector.test.tsx`, `AgentPanes.test.tsx` — 38/38 ✅
+- `bun run knip:check` ✅ within baseline
+
+The PageSpace board was not consulted for this review: `pagespace whoami` resolves to an unrelated
+project's drive set (per this session's own working context — the `pagespace-cli` companion tool,
+not this webapp), and no page in this repo's own board was named as the target. Findings are recorded
+here per the review skill's no-board fallback, matching this repo's existing convention
+(`pu-machine-pane-fixes.md`, `pu-activity-log-fk.md`).
+
+## What changed and why
+
+Two staleness races in the pane bar selector's switch decision (`selectPaneAgent`, unchanged — the
+data feeding it was the bug):
+
+1. **Cold-mount race** (Codex, [#2276 discussion_r3683989069](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989069)):
+   before the session's conversation list (`sessionConversations`, SWR-backed) loads even once, it
+   reads as `[]` — indistinguishable from "no thread yet." If the agent-picker's OWN list
+   (`pickableAgents`, a separate faster fetch) was already warm, a user could switch agents before the
+   conversation list caught up, and picking an agent that already had a thread would wrongly `mint` a
+   duplicate. Fixed: `sessionConversationsLoading` (SWR's own `isLoading`) folds into the selector's
+   existing `disabled` condition.
+2. **Post-mint staleness** (Codex, [#2276 discussion_r3683989078](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989078)):
+   a successful mint wrote straight into the pane store, but `sessionConversations` only caught up on
+   its next 20s SWR poll. Switching away from the freshly-minted agent and back within that window
+   re-ran the decision against a list that still didn't know the mint happened — a second mint. Fixed:
+   `recordMintedConversation` writes the new row into the SWR cache locally (`mutate(fn, {revalidate:
+   false})`) right after a successful mint, correctly reconciled by the next real poll rather than
+   racing it.
+
+## Findings
+
+- [x] **nit** · `AgentPanes.tsx:332-333` (verified, no code change needed) · Confirmed
+  `recordMintedConversation` is called ONLY after the `paneStillExists` early-return for a pane closed
+  mid-mint — an orphaned mint (cleaned up server-side via `cleanupOrphanedConversation`) is correctly
+  never recorded into `sessionConversations`. Traced the exact statement order to rule out a
+  false-positive record of a conversation about to be deleted.
+- [x] **nit** · concurrent-mint composition (verified, no code change needed) · `mutateSessionConversations`
+  uses a functional updater (`(current) => {...}`), which SWR serializes against its own cache rather
+  than a stale closure — two mints from different panes in the same session in quick succession both
+  land, neither overwrites the other. No test added (would require reaching into SWR's internal
+  mutate queue to observe ordering); reasoned through the SWR contract instead.
+- [ ] **minor, not actioned** · test coverage gap · No test exercises `recordMintedConversation` for a
+  `null` (Global Assistant) `agentPageId` specifically — the function is parameterized identically for
+  both cases and the existing agent-2 test exercises the same code path, so this is symmetric-logic
+  coverage rather than a distinct branch. Left out of scope for this narrowly-targeted fix; flagging so
+  it isn't silently forgotten if `recordMintedConversation` ever grows agent-specific branching.
+- [ ] **not a defect** · perpetual-disable-on-hang · If the `/api/agent-sessions` fetch never settles
+  (a true network hang, no timeout anywhere in this stack), `sessionConversationsLoading` stays `true`
+  forever and the selector never enables. This matches the existing, unrelated `agentsLoading` gate on
+  `PanePicker` (same shape, same lack of a timeout) — not a regression this PR introduces, and there is
+  no established timeout convention elsewhere in this codebase to diverge toward. No action.
+
+**Verdict: 0 blockers / 0 majors / 0 minors actioned / 1 minor noted-not-actioned / 2 nits verified.**
+Both Codex findings from #2276 are correctly and narrowly fixed, with a regression test per fix that
+would fail on a revert (traced by hand: removing `recordMintedConversation`'s call site makes the new
+switch-back-then-forward test fail on `mockPost` call count). No security-relevant surface touched
+(client-side SWR cache + a disabled boolean; no new network requests, no auth/permission code, no user
+input handling). Merge-ready.


### PR DESCRIPTION
## Summary

#2276 (the per-pane agent selector restore) merged before its post-merge review finished, so its findings — all real — land here instead. Two review ROUNDS on this branch itself, because the first-round fix was itself incomplete (see below) — this description reflects the final state across all four commits.

Both original Codex findings from #2276 share one root cause: `selectPaneAgent`'s switch decision reads `sessionConversations` (an SWR-backed list), which can legitimately lag what has actually happened:

- **[Cold-mount race](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989069)**: before the list loads even once, it reads as `[]` — indistinguishable from "no thread yet." If the agent-picker's own list was already warm, a user could switch before the conversation list caught up and mint a duplicate for an agent that already had a thread.
- **[Post-mint staleness](https://github.com/2witstudios/PageSpace/pull/2276#discussion_r3683989078)**: a successful mint wrote straight into the pane store, but `sessionConversations` only caught up on its next 20s SWR poll — switching away and back within that window minted a second duplicate. Fixed by `recordMintedConversation`: writes the new row into the SWR cache locally (`mutate(fn, {revalidate: false})`) right after a successful mint.

**The first-round fix (gating the selector on SWR's `isLoading`) was itself incomplete** — flagged as "not a defect" in my own review of that commit, which was the wrong call. Two follow-up passes on THIS PR caught what it missed:

- **CodeRabbit (major)**: `isLoading` reads `false` once a fetch *settles*, including on error — not once real data exists. An initial-fetch failure left `sessionsData` `undefined` forever while `isLoading` had already gone `false`, silently reopening the cold-mount race.
- **Codex (P1)**: the SWR key is a *shared, per-drive* cache, already warm from before a brand-new session was spawned. Neither `isLoading` nor `sessionsData !== undefined` (CodeRabbit's own suggested fix) catches a real, non-empty response that simply has no row for a session this new yet.

**Final fix**: replaced the loading-flag gate with presence — `sessionKnownToConversationsCache` checks whether THIS session's own entry exists in `sessionsData.sessions` (looked up once via `currentSessionConversationsEntry`, reused for both the conversation list and the readiness check). One condition, subsumes cold mount, fetch error, and warm-but-incomplete cache alike, because it asks the one fact the decision actually depends on instead of a proxy for "did something happen."

Full write-up, including the self-critique of the first-round miss: `tasks/reviews/pu-pane-agent-selector-followup.md`.

## Test plan

- [x] `bun run typecheck` (apps/web, `tsc --noEmit` — clean `.next/types` rebuild)
- [x] `bun run lint` (apps/web) — only pre-existing warnings in unrelated files
- [x] `bun x vitest run` on `select-pane-agent.test.ts`, `AISelector.test.tsx`, `AgentPanes.test.tsx` — 41/41 green, including: disabled while the switch-decision data is loading; disabled on an outright initial-fetch failure; disabled when the shared per-drive cache is warm but doesn't yet list this session; switch-back-then-forward mints exactly once (named agent AND Global Assistant)
- [x] `bun run test:unit` (full monorepo, local) — 15,179 passed, 1 pre-existing unrelated failure (`src/lib/messages/__tests__/grouping.test.ts`, a timezone-dependent test in a file this branch never touches)
- [x] `bun run knip:check` — within baseline
- [ ] Manual: `bun run dev` → Agents console → switch a pane's agent rapidly back and forth right after a fresh page load and right after minting a new conversation — confirm no duplicate conversations appear in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfWmmVg3RqktRfAHtzEikF