### PR TITLE
feat(agent-sessions): sidebar visual hierarchy inversion

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, Plus, SquareTerminal, X } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Folder, Plus, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
@@ -421,7 +421,10 @@ function SessionGroupHeader({
 }) {
   return (
     <div className="flex items-center justify-between gap-1 px-2 pb-0.5 pt-1.5">
-      <span className="truncate text-[11px] font-semibold tracking-wide text-muted-foreground">{label}</span>
+      <span className="flex min-w-0 items-center gap-1.5 truncate text-sm font-semibold text-foreground">
+        <Folder className="size-4 shrink-0" aria-hidden="true" />
+        <span className="truncate">{label}</span>
+      </span>
       {onNewSession && (
         <button
           type="button"
@@ -552,7 +555,7 @@ function SessionRow({
       <RowMenu
         items={menuItems}
         menuLabel="Session actions"
-        className={cn('gap-1 rounded-md px-1.5 py-1 text-[13px] hover:bg-accent', isSelected && 'bg-accent')}
+        className={cn('gap-1 rounded-md px-1.5 py-1 text-xs hover:bg-accent', isSelected && 'bg-accent')}
       >
         <button
           type="button"
@@ -574,7 +577,7 @@ function SessionRow({
               className="size-1.5 shrink-0 rounded-full bg-emerald-500"
             />
           )}
-          <span className="truncate">{session.name || 'Session'}</span>
+          <span className="truncate text-muted-foreground">{session.name || 'Session'}</span>
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Phase 5 (final phase) of the "Sidebar Session Naming & Visual Hierarchy" epic — purely visual, no behavioral change.
- `SessionGroupHeader`: added the `Folder` icon (same one used app-wide for drives, e.g. `DriveSwitcher.tsx`) before the label, and promoted the label from `text-[11px] font-semibold tracking-wide text-muted-foreground` to `text-sm font-semibold text-foreground`.
- `SessionRow`'s header row: shrunk from `text-[13px]` to `text-xs` and muted the session name span with `text-muted-foreground`, so it reads as subordinate to the drive header above it. Selection background (`hover:bg-accent` / `isSelected && 'bg-accent'`) and the green "Sandbox running" dot are unchanged.
- This inverts the previous (backwards) weighting to match the PurePoint reference: bold, white, folder-icon'd drive headers with smaller, muted session rows nested below.

**This is the last phase of the epic.** Once this merges, the umbrella PR (#2284, draft) is ready for final review and to be marked ready-for-review — not something done as part of this PR.

## Test plan
- [x] `bun run typecheck` (scoped to `web` via turbo) — green
- [x] `bun run lint` (scoped to `web` via turbo) — green, only pre-existing warnings in unrelated files
- [x] `AgentsSidebar.test.tsx` — 38/38 passing
- [x] Manual comparison of the resulting class list against the PurePoint reference screenshots (bold/white/icon'd header vs. smaller/muted rows beneath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYeDGBFKjPRSiM2xHnDN34