### PR TITLE
feat(agent-sessions): shell-first spawn + auto-unique blank names

### DIFF
--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -14,6 +14,8 @@ const {
   mockSpawnSession,
   mockGetAiAgent,
   mockCanPrincipalViewPage,
+  mockProvisionSessionSandbox,
+  mockSpawnShell,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAuditRequest: vi.fn(),
@@ -27,6 +29,8 @@ const {
   mockSpawnSession: vi.fn(),
   mockGetAiAgent: vi.fn(),
   mockCanPrincipalViewPage: vi.fn(),
+  mockProvisionSessionSandbox: vi.fn(),
+  mockSpawnShell: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -53,9 +57,11 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   endSession: (...args: unknown[]) => mockEndSession(...args),
   spawnSession: (...args: unknown[]) => mockSpawnSession(...args),
   toAgentSessionDTO: (row: { id: string }) => ({ sessionId: row.id, dto: true }),
+  provisionSessionSandbox: (...args: unknown[]) => mockProvisionSessionSandbox(...args),
 }));
 vi.mock('@/lib/agent-sessions/session-shells-runtime', () => ({
   listShellsBulk: (...args: unknown[]) => mockListShellsBulk(...args),
+  spawnShell: (...args: unknown[]) => mockSpawnShell(...args),
 }));
 
 import { GET, POST } from '../route';
@@ -171,6 +177,12 @@ describe('POST /api/agent-sessions — spawn', () => {
     mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Agent', type: 'AI_CHAT', driveId: 'drive-1' });
     mockCanPrincipalViewPage.mockResolvedValue(true);
     mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockListSessions.mockResolvedValue([]);
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sb-1', resumed: false });
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
   });
 
   it('spawns ONE session with ONE bound conversation — and NO sandbox', async () => {
@@ -188,12 +200,12 @@ describe('POST /api/agent-sessions — spawn', () => {
     // the absence is structural.
   });
 
-  it('spawns a GLOBAL-ASSISTANT session from the both-null shape', async () => {
+  it('spawns a GLOBAL-ASSISTANT session from the both-null shape, auto-naming it "Assistant"', async () => {
     const response = await spawn({});
     expect(response.status).toBe(201);
     const body = await response.json();
     expect(typeof body.conversationId).toBe('string');
-    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null, name: null });
+    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null, name: 'Assistant' });
     // The first conversation is an assistant thread: no agent page.
     expect(mockCreateConversationInSession).toHaveBeenCalledWith(
       expect.objectContaining({ agentPageId: null, sessionId: 'ses-new' }),
@@ -223,6 +235,91 @@ describe('POST /api/agent-sessions — spawn', () => {
   it('given the first conversation fails, ENDS the just-minted session — no empty workspace exists', async () => {
     mockCreateConversationInSession.mockRejectedValue(new Error('squat guard refused'));
     const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(502);
+    expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+  });
+});
+
+describe("POST /api/agent-sessions — firstThing: 'shell'", () => {
+  const spawn = (body: unknown) =>
+    POST(
+      new Request('http://localhost/api/agent-sessions', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+  beforeEach(() => {
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+    mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-new' } });
+    mockEndSession.mockResolvedValue({ ok: true, spriteTornDown: false });
+    mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockListSessions.mockResolvedValue([]);
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sb-1', resumed: false });
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Agent', type: 'AI_CHAT', driveId: 'drive-1' });
+    mockCanPrincipalViewPage.mockResolvedValue(true);
+    mockCreateConversationInSession.mockResolvedValue(undefined);
+  });
+
+  it("given firstThing: 'shell', should provision the sandbox then spawn a shell — NOT a conversation — and respond { session, shellId }", async () => {
+    const order: string[] = [];
+    mockProvisionSessionSandbox.mockImplementation(async () => {
+      order.push('provision');
+      return { ok: true, sandboxId: 'sb-1', resumed: false };
+    });
+    mockSpawnShell.mockImplementation(async () => {
+      order.push('spawn');
+      return {
+        ok: true,
+        shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+      };
+    });
+
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body).toEqual({ session: { sessionId: 'ses-new', dto: true }, shellId: 'shell-new' });
+    expect(order).toEqual(['provision', 'spawn']);
+    expect(mockProvisionSessionSandbox).toHaveBeenCalledWith({ id: 'ses-new' }, 'user-1');
+    expect(mockSpawnShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'ses-new', ownerId: 'user-1' }));
+    expect(mockCreateConversationInSession).not.toHaveBeenCalled();
+  });
+
+  it("given firstThing omitted, should behave exactly as today — first conversation, no shell", async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(typeof body.conversationId).toBe('string');
+    expect(body.shellId).toBeUndefined();
+    expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  it("given firstThing is some other value, should behave exactly as today — first conversation, no shell", async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1', firstThing: 'conversation' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(typeof body.conversationId).toBe('string');
+    expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  it('given the sandbox fails to provision, ENDS the just-minted session and never spawns a shell', async () => {
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: false, reason: 'provision_failed' });
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(502);
+    expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  it('given the first shell fails to spawn, ENDS the just-minted session', async () => {
+    mockSpawnShell.mockResolvedValue({ ok: false, reason: 'error' });
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
     expect(response.status).toBe(502);
     expect(mockEndSession).toHaveBeenCalledWith('ses-new');
   });
@@ -277,6 +374,113 @@ describe('POST /api/agent-sessions — spawn agent validation (review M6)', () =
     expect(response.status).toBe(201);
     expect(mockSpawnSession).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'x'.repeat(120) }),
+    );
+  });
+});
+
+describe('POST /api/agent-sessions — blank name auto-generates a unique one', () => {
+  const spawn = (body: unknown) =>
+    POST(
+      new Request('http://localhost/api/agent-sessions', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+  beforeEach(() => {
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+    mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-new' } });
+    mockCreateConversationInSession.mockResolvedValue(undefined);
+    mockEndSession.mockResolvedValue({ ok: true, spriteTornDown: false });
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Research Bot', type: 'AI_CHAT', driveId: 'drive-1' });
+    mockCanPrincipalViewPage.mockResolvedValue(true);
+    mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockListSessions.mockResolvedValue([]);
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sb-1', resumed: false });
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
+  });
+
+  it('given a blank name with an agent, should derive the base label from the agent title', async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1', name: '' });
+    expect(response.status).toBe(201);
+    expect(mockListSessions).toHaveBeenCalledWith({ ownerId: 'user-1' });
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Research Bot' }),
+    );
+  });
+
+  it('given an omitted name with an agent, should derive the base label from the agent title', async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Research Bot' }),
+    );
+  });
+
+  it("given a blank name with firstThing: 'shell', should derive the base label \"Shell\"", async () => {
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Shell' }),
+    );
+  });
+
+  it('given a blank name for the global-assistant shape, should derive the base label "Assistant"', async () => {
+    const response = await spawn({});
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Assistant' }),
+    );
+  });
+
+  it('given a non-blank name, should use it as-is — no collision lookup at all', async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1', name: 'api refactor' });
+    expect(response.status).toBe(201);
+    expect(mockListSessions).not.toHaveBeenCalled();
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'api refactor' }),
+    );
+  });
+
+  it('given the base label already taken, should append " 2" rather than collide', async () => {
+    mockListSessions.mockResolvedValue([
+      { sessionId: 'ses-old', driveId: null, ownerId: 'user-1', name: 'Shell', sandboxStatus: 'ended', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+    ]);
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Shell 2' }),
+    );
+  });
+
+  it('given two blank-named shell spawns back to back, should produce two distinct names', async () => {
+    mockListSessions.mockResolvedValueOnce([]);
+    const first = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(mockSpawnSession).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'Shell' }));
+
+    mockListSessions.mockResolvedValueOnce([
+      { sessionId: 'ses-old', driveId: 'drive-1', ownerId: 'user-1', name: 'Shell', sandboxStatus: 'running', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+    ]);
+    const second = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(mockSpawnSession).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'Shell 2' }));
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+  });
+
+  it('given "Shell" and "Shell 2" both taken, should scan past both collisions to "Shell 3"', async () => {
+    mockListSessions.mockResolvedValue([
+      { sessionId: 'ses-1', driveId: 'drive-1', ownerId: 'user-1', name: 'Shell', sandboxStatus: 'running', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+      { sessionId: 'ses-2', driveId: 'drive-1', ownerId: 'user-1', name: 'Shell 2', sandboxStatus: 'running', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+    ]);
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Shell 3' }),
     );
   });
 });

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -7,8 +7,8 @@
  *
  * GET ?driveId=<id> | (none = mine)
  *   → { sessions: [{ …AgentSessionDTO, shells: ShellDTO[], conversations }] }
- * POST { driveId, agentPageId, name? }
- *   → 201 { session, conversationId } — spawn (see below)
+ * POST { driveId, agentPageId, name?, firstThing? }
+ *   → 201 { session, conversationId } | { session, shellId } — spawn (see below)
  *
  * Every listing is scoped to the REQUESTER's own sessions (`ownerId` rides
  * every filter): `driveId` narrows *where*, never *whose*. Admin gate first,
@@ -30,15 +30,31 @@ import {
   listSessions,
   listSessionConversationsBulk,
   MAX_ACTIVE_SESSIONS_PER_OWNER,
+  provisionSessionSandbox,
   spawnSession,
   toAgentSessionDTO,
   type AgentSessionListFilter,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
-import { listShellsBulk } from '@/lib/agent-sessions/session-shells-runtime';
+import { listShellsBulk, spawnShell } from '@/lib/agent-sessions/session-shells-runtime';
 import { sessionQuotaExceeded } from '@/lib/agent-sessions/quota-response';
 
 /** Bound on the stored display label — rendered everywhere the session appears. */
 const MAX_SESSION_NAME_LENGTH = 120;
+
+/**
+ * A blank-name spawn's auto-label: the first collision-free of `base`,
+ * `base 2`, `base 3`, … — mirroring `nextShellLabel`'s "count existing,
+ * append a number, scan past collisions" pattern
+ * (`plan-spawn-session.ts:61-68`), but starting at the bare label rather than
+ * always suffixing a number: no session is ever born "Shell 1".
+ */
+function nextUniqueSessionName(base: string, existingNames: readonly string[]): string {
+  const taken = new Set(existingNames);
+  if (!taken.has(base)) return base;
+  let index = 2;
+  while (taken.has(`${base} ${index}`)) index += 1;
+  return `${base} ${index}`;
+}
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -97,11 +113,11 @@ export async function GET(request: Request) {
 }
 
 /**
- * POST → 201 { session, conversationId } — SPAWN a session.
+ * POST → 201 { session, conversationId } | { session, shellId } — SPAWN a session.
  *
  * One act, per the lifecycle invariant: a session is born with its first
- * conversation, so this creates the workspace row AND a conversation already
- * bound to it. Two shapes, matching the two session kinds:
+ * thing, so this creates the workspace row AND that first thing already bound
+ * to it. Two shapes, matching the two session kinds:
  *
  * - `{ driveId, agentPageId }` — a DRIVE session, first conversation with that
  *   drive agent.
@@ -110,11 +126,24 @@ export async function GET(request: Request) {
  *   access decision (there is no drive whose membership could admit anyone
  *   else).
  *
- * Half-specified shapes are refused: an agent without its drive is
- * unresolvable, and a drive without an agent would mint an empty session.
+ * `firstThing: 'shell'` swaps the first-conversation act for a first-shell
+ * one: the session's first thing is a shell instead, reusing the exact
+ * sandbox-provisioning + shell-spawn logic the shells route uses
+ * (`provisionSessionSandbox` + `spawnShell`) rather than reimplementing it.
+ * Omitted/anything else behaves exactly as before — the conversation path.
  *
- * Spawn is instant and free: NO sandbox is provisioned here. The first tool
- * call or shell open provisions lazily through the one shared path.
+ * Half-specified shapes are refused: an agent without its drive is
+ * unresolvable, and a drive without an agent would mint an empty session —
+ * UNLESS `firstThing: 'shell'`, whose first thing needs no agent.
+ *
+ * A blank/omitted `name` is not left null: it is auto-derived from the spawn
+ * target (the agent's title, "Shell", or "Assistant") and made unique among
+ * the owner's own existing session names before the row is inserted.
+ *
+ * Spawn itself is instant and free: NO sandbox is provisioned for the
+ * conversation path. `firstThing: 'shell'` is the exception — opening a shell
+ * always needs a live sandbox, so this branch provisions eagerly instead of
+ * waiting for the first tool call.
  *
  * Access: the same pure decision every session surface uses, applied to the
  * row-to-be — drive membership + code-execution for a drive session, owner +
@@ -124,7 +153,7 @@ export async function POST(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
 
-  let body: { driveId?: unknown; agentPageId?: unknown; name?: unknown } = {};
+  let body: { driveId?: unknown; agentPageId?: unknown; name?: unknown; firstThing?: unknown } = {};
   try {
     body = await request.json();
   } catch {
@@ -134,19 +163,23 @@ export async function POST(request: Request) {
   const agentPageId =
     typeof body.agentPageId === 'string' && body.agentPageId.length > 0 ? body.agentPageId : null;
   const rawName = typeof body.name === 'string' ? body.name.trim() : '';
-  // A label, never an address — but still bounded: it is stored, listed and
-  // rendered everywhere the session appears.
-  const name = rawName.length > 0 ? rawName.slice(0, MAX_SESSION_NAME_LENGTH) : null;
+  const wantsShellFirst = body.firstThing === 'shell';
 
-  if ((driveId === null) !== (agentPageId === null)) {
+  if (!wantsShellFirst && (driveId === null) !== (agentPageId === null)) {
     // Half-specified: an agent without its drive is unresolvable, and a drive
     // without an agent would mint an empty session. Both-null is the
-    // global-assistant spawn; both-present is the drive spawn.
+    // global-assistant spawn; both-present is the drive spawn. A shell-first
+    // spawn needs no agent, so it is exempt from this shape check.
     return NextResponse.json(
       { error: 'A session needs a drive and an agent to start with, or neither for the assistant' },
       { status: 400 },
     );
   }
+
+  // The agent's title, when one is being spawned into — the base label a
+  // blank `name` derives from (see below). Captured here rather than
+  // re-fetched, since the lookup already happened for validation.
+  let agentTitle: string | null = null;
 
   if (agentPageId !== null && driveId !== null) {
     // The same checks the conversation routes make, BEFORE any row is minted
@@ -179,6 +212,7 @@ export async function POST(request: Request) {
         { status: 403 },
       );
     }
+    agentTitle = agent.title;
   }
 
   // Advisory fast-path only (review #2261/2): count-then-branch here is
@@ -215,6 +249,21 @@ export async function POST(request: Request) {
     );
   }
 
+  // A label, never an address — but still bounded: it is stored, listed and
+  // rendered everywhere the session appears. Blank/omitted does not stay
+  // null: it is derived from the spawn target and made unique among the
+  // owner's own existing session names, so the sidebar never renders the
+  // literal fallback "Session" for a spawn that went through this route.
+  let name: string;
+  if (rawName.length > 0) {
+    name = rawName.slice(0, MAX_SESSION_NAME_LENGTH);
+  } else {
+    const baseLabel = wantsShellFirst ? 'Shell' : agentPageId !== null ? (agentTitle ?? 'Agent') : 'Assistant';
+    const existingSessions = await listSessions({ ownerId: auth.userId });
+    const existingNames = existingSessions.map((session) => session.name);
+    name = nextUniqueSessionName(baseLabel, existingNames).slice(0, MAX_SESSION_NAME_LENGTH);
+  }
+
   const spawned = await spawnSession({ userId: auth.userId, driveId, name });
   if (!spawned.ok) {
     if (spawned.reason === 'session_limit_reached') {
@@ -226,6 +275,49 @@ export async function POST(request: Request) {
     }
     loggers.api.error('Agent session spawn failed', undefined, { driveId, detail: spawned.detail });
     return NextResponse.json({ error: 'Could not start a session', reason: spawned.reason }, { status: 502 });
+  }
+
+  if (wantsShellFirst) {
+    // The first shell — same provisioning + spawn pair the shells route uses
+    // (`[sessionId]/shells/route.ts` POST, lines 88-167): a shell always
+    // needs a live sandbox, so unlike the conversation path this provisions
+    // eagerly rather than waiting for the first tool call.
+    const provisioned = await provisionSessionSandbox(spawned.session, auth.userId);
+    if (!provisioned.ok) {
+      await endSession(spawned.session.id).catch(() => {});
+      loggers.api.error(
+        'Agent session spawn: first shell sandbox provision failed',
+        undefined,
+        { sessionId: spawned.session.id, reason: provisioned.reason },
+      );
+      return NextResponse.json({ error: 'Could not start a session' }, { status: 502 });
+    }
+
+    const shellSpawned = await spawnShell({ sessionId: spawned.session.id, ownerId: auth.userId });
+    if (!shellSpawned.ok) {
+      // The session row exists but its first shell failed: end it rather than
+      // leave an empty workspace the model says cannot exist.
+      await endSession(spawned.session.id).catch(() => {});
+      loggers.api.error(
+        'Agent session spawn: first shell failed',
+        undefined,
+        { sessionId: spawned.session.id, reason: shellSpawned.reason },
+      );
+      return NextResponse.json({ error: 'Could not start a session' }, { status: 502 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'agent_session',
+      resourceId: spawned.session.id,
+      details: { op: 'spawn_session', driveId, agentPageId: null, shellId: shellSpawned.shell.shellId },
+    });
+
+    return NextResponse.json(
+      { session: toAgentSessionDTO(spawned.session), shellId: shellSpawned.shell.shellId },
+      { status: 201 },
+    );
   }
 
   // The first conversation — the session is never empty. Created through the


### PR DESCRIPTION
## Summary

Phase 1 of the sidebar-sessions-naming epic (backend only, one route file: `apps/web/src/app/api/agent-sessions/route.ts`).

**Add `firstThing: 'shell'` branch to `POST /api/agent-sessions`**
- Accepts an optional `firstThing: 'shell'` body field. When set, after `spawnSession(...)` mints the session row, it spawns the session's first shell — reusing the exact `provisionSessionSandbox` + `spawnShell` pair the shells route (`[sessionId]/shells/route.ts`) already uses — instead of `createConversationInSession`. Response becomes `{ session, shellId }`.
- `firstThing` omitted/anything else behaves exactly as before: `{ session, conversationId }`, zero regression for existing callers.
- Provisioning or shell-spawn failure ends the just-minted session (same "no empty workspace" invariant the conversation path already enforces).

**Auto-generate a unique session name when the submitted name is blank**
- A blank/omitted `name` no longer stays `null`. It derives a base label from the spawn target (the agent's title, `"Shell"`, or `"Assistant"`) and scans for the first collision-free `base` / `base 2` / `base 3` / … among the *same owner's* existing session names — mirroring `nextShellLabel`'s "count existing, append a number, scan past collisions" pattern, reusing the existing `listSessions({ ownerId })` lookup for the collision check.
- A non-blank name is still used as-is, capped at `MAX_SESSION_NAME_LENGTH` (120) — unchanged.

Both deliverables built TDD (RED then GREEN); route docblock updated to reflect the new response union and the blank-name invariant.

## Test plan
- [x] `bun run --filter web test -- src/app/api/agent-sessions` — 113/113 passing (30 in the touched route's own suite)
- [x] `bun run --filter web typecheck` — clean
- [x] `bun run --filter web lint` — clean (only pre-existing warnings in unrelated files)
- [x] Rebased onto the current tip of `pu/sidebar-sessions` (which already includes the merged Phase 2 auto-titling work) — diff is scoped to the two touched files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Rt5FWprJmAnnYN7DDKoV