### PR TITLE
fix(auth): timeout hasDeviceToken() to prevent infinite signin hang

### DIFF
--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StrictMode } from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useSigninRecovery } from '../useSigninRecovery';
 
 // Shell-level coverage for the recovery effect. The DECISION branches live in
@@ -281,6 +281,29 @@ describe('useSigninRecovery', () => {
     await Promise.resolve();
 
     expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('never hangs forever if getStoredSession never resolves (iOS Keychain hang regression)', async () => {
+    // Reproduces the reported bug: a hung native Keychain read used to leave `recovering`
+    // stuck `true` forever, stranding the user on the "Welcome back / Loading..." screen.
+    vi.useFakeTimers();
+    try {
+      mockMe(false);
+      getStoredSession.mockReturnValue(new Promise(() => {})); // never resolves
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      expect(result.current.recovering).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(result.current.recovering).toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('completes recovery under React StrictMode (does not get stuck on loading)', async () => {

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StrictMode } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { useSigninRecovery } from '../useSigninRecovery';
+import { useSigninRecovery, DEVICE_TOKEN_TIMEOUT_MS } from '../useSigninRecovery';
 
 // Shell-level coverage for the recovery effect. The DECISION branches live in
 // signin-recovery.test.ts; here we assert the effects are wired to the right actions AND to the
@@ -296,7 +296,7 @@ describe('useSigninRecovery', () => {
       expect(result.current.recovering).toBe(true);
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(3000);
+        await vi.advanceTimersByTimeAsync(DEVICE_TOKEN_TIMEOUT_MS);
       });
 
       expect(result.current.recovering).toBe(false);

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -9,19 +9,38 @@ import { decideSigninRecovery, type SigninRecoveryInput } from './signin-recover
 
 const DEFAULT_NEXT = '/dashboard';
 
+// Matches AuthFetch's TOKEN_RETRIEVAL_TIMEOUT_MS (auth-fetch.ts) — same underlying Keychain
+// round-trip, same "can hang during app launch on iOS" hazard.
+const DEVICE_TOKEN_TIMEOUT_MS = 3000;
+
 /**
  * Whether a device token exists to recover an expired session from — read from PLATFORM storage
  * (D1): desktop reads safeStorage over IPC (window.electron.auth) via DesktopStorage, web reads
  * localStorage via WebStorage. The old localStorage-only check saw nothing on desktop, which is
  * why native shells could never self-recover. Async because the desktop read is an IPC round-trip.
+ *
+ * Raced against a timeout because the underlying native call can hang indefinitely (iOS
+ * Keychain access during app launch) — same hazard `getSessionTokenWithTimeout` guards
+ * against in auth-fetch.ts. Without this, a hung call leaves `recovering` stuck `true`
+ * forever, stranding the user on the loading screen.
  */
 async function hasDeviceToken(): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeoutId = setTimeout(() => resolve(null), DEVICE_TOKEN_TIMEOUT_MS);
+  });
+
   try {
-    const session = await getPlatformStorage().getStoredSession();
+    const session = await Promise.race([
+      getPlatformStorage().getStoredSession(),
+      timeoutPromise,
+    ]);
     return !!session?.deviceToken;
   } catch {
     // Storage unavailable (IPC failure / SSR) — treat as no token and fall through to the form.
     return false;
+  } finally {
+    clearTimeout(timeoutId!);
   }
 }
 

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -10,8 +10,9 @@ import { decideSigninRecovery, type SigninRecoveryInput } from './signin-recover
 const DEFAULT_NEXT = '/dashboard';
 
 // Matches AuthFetch's TOKEN_RETRIEVAL_TIMEOUT_MS (auth-fetch.ts) — same underlying Keychain
-// round-trip, same "can hang during app launch on iOS" hazard.
-const DEVICE_TOKEN_TIMEOUT_MS = 3000;
+// round-trip, same "can hang during app launch on iOS" hazard. Exported so the regression test
+// can assert against it directly instead of a hardcoded duplicate that could silently drift.
+export const DEVICE_TOKEN_TIMEOUT_MS = 3000;
 
 /**
  * Whether a device token exists to recover an expired session from — read from PLATFORM storage

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Regression coverage for the Codex P1 finding on PR #2291: `refreshBearerSession()` used to
+// await `storage.getStoredSession()` with no timeout — the identical iOS Keychain bridge call
+// `getSessionTokenWithTimeout` already guards elsewhere in this file. A hung read here stranded
+// the signin-recovery flow (`checkMeAuthenticated` -> 401 -> refresh -> refreshBearerSession)
+// forever, via a different call site than the one useSigninRecovery.ts's hasDeviceToken() fix
+// covers. See getStoredSessionWithTimeout in auth-fetch.ts.
+
+vi.mock('@/lib/logging/client-logger', () => ({
+  createClientLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const getStoredSession = vi.fn();
+const getDeviceInfo = vi.fn().mockResolvedValue({ deviceId: 'device-1', userAgent: 'ua', appVersion: '1.0.0' });
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({
+    platform: 'ios',
+    getSessionToken: vi.fn().mockResolvedValue(null),
+    getStoredSession,
+    storeSession: vi.fn().mockResolvedValue(undefined),
+    clearSession: vi.fn().mockResolvedValue(undefined),
+    getDeviceInfo,
+    usesBearer: vi.fn().mockReturnValue(true),
+    supportsCSRF: vi.fn().mockReturnValue(false),
+    dispatchAuthEvent: vi.fn(),
+  }),
+  resetPlatformStorage: vi.fn(),
+}));
+
+type RefreshInternals = {
+  refreshBearerSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
+};
+
+describe('refreshBearerSession: getStoredSession timeout', () => {
+  let originalFetch: typeof global.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    getStoredSession.mockReset();
+    getDeviceInfo.mockClear();
+
+    delete (globalThis as typeof globalThis & { [key: symbol]: unknown })[
+      Symbol.for('pagespace.authfetch.singleton')
+    ];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('never hangs if getStoredSession never resolves, and does NOT force a logout', async () => {
+    vi.useFakeTimers();
+    try {
+      getStoredSession.mockReturnValue(new Promise(() => {})); // never resolves
+
+      const { AuthFetch } = await import('../auth-fetch');
+      const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+      const resultPromise = authFetch.refreshBearerSession();
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      const result = await resultPromise;
+
+      // Transient timeout is retryable, not proof the device token is invalid — must not
+      // force a logout of what may still be a perfectly valid session.
+      expect(result).toEqual({ success: false, shouldLogout: false });
+      // The hung read must short-circuit the refresh — no network call was ever attempted.
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a genuinely missing device token (resolved null) still forces a logout, unlike a timeout', async () => {
+    getStoredSession.mockResolvedValue(null);
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshBearerSession();
+
+    expect(result).toEqual({ success: false, shouldLogout: true });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { createClientLogger } from '@/lib/logging/client-logger';
-import { getPlatformStorage, type PlatformStorage } from './platform-storage';
+import { getPlatformStorage, type PlatformStorage, type StoredSession } from './platform-storage';
 import { isCapacitorApp, getPlatform } from '@/lib/capacitor-bridge';
 
 interface FetchOptions extends RequestInit {
@@ -561,13 +561,53 @@ class AuthFetch {
   }
 
   /**
+   * Reads the stored session with the same timeout `getSessionTokenWithTimeout` applies to
+   * bearer token retrieval — on iOS, Keychain access can hang during app launch, and
+   * `getStoredSession()` is the identical underlying bridge call. Without this, a hung read
+   * here would strand `refreshBearerSession()` (and anything awaiting it) indefinitely, on
+   * the same recovery path this timeout was added to protect elsewhere.
+   *
+   * Distinguishes a timeout from a resolved-null session: a timeout tells us nothing about
+   * whether a device token exists, so the caller must treat it as transient/retryable — never
+   * as proof the token is missing (that would force an incorrect logout of a session that may
+   * still be perfectly valid).
+   */
+  private async getStoredSessionWithTimeout(
+    storage: PlatformStorage,
+  ): Promise<{ session: StoredSession | null; timedOut: boolean }> {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<{ session: null; timedOut: true }>((resolve) => {
+      timeoutId = setTimeout(() => {
+        this.logger.warn(`${storage.platform}: getStoredSession timed out after ${this.TOKEN_RETRIEVAL_TIMEOUT_MS}ms`);
+        resolve({ session: null, timedOut: true });
+      }, this.TOKEN_RETRIEVAL_TIMEOUT_MS);
+    });
+
+    try {
+      return await Promise.race([
+        storage.getStoredSession().then((session) => ({ session, timedOut: false as const })),
+        timeoutPromise,
+      ]);
+    } finally {
+      clearTimeout(timeoutId!);
+    }
+  }
+
+  /**
    * Refresh session for Bearer token platforms (iOS, Android)
    */
   private async refreshBearerSession(): Promise<SessionRefreshResult> {
     const storage = this.getStorage();
 
     try {
-      const session = await storage.getStoredSession();
+      const { session, timedOut } = await this.getStoredSessionWithTimeout(storage);
+
+      if (timedOut) {
+        // Transient Keychain hang, not proof the device token is missing — retryable, same
+        // as the 429/5xx branch below, so we don't force a logout on a merely-slow read.
+        return { success: false, shouldLogout: false };
+      }
+
       const info = await storage.getDeviceInfo();
 
       if (!session?.deviceToken || !info.deviceId) {


### PR DESCRIPTION
## Summary
- A TestFlight user got permanently stuck on the "Welcome back / Loading..." signin screen. Root cause: `hasDeviceToken()` in `useSigninRecovery.ts` awaited a raw iOS Keychain bridge call (`getStoredSession()`) with no timeout — if that native promise hangs (cold-launch timing, app backgrounded mid-call), `recovering` never flips to `false` and the user is stranded with no way out.
- Fix wraps the await in a 3s `Promise.race`, mirroring the identical fix already shipped for `getSessionTokenWithTimeout` in `auth-fetch.ts` (which has the exact comment: "On iOS, Keychain access can hang during app launch"). On timeout it resolves to `false` ("no device token"), which fails open to the signin form via the existing `decideSigninRecovery` logic — same behavior as the existing catch-block for storage errors.
- **Follow-up from review (Codex P1):** the same recovery flow can hang one hop later. `checkMeAuthenticated()` goes through `fetchWithAuth`, which on a 401 calls `refreshToken() -> doRefresh() -> refreshBearerSession()` for iOS — and that path awaited the *identical* unbounded `storage.getStoredSession()` Keychain call (`auth-fetch.ts:570`). Added `getStoredSessionWithTimeout()` there too, reusing `AuthFetch`'s existing `TOKEN_RETRIEVAL_TIMEOUT_MS` (safe to reference directly since it's internal to the same class). A timeout is treated as **transient/retryable** (`shouldLogout: false`), not as proof the device token is missing (`shouldLogout: true`) — conflating the two would turn a merely-slow Keychain read into an incorrect forced logout of a still-valid session. A genuinely resolved-`null` session still forces `shouldLogout: true`, unchanged.
- Pure decision core (`signin-recovery.ts`) is untouched; scope intentionally excludes `AbortController` timeouts on `auth-fetch.ts`'s `fetch()` calls themselves, a top-level failsafe timer on `recovering`, or logging changes — those remain deferred follow-ups.

## Test plan
- [x] `bun run --filter web test -- src/app/auth/signin/__tests__/useSigninRecovery.test.ts src/app/auth/signin/__tests__/signin-recovery.test.ts` — 27/27 pass, including a regression test that hangs `getStoredSession()` forever (fake timers) and asserts `recovering` still resolves to `false` within the timeout window
- [x] `bun run --filter web test -- src/lib/auth` — 37 files / 646 tests pass, including new `auth-fetch-refresh-bearer-session-timeout.test.ts` covering the `refreshBearerSession()` timeout (hang case + resolved-null control case)
- [x] `tsc --noEmit` in `apps/web` — no new errors
- [x] `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Hk45ocq9qYQnbqVXQqkZ
