### PR TITLE
Agent sessions: deliberate naming, shells, and sidebar visual hierarchy

### DIFF
--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -16,6 +16,7 @@ const {
   mockCanPrincipalViewPage,
   mockProvisionSessionSandbox,
   mockSpawnShell,
+  mockFindSessionRecord,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAuditRequest: vi.fn(),
@@ -31,6 +32,7 @@ const {
   mockCanPrincipalViewPage: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
   mockSpawnShell: vi.fn(),
+  mockFindSessionRecord: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -58,6 +60,7 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   spawnSession: (...args: unknown[]) => mockSpawnSession(...args),
   toAgentSessionDTO: (row: { id: string }) => ({ sessionId: row.id, dto: true }),
   provisionSessionSandbox: (...args: unknown[]) => mockProvisionSessionSandbox(...args),
+  findSessionRecord: (...args: unknown[]) => mockFindSessionRecord(...args),
 }));
 vi.mock('@/lib/agent-sessions/session-shells-runtime', () => ({
   listShellsBulk: (...args: unknown[]) => mockListShellsBulk(...args),
@@ -333,6 +336,32 @@ describe("POST /api/agent-sessions — firstThing: 'shell'", () => {
     const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
     expect(response.status).toBe(502);
     expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+  });
+
+  // Codex review finding on PR #2284: a live-sandbox quota denial during shell-first
+  // provisioning was reported as a generic 502 instead of the actionable 429 the
+  // [sessionId]/shells/route.ts POST already gives the same denial.
+  it('given sandbox provisioning is denied for hitting the live-sandbox quota, ENDS the session and responds 429 (not 502)', async () => {
+    mockProvisionSessionSandbox.mockResolvedValue({
+      ok: false,
+      reason: 'denied',
+      denial: 'session_limit_reached',
+      detail: 'concurrency_limit',
+    });
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(429);
+    expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  // Codex review finding on PR #2284: spawned.session is the PRE-provision row, so
+  // responding with it directly reports a stale sandboxStatus even though provisioning
+  // just succeeded. The route must refetch before building the response DTO.
+  it('given the shell spawns successfully, refetches the session row after provisioning rather than reporting the stale pre-provision one', async () => {
+    mockFindSessionRecord.mockResolvedValue({ id: 'ses-new', sandboxStatus: 'running' });
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockFindSessionRecord).toHaveBeenCalledWith('ses-new');
   });
 });
 

--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -266,7 +266,7 @@ describe("POST /api/agent-sessions — firstThing: 'shell'", () => {
     mockCreateConversationInSession.mockResolvedValue(undefined);
   });
 
-  it("given firstThing: 'shell', should provision the sandbox then spawn a shell — NOT a conversation — and respond { session, shellId }", async () => {
+  it("given firstThing: 'shell', should provision the sandbox then spawn a shell — NOT a conversation — and respond { session, shellId, shellName }", async () => {
     const order: string[] = [];
     mockProvisionSessionSandbox.mockImplementation(async () => {
       order.push('provision');
@@ -283,11 +283,22 @@ describe("POST /api/agent-sessions — firstThing: 'shell'", () => {
     const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
     expect(response.status).toBe(201);
     const body = await response.json();
-    expect(body).toEqual({ session: { sessionId: 'ses-new', dto: true }, shellId: 'shell-new' });
+    expect(body).toEqual({ session: { sessionId: 'ses-new', dto: true }, shellId: 'shell-new', shellName: 'Shell' });
     expect(order).toEqual(['provision', 'spawn']);
     expect(mockProvisionSessionSandbox).toHaveBeenCalledWith({ id: 'ses-new' }, 'user-1');
     expect(mockSpawnShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'ses-new', ownerId: 'user-1' }));
     expect(mockCreateConversationInSession).not.toHaveBeenCalled();
+  });
+
+  it("given the shell auto-labels itself differently from the session's own name, responds with the SHELL's actual name (not the session label)", async () => {
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell 2', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
+
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell', name: 'My Custom Session' });
+    const body = await response.json();
+    expect(body.shellName).toBe('Shell 2');
   });
 
   it("given firstThing omitted, should behave exactly as today — first conversation, no shell", async () => {

--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -14,6 +14,8 @@ const {
   mockSpawnSession,
   mockGetAiAgent,
   mockCanPrincipalViewPage,
+  mockProvisionSessionSandbox,
+  mockSpawnShell,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAuditRequest: vi.fn(),
@@ -27,6 +29,8 @@ const {
   mockSpawnSession: vi.fn(),
   mockGetAiAgent: vi.fn(),
   mockCanPrincipalViewPage: vi.fn(),
+  mockProvisionSessionSandbox: vi.fn(),
+  mockSpawnShell: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -53,9 +57,11 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   endSession: (...args: unknown[]) => mockEndSession(...args),
   spawnSession: (...args: unknown[]) => mockSpawnSession(...args),
   toAgentSessionDTO: (row: { id: string }) => ({ sessionId: row.id, dto: true }),
+  provisionSessionSandbox: (...args: unknown[]) => mockProvisionSessionSandbox(...args),
 }));
 vi.mock('@/lib/agent-sessions/session-shells-runtime', () => ({
   listShellsBulk: (...args: unknown[]) => mockListShellsBulk(...args),
+  spawnShell: (...args: unknown[]) => mockSpawnShell(...args),
 }));
 
 import { GET, POST } from '../route';
@@ -171,6 +177,12 @@ describe('POST /api/agent-sessions — spawn', () => {
     mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Agent', type: 'AI_CHAT', driveId: 'drive-1' });
     mockCanPrincipalViewPage.mockResolvedValue(true);
     mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockListSessions.mockResolvedValue([]);
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sb-1', resumed: false });
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
   });
 
   it('spawns ONE session with ONE bound conversation — and NO sandbox', async () => {
@@ -188,12 +200,12 @@ describe('POST /api/agent-sessions — spawn', () => {
     // the absence is structural.
   });
 
-  it('spawns a GLOBAL-ASSISTANT session from the both-null shape', async () => {
+  it('spawns a GLOBAL-ASSISTANT session from the both-null shape, auto-naming it "Assistant"', async () => {
     const response = await spawn({});
     expect(response.status).toBe(201);
     const body = await response.json();
     expect(typeof body.conversationId).toBe('string');
-    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null, name: null });
+    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null, name: 'Assistant' });
     // The first conversation is an assistant thread: no agent page.
     expect(mockCreateConversationInSession).toHaveBeenCalledWith(
       expect.objectContaining({ agentPageId: null, sessionId: 'ses-new' }),
@@ -223,6 +235,91 @@ describe('POST /api/agent-sessions — spawn', () => {
   it('given the first conversation fails, ENDS the just-minted session — no empty workspace exists', async () => {
     mockCreateConversationInSession.mockRejectedValue(new Error('squat guard refused'));
     const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(502);
+    expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+  });
+});
+
+describe("POST /api/agent-sessions — firstThing: 'shell'", () => {
+  const spawn = (body: unknown) =>
+    POST(
+      new Request('http://localhost/api/agent-sessions', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+  beforeEach(() => {
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+    mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-new' } });
+    mockEndSession.mockResolvedValue({ ok: true, spriteTornDown: false });
+    mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockListSessions.mockResolvedValue([]);
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sb-1', resumed: false });
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Agent', type: 'AI_CHAT', driveId: 'drive-1' });
+    mockCanPrincipalViewPage.mockResolvedValue(true);
+    mockCreateConversationInSession.mockResolvedValue(undefined);
+  });
+
+  it("given firstThing: 'shell', should provision the sandbox then spawn a shell — NOT a conversation — and respond { session, shellId }", async () => {
+    const order: string[] = [];
+    mockProvisionSessionSandbox.mockImplementation(async () => {
+      order.push('provision');
+      return { ok: true, sandboxId: 'sb-1', resumed: false };
+    });
+    mockSpawnShell.mockImplementation(async () => {
+      order.push('spawn');
+      return {
+        ok: true,
+        shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+      };
+    });
+
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body).toEqual({ session: { sessionId: 'ses-new', dto: true }, shellId: 'shell-new' });
+    expect(order).toEqual(['provision', 'spawn']);
+    expect(mockProvisionSessionSandbox).toHaveBeenCalledWith({ id: 'ses-new' }, 'user-1');
+    expect(mockSpawnShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'ses-new', ownerId: 'user-1' }));
+    expect(mockCreateConversationInSession).not.toHaveBeenCalled();
+  });
+
+  it("given firstThing omitted, should behave exactly as today — first conversation, no shell", async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(typeof body.conversationId).toBe('string');
+    expect(body.shellId).toBeUndefined();
+    expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  it("given firstThing is some other value, should behave exactly as today — first conversation, no shell", async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1', firstThing: 'conversation' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(typeof body.conversationId).toBe('string');
+    expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  it('given the sandbox fails to provision, ENDS the just-minted session and never spawns a shell', async () => {
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: false, reason: 'provision_failed' });
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(502);
+    expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+    expect(mockSpawnShell).not.toHaveBeenCalled();
+  });
+
+  it('given the first shell fails to spawn, ENDS the just-minted session', async () => {
+    mockSpawnShell.mockResolvedValue({ ok: false, reason: 'error' });
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
     expect(response.status).toBe(502);
     expect(mockEndSession).toHaveBeenCalledWith('ses-new');
   });
@@ -277,6 +374,113 @@ describe('POST /api/agent-sessions — spawn agent validation (review M6)', () =
     expect(response.status).toBe(201);
     expect(mockSpawnSession).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'x'.repeat(120) }),
+    );
+  });
+});
+
+describe('POST /api/agent-sessions — blank name auto-generates a unique one', () => {
+  const spawn = (body: unknown) =>
+    POST(
+      new Request('http://localhost/api/agent-sessions', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+  beforeEach(() => {
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+    mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-new' } });
+    mockCreateConversationInSession.mockResolvedValue(undefined);
+    mockEndSession.mockResolvedValue({ ok: true, spriteTornDown: false });
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', title: 'Research Bot', type: 'AI_CHAT', driveId: 'drive-1' });
+    mockCanPrincipalViewPage.mockResolvedValue(true);
+    mockCountActiveSessionsForOwner.mockResolvedValue(0);
+    mockListSessions.mockResolvedValue([]);
+    mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sb-1', resumed: false });
+    mockSpawnShell.mockResolvedValue({
+      ok: true,
+      shell: { shellId: 'shell-new', sessionId: 'ses-new', ownerId: 'user-1', name: 'Shell', agentType: 'shell', command: null, createdAt: '2026-07-28T00:00:00.000Z' },
+    });
+  });
+
+  it('given a blank name with an agent, should derive the base label from the agent title', async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1', name: '' });
+    expect(response.status).toBe(201);
+    expect(mockListSessions).toHaveBeenCalledWith({ ownerId: 'user-1' });
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Research Bot' }),
+    );
+  });
+
+  it('given an omitted name with an agent, should derive the base label from the agent title', async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Research Bot' }),
+    );
+  });
+
+  it("given a blank name with firstThing: 'shell', should derive the base label \"Shell\"", async () => {
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Shell' }),
+    );
+  });
+
+  it('given a blank name for the global-assistant shape, should derive the base label "Assistant"', async () => {
+    const response = await spawn({});
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Assistant' }),
+    );
+  });
+
+  it('given a non-blank name, should use it as-is — no collision lookup at all', async () => {
+    const response = await spawn({ driveId: 'drive-1', agentPageId: 'agent-1', name: 'api refactor' });
+    expect(response.status).toBe(201);
+    expect(mockListSessions).not.toHaveBeenCalled();
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'api refactor' }),
+    );
+  });
+
+  it('given the base label already taken, should append " 2" rather than collide', async () => {
+    mockListSessions.mockResolvedValue([
+      { sessionId: 'ses-old', driveId: null, ownerId: 'user-1', name: 'Shell', sandboxStatus: 'ended', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+    ]);
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Shell 2' }),
+    );
+  });
+
+  it('given two blank-named shell spawns back to back, should produce two distinct names', async () => {
+    mockListSessions.mockResolvedValueOnce([]);
+    const first = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(mockSpawnSession).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'Shell' }));
+
+    mockListSessions.mockResolvedValueOnce([
+      { sessionId: 'ses-old', driveId: 'drive-1', ownerId: 'user-1', name: 'Shell', sandboxStatus: 'running', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+    ]);
+    const second = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(mockSpawnSession).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'Shell 2' }));
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+  });
+
+  it('given "Shell" and "Shell 2" both taken, should scan past both collisions to "Shell 3"', async () => {
+    mockListSessions.mockResolvedValue([
+      { sessionId: 'ses-1', driveId: 'drive-1', ownerId: 'user-1', name: 'Shell', sandboxStatus: 'running', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+      { sessionId: 'ses-2', driveId: 'drive-1', ownerId: 'user-1', name: 'Shell 2', sandboxStatus: 'running', createdAt: '2026-07-28T00:00:00.000Z', lastActiveAt: null, endedAt: null },
+    ]);
+    const response = await spawn({ driveId: 'drive-1', firstThing: 'shell' });
+    expect(response.status).toBe(201);
+    expect(mockSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Shell 3' }),
     );
   });
 });

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -8,7 +8,7 @@
  * GET ?driveId=<id> | (none = mine)
  *   → { sessions: [{ …AgentSessionDTO, shells: ShellDTO[], conversations }] }
  * POST { driveId, agentPageId, name?, firstThing? }
- *   → 201 { session, conversationId } | { session, shellId } — spawn (see below)
+ *   → 201 { session, conversationId } | { session, shellId, shellName } — spawn (see below)
  *
  * Every listing is scoped to the REQUESTER's own sessions (`ownerId` rides
  * every filter): `driveId` narrows *where*, never *whose*. Admin gate first,
@@ -315,7 +315,11 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json(
-      { session: toAgentSessionDTO(spawned.session), shellId: shellSpawned.shell.shellId },
+      {
+        session: toAgentSessionDTO(spawned.session),
+        shellId: shellSpawned.shell.shellId,
+        shellName: shellSpawned.shell.name,
+      },
       { status: 201 },
     );
   }

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -7,8 +7,8 @@
  *
  * GET ?driveId=<id> | (none = mine)
  *   → { sessions: [{ …AgentSessionDTO, shells: ShellDTO[], conversations }] }
- * POST { driveId, agentPageId, name? }
- *   → 201 { session, conversationId } — spawn (see below)
+ * POST { driveId, agentPageId, name?, firstThing? }
+ *   → 201 { session, conversationId } | { session, shellId } — spawn (see below)
  *
  * Every listing is scoped to the REQUESTER's own sessions (`ownerId` rides
  * every filter): `driveId` narrows *where*, never *whose*. Admin gate first,
@@ -30,15 +30,31 @@ import {
   listSessions,
   listSessionConversationsBulk,
   MAX_ACTIVE_SESSIONS_PER_OWNER,
+  provisionSessionSandbox,
   spawnSession,
   toAgentSessionDTO,
   type AgentSessionListFilter,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
-import { listShellsBulk } from '@/lib/agent-sessions/session-shells-runtime';
+import { listShellsBulk, spawnShell } from '@/lib/agent-sessions/session-shells-runtime';
 import { sessionQuotaExceeded } from '@/lib/agent-sessions/quota-response';
 
 /** Bound on the stored display label — rendered everywhere the session appears. */
 const MAX_SESSION_NAME_LENGTH = 120;
+
+/**
+ * A blank-name spawn's auto-label: the first collision-free of `base`,
+ * `base 2`, `base 3`, … — mirroring `nextShellLabel`'s "count existing,
+ * append a number, scan past collisions" pattern
+ * (`plan-spawn-session.ts:61-68`), but starting at the bare label rather than
+ * always suffixing a number: no session is ever born "Shell 1".
+ */
+function nextUniqueSessionName(base: string, existingNames: readonly string[]): string {
+  const taken = new Set(existingNames);
+  if (!taken.has(base)) return base;
+  let index = 2;
+  while (taken.has(`${base} ${index}`)) index += 1;
+  return `${base} ${index}`;
+}
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -97,11 +113,11 @@ export async function GET(request: Request) {
 }
 
 /**
- * POST → 201 { session, conversationId } — SPAWN a session.
+ * POST → 201 { session, conversationId } | { session, shellId } — SPAWN a session.
  *
  * One act, per the lifecycle invariant: a session is born with its first
- * conversation, so this creates the workspace row AND a conversation already
- * bound to it. Two shapes, matching the two session kinds:
+ * thing, so this creates the workspace row AND that first thing already bound
+ * to it. Two shapes, matching the two session kinds:
  *
  * - `{ driveId, agentPageId }` — a DRIVE session, first conversation with that
  *   drive agent.
@@ -110,11 +126,24 @@ export async function GET(request: Request) {
  *   access decision (there is no drive whose membership could admit anyone
  *   else).
  *
- * Half-specified shapes are refused: an agent without its drive is
- * unresolvable, and a drive without an agent would mint an empty session.
+ * `firstThing: 'shell'` swaps the first-conversation act for a first-shell
+ * one: the session's first thing is a shell instead, reusing the exact
+ * sandbox-provisioning + shell-spawn logic the shells route uses
+ * (`provisionSessionSandbox` + `spawnShell`) rather than reimplementing it.
+ * Omitted/anything else behaves exactly as before — the conversation path.
  *
- * Spawn is instant and free: NO sandbox is provisioned here. The first tool
- * call or shell open provisions lazily through the one shared path.
+ * Half-specified shapes are refused: an agent without its drive is
+ * unresolvable, and a drive without an agent would mint an empty session —
+ * UNLESS `firstThing: 'shell'`, whose first thing needs no agent.
+ *
+ * A blank/omitted `name` is not left null: it is auto-derived from the spawn
+ * target (the agent's title, "Shell", or "Assistant") and made unique among
+ * the owner's own existing session names before the row is inserted.
+ *
+ * Spawn itself is instant and free: NO sandbox is provisioned for the
+ * conversation path. `firstThing: 'shell'` is the exception — opening a shell
+ * always needs a live sandbox, so this branch provisions eagerly instead of
+ * waiting for the first tool call.
  *
  * Access: the same pure decision every session surface uses, applied to the
  * row-to-be — drive membership + code-execution for a drive session, owner +
@@ -124,7 +153,7 @@ export async function POST(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
 
-  let body: { driveId?: unknown; agentPageId?: unknown; name?: unknown } = {};
+  let body: { driveId?: unknown; agentPageId?: unknown; name?: unknown; firstThing?: unknown } = {};
   try {
     body = await request.json();
   } catch {
@@ -134,19 +163,23 @@ export async function POST(request: Request) {
   const agentPageId =
     typeof body.agentPageId === 'string' && body.agentPageId.length > 0 ? body.agentPageId : null;
   const rawName = typeof body.name === 'string' ? body.name.trim() : '';
-  // A label, never an address — but still bounded: it is stored, listed and
-  // rendered everywhere the session appears.
-  const name = rawName.length > 0 ? rawName.slice(0, MAX_SESSION_NAME_LENGTH) : null;
+  const wantsShellFirst = body.firstThing === 'shell';
 
-  if ((driveId === null) !== (agentPageId === null)) {
+  if (!wantsShellFirst && (driveId === null) !== (agentPageId === null)) {
     // Half-specified: an agent without its drive is unresolvable, and a drive
     // without an agent would mint an empty session. Both-null is the
-    // global-assistant spawn; both-present is the drive spawn.
+    // global-assistant spawn; both-present is the drive spawn. A shell-first
+    // spawn needs no agent, so it is exempt from this shape check.
     return NextResponse.json(
       { error: 'A session needs a drive and an agent to start with, or neither for the assistant' },
       { status: 400 },
     );
   }
+
+  // The agent's title, when one is being spawned into — the base label a
+  // blank `name` derives from (see below). Captured here rather than
+  // re-fetched, since the lookup already happened for validation.
+  let agentTitle: string | null = null;
 
   if (agentPageId !== null && driveId !== null) {
     // The same checks the conversation routes make, BEFORE any row is minted
@@ -179,6 +212,7 @@ export async function POST(request: Request) {
         { status: 403 },
       );
     }
+    agentTitle = agent.title;
   }
 
   // Advisory fast-path only (review #2261/2): count-then-branch here is
@@ -215,6 +249,21 @@ export async function POST(request: Request) {
     );
   }
 
+  // A label, never an address — but still bounded: it is stored, listed and
+  // rendered everywhere the session appears. Blank/omitted does not stay
+  // null: it is derived from the spawn target and made unique among the
+  // owner's own existing session names, so the sidebar never renders the
+  // literal fallback "Session" for a spawn that went through this route.
+  let name: string;
+  if (rawName.length > 0) {
+    name = rawName.slice(0, MAX_SESSION_NAME_LENGTH);
+  } else {
+    const baseLabel = wantsShellFirst ? 'Shell' : agentPageId !== null ? (agentTitle ?? 'Agent') : 'Assistant';
+    const existingSessions = await listSessions({ ownerId: auth.userId });
+    const existingNames = existingSessions.map((session) => session.name);
+    name = nextUniqueSessionName(baseLabel, existingNames).slice(0, MAX_SESSION_NAME_LENGTH);
+  }
+
   const spawned = await spawnSession({ userId: auth.userId, driveId, name });
   if (!spawned.ok) {
     if (spawned.reason === 'session_limit_reached') {
@@ -226,6 +275,49 @@ export async function POST(request: Request) {
     }
     loggers.api.error('Agent session spawn failed', undefined, { driveId, detail: spawned.detail });
     return NextResponse.json({ error: 'Could not start a session', reason: spawned.reason }, { status: 502 });
+  }
+
+  if (wantsShellFirst) {
+    // The first shell — same provisioning + spawn pair the shells route uses
+    // (`[sessionId]/shells/route.ts` POST, lines 88-167): a shell always
+    // needs a live sandbox, so unlike the conversation path this provisions
+    // eagerly rather than waiting for the first tool call.
+    const provisioned = await provisionSessionSandbox(spawned.session, auth.userId);
+    if (!provisioned.ok) {
+      await endSession(spawned.session.id).catch(() => {});
+      loggers.api.error(
+        'Agent session spawn: first shell sandbox provision failed',
+        undefined,
+        { sessionId: spawned.session.id, reason: provisioned.reason },
+      );
+      return NextResponse.json({ error: 'Could not start a session' }, { status: 502 });
+    }
+
+    const shellSpawned = await spawnShell({ sessionId: spawned.session.id, ownerId: auth.userId });
+    if (!shellSpawned.ok) {
+      // The session row exists but its first shell failed: end it rather than
+      // leave an empty workspace the model says cannot exist.
+      await endSession(spawned.session.id).catch(() => {});
+      loggers.api.error(
+        'Agent session spawn: first shell failed',
+        undefined,
+        { sessionId: spawned.session.id, reason: shellSpawned.reason },
+      );
+      return NextResponse.json({ error: 'Could not start a session' }, { status: 502 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'agent_session',
+      resourceId: spawned.session.id,
+      details: { op: 'spawn_session', driveId, agentPageId: null, shellId: shellSpawned.shell.shellId },
+    });
+
+    return NextResponse.json(
+      { session: toAgentSessionDTO(spawned.session), shellId: shellSpawned.shell.shellId },
+      { status: 201 },
+    );
   }
 
   // The first conversation — the session is never empty. Created through the

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -27,6 +27,7 @@ import {
   countActiveSessionsForOwner,
   createConversationInSession,
   endSession,
+  findSessionRecord,
   listSessions,
   listSessionConversationsBulk,
   MAX_ACTIVE_SESSIONS_PER_OWNER,
@@ -285,6 +286,14 @@ export async function POST(request: Request) {
     const provisioned = await provisionSessionSandbox(spawned.session, auth.userId);
     if (!provisioned.ok) {
       await endSession(spawned.session.id).catch(() => {});
+      // A plan-limit refusal is not an infrastructure failure — same split the
+      // shells route draws (`[sessionId]/shells/route.ts` POST): a live-sandbox
+      // quota denial gets the actionable 429, not a generic 502.
+      if (provisioned.reason === 'denied' && provisioned.denial === 'session_limit_reached') {
+        return sessionQuotaExceeded(request, auth.userId, spawned.session.id, 'agent-sessions', {
+          reasonCode: provisioned.detail,
+        });
+      }
       loggers.api.error(
         'Agent session spawn: first shell sandbox provision failed',
         undefined,
@@ -314,9 +323,14 @@ export async function POST(request: Request) {
       details: { op: 'spawn_session', driveId, agentPageId: null, shellId: shellSpawned.shell.shellId },
     });
 
+    // spawned.session is the PRE-provision row — provisioning just flipped its
+    // sandbox state, so refetch rather than report the stale 'none' status a
+    // caller would otherwise read off the DTO it just successfully spawned.
+    const provisionedSession = (await findSessionRecord(spawned.session.id)) ?? spawned.session;
+
     return NextResponse.json(
       {
-        session: toAgentSessionDTO(spawned.session),
+        session: toAgentSessionDTO(provisionedSession),
         shellId: shellSpawned.shell.shellId,
         shellName: shellSpawned.shell.name,
       },

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -301,6 +301,7 @@ vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
 }));
 
 import { POST } from '../route';
+import { extractMessageContent } from '@/lib/ai/core/message-utils';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import type { SessionAuthResult } from '@/lib/auth';
 import { MAX_BROWSER_SESSION_ID_LENGTH } from '@/lib/ai/core/browser-session-id-validation';
@@ -684,6 +685,31 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
       const saveCalls = mockSaveMessageToDatabase.mock.calls;
       const assistantSave = saveCalls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
       expect(assistantSave?.[0]?.mentionNotify).toBeDefined();
+    });
+  });
+
+  describe('conversation auto-titling on first message', () => {
+    it('given a session conversation and non-empty extracted content, calls autoTitleConversation with the derived title', async () => {
+      mockGetConversation.mockResolvedValueOnce({ id: CONV_ID, userId: 'user-1', isShared: false });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+
+      // extractMessageContent is fixture-mocked (always 'test content' by default —
+      // see the module mock above); deriveConversationTitle is the real function.
+      expect(mockAutoTitleConversation).toHaveBeenCalledWith(CONV_ID, 'test content');
+    });
+
+    // Codex review finding on PR #2284: a file/image-only first message extracts as ''
+    // (extractMessageContent has no text part to read). autoTitleConversation only fills
+    // rows where title IS NULL, so persisting '' would permanently block a later textual
+    // message from ever titling the conversation — the route must skip the write instead.
+    it('given a session conversation and empty extracted content (e.g. a file-only message), does NOT call autoTitleConversation', async () => {
+      mockGetConversation.mockResolvedValueOnce({ id: CONV_ID, userId: 'user-1', isShared: false });
+      vi.mocked(extractMessageContent).mockReturnValueOnce('');
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(mockAutoTitleConversation).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -19,6 +19,7 @@ const {
   mockHasConflictingMessageOwner,
   mockTakeOverConversationStreams,
   mockCreateConversation,
+  mockAutoTitleConversation,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
@@ -29,6 +30,7 @@ const {
   mockHasConflictingMessageOwner: vi.fn().mockResolvedValue(false),
   mockTakeOverConversationStreams: vi.fn().mockResolvedValue({ aborted: [], reconciled: [] }),
   mockCreateConversation: vi.fn().mockResolvedValue(undefined),
+  mockAutoTitleConversation: vi.fn().mockResolvedValue(undefined),
 }));
 
 interface MockUIStreamOptions {
@@ -231,6 +233,7 @@ vi.mock('@/lib/repositories/conversation-repository', () => ({
     getConversation: mockGetConversation,
     hasConflictingMessageOwner: mockHasConflictingMessageOwner,
     createConversation: mockCreateConversation,
+    autoTitleConversation: mockAutoTitleConversation,
   },
 }));
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -120,6 +120,7 @@ import type { ContextRef } from '@/lib/ai/shared/buildContextRef';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { deriveConversationTitle } from '@/lib/repositories/derive-conversation-title';
 
 
 // Allow streaming responses up to 5 minutes for complex AI agent interactions
@@ -698,7 +699,18 @@ export async function POST(request: Request) {
           toolResults: undefined,
           uiMessage: userMessage,
         });
-        
+
+        // Fire-and-forget: title derivation must never fail or delay the chat
+        // response, matching how createConversation above is treated as
+        // non-fatal. existingConversation is always populated for a session's
+        // conversation (its row is created before the first message ever
+        // reaches this route) — the null check guards the non-session path.
+        if (existingConversation) {
+          conversationRepository
+            .autoTitleConversation(existingConversation.id, deriveConversationTitle(messageContent))
+            .catch(() => {});
+        }
+
         loggers.ai.debug('AI Chat API: User message saved to database');
 
         auditRequest(request, { eventType: 'data.write', userId, resourceType: 'ai_chat', resourceId: chatId, details: {

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -705,10 +705,16 @@ export async function POST(request: Request) {
         // non-fatal. existingConversation is always populated for a session's
         // conversation (its row is created before the first message ever
         // reaches this route) — the null check guards the non-session path.
+        // A file/image-only first message derives an empty title; skip the
+        // write so a later textual message still finds title IS NULL and can
+        // title the conversation (autoTitleConversation only fills nulls).
         if (existingConversation) {
-          conversationRepository
-            .autoTitleConversation(existingConversation.id, deriveConversationTitle(messageContent))
-            .catch(() => {});
+          const derivedTitle = deriveConversationTitle(messageContent);
+          if (derivedTitle.length > 0) {
+            conversationRepository
+              .autoTitleConversation(existingConversation.id, derivedTitle)
+              .catch(() => {});
+          }
         }
 
         loggers.ai.debug('AI Chat API: User message saved to database');

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -94,6 +94,7 @@ import {
 } from '@/lib/ai/core/prompt-assembly';
 import { prepareHistoryForModel, finishModelRequest } from '@/lib/ai/core/context-assembly';
 import { resolveOrCreateConversation, ConversationOwnershipError } from './resolve-or-create-conversation';
+import { deriveConversationTitle } from '@/lib/repositories/derive-conversation-title';
 
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
@@ -536,7 +537,7 @@ export async function POST(
 
         if (!conversation.title) {
           // Auto-generate title from first user message
-          const title = messageContent.slice(0, 50) + (messageContent.length > 50 ? '...' : '');
+          const title = deriveConversationTitle(messageContent);
           updateData.title = title;
           resolvedConversationTitle = title;
         }

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -10,7 +10,6 @@ import EndSessionDialog from '@/components/agents/EndSessionDialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   CommandDialog,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -261,27 +260,54 @@ function SessionList({
   }, [driveId, sessions, canSpawn, roster]);
 
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
-  const [spawnTarget, setSpawnTarget] = useState<{ driveId: string; driveName: string | null } | null>(null);
+  const selectSession = useAgentSurfaceStore((state) => state.selectSession);
+  const [spawnTarget, setSpawnTarget] = useState<{ driveId: string | null; driveName: string | null } | null>(null);
+  // Set once a target (agent/shell/assistant) is picked in the palette's first
+  // step — its presence is what swaps the dialog to the naming step. Null
+  // driveId + kind 'assistant' is the only shape the Assistant group's "+"
+  // ever produces (it skips the picker entirely, see handleNewSession).
+  const [spawnPick, setSpawnPick] = useState<SpawnPick | null>(null);
   const [spawning, setSpawning] = useState(false);
 
   const spawn = useCallback(
-    async (targetDriveId: string | null, agentPageId: string | null) => {
+    async (input: { driveId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
       if (spawning) return;
       setSpawning(true);
       try {
+        if (input.kind === 'shell') {
+          const created = await post<{ session: { sessionId: string }; shellId: string }>('/api/agent-sessions', {
+            driveId: input.driveId,
+            firstThing: 'shell',
+            name: input.name,
+          });
+          setSpawnTarget(null);
+          setSpawnPick(null);
+          onChanged();
+          // useAgentSurfaceStore has no shell concept — land by selecting the
+          // session there, then placing the pane directly on the workspace
+          // store, mirroring AgentPanes.tsx's handleReattachShell.
+          selectSession(created.session.sessionId);
+          useAgentWorkspaceStore.getState().openConversation(created.session.sessionId, {
+            kind: 'terminal',
+            name: input.name,
+            targetId: created.shellId,
+            agentPageId: null,
+          });
+          return;
+        }
         const created = await post<{ session: { sessionId: string }; conversationId: string }>(
           '/api/agent-sessions',
-          // Both-null is the global-assistant spawn shape.
-          agentPageId === null ? {} : { driveId: targetDriveId, agentPageId },
+          { driveId: input.driveId, agentPageId: input.agentPageId, name: input.name },
         );
         setSpawnTarget(null);
+        setSpawnPick(null);
         onChanged();
         // Land the user IN the new session's first conversation — no empty
         // state is ever visible.
         selectConversation({
           sessionId: created.session.sessionId,
           conversationId: created.conversationId,
-          agentId: agentPageId,
+          agentId: input.agentPageId,
         });
       } catch (error) {
         console.error('Failed to start a session:', error);
@@ -292,21 +318,30 @@ function SessionList({
         setSpawning(false);
       }
     },
-    [spawning, onChanged, selectConversation],
+    [spawning, onChanged, selectConversation, selectSession],
   );
 
-  // The ASSISTANT group has nothing to choose — the assistant IS the
-  // counterpart — so its "+" spawns directly, one click. A DRIVE group's "+"
-  // opens the palette to pick which agent the new session pairs with.
-  const handleNewSession = useCallback(
-    (groupDriveId: string, groupDriveName: string | null) => {
-      if (groupDriveId === ASSISTANT_GROUP_KEY) {
-        void spawn(null, null);
-        return;
-      }
-      setSpawnTarget({ driveId: groupDriveId, driveName: groupDriveName });
+  // Sessions are always deliberately named now — both groups open the same
+  // naming step. The ASSISTANT group has nothing to pick (the assistant IS
+  // the counterpart), so it skips straight to naming; a DRIVE group's "+"
+  // opens the picker first so the naming step's placeholder can reflect
+  // whichever agent/shell was chosen.
+  const handleNewSession = useCallback((groupDriveId: string, groupDriveName: string | null) => {
+    if (groupDriveId === ASSISTANT_GROUP_KEY) {
+      setSpawnTarget({ driveId: null, driveName: null });
+      setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Assistant' });
+      return;
+    }
+    setSpawnTarget({ driveId: groupDriveId, driveName: groupDriveName });
+    setSpawnPick(null);
+  }, []);
+
+  const handleSubmitName = useCallback(
+    (name: string) => {
+      if (!spawnTarget || !spawnPick) return;
+      void spawn({ driveId: spawnTarget.driveId, agentPageId: spawnPick.agentPageId, kind: spawnPick.kind, name });
     },
-    [spawn],
+    [spawn, spawnTarget, spawnPick],
   );
 
   const paletteAgents = useMemo(
@@ -342,9 +377,15 @@ function SessionList({
         open={spawnTarget !== null}
         driveName={spawnTarget?.driveName ?? null}
         agents={paletteAgents}
+        pick={spawnPick}
         spawning={spawning}
-        onOpenChange={(open) => !open && setSpawnTarget(null)}
-        onSelectAgent={(agentId) => spawnTarget && void spawn(spawnTarget.driveId, agentId)}
+        onOpenChange={(open) => {
+          if (open) return;
+          setSpawnTarget(null);
+          setSpawnPick(null);
+        }}
+        onPickTarget={setSpawnPick}
+        onSubmitName={handleSubmitName}
       />
     </div>
   );
@@ -599,57 +640,118 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
   );
 }
 
+type SpawnKind = 'agent' | 'shell' | 'assistant';
+
+/** What the palette's first step picked — drives the naming step's placeholder and spawn() call. */
+interface SpawnPick {
+  kind: SpawnKind;
+  agentPageId: string | null;
+  /** The sensible default: the agent's title, "Shell", or "Assistant". */
+  label: string;
+}
+
 /**
- * The agent picker for spawning a new DRIVE session, Raycast-style: search or
- * arrow-key to an agent and hit Enter — the same keyboard-first pattern
- * `QuickCreatePalette` established for page creation, reused here so a future
- * mouseless-navigation pass has one command-palette idiom to build on, not two.
- * Only ever opened for a drive group (the ASSISTANT group spawns directly —
- * it has nothing to choose, since the assistant IS the counterpart).
+ * The spawn palette for a new session, Raycast-style: search or arrow-key to
+ * a target and hit Enter — the same keyboard-first pattern `QuickCreatePalette`
+ * established for page creation, reused here so a future mouseless-navigation
+ * pass has one command-palette idiom to build on, not two. Two steps: pick a
+ * target (an agent, Shell, or — for the ASSISTANT group, which skips straight
+ * here since it has nothing else to choose — Assistant), then name the
+ * session. Naming is always the last step, even for a one-click assistant
+ * spawn, so every session gets a deliberate name.
  */
 function SpawnSessionPalette({
   open,
   driveName,
   agents,
+  pick,
   spawning,
   onOpenChange,
-  onSelectAgent,
+  onPickTarget,
+  onSubmitName,
 }: {
   open: boolean;
   driveName: string | null;
   agents: DriveWithAgents['agents'];
+  pick: SpawnPick | null;
   spawning: boolean;
   onOpenChange: (open: boolean) => void;
-  onSelectAgent: (agentId: string) => void;
+  onPickTarget: (pick: SpawnPick) => void;
+  onSubmitName: (name: string) => void;
 }) {
+  const [name, setName] = useState('');
+
+  // Blank by default every time a new naming step starts — a stale typed
+  // value from resolving one spawn must never prefill the next.
+  useEffect(() => {
+    if (open) setName('');
+  }, [open, pick]);
+
   return (
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="New session"
+      title={pick ? 'Name your session' : 'New session'}
       description={
-        driveName ? `Choose an agent to start a session with in ${driveName}` : 'Choose an agent to start a session with'
+        pick
+          ? `Leave blank to use "${pick.label}"`
+          : driveName
+            ? `Choose an agent to start a session with in ${driveName}`
+            : 'Choose an agent to start a session with'
       }
       showCloseButton={false}
       className="max-w-[420px]"
     >
-      <CommandInput placeholder="Search agents…" autoFocus />
-      <CommandList>
-        <CommandEmpty>No agents in this drive yet.</CommandEmpty>
-        <CommandGroup>
-          {agents.map((agent) => (
-            <CommandItem
-              key={agent.id}
-              value={`${agent.id}-${agent.title ?? 'Agent'}`}
-              disabled={spawning}
-              onSelect={() => onSelectAgent(agent.id)}
-            >
-              <Bot className="size-3.5" aria-hidden="true" />
-              <span className="truncate">{agent.title ?? 'Agent'}</span>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
+      {pick ? (
+        <form
+          className="p-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmitName(name);
+          }}
+        >
+          <input
+            autoFocus
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter') return;
+              event.preventDefault();
+              onSubmitName(name);
+            }}
+            placeholder={pick.label}
+            disabled={spawning}
+            className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </form>
+      ) : (
+        <>
+          <CommandInput placeholder="Search agents…" autoFocus />
+          <CommandList>
+            <CommandGroup>
+              {agents.map((agent) => (
+                <CommandItem
+                  key={agent.id}
+                  value={`${agent.id}-${agent.title ?? 'Agent'}`}
+                  disabled={spawning}
+                  onSelect={() => onPickTarget({ kind: 'agent', agentPageId: agent.id, label: agent.title ?? 'Agent' })}
+                >
+                  <Bot className="size-3.5" aria-hidden="true" />
+                  <span className="truncate">{agent.title ?? 'Agent'}</span>
+                </CommandItem>
+              ))}
+              <CommandItem
+                value="shell-Shell"
+                disabled={spawning}
+                onSelect={() => onPickTarget({ kind: 'shell', agentPageId: null, label: 'Shell' })}
+              >
+                <SquareTerminal className="size-3.5" aria-hidden="true" />
+                <span className="truncate">Shell</span>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </>
+      )}
     </CommandDialog>
   );
 }

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -473,14 +473,6 @@ function SessionRow({
     [selectConversation, session.sessionId],
   );
 
-  const openSession = useCallback(() => {
-    // Selecting a SESSION opens its most recent conversation — the row is a
-    // workspace, and a workspace opens on its work, not on a placeholder.
-    setExpanded(true);
-    const first = session.conversations[0];
-    if (first) openConversation(first);
-  }, [openConversation, session.conversations]);
-
   const openShell = useCallback(
     (shell: { shellId: string; name: string }) => {
       selectSession(session.sessionId);
@@ -493,6 +485,21 @@ function SessionRow({
     },
     [selectSession, session.sessionId],
   );
+
+  const openSession = useCallback(() => {
+    // Selecting a SESSION opens its most recent conversation — the row is a
+    // workspace, and a workspace opens on its work, not on a placeholder. A
+    // shell-first session has no conversations at all, so fall back to its
+    // first shell rather than leave the click a no-op.
+    setExpanded(true);
+    const first = session.conversations[0];
+    if (first) {
+      openConversation(first);
+      return;
+    }
+    const firstShell = session.shells[0];
+    if (firstShell) openShell(firstShell);
+  }, [openConversation, openShell, session.conversations, session.shells]);
 
   const endSession = useCallback(async () => {
     setEnding(true);

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -288,21 +288,23 @@ function SessionList({
       setSpawning(true);
       try {
         if (input.kind === 'shell') {
-          const created = await post<{ session: { sessionId: string }; shellId: string }>('/api/agent-sessions', {
-            driveId: input.driveId,
-            firstThing: 'shell',
-            name: input.name,
-          });
+          const created = await post<{ session: { sessionId: string }; shellId: string; shellName: string }>(
+            '/api/agent-sessions',
+            { driveId: input.driveId, firstThing: 'shell', name: input.name },
+          );
           setSpawnTarget(null);
           setSpawnPick(null);
           onChanged();
           // useAgentSurfaceStore has no shell concept — land by selecting the
           // session there, then placing the pane directly on the workspace
-          // store, mirroring AgentPanes.tsx's handleReattachShell.
+          // store, mirroring AgentPanes.tsx's handleReattachShell. The shell
+          // is named independently server-side (spawnShell, no name passed) —
+          // use its own name, not the session label, so the pane title
+          // matches the shell row shown in the sidebar.
           selectSession(created.session.sessionId);
           useAgentWorkspaceStore.getState().openConversation(created.session.sessionId, {
             kind: 'terminal',
-            name: input.name,
+            name: created.shellName,
             targetId: created.shellId,
             agentPageId: null,
           });

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, MessageSquarePlus, Plus, SquareTerminal, X } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Plus, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
@@ -250,6 +250,19 @@ function SessionList({
   // session, but must not offer to spawn a NEW one into a trashed drive.
   const trashedDriveIds = useMemo(() => new Set(drives.filter((d) => d.isTrashed).map((d) => d.id)), [drives]);
 
+  // Flattened once here (not per-SessionRow) so every session's conversation
+  // labels share one lookup instead of re-deriving it from `agentsByDrive` N
+  // times.
+  const agentNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const drive of agentsByDrive) {
+      for (const agent of drive.agents) {
+        map.set(agent.id, agent.title ?? 'Agent');
+      }
+    }
+    return map;
+  }, [agentsByDrive]);
+
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
   // first — see session-groups.ts for the ordering rule); a single implicit
   // group in drive mode, always present (even with zero sessions) so its
@@ -368,7 +381,12 @@ function SessionList({
             />
           )}
           {group.sessions.map((session) => (
-            <SessionRow key={session.sessionId} session={session} onChanged={onChanged} />
+            <SessionRow
+              key={session.sessionId}
+              session={session}
+              onChanged={onChanged}
+              agentNamesById={agentNamesById}
+            />
           ))}
         </div>
       ))}
@@ -419,7 +437,15 @@ function SessionGroupHeader({
 }
 
 /** One session: name + running dot, expanding to its conversations (never its panes). */
-function SessionRow({ session, onChanged }: { session: SessionListEntry; onChanged: () => void }) {
+function SessionRow({
+  session,
+  onChanged,
+  agentNamesById,
+}: {
+  session: SessionListEntry;
+  onChanged: () => void;
+  agentNamesById: Map<string, string>;
+}) {
   const selectedSessionId = useAgentSurfaceStore((state) => state.selectedSessionId);
   const selectedConversationId = useAgentSurfaceStore((state) => state.selectedConversationId);
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
@@ -450,37 +476,18 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
     if (first) openConversation(first);
   }, [openConversation, session.conversations]);
 
-  const newConversation = useCallback(async () => {
-    // A new thread defaults to the session's most recent conversation's
-    // counterpart — the full drive picker lives in the pane grid. A null
-    // agent (a global session, or a drive session whose latest thread is an
-    // assistant thread) means the ASSISTANT, created through the
-    // session-centric route since it has no agent page.
-    const agentPageId = session.conversations[0]?.agentPageId ?? null;
-    try {
-      const created =
-        agentPageId === null
-          ? await post<{ conversationId: string }>(
-              `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations`,
-              {},
-            )
-          : await post<{ conversationId: string }>(
-              `/api/ai/page-agents/${encodeURIComponent(agentPageId)}/conversations`,
-              { sessionId: session.sessionId },
-            );
-      onChanged();
-      selectConversation({
-        sessionId: session.sessionId,
-        conversationId: created.conversationId,
-        agentId: agentPageId,
+  const openShell = useCallback(
+    (shell: { shellId: string; name: string }) => {
+      selectSession(session.sessionId);
+      useAgentWorkspaceStore.getState().openConversation(session.sessionId, {
+        kind: 'terminal',
+        name: shell.name,
+        targetId: shell.shellId,
+        agentPageId: null,
       });
-    } catch (error) {
-      console.error('Failed to start a conversation:', error);
-      toast.error('Could not start a conversation', {
-        description: error instanceof Error ? error.message : 'Please try again.',
-      });
-    }
-  }, [onChanged, selectConversation, session.conversations, session.sessionId]);
+    },
+    [selectSession, session.sessionId],
+  );
 
   const endSession = useCallback(async () => {
     setEnding(true);
@@ -530,16 +537,14 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
 
   const menuItems: RowMenuItem[] = useMemo(
     () => [
-      { label: 'New conversation', icon: MessageSquarePlus, onSelect: () => void newConversation() },
       {
         label: 'End session',
         icon: X,
         onSelect: () => setConfirmingEnd(true),
         destructive: true,
-        separatorBefore: true,
       },
     ],
-    [newConversation],
+    [],
   );
 
   return (
@@ -573,14 +578,6 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
         </button>
         <button
           type="button"
-          aria-label="New conversation in this session"
-          className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
-          onClick={() => void newConversation()}
-        >
-          <MessageSquarePlus className="size-3.5" />
-        </button>
-        <button
-          type="button"
           aria-label="End session"
           className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-destructive focus:opacity-100 group-hover:opacity-100"
           onClick={() => setConfirmingEnd(true)}
@@ -599,38 +596,50 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
 
       {expanded && (
         <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">
-          {session.conversations.map((conversation) => (
-            <RowMenu
-              key={conversation.conversationId}
-              items={[
-                {
-                  label: 'Close',
-                  icon: X,
-                  onSelect: () => void closeConversation(conversation.conversationId),
-                  destructive: true,
-                },
-              ]}
-              menuLabel="Conversation actions"
-              className={cn(
-                'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
-                selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
-              )}
-            >
-              <button
-                type="button"
-                className="flex min-w-0 flex-1 items-center text-left"
-                onClick={() => openConversation(conversation)}
+          {session.conversations.map((conversation) => {
+            const agentName =
+              conversation.agentPageId === null
+                ? 'Assistant'
+                : (agentNamesById.get(conversation.agentPageId) ?? 'Agent');
+            const label = conversation.title ? `${agentName} — ${conversation.title}` : agentName;
+            return (
+              <RowMenu
+                key={conversation.conversationId}
+                items={[
+                  {
+                    label: 'Close',
+                    icon: X,
+                    onSelect: () => void closeConversation(conversation.conversationId),
+                    destructive: true,
+                  },
+                ]}
+                menuLabel="Conversation actions"
+                className={cn(
+                  'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
+                  selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
+                )}
               >
-                <span className="truncate">{conversation.title || 'New conversation'}</span>
-              </button>
-            </RowMenu>
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center text-left"
+                  onClick={() => openConversation(conversation)}
+                >
+                  <span className="truncate">{label}</span>
+                </button>
+              </RowMenu>
+            );
+          })}
+          {session.shells.map((shell) => (
+            <button
+              key={shell.shellId}
+              type="button"
+              className="flex min-w-0 w-full items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={() => openShell(shell)}
+            >
+              <SquareTerminal className="size-3 shrink-0" aria-hidden="true" />
+              <span className="truncate">{shell.name}</span>
+            </button>
           ))}
-          {session.shells.length > 0 && (
-            <div className="flex items-center gap-1.5 px-1.5 py-0.5 text-[11px] text-muted-foreground">
-              <SquareTerminal className="size-3" aria-hidden="true" />
-              {session.shells.length === 1 ? '1 shell' : `${session.shells.length} shells`}
-            </div>
-          )}
           {session.conversations.length === 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">No conversations</div>
           )}

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, Plus, SquareTerminal, X } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Folder, Plus, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
@@ -421,7 +421,10 @@ function SessionGroupHeader({
 }) {
   return (
     <div className="flex items-center justify-between gap-1 px-2 pb-0.5 pt-1.5">
-      <span className="truncate text-[11px] font-semibold tracking-wide text-muted-foreground">{label}</span>
+      <span className="flex min-w-0 items-center gap-1.5 truncate text-sm font-semibold text-foreground">
+        <Folder className="size-4 shrink-0" aria-hidden="true" />
+        <span className="truncate">{label}</span>
+      </span>
       {onNewSession && (
         <button
           type="button"
@@ -552,7 +555,7 @@ function SessionRow({
       <RowMenu
         items={menuItems}
         menuLabel="Session actions"
-        className={cn('gap-1 rounded-md px-1.5 py-1 text-[13px] hover:bg-accent', isSelected && 'bg-accent')}
+        className={cn('gap-1 rounded-md px-1.5 py-1 text-xs hover:bg-accent', isSelected && 'bg-accent')}
       >
         <button
           type="button"
@@ -574,7 +577,7 @@ function SessionRow({
               className="size-1.5 shrink-0 rounded-full bg-emerald-500"
             />
           )}
-          <span className="truncate">{session.name || 'Session'}</span>
+          <span className="truncate text-muted-foreground">{session.name || 'Session'}</span>
         </button>
         <button
           type="button"

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -236,7 +236,7 @@ describe('AgentsSidebar', () => {
     await user.click(await screen.findByLabelText(/expand api refactor/i));
 
     // Conversations, yes; anything pane-shaped, no.
-    expect(screen.getByText('First chat')).toBeDefined();
+    expect(screen.getByText('Researcher — First chat')).toBeDefined();
     expect(screen.queryByText(/pane/i)).toBeNull();
     expect(screen.queryByText(/split/i)).toBeNull();
   });
@@ -263,7 +263,7 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      await user.click(await screen.findByText('Second chat'));
+      await user.click(await screen.findByText('Researcher — Second chat'));
 
       expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-2');
@@ -324,24 +324,83 @@ describe('AgentsSidebar', () => {
     });
   });
 
-  describe('new conversation in a session', () => {
-    test("posts into the session with the last conversation's agent and selects the new thread", async () => {
-      mockPost.mockResolvedValue({ conversationId: 'conv-new' });
+  describe('conversation sub-item labels', () => {
+    test('composes <Agent> — <title> once a title is populated', async () => {
       const user = userEvent.setup();
       renderSidebar();
 
-      await screen.findByText('api refactor');
-      await user.click(screen.getByLabelText('New conversation in this session'));
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
 
-      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
-      expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-1/conversations', {
-        sessionId: 'ses-1',
-      });
-      await waitFor(() =>
-        expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new'),
-      );
+      expect(screen.getByText('Researcher — First chat')).toBeDefined();
+      expect(screen.getByText('Researcher — Second chat')).toBeDefined();
+    });
+
+    test('shows just the agent name when no title has been set yet', async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          conversations: [{ conversationId: 'conv-1', title: null, agentPageId: 'agent-1' }],
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('Researcher')).toBeDefined();
+      expect(screen.queryByText(/—/)).toBeNull();
+    });
+
+    test('falls back to "Assistant" for a null agentPageId, and "Agent" for an unknown one', async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          conversations: [
+            { conversationId: 'conv-1', title: null, agentPageId: null },
+            { conversationId: 'conv-2', title: null, agentPageId: 'agent-deleted' },
+          ],
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('Assistant')).toBeDefined();
+      expect(screen.getByText('Agent')).toBeDefined();
+    });
+  });
+
+  describe('shells', () => {
+    test('renders each shell as its own row, not a count', async () => {
+      respondWithSessions([
+        { ...SESSION, shells: [{ shellId: 'shell-a', name: 'shell-1' }, { shellId: 'shell-b', name: 'shell-2' }] },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('shell-1')).toBeDefined();
+      expect(screen.getByText('shell-2')).toBeDefined();
+      expect(screen.queryByText(/shells$/)).toBeNull();
+    });
+
+    test('clicking a shell selects its session and opens its terminal pane', async () => {
+      respondWithSessions([{ ...SESSION, shells: [{ shellId: 'shell-a', name: 'shell-1' }] }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('shell-1'));
+
       expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
-      expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']?.columns[0]?.panes[0]?.scope).toEqual({
+        kind: 'terminal',
+        name: 'shell-1',
+        targetId: 'shell-a',
+        agentPageId: null,
+      });
     });
   });
 
@@ -450,21 +509,6 @@ describe('AgentsSidebar', () => {
       expect(screen.getByLabelText('Session actions').className).toContain('opacity-0');
     });
 
-    test('right-click opens a context menu; "New conversation" drives the same handler as the inline icon', async () => {
-      mockPost.mockResolvedValue({ conversationId: 'conv-new' });
-      const user = userEvent.setup();
-      renderSidebar();
-
-      await screen.findByText('api refactor');
-      fireEvent.contextMenu(screen.getByText('api refactor'));
-      await user.click(await screen.findByText('New conversation'));
-
-      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
-      expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-1/conversations', {
-        sessionId: 'ses-1',
-      });
-    });
-
     test('"End session" from the context menu opens the same confirm dialog as the inline X', async () => {
       const user = userEvent.setup();
       renderSidebar();
@@ -476,17 +520,25 @@ describe('AgentsSidebar', () => {
       expect(await screen.findByRole('alertdialog')).toBeDefined();
     });
 
-    test('the 3-dots dropdown opens the same two items, driving the same handlers', async () => {
+    test('the 3-dots dropdown opens the same single item, driving the same handler', async () => {
       const user = userEvent.setup();
       renderSidebar();
 
       await screen.findByText('api refactor');
       await user.click(screen.getByLabelText('Session actions'));
 
-      expect(await screen.findByText('New conversation')).toBeDefined();
-      await user.click(screen.getByText('End session'));
+      await user.click(await screen.findByText('End session'));
 
       expect(await screen.findByRole('alertdialog')).toBeDefined();
+    });
+
+    test('the inline "New conversation" affordance is gone — switching an agent in an open pane is the only way to mint one', async () => {
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      expect(screen.queryByLabelText('New conversation in this session')).toBeNull();
+      fireEvent.contextMenu(screen.getByText('api refactor'));
+      expect(screen.queryByText('New conversation')).toBeNull();
     });
   });
 
@@ -498,7 +550,7 @@ describe('AgentsSidebar', () => {
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       const fetchesBefore = mockFetchWithAuth.mock.calls.length;
-      fireEvent.contextMenu(await screen.findByText('First chat'));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       await waitFor(() =>
@@ -516,7 +568,7 @@ describe('AgentsSidebar', () => {
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       // Two conversations render — each gets its own "Conversation actions"
       // trigger, so scope to "First chat"'s own row.
-      const firstChatRow = (await screen.findByText('First chat')).closest(
+      const firstChatRow = (await screen.findByText('Researcher — First chat')).closest(
         '[data-slot="context-menu-trigger"]',
       ) as HTMLElement;
       await user.click(within(firstChatRow).getByLabelText('Conversation actions'));
@@ -533,7 +585,7 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      fireEvent.contextMenu(await screen.findByText('First chat'));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       expect(await screen.findByRole('alertdialog')).toBeDefined();
@@ -545,7 +597,7 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      fireEvent.contextMenu(await screen.findByText('First chat'));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       await waitFor(() => expect(mockDel).toHaveBeenCalled());
@@ -722,34 +774,6 @@ describe('AgentsSidebar', () => {
       await screen.findByText('api refactor');
       const headers = screen.getAllByText(/^(Alpha|Assistant)$/);
       expect(headers.map((el) => el.textContent)).toEqual(['Assistant', 'Alpha']);
-    });
-
-    test('a new conversation in an assistant session goes through the session-centric creator', async () => {
-      // The assistant has no agent page, so the page-agents route has nothing
-      // to hang it on — the session route is the path.
-      mockPost.mockResolvedValue({ conversationId: 'conv-new' });
-      respondWithSessions([
-        {
-          ...SESSION,
-          sessionId: 'ses-g',
-          driveId: null,
-          name: 'assistant session',
-          conversations: [{ conversationId: 'conv-g', title: 'Thread', agentPageId: null }],
-        },
-      ]);
-      const user = userEvent.setup();
-      renderSidebar();
-
-      await screen.findByText('assistant session');
-      await user.click(screen.getByLabelText('New conversation in this session'));
-
-      await waitFor(() =>
-        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions/ses-g/conversations', {}),
-      );
-      await waitFor(() =>
-        expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new'),
-      );
-      expect(useAgentSurfaceStore.getState().selectedAgentId).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -173,6 +173,10 @@ beforeEach(() => {
   // test so one test's fixture never leaks into the next via the persisted
   // store.
   useDriveStore.setState({ drives: [] });
+  // Same leak risk for panes: two tests opening the same session id (every
+  // fixture here is 'ses-1' or 'ses-new') would otherwise see each other's
+  // panes[0], since nothing else clears this store between tests.
+  useAgentWorkspaceStore.setState({ workspaces: {} });
   mockUseAuth.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
   mockUseParams.mockReturnValue({ driveId: 'drive-1' });
   mockUsePathname.mockReturnValue('/dashboard/drive-1/agents');
@@ -256,6 +260,24 @@ describe('AgentsSidebar', () => {
       expect(window.location.search).toBe('?session=ses-1&c=conv-1&agent=agent-1');
       // The whole point: no route change, so nothing remounts.
       expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    test('clicking a shell-only session (no conversations) falls back to opening its first shell', async () => {
+      respondWithSessions([
+        { ...SESSION, conversations: [], shells: [{ shellId: 'shell-fallback-1', name: 'Shell' }] },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByText('api refactor'));
+
+      expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']?.columns[0]?.panes[0]?.scope).toEqual({
+        kind: 'terminal',
+        name: 'Shell',
+        targetId: 'shell-fallback-1',
+        agentPageId: null,
+      });
     });
 
     test('clicking a conversation selects it under its session, still without navigating', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -433,6 +433,29 @@ describe('AgentsSidebar', () => {
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
     });
 
+    test('spawning a shell-first session names its terminal pane from the SHELL\'s own auto-assigned name, not the session label', async () => {
+      mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, shellId: 'shell-new', shellName: 'Shell 2' });
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Shell'));
+
+      const nameInput = await screen.findByPlaceholderText('Shell');
+      await user.type(nameInput, 'My Custom Session{Enter}');
+
+      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-new']?.columns[0]?.panes[0]?.scope).toEqual({
+          kind: 'terminal',
+          name: 'Shell 2',
+          targetId: 'shell-new',
+          agentPageId: null,
+        }),
+      );
+    });
+
     test('a drive with no agents still offers Shell — no empty chooser', async () => {
       mockUsePageAgents.mockImplementation(() => ({
         agentsByDrive: [],

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -346,7 +346,7 @@ describe('AgentsSidebar', () => {
   });
 
   describe('new session', () => {
-    test('the inline "+" opens a searchable agent palette; picking an agent is one act: session AND its first conversation, land inside it', async () => {
+    test('the inline "+" opens a searchable agent palette; picking an agent advances to a naming step, and submitting blank still spawns the session AND its first conversation, landing inside it', async () => {
       mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, conversationId: 'conv-new' });
       const user = userEvent.setup();
       renderSidebar();
@@ -355,10 +355,16 @@ describe('AgentsSidebar', () => {
       await user.click(screen.getByLabelText('New session'));
       await user.click(await screen.findByText('Researcher'));
 
+      // Naming step: input starts empty with the agent's title as placeholder.
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      expect(nameInput).toHaveValue('');
+      await user.type(nameInput, '{Enter}');
+
       await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
       expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {
         driveId: 'drive-1',
         agentPageId: 'agent-1',
+        name: '',
       });
       await waitFor(() =>
         expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-new'),
@@ -368,7 +374,7 @@ describe('AgentsSidebar', () => {
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
     });
 
-    test('a drive with no agents says so instead of offering an empty chooser', async () => {
+    test('a drive with no agents still offers Shell — no empty chooser', async () => {
       mockUsePageAgents.mockImplementation(() => ({
         agentsByDrive: [],
         isLoading: false,
@@ -381,7 +387,8 @@ describe('AgentsSidebar', () => {
       await screen.findByText('api refactor');
       await user.click(screen.getByLabelText('New session'));
 
-      expect(await screen.findByText(/no agents in this drive/i)).toBeDefined();
+      expect(await screen.findByText('Shell')).toBeDefined();
+      expect(screen.queryByText('Researcher')).toBeNull();
     });
   });
 
@@ -640,7 +647,7 @@ describe('AgentsSidebar', () => {
       expect(mockFetchWithAuth).not.toHaveBeenCalled();
     });
 
-    test('spawning from a roster drive with zero sessions posts its driveId + the chosen agent', async () => {
+    test('spawning from a roster drive with zero sessions posts its driveId + the chosen agent + the typed name', async () => {
       mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, conversationId: 'conv-new' });
       respondWithSessions([]);
       const user = userEvent.setup();
@@ -650,17 +657,24 @@ describe('AgentsSidebar', () => {
       await user.click(within(groupContainer('Alpha')).getByRole('button', { name: /^New session/i }));
       await user.click(await screen.findByText('Researcher'));
 
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      await user.type(nameInput, 'my session{Enter}');
+
       await waitFor(() =>
-        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', { driveId: 'drive-1', agentPageId: 'agent-1' }),
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {
+          driveId: 'drive-1',
+          agentPageId: 'agent-1',
+          name: 'my session',
+        }),
       );
       await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-new'));
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new');
     });
 
-    test('the Assistant group exists with zero sessions, and spawning it is ONE click', async () => {
-      // The affordance to start an assistant session IS the group — and there
-      // is no agent to choose (the assistant is the counterpart), so the click
-      // spawns directly with the both-null shape.
+    test('the Assistant group exists with zero sessions, and its "+" opens the same naming step (not an instant spawn)', async () => {
+      // Sessions are always deliberately named now — the Assistant group's "+"
+      // goes through the naming step too, even though there's no agent to
+      // choose (the assistant is the counterpart).
       mockPost.mockResolvedValue({ session: { sessionId: 'ses-a' }, conversationId: 'conv-a' });
       respondWithSessions([]);
       const user = userEvent.setup();
@@ -671,7 +685,17 @@ describe('AgentsSidebar', () => {
       // now, so an unscoped query would be ambiguous.
       await user.click(within(groupContainer('Assistant')).getByRole('button', { name: /^New session/i }));
 
-      await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {}));
+      const nameInput = await screen.findByPlaceholderText('Assistant');
+      expect(nameInput).toHaveValue('');
+      await user.type(nameInput, '{Enter}');
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {
+          driveId: null,
+          agentPageId: null,
+          name: '',
+        }),
+      );
       await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-a'));
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-a');
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBeNull();

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -39,6 +39,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ kind: 'eq', field, value })),
   and: vi.fn((...conds) => ({ kind: 'and', conds })),
   inArray: vi.fn((field, values) => ({ kind: 'inArray', field, values })),
+  isNull: vi.fn((field) => ({ kind: 'isNull', field })),
   sql: Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       kind: 'sql',
@@ -54,6 +55,7 @@ vi.mock('@pagespace/db/schema/conversations', () => ({
     id: 'conversations.id',
     userId: 'conversations.userId',
     isShared: 'conversations.isShared',
+    title: 'conversations.title',
     updatedAt: 'conversations.updatedAt',
   },
 }));
@@ -345,6 +347,43 @@ describe('conversationRepository.createConversation', () => {
     await conversationRepository.createConversation('conv-legacy', 'attacker-user', 'machine-1', { isShared: true });
 
     expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('conversationRepository.autoTitleConversation', () => {
+  // The IS-NULL guard lives in the SQL WHERE clause, not an in-memory check —
+  // that's what makes this safe to call on every message without a separate
+  // "is this the first message" lookup, and race-safe under concurrent calls.
+  it('updates title guarded by "title IS NULL" in the WHERE clause', async () => {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mockDb.update = vi.fn().mockReturnValue({ set: setMock });
+
+    await conversationRepository.autoTitleConversation('conv_abc', 'Summarize this doc');
+
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Summarize this doc' }));
+    const predicate = whereMock.mock.calls[0][0] as { kind: string; conds: Array<{ kind: string; field?: string }> };
+    const idCond = predicate.conds.find((c) => c.field === 'conversations.id');
+    const nullTitleCond = predicate.conds.find((c) => c.kind === 'isNull');
+    expect(idCond).toBeDefined();
+    expect(nullTitleCond).toEqual({ kind: 'isNull', field: 'conversations.title' });
+  });
+
+  it('never overwrites an existing title — the guard is baked into every UPDATE\'s WHERE clause, not an in-memory check', async () => {
+    // A row with a non-null title simply matches zero rows against the
+    // "title IS NULL" predicate. There is no in-memory "if title" branch
+    // for a race to slip through — the second of two concurrent calls
+    // still issues the same guarded UPDATE and updates zero rows.
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mockDb.update = vi.fn().mockReturnValue({ set: setMock });
+
+    await conversationRepository.autoTitleConversation('conv_titled', 'New attempted title');
+
+    const predicate = whereMock.mock.calls[0][0] as { kind: string; conds: Array<{ kind: string; field?: string }> };
+    const nullTitleCond = predicate.conds.find((c) => c.kind === 'isNull');
+    expect(nullTitleCond).toEqual({ kind: 'isNull', field: 'conversations.title' });
   });
 });
 

--- a/apps/web/src/lib/repositories/__tests__/derive-conversation-title.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/derive-conversation-title.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for deriveConversationTitle.
+ *
+ * Pure string logic — PurePoint-style cleanup (ClaudeConversationIndex.swift:411-434,372-385):
+ * strip a filler prefix, take the first non-empty line, strip a leading markdown heading, then
+ * truncate to ~50 chars.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveConversationTitle } from '../derive-conversation-title';
+
+describe('deriveConversationTitle', () => {
+  it('strips a filler prefix, takes the first line, and returns it unchanged when under the cap', () => {
+    expect(deriveConversationTitle('Can you help me summarize this doc')).toBe(
+      'help me summarize this doc'
+    );
+  });
+
+  it('strips "Please" as a filler prefix', () => {
+    expect(deriveConversationTitle('Please review this PR')).toBe('review this PR');
+  });
+
+  it('strips the "Implement the following plan:" boilerplate prefix', () => {
+    expect(deriveConversationTitle('Implement the following plan: add dark mode')).toBe(
+      'add dark mode'
+    );
+  });
+
+  it('takes only the first non-empty line', () => {
+    expect(deriveConversationTitle('\n\nFirst real line\nSecond line')).toBe('First real line');
+  });
+
+  it('strips a leading markdown heading marker', () => {
+    expect(deriveConversationTitle('# Heading title')).toBe('Heading title');
+  });
+
+  it('truncates to ~50 chars with a trailing "..." when the content is cut', () => {
+    const long = 'a'.repeat(80);
+    const result = deriveConversationTitle(long);
+    expect(result).toBe('a'.repeat(50) + '...');
+  });
+
+  it('returns content unchanged (no spurious "...") when already under the length cap', () => {
+    expect(deriveConversationTitle('short message')).toBe('short message');
+  });
+
+  it('returns "" for empty content', () => {
+    expect(deriveConversationTitle('')).toBe('');
+  });
+
+  it('returns "" for whitespace-only content', () => {
+    expect(deriveConversationTitle('   \n\t  ')).toBe('');
+  });
+});

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { eq, and, sql, inArray } from '@pagespace/db/operators'
+import { eq, and, sql, inArray, isNull } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core'
 import { userActivities } from '@pagespace/db/schema/monitoring'
 import { conversations } from '@pagespace/db/schema/conversations';
@@ -433,6 +433,22 @@ export const conversationRepository = {
       .returning({ id: conversations.id, title: conversations.title });
 
     return result;
+  },
+
+  /**
+   * Auto-title a conversation from its first message, without ever
+   * overwriting a title that's already set (including a user's manual
+   * rename via upsertConversationTitle). The IS-NULL guard lives in the SQL
+   * WHERE clause rather than an in-memory check, so it's safe to call on
+   * every message — no separate "is this the first message" lookup needed
+   * — and race-safe: two concurrent calls both issue this same guarded
+   * UPDATE, and only the one that lands first actually sets a row.
+   */
+  async autoTitleConversation(conversationId: string, title: string): Promise<void> {
+    await db
+      .update(conversations)
+      .set({ title, updatedAt: new Date() })
+      .where(and(eq(conversations.id, conversationId), isNull(conversations.title)));
   },
 
   /**

--- a/apps/web/src/lib/repositories/derive-conversation-title.ts
+++ b/apps/web/src/lib/repositories/derive-conversation-title.ts
@@ -1,0 +1,26 @@
+/**
+ * Derives a short conversation title from a message's raw content.
+ * PurePoint-style cleanup (ClaudeConversationIndex.swift:411-434,372-385) —
+ * pure string logic, no LLM.
+ */
+
+const PLAN_BOILERPLATE_PREFIX_RE = /^implement the following plan:\s*/i;
+const FILLER_PREFIX_RE = /^(can you |could you |please |help me |i need to |i want to )/i;
+const LEADING_HEADING_RE = /^#+\s*/;
+const MAX_LENGTH = 50;
+
+export function deriveConversationTitle(content: string): string {
+  const cleaned = content
+    .replace(PLAN_BOILERPLATE_PREFIX_RE, '')
+    .replace(FILLER_PREFIX_RE, '');
+
+  const firstLine = cleaned
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0) ?? '';
+
+  const title = firstLine.replace(LEADING_HEADING_RE, '');
+
+  if (title.length <= MAX_LENGTH) return title;
+  return title.slice(0, MAX_LENGTH) + '...';
+}


### PR DESCRIPTION
## Summary
Sidebar Session Naming & Visual Hierarchy epic (PageSpace task board: drive `lng6q95adrfndmdnnf9z8g6p`, epic page `itgnhpqjd1rv19d3zhb50h65`, 100% complete). Each phase landed as its own reviewed, tested PR merged into this branch by the point guard (adversarial review + local typecheck/lint/test verification before each merge, not self-merged by the phase agents). All five phases plus the final full-monorepo quality gate are done — ready for human review before merging into `master`.

- [x] Phase 1 — Session spawn: shell-first + auto-unique naming (#2283)
- [x] Phase 2 — Conversation auto-titling on first message (#2281)
- [x] Phase 3 — Spawn palette: naming step + Shell option (#2285)
- [x] Phase 4 — Sidebar sub-item rendering (#2287)
- [x] Phase 5 — Visual hierarchy inversion (#2288)
- [x] Quality gate — full-monorepo `bun run typecheck` + `bun run lint`, both green (16/16 and 14/14 packages)

## What changed, end to end
- A session can now be spawned with a deliberate name (typed in the "+" Raycast-style palette's new naming step) as either an agent conversation, a global-assistant thread, or — new — a shell. A blank submitted name auto-resolves to a unique one server-side (`<Agent title>`/`"Shell"`/`"Assistant"`, deduped as `"X 2"`, `"X 3"`, ... among the owner's existing session names).
- Conversations auto-title from their first message (PurePoint-style cleanup: strips filler prefixes, takes the first line, truncates) — previously only the global-assistant surface did this; now drive/page-agent conversations do too.
- Sidebar sub-items are actually legible now: conversations show `<Agent>` before a title exists, `<Agent> — <title>` after; shells render as individual clickable rows (not just a count) and open their terminal pane directly.
- The redundant inline "New conversation" button/menu item is gone — switching an agent inside an open pane already correctly mints a new conversation sub-item, so there's only one way to do it now.
- Sidebar visual hierarchy inverted to match the reference: drive group headers are bold/foreground with a folder icon; session rows are smaller/muted beneath them.

## Test plan
- [x] Full-monorepo `bun run typecheck` — 16/16 packages green (includes a real `next build` of `web`)
- [x] Full-monorepo `bun run lint` — 14/14 packages green
- [x] Each phase's own test suite re-run and verified independently by the point guard before merging (agent-sessions route: 113 tests; conversation-repository/derive-conversation-title: 109 tests; AgentsSidebar: 38 tests) — see each phase PR linked above for details
- [ ] Manual click-through in a live browser was not performed in this session (no browser-automation tool available) — verified instead via the automated suites above plus point-guard code review against each phase's PageSpace spec. **Recommend a manual pass before merging**: spawn a shell-first session and confirm it lands on a terminal pane with no stray conversation; send a first message in an agent session and confirm the sidebar sub-item updates from `<Agent>` to `<Agent> — <prompt>`; visually compare the sidebar against the PurePoint reference hierarchy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013py97Wc6TPXKRDQcTTCEgM