### PR TITLE
feat(agents): add session search to sidebar, drive + dashboard level

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -168,7 +168,7 @@ async function sessionsFetcher(url: string): Promise<{ sessions: SessionListEntr
  * load" just because the current search happens to match nothing — that case
  * belongs to the plain empty-result branch (`isResultEmpty`) instead.
  */
-function resolveListNotice({
+export function resolveListNotice({
   authLoading,
   isAdmin,
   hasError,
@@ -472,6 +472,7 @@ function SessionSearchHeader({
         <Search className="absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground" />
         <Input
           placeholder="Search sessions…"
+          aria-label="Search sessions"
           className="h-7 pl-6 text-xs"
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -467,7 +467,7 @@ function SessionSearchHeader({
   actionLabel: string;
 }) {
   return (
-    <div className="flex items-center gap-1 px-2 pb-1 pt-1.5">
+    <div className="flex items-center gap-1 pl-2 pr-4 pb-1 pt-1.5">
       <div className="relative flex-1">
         <Search className="absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground" />
         <Input

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -229,7 +229,8 @@ function SessionList({
   onChanged: () => void;
 }) {
   const [searchQuery, setSearchQuery] = useState('');
-  const hasSearch = searchQuery.trim().length > 0;
+  const trimmedQuery = searchQuery.trim();
+  const hasSearch = trimmedQuery.length > 0;
 
   const canSpawn = isAdmin && !authLoading;
 
@@ -270,9 +271,9 @@ function SessionList({
   // idiom as PageTree's filterTree.
   const filteredSessions = useMemo(() => {
     if (!hasSearch) return sessions;
-    const query = searchQuery.trim().toLowerCase();
+    const query = trimmedQuery.toLowerCase();
     return sessions.filter((session) => (session.name || 'Session').toLowerCase().includes(query));
-  }, [sessions, hasSearch, searchQuery]);
+  }, [sessions, hasSearch, trimmedQuery]);
 
   const notice = resolveListNotice({
     authLoading,
@@ -402,20 +403,12 @@ function SessionList({
 
   return (
     <div className="space-y-1">
-      {driveId && canSpawn && (
+      {canSpawn && (
         <SessionSearchHeader
           value={searchQuery}
           onChange={setSearchQuery}
-          onAction={() => handleNewSession(driveId, null)}
-          actionLabel="New session"
-        />
-      )}
-      {!driveId && canSpawn && (
-        <SessionSearchHeader
-          value={searchQuery}
-          onChange={setSearchQuery}
-          onAction={() => setCreateDriveOpen(true)}
-          actionLabel="New drive"
+          onAction={driveId ? () => handleNewSession(driveId, null) : () => setCreateDriveOpen(true)}
+          actionLabel={driveId ? 'New session' : 'New drive'}
         />
       )}
       {visibleGroups.map((group) => (
@@ -456,7 +449,7 @@ function SessionList({
         onPickTarget={setSpawnPick}
         onSubmitName={handleSubmitName}
       />
-      <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />
+      {!driveId && <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />}
     </div>
   );
 }

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,12 +2,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, Folder, Plus, SquareTerminal, X } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Folder, Plus, Search, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
 import EndSessionDialog from '@/components/agents/EndSessionDialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Input } from '@/components/ui/input';
 import {
   CommandDialog,
   CommandGroup,
@@ -18,6 +19,7 @@ import {
 import { cn, isElectron } from '@/lib/utils';
 import type { SidebarProps } from './index';
 import DriveSwitcher from '@/components/layout/navbar/DriveSwitcher';
+import CreateDriveDialog from './CreateDriveDialog';
 import DashboardFooter from './DashboardFooter';
 import DriveFooter from './DriveFooter';
 import PrimaryNavigation from './PrimaryNavigation';
@@ -159,13 +161,20 @@ async function sessionsFetcher(url: string): Promise<{ sessions: SessionListEntr
  * a rerun of the failure text), error ahead of empty (SWR's error path is
  * indistinguishable from empty unless checked first), and a background poll's
  * error never tears down a list the caller already has.
+ *
+ * `isDataEmpty` and `isResultEmpty` are deliberately separate: the error
+ * branch must key off the raw fetch result (`isDataEmpty`) so a background
+ * refresh failure on a drive with cached sessions never reads as "failed to
+ * load" just because the current search happens to match nothing — that case
+ * belongs to the plain empty-result branch (`isResultEmpty`) instead.
  */
 function resolveListNotice({
   authLoading,
   isAdmin,
   hasError,
   isLoading,
-  isEmpty,
+  isDataEmpty,
+  isResultEmpty,
   emptyTitle,
   onRetry,
 }: {
@@ -173,14 +182,15 @@ function resolveListNotice({
   isAdmin: boolean;
   hasError: boolean;
   isLoading: boolean;
-  isEmpty: boolean;
+  isDataEmpty: boolean;
+  isResultEmpty: boolean;
   emptyTitle: string;
   onRetry: () => void;
 }): React.ReactNode {
   if (authLoading) return <SidebarLoading message="Loading…" />;
   if (!isAdmin) return <SidebarNotice title="Agent sandboxes require administrator privileges" />;
   if (isLoading) return <SidebarLoading message="Loading sessions…" />;
-  if (hasError && isEmpty) {
+  if (hasError && isDataEmpty) {
     return (
       <SidebarNotice
         title="Failed to load sessions"
@@ -191,7 +201,7 @@ function resolveListNotice({
       />
     );
   }
-  if (isEmpty) return <SidebarNotice title={emptyTitle} />;
+  if (isResultEmpty) return <SidebarNotice title={emptyTitle} />;
   return null;
 }
 
@@ -218,15 +228,8 @@ function SessionList({
   agentsByDrive: DriveWithAgents[];
   onChanged: () => void;
 }) {
-  const notice = resolveListNotice({
-    authLoading,
-    isAdmin,
-    hasError,
-    isLoading,
-    isEmpty: sessions.length === 0,
-    emptyTitle: driveId ? 'No sessions in this drive yet' : 'No sessions yet',
-    onRetry,
-  });
+  const [searchQuery, setSearchQuery] = useState('');
+  const hasSearch = searchQuery.trim().length > 0;
 
   const canSpawn = isAdmin && !authLoading;
 
@@ -263,14 +266,46 @@ function SessionList({
     return map;
   }, [agentsByDrive]);
 
+  // Search filters by session name only, client-side, no debounce — same
+  // idiom as PageTree's filterTree.
+  const filteredSessions = useMemo(() => {
+    if (!hasSearch) return sessions;
+    const query = searchQuery.trim().toLowerCase();
+    return sessions.filter((session) => (session.name || 'Session').toLowerCase().includes(query));
+  }, [sessions, hasSearch, searchQuery]);
+
+  const notice = resolveListNotice({
+    authLoading,
+    isAdmin,
+    hasError,
+    isLoading,
+    isDataEmpty: sessions.length === 0,
+    isResultEmpty: filteredSessions.length === 0,
+    emptyTitle: hasSearch
+      ? 'No sessions match your search'
+      : driveId
+        ? 'No sessions in this drive yet'
+        : 'No sessions yet',
+    onRetry,
+  });
+
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
   // first — see session-groups.ts for the ordering rule); a single implicit
   // group in drive mode, always present (even with zero sessions) so its
   // header — and the header's spawn affordance — never disappears mid-load.
   const groups = useMemo(() => {
-    if (driveId) return [{ driveId, driveName: null, sessions }];
-    return buildSessionGroups(sessions, { assistant: canSpawn, drives: roster });
-  }, [driveId, sessions, canSpawn, roster]);
+    if (driveId) return [{ driveId, driveName: null, sessions: filteredSessions }];
+    return buildSessionGroups(filteredSessions, { assistant: canSpawn, drives: roster });
+  }, [driveId, filteredSessions, canSpawn, roster]);
+
+  // While actively searching, a group with no matches is noise — hide it
+  // rather than showing an empty group with a spawn "+". Outside search the
+  // roster still forces every group to render (even with zero sessions) so
+  // its spawn affordance never disappears mid-load.
+  const visibleGroups = useMemo(
+    () => (hasSearch ? groups.filter((group) => group.sessions.length > 0) : groups),
+    [groups, hasSearch],
+  );
 
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const selectSession = useAgentSurfaceStore((state) => state.selectSession);
@@ -281,6 +316,7 @@ function SessionList({
   // ever produces (it skips the picker entirely, see handleNewSession).
   const [spawnPick, setSpawnPick] = useState<SpawnPick | null>(null);
   const [spawning, setSpawning] = useState(false);
+  const [createDriveOpen, setCreateDriveOpen] = useState(false);
 
   const spawn = useCallback(
     async (input: { driveId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
@@ -367,9 +403,22 @@ function SessionList({
   return (
     <div className="space-y-1">
       {driveId && canSpawn && (
-        <SessionGroupHeader label="Agent Sessions" onNewSession={() => handleNewSession(driveId, null)} />
+        <SessionSearchHeader
+          value={searchQuery}
+          onChange={setSearchQuery}
+          onAction={() => handleNewSession(driveId, null)}
+          actionLabel="New session"
+        />
       )}
-      {groups.map((group) => (
+      {!driveId && canSpawn && (
+        <SessionSearchHeader
+          value={searchQuery}
+          onChange={setSearchQuery}
+          onAction={() => setCreateDriveOpen(true)}
+          actionLabel="New drive"
+        />
+      )}
+      {visibleGroups.map((group) => (
         <div key={group.driveId}>
           {!driveId && (
             <SessionGroupHeader
@@ -407,11 +456,47 @@ function SessionList({
         onPickTarget={setSpawnPick}
         onSubmitName={handleSubmitName}
       />
+      <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />
     </div>
   );
 }
 
-/** A group's header row: name (or "Agent Sessions" in drive-scoped mode) plus an inline "+" spawn affordance — condensed in place of a separate full-width row. */
+/** The search+"+" row atop the list: search filters sessions by name; "+" spawns a new session (drive-scoped) or creates a new drive (global). Replaces the old static "Agent Sessions" label. */
+function SessionSearchHeader({
+  value,
+  onChange,
+  onAction,
+  actionLabel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onAction: () => void;
+  actionLabel: string;
+}) {
+  return (
+    <div className="flex items-center gap-1 px-2 pb-1 pt-1.5">
+      <div className="relative flex-1">
+        <Search className="absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search sessions…"
+          className="h-7 pl-6 text-xs"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </div>
+      <button
+        type="button"
+        aria-label={actionLabel}
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+        onClick={onAction}
+      >
+        <Plus className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
+/** A group's header row: drive name plus an inline "+" spawn affordance — condensed in place of a separate full-width row. */
 function SessionGroupHeader({
   label,
   newSessionLabel,

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -101,7 +101,7 @@ vi.mock('../DashboardFooter', () => ({ default: () => <div /> }));
 
 import { within } from '@testing-library/react';
 import { ApiRequestError } from '@/lib/auth/auth-fetch';
-import AgentsSidebar from '../AgentsSidebar';
+import AgentsSidebar, { resolveListNotice } from '../AgentsSidebar';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { useLayoutStore } from '@/stores/useLayoutStore';
@@ -865,20 +865,59 @@ describe('AgentsSidebar', () => {
       expect(screen.queryByText(/no sessions in this drive/i)).toBeNull();
     });
 
-    test('a background refresh failure on cached sessions still shows the no-match notice, not "Failed to load sessions"', async () => {
-      // Regression pin for the isDataEmpty/isResultEmpty split: hasError can
-      // be true (a background 20s refresh failing) while sessions is still
-      // the last-known-good, non-empty cache. Filtering that cache down to
-      // zero results must never read as a load failure.
-      const user = userEvent.setup();
-      renderSidebar();
-      await screen.findByText('api refactor');
+    describe('resolveListNotice', () => {
+      // Unit-level, not through the full SWR + component stack: getting a real
+      // `hasError` while `sessions` is still non-empty means forcing an SWR
+      // background revalidation to actually fail (the 20s refreshInterval, or
+      // a mutate()), which an integration test can't trigger deterministically
+      // without fake timers fighting userEvent's own. Calling the (exported)
+      // helper directly pins the exact branch logic instead.
+      const baseArgs = {
+        authLoading: false,
+        isAdmin: true,
+        hasError: false,
+        isLoading: false,
+        isDataEmpty: false,
+        isResultEmpty: false,
+        emptyTitle: 'No sessions yet',
+        onRetry: vi.fn(),
+      };
 
-      mockFetchWithAuth.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
-      await user.type(screen.getByPlaceholderText('Search sessions…'), 'zzz-nope');
+      test('a background refresh failure on cached sessions shows the no-match notice, not "Failed to load sessions"', () => {
+        // Regression pin for the isDataEmpty/isResultEmpty split: hasError can
+        // be true (a background refresh failing) while sessions is still the
+        // last-known-good, non-empty cache (isDataEmpty stays false) — the
+        // error branch must be skipped in favor of the search-driven notice.
+        render(
+          <>
+            {resolveListNotice({
+              ...baseArgs,
+              hasError: true,
+              isDataEmpty: false,
+              isResultEmpty: true,
+              emptyTitle: 'No sessions match your search',
+            })}
+          </>,
+        );
 
-      expect(await screen.findByText('No sessions match your search')).toBeDefined();
-      expect(screen.queryByText(/failed to load sessions/i)).toBeNull();
+        expect(screen.getByText('No sessions match your search')).toBeDefined();
+        expect(screen.queryByText(/failed to load sessions/i)).toBeNull();
+      });
+
+      test('a failed load with nothing cached still shows "Failed to load sessions"', () => {
+        render(
+          <>
+            {resolveListNotice({
+              ...baseArgs,
+              hasError: true,
+              isDataEmpty: true,
+              isResultEmpty: true,
+            })}
+          </>,
+        );
+
+        expect(screen.getByText(/failed to load sessions/i)).toBeDefined();
+      });
     });
 
     describe('global mode', () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -821,4 +821,98 @@ describe('AgentsSidebar', () => {
       expect(headers.map((el) => el.textContent)).toEqual(['Global Assistant', 'Alpha']);
     });
   });
+
+  describe('session search', () => {
+    test('replaces the old static "Agent Sessions" label with a search box, and its "+" still opens the new-session flow', async () => {
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      expect(screen.queryByText('Agent Sessions')).toBeNull();
+
+      await user.click(screen.getByLabelText('New session'));
+      // Same agent palette the pre-existing "new session" tests assert on —
+      // confirms the "+" next to the search box still drives the real flow.
+      expect(await screen.findByText('Researcher')).toBeDefined();
+    });
+
+    test('typing filters the drive\'s sessions by name, and clearing the query restores the rest', async () => {
+      respondWithSessions([SESSION, { ...SESSION, sessionId: 'ses-2', name: 'design review' }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      expect(screen.getByText('design review')).toBeDefined();
+
+      const search = screen.getByPlaceholderText('Search sessions…');
+      await user.type(search, 'design');
+
+      expect(screen.queryByText('api refactor')).toBeNull();
+      expect(screen.getByText('design review')).toBeDefined();
+
+      await user.clear(search);
+      expect(await screen.findByText('api refactor')).toBeDefined();
+    });
+
+    test('a query with no matches shows a distinct notice, not the empty-drive one', async () => {
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      await user.type(screen.getByPlaceholderText('Search sessions…'), 'zzz-nope');
+
+      expect(await screen.findByText('No sessions match your search')).toBeDefined();
+      expect(screen.queryByText(/no sessions in this drive/i)).toBeNull();
+    });
+
+    test('a background refresh failure on cached sessions still shows the no-match notice, not "Failed to load sessions"', async () => {
+      // Regression pin for the isDataEmpty/isResultEmpty split: hasError can
+      // be true (a background 20s refresh failing) while sessions is still
+      // the last-known-good, non-empty cache. Filtering that cache down to
+      // zero results must never read as a load failure.
+      const user = userEvent.setup();
+      renderSidebar();
+      await screen.findByText('api refactor');
+
+      mockFetchWithAuth.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+      await user.type(screen.getByPlaceholderText('Search sessions…'), 'zzz-nope');
+
+      expect(await screen.findByText('No sessions match your search')).toBeDefined();
+      expect(screen.queryByText(/failed to load sessions/i)).toBeNull();
+    });
+
+    describe('global mode', () => {
+      beforeEach(() => {
+        mockUseParams.mockReturnValue({});
+        mockUsePathname.mockReturnValue('/dashboard/agents');
+        window.history.replaceState({}, '', '/dashboard/agents');
+        useAgentSurfaceStore.setState({ driveId: null });
+        useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha')] });
+      });
+
+      test('a search+"+" row sits above the per-drive groups, and its "+" opens Create a new drive — not a session', async () => {
+        const user = userEvent.setup();
+        renderSidebar();
+
+        await screen.findByText('Alpha');
+        await user.click(screen.getByLabelText('New drive'));
+
+        expect(await screen.findByText('Create a new drive')).toBeDefined();
+        // Distinct from the roster groups' own per-drive spawn affordance.
+        expect(mockPost).not.toHaveBeenCalled();
+      });
+
+      test('searching hides every drive group with no matching sessions, across the whole roster', async () => {
+        const user = userEvent.setup();
+        renderSidebar();
+
+        await screen.findByText('Alpha');
+        await user.type(screen.getByPlaceholderText('Search sessions…'), 'zzz-nope');
+
+        expect(screen.queryByText('Alpha')).toBeNull();
+        expect(screen.queryByText('Global Assistant')).toBeNull();
+        expect(await screen.findByText('No sessions match your search')).toBeDefined();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Drive-scoped agents page: replaces the static "Agent Sessions" label with a search input filtering sessions by name; the "+" next to it keeps its existing behavior (spawn a new session in this drive).
- Dashboard (global) agents page: adds a search+"+" row above the per-drive groups; its "+" opens the existing "Create a new drive" dialog, since there's no single drive to spawn a session into at this level.
- Search filters client-side by session name, no debounce (same idiom as the file tree's `PageTree.filterTree`). While a search is active, drive groups with zero matching sessions are hidden instead of showing an empty group with a spawn "+".
- Rebased onto master after `fix(agents): add clearance between group-header + button and scrollbar` and the naming-step spawn-flow rewrite landed — reconciled by hand (not a blind merge) so the search feature composes with the new `spawnPick`/naming-step flow rather than reverting it.
- Applied a 4-angle `/simplify` pass (reuse/simplification/efficiency/altitude): collapsed the two mutually-exclusive `SessionSearchHeader` JSX blocks into one, gated `CreateDriveDialog`'s mount to global mode only (it was previously mounted — and subscribing to 3 Zustand selectors — even in drive-scoped mode where it can never open), and removed a duplicate `.trim()` call.
- Addressed reviewer findings (Codex + CodeRabbit): split `resolveListNotice`'s emptiness check into `isDataEmpty`/`isResultEmpty` so a background refresh failure on cached sessions doesn't misreport as "Failed to load sessions" when the active search just has no matches; fixed the search row's padding (`px-2` → `pl-2 pr-4`) to clear the scrollbar, matching the fix already applied to the group header; added `aria-label="Search sessions"` since the placeholder isn't a reliable accessible name; and replaced a test that never actually exercised the `hasError` path (nothing advanced SWR's 20s refresh interval) with direct unit tests of the exported `resolveListNotice`.

## Test plan
- [x] `bun run --filter web typecheck` passes
- [x] `AgentsSidebar.test.tsx` — 47/47 passing (12 new/corrected tests for this feature: search filtering, the distinct no-match notice, two `resolveListNotice` unit tests pinning the isDataEmpty/isResultEmpty split, and the dashboard "+" opening Create Drive instead of a session)
- [x] `eslint` and `knip` clean on both touched files (confirmed the newly-exported `resolveListNotice` isn't flagged as unused)
- [x] CI: `ci / Lint & TypeScript Check` and `ci / Unit Tests` both green across all pushes; CodeRabbit's final pass on the latest commit found nothing further
- [x] Verified in a real logged-in browser (production build, admin session minted via the DB test factories): dashboard-level search+"+" renders above per-drive groups, filters/hides empty groups, "+" opens "Create a new drive"; drive-level search replaces "Agent Sessions" label, "+" still opens the agent-spawn palette

https://claude.ai/code/session_01KNeNyrGgztKNPsrkia5Vim