### PR TITLE
feat(agent-sessions): sidebar sub-item rendering

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, MessageSquarePlus, Plus, SquareTerminal, X } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Plus, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
@@ -250,6 +250,19 @@ function SessionList({
   // session, but must not offer to spawn a NEW one into a trashed drive.
   const trashedDriveIds = useMemo(() => new Set(drives.filter((d) => d.isTrashed).map((d) => d.id)), [drives]);
 
+  // Flattened once here (not per-SessionRow) so every session's conversation
+  // labels share one lookup instead of re-deriving it from `agentsByDrive` N
+  // times.
+  const agentNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const drive of agentsByDrive) {
+      for (const agent of drive.agents) {
+        map.set(agent.id, agent.title ?? 'Agent');
+      }
+    }
+    return map;
+  }, [agentsByDrive]);
+
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
   // first — see session-groups.ts for the ordering rule); a single implicit
   // group in drive mode, always present (even with zero sessions) so its
@@ -368,7 +381,12 @@ function SessionList({
             />
           )}
           {group.sessions.map((session) => (
-            <SessionRow key={session.sessionId} session={session} onChanged={onChanged} />
+            <SessionRow
+              key={session.sessionId}
+              session={session}
+              onChanged={onChanged}
+              agentNamesById={agentNamesById}
+            />
           ))}
         </div>
       ))}
@@ -419,7 +437,15 @@ function SessionGroupHeader({
 }
 
 /** One session: name + running dot, expanding to its conversations (never its panes). */
-function SessionRow({ session, onChanged }: { session: SessionListEntry; onChanged: () => void }) {
+function SessionRow({
+  session,
+  onChanged,
+  agentNamesById,
+}: {
+  session: SessionListEntry;
+  onChanged: () => void;
+  agentNamesById: Map<string, string>;
+}) {
   const selectedSessionId = useAgentSurfaceStore((state) => state.selectedSessionId);
   const selectedConversationId = useAgentSurfaceStore((state) => state.selectedConversationId);
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
@@ -450,37 +476,18 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
     if (first) openConversation(first);
   }, [openConversation, session.conversations]);
 
-  const newConversation = useCallback(async () => {
-    // A new thread defaults to the session's most recent conversation's
-    // counterpart — the full drive picker lives in the pane grid. A null
-    // agent (a global session, or a drive session whose latest thread is an
-    // assistant thread) means the ASSISTANT, created through the
-    // session-centric route since it has no agent page.
-    const agentPageId = session.conversations[0]?.agentPageId ?? null;
-    try {
-      const created =
-        agentPageId === null
-          ? await post<{ conversationId: string }>(
-              `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations`,
-              {},
-            )
-          : await post<{ conversationId: string }>(
-              `/api/ai/page-agents/${encodeURIComponent(agentPageId)}/conversations`,
-              { sessionId: session.sessionId },
-            );
-      onChanged();
-      selectConversation({
-        sessionId: session.sessionId,
-        conversationId: created.conversationId,
-        agentId: agentPageId,
+  const openShell = useCallback(
+    (shell: { shellId: string; name: string }) => {
+      selectSession(session.sessionId);
+      useAgentWorkspaceStore.getState().openConversation(session.sessionId, {
+        kind: 'terminal',
+        name: shell.name,
+        targetId: shell.shellId,
+        agentPageId: null,
       });
-    } catch (error) {
-      console.error('Failed to start a conversation:', error);
-      toast.error('Could not start a conversation', {
-        description: error instanceof Error ? error.message : 'Please try again.',
-      });
-    }
-  }, [onChanged, selectConversation, session.conversations, session.sessionId]);
+    },
+    [selectSession, session.sessionId],
+  );
 
   const endSession = useCallback(async () => {
     setEnding(true);
@@ -530,16 +537,14 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
 
   const menuItems: RowMenuItem[] = useMemo(
     () => [
-      { label: 'New conversation', icon: MessageSquarePlus, onSelect: () => void newConversation() },
       {
         label: 'End session',
         icon: X,
         onSelect: () => setConfirmingEnd(true),
         destructive: true,
-        separatorBefore: true,
       },
     ],
-    [newConversation],
+    [],
   );
 
   return (
@@ -573,14 +578,6 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
         </button>
         <button
           type="button"
-          aria-label="New conversation in this session"
-          className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
-          onClick={() => void newConversation()}
-        >
-          <MessageSquarePlus className="size-3.5" />
-        </button>
-        <button
-          type="button"
           aria-label="End session"
           className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-destructive focus:opacity-100 group-hover:opacity-100"
           onClick={() => setConfirmingEnd(true)}
@@ -599,38 +596,50 @@ function SessionRow({ session, onChanged }: { session: SessionListEntry; onChang
 
       {expanded && (
         <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">
-          {session.conversations.map((conversation) => (
-            <RowMenu
-              key={conversation.conversationId}
-              items={[
-                {
-                  label: 'Close',
-                  icon: X,
-                  onSelect: () => void closeConversation(conversation.conversationId),
-                  destructive: true,
-                },
-              ]}
-              menuLabel="Conversation actions"
-              className={cn(
-                'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
-                selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
-              )}
-            >
-              <button
-                type="button"
-                className="flex min-w-0 flex-1 items-center text-left"
-                onClick={() => openConversation(conversation)}
+          {session.conversations.map((conversation) => {
+            const agentName =
+              conversation.agentPageId === null
+                ? 'Assistant'
+                : (agentNamesById.get(conversation.agentPageId) ?? 'Agent');
+            const label = conversation.title ? `${agentName} — ${conversation.title}` : agentName;
+            return (
+              <RowMenu
+                key={conversation.conversationId}
+                items={[
+                  {
+                    label: 'Close',
+                    icon: X,
+                    onSelect: () => void closeConversation(conversation.conversationId),
+                    destructive: true,
+                  },
+                ]}
+                menuLabel="Conversation actions"
+                className={cn(
+                  'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
+                  selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
+                )}
               >
-                <span className="truncate">{conversation.title || 'New conversation'}</span>
-              </button>
-            </RowMenu>
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center text-left"
+                  onClick={() => openConversation(conversation)}
+                >
+                  <span className="truncate">{label}</span>
+                </button>
+              </RowMenu>
+            );
+          })}
+          {session.shells.map((shell) => (
+            <button
+              key={shell.shellId}
+              type="button"
+              className="flex min-w-0 w-full items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={() => openShell(shell)}
+            >
+              <SquareTerminal className="size-3 shrink-0" aria-hidden="true" />
+              <span className="truncate">{shell.name}</span>
+            </button>
           ))}
-          {session.shells.length > 0 && (
-            <div className="flex items-center gap-1.5 px-1.5 py-0.5 text-[11px] text-muted-foreground">
-              <SquareTerminal className="size-3" aria-hidden="true" />
-              {session.shells.length === 1 ? '1 shell' : `${session.shells.length} shells`}
-            </div>
-          )}
           {session.conversations.length === 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">No conversations</div>
           )}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -236,7 +236,7 @@ describe('AgentsSidebar', () => {
     await user.click(await screen.findByLabelText(/expand api refactor/i));
 
     // Conversations, yes; anything pane-shaped, no.
-    expect(screen.getByText('First chat')).toBeDefined();
+    expect(screen.getByText('Researcher — First chat')).toBeDefined();
     expect(screen.queryByText(/pane/i)).toBeNull();
     expect(screen.queryByText(/split/i)).toBeNull();
   });
@@ -263,7 +263,7 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      await user.click(await screen.findByText('Second chat'));
+      await user.click(await screen.findByText('Researcher — Second chat'));
 
       expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-2');
@@ -324,24 +324,83 @@ describe('AgentsSidebar', () => {
     });
   });
 
-  describe('new conversation in a session', () => {
-    test("posts into the session with the last conversation's agent and selects the new thread", async () => {
-      mockPost.mockResolvedValue({ conversationId: 'conv-new' });
+  describe('conversation sub-item labels', () => {
+    test('composes <Agent> — <title> once a title is populated', async () => {
       const user = userEvent.setup();
       renderSidebar();
 
-      await screen.findByText('api refactor');
-      await user.click(screen.getByLabelText('New conversation in this session'));
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
 
-      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
-      expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-1/conversations', {
-        sessionId: 'ses-1',
-      });
-      await waitFor(() =>
-        expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new'),
-      );
+      expect(screen.getByText('Researcher — First chat')).toBeDefined();
+      expect(screen.getByText('Researcher — Second chat')).toBeDefined();
+    });
+
+    test('shows just the agent name when no title has been set yet', async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          conversations: [{ conversationId: 'conv-1', title: null, agentPageId: 'agent-1' }],
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('Researcher')).toBeDefined();
+      expect(screen.queryByText(/—/)).toBeNull();
+    });
+
+    test('falls back to "Assistant" for a null agentPageId, and "Agent" for an unknown one', async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          conversations: [
+            { conversationId: 'conv-1', title: null, agentPageId: null },
+            { conversationId: 'conv-2', title: null, agentPageId: 'agent-deleted' },
+          ],
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('Assistant')).toBeDefined();
+      expect(screen.getByText('Agent')).toBeDefined();
+    });
+  });
+
+  describe('shells', () => {
+    test('renders each shell as its own row, not a count', async () => {
+      respondWithSessions([
+        { ...SESSION, shells: [{ shellId: 'shell-a', name: 'shell-1' }, { shellId: 'shell-b', name: 'shell-2' }] },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('shell-1')).toBeDefined();
+      expect(screen.getByText('shell-2')).toBeDefined();
+      expect(screen.queryByText(/shells$/)).toBeNull();
+    });
+
+    test('clicking a shell selects its session and opens its terminal pane', async () => {
+      respondWithSessions([{ ...SESSION, shells: [{ shellId: 'shell-a', name: 'shell-1' }] }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('shell-1'));
+
       expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
-      expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']?.columns[0]?.panes[0]?.scope).toEqual({
+        kind: 'terminal',
+        name: 'shell-1',
+        targetId: 'shell-a',
+        agentPageId: null,
+      });
     });
   });
 
@@ -450,21 +509,6 @@ describe('AgentsSidebar', () => {
       expect(screen.getByLabelText('Session actions').className).toContain('opacity-0');
     });
 
-    test('right-click opens a context menu; "New conversation" drives the same handler as the inline icon', async () => {
-      mockPost.mockResolvedValue({ conversationId: 'conv-new' });
-      const user = userEvent.setup();
-      renderSidebar();
-
-      await screen.findByText('api refactor');
-      fireEvent.contextMenu(screen.getByText('api refactor'));
-      await user.click(await screen.findByText('New conversation'));
-
-      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
-      expect(mockPost).toHaveBeenCalledWith('/api/ai/page-agents/agent-1/conversations', {
-        sessionId: 'ses-1',
-      });
-    });
-
     test('"End session" from the context menu opens the same confirm dialog as the inline X', async () => {
       const user = userEvent.setup();
       renderSidebar();
@@ -476,17 +520,25 @@ describe('AgentsSidebar', () => {
       expect(await screen.findByRole('alertdialog')).toBeDefined();
     });
 
-    test('the 3-dots dropdown opens the same two items, driving the same handlers', async () => {
+    test('the 3-dots dropdown opens the same single item, driving the same handler', async () => {
       const user = userEvent.setup();
       renderSidebar();
 
       await screen.findByText('api refactor');
       await user.click(screen.getByLabelText('Session actions'));
 
-      expect(await screen.findByText('New conversation')).toBeDefined();
-      await user.click(screen.getByText('End session'));
+      await user.click(await screen.findByText('End session'));
 
       expect(await screen.findByRole('alertdialog')).toBeDefined();
+    });
+
+    test('the inline "New conversation" affordance is gone — switching an agent in an open pane is the only way to mint one', async () => {
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      expect(screen.queryByLabelText('New conversation in this session')).toBeNull();
+      fireEvent.contextMenu(screen.getByText('api refactor'));
+      expect(screen.queryByText('New conversation')).toBeNull();
     });
   });
 
@@ -498,7 +550,7 @@ describe('AgentsSidebar', () => {
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       const fetchesBefore = mockFetchWithAuth.mock.calls.length;
-      fireEvent.contextMenu(await screen.findByText('First chat'));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       await waitFor(() =>
@@ -516,7 +568,7 @@ describe('AgentsSidebar', () => {
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       // Two conversations render — each gets its own "Conversation actions"
       // trigger, so scope to "First chat"'s own row.
-      const firstChatRow = (await screen.findByText('First chat')).closest(
+      const firstChatRow = (await screen.findByText('Researcher — First chat')).closest(
         '[data-slot="context-menu-trigger"]',
       ) as HTMLElement;
       await user.click(within(firstChatRow).getByLabelText('Conversation actions'));
@@ -533,7 +585,7 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      fireEvent.contextMenu(await screen.findByText('First chat'));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       expect(await screen.findByRole('alertdialog')).toBeDefined();
@@ -545,7 +597,7 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      fireEvent.contextMenu(await screen.findByText('First chat'));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       await waitFor(() => expect(mockDel).toHaveBeenCalled());
@@ -722,34 +774,6 @@ describe('AgentsSidebar', () => {
       await screen.findByText('api refactor');
       const headers = screen.getAllByText(/^(Alpha|Assistant)$/);
       expect(headers.map((el) => el.textContent)).toEqual(['Assistant', 'Alpha']);
-    });
-
-    test('a new conversation in an assistant session goes through the session-centric creator', async () => {
-      // The assistant has no agent page, so the page-agents route has nothing
-      // to hang it on — the session route is the path.
-      mockPost.mockResolvedValue({ conversationId: 'conv-new' });
-      respondWithSessions([
-        {
-          ...SESSION,
-          sessionId: 'ses-g',
-          driveId: null,
-          name: 'assistant session',
-          conversations: [{ conversationId: 'conv-g', title: 'Thread', agentPageId: null }],
-        },
-      ]);
-      const user = userEvent.setup();
-      renderSidebar();
-
-      await screen.findByText('assistant session');
-      await user.click(screen.getByLabelText('New conversation in this session'));
-
-      await waitFor(() =>
-        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions/ses-g/conversations', {}),
-      );
-      await waitFor(() =>
-        expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new'),
-      );
-      expect(useAgentSurfaceStore.getState().selectedAgentId).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
Phase 4 of the sidebar-sessions epic — the sidebar finally *shows* what Phases 1–3 set up (deliberate session names, `conversations.title` auto-population, shell-first spawn).

- **Conversation labels**: `SessionList` now builds a `useMemo`'d `agentNamesById: Map<string, string>` from `agentsByDrive` and passes it to `SessionRow`. Each conversation sub-item renders `<Agent>` (`"Assistant"` for `agentPageId === null`, the mapped title for a known agent, `"Agent"` fallback for an unknown one) when `conversation.title` is null, or `"<Agent> — <title>"` once a title is populated.
- **Shell rows**: the `{session.shells.length} shells` count block is replaced with one clickable row per shell (rendering `shell.name` as-is). Clicking calls `selectSession(session.sessionId)` plus `useAgentWorkspaceStore.getState().openConversation(session.sessionId, { kind: 'terminal', name: shell.name, targetId: shell.shellId, agentPageId: null })` — the same pairing Phase 3 already uses for a freshly-spawned shell. No close/delete action on these rows in this pass.
- **Removed the inline "New conversation" affordance**: the `menuItems` entry, the `MessageSquarePlus` icon button, and the now-dead `newConversation` callback (plus its now-unused import). Confirmed via reading `AgentPanes.tsx` that `handlePickAgent`/`handleSwitchAgent` is a genuinely separate code path (only shares the two POST endpoint shapes, no code) — switching an agent inside an open pane is untouched and still mints a new conversation sub-item correctly.

## Test plan
- [x] `bun run typecheck` (scoped to `web`) — green
- [x] `bun run lint` (scoped to `web`) — green (only pre-existing warnings in unrelated files)
- [x] `AgentsSidebar.test.tsx` updated and green (38/38): added coverage for the `<Agent>` / `<Agent> — <title>` label composition (including the `Assistant`/`Agent` fallbacks), added coverage for shell rows rendering individually and their click behavior (session selection + workspace store `openConversation` call with a `terminal` scope), removed/updated the tests that exercised the now-deleted inline "New conversation" affordance, and added a test asserting the button/menu item are gone.
- [ ] **Not verified live in a browser** — no browser-automation tool is available in this environment. All verification is via the updated automated test suite plus manual code reading (including confirming `AgentPanes.tsx`'s `handlePickAgent`/`handleSwitchAgent` is unaffected). The PR author should do a quick manual pass per the phase's Acceptance criteria (spawn an agent session → confirm agent-name-only label → send a message → confirm it updates to `"<Agent> — <first prompt>"`; spawn/open a session with 2+ shells → confirm individual rows + click-to-open; confirm the inline add-conversation button/menu item are gone and switching agents in an open pane still works) before merging.

Base is `pu/sidebar-sessions` (not `master`) per the epic's stacking plan — Phase 5 (visual styling) touches the same file in adjacent regions and will be spawned serially after this merges to avoid conflicts.

PageSpace task statuses flipped to `completed` for all three named tasks under this phase.

https://claude.ai/code/session_015JCNvnz4zhX5RjmgUEfq9L