### PR TITLE
feat(canvas): fullscreen preview button on the View tab

### DIFF
--- a/apps/web/src/components/canvas/CanvasFrame.tsx
+++ b/apps/web/src/components/canvas/CanvasFrame.tsx
@@ -19,6 +19,15 @@ interface CanvasFrameProps {
    *  the canvas Settings tab's Appearance category) so the editor's live
    *  preview matches what publishing will produce. Defaults to `true`. */
   themeBridgeEnabled?: boolean;
+  /**
+   * Called when the user presses Escape inside the iframe. The sandboxed
+   * iframe is a separate browsing context, so a parent-level `keydown`
+   * listener (e.g. a Radix Dialog wrapping this frame) never sees the key
+   * press once focus moves inside — this bridges it via `postMessage`
+   * (`escapeBridge` on `renderCanvasDocument`). Omit when this CanvasFrame
+   * isn't inside anything Escape should close (e.g. the plain View tab).
+   */
+  onEscape?: () => void;
 }
 
 /**
@@ -73,7 +82,7 @@ function hasRecentUserActivation(): boolean {
  * The document string is the same one produced for published pages, so the
  * in-app view and the published artifact render identically.
  */
-export function CanvasFrame({ html, title, themeBridgeEnabled = true }: CanvasFrameProps) {
+export function CanvasFrame({ html, title, themeBridgeEnabled = true, onEscape }: CanvasFrameProps) {
   const nonce = useNonce();
   const router = useRouter();
   const [previewHtml, setPreviewHtml] = useState(html);
@@ -130,9 +139,16 @@ export function CanvasFrame({ html, title, themeBridgeEnabled = true }: CanvasFr
   // navigationBridge: true injects a script that intercepts clicks on internal
   // dashboard page links and hands them to the message handler below, so they
   // route in-app instead of falling through to baseTarget's new-tab behavior.
+  // escapeBridge is only injected when a caller actually wants Escape
+  // forwarded (see onEscape doc) — no point wiring it up with nothing to
+  // notify. Keyed on the BOOLEAN presence, not the callback identity itself:
+  // an inline arrow prop (e.g. `onEscape={() => setOpen(false)}`) is a new
+  // function every render, and including it directly here would recompute
+  // srcDoc — and so reload the iframe — on every unrelated parent re-render.
+  const hasEscapeHandler = Boolean(onEscape);
   const srcDoc = useMemo(
-    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank', injectThemeBridge: themeBridgeEnabled, navigationBridge: true, nonce }),
-    [previewHtml, title, nonce, themeBridgeEnabled],
+    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank', injectThemeBridge: themeBridgeEnabled, navigationBridge: true, escapeBridge: hasEscapeHandler, nonce }),
+    [previewHtml, title, nonce, themeBridgeEnabled, hasEscapeHandler],
   );
 
   // Send the current theme to the canvas iframe whenever it changes or the
@@ -151,7 +167,8 @@ export function CanvasFrame({ html, title, themeBridgeEnabled = true }: CanvasFr
   }, [resolvedTheme, srcDoc]);
 
   // Respond to the iframe's initial theme request (fires on load before the
-  // resolvedTheme effect above catches it) and handle in-app navigation
+  // resolvedTheme effect above catches it), forward Escape from the injected
+  // escape-bridge script (escapeBridge), and handle in-app navigation
   // requests from the injected click-interceptor script (navigationBridge).
   useEffect(() => {
     function handleMessage(e: MessageEvent) {
@@ -162,6 +179,11 @@ export function CanvasFrame({ html, title, themeBridgeEnabled = true }: CanvasFr
           { type: 'pagespace-theme', isDark: resolvedTheme === 'dark' },
           '*',
         );
+        return;
+      }
+
+      if (e.data?.type === 'pagespace-escape') {
+        onEscape?.();
         return;
       }
 
@@ -186,7 +208,7 @@ export function CanvasFrame({ html, title, themeBridgeEnabled = true }: CanvasFr
     }
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [resolvedTheme, router]);
+  }, [resolvedTheme, router, onEscape]);
 
   return (
     <iframe

--- a/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
+++ b/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
@@ -383,3 +383,83 @@ describe('CanvasFrame — navigation bridge', () => {
     });
   });
 });
+
+describe('CanvasFrame — escape bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useThemeMock.mockReturnValue({ resolvedTheme: 'dark' });
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ links: [] }),
+    });
+  });
+
+  it('given no onEscape prop, should NOT inject the escape bridge script into the srcDoc', () => {
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    expect(iframe.srcdoc).not.toContain('pagespace-escape');
+  });
+
+  it('given an onEscape prop, should inject the escape bridge script into the srcDoc', () => {
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+      onEscape: vi.fn(),
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    expect(iframe.srcdoc).toContain('pagespace-escape');
+  });
+
+  it('given a pagespace-escape message from the iframe, should call onEscape', () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+    const onEscape = vi.fn();
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+      onEscape,
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-escape' },
+      source: mockContentWindow as unknown as MessageEventSource,
+    }));
+
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('given a pagespace-escape message from a different source, should NOT call onEscape', () => {
+    const mockContentWindow = { postMessage: vi.fn() };
+    const onEscape = vi.fn();
+
+    render(React.createElement(CanvasFrame, {
+      html: '<p>x</p>',
+      title: 'Canvas',
+      onEscape,
+    }));
+
+    const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+    Object.defineProperty(iframe, 'contentWindow', {
+      value: mockContentWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'pagespace-escape' },
+      source: window,
+    }));
+
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -276,7 +276,9 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
           className="w-screen h-screen max-w-none max-h-none p-0 gap-0 rounded-none border-0 sm:max-w-none"
         >
           <DialogTitle className="sr-only">Canvas preview</DialogTitle>
-          <CanvasFrame html={content} title="Canvas preview" themeBridgeEnabled={themeBridgeEnabled} onEscape={closePreview} />
+          <ErrorBoundary>
+            <CanvasFrame html={content} title="Canvas preview" themeBridgeEnabled={themeBridgeEnabled} onEscape={closePreview} />
+          </ErrorBoundary>
         </DialogContent>
       </Dialog>
 

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -252,9 +252,11 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
           >
             <Maximize2 className="h-4 w-4" />
           </button>
-          <ErrorBoundary>
-            <CanvasFrame html={content} themeBridgeEnabled={themeBridgeEnabled} />
-          </ErrorBoundary>
+          {!isPreviewOpen && (
+            <ErrorBoundary>
+              <CanvasFrame html={content} themeBridgeEnabled={themeBridgeEnabled} />
+            </ErrorBoundary>
+          )}
         </div>
       )}
       {activeTab === 'settings' && (

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import React, { useEffect, useCallback, useRef } from 'react';
+import React, { useEffect, useCallback, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Maximize2 } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import dynamic from 'next/dynamic';
 import { CanvasFrame } from '@/components/canvas/CanvasFrame';
 import { ErrorBoundary } from '@/components/ai/shared';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { useDocument } from '@/hooks/useDocument';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
 import { useEditingStore } from '@/stores/useEditingStore';
@@ -49,6 +51,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   }, [searchParams, pathname, router]);
 
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasInitializedRef = useRef(false);
   const isDirtyRef = useRef(false);
@@ -239,7 +242,16 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
         </div>
       )}
       {activeTab === 'view' && (
-        <div className="flex-1 w-full bg-background text-foreground">
+        <div className="relative flex-1 w-full bg-background text-foreground">
+          <button
+            type="button"
+            title="Fullscreen preview"
+            aria-label="Fullscreen preview"
+            onClick={() => setIsPreviewOpen(true)}
+            className="absolute top-2 right-2 z-10 rounded-md bg-background/70 p-1.5 text-muted-foreground backdrop-blur-sm hover:bg-background hover:text-foreground"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </button>
           <ErrorBoundary>
             <CanvasFrame html={content} themeBridgeEnabled={themeBridgeEnabled} />
           </ErrorBoundary>
@@ -254,6 +266,16 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
           />
         </div>
       )}
+
+      <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
+        <DialogContent
+          showCloseButton
+          className="w-screen h-screen max-w-none max-h-none p-0 gap-0 rounded-none border-0 sm:max-w-none"
+        >
+          <DialogTitle className="sr-only">Canvas preview</DialogTitle>
+          <CanvasFrame html={content} title="Canvas preview" themeBridgeEnabled={themeBridgeEnabled} />
+        </DialogContent>
+      </Dialog>
 
       {isLoading && (
         <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center">

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -52,6 +52,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
   }, [searchParams, pathname, router]);
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const closePreview = useCallback(() => setIsPreviewOpen(false), []);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasInitializedRef = useRef(false);
   const isDirtyRef = useRef(false);
@@ -275,7 +276,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
           className="w-screen h-screen max-w-none max-h-none p-0 gap-0 rounded-none border-0 sm:max-w-none"
         >
           <DialogTitle className="sr-only">Canvas preview</DialogTitle>
-          <CanvasFrame html={content} title="Canvas preview" themeBridgeEnabled={themeBridgeEnabled} />
+          <CanvasFrame html={content} title="Canvas preview" themeBridgeEnabled={themeBridgeEnabled} onEscape={closePreview} />
         </DialogContent>
       </Dialog>
 

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET, THEME_BRIDGE_SCRIPT, NAVIGATION_BRIDGE_SCRIPT } from '../render-document';
+import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET, THEME_BRIDGE_SCRIPT, NAVIGATION_BRIDGE_SCRIPT, ESCAPE_BRIDGE_SCRIPT } from '../render-document';
 
 describe('renderCanvasDocument', () => {
   it('given any input, should return a full HTML document', () => {
@@ -235,6 +235,38 @@ describe('renderCanvasDocument — navigation bridge', () => {
     // Both injected scripts (theme + navigation) would need the nonce if both
     // were present; here only navigationBridge is set, so exactly one stamped
     // inline script should carry it.
+    expect(out).toContain('<script nonce="app-nonce==">(function(){');
+  });
+});
+
+describe('renderCanvasDocument — escape bridge', () => {
+  it('given escapeBridge: true, should inject the bridge script inside <head>', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', escapeBridge: true });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain(ESCAPE_BRIDGE_SCRIPT);
+  });
+
+  it('given no escapeBridge, should NOT inject the bridge script (covers the published-page default and the plain in-app View tab)', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>' });
+    expect(out).not.toContain('pagespace-escape');
+  });
+
+  it('given escapeBridge: true, the bridge should listen for a bare Escape keydown and postMessage', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', escapeBridge: true });
+    expect(out).toContain("postMessage({type:'pagespace-escape'}");
+    expect(out).toContain("e.key!=='Escape'");
+  });
+
+  // Regression: a canvas author might bind their own modifier-key shortcut
+  // (e.g. Cmd+Escape) — the bridge must only forward a BARE Escape press, not
+  // steal every Escape-adjacent combination the author's own JS might want.
+  it('given escapeBridge: true, the bridge should ignore Escape with a modifier key held', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', escapeBridge: true });
+    expect(out).toContain('e.metaKey||e.ctrlKey||e.altKey');
+  });
+
+  it('given escapeBridge: true AND a nonce, should stamp the nonce onto the escape-bridge script too', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', escapeBridge: true, nonce: 'app-nonce==' });
     expect(out).toContain('<script nonce="app-nonce==">(function(){');
   });
 });

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -133,6 +133,25 @@ export interface RenderCanvasDocumentInput {
    */
   navigationBridge?: boolean;
   /**
+   * When true, injects a lightweight <script> into <head> that listens for a
+   * top-level `Escape` keydown inside the iframe's own document and posts
+   * `{ type: 'pagespace-escape' }` to the parent.
+   *
+   * Sandboxed/cross-origin iframes are a separate browsing context: keyboard
+   * events (including Escape) never bubble out to the parent document, so a
+   * parent-side modal (e.g. the in-app fullscreen canvas preview) built on a
+   * `keydown` listener never sees Escape once focus moves inside the iframe.
+   * This bridges it the same way the theme/navigation bridges cross the
+   * origin boundary — via `postMessage`, with the parent (CanvasFrame)
+   * deciding what "close" means.
+   *
+   * Pass ONLY from the in-app dashboard renderer, and only while something is
+   * actually listening (e.g. the fullscreen preview dialog is open) — see
+   * `navigationBridge` doc above for why the publish pipeline must not set
+   * this.
+   */
+  escapeBridge?: boolean;
+  /**
    * When set, used VERBATIM as the emitted CSP `<meta>` content instead of
    * `buildBaselineCsp(formActionOrigin)`. Lets other renderers (e.g. the
    * published-document pipeline, which needs `script-src 'none'`) reuse this
@@ -267,6 +286,24 @@ export const NAVIGATION_BRIDGE_SCRIPT =
   "});" +
   "})();</script>";
 
+/**
+ * Inline script injected when `escapeBridge` is true. Runs ONLY inside the
+ * in-app canvas iframe (see `escapeBridge` doc above).
+ *
+ * Listens on `document` for a bare `Escape` keydown (no modifier keys, so
+ * e.g. a canvas-internal "close panel on Cmd+Escape" shortcut is left alone)
+ * and posts `{ type: 'pagespace-escape' }` to the parent. Never calls
+ * `preventDefault()` — author JS retains full control of its own Escape
+ * handling; this is purely an additional notification to the parent.
+ */
+export const ESCAPE_BRIDGE_SCRIPT =
+  "<script>(function(){" +
+  "document.addEventListener('keydown',function(e){" +
+  "if(e.key!=='Escape'||e.metaKey||e.ctrlKey||e.altKey)return;" +
+  "try{window.parent.postMessage({type:'pagespace-escape'},'*');}catch(err){}" +
+  "});" +
+  "})();</script>";
+
 // Re-exported for existing consumers — the implementation lives in a
 // dependency-free shared module so non-canvas modules (e.g. forms) don't
 // couple to canvas internals to escape a string.
@@ -396,7 +433,7 @@ function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[], no
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, navigationBridge, nonce, cspOverride } = input;
+  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, navigationBridge, escapeBridge, nonce, cspOverride } = input;
   const csp = cspOverride ?? buildBaselineCsp(formActionOrigin);
 
   const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts, nonce);
@@ -441,6 +478,7 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
     `<style>${BASELINE_RESET}${css}</style>` +
     (injectThemeBridge ? (nonce ? stampScriptNonce(THEME_BRIDGE_SCRIPT, nonce) : THEME_BRIDGE_SCRIPT) : '') +
     (navigationBridge ? (nonce ? stampScriptNonce(NAVIGATION_BRIDGE_SCRIPT, nonce) : NAVIGATION_BRIDGE_SCRIPT) : '') +
+    (escapeBridge ? (nonce ? stampScriptNonce(ESCAPE_BRIDGE_SCRIPT, nonce) : ESCAPE_BRIDGE_SCRIPT) : '') +
     '</head><body>' +
     body +
     '</body></html>'


### PR DESCRIPTION
## Summary
- Adds a small expand (`Maximize2`) icon button in the corner of the Canvas page's View tab.
- Clicking it opens a viewport-filling `Dialog` rendering the same live `CanvasFrame` (current unsaved content, no app chrome), closable via the built-in `X`, Escape, or clicking outside.
- Not tied to publish state — works on pages that have never been published, and always reflects the latest unsaved edits since it renders the same in-memory `content` the View tab already uses.
- Passes `themeBridgeEnabled` through to match the appearance-settings behavior from #2286.
- **Avoids double-mounting `CanvasFrame`**: the View tab's underlying frame now unmounts while the preview dialog is open, so there is never more than one live sandboxed iframe executing the canvas HTML/JS at once (author scripts — WebSocket connections, on-load fetches, timers, audio/video — would otherwise run twice concurrently).
- **Escape now works even with focus inside the preview**: the sandboxed iframe is a separate browsing context, so keyboard events don't bubble to the parent `Dialog`. Adds an opt-in `escapeBridge` to the shared `renderCanvasDocument` (same `postMessage` pattern as the existing theme/navigation bridges) that forwards a bare Escape keydown to the parent, which closes the preview.
- The fullscreen preview's `CanvasFrame` is wrapped in the same `ErrorBoundary` as the View tab's instance, so a render error there is contained instead of propagating further up the tree.

## Test plan
- [x] `bun run typecheck` (web, lib)
- [x] `bun run lint` (web, lib) on touched files
- [x] Unit tests: `CanvasFrame.test.ts` (18 passing, incl. 4 new escape-bridge tests) and `render-document.test.ts` (114 passing, incl. 5 new escape-bridge tests)
- [ ] Manual: open a CANVAS page, click the expand icon on the View tab, confirm the iframe fills the viewport with no app chrome
- [ ] Manual: edit HTML in the Code tab (don't wait for save), switch to View, open preview — confirm it reflects the unsaved edit
- [ ] Manual: confirm Escape and the X button both close the overlay, including after clicking/tabbing into the iframe content itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBw8pUxkGjbjSL2y8BpL2u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen preview option for canvas content.
  * Fullscreen previews preserve the current canvas content and theme settings.
  * Included accessible labeling for the fullscreen preview dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->