### PR TITLE
feat(ai): auto-title drive/page-agent conversations on first message

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -19,6 +19,7 @@ const {
   mockHasConflictingMessageOwner,
   mockTakeOverConversationStreams,
   mockCreateConversation,
+  mockAutoTitleConversation,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
@@ -29,6 +30,7 @@ const {
   mockHasConflictingMessageOwner: vi.fn().mockResolvedValue(false),
   mockTakeOverConversationStreams: vi.fn().mockResolvedValue({ aborted: [], reconciled: [] }),
   mockCreateConversation: vi.fn().mockResolvedValue(undefined),
+  mockAutoTitleConversation: vi.fn().mockResolvedValue(undefined),
 }));
 
 interface MockUIStreamOptions {
@@ -231,6 +233,7 @@ vi.mock('@/lib/repositories/conversation-repository', () => ({
     getConversation: mockGetConversation,
     hasConflictingMessageOwner: mockHasConflictingMessageOwner,
     createConversation: mockCreateConversation,
+    autoTitleConversation: mockAutoTitleConversation,
   },
 }));
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -120,6 +120,7 @@ import type { ContextRef } from '@/lib/ai/shared/buildContextRef';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { deriveConversationTitle } from '@/lib/repositories/derive-conversation-title';
 
 
 // Allow streaming responses up to 5 minutes for complex AI agent interactions
@@ -698,7 +699,18 @@ export async function POST(request: Request) {
           toolResults: undefined,
           uiMessage: userMessage,
         });
-        
+
+        // Fire-and-forget: title derivation must never fail or delay the chat
+        // response, matching how createConversation above is treated as
+        // non-fatal. existingConversation is always populated for a session's
+        // conversation (its row is created before the first message ever
+        // reaches this route) — the null check guards the non-session path.
+        if (existingConversation) {
+          conversationRepository
+            .autoTitleConversation(existingConversation.id, deriveConversationTitle(messageContent))
+            .catch(() => {});
+        }
+
         loggers.ai.debug('AI Chat API: User message saved to database');
 
         auditRequest(request, { eventType: 'data.write', userId, resourceType: 'ai_chat', resourceId: chatId, details: {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -94,6 +94,7 @@ import {
 } from '@/lib/ai/core/prompt-assembly';
 import { prepareHistoryForModel, finishModelRequest } from '@/lib/ai/core/context-assembly';
 import { resolveOrCreateConversation, ConversationOwnershipError } from './resolve-or-create-conversation';
+import { deriveConversationTitle } from '@/lib/repositories/derive-conversation-title';
 
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
@@ -536,7 +537,7 @@ export async function POST(
 
         if (!conversation.title) {
           // Auto-generate title from first user message
-          const title = messageContent.slice(0, 50) + (messageContent.length > 50 ? '...' : '');
+          const title = deriveConversationTitle(messageContent);
           updateData.title = title;
           resolvedConversationTitle = title;
         }

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -39,6 +39,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ kind: 'eq', field, value })),
   and: vi.fn((...conds) => ({ kind: 'and', conds })),
   inArray: vi.fn((field, values) => ({ kind: 'inArray', field, values })),
+  isNull: vi.fn((field) => ({ kind: 'isNull', field })),
   sql: Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       kind: 'sql',
@@ -54,6 +55,7 @@ vi.mock('@pagespace/db/schema/conversations', () => ({
     id: 'conversations.id',
     userId: 'conversations.userId',
     isShared: 'conversations.isShared',
+    title: 'conversations.title',
     updatedAt: 'conversations.updatedAt',
   },
 }));
@@ -345,6 +347,43 @@ describe('conversationRepository.createConversation', () => {
     await conversationRepository.createConversation('conv-legacy', 'attacker-user', 'machine-1', { isShared: true });
 
     expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('conversationRepository.autoTitleConversation', () => {
+  // The IS-NULL guard lives in the SQL WHERE clause, not an in-memory check —
+  // that's what makes this safe to call on every message without a separate
+  // "is this the first message" lookup, and race-safe under concurrent calls.
+  it('updates title guarded by "title IS NULL" in the WHERE clause', async () => {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mockDb.update = vi.fn().mockReturnValue({ set: setMock });
+
+    await conversationRepository.autoTitleConversation('conv_abc', 'Summarize this doc');
+
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Summarize this doc' }));
+    const predicate = whereMock.mock.calls[0][0] as { kind: string; conds: Array<{ kind: string; field?: string }> };
+    const idCond = predicate.conds.find((c) => c.field === 'conversations.id');
+    const nullTitleCond = predicate.conds.find((c) => c.kind === 'isNull');
+    expect(idCond).toBeDefined();
+    expect(nullTitleCond).toEqual({ kind: 'isNull', field: 'conversations.title' });
+  });
+
+  it('never overwrites an existing title — the guard is baked into every UPDATE\'s WHERE clause, not an in-memory check', async () => {
+    // A row with a non-null title simply matches zero rows against the
+    // "title IS NULL" predicate. There is no in-memory "if title" branch
+    // for a race to slip through — the second of two concurrent calls
+    // still issues the same guarded UPDATE and updates zero rows.
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mockDb.update = vi.fn().mockReturnValue({ set: setMock });
+
+    await conversationRepository.autoTitleConversation('conv_titled', 'New attempted title');
+
+    const predicate = whereMock.mock.calls[0][0] as { kind: string; conds: Array<{ kind: string; field?: string }> };
+    const nullTitleCond = predicate.conds.find((c) => c.kind === 'isNull');
+    expect(nullTitleCond).toEqual({ kind: 'isNull', field: 'conversations.title' });
   });
 });
 

--- a/apps/web/src/lib/repositories/__tests__/derive-conversation-title.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/derive-conversation-title.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for deriveConversationTitle.
+ *
+ * Pure string logic — PurePoint-style cleanup (ClaudeConversationIndex.swift:411-434,372-385):
+ * strip a filler prefix, take the first non-empty line, strip a leading markdown heading, then
+ * truncate to ~50 chars.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveConversationTitle } from '../derive-conversation-title';
+
+describe('deriveConversationTitle', () => {
+  it('strips a filler prefix, takes the first line, and returns it unchanged when under the cap', () => {
+    expect(deriveConversationTitle('Can you help me summarize this doc')).toBe(
+      'help me summarize this doc'
+    );
+  });
+
+  it('strips "Please" as a filler prefix', () => {
+    expect(deriveConversationTitle('Please review this PR')).toBe('review this PR');
+  });
+
+  it('strips the "Implement the following plan:" boilerplate prefix', () => {
+    expect(deriveConversationTitle('Implement the following plan: add dark mode')).toBe(
+      'add dark mode'
+    );
+  });
+
+  it('takes only the first non-empty line', () => {
+    expect(deriveConversationTitle('\n\nFirst real line\nSecond line')).toBe('First real line');
+  });
+
+  it('strips a leading markdown heading marker', () => {
+    expect(deriveConversationTitle('# Heading title')).toBe('Heading title');
+  });
+
+  it('truncates to ~50 chars with a trailing "..." when the content is cut', () => {
+    const long = 'a'.repeat(80);
+    const result = deriveConversationTitle(long);
+    expect(result).toBe('a'.repeat(50) + '...');
+  });
+
+  it('returns content unchanged (no spurious "...") when already under the length cap', () => {
+    expect(deriveConversationTitle('short message')).toBe('short message');
+  });
+
+  it('returns "" for empty content', () => {
+    expect(deriveConversationTitle('')).toBe('');
+  });
+
+  it('returns "" for whitespace-only content', () => {
+    expect(deriveConversationTitle('   \n\t  ')).toBe('');
+  });
+});

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { eq, and, sql, inArray } from '@pagespace/db/operators'
+import { eq, and, sql, inArray, isNull } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core'
 import { userActivities } from '@pagespace/db/schema/monitoring'
 import { conversations } from '@pagespace/db/schema/conversations';
@@ -433,6 +433,22 @@ export const conversationRepository = {
       .returning({ id: conversations.id, title: conversations.title });
 
     return result;
+  },
+
+  /**
+   * Auto-title a conversation from its first message, without ever
+   * overwriting a title that's already set (including a user's manual
+   * rename via upsertConversationTitle). The IS-NULL guard lives in the SQL
+   * WHERE clause rather than an in-memory check, so it's safe to call on
+   * every message — no separate "is this the first message" lookup needed
+   * — and race-safe: two concurrent calls both issue this same guarded
+   * UPDATE, and only the one that lands first actually sets a row.
+   */
+  async autoTitleConversation(conversationId: string, title: string): Promise<void> {
+    await db
+      .update(conversations)
+      .set({ title, updatedAt: new Date() })
+      .where(and(eq(conversations.id, conversationId), isNull(conversations.title)));
   },
 
   /**

--- a/apps/web/src/lib/repositories/derive-conversation-title.ts
+++ b/apps/web/src/lib/repositories/derive-conversation-title.ts
@@ -1,0 +1,26 @@
+/**
+ * Derives a short conversation title from a message's raw content.
+ * PurePoint-style cleanup (ClaudeConversationIndex.swift:411-434,372-385) —
+ * pure string logic, no LLM.
+ */
+
+const PLAN_BOILERPLATE_PREFIX_RE = /^implement the following plan:\s*/i;
+const FILLER_PREFIX_RE = /^(can you |could you |please |help me |i need to |i want to )/i;
+const LEADING_HEADING_RE = /^#+\s*/;
+const MAX_LENGTH = 50;
+
+export function deriveConversationTitle(content: string): string {
+  const cleaned = content
+    .replace(PLAN_BOILERPLATE_PREFIX_RE, '')
+    .replace(FILLER_PREFIX_RE, '');
+
+  const firstLine = cleaned
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0) ?? '';
+
+  const title = firstLine.replace(LEADING_HEADING_RE, '');
+
+  if (title.length <= MAX_LENGTH) return title;
+  return title.slice(0, MAX_LENGTH) + '...';
+}


### PR DESCRIPTION
## Summary
Phase 2 of the Sidebar Sessions epic — pure backend, disjoint from Phase 1 (running in parallel, no shared files).

- New pure helper `deriveConversationTitle(content)` (`apps/web/src/lib/repositories/derive-conversation-title.ts`): PurePoint-style cleanup — strips filler/boilerplate prefixes ("Can you", "Please", "Implement the following plan:", etc.), takes the first non-empty line, strips a leading markdown `#`, truncates to ~50 chars with a trailing `...`.
- New guarded writer `autoTitleConversation(conversationId, title)` in `conversation-repository.ts`, alongside the existing manual-rename `upsertConversationTitle`. Does `UPDATE conversations SET title = ? WHERE id = ? AND title IS NULL` — race-safe, never overwrites an existing title, safe to call on every message.
- Wired into `apps/web/src/app/api/ai/chat/route.ts` right after `saveMessageToDatabase`, fire-and-forget with a swallowed error (matches how `createConversation` is already treated as non-fatal in this route) — guarded on `existingConversation` being populated.
- Swapped the global-assistant route's inline `messageContent.slice(0, 50) + '...'` for the same shared helper, so both surfaces get identical title cleanup. The existing `if (!conversation.title)` guard is unchanged.

This unblocks Phase 4 (sidebar sub-item labels — `<Agent> — <first prompt>`), which depends on `conversations.title` actually getting populated for drive/page-agent conversations.

## Test plan
- [x] RED → GREEN unit tests for `deriveConversationTitle` (filler-stripping, first-line, heading-strip, truncation, empty input) — `apps/web/src/lib/repositories/__tests__/derive-conversation-title.test.ts`
- [x] RED → GREEN unit tests for `autoTitleConversation` (IS-NULL guard, never-overwrite) — `apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts`
- [x] Updated `stream-socket-events.test.ts`'s `conversationRepository` mock to include the new method (was missing it, breaking 13 tests that hit the guarded path)
- [x] Full test suites for `apps/web/src/app/api/ai/chat/__tests__` and `apps/web/src/app/api/ai/global/[id]/messages/__tests__` — 197 passed
- [x] `bun run typecheck` (web, scoped) — green
- [x] `bun run lint` (web, scoped) — green, only pre-existing unrelated warnings
- [ ] Manual verification (send a first message, confirm `conversations.title` populates; send a second, confirm unchanged) was **not** run against a live dev server/DB in this session — verified instead via the unit/integration test suites above plus code review of the wiring. Flagging per the "don't claim what wasn't tested" rule.

PageSpace task board (Phase 2, all 4 tasks + RED/GREEN sub-tasks) updated to 100% complete.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E6iCJ4r9A8c5HhyEJKZp4i