### PR TITLE
fix(agents): dashboard sidebar lists every drive — roster-first session groups

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -17,13 +17,13 @@ import PrimaryNavigation from './PrimaryNavigation';
 import { SidebarLoading, SidebarNotice } from './sidebar-states';
 import { useAuth } from '@/hooks/useAuth';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
-import { useDriveStore } from '@/hooks/useDrive';
+import { useDriveStore, type Drive } from '@/hooks/useDrive';
 import { canManageDrive } from '@/hooks/usePermissions';
 import { usePageAgents, type DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
 import { useAgentSurfaceStore, SHEET_BREAKPOINT_QUERY } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
-import { groupSessionsByDrive, ASSISTANT_GROUP_KEY } from './session-groups';
+import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 
 /**
  * The Agents console's left sidebar: **Drive → Session → conversations.**
@@ -107,6 +107,7 @@ export default function AgentsSidebar({ className }: SidebarProps) {
               authLoading={authLoading}
               isAdmin={isAdmin}
               driveId={driveId}
+              drives={drives}
               sessions={data?.sessions ?? []}
               isLoading={sessionsLoading && !data}
               hasError={!!sessionsError}
@@ -190,6 +191,7 @@ function SessionList({
   authLoading,
   isAdmin,
   driveId,
+  drives,
   sessions,
   isLoading,
   hasError,
@@ -200,6 +202,7 @@ function SessionList({
   authLoading: boolean;
   isAdmin: boolean;
   driveId: string | undefined;
+  drives: Drive[];
   sessions: SessionListEntry[];
   isLoading: boolean;
   hasError: boolean;
@@ -218,33 +221,30 @@ function SessionList({
   });
 
   const canSpawn = isAdmin && !authLoading;
-  // The Assistant group exists in global mode even with zero sessions — the
-  // affordance to start one IS the group. Not while loading or on a dead
-  // fetch, though: an offer to spawn under a spinner would remount mid-click.
-  const showEmptyAssistantGroup = !driveId && canSpawn && !isLoading && !(hasError && sessions.length === 0);
 
-  // Group by drive in global mode (Assistant first — it is the user's own,
-  // sorted there deterministically rather than by fetch order); a single
-  // implicit group in drive mode.
+  // The roster — every drive the user can work in, whether or not it has a
+  // live session — is the canonical drive-group source in global mode. Not
+  // `agentsByDrive`: that fetch's drive enumeration is an implementation
+  // detail of the multi-drive agents feature, and coupling the sidebar's
+  // drive list to it would regress silently if that feature's shape changes.
+  const roster = useMemo(() => drives.map((d) => ({ driveId: d.id, driveName: d.name })), [drives]);
+
+  // Group by drive in global mode (roster ∪ session-implied drives, Assistant
+  // first — see session-groups.ts for the ordering rule); a single implicit
+  // group in drive mode.
   const groups = useMemo(() => {
-    if (driveId) return sessions.length > 0 || notice === null ? [{ driveId, sessions }] : [];
-    return groupSessionsByDrive(sessions, { seedEmptyAssistantGroup: showEmptyAssistantGroup });
-  }, [driveId, sessions, notice, showEmptyAssistantGroup]);
-
-  const driveTitle = useCallback(
-    (id: string) => {
-      if (id === ASSISTANT_GROUP_KEY) return 'Assistant';
-      return agentsByDrive.find((entry) => entry.driveId === id)?.driveName ?? id;
-    },
-    [agentsByDrive],
-  );
+    if (driveId) return sessions.length > 0 || notice === null ? [{ driveId, driveName: null, sessions }] : [];
+    return buildSessionGroups(sessions, { assistant: canSpawn, drives: roster });
+  }, [driveId, sessions, notice, canSpawn, roster]);
 
   return (
     <div className="space-y-2">
       {groups.map((group) => (
         <div key={group.driveId}>
           {!driveId && (
-            <div className="px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground">{driveTitle(group.driveId)}</div>
+            <div className="px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground">
+              {group.driveName ?? group.driveId}
+            </div>
           )}
           {group.sessions.map((session) => (
             <SessionRow key={session.sessionId} session={session} onChanged={onChanged} />

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -227,7 +227,15 @@ function SessionList({
   // `agentsByDrive`: that fetch's drive enumeration is an implementation
   // detail of the multi-drive agents feature, and coupling the sidebar's
   // drive list to it would regress silently if that feature's shape changes.
-  const roster = useMemo(() => drives.map((d) => ({ driveId: d.id, driveName: d.name })), [drives]);
+  // Empty for a non-admin (or while auth is still resolving): this is a
+  // refusal-only surface for them, and `useDriveStore` can otherwise hold
+  // trashed drives too — `useGlobalDriveSocket` refetches with
+  // `includeTrash: true` on drive events — so those are filtered out to match
+  // DriveSwitcher and the multi-drive agents API, both active-drives-only.
+  const roster = useMemo(
+    () => (canSpawn ? drives.filter((d) => !d.isTrashed).map((d) => ({ driveId: d.id, driveName: d.name })) : []),
+    [canSpawn, drives],
+  );
 
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
   // first — see session-groups.ts for the ordering rule); a single implicit

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -237,6 +237,11 @@ function SessionList({
     [canSpawn, drives],
   );
 
+  // A trashed drive with a lingering session becomes an orphan group (it's
+  // excluded from the roster above) — it must still surface its existing
+  // session, but must not offer to spawn a NEW one into a trashed drive.
+  const trashedDriveIds = useMemo(() => new Set(drives.filter((d) => d.isTrashed).map((d) => d.id)), [drives]);
+
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
   // first — see session-groups.ts for the ordering rule); a single implicit
   // group in drive mode.
@@ -257,11 +262,13 @@ function SessionList({
           {group.sessions.map((session) => (
             <SessionRow key={session.sessionId} session={session} onChanged={onChanged} />
           ))}
-          <NewSessionRow
-            driveId={group.driveId === ASSISTANT_GROUP_KEY ? null : group.driveId}
-            agentsByDrive={agentsByDrive}
-            onSpawned={onChanged}
-          />
+          {!trashedDriveIds.has(group.driveId) && (
+            <NewSessionRow
+              driveId={group.driveId === ASSISTANT_GROUP_KEY ? null : group.driveId}
+              agentsByDrive={agentsByDrive}
+              onSpawned={onChanged}
+            />
+          )}
         </div>
       ))}
       {notice}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -468,6 +468,25 @@ describe('AgentsSidebar', () => {
       expect(screen.queryByText('Gamma')).toBeNull();
     });
 
+    test('a trashed drive with a lingering session keeps it visible but offers no new-session spawn', async () => {
+      // The trashed drive is excluded from the roster, so its lingering
+      // session surfaces as an orphan group (session-groups.ts never drops a
+      // session) — but that orphan group must not let an admin spawn a NEW
+      // session into a drive that was explicitly excluded for being trashed.
+      useDriveStore.setState({
+        drives: [driveFixture('drive-1', 'Alpha'), driveFixture('drive-2', 'Gamma', { isTrashed: true })],
+      });
+      respondWithSessions([{ ...SESSION, sessionId: 'ses-trashed', driveId: 'drive-2', name: 'lingering session' }]);
+      renderSidebar();
+
+      await screen.findByText('lingering session');
+      // The orphan header falls back to the raw id — the trash-filtered
+      // roster has no name to offer for it.
+      expect(within(groupContainer('drive-2')).queryByText('New session')).toBeNull();
+      // An active roster drive is unaffected.
+      expect(within(groupContainer('Alpha')).getByText('New session')).toBeDefined();
+    });
+
     test('shows no roster groups for a non-admin — refusal-only, not a dead spawn chooser', () => {
       // The admin gate must cover the roster too: previously only the
       // Assistant group's visibility was tied to admin status, so a

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -94,6 +94,19 @@ import AgentsSidebar from '../AgentsSidebar';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { useLayoutStore } from '@/stores/useLayoutStore';
+import { useDriveStore, type Drive } from '@/hooks/useDrive';
+
+const driveFixture = (id: string, name: string): Drive => ({
+  id,
+  name,
+  slug: name.toLowerCase(),
+  ownerId: 'user-1',
+  isTrashed: false,
+  trashedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  isOwned: true,
+});
 
 interface SessionFixture {
   sessionId: string;
@@ -144,6 +157,10 @@ beforeEach(() => {
     selectedAgentId: null,
   });
   useLayoutStore.setState({ leftSheetOpen: false });
+  // The roster is the canonical drive-group source in global mode — reset per
+  // test so one test's fixture never leaks into the next via the persisted
+  // store.
+  useDriveStore.setState({ drives: [] });
   mockUseAuth.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
   mockUseParams.mockReturnValue({ driveId: 'drive-1' });
   mockUsePathname.mockReturnValue('/dashboard/drive-1/agents');
@@ -406,15 +423,51 @@ describe('AgentsSidebar', () => {
       mockUsePathname.mockReturnValue('/dashboard/agents');
       window.history.replaceState({}, '', '/dashboard/agents');
       useAgentSurfaceStore.setState({ driveId: null });
+      // The roster — every drive the user can work in — is what makes a
+      // drive's group appear at all, independent of whether it has a live
+      // session. `useDriveStore` (not `agentsByDrive`) is the canonical source.
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha')] });
     });
+
+    /** The group div wrapping a header, its sessions, and its "+ New session" row. */
+    const groupContainer = (headerText: string) => screen.getByText(headerText).parentElement as HTMLElement;
 
     test('fetches every accessible session and groups them under a drive header', async () => {
       renderSidebar();
 
       expect(await screen.findByText('api refactor')).toBeDefined();
       expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/agent-sessions');
-      // The drive name resolves through the agents-by-drive fetch.
+      // The drive name resolves through the roster, not the agents-by-drive fetch.
       expect(screen.getByText('Alpha')).toBeDefined();
+    });
+
+    test('lists every roster drive, not just ones with a live session', async () => {
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha'), driveFixture('drive-2', 'Beta')] });
+      respondWithSessions([]);
+      renderSidebar();
+
+      expect(await screen.findByText('Alpha')).toBeDefined();
+      expect(screen.getByText('Beta')).toBeDefined();
+      // Every roster drive gets its own spawn affordance, whether or not it has
+      // a session — plus the Assistant group's own.
+      expect(screen.getAllByText('New session')).toHaveLength(3);
+    });
+
+    test('spawning from a roster drive with zero sessions posts its driveId + the chosen agent', async () => {
+      mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, conversationId: 'conv-new' });
+      respondWithSessions([]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('Alpha');
+      await user.click(within(groupContainer('Alpha')).getByText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', { driveId: 'drive-1', agentPageId: 'agent-1' }),
+      );
+      await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-new'));
+      expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new');
     });
 
     test('the Assistant group exists with zero sessions, and spawning it is ONE click', async () => {
@@ -427,7 +480,9 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       expect(await screen.findByText('Assistant')).toBeDefined();
-      await user.click(screen.getByText('New session'));
+      // Scoped: the roster's own drive group also renders its own "New
+      // session" row now, so an unscoped query would be ambiguous.
+      await user.click(within(groupContainer('Assistant')).getByText('New session'));
 
       await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {}));
       await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-a'));

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -96,7 +96,7 @@ import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspa
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
 
-const driveFixture = (id: string, name: string): Drive => ({
+const driveFixture = (id: string, name: string, overrides: Partial<Drive> = {}): Drive => ({
   id,
   name,
   slug: name.toLowerCase(),
@@ -106,6 +106,7 @@ const driveFixture = (id: string, name: string): Drive => ({
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
   isOwned: true,
+  ...overrides,
 });
 
 interface SessionFixture {
@@ -451,6 +452,39 @@ describe('AgentsSidebar', () => {
       // Every roster drive gets its own spawn affordance, whether or not it has
       // a session — plus the Assistant group's own.
       expect(screen.getAllByText('New session')).toHaveLength(3);
+    });
+
+    test('excludes trashed drives from the roster, matching DriveSwitcher and the multi-drive agents API', async () => {
+      // useDriveStore can legitimately hold trashed drives — useGlobalDriveSocket
+      // refetches with includeTrash: true on drive events — so the roster must
+      // filter them out itself rather than trusting the store's contents.
+      useDriveStore.setState({
+        drives: [driveFixture('drive-1', 'Alpha'), driveFixture('drive-2', 'Gamma', { isTrashed: true })],
+      });
+      respondWithSessions([]);
+      renderSidebar();
+
+      expect(await screen.findByText('Alpha')).toBeDefined();
+      expect(screen.queryByText('Gamma')).toBeNull();
+    });
+
+    test('shows no roster groups for a non-admin — refusal-only, not a dead spawn chooser', () => {
+      // The admin gate must cover the roster too: previously only the
+      // Assistant group's visibility was tied to admin status, so a
+      // non-admin with drives in the persisted store would see every
+      // roster drive's header and "+ New session" row alongside the
+      // refusal notice, each expanding into an empty chooser since
+      // usePageAgents is disabled for them.
+      mockUseAuth.mockReturnValue({ user: { role: 'user' }, isLoading: false });
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha')] });
+
+      renderSidebar();
+
+      expect(screen.getByText(/administrator privileges/i)).toBeDefined();
+      expect(screen.queryByText('Alpha')).toBeNull();
+      expect(screen.queryByText('Assistant')).toBeNull();
+      expect(screen.queryByText('New session')).toBeNull();
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
     });
 
     test('spawning from a roster drive with zero sessions posts its driveId + the chosen agent', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/session-groups.test.ts
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/session-groups.test.ts
@@ -1,46 +1,78 @@
 /**
- * The global console's drive grouping — a pure decision, kept out of the
- * component. The property worth pinning: the ASSISTANT group is
- * deterministically first because it is the user's own, not because a seeded
- * Map entry happened to be inserted before the fetch results.
+ * The global console's roster-first grouping — a pure decision, kept out of
+ * the component. Groups are the UNION of the roster (every drive the user can
+ * work in) and any drive a session names that the roster omits, so a drive
+ * with zero live sessions still gets a group (and its spawn affordance), and
+ * a session never disappears just because the roster doesn't (yet) list its
+ * drive.
  */
 import { describe, it, expect } from 'vitest';
 
-import { groupSessionsByDrive, ASSISTANT_GROUP_KEY } from '../session-groups';
+import { buildSessionGroups, ASSISTANT_GROUP_KEY } from '../session-groups';
 
 const session = (sessionId: string, driveId: string | null) => ({ sessionId, driveId });
+const drive = (driveId: string, driveName: string) => ({ driveId, driveName });
 
-describe('groupSessionsByDrive', () => {
-  it('puts the Assistant group first regardless of fetch order', () => {
-    const groups = groupSessionsByDrive(
-      [session('s1', 'drive-1'), session('s2', null), session('s3', 'drive-2')],
-      { seedEmptyAssistantGroup: false },
-    );
+describe('buildSessionGroups', () => {
+  it('renders every roster drive as a group, even with zero sessions', () => {
+    const groups = buildSessionGroups([], {
+      assistant: false,
+      drives: [drive('drive-1', 'Alpha'), drive('drive-2', 'Beta')],
+    });
+    expect(groups.map((group) => group.driveId)).toEqual(['drive-1', 'drive-2']);
+    expect(groups.every((group) => group.sessions.length === 0)).toBe(true);
+  });
+
+  it('puts the Assistant group first, then roster drives name-ascending', () => {
+    const groups = buildSessionGroups([], {
+      assistant: true,
+      drives: [drive('drive-2', 'Beta'), drive('drive-1', 'Alpha')],
+    });
     expect(groups.map((group) => group.driveId)).toEqual([ASSISTANT_GROUP_KEY, 'drive-1', 'drive-2']);
+    expect(groups.map((group) => group.driveName)).toEqual(['Assistant', 'Alpha', 'Beta']);
   });
 
-  it("keeps the server's listing order within each group, and between drives", () => {
-    const groups = groupSessionsByDrive(
-      [session('s1', 'drive-2'), session('s2', 'drive-1'), session('s3', 'drive-2')],
-      { seedEmptyAssistantGroup: false },
-    );
-    expect(groups.map((group) => group.driveId)).toEqual(['drive-2', 'drive-1']);
-    expect(groups[0].sessions.map((entry) => entry.sessionId)).toEqual(['s1', 's3']);
+  it('merges a roster drive with its sessions — union, not a duplicate group', () => {
+    const groups = buildSessionGroups([session('s1', 'drive-1'), session('s2', 'drive-1')], {
+      assistant: false,
+      drives: [drive('drive-1', 'Alpha')],
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions.map((entry) => entry.sessionId)).toEqual(['s1', 's2']);
   });
 
-  it('seeds an empty Assistant group when asked — the affordance to start one IS the group', () => {
-    const groups = groupSessionsByDrive([session('s1', 'drive-1')], { seedEmptyAssistantGroup: true });
-    expect(groups.map((group) => group.driveId)).toEqual([ASSISTANT_GROUP_KEY, 'drive-1']);
-    expect(groups[0].sessions).toEqual([]);
+  it('surfaces a session in a drive the roster omits, ordered last as an orphan', () => {
+    const groups = buildSessionGroups([session('s1', 'drive-1'), session('s2', 'drive-orphan')], {
+      assistant: false,
+      drives: [drive('drive-1', 'Alpha')],
+    });
+    expect(groups.map((group) => group.driveId)).toEqual(['drive-1', 'drive-orphan']);
+    expect(groups[1].driveName).toBeNull();
+    expect(groups[1].sessions.map((entry) => entry.sessionId)).toEqual(['s2']);
   });
 
-  it('shows no Assistant group when there are no assistant sessions and no seed', () => {
-    const groups = groupSessionsByDrive([session('s1', 'drive-1')], { seedEmptyAssistantGroup: false });
+  it('omits the Assistant group when not requested and no assistant session exists', () => {
+    const groups = buildSessionGroups([session('s1', 'drive-1')], {
+      assistant: false,
+      drives: [drive('drive-1', 'Alpha')],
+    });
     expect(groups.map((group) => group.driveId)).toEqual(['drive-1']);
   });
 
-  it('an empty listing with the seed still yields exactly the Assistant group', () => {
-    const groups = groupSessionsByDrive([], { seedEmptyAssistantGroup: true });
-    expect(groups).toEqual([{ driveId: ASSISTANT_GROUP_KEY, sessions: [] }]);
+  it('keeps the Assistant group when a session already exists there, even if not requested', () => {
+    const groups = buildSessionGroups([session('s1', null)], {
+      assistant: false,
+      drives: [],
+    });
+    expect(groups.map((group) => group.driveId)).toEqual([ASSISTANT_GROUP_KEY]);
+    expect(groups[0].sessions.map((entry) => entry.sessionId)).toEqual(['s1']);
+  });
+
+  it('breaks a roster name tie on driveId', () => {
+    const groups = buildSessionGroups([], {
+      assistant: false,
+      drives: [drive('drive-b', 'Same'), drive('drive-a', 'Same')],
+    });
+    expect(groups.map((group) => group.driveId)).toEqual(['drive-a', 'drive-b']);
   });
 });

--- a/apps/web/src/components/layout/left-sidebar/session-groups.ts
+++ b/apps/web/src/components/layout/left-sidebar/session-groups.ts
@@ -1,40 +1,76 @@
 /**
- * Groups the global console's sessions by drive, for the sidebar's tree.
- * Pure and side-effect free — the one branching decision (where the Assistant
- * group sorts) belongs here, not inline in the component render.
+ * Builds the global console's sidebar groups — pure and side-effect free.
  *
- * The Assistant group (the user's own, driveId `null`) is always FIRST,
- * regardless of where its sessions land in the fetch response — sorted
- * explicitly rather than relying on Map insertion order, which only put it
- * first when `showEmptyAssistantGroup` happened to seed the Map before any
- * drive session was iterated.
+ * Roster-first: the honest model of the dashboard sidebar is "for each place
+ * I can work (Assistant + each of my drives), show my sessions there." Groups
+ * are the UNION of the roster (every drive the user can work in, whether or
+ * not it has a live session) and any drive a returned session names but the
+ * roster omits (an orphan — surfaced rather than dropped, so a session never
+ * vanishes because of a roster gap; its name falls back to its id at the
+ * render layer since the roster is the only source of drive names here).
+ *
+ * Ordering is the one branching decision that belongs here, not inline in the
+ * component: Assistant first (when requested, or when an assistant session
+ * exists even if not requested — a session already in hand is never dropped),
+ * then roster drives name-ascending (ties broken on driveId), then orphan
+ * drives last, same tiebreak.
  */
 
 export const ASSISTANT_GROUP_KEY = 'global';
 
 export interface DriveGroup<T> {
   driveId: string;
+  driveName: string | null;
   sessions: T[];
 }
 
-export function groupSessionsByDrive<T extends { driveId: string | null }>(
+export interface RosterDrive {
+  driveId: string;
+  driveName: string;
+}
+
+function byDisplayName<T>(a: DriveGroup<T>, b: DriveGroup<T>): number {
+  const nameA = a.driveName ?? a.driveId;
+  const nameB = b.driveName ?? b.driveId;
+  return nameA.localeCompare(nameB) || a.driveId.localeCompare(b.driveId);
+}
+
+export function buildSessionGroups<T extends { driveId: string | null }>(
   sessions: T[],
-  { seedEmptyAssistantGroup }: { seedEmptyAssistantGroup: boolean },
+  { assistant, drives }: { assistant: boolean; drives: readonly RosterDrive[] },
 ): DriveGroup<T>[] {
-  const byDrive = new Map<string, T[]>(seedEmptyAssistantGroup ? [[ASSISTANT_GROUP_KEY, []]] : []);
+  const sessionsByDrive = new Map<string, T[]>();
   for (const session of sessions) {
     const key = session.driveId ?? ASSISTANT_GROUP_KEY;
-    byDrive.set(key, [...(byDrive.get(key) ?? []), session]);
+    sessionsByDrive.set(key, [...(sessionsByDrive.get(key) ?? []), session]);
   }
 
-  // A stable sort: the Assistant group moves to the front, and every other
-  // group keeps the server's original ordering relative to the others.
-  const entries = [...byDrive.entries()];
-  entries.sort(([a], [b]) => {
-    if (a === ASSISTANT_GROUP_KEY) return -1;
-    if (b === ASSISTANT_GROUP_KEY) return 1;
-    return 0;
-  });
+  const rosterIds = new Set(drives.map((drive) => drive.driveId));
 
-  return entries.map(([driveId, list]) => ({ driveId, sessions: list }));
+  const rosterGroups = drives
+    .map((drive) => ({
+      driveId: drive.driveId,
+      driveName: drive.driveName,
+      sessions: sessionsByDrive.get(drive.driveId) ?? [],
+    }))
+    .sort(byDisplayName);
+
+  const orphanGroups = [...sessionsByDrive.keys()]
+    .filter((key) => key !== ASSISTANT_GROUP_KEY && !rosterIds.has(key))
+    .map((driveId) => ({ driveId, driveName: null, sessions: sessionsByDrive.get(driveId) ?? [] }))
+    .sort(byDisplayName);
+
+  const hasAssistantSessions = (sessionsByDrive.get(ASSISTANT_GROUP_KEY)?.length ?? 0) > 0;
+  const assistantGroup: DriveGroup<T>[] =
+    assistant || hasAssistantSessions
+      ? [
+          {
+            driveId: ASSISTANT_GROUP_KEY,
+            driveName: 'Assistant',
+            sessions: sessionsByDrive.get(ASSISTANT_GROUP_KEY) ?? [],
+          },
+        ]
+      : [];
+
+  return [...assistantGroup, ...rosterGroups, ...orphanGroups];
 }


### PR DESCRIPTION
## Summary

- `/dashboard/agents` showed only the Assistant group when the admin had no active drive sessions, because the sidebar grouped *sessions* by drive and never rendered a drive with zero sessions.
- `session-groups.ts` is reshaped into `buildSessionGroups({ assistant, drives, sessions })`: groups are the **union** of the drive roster (`useDriveStore.drives` — populated by `DriveSwitcher`'s `fetchDrives()`) and any drive a returned session names. A drive with zero live sessions still gets a group, with its own "+ New session" spawn affordance — fixing the chicken-and-egg where a drive's first session couldn't be started from the dashboard console.
- Ordering: Assistant first (when requested, or when an assistant session already exists), roster drives name-ascending (ties on `driveId`), orphan session-drives last.
- `AgentsSidebar.tsx` now reads the roster from `useDriveStore`, not `agentsByDrive` — that fetch's drive enumeration is an implementation detail of the multi-drive agents feature and shouldn't be coupled to for the sidebar's drive list. `agentsByDrive` keeps its real job: the spawn chooser's per-drive agent list.
- **Roster is gated on `canSpawn` (`isAdmin && !authLoading`)** — a non-admin sees only the refusal notice, never roster drive groups (caught by automated review, fixed).
- **Roster excludes trashed drives** (`!d.isTrashed`) — `useGlobalDriveSocket` can populate `useDriveStore` with trashed drives via `fetchDrives(true, true)`; the roster now matches `DriveSwitcher` and the multi-drive agents API's active-drives-only behavior (caught by automated review, fixed).
- **Orphan groups for trashed drives suppress the spawn row** — a trashed drive's lingering session still surfaces (no data loss), but "+ New session" is hidden for it, closing the gap the trash-filter fix above introduced (caught by automated review, fixed).
- No API changes — the driveless `GET /api/agent-sessions` already returns sessions across all drives.

This is a follow-up from the six-slice adversarial audit of the "Dev → Agents Rebuild" epic (no tracked GitHub issue number for this specific item).

## Test plan

- [x] `session-groups.test.ts` rewritten for `buildSessionGroups`: roster drives render as groups even with zero sessions; Assistant-first then name-ascending ordering; roster ∪ session union merges without duplicating a group; an orphan session-drive not in the roster still surfaces, ordered last; Assistant omitted when not requested and no assistant session exists (but kept if one already exists); name ties break on `driveId`.
- [x] `AgentsSidebar.test.tsx` global-mode describe: seeds `useDriveStore` with a roster fixture; asserts a roster drive with zero sessions renders its header + "+ New session", and spawning from it POSTs `{ driveId, agentPageId }`; verifies every roster drive gets its own spawn affordance; a non-admin sees no roster groups; a trashed drive is excluded from the roster; a trashed drive's lingering session stays visible without its own spawn row.
- [x] `bun run typecheck && bun run lint && bun run test:unit && bun run knip:check` — all pass. One pre-existing failure (`grouping.test.ts` midnight-boundary test) is a known TZ-sensitive test in a file this branch never touches; unrelated to this change.
- [ ] Manual: as admin with ≥1 drive and no active drive sessions, `/dashboard/agents` shows Assistant first, then every drive by name, each with "+ New session"; picking an agent spawns into that drive; a zero-agent drive shows "No agents in this drive yet"; `/dashboard/{driveId}/agents` behavior unchanged.

## Review notes

Two automated reviewers weighed in; all findings replied to inline or via comment:

**Codex** raised 3 findings:
1. **Fixed** — non-admin users could see roster drive groups/spawn rows alongside the refusal notice. Roster is now gated on `canSpawn`.
2. **Fixed** — trashed drives could leak into the roster via `useGlobalDriveSocket`'s `includeTrash: true` refetch. Roster now filters `isTrashed`.
3. **Investigated, not reproduced** — the claim that a growing `.map()` of `SessionRow`s remounts the trailing `NewSessionRow` sibling does not hold up; verified with an isolated React Testing Library repro (a static sibling after a growing keyed list is not remounted, consistent with React's per-slot reconciliation). No change made; explained with the repro in the thread reply.

**CodeRabbit** raised 1 nitpick, building on fix #2 above:
4. **Fixed** — a trashed drive's lingering session (an orphan group, since the drive is excluded from the roster) still exposed "+ New session", letting an admin spawn a brand-new session into a trashed drive. The row is now suppressed for such orphan groups while the existing session stays visible.

https://claude.ai/code/session_01KvHJimQTUKGE5Em4co6iKV