### PR TITLE
feat(agents): let a global-assistant session host any accessible agent

### DIFF
--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -38,7 +38,7 @@ import {
   Webhook,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import useSWR, { mutate } from 'swr';
+import { mutate } from 'swr';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -61,6 +61,7 @@ import {
   type ResolvedConversation,
 } from './useResolvedConversation';
 import { useResolvedAgent } from './useResolvedAgent';
+import { useSessionRecord } from './useSessionRecord';
 import SessionChat from './chat/SessionChat';
 import AgentPanes from './panes/AgentPanes';
 import { agentSessionsKey, isAgentSessionsKey, type SessionListEntry } from './panes/session-conversations';
@@ -70,14 +71,6 @@ import type { AgentConfig } from '@/lib/ai/shared/chat-types';
 
 export interface AgentPageViewProps {
   page: TreePage;
-}
-
-/** The session's own `driveId` (null = global-assistant session) — never the hosted agent's. */
-async function sessionDriveIdFetcher(url: string): Promise<string | null> {
-  const response = await fetchWithAuth(url);
-  if (!response.ok) throw new Error(`Failed to load session (${response.status})`);
-  const data = (await response.json()) as { session: { driveId: string | null } | null };
-  return data.session?.driveId ?? null;
 }
 
 export default function AgentPageView({ page }: AgentPageViewProps) {
@@ -107,12 +100,12 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // its `agentSessionsKey`/picker scope to a workspace this session isn't in.
   // Defaults to `page.driveId` while unresolved — correct for every
   // pre-existing conversation, and self-corrects once the session record
-  // loads for the new cross-drive case.
-  const { data: resolvedSessionDriveId } = useSWR(
-    current?.sessionId ? `/api/agent-sessions/${encodeURIComponent(current.sessionId)}` : null,
-    sessionDriveIdFetcher,
-  );
-  const panesDriveId = resolvedSessionDriveId !== undefined ? resolvedSessionDriveId : page.driveId;
+  // loads for the new cross-drive case. Checked as `sessionData?.session ? : `
+  // rather than `??` — a RESOLVED session's `driveId` can itself legitimately
+  // be `null` (a global session), which `??` would wrongly treat the same as
+  // "unresolved" and fall through to `page.driveId`.
+  const { data: sessionData } = useSessionRecord(current?.sessionId ?? null);
+  const panesDriveId = sessionData?.session ? sessionData.session.driveId : page.driveId;
 
   const [activeTab, setActiveTab] = useState<string>('chat');
   const [webhooksOpen, setWebhooksOpen] = useState(false);
@@ -221,8 +214,18 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
           // `recordMintedConversation` before it ever revalidates).
           if (created.sessionId) {
             const insertedSessionId = created.sessionId;
+            // A REUSED session (sessionId set) keeps its own drive — which for
+            // a global session hosting this cross-drive agent's conversation
+            // is NOT `page.driveId` — while a freshly SPAWNED one (sessionId
+            // null going in) is always minted scoped to this page's own drive
+            // (`createPageConversation`'s spawn branch). Using `page.driveId`
+            // unconditionally here silently patched the wrong SWR cache entry
+            // for the reused-global case (`agentSessionsKey`'s own doc
+            // comment warns against exactly this drift) — the broader
+            // `mutate(isAgentSessionsKey)` below still catches it, just not
+            // instantly.
             void mutate(
-              agentSessionsKey(page.driveId),
+              agentSessionsKey(sessionId !== null ? panesDriveId : page.driveId),
               (current: { sessions: SessionListEntry[] } | undefined) => {
                 if (!current) return current;
                 return {
@@ -282,7 +285,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
         }
       })();
     },
-    [newConversation, page.id, currentRef],
+    [newConversation, page.id, page.driveId, panesDriveId, currentRef],
   );
 
   const {
@@ -360,12 +363,18 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   const openInAgentsHref = useMemo(
     () =>
       buildAgentSelectionUrl({
-        driveId: page.driveId,
+        // The SESSION's own drive, not the hosted page's — for a global
+        // session hosting this cross-drive agent's conversation, that
+        // session only appears in the GLOBAL console (`/dashboard/agents`),
+        // not a drive-scoped one; `page.driveId` here would build a link to
+        // a console that self-corrects late (or, for the console's own
+        // pre-existing null/undefined-conflating fallback, not at all).
+        driveId: panesDriveId,
         sessionId: current?.sessionId ?? null,
         agentId: page.id,
         conversationId: current?.conversationId ?? null,
       }),
-    [page.driveId, page.id, current],
+    [panesDriveId, page.id, current],
   );
 
   if (!current) {

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -38,7 +38,7 @@ import {
   Webhook,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { mutate } from 'swr';
+import useSWR, { mutate } from 'swr';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -72,6 +72,14 @@ export interface AgentPageViewProps {
   page: TreePage;
 }
 
+/** The session's own `driveId` (null = global-assistant session) — never the hosted agent's. */
+async function sessionDriveIdFetcher(url: string): Promise<string | null> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to load session (${response.status})`);
+  const data = (await response.json()) as { session: { driveId: string | null } | null };
+  return data.session?.driveId ?? null;
+}
+
 export default function AgentPageView({ page }: AgentPageViewProps) {
   const { user, isLoading: authLoading } = useAuth();
   // The same gate every session surface uses — the server still decides
@@ -90,6 +98,21 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // The conversation on screen: the user's own switching (history select, new,
   // delete-replacement) wins over the initial resolution.
   const current = override ?? initialResolved;
+
+  // The SESSION's own driveId — usually `page.driveId`, but NOT when this
+  // conversation lives in a global-assistant session hosting a cross-drive
+  // agent (a global session may now host any accessible agent's conversation;
+  // see create-conversation-in-session.ts). `AgentPanes` needs the SESSION's
+  // real drive (null for global), never the agent page's fixed home drive, or
+  // its `agentSessionsKey`/picker scope to a workspace this session isn't in.
+  // Defaults to `page.driveId` while unresolved — correct for every
+  // pre-existing conversation, and self-corrects once the session record
+  // loads for the new cross-drive case.
+  const { data: resolvedSessionDriveId } = useSWR(
+    current?.sessionId ? `/api/agent-sessions/${encodeURIComponent(current.sessionId)}` : null,
+    sessionDriveIdFetcher,
+  );
+  const panesDriveId = resolvedSessionDriveId !== undefined ? resolvedSessionDriveId : page.driveId;
 
   const [activeTab, setActiveTab] = useState<string>('chat');
   const [webhooksOpen, setWebhooksOpen] = useState(false);
@@ -430,7 +453,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
             <AgentPanes
               key={current.sessionId}
               sessionId={current.sessionId}
-              driveId={page.driveId}
+              driveId={panesDriveId}
               initialConversation={{
                 conversationId: current.conversationId,
                 agentPageId: page.id,

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -2,26 +2,13 @@
 
 import { useCallback, useEffect } from 'react';
 import { Bot } from 'lucide-react';
-import useSWR from 'swr';
 
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { panesOf } from '@/stores/agent-workspace/pane-reducer';
-import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useLatestRef } from '@/hooks/useLatestRef';
+import { useSessionRecord } from './useSessionRecord';
 import AgentPanes from './panes/AgentPanes';
-
-/**
- * The selected session's own record — the authority on ITS drive. The surface
- * store only knows the drive the CONSOLE is mounted under, which is null on
- * `/dashboard/agents`; passing that to the grid left every drive session's
- * pane picker with no agents to offer in global mode (review M5).
- */
-async function sessionFetcher(url: string): Promise<{ session: { driveId: string | null } | null }> {
-  const response = await fetchWithAuth(url);
-  if (!response.ok) throw new Error(`Failed to load session (${response.status})`);
-  return response.json();
-}
 
 /**
  * The Agents console: mounted for the lifetime of the route, whatever is
@@ -51,14 +38,14 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const storeDriveId = useAgentSurfaceStore((state) => state.driveId);
 
-  const { data: sessionData } = useSWR(
-    selectedSessionId ? `/api/agent-sessions/${encodeURIComponent(selectedSessionId)}` : null,
-    sessionFetcher,
-    { revalidateOnFocus: false, dedupingInterval: 30_000 },
-  );
+  const { data: sessionData } = useSessionRecord(selectedSessionId);
   // The session's own drive wins; the surface's drive covers the in-flight
   // window (they agree in drive mode, and global mode has nothing better).
-  const sessionDriveId = sessionData?.session?.driveId ?? storeDriveId;
+  // Checked as `sessionData?.session ?  : ` rather than `??` — `driveId` on a
+  // RESOLVED session can itself legitimately be `null` (a global session),
+  // which `??` would wrongly treat as "unresolved" and fall through to
+  // `storeDriveId` (caught alongside the AgentPageView cross-drive fix).
+  const sessionDriveId = sessionData?.session ? sessionData.session.driveId : storeDriveId;
 
   // The server is the authority on whether the selected session still
   // exists. `session: null` means it doesn't (ended elsewhere, reaped,

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect } from 'react';
-import { Bot } from 'lucide-react';
+import { Bot, Loader2 } from 'lucide-react';
 
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
@@ -39,8 +39,18 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
   const storeDriveId = useAgentSurfaceStore((state) => state.driveId);
 
   const { data: sessionData } = useSessionRecord(selectedSessionId);
+  // Resolved vs. not — NOT the same question as "which drive". On the global
+  // route (`storeDriveId` null), an unresolved DRIVE session must not render
+  // as global in the meantime: `AgentPanes` treats `driveId === null` as a
+  // CONFIRMED global session and offers every accessible agent, so a pick
+  // made during that window can hit the server's cross-drive gate and 400
+  // (caught in review — the picker's loading fallback was previously "no
+  // agents", harmless; once a null driveId means "show everyone", the same
+  // fallback became a live footgun). The grid only mounts once this is true.
+  const sessionDriveResolved = sessionData !== undefined;
   // The session's own drive wins; the surface's drive covers the in-flight
-  // window (they agree in drive mode, and global mode has nothing better).
+  // window (they agree in drive mode, and global mode has nothing better,
+  // but only reached this UNGATED by the `sessionDriveResolved` check above).
   // Checked as `sessionData?.session ?  : ` rather than `??` — `driveId` on a
   // RESOLVED session can itself legitimately be `null` (a global session),
   // which `??` would wrongly treat as "unresolved" and fall through to
@@ -125,18 +135,24 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
   return (
     <div className="flex h-full flex-col">
       {selectedSessionId && selectedConversationId ? (
-        <AgentPanes
-          key={selectedSessionId}
-          sessionId={selectedSessionId}
-          driveId={sessionDriveId}
-          initialConversation={{
-            conversationId: selectedConversationId,
-            agentPageId: selectedAgentId,
-            name: 'Conversation',
-          }}
-          onSessionEnded={() => selectSession(null)}
-          onConversationClosed={handleConversationClosed}
-        />
+        sessionDriveResolved ? (
+          <AgentPanes
+            key={selectedSessionId}
+            sessionId={selectedSessionId}
+            driveId={sessionDriveId}
+            initialConversation={{
+              conversationId: selectedConversationId,
+              agentPageId: selectedAgentId,
+              name: 'Conversation',
+            }}
+            onSessionEnded={() => selectSession(null)}
+            onConversationClosed={handleConversationClosed}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden="true" />
+          </div>
+        )
       ) : selectedSessionId ? (
         // A session is selected but its opening conversation has not resolved
         // from the URL (a hand-trimmed link). The sidebar's session rows always

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -27,10 +27,11 @@ const mockMutate = vi.hoisted(() => vi.fn());
 // Defaults to "not yet loaded" (`data: undefined`) so `panesDriveId` falls
 // back to `page.driveId` — identical to every pre-existing test's behavior.
 // One dedicated test below overrides this to pin the cross-drive-session
-// correction (the session's OWN driveId, not the hosted agent page's).
-const mockUseSWR = vi.hoisted(() =>
-  vi.fn((..._args: unknown[]) => ({ data: undefined as string | null | undefined })),
-);
+// correction (the session's OWN driveId, not the hosted agent page's). Shape
+// matches `useSessionRecord`'s raw session-record result, not a pre-coalesced
+// driveId.
+type MockSessionRecordData = { session: { driveId: string | null } | null } | undefined;
+const mockUseSWR = vi.hoisted(() => vi.fn((..._args: unknown[]) => ({ data: undefined as MockSessionRecordData })));
 vi.mock('swr', () => ({
   default: (...args: unknown[]) => mockUseSWR(...args),
   mutate: (...args: unknown[]) => mockMutate(...args),
@@ -191,6 +192,11 @@ const resolveTo = (resolved: ResolvedConversation) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `vi.clearAllMocks()` clears call/result history but NOT a persistent
+  // `mockReturnValue` override — re-establish the documented default here so
+  // one test's override (the global-assistant-session test below) can never
+  // leak into whichever test happens to run next.
+  mockUseSWR.mockReturnValue({ data: undefined });
   resolvedConversation.current = { resolved: null, isLoading: true };
   authState.current = { user: { id: 'user-1', role: 'admin' } };
   conversationsState.current = {
@@ -246,7 +252,9 @@ describe('AgentPageView', () => {
     // most-recent conversation can be bound to a global session. AgentPanes
     // must scope to the session's OWN drive (null), never `page.driveId` —
     // otherwise `agentSessionsKey`/the picker look in the wrong workspace.
-    mockUseSWR.mockReturnValue({ data: null });
+    // The raw session-record shape `useSessionRecord` resolves to (not a
+    // pre-coalesced driveId) — a RESOLVED global session, session.driveId null.
+    mockUseSWR.mockReturnValue({ data: { session: { driveId: null } } });
     resolveTo({ conversationId: 'conv-1', sessionId: 'ses-global' });
     render(<AgentPageView page={pageFixture()} />);
 

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -24,7 +24,17 @@ vi.mock('../useResolvedConversation', () => ({
 }));
 
 const mockMutate = vi.hoisted(() => vi.fn());
-vi.mock('swr', () => ({ mutate: (...args: unknown[]) => mockMutate(...args) }));
+// Defaults to "not yet loaded" (`data: undefined`) so `panesDriveId` falls
+// back to `page.driveId` — identical to every pre-existing test's behavior.
+// One dedicated test below overrides this to pin the cross-drive-session
+// correction (the session's OWN driveId, not the hosted agent page's).
+const mockUseSWR = vi.hoisted(() =>
+  vi.fn((..._args: unknown[]) => ({ data: undefined as string | null | undefined })),
+);
+vi.mock('swr', () => ({
+  default: (...args: unknown[]) => mockUseSWR(...args),
+  mutate: (...args: unknown[]) => mockMutate(...args),
+}));
 
 vi.mock('../useResolvedAgent', () => ({
   useResolvedAgent: () => ({
@@ -60,12 +70,14 @@ const agentPanesState = vi.hoisted(() => ({
 vi.mock('../panes/AgentPanes', () => ({
   default: ({
     sessionId,
+    driveId,
     initialConversation,
     chatContext,
     isReadOnly,
     onConversationClosed,
   }: {
     sessionId: string;
+    driveId: string | null;
     initialConversation: { conversationId: string };
     chatContext?: string;
     isReadOnly?: boolean;
@@ -76,7 +88,12 @@ vi.mock('../panes/AgentPanes', () => ({
       agentPanesState.firstOnConversationClosed = onConversationClosed ?? null;
     }
     return (
-      <div data-testid="agent-panes" data-chat-context={chatContext} data-readonly={String(!!isReadOnly)}>
+      <div
+        data-testid="agent-panes"
+        data-chat-context={chatContext}
+        data-readonly={String(!!isReadOnly)}
+        data-drive-id={driveId ?? ''}
+      >
         {sessionId}/{initialConversation.conversationId}
       </div>
     );
@@ -217,7 +234,24 @@ describe('AgentPageView', () => {
 
     await waitFor(() => expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-1/conv-1'));
     expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-chat-context', 'page');
+    // Defaults to the agent page's own drive while the session record is
+    // unresolved — correct for the overwhelming common case.
+    expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-drive-id', 'drive-1');
     expect(screen.queryByTestId('plain-chat')).not.toBeInTheDocument();
+  });
+
+  it('a conversation whose SESSION is a global-assistant session passes the SESSION drive (null), not the agent page drive', async () => {
+    // Reachable now that a global session can host any accessible agent's
+    // conversation (create-conversation-in-session.ts): this agent page's
+    // most-recent conversation can be bound to a global session. AgentPanes
+    // must scope to the session's OWN drive (null), never `page.driveId` —
+    // otherwise `agentSessionsKey`/the picker look in the wrong workspace.
+    mockUseSWR.mockReturnValue({ data: null });
+    resolveTo({ conversationId: 'conv-1', sessionId: 'ses-global' });
+    render(<AgentPageView page={pageFixture()} />);
+
+    await waitFor(() => expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-global/conv-1'));
+    expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-drive-id', '');
   });
 
   it('a NON-session user gets the plain chat even for a session-bound conversation (review M2)', async () => {

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -228,6 +228,32 @@ describe('the grid gets the SESSION\'s drive, not the surface\'s (review M5)', (
     );
     expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/agent-sessions/ses-m5');
   });
+
+  it('does not mount the grid as global while the session record is still unresolved', async () => {
+    // On the global route, `storeDriveId` is null — the same value a
+    // CONFIRMED global session's driveId legitimately has. `AgentPanes`
+    // treats `driveId === null` as "show every accessible agent", so
+    // mounting it with that fallback DURING the loading window would offer
+    // a drive session's picker agents it doesn't actually have, and picking
+    // one would hit the server's cross-drive gate and 400 (caught in
+    // review — chatgpt-codex-connector, P2).
+    let resolveSession!: (value: { ok: true; json: () => Promise<{ session: { driveId: string } }> }) => void;
+    mockFetchWithAuth.mockReturnValue(new Promise((resolve) => (resolveSession = resolve)));
+    // A session id no earlier test fetched — SWR's cache is module-global.
+    window.history.replaceState({}, '', '/dashboard/agents?session=ses-unresolved&c=conv-1&agent=agent-1');
+    render(<AgentsSurface />);
+
+    // Still unresolved: the grid must not be mounted at all (neither as
+    // "global" nor with any other guessed driveId) — a loading state, not a
+    // wrong one.
+    expect(screen.queryByTestId('agent-panes')).toBeNull();
+
+    resolveSession({ ok: true, json: async () => ({ session: { driveId: 'drive-9' } }) });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-drive-id', 'drive-9'),
+    );
+  });
 });
 
 describe('onConversationClosed — following the grid\'s own close/rebind', () => {

--- a/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
+++ b/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
@@ -31,7 +31,7 @@ export default function AssistantSessionChat({
   return (
     <SessionChatView
       chat={chat}
-      name="Assistant"
+      name="Global Assistant"
       visionModel={currentModel || ''}
       context={context}
       isReadOnly={isReadOnly}

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -150,7 +150,13 @@ export default function AgentPanes({
     () =>
       (allAgents ?? [])
         .filter((agent) => driveId === null || agent.driveId === driveId)
-        .map((agent) => ({ id: agent.id, title: agent.title ?? 'Agent' })),
+        .map((agent) => ({
+          id: agent.id,
+          title: agent.title ?? 'Agent',
+          // Only carried for a global session's cross-drive list — a single
+          // drive's own picker has no cross-drive ambiguity to disambiguate.
+          driveName: driveId === null ? agent.driveName : undefined,
+        })),
     [allAgents, driveId],
   );
 
@@ -740,9 +746,10 @@ export default function AgentPanes({
               existingShells={reattachableShells}
               // The assistant identity path is live (AssistantSessionChat), so
               // every session can host an assistant thread beside its agents.
-              // Hardcoded true rather than reading a prop — flagged in issue
-              // #2263 (finding 8) as a product decision to confirm; left
-              // unchanged here.
+              // Confirmed intent (was flagged in issue #2263, finding 8, as a
+              // product decision to confirm): every session offers the global
+              // assistant, symmetric with a global session now offering every
+              // accessible agent (see pickableAgents above).
               canPickAssistant
               autoFocus={workspace.pendingPickerPaneId === pane.id}
               onPickAgent={(agentPageId) => void handlePickAgent(pane.id, agentPageId)}

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -140,15 +140,16 @@ export default function AgentPanes({
   const replaceConversation = useAgentWorkspaceStore((state) => state.replaceConversation);
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
 
-  // The picker's agent list — the session's drive only. A global-assistant
-  // session offers no drive agents (there is no drive to list).
-  const { allAgents, isLoading: agentsLoading } = usePageAgents(driveId ?? undefined, {
-    enabled: driveId !== null,
-  });
+  // The picker's agent list. A drive session offers only that drive's agents;
+  // a global-assistant session (driveId null) has no home drive to filter by,
+  // so it offers every agent the caller can access, across all their drives —
+  // billing/tenant still resolve to the session's own owner regardless of
+  // which agent's conversation runs inside it (see AgentNotInSessionDriveError).
+  const { allAgents, isLoading: agentsLoading } = usePageAgents(driveId ?? undefined);
   const pickableAgents: PickableAgent[] = useMemo(
     () =>
       (allAgents ?? [])
-        .filter((agent) => agent.driveId === driveId)
+        .filter((agent) => driveId === null || agent.driveId === driveId)
         .map((agent) => ({ id: agent.id, title: agent.title ?? 'Agent' })),
     [allAgents, driveId],
   );
@@ -708,7 +709,7 @@ export default function AgentPanes({
                 scope={pane.scope}
                 surface={surface}
                 pickableAgents={pickableAgents}
-                agentsLoading={driveId !== null && agentsLoading}
+                agentsLoading={agentsLoading}
                 conversationsReady={sessionKnownToConversationsCache}
                 driveId={driveId}
                 onSelectAgent={(nextAgentPageId) =>
@@ -735,7 +736,7 @@ export default function AgentPanes({
           {showPicker ? (
             <PanePicker
               agents={pickableAgents}
-              isLoading={driveId !== null && agentsLoading}
+              isLoading={agentsLoading}
               existingShells={reattachableShells}
               // The assistant identity path is live (AssistantSessionChat), so
               // every session can host an assistant thread beside its agents.

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -21,6 +21,13 @@ import { Button } from '@/components/ui/button';
 export interface PickableAgent {
   id: string;
   title: string;
+  /**
+   * Set only for a cross-drive list (a global-assistant session's picker
+   * spans every accessible drive) — page titles aren't unique, so two drives
+   * can hold identically-titled agents that would otherwise be
+   * indistinguishable in the list.
+   */
+  driveName?: string;
 }
 
 /** A shell already open in this session but not currently shown in any pane. */
@@ -154,6 +161,9 @@ export default function PanePicker({
             >
               <Bot className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
               <span className="truncate">{agent.title}</span>
+              {agent.driveName && (
+                <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">{agent.driveName}</span>
+              )}
             </Button>
           ))}
         </div>

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -106,7 +106,7 @@ export default function PanePicker({
             data-testid="pick-global-assistant"
           >
             <Bot className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
-            Assistant
+            Global Assistant
           </Button>
         )}
       </div>

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -45,7 +45,14 @@ vi.mock('@paralleldrive/cuid2', () => ({
   createId: () => `new-id-${++cuidCounter}`,
 }));
 
-const mockUsePageAgents = vi.fn(() => ({
+interface MockPageAgent {
+  id: string;
+  title: string;
+  driveId: string;
+  /** Only set in the cross-drive (global-assistant) fixtures below. */
+  driveName?: string;
+}
+const mockUsePageAgents = vi.fn<() => { allAgents: MockPageAgent[]; isLoading: boolean }>(() => ({
   allAgents: [
     { id: 'agent-1', title: 'Researcher', driveId: 'drive-1' },
     { id: 'agent-2', title: 'Writer', driveId: 'drive-1' },
@@ -739,6 +746,21 @@ describe('AgentPanes', () => {
   });
 
   describe('a global-assistant session (driveId null)', () => {
+    beforeEach(() => {
+      // Genuinely cross-drive (unlike the shared drive-1-only default
+      // fixture): proves the picker aggregates across every accessible
+      // drive, not just whichever single drive the fixture happens to use
+      // (a narrower, buggy filter could pass against a single-drive fixture
+      // by coincidence).
+      mockUsePageAgents.mockReturnValue({
+        allAgents: [
+          { id: 'agent-1', title: 'Researcher', driveId: 'drive-1', driveName: 'Alpha' },
+          { id: 'agent-2', title: 'Writer', driveId: 'drive-2', driveName: 'Beta' },
+        ],
+        isLoading: false,
+      });
+    });
+
     it('offers every accessible agent across drives, not an empty list', async () => {
       renderPanes({
         driveId: null,
@@ -754,6 +776,11 @@ describe('AgentPanes', () => {
       expect(await screen.findByTestId('pick-agent-agent-1')).toBeInTheDocument();
       expect(screen.getByTestId('pick-agent-agent-2')).toBeInTheDocument();
       expect(screen.getByTestId('pick-global-assistant')).toBeInTheDocument();
+      // Cross-drive entries are labeled with their own drive — page titles
+      // aren't unique, so two drives can hold identically-titled agents that
+      // would otherwise be indistinguishable in the list.
+      expect(within(screen.getByTestId('pick-agent-agent-1')).getByText('Alpha')).toBeInTheDocument();
+      expect(within(screen.getByTestId('pick-agent-agent-2')).getByText('Beta')).toBeInTheDocument();
     });
 
     it('mints a picked cross-drive agent into the session, same as a drive session would', async () => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -738,6 +738,47 @@ describe('AgentPanes', () => {
     });
   });
 
+  describe('a global-assistant session (driveId null)', () => {
+    it('offers every accessible agent across drives, not an empty list', async () => {
+      renderPanes({
+        driveId: null,
+        initialConversation: { conversationId: 'conv-1', agentPageId: null, name: 'Conversation' },
+      });
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      // Both cross-drive fixture agents show up — the picker used to be
+      // unconditionally empty for a null driveId (`enabled: driveId !== null`
+      // plus a `agent.driveId === driveId` filter that could never match).
+      expect(await screen.findByTestId('pick-agent-agent-1')).toBeInTheDocument();
+      expect(screen.getByTestId('pick-agent-agent-2')).toBeInTheDocument();
+      expect(screen.getByTestId('pick-global-assistant')).toBeInTheDocument();
+    });
+
+    it('mints a picked cross-drive agent into the session, same as a drive session would', async () => {
+      mockPost.mockResolvedValue({});
+      renderPanes({
+        driveId: null,
+        initialConversation: { conversationId: 'conv-1', agentPageId: null, name: 'Conversation' },
+      });
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', paneId));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByTestId('pick-agent-agent-2'));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-2/conversations', {
+          conversationId: 'new-id-1',
+          sessionId: 'ses-1',
+        }),
+      );
+      await waitFor(() => expect(screen.getAllByTestId('pane-chat')).toHaveLength(2));
+    });
+  });
+
   describe('picking a shell', () => {
     it('opens a shell in the session and binds the pane to it', async () => {
       mockPost.mockResolvedValue({ shell: { shellId: 'shell-9', name: 'shell-1' } });

--- a/apps/web/src/components/agents/useSessionRecord.ts
+++ b/apps/web/src/components/agents/useSessionRecord.ts
@@ -1,0 +1,40 @@
+'use client';
+
+/**
+ * A session's own record — the authority on ITS drive. Never infer a
+ * session's drive from a hosted page's own drive, or a UI's mount-time drive
+ * context: a session can be global (`driveId` null) while hosting a
+ * drive-scoped agent's conversation, or drive-scoped while hosting the global
+ * assistant (`create-conversation-in-session.ts`) — the two can diverge, and
+ * only the session's own record is truthful about which.
+ *
+ * `session: null` means the id doesn't resolve to one the caller may see
+ * (never existed, ended elsewhere, reaped, or someone else's) — every caller
+ * decides for itself what that means (e.g. `AgentsSurface` forgets its
+ * persisted grid; `AgentPageView` falls back to the hosted page's own drive).
+ *
+ * Shared by every reader of a single session's record so the fetch shape and
+ * caching policy (`revalidateOnFocus: false` — a session's drive is
+ * effectively static, not worth refetching on every window focus;
+ * `dedupingInterval: 30_000`) can't drift between call sites.
+ */
+import useSWR from 'swr';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+export interface SessionRecordSummary {
+  driveId: string | null;
+}
+
+async function sessionFetcher(url: string): Promise<{ session: SessionRecordSummary | null }> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to load session (${response.status})`);
+  return response.json();
+}
+
+export function useSessionRecord(sessionId: string | null) {
+  return useSWR(
+    sessionId ? `/api/agent-sessions/${encodeURIComponent(sessionId)}` : null,
+    sessionFetcher,
+    { revalidateOnFocus: false, dedupingInterval: 30_000 },
+  );
+}

--- a/apps/web/src/components/ai/shared/AISelector.tsx
+++ b/apps/web/src/components/ai/shared/AISelector.tsx
@@ -20,6 +20,13 @@ import { cn } from '@/lib/utils';
 export interface AISelectorAgentOption {
   id: string;
   title: string;
+  /**
+   * Set only for a cross-drive list (a global-assistant session's switcher
+   * spans every accessible drive) — page titles aren't unique, so two drives
+   * can hold identically-titled agents that would otherwise be
+   * indistinguishable in the dropdown.
+   */
+  driveName?: string;
 }
 
 interface AISelectorProps {
@@ -146,6 +153,9 @@ export function AISelector({
                       aria-current={isSelected ? 'true' : undefined}
                     >
                       <span className="truncate">{agent.title || 'Unnamed Agent'}</span>
+                      {agent.driveName && (
+                        <span className="shrink-0 truncate text-xs text-muted-foreground">{agent.driveName}</span>
+                      )}
                       {isSelected && (
                         <span className="ml-auto text-xs text-muted-foreground">Active</span>
                       )}

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -488,7 +488,7 @@ function Layout({ children }: LayoutProps) {
           >
             <SheetContent side="right" className="w-full max-w-[22rem] border-l p-0 sm:max-w-sm">
               <SheetHeader className="sr-only">
-                <SheetTitle>Assistant panel</SheetTitle>
+                <SheetTitle>Global Assistant panel</SheetTitle>
                 <SheetDescription>Chat with the global assistant</SheetDescription>
               </SheetHeader>
               <RightPanel variant="overlay" className="h-full w-full" />

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -635,7 +635,7 @@ describe('AgentsSidebar', () => {
 
       expect(screen.getByText(/administrator privileges/i)).toBeDefined();
       expect(screen.queryByText('Alpha')).toBeNull();
-      expect(screen.queryByText('Assistant')).toBeNull();
+      expect(screen.queryByText('Global Assistant')).toBeNull();
       expect(screen.queryByRole('button', { name: /^New session/i })).toBeNull();
       expect(mockFetchWithAuth).not.toHaveBeenCalled();
     });
@@ -666,10 +666,10 @@ describe('AgentsSidebar', () => {
       const user = userEvent.setup();
       renderSidebar();
 
-      expect(await screen.findByText('Assistant')).toBeDefined();
+      expect(await screen.findByText('Global Assistant')).toBeDefined();
       // Scoped: the roster's own drive group also renders its own inline "+"
       // now, so an unscoped query would be ambiguous.
-      await user.click(within(groupContainer('Assistant')).getByRole('button', { name: /^New session/i }));
+      await user.click(within(groupContainer('Global Assistant')).getByRole('button', { name: /^New session/i }));
 
       await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {}));
       await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-a'));
@@ -696,8 +696,8 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await screen.findByText('api refactor');
-      const headers = screen.getAllByText(/^(Alpha|Assistant)$/);
-      expect(headers.map((el) => el.textContent)).toEqual(['Assistant', 'Alpha']);
+      const headers = screen.getAllByText(/^(Alpha|Global Assistant)$/);
+      expect(headers.map((el) => el.textContent)).toEqual(['Global Assistant', 'Alpha']);
     });
 
     test('a new conversation in an assistant session goes through the session-centric creator', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/session-groups.test.ts
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/session-groups.test.ts
@@ -29,7 +29,7 @@ describe('buildSessionGroups', () => {
       drives: [drive('drive-2', 'Beta'), drive('drive-1', 'Alpha')],
     });
     expect(groups.map((group) => group.driveId)).toEqual([ASSISTANT_GROUP_KEY, 'drive-1', 'drive-2']);
-    expect(groups.map((group) => group.driveName)).toEqual(['Assistant', 'Alpha', 'Beta']);
+    expect(groups.map((group) => group.driveName)).toEqual(['Global Assistant', 'Alpha', 'Beta']);
   });
 
   it('merges a roster drive with its sessions — union, not a duplicate group', () => {

--- a/apps/web/src/components/layout/left-sidebar/session-groups.ts
+++ b/apps/web/src/components/layout/left-sidebar/session-groups.ts
@@ -66,7 +66,7 @@ export function buildSessionGroups<T extends { driveId: string | null }>(
       ? [
           {
             driveId: ASSISTANT_GROUP_KEY,
-            driveName: 'Assistant',
+            driveName: 'Global Assistant',
             sessions: sessionsByDrive.get(ASSISTANT_GROUP_KEY) ?? [],
           },
         ]

--- a/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
@@ -162,10 +162,12 @@ describe('the cross-drive gate (one binding path, review #43)', () => {
     expect(deps.createPageConversation).not.toHaveBeenCalled();
   });
 
-  it('a GLOBAL session (driveId null) hosts ONLY assistant threads — any agent page is a mismatch', async () => {
+  it('a GLOBAL session (driveId null) may host any accessible agent — no drive to mismatch against', async () => {
     deps.findSessionDriveId.mockResolvedValue({ driveId: null });
-    await expect(run()).rejects.toThrow(AgentNotInSessionDriveError);
-    expect(deps.createPageConversation).not.toHaveBeenCalled();
+    await run();
+    expect(deps.createPageConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ agentPageId: 'agent-1', sessionId: 'ses-1' }),
+    );
   });
 
   it('the assistant is exempt — it has no drive to mismatch', async () => {

--- a/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
+++ b/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
@@ -49,13 +49,19 @@ export class SessionFullError extends Error {
 }
 
 /**
- * The agent page belongs to a different drive than the session. A session is
- * a DRIVE-level workspace: its sandbox tenant, payer and access decision all
- * derive from ITS drive, so hosting another drive's agent would execute that
- * agent's turns — and bill their runtime — inside a workspace its drive never
- * admitted (three reviewers converged on this: codex p58/p59 + review M6).
- * The global assistant is exempt (no drive); a GLOBAL session (driveId null)
- * therefore hosts ONLY assistant threads.
+ * The agent page belongs to a different DRIVE than the session's own drive. A
+ * drive-scoped session's sandbox tenant, payer and access decision all derive
+ * from ITS drive, so hosting another drive's agent would execute that agent's
+ * turns — and bill their runtime — inside a workspace its drive never admitted
+ * (three reviewers converged on this: codex p58/p59 + review M6).
+ *
+ * A GLOBAL session (driveId null) is exempt from this gate: its tenant/payer
+ * already resolve to the session's own owner regardless of which agent's
+ * conversation runs inside it (`resolveSessionTenantId`/`resolveSessionPayerId`
+ * key off the SESSION's driveId/ownerId, never the hosted agent's), and each
+ * conversation-creation route independently checks the caller can view the
+ * target agent page before this gate ever runs. So a global session may host
+ * any accessible agent, not just assistant threads.
  */
 export class AgentNotInSessionDriveError extends Error {
   constructor() {
@@ -145,14 +151,18 @@ export async function createConversationInSessionWith(
   }
 
   // THE cross-drive gate, at the ONE binding path so no call site can forget
-  // it: the agent must belong to the session's drive. Checked before any row
-  // is written, and fail-closed on unresolved facts.
+  // it: a DRIVE session's agent must belong to that same drive. Checked before
+  // any row is written, and fail-closed on unresolved facts. A GLOBAL session
+  // (driveId null) has no drive to mismatch against, so it is exempt — see
+  // AgentNotInSessionDriveError's doc comment.
   const [agentDriveId, sessionRow] = await Promise.all([
     deps.findAgentDriveId(agentPageId),
     deps.findSessionDriveId(sessionId),
   ]);
   if (agentDriveId === null || sessionRow === null) throw new ConversationUnavailableError();
-  if (sessionRow.driveId !== agentDriveId) throw new AgentNotInSessionDriveError();
+  if (sessionRow.driveId !== null && sessionRow.driveId !== agentDriveId) {
+    throw new AgentNotInSessionDriveError();
+  }
 
   const outcome = await deps.createPageConversation({ conversationId, userId, agentPageId, sessionId, title });
   if (outcome === 'created') return;

--- a/tasks/reviews/pu-globl-ass.md
+++ b/tasks/reviews/pu-globl-ass.md
@@ -16,10 +16,20 @@ reviewers (CodeRabbit, chatgpt-codex-connector) on commit 8384f8063.
 - [x] MINOR · `apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx:755` (pre-fix) · New cross-drive picker tests used a fixture where both mock agents were on `drive-1`, so the test could pass even against a narrower, buggy single-drive filter. Correct is: agent-2 on a distinct drive. — fixed in da06aedda (coderabbitai)
 - [x] NIT · `apps/web/src/components/agents/panes/AgentPanes.tsx:744` · `canPickAssistant` hardcoded-true comment still described issue #2263 finding 8 as "to confirm" — now confirmed intent given both directions (assistant-in-drive, any-agent-in-global) are deliberately symmetric. — fixed in da06aedda (self-review)
 
+### Second pass — 4-angle /simplify review on da06aedda
+
+- [x] MAJOR · `apps/web/src/components/agents/AgentPageView.tsx:225,363` (pre-fix) · The first cross-drive fix (`panesDriveId`) was only wired into the `AgentPanes` prop — two OTHER spots in the same file still assumed `page.driveId` equals the session's driveId: an optimistic SWR cache-key patch (silently wrong bucket) and the "Open in Agents" link builder (wrong console route). Both reachable in the same cross-drive-global scenario. Correct is: use the resolved session driveId at every site, not just one. — fixed in 57ce0b2ed (self-review, altitude pass)
+- [x] MINOR · `apps/web/src/components/agents/AgentPageView.tsx` / `AgentsSurface.tsx` (pre-fix) · Near-identical session-record fetcher + useSWR call duplicated across two files, with drifted caching options (missing `revalidateOnFocus: false, dedupingInterval: 30_000` on the newer one). Correct is: one shared hook. — fixed in 57ce0b2ed (self-review, reuse+efficiency+simplification passes; 3/4 agents independently flagged it)
+- [x] MINOR · `apps/web/src/components/agents/__tests__/AgentPageView.test.tsx` (pre-fix) · `mockUseSWR.mockReturnValue(...)` override in one test wasn't reset by `vi.clearAllMocks()` (doesn't revert persistent mock implementations) — silently leaked into every later test in the file. Correct is: reset in `beforeEach`. — fixed in 57ce0b2ed (self-review, simplification pass)
+
+### Third pass — chatgpt-codex-connector re-review of 57ce0b2ed
+
+- [x] MAJOR · `apps/web/src/components/agents/AgentsSurface.tsx:48` (pre-fix) · The shared-hook extraction's fallback (`sessionData?.session ? ... : storeDriveId`) returns `storeDriveId` (null on the global console route) while the session record is still unresolved — indistinguishable from a CONFIRMED global session. Since `AgentPanes` now treats `driveId === null` as "show every accessible agent," mounting the grid during that window could let a user pick a cross-drive agent that then 400s server-side. Reachable on every session selection from the global console not already SWR-cached. Correct is: track resolved-vs-not separately and don't mount the grid until known. — fixed in 357fbacbf (chatgpt-codex-connector, P2)
+
 ## Verified, no change needed
 - Both production callers of `createConversationInSessionWith` (the `POST /api/ai/page-agents/[agentId]/conversations` route, and the `spawn_session` agent tool via `session-tools-runtime.ts`'s `createWorkerSession`) independently gate on per-agent view permission (`canPrincipalViewPage` / `canUseAgent`) before this path runs — relaxing the drive gate for global sessions does not bypass access control on either path.
 - Billing/tenant resolution (`resolveSessionTenantId`/`resolveSessionPayerId`) is keyed on the SESSION's own `driveId`/`ownerId`, never the hosted agent's — a global session's sandbox always bills its owner regardless of which agent's conversation runs inside it.
 - Drive content access is API-mediated per tool call (`canActorViewPage`/agent-permission checks), not filesystem-mounted to a session's drive — no content-safety concern from cross-drive hosting.
 
 ## Verdict
-0 blockers / 0 majors / 0 minors / 0 nits outstanding; 4 fixed (1 blocker, 1 major, 1 minor, 1 nit).
+0 blockers / 0 majors / 0 minors / 0 nits outstanding; 8 fixed (1 blocker, 3 majors, 3 minors, 1 nit) across 3 review passes and 3 commits (da06aedda, 57ce0b2ed, 357fbacbf).

--- a/tasks/reviews/pu-globl-ass.md
+++ b/tasks/reviews/pu-globl-ass.md
@@ -1,0 +1,25 @@
+# Review: pu/globl-ass — PR #2282
+
+feat(agents): let a global-assistant session host any accessible agent
+
+## Context
+Global-assistant sessions (`driveId === null`) previously could only host assistant threads. Verified
+that both the sandbox tenant/payer (`resolveSessionTenantId`/`resolveSessionPayerId`) and per-agent view
+permission checks are keyed independently of the cross-drive gate, so relaxing the gate for global
+sessions only is safe. Full self-review (correctness, OWASP top 10, test coverage) plus two automated
+reviewers (CodeRabbit, chatgpt-codex-connector) on commit 8384f8063.
+
+## Findings
+
+- [x] BLOCKER · `apps/web/src/components/agents/AgentPageView.tsx:433` (pre-fix) · `AgentPanes` was given `page.driveId` (the hosted agent's own drive) instead of the session's own driveId — now reachable-wrong once a global session can host a cross-drive agent's conversation (previously provably impossible). Correct is: resolve the SESSION's real driveId and pass that. — fixed in da06aedda (chatgpt-codex-connector, P2)
+- [x] MAJOR · `apps/web/src/components/agents/panes/AgentPanes.tsx:153` (pre-fix) · Cross-drive picker/selector entries carried only `{id, title}`, losing drive identity — two drives could hold identically-titled agents, indistinguishable in the global session's aggregated list. Correct is: carry and render `driveName` for cross-drive entries. — fixed in da06aedda (chatgpt-codex-connector, P2)
+- [x] MINOR · `apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx:755` (pre-fix) · New cross-drive picker tests used a fixture where both mock agents were on `drive-1`, so the test could pass even against a narrower, buggy single-drive filter. Correct is: agent-2 on a distinct drive. — fixed in da06aedda (coderabbitai)
+- [x] NIT · `apps/web/src/components/agents/panes/AgentPanes.tsx:744` · `canPickAssistant` hardcoded-true comment still described issue #2263 finding 8 as "to confirm" — now confirmed intent given both directions (assistant-in-drive, any-agent-in-global) are deliberately symmetric. — fixed in da06aedda (self-review)
+
+## Verified, no change needed
+- Both production callers of `createConversationInSessionWith` (the `POST /api/ai/page-agents/[agentId]/conversations` route, and the `spawn_session` agent tool via `session-tools-runtime.ts`'s `createWorkerSession`) independently gate on per-agent view permission (`canPrincipalViewPage` / `canUseAgent`) before this path runs — relaxing the drive gate for global sessions does not bypass access control on either path.
+- Billing/tenant resolution (`resolveSessionTenantId`/`resolveSessionPayerId`) is keyed on the SESSION's own `driveId`/`ownerId`, never the hosted agent's — a global session's sandbox always bills its owner regardless of which agent's conversation runs inside it.
+- Drive content access is API-mediated per tool call (`canActorViewPage`/agent-permission checks), not filesystem-mounted to a session's drive — no content-safety concern from cross-drive hosting.
+
+## Verdict
+0 blockers / 0 majors / 0 minors / 0 nits outstanding; 4 fixed (1 blocker, 1 major, 1 minor, 1 nit).


### PR DESCRIPTION
## Summary
- A global-assistant session's pane picker/switcher was unconditionally empty — the agent fetch was disabled for `driveId === null` and the result was filtered by `agent.driveId === driveId`, which can never match against a null drive. Server-side, `create-conversation-in-session.ts` refused any non-null `agentPageId` in a driveId-null session outright.
- That refusal was a deliberate, reviewed rule protecting drive billing/tenant attribution — but verified against the actual mechanics (`resolveSessionTenantId`/`resolveSessionPayerId`), it doesn't apply here: they key off the *session's own* `driveId`/`ownerId`, never the hosted agent's, so a global session's sandbox always bills its owner regardless of which agent's conversation runs inside it. Per-agent view permission is independently checked at the conversation-creation route before the cross-drive gate ever runs.
- So the server gate now only fires for a genuine drive-to-drive mismatch; a global-assistant session may host any agent the caller can access, symmetric with a drive session already being able to host the global assistant.
- Renamed the 4 remaining UI spots that said bare "Assistant" instead of "Global Assistant" for consistency (`PanePicker` button, sidebar group name, `AssistantSessionChat`'s display name, mobile sheet title), plus their companion test assertions.

## Review follow-ups (2 commits after initial review)
- **`da06aedda`** — fixed 2 P2 findings from an automated pass (chatgpt-codex-connector) plus a CodeRabbit test-fixture nitpick:
  - `AgentPageView.tsx` was passing the hosted agent PAGE's `driveId` to `AgentPanes` instead of the SESSION's own driveId — provably wrong once a global session can host a cross-drive agent's conversation (previously impossible). Now resolves the session's real driveId via `GET /api/agent-sessions/[sessionId]`.
  - Cross-drive picker/selector entries carried only `{id, title}`, losing drive identity — two drives could hold identically-titled agents, indistinguishable in the aggregated list. `PickableAgent`/`AISelectorAgentOption` now carry an optional `driveName`, rendered alongside the title.
  - Test fixture for the new cross-drive tests used a single drive for both mock agents, which could pass by coincidence against a narrower, buggy filter; now genuinely spans two drives.
- **`57ce0b2ed`** — a 4-angle `/simplify` pass (reuse, simplification, efficiency, altitude) found the first fix was still too shallow:
  - Extracted `useSessionRecord` (shared by `AgentPageView` and `AgentsSurface`, which had a near-identical, independently-declared fetcher) instead of reimplementing the session-record fetch per component. Also fixes a missing SWR caching-options gap the new fetch had introduced.
  - Two OTHER call sites in `AgentPageView.tsx` still assumed `page.driveId` equals the session's driveId, both reachable in the same cross-drive-global scenario: an optimistic SWR cache-key patch after minting a replacement conversation (silently targeted the wrong cache bucket), and the "Open in Agents" link builder (built a drive-scoped console URL for a session that isn't drive-scoped). Both now use the resolved session driveId.
  - `AgentsSurface.tsx` had a latent instance of the same defect class (`sessionData?.session?.driveId ?? storeDriveId` conflates a resolved global session's real `driveId: null` with "unresolved") — fixed alongside the shared-hook extraction.
  - Fixed a test-isolation gap: a `mockReturnValue` override in one `AgentPageView.test.tsx` test wasn't being reset by `vi.clearAllMocks()` (which doesn't revert persistent mock implementations), silently leaking into every later test in the file.

## Test plan
- [x] `bun run --filter web test -- create-conversation-in-session AgentPanes AgentPageView AgentsSurface AISelector AgentsSidebar session-groups` — 7 files, 162 tests passing
- [x] `bun run typecheck` — clean across all packages
- [x] `bunx eslint` on every touched file — 0 errors/warnings (including a pre-existing missing-dependency warning resolved as a side effect of the deeper fix)
- [x] CI: Lint & TypeScript Check, Unit Tests, CodeRabbit all green on the final commit
- [ ] Manual: open a global-assistant session, split a new pane, confirm the picker lists cross-drive agents labeled "Global Assistant" + drive agents (with drive-name disambiguation), pick a drive agent, confirm the conversation starts in that pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USJjkq5xPJTXdiDtu9JhEP