### PR TITLE
feat(agents): default to a paginated past-conversations list

### DIFF
--- a/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
@@ -6,11 +6,13 @@ const {
   mockAuditRequest,
   mockListAllConversationsPaginated,
   mockGetBatchPagePermissions,
+  mockResolveDriveMembership,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAuditRequest: vi.fn(),
   mockListAllConversationsPaginated: vi.fn(),
   mockGetBatchPagePermissions: vi.fn(),
+  mockResolveDriveMembership: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -25,6 +27,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 }));
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
+}));
+vi.mock('@pagespace/lib/services/agent-sessions/agent-session-tenant', () => ({
+  resolveDriveMembership: (...args: unknown[]) => mockResolveDriveMembership(...args),
 }));
 vi.mock('@/lib/agent-sessions/agent-sessions-conversations-runtime', () => ({
   listAllConversationsPaginated: (...args: unknown[]) => mockListAllConversationsPaginated(...args),
@@ -63,6 +68,24 @@ const PAGE_ROW = {
   sessionName: null,
   sessionEndedAt: null,
   driveId: 'drive-1',
+};
+
+// A `type: 'global'` conversation bound to a drive-scoped agent session —
+// any accepted member of `driveId` may have created this (session access is
+// granted by drive membership, not session ownership), so this row can exist
+// even for a session `user-1` doesn't own.
+const SESSION_GLOBAL_ROW = {
+  conversationId: 'conv-session-global',
+  title: null,
+  type: 'global',
+  agentPageId: null,
+  pageTitle: null,
+  lastMessageAt: '2026-07-28T00:00:00.000Z',
+  createdAt: '2026-07-27T00:00:00.000Z',
+  sessionId: 'session-1',
+  sessionName: 'My Sandbox',
+  sessionEndedAt: null,
+  driveId: 'drive-2',
 };
 
 beforeEach(() => {
@@ -268,6 +291,133 @@ describe('GET /api/agent-sessions/conversations', () => {
       // reached — the caller can page again rather than being told (falsely)
       // that history has ended.
       expect(body.pagination).toEqual({ hasMore: true, nextCursor: 'cursor-5', limit: 20 });
+    });
+
+    it('accumulating past `limit` across internal fetches truncates to `limit` and derives nextCursor from the last KEPT row, not the raw DB cursor', async () => {
+      mockListAllConversationsPaginated
+        .mockResolvedValueOnce({
+          // Entirely dropped — forces a second internal fetch.
+          conversations: [PAGE_ROW],
+          pagination: { hasMore: true, nextCursor: 'cursor-1', limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          // 3 visible rows against a limit of 2 — pushes `visible` past `limit`.
+          conversations: [
+            { ...GLOBAL_ROW, conversationId: 'conv-a', lastMessageAt: '2026-07-29T00:00:00.000Z' },
+            { ...GLOBAL_ROW, conversationId: 'conv-b', lastMessageAt: '2026-07-28T00:00:00.000Z' },
+            { ...GLOBAL_ROW, conversationId: 'conv-c', lastMessageAt: '2026-07-27T00:00:00.000Z' },
+          ],
+          pagination: { hasMore: true, nextCursor: 'cursor-2', limit: 2 },
+        });
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: false }]]));
+
+      // Drive-scoped so the first fetch's row is DROPPED (not masked) —
+      // otherwise a masked-but-kept row would occupy one of the two `limit`
+      // slots itself, muddying what this test is isolating.
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?limit=2&driveId=drive-1'));
+      const body = await response.json();
+
+      // Truncated to the requested limit, not the 3 rows the second fetch found.
+      expect(body.conversations).toEqual([
+        expect.objectContaining({ conversationId: 'conv-a' }),
+        expect.objectContaining({ conversationId: 'conv-b' }),
+      ]);
+      expect(body.pagination.hasMore).toBe(true);
+      // The cursor must come from `conv-b` (the last KEPT row) — not `cursor-2`
+      // (the raw DB cursor, which would skip past `conv-b` and re-admit
+      // `conv-c` a second time on the next page if it leaked through instead).
+      const expectedCursor = Buffer.from(
+        JSON.stringify({ sortKey: new Date('2026-07-28T00:00:00.000Z').toISOString(), id: 'conv-b' }),
+      ).toString('base64url');
+      expect(body.pagination.nextCursor).toBe(expectedCursor);
+    });
+  });
+
+  describe('session-bound global rows: the session drive can belong to a different member than the requester', () => {
+    // A drive-scoped agent session is a shared working context — any
+    // accepted member may create their own `type: 'global'` conversation
+    // inside it (session access is granted by drive membership, not session
+    // ownership), so `conversations.userId` and the session's own `ownerId`
+    // can legitimately differ. Conversation ownership never lapses, but
+    // membership in that session's drive can — the same "authored it once,
+    // current access unproven" gap already covered above for pages.
+    beforeEach(() => {
+      mockListAllConversationsPaginated.mockResolvedValue({
+        conversations: [SESSION_GLOBAL_ROW, GLOBAL_ROW],
+        pagination: { hasMore: false, nextCursor: null, limit: 20 },
+      });
+    });
+
+    it('keeps the row in full when the requester still has access to the session drive', async () => {
+      mockResolveDriveMembership.mockResolvedValue('member');
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+      const body = await response.json();
+
+      expect(mockResolveDriveMembership).toHaveBeenCalledWith({ userId: 'user-1', driveId: 'drive-2' });
+      expect(body.conversations).toEqual([SESSION_GLOBAL_ROW, GLOBAL_ROW]);
+    });
+
+    it('masks the session-derived fields (keeps the row, as the conversation is still readable) when unscoped and access is lost', async () => {
+      // The global-assistant message GET gates purely on `conversations.userId`
+      // — never session or drive membership — so the conversation's own
+      // content stays fully readable. Only the session-derived fields (which
+      // `resolveNavigationTarget` would otherwise use to route into a pane
+      // the requester can no longer open) are nulled.
+      mockResolveDriveMembership.mockResolvedValue('none');
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+      const body = await response.json();
+
+      expect(body.conversations).toEqual([
+        { ...SESSION_GLOBAL_ROW, sessionId: null, driveId: null, sessionName: null, sessionEndedAt: null },
+        GLOBAL_ROW,
+      ]);
+    });
+
+    it('drops the row entirely when driveId is scoped and access is lost (same oracle risk as page rows)', async () => {
+      mockResolveDriveMembership.mockResolvedValue('none');
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-2'));
+      const body = await response.json();
+
+      expect(mockListAllConversationsPaginated).toHaveBeenCalledWith(
+        { ownerId: 'user-1', driveId: 'drive-2' },
+        { limit: 20, cursor: undefined },
+      );
+      expect(body.conversations).toEqual([GLOBAL_ROW]);
+    });
+
+    it('keeps the row in full when driveId is scoped and access is NOT lost', async () => {
+      mockResolveDriveMembership.mockResolvedValue('owner');
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-2'));
+      const body = await response.json();
+
+      expect(body.conversations).toEqual([SESSION_GLOBAL_ROW, GLOBAL_ROW]);
+    });
+
+    it('never checks drive membership for a driveless global-assistant conversation (no session, nothing to check)', async () => {
+      mockListAllConversationsPaginated.mockResolvedValue({
+        conversations: [GLOBAL_ROW],
+        pagination: { hasMore: false, nextCursor: null, limit: 20 },
+      });
+
+      await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+
+      expect(mockResolveDriveMembership).not.toHaveBeenCalled();
+    });
+
+    it('batch-checks once per distinct driveId, never per-row (no N+1)', async () => {
+      mockListAllConversationsPaginated.mockResolvedValue({
+        conversations: [SESSION_GLOBAL_ROW, { ...SESSION_GLOBAL_ROW, conversationId: 'conv-session-global-2' }],
+        pagination: { hasMore: false, nextCursor: null, limit: 20 },
+      });
+      mockResolveDriveMembership.mockResolvedValue('member');
+
+      await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+
+      expect(mockResolveDriveMembership).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
@@ -171,4 +171,46 @@ describe('GET /api/agent-sessions/conversations', () => {
       expect(mockGetBatchPagePermissions).toHaveBeenCalledWith('user-1', ['agent-1']);
     });
   });
+
+  describe('drive-scoped requests DROP (not mask) an inaccessible page row', () => {
+    // The ?driveId= filter runs against the page's CURRENT driveId before any
+    // permission check — so a masked-but-present row in a driveId-scoped
+    // result would itself confirm "this inaccessible page currently belongs
+    // to this drive", an oracle a caller could probe across candidate drive
+    // ids (review finding). Masking alone (keep the row, null the fields) is
+    // only safe when NOT scoped to a specific drive.
+    beforeEach(() => {
+      mockListAllConversationsPaginated.mockResolvedValue({
+        conversations: [PAGE_ROW, GLOBAL_ROW],
+        pagination: { hasMore: false, nextCursor: null, limit: 20 },
+      });
+    });
+
+    it('drops the row entirely when driveId is scoped and the page is inaccessible', async () => {
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: false }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-1'));
+      const body = await response.json();
+
+      expect(body.conversations).toEqual([GLOBAL_ROW]);
+    });
+
+    it('still masks (keeps the row) rather than dropping when driveId is NOT scoped', async () => {
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: false }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+      const body = await response.json();
+
+      expect(body.conversations).toEqual([{ ...PAGE_ROW, pageTitle: null, driveId: null }, GLOBAL_ROW]);
+    });
+
+    it('keeps the row in full when driveId is scoped and the page IS accessible', async () => {
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: true }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-1'));
+      const body = await response.json();
+
+      expect(body.conversations).toEqual([PAGE_ROW, GLOBAL_ROW]);
+    });
+  });
 });

--- a/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
@@ -28,6 +28,8 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 }));
 vi.mock('@/lib/agent-sessions/agent-sessions-conversations-runtime', () => ({
   listAllConversationsPaginated: (...args: unknown[]) => mockListAllConversationsPaginated(...args),
+  encodeCursor: (sortKey: Date | string, id: string) =>
+    Buffer.from(JSON.stringify({ sortKey: new Date(sortKey).toISOString(), id })).toString('base64url'),
 }));
 
 import { GET } from '../route';
@@ -211,6 +213,61 @@ describe('GET /api/agent-sessions/conversations', () => {
       const body = await response.json();
 
       expect(body.conversations).toEqual([PAGE_ROW, GLOBAL_ROW]);
+    });
+  });
+
+  describe('dropping inaccessible rows keeps fetching rather than returning a stuck-empty page', () => {
+    // Dropping (not masking) can turn a full DB-level page into fewer, or
+    // zero, visible rows while `hasMore`/`nextCursor` still describe the
+    // unfiltered page underneath. Returning that directly breaks the
+    // frontend: an empty first page renders the terminal empty state and
+    // hides Prev/Next, permanently hiding a later, actually-visible row
+    // (review finding).
+    it('the first DB page is entirely dropped rows: transparently fetches the next page and returns its visible row', async () => {
+      mockListAllConversationsPaginated
+        .mockResolvedValueOnce({
+          conversations: [PAGE_ROW],
+          pagination: { hasMore: true, nextCursor: 'cursor-1', limit: 20 },
+        })
+        .mockResolvedValueOnce({
+          conversations: [{ ...GLOBAL_ROW, conversationId: 'conv-global-2' }],
+          pagination: { hasMore: false, nextCursor: null, limit: 20 },
+        });
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: false }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-1'));
+      const body = await response.json();
+
+      expect(mockListAllConversationsPaginated).toHaveBeenCalledTimes(2);
+      expect(mockListAllConversationsPaginated).toHaveBeenNthCalledWith(
+        2,
+        { ownerId: 'user-1', driveId: 'drive-1' },
+        { limit: 20, cursor: 'cursor-1' },
+      );
+      expect(body.conversations).toEqual([{ ...GLOBAL_ROW, conversationId: 'conv-global-2' }]);
+      expect(body.pagination).toEqual({ hasMore: false, nextCursor: null, limit: 20 });
+    });
+
+    it('an unbroken run of dropped rows stops at the internal fetch cap and still returns a real, continuable answer', async () => {
+      for (let i = 1; i <= 5; i++) {
+        mockListAllConversationsPaginated.mockResolvedValueOnce({
+          conversations: [PAGE_ROW],
+          pagination: { hasMore: true, nextCursor: `cursor-${i}`, limit: 20 },
+        });
+      }
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: false }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-1'));
+      const body = await response.json();
+
+      // Capped, not unbounded: exactly 5 internal fetches, not one per
+      // remaining page of a user's entire (hypothetically huge) history.
+      expect(mockListAllConversationsPaginated).toHaveBeenCalledTimes(5);
+      expect(body.conversations).toEqual([]);
+      // hasMore stays true and nextCursor carries the last cursor actually
+      // reached — the caller can page again rather than being told (falsely)
+      // that history has ended.
+      expect(body.pagination).toEqual({ hasMore: true, nextCursor: 'cursor-5', limit: 20 });
     });
   });
 });

--- a/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/__tests__/route.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockAuthenticateRequest,
+  mockAuditRequest,
+  mockListAllConversationsPaginated,
+  mockGetBatchPagePermissions,
+} = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockAuditRequest: vi.fn(),
+  mockListAllConversationsPaginated: vi.fn(),
+  mockGetBatchPagePermissions: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => result != null && typeof result === 'object' && 'error' in result,
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
+}));
+vi.mock('@/lib/agent-sessions/agent-sessions-conversations-runtime', () => ({
+  listAllConversationsPaginated: (...args: unknown[]) => mockListAllConversationsPaginated(...args),
+}));
+
+import { GET } from '../route';
+
+const AUTH_ADMIN = { userId: 'user-1', role: 'admin' };
+const AUTH_NON_ADMIN = { userId: 'user-2', role: 'user' };
+
+const GLOBAL_ROW = {
+  conversationId: 'conv-global',
+  title: 'Global chat',
+  type: 'global',
+  agentPageId: null,
+  pageTitle: null,
+  lastMessageAt: '2026-07-28T00:00:00.000Z',
+  createdAt: '2026-07-27T00:00:00.000Z',
+  sessionId: null,
+  sessionName: null,
+  sessionEndedAt: null,
+  driveId: null,
+};
+
+const PAGE_ROW = {
+  conversationId: 'conv-page',
+  title: null,
+  type: 'page',
+  agentPageId: 'agent-1',
+  pageTitle: 'My Agent',
+  lastMessageAt: '2026-07-28T00:00:00.000Z',
+  createdAt: '2026-07-27T00:00:00.000Z',
+  sessionId: null,
+  sessionName: null,
+  sessionEndedAt: null,
+  driveId: 'drive-1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH_ADMIN);
+  mockListAllConversationsPaginated.mockResolvedValue({
+    conversations: [GLOBAL_ROW],
+    pagination: { hasMore: false, nextCursor: null, limit: 20 },
+  });
+});
+
+describe('GET /api/agent-sessions/conversations', () => {
+  it('given an admin with no filter, lists their conversations', async () => {
+    const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      conversations: [GLOBAL_ROW],
+      pagination: { hasMore: false, nextCursor: null, limit: 20 },
+    });
+    expect(mockListAllConversationsPaginated).toHaveBeenCalledWith(
+      { ownerId: 'user-1', driveId: undefined },
+      { limit: 20, cursor: undefined },
+    );
+    // No page rows in this page of results — the batch permission check
+    // never runs (nothing to mask).
+    expect(mockGetBatchPagePermissions).not.toHaveBeenCalled();
+  });
+
+  it('given ?driveId=, narrows the listing filter', async () => {
+    await GET(new Request('http://localhost/api/agent-sessions/conversations?driveId=drive-1'));
+    expect(mockListAllConversationsPaginated).toHaveBeenCalledWith(
+      { ownerId: 'user-1', driveId: 'drive-1' },
+      { limit: 20, cursor: undefined },
+    );
+  });
+
+  it('given ?limit=&cursor=, passes them through bounded', async () => {
+    await GET(new Request('http://localhost/api/agent-sessions/conversations?limit=5&cursor=conv-9'));
+    expect(mockListAllConversationsPaginated).toHaveBeenCalledWith(
+      { ownerId: 'user-1', driveId: undefined },
+      { limit: 5, cursor: 'conv-9' },
+    );
+  });
+
+  it('given a non-admin, 403s without enumerating anything, and audits the denial', async () => {
+    mockAuthenticateRequest.mockResolvedValue(AUTH_NON_ADMIN);
+    const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+    expect(response.status).toBe(403);
+    expect(mockListAllConversationsPaginated).not.toHaveBeenCalled();
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'authz.access.denied' }),
+    );
+  });
+
+  describe('page-derived metadata masking (app-admin status does not imply current page access)', () => {
+    beforeEach(() => {
+      mockListAllConversationsPaginated.mockResolvedValue({
+        conversations: [PAGE_ROW, GLOBAL_ROW],
+        pagination: { hasMore: false, nextCursor: null, limit: 20 },
+      });
+    });
+
+    it('keeps pageTitle/driveId when the requester can still view the page', async () => {
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: true }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+      const body = await response.json();
+
+      expect(mockGetBatchPagePermissions).toHaveBeenCalledWith('user-1', ['agent-1']);
+      expect(body.conversations).toEqual([PAGE_ROW, GLOBAL_ROW]);
+    });
+
+    it('masks pageTitle/driveId — but keeps the conversation row — when the requester can no longer view the page', async () => {
+      // The requester authored this conversation while a member of the page's
+      // drive, then lost that membership. App-admin status alone must not
+      // stand in for a page-level view check (review finding).
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: false }]]));
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+      const body = await response.json();
+
+      expect(body.conversations).toEqual([
+        { ...PAGE_ROW, pageTitle: null, driveId: null },
+        GLOBAL_ROW,
+      ]);
+    });
+
+    it('masks when the permission map has no entry at all for the page (fails closed)', async () => {
+      mockGetBatchPagePermissions.mockResolvedValue(new Map());
+
+      const response = await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+      const body = await response.json();
+
+      expect(body.conversations[0]).toEqual({ ...PAGE_ROW, pageTitle: null, driveId: null });
+    });
+
+    it('batch-checks once for every distinct agentPageId, never per-row (no N+1)', async () => {
+      mockListAllConversationsPaginated.mockResolvedValue({
+        conversations: [PAGE_ROW, { ...PAGE_ROW, conversationId: 'conv-page-2' }],
+        pagination: { hasMore: false, nextCursor: null, limit: 20 },
+      });
+      mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: true }]]));
+
+      await GET(new Request('http://localhost/api/agent-sessions/conversations'));
+
+      expect(mockGetBatchPagePermissions).toHaveBeenCalledTimes(1);
+      expect(mockGetBatchPagePermissions).toHaveBeenCalledWith('user-1', ['agent-1']);
+    });
+  });
+});

--- a/apps/web/src/app/api/agent-sessions/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET ?driveId=<id> | (none = every drive) & limit & cursor & direction
+ *   → { conversations: PastConversationRow[], pagination: { hasMore, nextCursor, prevCursor, limit } }
+ *
+ * The Agents surface's default middle-panel view: every conversation the
+ * requester owns — session-bound or not, page-agent or global-assistant —
+ * newest first, cursor-paginated (see `agent-sessions-conversations-runtime.ts`
+ * for why: agent_sessions rows are never deleted, so history is unbounded).
+ *
+ * Same admin gate as `/api/agent-sessions` (GET) — this is the same
+ * admin-only-plus-CODE_EXECUTION surface, just listing conversations instead
+ * of sessions.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import { listAllConversationsPaginated } from '@/lib/agent-sessions/agent-sessions-conversations-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const driveId = url.searchParams.get('driveId');
+
+  if (auth.role !== 'admin') {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      userId: auth.userId,
+      resourceType: driveId ? 'drive' : 'agent_sessions',
+      resourceId: driveId ?? undefined,
+      details: { reason: 'app_admin_required', method: 'GET', route: 'agent-sessions/conversations' },
+      riskScore: 0.5,
+    });
+    return NextResponse.json({ error: 'Agent sessions require administrator privileges' }, { status: 403 });
+  }
+
+  const limit = parseBoundedIntParam(url.searchParams.get('limit'), {
+    defaultValue: 20,
+    min: 1,
+    max: 100,
+  });
+  const cursor = url.searchParams.get('cursor') || undefined;
+  const directionParam = url.searchParams.get('direction');
+  const direction = directionParam === 'after' ? 'after' : 'before';
+
+  try {
+    const result = await listAllConversationsPaginated(
+      { ownerId: auth.userId, driveId: driveId && driveId.length > 0 ? driveId : undefined },
+      { limit, cursor, direction },
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    loggers.api.error(
+      'Past conversations list failed',
+      error instanceof Error ? error : undefined,
+      { driveId },
+    );
+    return NextResponse.json({ error: 'Failed to list conversations' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/agent-sessions/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/route.ts
@@ -20,6 +20,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
+import { resolveDriveMembership } from '@pagespace/lib/services/agent-sessions/agent-session-tenant';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import {
   listAllConversationsPaginated,
@@ -48,21 +49,61 @@ const MAX_INTERNAL_FETCHES = 5;
 function maskOrDrop(
   row: PastConversationRow,
   canViewPage: (agentPageId: string) => boolean,
+  canAccessSessionDrive: (driveId: string) => boolean,
   scopedDriveId: string | undefined,
 ): PastConversationRow[] {
-  if (row.type !== 'page' || row.agentPageId === null || canViewPage(row.agentPageId)) return [row];
-  // Drive-scoped requests must DROP the row entirely, not just mask its
-  // fields: the drive filter itself runs against the page's CURRENT
-  // `driveId` before any permission check, so a masked-but-present row in
-  // a `?driveId=X` result already confirms "this inaccessible page
-  // currently belongs to drive X" — an oracle a caller could probe across
-  // candidate drive ids (review finding). Un-scoped (global) requests
-  // don't have this problem — presence there isn't tied to any specific
-  // drive being asked about — so masking (keep the row, as the
-  // requester's own history, but hide the page-derived fields) is still
-  // correct there, matching the `storage/info/route.ts` pattern.
-  if (scopedDriveId) return [];
-  return [{ ...row, pageTitle: null, driveId: null }];
+  if (row.type === 'page' && row.agentPageId !== null && !canViewPage(row.agentPageId)) {
+    // Drive-scoped requests must DROP the row entirely, not just mask its
+    // fields: the drive filter itself runs against the page's CURRENT
+    // `driveId` before any permission check, so a masked-but-present row in
+    // a `?driveId=X` result already confirms "this inaccessible page
+    // currently belongs to drive X" — an oracle a caller could probe across
+    // candidate drive ids (review finding). Un-scoped (global) requests
+    // don't have this problem — presence there isn't tied to any specific
+    // drive being asked about — so masking (keep the row, as the
+    // requester's own history, but hide the page-derived fields) is still
+    // correct there, matching the `storage/info/route.ts` pattern.
+    if (scopedDriveId) return [];
+    return [{ ...row, pageTitle: null, driveId: null }];
+  }
+
+  // A `type: 'global'` conversation can be bound to a DRIVE-SCOPED agent
+  // session — any accepted drive member may create their own global
+  // conversation inside another member's session (`decideAgentSessionAccess`
+  // grants access by drive membership, not session ownership), so
+  // `conversations.userId` and the joined `agent_sessions.ownerId` can
+  // legitimately differ. Conversation OWNERSHIP never lapses, but the
+  // requester's membership in that session's drive can — the identical
+  // "authored it once, current access unproven" gap already fixed above for
+  // pages, with the identical oracle risk: a drive-scoped `?driveId=X`
+  // request that still returns this row already confirms "this session
+  // currently belongs to drive X". Caught proactively (not yet a reviewer
+  // finding) by re-applying the exact fix this PR already established for
+  // pages, to the one other row shape with the same shared-resource shape.
+  if (row.type === 'global' && row.sessionId !== null && row.driveId !== null && !canAccessSessionDrive(row.driveId)) {
+    if (scopedDriveId) return [];
+    // Masking (not dropping) is safe unscoped: the global-assistant message
+    // GET gates purely on `conversations.userId` — never session or drive
+    // membership (`/api/ai/global/[id]/messages` route) — so the
+    // conversation's own content stays fully readable. Nulling the
+    // session-derived fields just stops it from presenting as session-bound;
+    // `resolveNavigationTarget` then falls through to the ordinary
+    // `case 'global'` branch on its own, no extra signal needed.
+    return [{ ...row, sessionId: null, driveId: null, sessionName: null, sessionEndedAt: null }];
+  }
+
+  return [row];
+}
+
+async function getBatchDriveMembership(userId: string, driveIds: string[]): Promise<Map<string, boolean>> {
+  const distinct = Array.from(new Set(driveIds));
+  const entries = await Promise.all(
+    distinct.map(async (driveId): Promise<[string, boolean]> => [
+      driveId,
+      (await resolveDriveMembership({ userId, driveId })) !== 'none',
+    ]),
+  );
+  return new Map(entries);
 }
 
 async function fetchVisiblePage(
@@ -91,8 +132,14 @@ async function fetchVisiblePage(
     const pagePermissions = pageIds.length > 0 ? await getBatchPagePermissions(ownerId, pageIds) : null;
     const canViewPage = (agentPageId: string) => pagePermissions?.get(agentPageId)?.canView ?? false;
 
+    const sessionDriveIds = result.conversations
+      .filter((c) => c.type === 'global' && c.sessionId !== null && c.driveId !== null)
+      .map((c) => c.driveId as string);
+    const driveMembership = sessionDriveIds.length > 0 ? await getBatchDriveMembership(ownerId, sessionDriveIds) : null;
+    const canAccessSessionDrive = (driveId: string) => driveMembership?.get(driveId) ?? false;
+
     for (const row of result.conversations) {
-      visible.push(...maskOrDrop(row, canViewPage, scopedDriveId));
+      visible.push(...maskOrDrop(row, canViewPage, canAccessSessionDrive, scopedDriveId));
     }
   }
 

--- a/apps/web/src/app/api/agent-sessions/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/route.ts
@@ -1,11 +1,14 @@
 /**
- * GET ?driveId=<id> | (none = every drive) & limit & cursor & direction
- *   → { conversations: PastConversationRow[], pagination: { hasMore, nextCursor, prevCursor, limit } }
+ * GET ?driveId=<id> | (none = every drive) & limit & cursor
+ *   → { conversations: PastConversationRow[], pagination: { hasMore, nextCursor, limit } }
  *
  * The Agents surface's default middle-panel view: every conversation the
  * requester owns — session-bound or not, page-agent or global-assistant —
  * newest first, cursor-paginated (see `agent-sessions-conversations-runtime.ts`
  * for why: agent_sessions rows are never deleted, so history is unbounded).
+ * `cursor` always means "older than this" — the only direction the surface's
+ * Prev/Next actually needs (Prev replays an already-fetched, SWR-cached page
+ * rather than asking the server to go forward).
  *
  * Same admin gate as `/api/agent-sessions` (GET) — this is the same
  * admin-only-plus-CODE_EXECUTION surface, just listing conversations instead
@@ -16,6 +19,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { listAllConversationsPaginated } from '@/lib/agent-sessions/agent-sessions-conversations-runtime';
 
@@ -46,15 +50,38 @@ export async function GET(request: Request) {
     max: 100,
   });
   const cursor = url.searchParams.get('cursor') || undefined;
-  const directionParam = url.searchParams.get('direction');
-  const direction = directionParam === 'after' ? 'after' : 'before';
 
   try {
     const result = await listAllConversationsPaginated(
       { ownerId: auth.userId, driveId: driveId && driveId.length > 0 ? driveId : undefined },
-      { limit, cursor, direction },
+      { limit, cursor },
     );
-    return NextResponse.json(result);
+
+    // App-admin status alone does not prove the requester can still see a
+    // page's CURRENT title/drive — they may have authored this conversation
+    // back when they were a member of that page's drive, and lost that
+    // membership since (review finding: the join surfaced the page's live
+    // metadata keyed only on conversation ownership). Batch-check once, then
+    // MASK the two page-derived fields rather than dropping the row — the
+    // conversation itself is still the requester's own history, exactly the
+    // `pagePermissions`/`canShowPage` pattern `storage/info/route.ts` already
+    // uses for the same class of leak.
+    const pageIds = Array.from(
+      new Set(
+        result.conversations
+          .filter((c) => c.type === 'page')
+          .map((c) => c.agentPageId)
+          .filter((id): id is string => id !== null),
+      ),
+    );
+    const pagePermissions = pageIds.length > 0 ? await getBatchPagePermissions(auth.userId, pageIds) : null;
+    const conversations = result.conversations.map((c) => {
+      if (c.type !== 'page' || c.agentPageId === null) return c;
+      const canView = pagePermissions?.get(c.agentPageId)?.canView ?? false;
+      return canView ? c : { ...c, pageTitle: null, driveId: null };
+    });
+
+    return NextResponse.json({ ...result, conversations });
   } catch (error) {
     loggers.api.error(
       'Past conversations list failed',

--- a/apps/web/src/app/api/agent-sessions/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/route.ts
@@ -51,9 +51,11 @@ export async function GET(request: Request) {
   });
   const cursor = url.searchParams.get('cursor') || undefined;
 
+  const scopedDriveId = driveId && driveId.length > 0 ? driveId : undefined;
+
   try {
     const result = await listAllConversationsPaginated(
-      { ownerId: auth.userId, driveId: driveId && driveId.length > 0 ? driveId : undefined },
+      { ownerId: auth.userId, driveId: scopedDriveId },
       { limit, cursor },
     );
 
@@ -61,11 +63,7 @@ export async function GET(request: Request) {
     // page's CURRENT title/drive — they may have authored this conversation
     // back when they were a member of that page's drive, and lost that
     // membership since (review finding: the join surfaced the page's live
-    // metadata keyed only on conversation ownership). Batch-check once, then
-    // MASK the two page-derived fields rather than dropping the row — the
-    // conversation itself is still the requester's own history, exactly the
-    // `pagePermissions`/`canShowPage` pattern `storage/info/route.ts` already
-    // uses for the same class of leak.
+    // metadata keyed only on conversation ownership). Batch-check once.
     const pageIds = Array.from(
       new Set(
         result.conversations
@@ -75,10 +73,22 @@ export async function GET(request: Request) {
       ),
     );
     const pagePermissions = pageIds.length > 0 ? await getBatchPagePermissions(auth.userId, pageIds) : null;
-    const conversations = result.conversations.map((c) => {
-      if (c.type !== 'page' || c.agentPageId === null) return c;
-      const canView = pagePermissions?.get(c.agentPageId)?.canView ?? false;
-      return canView ? c : { ...c, pageTitle: null, driveId: null };
+    const canViewPage = (agentPageId: string) => pagePermissions?.get(agentPageId)?.canView ?? false;
+
+    const conversations = result.conversations.flatMap((c) => {
+      if (c.type !== 'page' || c.agentPageId === null || canViewPage(c.agentPageId)) return [c];
+      // Drive-scoped requests must DROP the row entirely, not just mask its
+      // fields: the drive filter itself runs against the page's CURRENT
+      // `driveId` before any permission check, so a masked-but-present row in
+      // a `?driveId=X` result already confirms "this inaccessible page
+      // currently belongs to drive X" — an oracle a caller could probe across
+      // candidate drive ids (review finding). Un-scoped (global) requests
+      // don't have this problem — presence there isn't tied to any specific
+      // drive being asked about — so masking (keep the row, as the
+      // requester's own history, but hide the page-derived fields) is still
+      // correct there, matching the `storage/info/route.ts` pattern.
+      if (scopedDriveId) return [];
+      return [{ ...c, pageTitle: null, driveId: null }];
     });
 
     return NextResponse.json({ ...result, conversations });

--- a/apps/web/src/app/api/agent-sessions/conversations/route.ts
+++ b/apps/web/src/app/api/agent-sessions/conversations/route.ts
@@ -21,9 +21,98 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
-import { listAllConversationsPaginated } from '@/lib/agent-sessions/agent-sessions-conversations-runtime';
+import {
+  listAllConversationsPaginated,
+  encodeCursor,
+  type PastConversationRow,
+} from '@/lib/agent-sessions/agent-sessions-conversations-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+/**
+ * Drive-scoped requests DROP inaccessible page rows entirely (see the
+ * flatMap below) rather than masking them — so a single DB-level page of
+ * `limit` rows can filter down to fewer, or even zero, visible rows while
+ * `hasMore`/`nextCursor` still describe the unfiltered DB page. Returning
+ * that directly breaks the frontend: an empty `conversations` array on the
+ * first page renders the terminal "no history" empty state and hides
+ * Prev/Next entirely, permanently hiding any later, actually-visible row
+ * (review finding). Keep fetching subsequent DB pages — filtering each the
+ * same way — until either `limit` visible rows have been collected or the
+ * underlying data is exhausted. Bounded by `MAX_INTERNAL_FETCHES` so a
+ * pathological history (long unbroken run of now-inaccessible pages) can't
+ * turn one request into an unbounded scan.
+ */
+const MAX_INTERNAL_FETCHES = 5;
+
+function maskOrDrop(
+  row: PastConversationRow,
+  canViewPage: (agentPageId: string) => boolean,
+  scopedDriveId: string | undefined,
+): PastConversationRow[] {
+  if (row.type !== 'page' || row.agentPageId === null || canViewPage(row.agentPageId)) return [row];
+  // Drive-scoped requests must DROP the row entirely, not just mask its
+  // fields: the drive filter itself runs against the page's CURRENT
+  // `driveId` before any permission check, so a masked-but-present row in
+  // a `?driveId=X` result already confirms "this inaccessible page
+  // currently belongs to drive X" — an oracle a caller could probe across
+  // candidate drive ids (review finding). Un-scoped (global) requests
+  // don't have this problem — presence there isn't tied to any specific
+  // drive being asked about — so masking (keep the row, as the
+  // requester's own history, but hide the page-derived fields) is still
+  // correct there, matching the `storage/info/route.ts` pattern.
+  if (scopedDriveId) return [];
+  return [{ ...row, pageTitle: null, driveId: null }];
+}
+
+async function fetchVisiblePage(
+  ownerId: string,
+  scopedDriveId: string | undefined,
+  limit: number,
+  initialCursor: string | undefined,
+): Promise<{ conversations: PastConversationRow[]; hasMore: boolean; nextCursor: string | null }> {
+  const visible: PastConversationRow[] = [];
+  let cursor = initialCursor;
+  let hasMore = true;
+
+  for (let i = 0; i < MAX_INTERNAL_FETCHES && visible.length < limit && hasMore; i++) {
+    const result = await listAllConversationsPaginated({ ownerId, driveId: scopedDriveId }, { limit, cursor });
+    hasMore = result.pagination.hasMore;
+    cursor = result.pagination.nextCursor ?? undefined;
+
+    const pageIds = Array.from(
+      new Set(
+        result.conversations
+          .filter((c) => c.type === 'page')
+          .map((c) => c.agentPageId)
+          .filter((id): id is string => id !== null),
+      ),
+    );
+    const pagePermissions = pageIds.length > 0 ? await getBatchPagePermissions(ownerId, pageIds) : null;
+    const canViewPage = (agentPageId: string) => pagePermissions?.get(agentPageId)?.canView ?? false;
+
+    for (const row of result.conversations) {
+      visible.push(...maskOrDrop(row, canViewPage, scopedDriveId));
+    }
+  }
+
+  const page = visible.slice(0, limit);
+  const truncated = visible.length > limit;
+  const lastRow = truncated ? page[page.length - 1] : null;
+
+  return {
+    conversations: page,
+    hasMore: truncated || hasMore,
+    // A row we truncated off ourselves is a real, already-fetched row — its
+    // own cursor is exactly as valid a boundary as one the DB query would
+    // have produced, so the next request resumes from it correctly (any
+    // rows dropped alongside it get re-fetched-and-refiltered next call,
+    // harmlessly). Otherwise carry forward wherever the internal loop
+    // itself left off (still `hasMore` but hit the fetch cap, or genuinely
+    // out of data).
+    nextCursor: lastRow ? encodeCursor(lastRow.lastMessageAt ?? lastRow.createdAt, lastRow.conversationId) : (hasMore ? cursor ?? null : null),
+  };
+}
 
 export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
@@ -54,44 +143,20 @@ export async function GET(request: Request) {
   const scopedDriveId = driveId && driveId.length > 0 ? driveId : undefined;
 
   try {
-    const result = await listAllConversationsPaginated(
-      { ownerId: auth.userId, driveId: scopedDriveId },
-      { limit, cursor },
-    );
-
     // App-admin status alone does not prove the requester can still see a
     // page's CURRENT title/drive — they may have authored this conversation
     // back when they were a member of that page's drive, and lost that
     // membership since (review finding: the join surfaced the page's live
-    // metadata keyed only on conversation ownership). Batch-check once.
-    const pageIds = Array.from(
-      new Set(
-        result.conversations
-          .filter((c) => c.type === 'page')
-          .map((c) => c.agentPageId)
-          .filter((id): id is string => id !== null),
-      ),
+    // metadata keyed only on conversation ownership). Batch-checked inside
+    // `fetchVisiblePage`, once per internal DB fetch.
+    const { conversations, hasMore, nextCursor } = await fetchVisiblePage(
+      auth.userId,
+      scopedDriveId,
+      limit,
+      cursor,
     );
-    const pagePermissions = pageIds.length > 0 ? await getBatchPagePermissions(auth.userId, pageIds) : null;
-    const canViewPage = (agentPageId: string) => pagePermissions?.get(agentPageId)?.canView ?? false;
 
-    const conversations = result.conversations.flatMap((c) => {
-      if (c.type !== 'page' || c.agentPageId === null || canViewPage(c.agentPageId)) return [c];
-      // Drive-scoped requests must DROP the row entirely, not just mask its
-      // fields: the drive filter itself runs against the page's CURRENT
-      // `driveId` before any permission check, so a masked-but-present row in
-      // a `?driveId=X` result already confirms "this inaccessible page
-      // currently belongs to drive X" — an oracle a caller could probe across
-      // candidate drive ids (review finding). Un-scoped (global) requests
-      // don't have this problem — presence there isn't tied to any specific
-      // drive being asked about — so masking (keep the row, as the
-      // requester's own history, but hide the page-derived fields) is still
-      // correct there, matching the `storage/info/route.ts` pattern.
-      if (scopedDriveId) return [];
-      return [{ ...c, pageTitle: null, driveId: null }];
-    });
-
-    return NextResponse.json({ ...result, conversations });
+    return NextResponse.json({ conversations, pagination: { hasMore, nextCursor, limit } });
   } catch (error) {
     loggers.api.error(
       'Past conversations list failed',

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -27,6 +27,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import {
   AlertCircle,
   ExternalLink,
@@ -78,6 +79,15 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // (drive membership + code-execution) on every spawn.
   const canUseSessions = user?.role === 'admin';
 
+  // A deep link from the Agents surface's past-conversations list
+  // (`?conversationId=&sessionId=`) — one-time intent, not durable state like
+  // the Agents surface's own `?session=`/`?c=`/`?agent=`, so it's captured
+  // once at mount and never re-read afterward (a later History-tab pick or
+  // "new conversation" is not fighting a stale URL param).
+  const searchParams = useSearchParams();
+  const initialConversationIdRef = useRef(searchParams.get('conversationId') ?? undefined);
+  const initialSessionIdRef = useRef(searchParams.get('sessionId'));
+
   const { resolved: initialResolved } = useResolvedConversation(page.id, {
     driveId: page.driveId,
     canUseSessions,
@@ -85,6 +95,8 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
     // before the role loads — resolving then would mint the agent's first
     // conversation as permanently session-less. Wait it out.
     authLoading,
+    initialConversationId: initialConversationIdRef.current,
+    initialSessionId: initialSessionIdRef.current,
   });
   const [override, setOverride] = useState<ResolvedConversation | null>(null);
   // The conversation on screen: the user's own switching (history select, new,

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -89,6 +89,25 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   const initialConversationIdRef = useRef(searchParams.get('conversationId') ?? undefined);
   const initialSessionIdRef = useRef(searchParams.get('sessionId'));
 
+  // Consume-once, for real: strip the params from the URL immediately after
+  // capturing them. Left in place, a refresh after the user later switches
+  // to a DIFFERENT conversation (History tab, "new") would remount this
+  // component, re-read the same stale `conversationId` from the URL, and
+  // silently reopen the original deep-linked thread instead of respecting
+  // where the user actually navigated to (review finding — this was
+  // previously dismissed as "cosmetic", but it's a real functional bug on
+  // refresh, not just an untidy address bar).
+  useEffect(() => {
+    if (initialConversationIdRef.current === undefined) return;
+    const url = new URL(window.location.href);
+    url.searchParams.delete('conversationId');
+    url.searchParams.delete('sessionId');
+    window.history.replaceState({}, '', url.toString());
+    // Deliberately empty deps: this runs once, immediately after the refs
+    // above captured their values on this same mount — never re-runs for
+    // this component instance.
+  }, []);
+
   const { resolved: initialResolved } = useResolvedConversation(page.id, {
     driveId: page.driveId,
     canUseSessions,

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -158,8 +158,15 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
 
   const conversations = data?.conversations ?? [];
 
-  // True zero-history: keep the original blank-slate copy rather than an empty list shell.
-  if (conversations.length === 0 && pageIndex === 0 && !error) {
+  // True zero-history: keep the original blank-slate copy rather than an
+  // empty list shell. Requires `!hasMore` too — the backend drops
+  // now-inaccessible page rows from a drive-scoped listing, so a single
+  // response CAN come back empty while more (visible) history still exists
+  // a page or two further back; treating that as terminal would strand the
+  // user with no way to reach it (review finding). `hasMore` defaults true
+  // while `data` is still undefined, so this can't fire ahead of a real
+  // answer from the server.
+  if (conversations.length === 0 && pageIndex === 0 && !error && !(data?.pagination.hasMore ?? true)) {
     return (
       <EmptyState
         title="Select a session"

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -32,7 +32,7 @@ interface ConversationRowDTO {
 
 interface ConversationsResponse {
   conversations: ConversationRowDTO[];
-  pagination: { hasMore: boolean; nextCursor: string | null; prevCursor: string | null; limit: number };
+  pagination: { hasMore: boolean; nextCursor: string | null; limit: number };
 }
 
 async function conversationsFetcher(url: string): Promise<ConversationsResponse> {

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { formatDistanceToNow } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { toast } from 'sonner';
 import useSWR from 'swr';
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -53,6 +54,7 @@ function rowLabel(row: ConversationRowDTO): string {
   if (row.title) return row.title;
   if (row.type === 'page') return row.pageTitle ?? 'Untitled conversation';
   if (row.type === 'global') return 'Global assistant chat';
+  if (row.type === 'client') return 'API conversation';
   return 'Untitled conversation';
 }
 
@@ -64,6 +66,8 @@ function rowSubtitle(row: ConversationRowDTO, showDrive: boolean, driveName: str
     parts.push(row.pageTitle);
   } else if (row.type === 'global') {
     parts.push('Global assistant');
+  } else if (row.type === 'client') {
+    parts.push('Created via API');
   }
   if (showDrive && driveName) parts.push(driveName);
   return parts.join(' · ');
@@ -116,9 +120,6 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
           }`,
         );
         return;
-      case 'drive':
-        router.push(`/dashboard/${target.driveId}`);
-        return;
       case 'global':
         void loadConversation(target.conversationId);
         router.push(
@@ -126,6 +127,9 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
             ? `/dashboard/${target.driveId}?c=${encodeURIComponent(target.conversationId)}`
             : `/dashboard?c=${encodeURIComponent(target.conversationId)}`,
         );
+        return;
+      case 'unavailable':
+        toast.info("This conversation can't be opened here yet.");
         return;
     }
   };

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { formatDistanceToNow } from 'date-fns';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import useSWR from 'swr';
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
+import { useGlobalChatConversation } from '@/contexts/GlobalChatContext';
+import { useDriveStore } from '@/hooks/useDrive';
+import { cn } from '@/lib/utils';
+import EmptyState from './EmptyState';
+import { resolveNavigationTarget, type ConversationKind } from './resolveNavigationTarget';
+
+const PAGE_SIZE = 20;
+
+interface ConversationRowDTO {
+  conversationId: string;
+  title: string | null;
+  type: ConversationKind;
+  agentPageId: string | null;
+  pageTitle: string | null;
+  lastMessageAt: string | null;
+  createdAt: string;
+  sessionId: string | null;
+  sessionName: string | null;
+  sessionEndedAt: string | null;
+  driveId: string | null;
+}
+
+interface ConversationsResponse {
+  conversations: ConversationRowDTO[];
+  pagination: { hasMore: boolean; nextCursor: string | null; prevCursor: string | null; limit: number };
+}
+
+async function conversationsFetcher(url: string): Promise<ConversationsResponse> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to list conversations (${response.status})`);
+  return response.json();
+}
+
+function buildKey(driveId: string | undefined, cursor: string | null): string {
+  const params = new URLSearchParams();
+  if (driveId) params.set('driveId', driveId);
+  params.set('limit', String(PAGE_SIZE));
+  if (cursor) params.set('cursor', cursor);
+  return `/api/agent-sessions/conversations?${params.toString()}`;
+}
+
+function rowLabel(row: ConversationRowDTO): string {
+  if (row.title) return row.title;
+  if (row.type === 'page') return row.pageTitle ?? 'Untitled conversation';
+  if (row.type === 'global') return 'Global assistant chat';
+  return 'Untitled conversation';
+}
+
+function rowSubtitle(row: ConversationRowDTO, showDrive: boolean, driveName: string | undefined): string {
+  const parts: string[] = [];
+  if (row.sessionId) {
+    parts.push(row.sessionName ? row.sessionName : 'Session');
+  } else if (row.type === 'page' && row.pageTitle) {
+    parts.push(row.pageTitle);
+  } else if (row.type === 'global') {
+    parts.push('Global assistant');
+  }
+  if (showDrive && driveName) parts.push(driveName);
+  return parts.join(' · ');
+}
+
+/**
+ * Default middle-panel view for the Agents surface: every past conversation
+ * the requester owns, newest first, cursor-paginated. Each page is its own
+ * SWR key (`cursor` is part of the key) — already-visited pages replay from
+ * cache instead of refetching, and a new cursor's fetch can never race or
+ * clobber a different cursor's cached state.
+ */
+export default function AgentsPastConversationsList({ driveId }: { driveId?: string }) {
+  const router = useRouter();
+  const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
+  const { loadConversation } = useGlobalChatConversation();
+  const drives = useDriveStore((state) => state.drives);
+
+  const [cursorStack, setCursorStack] = useState<Array<string | null>>([null]);
+  const [pageIndex, setPageIndex] = useState(0);
+  const cursor = cursorStack[pageIndex];
+
+  const { data, error, isLoading } = useSWR<ConversationsResponse>(
+    buildKey(driveId, cursor),
+    conversationsFetcher,
+    { revalidateOnFocus: false },
+  );
+
+  const driveNameById = useMemo(() => new Map(drives.map((d) => [d.id, d.name])), [drives]);
+
+  const handleRowClick = (row: ConversationRowDTO) => {
+    const target = resolveNavigationTarget(row, driveId);
+    switch (target.kind) {
+      case 'pane':
+        selectConversation({ sessionId: target.sessionId, conversationId: target.conversationId, agentId: target.agentId });
+        return;
+      case 'page':
+        router.push(
+          `/dashboard/${target.driveId}/${target.pageId}?conversationId=${encodeURIComponent(target.conversationId)}${
+            target.sessionId ? `&sessionId=${encodeURIComponent(target.sessionId)}` : ''
+          }`,
+        );
+        return;
+      case 'drive':
+        router.push(`/dashboard/${target.driveId}`);
+        return;
+      case 'global':
+        void loadConversation(target.conversationId);
+        router.push(
+          target.driveId
+            ? `/dashboard/${target.driveId}?c=${encodeURIComponent(target.conversationId)}`
+            : `/dashboard?c=${encodeURIComponent(target.conversationId)}`,
+        );
+        return;
+    }
+  };
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
+        Loading past conversations…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        title="Couldn't load past conversations"
+        description="Something went wrong fetching your conversation history."
+      />
+    );
+  }
+
+  const conversations = data?.conversations ?? [];
+
+  // True zero-history: keep the original blank-slate copy rather than an empty list shell.
+  if (conversations.length === 0 && pageIndex === 0) {
+    return (
+      <EmptyState
+        title="Select a session"
+        description="Pick a session from the sidebar, or start a new one."
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex-1 overflow-y-auto divide-y divide-border">
+        {conversations.map((row) => (
+          <button
+            key={row.conversationId}
+            type="button"
+            onClick={() => handleRowClick(row)}
+            className="flex w-full flex-col items-start gap-0.5 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+          >
+            <div className="flex w-full items-center justify-between gap-2">
+              <span className="truncate text-sm font-medium">{rowLabel(row)}</span>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {formatDistanceToNow(new Date(row.lastMessageAt ?? row.createdAt), { addSuffix: true })}
+              </span>
+            </div>
+            <div className="flex w-full items-center gap-2 text-xs text-muted-foreground">
+              <span className="truncate">
+                {rowSubtitle(row, !driveId, row.driveId ? driveNameById.get(row.driveId) : undefined)}
+              </span>
+              {row.sessionEndedAt && (
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+                  Ended
+                </span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center justify-between border-t border-border px-4 py-2">
+        <button
+          type="button"
+          disabled={pageIndex === 0}
+          onClick={() => setPageIndex((i) => Math.max(0, i - 1))}
+          className={cn(
+            'flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:hover:text-muted-foreground',
+          )}
+        >
+          <ChevronLeft className="size-4" /> Prev
+        </button>
+        <button
+          type="button"
+          disabled={!data?.pagination.hasMore}
+          onClick={() => {
+            const nextCursor = data?.pagination.nextCursor;
+            if (!nextCursor) return;
+            setCursorStack((stack) => {
+              const next = stack.slice(0, pageIndex + 1);
+              next.push(nextCursor);
+              return next;
+            });
+            setPageIndex((i) => i + 1);
+          }}
+          className={cn(
+            'flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:hover:text-muted-foreground',
+          )}
+        >
+          Next <ChevronRight className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -89,7 +89,16 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
   const { data, error, isLoading } = useSWR<ConversationsResponse>(
     buildKey(driveId, cursor),
     conversationsFetcher,
-    { revalidateOnFocus: false },
+    {
+      revalidateOnFocus: false,
+      // A failed Next/Prev fetch must not strand the user on a dead-end
+      // error screen with no way back: keeping the last successful page's
+      // data visible means the list and Prev/Next stay usable (Prev — the
+      // one real escape hatch, since it replays an already-cached page)
+      // while an inline notice covers the failed request, instead of the
+      // whole view flipping to a full-screen error with no controls at all.
+      keepPreviousData: true,
+    },
   );
 
   const driveNameById = useMemo(() => new Map(drives.map((d) => [d.id, d.name])), [drives]);
@@ -129,7 +138,12 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
     );
   }
 
-  if (error) {
+  // A full-screen error only when there is truly nothing to show (the very
+  // first fetch failed). A failed Next/Prev fetch, with `keepPreviousData`,
+  // still has the last successful page in `data` — that's handled below by
+  // an inline notice instead, so Prev/Next stay usable rather than stranding
+  // the user on a dead end.
+  if (error && !data) {
     return (
       <EmptyState
         title="Couldn't load past conversations"
@@ -141,7 +155,7 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
   const conversations = data?.conversations ?? [];
 
   // True zero-history: keep the original blank-slate copy rather than an empty list shell.
-  if (conversations.length === 0 && pageIndex === 0) {
+  if (conversations.length === 0 && pageIndex === 0 && !error) {
     return (
       <EmptyState
         title="Select a session"
@@ -152,6 +166,11 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
+      {error && (
+        <div className="border-b border-border bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          {"Couldn't load this page — showing the last one loaded. Try Prev/Next again."}
+        </div>
+      )}
       <div className="flex-1 overflow-y-auto divide-y divide-border">
         {conversations.map((row) => (
           <button

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -90,7 +90,7 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
   const [pageIndex, setPageIndex] = useState(0);
   const cursor = cursorStack[pageIndex];
 
-  const { data, error, isLoading } = useSWR<ConversationsResponse>(
+  const { data, error, isLoading, isValidating } = useSWR<ConversationsResponse>(
     buildKey(driveId, cursor),
     conversationsFetcher,
     {
@@ -222,7 +222,12 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
         </button>
         <button
           type="button"
-          disabled={!data?.pagination.hasMore}
+          // `isValidating` also covers a fetch already in flight: without it,
+          // a fast double-click both reads the same (not-yet-updated)
+          // `data.pagination.nextCursor` before the first click's fetch
+          // resolves, pushing that identical cursor onto `cursorStack` twice
+          // and silently skipping a real page of history.
+          disabled={!data?.pagination.hasMore || isValidating}
           onClick={() => {
             const nextCursor = data?.pagination.nextCursor;
             if (!nextCursor) return;

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -165,7 +165,15 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
           description="This session's conversations are listed under it in the sidebar."
         />
       ) : (
-        <AgentsPastConversationsList driveId={driveId} />
+        // Keyed by drive: this surface's own `driveId` prop CAN change on an
+        // already-mounted instance (switching drives while staying on the
+        // agents tab re-renders with new `useParams()`, same as the
+        // `hydrateFromSearch({ driveId })` effect above already accounts
+        // for) — a bare prop change would leave the list's cursor/page state
+        // naming a position in the PREVIOUS drive's ordering. Remounting via
+        // `key` resets everything at once rather than chasing every piece of
+        // state that would otherwise need its own reset effect (review).
+        <AgentsPastConversationsList key={driveId ?? 'global'} driveId={driveId} />
       )}
     </div>
   );

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect } from 'react';
-import { Bot } from 'lucide-react';
 import useSWR from 'swr';
 
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
@@ -10,6 +9,8 @@ import { panesOf } from '@/stores/agent-workspace/pane-reducer';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useLatestRef } from '@/hooks/useLatestRef';
 import AgentPanes from './panes/AgentPanes';
+import EmptyState from './EmptyState';
+import AgentsPastConversationsList from './AgentsPastConversationsList';
 
 /**
  * The selected session's own record — the authority on ITS drive. The surface
@@ -160,23 +161,8 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
           description="This session's conversations are listed under it in the sidebar."
         />
       ) : (
-        <EmptyState
-          title="Select a session"
-          description="Pick a session from the sidebar, or start a new one."
-        />
+        <AgentsPastConversationsList driveId={driveId} />
       )}
-    </div>
-  );
-}
-
-function EmptyState({ title, description }: { title: string; description: string }) {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-      <Bot className="size-10 text-muted-foreground" aria-hidden="true" />
-      <div>
-        <h2 className="text-lg font-semibold">{title}</h2>
-        <p className="text-sm text-muted-foreground">{description}</p>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/components/agents/EmptyState.tsx
+++ b/apps/web/src/components/agents/EmptyState.tsx
@@ -1,0 +1,13 @@
+import { Bot } from 'lucide-react';
+
+export default function EmptyState({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <Bot className="size-10 text-muted-foreground" aria-hidden="true" />
+      <div>
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -722,29 +722,26 @@ describe('AgentPageView', () => {
         new URLSearchParams('conversationId=conv-deep-link&sessionId=ses-deep-link') as ReturnType<typeof useSearchParams>,
       );
       window.history.replaceState({}, '', '/dashboard/drive-1/page-1?conversationId=conv-deep-link&sessionId=ses-deep-link');
-      const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
 
       render(<AgentPageView page={pageFixture()} />);
 
-      expect(replaceStateSpy).toHaveBeenCalled();
-      // At least one replaceState call must have stripped both params — not
-      // necessarily the first call, if anything else in the render path also
-      // touches history.
-      const strippedBoth = replaceStateSpy.mock.calls.some(([, , newUrl]) => {
-        const params = new URL(newUrl as string, 'http://localhost').searchParams;
-        return !params.has('conversationId') && !params.has('sessionId');
-      });
-      expect(strippedBoth).toBe(true);
+      // Assert the user-visible CONTRACT (the final URL) rather than spying
+      // on replaceState call details — a call-history assertion would pass
+      // even if a LATER call re-added the params, and fail for an unrelated
+      // history write elsewhere in the render path (review finding).
+      const currentParams = new URL(window.location.href).searchParams;
+      expect(currentParams.has('conversationId')).toBe(false);
+      expect(currentParams.has('sessionId')).toBe(false);
     });
 
     it('does nothing when there was no deep-link conversationId to begin with', () => {
       vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as ReturnType<typeof useSearchParams>);
       window.history.replaceState({}, '', '/dashboard/drive-1/page-1');
-      const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
 
       render(<AgentPageView page={pageFixture()} />);
 
-      expect(replaceStateSpy).not.toHaveBeenCalled();
+      expect(window.location.pathname).toBe('/dashboard/drive-1/page-1');
+      expect(window.location.search).toBe('');
     });
   });
 });

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useSearchParams } from 'next/navigation';
 import type { TreePage } from '@/hooks/usePageTree';
 import type { ResolvedConversation } from '../useResolvedConversation';
 
@@ -707,6 +708,43 @@ describe('AgentPageView', () => {
       // The user's newer pick (conv-2) survives — not clobbered by conv-3,
       // the replacement for a conversation the user already moved on from.
       expect(screen.getByTestId('agent-panes')).toHaveTextContent('conv-2');
+    });
+  });
+
+  describe('the past-conversations deep link (?conversationId=&sessionId=) is consumed exactly once', () => {
+    // Left in the URL, a later refresh (after the user switches to a
+    // different conversation via the History tab) would remount this
+    // component, re-read the same stale params, and silently reopen the
+    // original deep-linked thread instead of wherever the user actually
+    // navigated to (review finding — a real bug on refresh, not cosmetic).
+    it('strips conversationId/sessionId from the URL right after capturing them', () => {
+      vi.mocked(useSearchParams).mockReturnValue(
+        new URLSearchParams('conversationId=conv-deep-link&sessionId=ses-deep-link') as ReturnType<typeof useSearchParams>,
+      );
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?conversationId=conv-deep-link&sessionId=ses-deep-link');
+      const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+      render(<AgentPageView page={pageFixture()} />);
+
+      expect(replaceStateSpy).toHaveBeenCalled();
+      // At least one replaceState call must have stripped both params — not
+      // necessarily the first call, if anything else in the render path also
+      // touches history.
+      const strippedBoth = replaceStateSpy.mock.calls.some(([, , newUrl]) => {
+        const params = new URL(newUrl as string, 'http://localhost').searchParams;
+        return !params.has('conversationId') && !params.has('sessionId');
+      });
+      expect(strippedBoth).toBe(true);
+    });
+
+    it('does nothing when there was no deep-link conversationId to begin with', () => {
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1');
+      const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+      render(<AgentPageView page={pageFixture()} />);
+
+      expect(replaceStateSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -80,6 +80,9 @@ vi.mock('@/contexts/GlobalChatContext', () => ({
   useGlobalChatConversation: () => ({ loadConversation: mockLoadConversation }),
 }));
 
+const mockToastInfo = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({ toast: { info: mockToastInfo, error: vi.fn() } }));
+
 import AgentsSurface from '../AgentsSurface';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
@@ -554,5 +557,43 @@ describe('past conversations (default view, replacing the old static prompt)', (
     act(() => prevButton.click());
     await waitFor(() => expect(screen.queryByText(/Couldn't load this page/)).toBeNull());
     expect(getByText('Page 1 chat')).toBeDefined();
+  });
+
+  it('clicking a client (API-managed) conversation shows a toast instead of navigating — no in-app surface can open it', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/api/agent-sessions/conversations')) {
+        return {
+          ok: true,
+          json: async () => ({
+            conversations: [
+              {
+                conversationId: 'conv-client-1',
+                title: 'My API thread',
+                type: 'client',
+                agentPageId: null,
+                pageTitle: null,
+                lastMessageAt: new Date().toISOString(),
+                createdAt: new Date().toISOString(),
+                sessionId: null,
+                sessionName: null,
+                sessionEndedAt: null,
+                driveId: 'drive-1',
+              },
+            ],
+            pagination: { hasMore: false, nextCursor: null, limit: 20 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ session: { driveId: null } }) };
+    });
+
+    render(<AgentsSurface driveId="drive-past-convos-client" />);
+
+    const label = await screen.findByText('My API thread');
+    act(() => label.closest('button')!.click());
+
+    expect(mockToastInfo).toHaveBeenCalledTimes(1);
+    expect(mockLoadConversation).not.toHaveBeenCalled();
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBeNull();
   });
 });

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -85,7 +85,7 @@ import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 
 /** Empty by default — the "no history yet" case is the common one across these tests; individual tests override with `mockFetchWithAuth.mockImplementation`. */
-const EMPTY_CONVERSATIONS = { conversations: [], pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 } };
+const EMPTY_CONVERSATIONS = { conversations: [], pagination: { hasMore: false, nextCursor: null, limit: 20 } };
 
 beforeEach(() => {
   // Two different endpoints share this mock — route by URL rather than one
@@ -397,7 +397,7 @@ describe('past conversations (default view, replacing the old static prompt)', (
                 driveId: null,
               },
             ],
-            pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 },
+            pagination: { hasMore: false, nextCursor: null, limit: 20 },
           }),
         };
       }
@@ -432,7 +432,7 @@ describe('past conversations (default view, replacing the old static prompt)', (
                 driveId: 'drive-1',
               },
             ],
-            pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 },
+            pagination: { hasMore: false, nextCursor: null, limit: 20 },
           }),
         };
       }

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -75,14 +75,30 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
 }));
 
+const mockLoadConversation = vi.hoisted(() => vi.fn());
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  useGlobalChatConversation: () => ({ loadConversation: mockLoadConversation }),
+}));
+
 import AgentsSurface from '../AgentsSurface';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 
+/** Empty by default — the "no history yet" case is the common one across these tests; individual tests override with `mockFetchWithAuth.mockImplementation`. */
+const EMPTY_CONVERSATIONS = { conversations: [], pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 } };
+
 beforeEach(() => {
-  // A selected session exists by default — the tests that care about a GONE
-  // session (finding 6's GC) set their own `{ session: null }` response.
-  mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ session: { driveId: null } }) });
+  // Two different endpoints share this mock — route by URL rather than one
+  // blanket response, since a session-fetch shape and a conversations-list
+  // shape are never interchangeable.
+  mockFetchWithAuth.mockImplementation(async (url: string) => {
+    if (url.includes('/api/agent-sessions/conversations')) {
+      return { ok: true, json: async () => EMPTY_CONVERSATIONS };
+    }
+    // A selected session exists by default — the tests that care about a GONE
+    // session (finding 6's GC) set their own `{ session: null }` response.
+    return { ok: true, json: async () => ({ session: { driveId: null } }) };
+  });
   window.history.replaceState({}, '', '/dashboard/agents');
   useAgentSurfaceStore.setState({
     driveId: null,
@@ -328,5 +344,82 @@ describe('onConversationClosed — following the grid\'s own close/rebind', () =
     // overwrite the user's newer pick with the stale rebind target.
     expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-switched');
     expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-switched');
+  });
+});
+
+describe('past conversations (default view, replacing the old static prompt)', () => {
+  it('renders the paginated list instead of the empty-state prompt when history exists', async () => {
+    // A drive scope no earlier test fetched — SWR's cache is module-global and
+    // an earlier test's empty answer for the SAME key would otherwise win here.
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/api/agent-sessions/conversations')) {
+        return {
+          ok: true,
+          json: async () => ({
+            conversations: [
+              {
+                conversationId: 'conv-hist-1',
+                title: 'A past chat',
+                type: 'global',
+                agentPageId: null,
+                pageTitle: null,
+                lastMessageAt: new Date().toISOString(),
+                createdAt: new Date().toISOString(),
+                sessionId: null,
+                sessionName: null,
+                sessionEndedAt: null,
+                driveId: null,
+              },
+            ],
+            pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ session: { driveId: null } }) };
+    });
+
+    render(<AgentsSurface driveId="drive-past-convos-render" />);
+
+    await waitFor(() => expect(screen.getByText('A past chat')).toBeDefined());
+    expect(screen.queryByText('Select a session')).toBeNull();
+  });
+
+  it('clicking a session-bound row opens it in the pane grid, same as picking it from the sidebar', async () => {
+    // A drive scope no earlier test fetched — see the cache note above.
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/api/agent-sessions/conversations')) {
+        return {
+          ok: true,
+          json: async () => ({
+            conversations: [
+              {
+                conversationId: 'conv-1',
+                title: 'Session chat',
+                type: 'page',
+                agentPageId: 'agent-1',
+                pageTitle: 'My Agent',
+                lastMessageAt: new Date().toISOString(),
+                createdAt: new Date().toISOString(),
+                sessionId: 'ses-1',
+                sessionName: 'My Session',
+                sessionEndedAt: null,
+                driveId: 'drive-1',
+              },
+            ],
+            pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ session: { driveId: null } }) };
+    });
+
+    render(<AgentsSurface driveId="drive-past-convos-click" />);
+
+    const label = await screen.findByText('Session chat');
+    act(() => label.closest('button')!.click());
+
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
+    expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-1');
+    expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
   });
 });

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -559,6 +559,67 @@ describe('past conversations (default view, replacing the old static prompt)', (
     expect(getByText('Page 1 chat')).toBeDefined();
   });
 
+  it('the Next button is disabled while a page fetch is in flight — a fast double-click cannot skip a page', async () => {
+    // Without gating on `isValidating`, a second click before the first
+    // click's fetch resolves would read the same (still page-1) `nextCursor`
+    // twice, pushing it onto `cursorStack` for two different page indices
+    // and silently skipping whatever page actually follows page 2.
+    let resolvePageTwoFetch!: (value: { ok: true; json: () => Promise<unknown> }) => void;
+    const pageTwoFetch = new Promise<{ ok: true; json: () => Promise<unknown> }>((resolve) => {
+      resolvePageTwoFetch = resolve;
+    });
+
+    const pageResponse = (label: string, nextCursor: string | null) => ({
+      ok: true as const,
+      json: async () => ({
+        conversations: [
+          {
+            conversationId: `conv-${label}`,
+            title: label,
+            type: 'global',
+            agentPageId: null,
+            pageTitle: null,
+            lastMessageAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            sessionId: null,
+            sessionName: null,
+            sessionEndedAt: null,
+            driveId: null,
+          },
+        ],
+        pagination: { hasMore: nextCursor !== null, nextCursor, limit: 20 },
+      }),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/api/agent-sessions/conversations')) {
+        const cursor = new URL(url, 'http://localhost').searchParams.get('cursor');
+        if (!cursor) return pageResponse('page-1', 'conv-page-1');
+        return pageTwoFetch;
+      }
+      return { ok: true, json: async () => ({ session: { driveId: null } }) };
+    });
+
+    const { getByText, findByText } = render(<AgentsSurface driveId="drive-race" />);
+    await findByText('page-1');
+
+    const nextButton = getByText('Next').closest('button')!;
+    act(() => nextButton.click());
+
+    // The fetch for page 2 is now in flight (not yet resolved) — the button
+    // must already be disabled, so a second click here is a no-op rather
+    // than queuing a second page-advance against the same stale cursor.
+    expect(nextButton).toBeDisabled();
+    act(() => nextButton.click());
+
+    resolvePageTwoFetch(pageResponse('page-2', null));
+    await findByText('page-2');
+
+    // Exactly one page-advance happened: still on page-2's content, not
+    // having silently skipped to a (nonexistent) page-3.
+    expect(screen.queryByText('page-1')).toBeNull();
+  });
+
   it('clicking a client (API-managed) conversation shows a toast instead of navigating — no in-app surface can open it', async () => {
     mockFetchWithAuth.mockImplementation(async (url: string) => {
       if (url.includes('/api/agent-sessions/conversations')) {

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -448,4 +448,57 @@ describe('past conversations (default view, replacing the old static prompt)', (
     expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-1');
     expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
   });
+
+  it('resets the list to page one when driveId changes on an already-mounted surface (review: switching drives mid-session must not keep a stale cursor)', async () => {
+    const conversationsFor = (driveLabel: string, cursor: string | null) => ({
+      ok: true,
+      json: async () => ({
+        conversations: [
+          {
+            conversationId: cursor ? `conv-${driveLabel}-page2` : `conv-${driveLabel}-page1`,
+            title: cursor ? `${driveLabel} page 2` : `${driveLabel} page 1`,
+            type: 'global',
+            agentPageId: null,
+            pageTitle: null,
+            lastMessageAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            sessionId: null,
+            sessionName: null,
+            sessionEndedAt: null,
+            driveId: null,
+          },
+        ],
+        // Page 1 always advertises more, so the Next button is enabled —
+        // page 2 (any `cursor` present) is the end of the list.
+        pagination: { hasMore: !cursor, nextCursor: cursor ? null : `conv-${driveLabel}-page1`, limit: 20 },
+      }),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/api/agent-sessions/conversations')) {
+        const parsed = new URL(url, 'http://localhost');
+        const driveLabel = parsed.searchParams.get('driveId') ?? 'none';
+        const cursor = parsed.searchParams.get('cursor');
+        return conversationsFor(driveLabel, cursor);
+      }
+      return { ok: true, json: async () => ({ session: { driveId: null } }) };
+    });
+
+    const { rerender, getByText, findByText } = render(<AgentsSurface driveId="drive-reset-a" />);
+
+    await findByText('drive-reset-a page 1');
+    act(() => getByText('Next').click());
+    await findByText('drive-reset-a page 2');
+
+    // Switch drives WITHOUT unmounting AgentsSurface itself — the exact
+    // scenario the `key` fix targets (a route-param change re-renders, it
+    // does not remount, the surface above this list).
+    rerender(<AgentsSurface driveId="drive-reset-b" />);
+
+    // Without the fix, the list would still be on page 2, replaying
+    // drive-reset-a's cursor against drive-reset-b's data. With it, a fresh
+    // instance mounts and asks for page one of the NEW drive.
+    await waitFor(() => expect(screen.getByText('drive-reset-b page 1')).toBeDefined());
+    expect(screen.queryByText(/page 2/)).toBeNull();
+  });
 });

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -501,4 +501,58 @@ describe('past conversations (default view, replacing the old static prompt)', (
     await waitFor(() => expect(screen.getByText('drive-reset-b page 1')).toBeDefined());
     expect(screen.queryByText(/page 2/)).toBeNull();
   });
+
+  it('a failed Next fetch does not strand the user — the last loaded page and Prev/Next stay usable', async () => {
+    let pageTwoShouldFail = false;
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/api/agent-sessions/conversations')) {
+        const parsed = new URL(url, 'http://localhost');
+        const cursor = parsed.searchParams.get('cursor');
+        if (cursor && pageTwoShouldFail) {
+          return { ok: false, status: 500, json: async () => ({ error: 'boom' }) };
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            conversations: [
+              {
+                conversationId: cursor ? 'conv-page2' : 'conv-page1',
+                title: cursor ? 'Page 2 chat' : 'Page 1 chat',
+                type: 'global',
+                agentPageId: null,
+                pageTitle: null,
+                lastMessageAt: new Date().toISOString(),
+                createdAt: new Date().toISOString(),
+                sessionId: null,
+                sessionName: null,
+                sessionEndedAt: null,
+                driveId: null,
+              },
+            ],
+            pagination: { hasMore: !cursor, nextCursor: cursor ? null : 'conv-page1', limit: 20 },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ session: { driveId: null } }) };
+    });
+
+    const { getByText, findByText, queryByText } = render(<AgentsSurface driveId="drive-fail-recover" />);
+    await findByText('Page 1 chat');
+
+    pageTwoShouldFail = true;
+    act(() => getByText('Next').click());
+
+    // The failed page must not wipe the view: page 1's row is still there,
+    // an inline notice covers the failure, and Prev is still the way out.
+    await waitFor(() => expect(screen.getByText(/Couldn't load this page/)).toBeDefined());
+    expect(getByText('Page 1 chat')).toBeDefined();
+    expect(queryByText("Couldn't load past conversations")).toBeNull();
+    const prevButton = getByText('Prev').closest('button')!;
+    expect(prevButton).not.toBeDisabled();
+
+    act(() => prevButton.click());
+    await waitFor(() => expect(screen.queryByText(/Couldn't load this page/)).toBeNull());
+    expect(getByText('Page 1 chat')).toBeDefined();
+  });
 });

--- a/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
+++ b/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
@@ -43,19 +43,18 @@ describe('resolveNavigationTarget', () => {
     });
   });
 
-  it('a page conversation missing its agent/drive falls back to the global assistant rather than throwing', () => {
+  it('a page conversation missing its agent/drive is unavailable — never falls back to the global assistant', () => {
+    // The global assistant's loader reads the `messages` table; a page
+    // conversation's content lives in `chat_messages`, which that loader can
+    // never populate — routing there silently opened a blank, dead thread
+    // (review finding). "Nowhere to go" must be honest, not a fake target.
     const target = resolveNavigationTarget(row({ type: 'page', agentPageId: null, driveId: null }), 'drive-current');
-    expect(target).toEqual({ kind: 'global', conversationId: 'conv-1', driveId: 'drive-current' });
+    expect(target).toEqual({ kind: 'unavailable' });
   });
 
-  it('a drive-type conversation navigates to that drive\'s dashboard home', () => {
-    const target = resolveNavigationTarget(row({ type: 'drive', driveId: 'drive-9' }), undefined);
-    expect(target).toEqual({ kind: 'drive', driveId: 'drive-9' });
-  });
-
-  it('a drive-type conversation missing its driveId falls back to the global assistant', () => {
-    const target = resolveNavigationTarget(row({ type: 'drive', driveId: null }), 'drive-current');
-    expect(target).toEqual({ kind: 'global', conversationId: 'conv-1', driveId: 'drive-current' });
+  it('a client (API-managed) conversation is always unavailable — no in-app viewer exists for it', () => {
+    const target = resolveNavigationTarget(row({ type: 'client', driveId: 'drive-9' }), undefined);
+    expect(target).toEqual({ kind: 'unavailable' });
   });
 
   it('a global conversation navigates wherever the global assistant currently lives', () => {

--- a/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
+++ b/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
@@ -29,6 +29,19 @@ describe('resolveNavigationTarget', () => {
     expect(target).toEqual({ kind: 'pane', sessionId: 'ses-1', conversationId: 'conv-1', agentId: 'agent-1' });
   });
 
+  it('a session-bound page conversation whose page is currently inaccessible is unavailable, not a pane', () => {
+    // The API masks `driveId` to null (never a real value for a live page)
+    // specifically when it already checked and the requester can no longer
+    // view that page. Opening the pane anyway would hit a 403 on the message
+    // fetch and silently show nothing (review finding) — this must be caught
+    // before the unconditional sessionId branch below, not after it.
+    const target = resolveNavigationTarget(
+      row({ type: 'page', sessionId: 'ses-1', agentPageId: 'agent-1', driveId: null }),
+      undefined,
+    );
+    expect(target).toEqual({ kind: 'unavailable' });
+  });
+
   it('a plain page conversation navigates to its agent page, in its own drive', () => {
     const target = resolveNavigationTarget(
       row({ type: 'page', agentPageId: 'agent-1', driveId: 'drive-1' }),

--- a/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
+++ b/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure function, no I/O — a click on a past-conversation row must land in
+ * exactly the right place for that row's kind. A session-bound conversation
+ * always wins the pane grid, whatever its `type`; everything else branches on
+ * `type` with an exhaustive switch (compile-time guarded — see the `never`
+ * check in the source) so a future `ConversationKind` value can't silently
+ * misroute here.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveNavigationTarget, type PastConversationRow } from '../resolveNavigationTarget';
+
+function row(overrides: Partial<PastConversationRow> = {}): PastConversationRow {
+  return {
+    conversationId: 'conv-1',
+    type: 'global',
+    agentPageId: null,
+    sessionId: null,
+    driveId: null,
+    ...overrides,
+  };
+}
+
+describe('resolveNavigationTarget', () => {
+  it('a session-bound conversation opens the pane grid, whatever its type', () => {
+    const target = resolveNavigationTarget(
+      row({ type: 'page', sessionId: 'ses-1', agentPageId: 'agent-1', driveId: 'drive-1' }),
+      undefined,
+    );
+    expect(target).toEqual({ kind: 'pane', sessionId: 'ses-1', conversationId: 'conv-1', agentId: 'agent-1' });
+  });
+
+  it('a plain page conversation navigates to its agent page, in its own drive', () => {
+    const target = resolveNavigationTarget(
+      row({ type: 'page', agentPageId: 'agent-1', driveId: 'drive-1' }),
+      undefined,
+    );
+    expect(target).toEqual({
+      kind: 'page',
+      driveId: 'drive-1',
+      pageId: 'agent-1',
+      conversationId: 'conv-1',
+      sessionId: null,
+    });
+  });
+
+  it('a page conversation missing its agent/drive falls back to the global assistant rather than throwing', () => {
+    const target = resolveNavigationTarget(row({ type: 'page', agentPageId: null, driveId: null }), 'drive-current');
+    expect(target).toEqual({ kind: 'global', conversationId: 'conv-1', driveId: 'drive-current' });
+  });
+
+  it('a drive-type conversation navigates to that drive\'s dashboard home', () => {
+    const target = resolveNavigationTarget(row({ type: 'drive', driveId: 'drive-9' }), undefined);
+    expect(target).toEqual({ kind: 'drive', driveId: 'drive-9' });
+  });
+
+  it('a drive-type conversation missing its driveId falls back to the global assistant', () => {
+    const target = resolveNavigationTarget(row({ type: 'drive', driveId: null }), 'drive-current');
+    expect(target).toEqual({ kind: 'global', conversationId: 'conv-1', driveId: 'drive-current' });
+  });
+
+  it('a global conversation navigates wherever the global assistant currently lives', () => {
+    const target = resolveNavigationTarget(row({ type: 'global' }), 'drive-current');
+    expect(target).toEqual({ kind: 'global', conversationId: 'conv-1', driveId: 'drive-current' });
+  });
+
+  it('a global conversation with no current drive scope resolves to the dashboard home', () => {
+    const target = resolveNavigationTarget(row({ type: 'global' }), undefined);
+    expect(target).toEqual({ kind: 'global', conversationId: 'conv-1', driveId: null });
+  });
+});

--- a/apps/web/src/components/agents/__tests__/useResolvedConversation.test.ts
+++ b/apps/web/src/components/agents/__tests__/useResolvedConversation.test.ts
@@ -221,6 +221,45 @@ describe('useResolvedConversation', () => {
     await waitFor(() => expect(result.current.resolved).not.toBeNull());
     expect(result.current.resolved?.sessionId).toBeNull();
   });
+
+  describe('initialConversationId (deep link from the past-conversations list)', () => {
+    it('resolves directly to it, skipping the most-recent lookup entirely', async () => {
+      const { result } = renderHook(() =>
+        useResolvedConversation('agent-1', {
+          ...OPTS,
+          initialConversationId: 'conv-deep-link',
+          initialSessionId: 'ses-deep-link',
+        }),
+      );
+
+      await waitFor(() => expect(result.current.resolved?.conversationId).toBe('conv-deep-link'));
+      expect(result.current.resolved?.sessionId).toBe('ses-deep-link');
+      expect(agentConversations.fetchMostRecentAgentConversation).not.toHaveBeenCalled();
+      expect(agentConversations.createAgentConversation).not.toHaveBeenCalled();
+    });
+
+    it('defaults sessionId to null when none is given', async () => {
+      const { result } = renderHook(() =>
+        useResolvedConversation('agent-1', { ...OPTS, initialConversationId: 'conv-deep-link' }),
+      );
+
+      await waitFor(() => expect(result.current.resolved?.conversationId).toBe('conv-deep-link'));
+      expect(result.current.resolved?.sessionId).toBeNull();
+    });
+
+    it('still waits for auth to settle before resolving, same as the ordinary path', async () => {
+      const { result, rerender } = renderHook(
+        ({ authLoading }: { authLoading: boolean }) =>
+          useResolvedConversation('agent-1', { ...OPTS, authLoading, initialConversationId: 'conv-deep-link' }),
+        { initialProps: { authLoading: true } },
+      );
+
+      expect(result.current.isLoading).toBe(true);
+      rerender({ authLoading: false });
+
+      await waitFor(() => expect(result.current.resolved?.conversationId).toBe('conv-deep-link'));
+    });
+  });
 });
 
 describe('createPageConversation', () => {

--- a/apps/web/src/components/agents/resolveNavigationTarget.ts
+++ b/apps/web/src/components/agents/resolveNavigationTarget.ts
@@ -7,8 +7,14 @@
  * branch, which is what a bare `if/else if/else` chain would do.
  */
 
-/** Mirrors `conversations.type` (`packages/db/src/schema/conversations.ts`) — the only values ever written. */
-export type ConversationKind = 'global' | 'page' | 'drive';
+/**
+ * Mirrors `conversations.type` (`packages/db/src/schema/conversations.ts`) —
+ * the only values any production code path writes. `'client'` is the rare
+ * API-managed conversation created via `POST /api/v1/conversations` (never
+ * `'drive'` — that value was never actually written by any code path; it was
+ * a documentation mistake corrected once this got fixed).
+ */
+export type ConversationKind = 'global' | 'page' | 'client';
 
 export interface PastConversationRow {
   conversationId: string;
@@ -21,8 +27,20 @@ export interface PastConversationRow {
 export type NavigationTarget =
   | { kind: 'pane'; sessionId: string; conversationId: string; agentId: string | null }
   | { kind: 'page'; driveId: string; pageId: string; conversationId: string; sessionId: string | null }
-  | { kind: 'drive'; driveId: string }
-  | { kind: 'global'; conversationId: string; driveId: string | null };
+  | { kind: 'global'; conversationId: string; driveId: string | null }
+  /**
+   * No surface in the app can open this row today. NOT the same as an
+   * error — the row still belongs in "every conversation you own", it just
+   * has nowhere to click through to yet. Two real cases: a `type: 'page'`
+   * row missing its resolvable agent/drive, and a `type: 'client'`
+   * (API-managed) conversation, which has no dedicated in-app viewer.
+   * Deliberately NOT routed into the global assistant as a fallback — its
+   * loader reads the `messages` table, which a `chat_messages`-backed
+   * conversation (page/client) can never populate, so that fallback silently
+   * opened a blank thread that could never actually show the real history
+   * (review finding).
+   */
+  | { kind: 'unavailable' };
 
 /**
  * A session-bound conversation always wins, whatever its `type` — it opens in
@@ -38,11 +56,7 @@ export function resolveNavigationTarget(
 
   switch (row.type) {
     case 'page': {
-      if (!row.agentPageId || !row.driveId) {
-        // A page conversation with no resolvable page/drive is unreachable —
-        // the safest place to land is wherever the global assistant lives.
-        return { kind: 'global', conversationId: row.conversationId, driveId: currentDriveId ?? null };
-      }
+      if (!row.agentPageId || !row.driveId) return { kind: 'unavailable' };
       return {
         kind: 'page',
         driveId: row.driveId,
@@ -51,12 +65,11 @@ export function resolveNavigationTarget(
         sessionId: null,
       };
     }
-    case 'drive': {
-      if (!row.driveId) {
-        return { kind: 'global', conversationId: row.conversationId, driveId: currentDriveId ?? null };
-      }
-      return { kind: 'drive', driveId: row.driveId };
-    }
+    // API-managed (POST /api/v1/conversations) — always session-less (confirmed:
+    // nothing ever binds a `client` row to a session) and has no in-app chat
+    // surface to open into.
+    case 'client':
+      return { kind: 'unavailable' };
     case 'global':
       return { kind: 'global', conversationId: row.conversationId, driveId: currentDriveId ?? null };
     default: {

--- a/apps/web/src/components/agents/resolveNavigationTarget.ts
+++ b/apps/web/src/components/agents/resolveNavigationTarget.ts
@@ -1,0 +1,69 @@
+/**
+ * Where a click on a past-conversation row should go, computed as a pure
+ * function of the row's own fields — no I/O, nothing async, fully
+ * deterministic and unit-testable with a plain object. The exhaustive
+ * `switch` (with a `never` check) means a future `conversations.type` value
+ * fails to COMPILE here rather than silently falling through to the wrong
+ * branch, which is what a bare `if/else if/else` chain would do.
+ */
+
+/** Mirrors `conversations.type` (`packages/db/src/schema/conversations.ts`) — the only values ever written. */
+export type ConversationKind = 'global' | 'page' | 'drive';
+
+export interface PastConversationRow {
+  conversationId: string;
+  type: ConversationKind;
+  agentPageId: string | null;
+  sessionId: string | null;
+  driveId: string | null;
+}
+
+export type NavigationTarget =
+  | { kind: 'pane'; sessionId: string; conversationId: string; agentId: string | null }
+  | { kind: 'page'; driveId: string; pageId: string; conversationId: string; sessionId: string | null }
+  | { kind: 'drive'; driveId: string }
+  | { kind: 'global'; conversationId: string; driveId: string | null };
+
+/**
+ * A session-bound conversation always wins, whatever its `type` — it opens in
+ * the pane grid in-place, the one case that never leaves the Agents surface.
+ */
+export function resolveNavigationTarget(
+  row: PastConversationRow,
+  currentDriveId: string | undefined,
+): NavigationTarget {
+  if (row.sessionId) {
+    return { kind: 'pane', sessionId: row.sessionId, conversationId: row.conversationId, agentId: row.agentPageId };
+  }
+
+  switch (row.type) {
+    case 'page': {
+      if (!row.agentPageId || !row.driveId) {
+        // A page conversation with no resolvable page/drive is unreachable —
+        // the safest place to land is wherever the global assistant lives.
+        return { kind: 'global', conversationId: row.conversationId, driveId: currentDriveId ?? null };
+      }
+      return {
+        kind: 'page',
+        driveId: row.driveId,
+        pageId: row.agentPageId,
+        conversationId: row.conversationId,
+        sessionId: null,
+      };
+    }
+    case 'drive': {
+      if (!row.driveId) {
+        return { kind: 'global', conversationId: row.conversationId, driveId: currentDriveId ?? null };
+      }
+      return { kind: 'drive', driveId: row.driveId };
+    }
+    case 'global':
+      return { kind: 'global', conversationId: row.conversationId, driveId: currentDriveId ?? null };
+    default: {
+      // Exhaustiveness guard: adding a new `ConversationKind` value fails to
+      // compile here instead of silently misrouting through this switch.
+      const _exhaustive: never = row.type;
+      return _exhaustive;
+    }
+  }
+}

--- a/apps/web/src/components/agents/resolveNavigationTarget.ts
+++ b/apps/web/src/components/agents/resolveNavigationTarget.ts
@@ -45,11 +45,24 @@ export type NavigationTarget =
 /**
  * A session-bound conversation always wins, whatever its `type` — it opens in
  * the pane grid in-place, the one case that never leaves the Agents surface.
+ *
+ * EXCEPT a `type: 'page'` row whose `driveId` came back null: the API masks
+ * `driveId` to null (route.ts) ONLY when it already checked and the
+ * requester can no longer view that page — a real, live page always belongs
+ * to a drive, so this can never be a legitimate "no drive" value. Checking
+ * it before the `sessionId` branch matters because a session-bound page
+ * conversation would otherwise open `AgentPanes` unconditionally; the pane's
+ * message fetch enforces the same permission server-side and 403s, so the
+ * click would silently fail to show anything (review finding).
  */
 export function resolveNavigationTarget(
   row: PastConversationRow,
   currentDriveId: string | undefined,
 ): NavigationTarget {
+  if (row.type === 'page' && !row.driveId) {
+    return { kind: 'unavailable' };
+  }
+
   if (row.sessionId) {
     return { kind: 'pane', sessionId: row.sessionId, conversationId: row.conversationId, agentId: row.agentPageId };
   }

--- a/apps/web/src/components/agents/useResolvedConversation.ts
+++ b/apps/web/src/components/agents/useResolvedConversation.ts
@@ -112,7 +112,27 @@ export async function createPageConversation({
 
 export function useResolvedConversation(
   agentId: string,
-  { driveId, canUseSessions, authLoading }: { driveId: string; canUseSessions: boolean; authLoading: boolean },
+  {
+    driveId,
+    canUseSessions,
+    authLoading,
+    initialConversationId,
+    initialSessionId,
+  }: {
+    driveId: string;
+    canUseSessions: boolean;
+    authLoading: boolean;
+    /**
+     * A deep-linked conversation to open instead of the agent's most-recent
+     * one — e.g. a row clicked in the Agents surface's past-conversations
+     * list. Trusted as-is (same trust level `useAgentSurfaceStore` already
+     * extends to the session/conversation ids it passes through): read once,
+     * synchronously, before the async most-recent-fetch path even starts, so
+     * the two can never race each other.
+     */
+    initialConversationId?: string;
+    initialSessionId?: string | null;
+  },
 ): UseResolvedConversationResult {
   const [resolved, setResolved] = useState<ResolvedConversation | null>(null);
   const resolvingAgentIdRef = useRef<string | null>(null);
@@ -145,6 +165,14 @@ export function useResolvedConversation(
     setResolved(null);
 
     const resolve = async () => {
+      // Synchronous, before any await: a deep-linked id is used directly —
+      // this can never race the async most-recent-fetch path below, since
+      // exactly one of the two branches runs, chosen at the top.
+      if (initialConversationId) {
+        setResolved({ conversationId: initialConversationId, sessionId: initialSessionId ?? null });
+        return;
+      }
+
       try {
         const mostRecent = await fetchMostRecentAgentConversation(agentId);
         if (resolvingAgentIdRef.current !== agentId) return;
@@ -182,7 +210,12 @@ export function useResolvedConversation(
       }
     };
     void resolve();
-  }, [agentId, authLoading]);
+    // `initialConversationId`/`initialSessionId` are read once, at the top of
+    // `resolve()`, for whichever agentId resolution is starting — safe to
+    // list here because `startedForAgentIdRef` already blocks a second run
+    // for an agentId that has already started, so a later change to either
+    // (while a DIFFERENT agentId hasn't resolved yet) can't retrigger.
+  }, [agentId, authLoading, initialConversationId, initialSessionId]);
 
   return { resolved, isLoading: resolved === null };
 }

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { eq, sql } from '@pagespace/db/operators';
 import { pages, chatMessages } from '@pagespace/db/schema/core';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { factories } from '@pagespace/db/test/factories';
@@ -314,5 +314,56 @@ describe('listAllConversationsPaginated — cursor pagination is immune to concu
 
     const page2 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 2, cursor });
     expect(page2.conversations.map((c) => c.conversationId)).toEqual([oldest]);
+  });
+
+  // Confirmed empirically against this real test DB before writing this test:
+  // drizzle's own query builder returns `sortKeyExpr` (a raw computed
+  // COALESCE/subquery expression, not a schema-mapped column) as a STRING
+  // with full microsecond precision, e.g. "2020-03-01 00:00:00.123456" —
+  // Postgres timestamps carry six fractional digits, a plain JS `Date` only
+  // three. `encodeCursor` previously round-tripped every sort key through
+  // `new Date(...).toISOString()` regardless, silently truncating two
+  // distinct sub-millisecond sort keys onto the identical encoded value
+  // (review finding).
+  it('two rows whose sort keys differ only below the millisecond are still paginated correctly, not collapsed onto one cursor', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentNewer = await factories.createPage(drive.id, { type: 'AI_CHAT' });
+    const agentOlder = await factories.createPage(drive.id, { type: 'AI_CHAT' });
+
+    const makeConversation = async (agentId: string) => {
+      const conversationId = createId();
+      await db.insert(conversations).values({
+        id: conversationId, userId: owner.id, type: 'page', contextId: agentId, title: null, isActive: true,
+      });
+      const messageId = createId();
+      await db.insert(chatMessages).values({
+        id: messageId, pageId: agentId, conversationId, role: 'user', content: 'hi', isActive: true,
+      });
+      return { conversationId, messageId };
+    };
+
+    // A plain JS `Date` (and drizzle's own `.values({ createdAt })` insert
+    // path) cannot express microseconds at all — raw SQL is the only way to
+    // actually seed the sub-millisecond difference this test needs.
+    const newer = await makeConversation(agentNewer.id);
+    const older = await makeConversation(agentOlder.id);
+    await db.execute(sql`UPDATE chat_messages SET "createdAt" = '2020-03-01 00:00:00.123456' WHERE id = ${newer.messageId}`);
+    await db.execute(sql`UPDATE chat_messages SET "createdAt" = '2020-03-01 00:00:00.123400' WHERE id = ${older.messageId}`);
+
+    const page1 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 1 });
+    expect(page1.conversations.map((c) => c.conversationId)).toEqual([newer.conversationId]);
+    expect(page1.pagination.hasMore).toBe(true);
+    const cursor = page1.pagination.nextCursor!;
+
+    // With the pre-fix truncating cursor, both rows' sort keys collapse onto
+    // the exact same encoded millisecond, and the boundary comparison either
+    // re-admits `newer` (a duplicate) or drops `older` entirely, depending on
+    // how the id tie-breaker happens to land — never the single correct
+    // `[older]` this asserts.
+    const page2 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 1, cursor });
+    expect(page2.conversations.map((c) => c.conversationId)).toEqual([older.conversationId]);
   });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
@@ -19,10 +19,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
 import { pages, chatMessages } from '@pagespace/db/schema/core';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { factories } from '@pagespace/db/test/factories';
-import { listAllConversationsPaginated } from '../agent-sessions-conversations-runtime';
+import { listAllConversationsPaginated, decodeCursor } from '../agent-sessions-conversations-runtime';
 
 let dbAvailable = false;
 
@@ -205,5 +206,113 @@ describe('listAllConversationsPaginated — hasActiveMessage against real chat_m
     expect(row?.driveId).toBe(drive.id);
     expect(row?.agentPageId).toBeNull();
     expect(row?.pageTitle).toBeNull();
+  });
+});
+
+describe('listAllConversationsPaginated — cursor pagination is immune to concurrent mutation (P2 review finding)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('a message arriving in the cursor conversation between page fetches does not cause a duplicate or a skipped row', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agent1 = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent 1' });
+    const agent2 = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent 2' });
+    const agent3 = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent 3' });
+
+    // Three conversations, oldest to newest by their real last-activity time.
+    const makeConversation = async (agentId: string, activityAt: Date) => {
+      const conversationId = createId();
+      await db.insert(conversations).values({
+        id: conversationId, userId: owner.id, type: 'page', contextId: agentId, title: null, isActive: true,
+      });
+      await db.insert(chatMessages).values({
+        id: createId(), pageId: agentId, conversationId, role: 'user', content: 'hi', isActive: true, createdAt: activityAt,
+      });
+      return conversationId;
+    };
+
+    const oldest = await makeConversation(agent1.id, new Date('2020-01-01'));
+    const middle = await makeConversation(agent2.id, new Date('2020-01-02'));
+    const newest = await makeConversation(agent3.id, new Date('2020-01-03'));
+
+    // Page 1: newest first, limit 2 → [newest, middle]. nextCursor freezes
+    // `middle`'s sort key as it was AT THIS MOMENT.
+    const page1 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 2 });
+    expect(page1.conversations.map((c) => c.conversationId)).toEqual([newest, middle]);
+    expect(page1.pagination.hasMore).toBe(true);
+    const cursor = page1.pagination.nextCursor!;
+    // Sanity: the cursor really did freeze `middle`'s ORIGINAL sort key, not
+    // some later value — this is the whole point of the fix.
+    expect(decodeCursor(cursor)?.id).toBe(middle);
+
+    // Concurrent activity: `middle` receives a brand-new message NOW —
+    // this is what the review flagged as the race. With the old
+    // live-re-lookup design, decoding the cursor's id and re-querying its
+    // CURRENT sort key would see this new, much-more-recent timestamp
+    // instead of the frozen one.
+    await db.insert(chatMessages).values({
+      id: createId(), pageId: agent2.id, conversationId: middle, role: 'user', content: 'still here', isActive: true, createdAt: new Date(),
+    });
+
+    // Page 2, using the cursor obtained BEFORE that mutation.
+    const page2 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 2, cursor });
+
+    // Correct: exactly the one conversation strictly older than the FROZEN
+    // boundary — `middle` must not reappear (duplicate), and this must not
+    // silently return page one again either.
+    expect(page2.conversations.map((c) => c.conversationId)).toEqual([oldest]);
+  });
+
+  it('a cursor whose conversation was deleted in between still returns the correct next page, not page one again', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agent1 = await factories.createPage(drive.id, { type: 'AI_CHAT' });
+    const agent2 = await factories.createPage(drive.id, { type: 'AI_CHAT' });
+    const agent3 = await factories.createPage(drive.id, { type: 'AI_CHAT' });
+
+    const makeConversation = async (agentId: string, activityAt: Date) => {
+      const conversationId = createId();
+      await db.insert(conversations).values({
+        id: conversationId, userId: owner.id, type: 'page', contextId: agentId, title: null, isActive: true,
+      });
+      await db.insert(chatMessages).values({
+        id: createId(), pageId: agentId, conversationId, role: 'user', content: 'hi', isActive: true, createdAt: activityAt,
+      });
+      return conversationId;
+    };
+
+    // A THIRD, older conversation matters here: if the cursor's own row
+    // disappearing were allowed to silently drop the boundary entirely (the
+    // bug), the query would still exclude the now-inactive cursor row on its
+    // own merits — a weaker test with only two conversations would pass
+    // either way. With three, a dropped boundary wrongly re-admits `newest`
+    // (already shown on page 1) alongside `oldest`.
+    const oldest = await makeConversation(agent1.id, new Date('2020-02-01'));
+    const middle = await makeConversation(agent2.id, new Date('2020-02-02'));
+    const newest = await makeConversation(agent3.id, new Date('2020-02-03'));
+
+    const page1 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 2 });
+    expect(page1.conversations.map((c) => c.conversationId)).toEqual([newest, middle]);
+    const cursor = page1.pagination.nextCursor!;
+
+    // The cursor conversation (`middle`) is soft-deleted — a LIVE lookup by
+    // id would find nothing (or, if hard-deleted, literally nothing at all);
+    // the frozen cursor needs no lookup at all, so this can't degrade
+    // pagination into silently re-admitting `newest`.
+    await db.update(conversations).set({ isActive: false }).where(eq(conversations.id, middle));
+
+    const page2 = await listAllConversationsPaginated({ ownerId: owner.id }, { limit: 2, cursor });
+    expect(page2.conversations.map((c) => c.conversationId)).toEqual([oldest]);
   });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `hasActiveMessage` regression coverage against a REAL Postgres (real DB, not
+ * mocked) — the drizzle-mock unit test in this same directory can prove the
+ * pagination math, but "does this predicate actually see rows written by the
+ * real page-agent send path" needs real SQL against the real `chat_messages`
+ * table, joined the way `conversationRepository.conversationExists` does.
+ *
+ * The bug this guards: `hasActiveMessage` originally checked only the
+ * `messages` table, which only `type: 'global'` conversations ever write to —
+ * every `type: 'page'` conversation (including session-bound agent chats)
+ * writes its content to `chat_messages` instead, keyed by `pageId` +
+ * `conversationId` (review finding: this silently excluded every real
+ * page-agent conversation from the listing).
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable —
+ * mirrors `reorder-task-list.integration.test.ts` in this same convention.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { pages, chatMessages } from '@pagespace/db/schema/core';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { factories } from '@pagespace/db/test/factories';
+import { listAllConversationsPaginated } from '../agent-sessions-conversations-runtime';
+
+let dbAvailable = false;
+
+describe('listAllConversationsPaginated — hasActiveMessage against real chat_messages', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('surfaces a type: "page" conversation whose content lives in chat_messages, not messages', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'My Agent' });
+    const conversationId = createId();
+
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'page',
+      contextId: agentPage.id,
+      title: null,
+      isActive: true,
+    });
+    await db.insert(chatMessages).values({
+      id: createId(),
+      pageId: agentPage.id,
+      conversationId,
+      role: 'user',
+      content: 'hello',
+      isActive: true,
+    });
+
+    const result = await listAllConversationsPaginated({ ownerId: owner.id });
+
+    const row = result.conversations.find((c) => c.conversationId === conversationId);
+    expect(row).toBeDefined();
+    expect(row?.agentPageId).toBe(agentPage.id);
+    expect(row?.pageTitle).toBe('My Agent');
+  });
+
+  it('still excludes a type: "page" conversation with NO messages in either table', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Empty Agent' });
+    const conversationId = createId();
+
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'page',
+      contextId: agentPage.id,
+      title: null,
+      isActive: true,
+    });
+
+    const result = await listAllConversationsPaginated({ ownerId: owner.id });
+
+    expect(result.conversations.find((c) => c.conversationId === conversationId)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.integration.test.ts
@@ -90,4 +90,120 @@ describe('listAllConversationsPaginated — hasActiveMessage against real chat_m
 
     expect(result.conversations.find((c) => c.conversationId === conversationId)).toBeUndefined();
   });
+
+  it('sorts a page conversation by its ACTUAL last message time, not its creation time (P1 review finding)', async () => {
+    if (!dbAvailable) return;
+
+    // conversations.lastMessageAt is never set for type: 'page' (nothing writes
+    // it — the send path only touches chat_messages), so before the fix the
+    // sort/cursor key fell back to createdAt for every page conversation. An
+    // OLD thread (created first) that just received a message today must
+    // still sort AHEAD of a NEWER thread (created after it) with no recent
+    // activity — the opposite of createdAt order.
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const oldAgent = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Old Agent' });
+    const newAgent = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'New Agent' });
+
+    const oldConversationId = createId();
+    await db.insert(conversations).values({
+      id: oldConversationId,
+      userId: owner.id,
+      type: 'page',
+      contextId: oldAgent.id,
+      title: null,
+      isActive: true,
+      createdAt: new Date('2020-01-01'),
+    });
+    // Its only message is TODAY — real recent activity.
+    await db.insert(chatMessages).values({
+      id: createId(),
+      pageId: oldAgent.id,
+      conversationId: oldConversationId,
+      role: 'user',
+      content: 'still using this one',
+      isActive: true,
+      createdAt: new Date(),
+    });
+
+    const newConversationId = createId();
+    await db.insert(conversations).values({
+      id: newConversationId,
+      userId: owner.id,
+      type: 'page',
+      contextId: newAgent.id,
+      title: null,
+      isActive: true,
+      createdAt: new Date('2026-01-01'),
+    });
+    // Created much later, but its only message is old — no recent activity.
+    await db.insert(chatMessages).values({
+      id: createId(),
+      pageId: newAgent.id,
+      conversationId: newConversationId,
+      role: 'user',
+      content: 'sent right after creating, never touched again',
+      isActive: true,
+      createdAt: new Date('2026-01-01'),
+    });
+
+    const result = await listAllConversationsPaginated({ ownerId: owner.id });
+
+    const oldIndex = result.conversations.findIndex((c) => c.conversationId === oldConversationId);
+    const newIndex = result.conversations.findIndex((c) => c.conversationId === newConversationId);
+    expect(oldIndex).toBeGreaterThanOrEqual(0);
+    expect(newIndex).toBeGreaterThanOrEqual(0);
+    // Newest-first: the one with today's activity must come BEFORE the one
+    // whose only activity is from years ago, despite being created later.
+    expect(oldIndex).toBeLessThan(newIndex);
+
+    const oldRow = result.conversations.find((c) => c.conversationId === oldConversationId);
+    // The returned lastMessageAt must reflect the REAL message time, not stay
+    // null (conversations.lastMessageAt is never set for this type) and not
+    // silently fall back to createdAt while messages exist.
+    expect(oldRow?.lastMessageAt).not.toBeNull();
+    expect(new Date(oldRow!.lastMessageAt!).getFullYear()).toBeGreaterThan(2020);
+  });
+
+  it('surfaces a type: "client" (API-managed) conversation, whose messages can carry a DIFFERENT pageId per message', async () => {
+    if (!dbAvailable) return;
+
+    // v1-conversations.ts: a `client` conversation's own contextId is an
+    // optional driveId, never a pageId — its chat_messages rows are written
+    // by whatever page a given /v1/chat/completions call targeted, which can
+    // differ message-to-message. Matching hasActiveMessage on conversationId
+    // ALONE (no pageId equality) is what makes this findable at all.
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT' });
+    const conversationId = createId();
+
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'client',
+      contextId: drive.id,
+      title: 'My API thread',
+      isActive: true,
+    });
+    await db.insert(chatMessages).values({
+      id: createId(),
+      pageId: agentPage.id,
+      conversationId,
+      role: 'user',
+      content: 'hi from the API',
+      isActive: true,
+    });
+
+    const result = await listAllConversationsPaginated({ ownerId: owner.id });
+
+    const row = result.conversations.find((c) => c.conversationId === conversationId);
+    expect(row).toBeDefined();
+    expect(row?.type).toBe('client');
+    // Resolved directly from contextId (a driveId for this type), not via the
+    // `pages` join (which only ever matches type: 'page').
+    expect(row?.driveId).toBe(drive.id);
+    expect(row?.agentPageId).toBeNull();
+    expect(row?.pageTitle).toBeNull();
+  });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `listAllConversationsPaginated` had zero direct tests before this — the
+ * `direction: 'before' | 'after'` cursor bug a review caught (the `after`
+ * branch reused an unchanged `ORDER BY ... DESC`, so it returned the globally
+ * newest matches instead of the page adjacent to the cursor) shipped without
+ * one. That branch is now deleted entirely rather than fixed — this listing's
+ * only caller never asks to go "forward" — so what's left to verify is the
+ * unidirectional cursor's pagination math and the row mapping, not a
+ * direction toggle.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => {
+  // A single chainable stub: every non-terminal call returns itself, and
+  // `.limit()` is the ONE terminal method for both queries this module runs
+  // (the cursor lookup ends `.where().limit(1)`; the main query ends
+  // `.where().orderBy().limit(n)`) — a round-robin queue of canned responses,
+  // consumed in call order, needs no per-query-shape branching.
+  const responses: unknown[][] = [];
+  const chain = {
+    select: vi.fn(() => chain),
+    from: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(responses.shift() ?? [])),
+  };
+  return { db: chain, __queueResponse: (rows: unknown[]) => responses.push(rows) };
+});
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((col, val) => ({ op: 'eq', col, val })),
+  and: vi.fn((...args) => ({ op: 'and', args })),
+  desc: vi.fn((field) => ({ op: 'desc', field })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ op: 'sql', strings, values })),
+  exists: vi.fn((sub) => ({ op: 'exists', sub })),
+  isNotNull: vi.fn((col) => ({ op: 'isNotNull', col })),
+}));
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: {
+    id: 'conversations.id', userId: 'conversations.userId', isActive: 'conversations.isActive',
+    type: 'conversations.type', title: 'conversations.title', contextId: 'conversations.contextId',
+    lastMessageAt: 'conversations.lastMessageAt', createdAt: 'conversations.createdAt',
+    sessionId: 'conversations.sessionId', closedInSessionAt: 'conversations.closedInSessionAt',
+  },
+  messages: { conversationId: 'messages.conversationId', isActive: 'messages.isActive' },
+}));
+vi.mock('@pagespace/db/schema/agent-sessions', () => ({
+  agentSessions: { id: 'agentSessions.id', driveId: 'agentSessions.driveId', name: 'agentSessions.name', endedAt: 'agentSessions.endedAt' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', title: 'pages.title', driveId: 'pages.driveId' },
+}));
+
+import * as dbModule from '@pagespace/db/db';
+import { listAllConversationsPaginated } from '../agent-sessions-conversations-runtime';
+
+// The real `@pagespace/db/db` module only exports `db`, typed as
+// `NodePgDatabase<...>` (no `.limit()` of its own — only through a real query
+// chain). The mock above replaces `db` wholesale with a plain chainable stub
+// and adds its own `__queueResponse` export alongside it — untyped access is
+// the only way to reach either from here.
+const mockDb = dbModule as unknown as { db: { limit: ReturnType<typeof vi.fn> }; __queueResponse: (r: unknown[]) => void };
+const queueResponse = (rows: unknown[]) => mockDb.__queueResponse(rows);
+
+const GLOBAL_ROW = {
+  conversationId: 'conv-1', title: 'Chat', type: 'global', contextId: null,
+  lastMessageAt: new Date('2026-07-28'), createdAt: new Date('2026-07-27'),
+  sessionId: null, sessionName: null, sessionEndedAt: null, pageTitle: null, driveId: null,
+};
+const PAGE_ROW = {
+  conversationId: 'conv-2', title: null, type: 'page', contextId: 'agent-1',
+  lastMessageAt: new Date('2026-07-26'), createdAt: new Date('2026-07-25'),
+  sessionId: null, sessionName: null, sessionEndedAt: null, pageTitle: 'My Agent', driveId: 'drive-1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listAllConversationsPaginated', () => {
+  it('derives agentPageId from contextId ONLY for type === "page"', async () => {
+    queueResponse([GLOBAL_ROW, PAGE_ROW]);
+
+    const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { limit: 20 });
+
+    expect(result.conversations[0]).toMatchObject({ conversationId: 'conv-1', agentPageId: null });
+    expect(result.conversations[1]).toMatchObject({ conversationId: 'conv-2', agentPageId: 'agent-1' });
+  });
+
+  it('passes every joined field through unchanged', async () => {
+    queueResponse([PAGE_ROW]);
+
+    const result = await listAllConversationsPaginated({ ownerId: 'user-1' });
+
+    expect(result.conversations[0]).toEqual({
+      conversationId: 'conv-2',
+      title: null,
+      type: 'page',
+      agentPageId: 'agent-1',
+      pageTitle: 'My Agent',
+      lastMessageAt: PAGE_ROW.lastMessageAt,
+      createdAt: PAGE_ROW.createdAt,
+      sessionId: null,
+      sessionName: null,
+      sessionEndedAt: null,
+      driveId: 'drive-1',
+    });
+  });
+
+  describe('pagination math', () => {
+    it('no cursor: fetches maxLimit + 1 rows in one query, no cursor lookup', async () => {
+      queueResponse([GLOBAL_ROW]);
+
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { limit: 20 });
+
+      expect(result.pagination).toEqual({ hasMore: false, nextCursor: null, limit: 20 });
+      // Exactly one query ran (no separate cursor-lookup round trip).
+      expect(mockDb.db.limit).toHaveBeenCalledTimes(1);
+      expect(mockDb.db.limit).toHaveBeenCalledWith(21);
+    });
+
+    it('exactly maxLimit rows returned: hasMore is false, nextCursor is null', async () => {
+      queueResponse(Array.from({ length: 20 }, (_, i) => ({ ...GLOBAL_ROW, conversationId: `conv-${i}` })));
+
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { limit: 20 });
+
+      expect(result.conversations).toHaveLength(20);
+      expect(result.pagination.hasMore).toBe(false);
+      expect(result.pagination.nextCursor).toBeNull();
+    });
+
+    it('maxLimit + 1 rows returned: hasMore is true, the extra row is dropped, nextCursor is the LAST kept row', async () => {
+      const rows = Array.from({ length: 21 }, (_, i) => ({ ...GLOBAL_ROW, conversationId: `conv-${i}` }));
+      queueResponse(rows);
+
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { limit: 20 });
+
+      expect(result.conversations).toHaveLength(20);
+      expect(result.pagination.hasMore).toBe(true);
+      expect(result.pagination.nextCursor).toBe('conv-19');
+    });
+
+    it('with a cursor: looks it up first (one extra round trip), then runs the main query', async () => {
+      queueResponse([{ sortKey: new Date('2026-07-27'), id: 'conv-cursor' }]); // cursor lookup
+      queueResponse([GLOBAL_ROW]); // main query
+
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { cursor: 'conv-cursor', limit: 20 });
+
+      expect(mockDb.db.limit).toHaveBeenCalledTimes(2);
+      expect(mockDb.db.limit).toHaveBeenNthCalledWith(1, 1); // cursor lookup: limit(1)
+      expect(mockDb.db.limit).toHaveBeenNthCalledWith(2, 21); // main query: limit(maxLimit + 1)
+      expect(result.conversations).toEqual([expect.objectContaining({ conversationId: 'conv-1' })]);
+    });
+
+    it('a cursor that resolves to nothing (deleted/foreign id) is silently ignored — not an error', async () => {
+      queueResponse([]); // cursor lookup finds no row
+      queueResponse([GLOBAL_ROW]); // main query still runs, unfiltered by cursor
+
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { cursor: 'conv-gone' });
+
+      expect(result.conversations).toHaveLength(1);
+    });
+
+    it('clamps limit into [1, 100]', async () => {
+      queueResponse([]);
+      await listAllConversationsPaginated({ ownerId: 'user-1' }, { limit: 500 });
+      expect(mockDb.db.limit).toHaveBeenCalledWith(101);
+
+      vi.clearAllMocks();
+      queueResponse([]);
+      await listAllConversationsPaginated({ ownerId: 'user-1' }, { limit: -5 });
+      expect(mockDb.db.limit).toHaveBeenCalledWith(2);
+    });
+  });
+});

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
@@ -12,9 +12,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@pagespace/db/db', () => {
   // A single chainable stub: every non-terminal call returns itself, and
-  // `.limit()` is the ONE terminal method for both queries this module runs
-  // (the cursor lookup ends `.where().limit(1)`; the main query ends
-  // `.where().orderBy().limit(n)`) — a round-robin queue of canned responses,
+  // `.limit()` is the terminal method for the one query this module runs per
+  // call (the cursor is decoded synchronously, not looked up in the DB — see
+  // encodeCursor/decodeCursor) — a round-robin queue of canned responses,
   // consumed in call order, needs no per-query-shape branching.
   const responses: unknown[][] = [];
   const chain = {
@@ -54,7 +54,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 }));
 
 import * as dbModule from '@pagespace/db/db';
-import { listAllConversationsPaginated } from '../agent-sessions-conversations-runtime';
+import { listAllConversationsPaginated, encodeCursor, decodeCursor } from '../agent-sessions-conversations-runtime';
 
 // The real `@pagespace/db/db` module only exports `db`, typed as
 // `NodePgDatabase<...>` (no `.limit()` of its own — only through a real query
@@ -66,12 +66,12 @@ const queueResponse = (rows: unknown[]) => mockDb.__queueResponse(rows);
 
 const GLOBAL_ROW = {
   conversationId: 'conv-1', title: 'Chat', type: 'global', contextId: null,
-  lastMessageAt: new Date('2026-07-28'), createdAt: new Date('2026-07-27'),
+  lastMessageAt: new Date('2026-07-28'), sortKeyValue: new Date('2026-07-28'), createdAt: new Date('2026-07-27'),
   sessionId: null, sessionName: null, sessionEndedAt: null, pageTitle: null, driveId: null,
 };
 const PAGE_ROW = {
   conversationId: 'conv-2', title: null, type: 'page', contextId: 'agent-1',
-  lastMessageAt: new Date('2026-07-26'), createdAt: new Date('2026-07-25'),
+  lastMessageAt: new Date('2026-07-26'), sortKeyValue: new Date('2026-07-26'), createdAt: new Date('2026-07-25'),
   sessionId: null, sessionName: null, sessionEndedAt: null, pageTitle: 'My Agent', driveId: 'drive-1',
 };
 
@@ -131,7 +131,7 @@ describe('listAllConversationsPaginated', () => {
       expect(result.pagination.nextCursor).toBeNull();
     });
 
-    it('maxLimit + 1 rows returned: hasMore is true, the extra row is dropped, nextCursor is the LAST kept row', async () => {
+    it('maxLimit + 1 rows returned: hasMore is true, the extra row is dropped, nextCursor encodes the LAST kept row', async () => {
       const rows = Array.from({ length: 21 }, (_, i) => ({ ...GLOBAL_ROW, conversationId: `conv-${i}` }));
       queueResponse(rows);
 
@@ -139,27 +139,32 @@ describe('listAllConversationsPaginated', () => {
 
       expect(result.conversations).toHaveLength(20);
       expect(result.pagination.hasMore).toBe(true);
-      expect(result.pagination.nextCursor).toBe('conv-19');
+      expect(result.pagination.nextCursor).not.toBeNull();
+      expect(decodeCursor(result.pagination.nextCursor!)).toEqual({ sortKey: GLOBAL_ROW.sortKeyValue, id: 'conv-19' });
     });
 
-    it('with a cursor: looks it up first (one extra round trip), then runs the main query', async () => {
-      queueResponse([{ sortKey: new Date('2026-07-27'), id: 'conv-cursor' }]); // cursor lookup
-      queueResponse([GLOBAL_ROW]); // main query
+    it('with a cursor: decodes it synchronously (no extra DB round trip) and runs one query', async () => {
+      const cursor = encodeCursor(new Date('2026-07-27'), 'conv-cursor');
+      queueResponse([GLOBAL_ROW]); // the one and only query
 
-      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { cursor: 'conv-cursor', limit: 20 });
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { cursor, limit: 20 });
 
-      expect(mockDb.db.limit).toHaveBeenCalledTimes(2);
-      expect(mockDb.db.limit).toHaveBeenNthCalledWith(1, 1); // cursor lookup: limit(1)
-      expect(mockDb.db.limit).toHaveBeenNthCalledWith(2, 21); // main query: limit(maxLimit + 1)
+      // Exactly one query ran — no separate cursor-lookup round trip against
+      // LIVE data (review finding: re-deriving the boundary from mutable
+      // chat_messages let a concurrent message shift it forward, re-admitting
+      // already-shown rows, or — if the cursor row vanished — apply no
+      // boundary at all).
+      expect(mockDb.db.limit).toHaveBeenCalledTimes(1);
+      expect(mockDb.db.limit).toHaveBeenCalledWith(21);
       expect(result.conversations).toEqual([expect.objectContaining({ conversationId: 'conv-1' })]);
     });
 
-    it('a cursor that resolves to nothing (deleted/foreign id) is silently ignored — not an error', async () => {
-      queueResponse([]); // cursor lookup finds no row
-      queueResponse([GLOBAL_ROW]); // main query still runs, unfiltered by cursor
+    it('a malformed/tampered cursor is silently ignored — not an error', async () => {
+      queueResponse([GLOBAL_ROW]); // the query still runs, unfiltered by cursor
 
-      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { cursor: 'conv-gone' });
+      const result = await listAllConversationsPaginated({ ownerId: 'user-1' }, { cursor: 'not-valid-base64url-json' });
 
+      expect(mockDb.db.limit).toHaveBeenCalledTimes(1);
       expect(result.conversations).toHaveLength(1);
     });
 

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
@@ -30,6 +30,7 @@ vi.mock('@pagespace/db/db', () => {
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((col, val) => ({ op: 'eq', col, val })),
   and: vi.fn((...args) => ({ op: 'and', args })),
+  or: vi.fn((...args) => ({ op: 'or', args })),
   desc: vi.fn((field) => ({ op: 'desc', field })),
   sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ op: 'sql', strings, values })),
   exists: vi.fn((sub) => ({ op: 'exists', sub })),
@@ -49,6 +50,7 @@ vi.mock('@pagespace/db/schema/agent-sessions', () => ({
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'pages.id', title: 'pages.title', driveId: 'pages.driveId' },
+  chatMessages: { pageId: 'chatMessages.pageId', conversationId: 'chatMessages.conversationId', isActive: 'chatMessages.isActive' },
 }));
 
 import * as dbModule from '@pagespace/db/db';

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-conversations-runtime.test.ts
@@ -140,7 +140,14 @@ describe('listAllConversationsPaginated', () => {
       expect(result.conversations).toHaveLength(20);
       expect(result.pagination.hasMore).toBe(true);
       expect(result.pagination.nextCursor).not.toBeNull();
-      expect(decodeCursor(result.pagination.nextCursor!)).toEqual({ sortKey: GLOBAL_ROW.sortKeyValue, id: 'conv-19' });
+      // A string, not the `Date` instance the fixture holds: `decodeCursor`
+      // returns the sort key exactly as encoded, so a caller re-deriving a
+      // `Date` from it (as this fixture's own `sortKeyValue` is) would
+      // silently truncate any sub-millisecond precision right back out.
+      expect(decodeCursor(result.pagination.nextCursor!)).toEqual({
+        sortKey: GLOBAL_ROW.sortKeyValue.toISOString(),
+        id: 'conv-19',
+      });
     });
 
     it('with a cursor: decodes it synchronously (no extra DB round trip) and runs one query', async () => {

--- a/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
@@ -124,10 +124,55 @@ const recencyExpr = sql<Date | null>`COALESCE(
  * conversation can have zero messages yet — recency null — and still needs a
  * sensible position (its own creation time).
  */
-const sortKeyExpr = sql`COALESCE(${recencyExpr}, ${conversations.createdAt})`;
+const sortKeyExpr = sql<Date>`COALESCE(${recencyExpr}, ${conversations.createdAt})`;
 
 /** `pages.driveId` for a page conversation, `agentSessions.driveId` for a session-bound one, the conversation's own contextId for a `type: 'client'` one (that column holds an optional driveId for API-managed conversations — see `buildCreateConversationPayload`) — else null (a driveless global-assistant conversation). */
 const resolvedDriveIdExpr = sql<string | null>`COALESCE(${pages.driveId}, ${agentSessions.driveId}, CASE WHEN ${conversations.type} = 'client' THEN ${conversations.contextId} ELSE NULL END)`;
+
+/**
+ * The cursor is an OPAQUE token encoding the sort key the caller last saw —
+ * NOT just a bare conversationId re-resolved against LIVE data. `sortKeyExpr`
+ * is derived from `chat_messages`, which can change between one page fetch
+ * and the next: if the cursor conversation receives a new message in that
+ * window, re-deriving its sortKey fresh would shift the boundary FORWARD,
+ * re-admitting rows already shown on the previous page. Worse, if the cursor
+ * row disappeared entirely (deleted), a live re-lookup finds nothing and
+ * silently applies no boundary at all, returning page one again instead of
+ * the requested next page (review finding). Freezing the observed sort key
+ * into the cursor itself removes the live dependency — and the extra DB
+ * round-trip a live lookup needed — entirely.
+ */
+export function encodeCursor(sortKey: Date | string, id: string): string {
+  // The driver doesn't hydrate a raw computed SQL expression into a real
+  // `Date` the way it does a schema-known timestamp COLUMN (confirmed
+  // against real Postgres: `sortKeyExpr`'s runtime value is a string despite
+  // its `sql<Date>` type) — normalize defensively rather than trust the type.
+  const date = sortKey instanceof Date ? sortKey : new Date(sortKey);
+  return Buffer.from(JSON.stringify({ sortKey: date.toISOString(), id })).toString('base64url');
+}
+
+export function decodeCursor(cursor: string): { sortKey: Date; id: string } | null {
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as { sortKey?: unknown }).sortKey !== 'string' ||
+      typeof (parsed as { id?: unknown }).id !== 'string'
+    ) {
+      return null;
+    }
+    const sortKey = new Date((parsed as { sortKey: string }).sortKey);
+    if (Number.isNaN(sortKey.getTime())) return null;
+    return { sortKey, id: (parsed as { id: string }).id };
+  } catch {
+    // Malformed/tampered cursor — same treatment as a cursor whose id no
+    // longer resolves to anything: ignored, not an error (fails open to
+    // page one, consistent with how this listing already treats an unknown
+    // cursor id).
+    return null;
+  }
+}
 
 /**
  * Cursor pagination is unidirectional ("older than `cursor`") on purpose —
@@ -174,15 +219,10 @@ export async function listAllConversationsPaginated(
   }
 
   if (cursor) {
-    const [cursorRow] = await db
-      .select({ sortKey: sortKeyExpr, id: conversations.id })
-      .from(conversations)
-      .where(eq(conversations.id, cursor))
-      .limit(1);
-
-    if (cursorRow) {
+    const decoded = decodeCursor(cursor);
+    if (decoded) {
       conditions.push(
-        sql`(${sortKeyExpr} < ${cursorRow.sortKey} OR (${sortKeyExpr} = ${cursorRow.sortKey} AND ${conversations.id} < ${cursorRow.id}))`,
+        sql`(${sortKeyExpr} < ${decoded.sortKey} OR (${sortKeyExpr} = ${decoded.sortKey} AND ${conversations.id} < ${decoded.id}))`,
       );
     }
   }
@@ -194,6 +234,7 @@ export async function listAllConversationsPaginated(
       type: conversations.type,
       contextId: conversations.contextId,
       lastMessageAt: recencyExpr,
+      sortKeyValue: sortKeyExpr,
       createdAt: conversations.createdAt,
       sessionId: conversations.sessionId,
       sessionName: agentSessions.name,
@@ -210,6 +251,7 @@ export async function listAllConversationsPaginated(
 
   const hasMore = rows.length > maxLimit;
   const page = hasMore ? rows.slice(0, maxLimit) : rows;
+  const lastRow = page.length > 0 ? page[page.length - 1] : null;
 
   return {
     conversations: page.map((row) => ({
@@ -227,7 +269,7 @@ export async function listAllConversationsPaginated(
     })),
     pagination: {
       hasMore,
-      nextCursor: hasMore && page.length > 0 ? page[page.length - 1].conversationId : null,
+      nextCursor: hasMore && lastRow ? encodeCursor(lastRow.sortKeyValue, lastRow.conversationId) : null,
       limit: maxLimit,
     },
   };

--- a/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
@@ -145,13 +145,22 @@ const resolvedDriveIdExpr = sql<string | null>`COALESCE(${pages.driveId}, ${agen
 export function encodeCursor(sortKey: Date | string, id: string): string {
   // The driver doesn't hydrate a raw computed SQL expression into a real
   // `Date` the way it does a schema-known timestamp COLUMN (confirmed
-  // against real Postgres: `sortKeyExpr`'s runtime value is a string despite
-  // its `sql<Date>` type) — normalize defensively rather than trust the type.
-  const date = sortKey instanceof Date ? sortKey : new Date(sortKey);
-  return Buffer.from(JSON.stringify({ sortKey: date.toISOString(), id })).toString('base64url');
+  // against real Postgres via drizzle's own query builder: `sortKeyExpr`'s
+  // runtime value is a STRING, e.g. `"2026-07-28 12:00:00.123456"`, with full
+  // microsecond precision — Postgres timestamps carry six fractional digits,
+  // a plain JS `Date` only three). Round-tripping that string through
+  // `new Date(...).toISOString()` truncates it to milliseconds — verified
+  // against the real test DB that this silently collapses two distinct
+  // sub-millisecond sort keys onto the same encoded value, making the next
+  // page's boundary re-admit a row it should have excluded (review finding).
+  // Preserve a string AS GIVEN; only a genuine `Date` (e.g. a plain
+  // `createdAt` fallback, which is already millisecond-limited at the
+  // column level) goes through `toISOString()`.
+  const encoded = typeof sortKey === 'string' ? sortKey : sortKey.toISOString();
+  return Buffer.from(JSON.stringify({ sortKey: encoded, id })).toString('base64url');
 }
 
-export function decodeCursor(cursor: string): { sortKey: Date; id: string } | null {
+export function decodeCursor(cursor: string): { sortKey: string; id: string } | null {
   try {
     const parsed: unknown = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
     if (
@@ -162,8 +171,11 @@ export function decodeCursor(cursor: string): { sortKey: Date; id: string } | nu
     ) {
       return null;
     }
-    const sortKey = new Date((parsed as { sortKey: string }).sortKey);
-    if (Number.isNaN(sortKey.getTime())) return null;
+    const sortKey = (parsed as { sortKey: string }).sortKey;
+    // Validate it's a real, parseable timestamp — but return the ORIGINAL
+    // string, not a `new Date(sortKey)` reconstruction, which would
+    // re-truncate any sub-millisecond precision right back out again.
+    if (Number.isNaN(new Date(sortKey).getTime())) return null;
     return { sortKey, id: (parsed as { id: string }).id };
   } catch {
     // Malformed/tampered cursor — same treatment as a cursor whose id no

--- a/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
@@ -1,0 +1,166 @@
+/**
+ * Cross-type "past conversations" listing for the Agents surface's default
+ * middle-panel view — every conversation the requester owns, whatever kind it
+ * is (ran inside an agent-sandbox session, a plain page-agent chat, the
+ * global assistant, or the rare API-only `type: 'drive'` conversation), newest
+ * first, with real cursor pagination (agent_sessions rows are never deleted,
+ * so history grows unbounded over a user's lifetime — the same reason
+ * `globalConversationRepository.listConversationsPaginated` exists rather
+ * than a single unbounded fetch).
+ *
+ * Deliberately lives beside (not inside) `agent-sessions-runtime.ts`: that
+ * file wires the session STORE abstraction; this is a plain cross-table read
+ * with no session-lifecycle decision in it, mirroring how
+ * `listSessionConversationsBulk` already queries `conversations` directly
+ * rather than through the store.
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, desc, eq, exists, isNotNull, sql } from '@pagespace/db/operators';
+import { conversations, messages } from '@pagespace/db/schema/conversations';
+import { agentSessions } from '@pagespace/db/schema/agent-sessions';
+import { pages } from '@pagespace/db/schema/core';
+
+export interface PastConversationRow {
+  conversationId: string;
+  title: string | null;
+  type: string;
+  /** The page id when `type === 'page'`, else null. */
+  agentPageId: string | null;
+  /** The agent page's own title (distinct from the conversation's own title), when `type === 'page'`. */
+  pageTitle: string | null;
+  lastMessageAt: Date | null;
+  createdAt: Date;
+  sessionId: string | null;
+  /** '' when the session has no display name, mirroring `toAgentSessionDTO`'s `name ?? ''`. */
+  sessionName: string | null;
+  sessionEndedAt: Date | null;
+  /** Resolved from the page's drive, the session's drive, or (for `type: 'drive'`) the conversation's own contextId. Null only for a driveless global-assistant conversation. */
+  driveId: string | null;
+}
+
+export interface ListAllConversationsPaginatedInput {
+  limit?: number;
+  cursor?: string;
+  direction?: 'before' | 'after';
+}
+
+export interface PaginatedPastConversationsResult {
+  conversations: PastConversationRow[];
+  pagination: {
+    hasMore: boolean;
+    nextCursor: string | null;
+    prevCursor: string | null;
+    limit: number;
+  };
+}
+
+/** Keeps conversations that never got a first message out of "history" — same rule `globalConversationRepository` applies. */
+const hasActiveMessage = exists(
+  db
+    .select({ one: sql`1` })
+    .from(messages)
+    .where(and(eq(messages.conversationId, conversations.id), eq(messages.isActive, true))),
+);
+
+/**
+ * The sort/cursor key. NOT just `lastMessageAt`: unlike the global-chat
+ * listing (which only ever lists conversations already known to have
+ * messages), a brand-new agent-session conversation can have zero messages
+ * yet — `lastMessageAt` null — and still needs a sensible recency position.
+ */
+const sortKeyExpr = sql`COALESCE(${conversations.lastMessageAt}, ${conversations.createdAt})`;
+
+/** `pages.driveId` for a page conversation, `agentSessions.driveId` for a session-bound one, the conversation's own contextId for a `type: 'drive'` one — else null (a driveless global-assistant conversation). */
+const resolvedDriveIdExpr = sql<string | null>`COALESCE(${pages.driveId}, ${agentSessions.driveId}, CASE WHEN ${conversations.type} = 'drive' THEN ${conversations.contextId} ELSE NULL END)`;
+
+export async function listAllConversationsPaginated(
+  filter: { ownerId: string; driveId?: string },
+  options: ListAllConversationsPaginatedInput = {},
+): Promise<PaginatedPastConversationsResult> {
+  const { limit = 20, cursor, direction = 'before' } = options;
+  const maxLimit = Math.min(Math.max(limit, 1), 100);
+
+  const conditions = [
+    eq(conversations.userId, filter.ownerId),
+    eq(conversations.isActive, true),
+    hasActiveMessage,
+  ];
+
+  // Deliberately NOT filtering out `closedInSessionAt IS NOT NULL` here: a
+  // conversation closed from its session is still valid past-conversation
+  // HISTORY, just no longer part of the session's LIVE tree — that exclusion
+  // belongs to `listSessionConversationsBulk` (the sidebar), not this listing.
+
+  if (filter.driveId) {
+    const driveId = filter.driveId;
+    // A driveless global-assistant conversation is never shown in drive-scoped
+    // mode — there is no drive for it to belong to.
+    conditions.push(sql`(
+      (${conversations.type} = 'page' AND ${pages.driveId} = ${driveId})
+      OR (${isNotNull(conversations.sessionId)} AND ${agentSessions.driveId} = ${driveId})
+      OR (${conversations.type} = 'drive' AND ${conversations.contextId} = ${driveId})
+    )`);
+  }
+
+  if (cursor) {
+    const [cursorRow] = await db
+      .select({ sortKey: sortKeyExpr, id: conversations.id })
+      .from(conversations)
+      .where(eq(conversations.id, cursor))
+      .limit(1);
+
+    if (cursorRow) {
+      const comparator = direction === 'before' ? sql`<` : sql`>`;
+      conditions.push(
+        sql`(${sortKeyExpr} ${comparator} ${cursorRow.sortKey} OR (${sortKeyExpr} = ${cursorRow.sortKey} AND ${conversations.id} ${comparator} ${cursorRow.id}))`,
+      );
+    }
+  }
+
+  const rows = await db
+    .select({
+      conversationId: conversations.id,
+      title: conversations.title,
+      type: conversations.type,
+      contextId: conversations.contextId,
+      lastMessageAt: conversations.lastMessageAt,
+      createdAt: conversations.createdAt,
+      sessionId: conversations.sessionId,
+      sessionName: agentSessions.name,
+      sessionEndedAt: agentSessions.endedAt,
+      pageTitle: pages.title,
+      driveId: resolvedDriveIdExpr,
+    })
+    .from(conversations)
+    .leftJoin(agentSessions, eq(conversations.sessionId, agentSessions.id))
+    .leftJoin(pages, and(eq(conversations.contextId, pages.id), eq(conversations.type, 'page')))
+    .where(and(...conditions))
+    .orderBy(desc(sortKeyExpr), desc(conversations.id))
+    .limit(maxLimit + 1);
+
+  const hasMore = rows.length > maxLimit;
+  const page = hasMore ? rows.slice(0, maxLimit) : rows;
+
+  return {
+    conversations: page.map((row) => ({
+      conversationId: row.conversationId,
+      title: row.title,
+      type: row.type,
+      agentPageId: row.type === 'page' ? row.contextId : null,
+      pageTitle: row.pageTitle,
+      lastMessageAt: row.lastMessageAt,
+      createdAt: row.createdAt,
+      sessionId: row.sessionId,
+      sessionName: row.sessionName,
+      sessionEndedAt: row.sessionEndedAt,
+      driveId: row.driveId,
+    })),
+    pagination: {
+      hasMore,
+      nextCursor: hasMore && page.length > 0 ? page[page.length - 1].conversationId : null,
+      prevCursor: page.length > 0 && cursor ? page[0].conversationId : null,
+      limit: maxLimit,
+    },
+  };
+}

--- a/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
@@ -2,9 +2,10 @@
  * Cross-type "past conversations" listing for the Agents surface's default
  * middle-panel view — every conversation the requester owns, whatever kind it
  * is (ran inside an agent-sandbox session, a plain page-agent chat, the
- * global assistant, or the rare API-only `type: 'drive'` conversation), newest
- * first, with real cursor pagination (agent_sessions rows are never deleted,
- * so history grows unbounded over a user's lifetime — the same reason
+ * global assistant, or the rare API-only `type: 'client'` conversation
+ * created via `POST /api/v1/conversations`), newest first, with real cursor
+ * pagination (agent_sessions rows are never deleted, so history grows
+ * unbounded over a user's lifetime — the same reason
  * `globalConversationRepository.listConversationsPaginated` exists rather
  * than a single unbounded fetch).
  *
@@ -29,13 +30,14 @@ export interface PastConversationRow {
   agentPageId: string | null;
   /** The agent page's own title (distinct from the conversation's own title), when `type === 'page'`. */
   pageTitle: string | null;
+  /** Real recency — see `recencyExpr` below. Never simply `conversations.lastMessageAt`, which stays null forever for `type: 'page'`. */
   lastMessageAt: Date | null;
   createdAt: Date;
   sessionId: string | null;
   /** '' when the session has no display name, mirroring `toAgentSessionDTO`'s `name ?? ''`. */
   sessionName: string | null;
   sessionEndedAt: Date | null;
-  /** Resolved from the page's drive, the session's drive, or (for `type: 'drive'`) the conversation's own contextId. Null only for a driveless global-assistant conversation. */
+  /** Resolved from the page's drive, the session's drive, or (for `type: 'client'`) the conversation's own contextId. Null only for a driveless global-assistant conversation. */
   driveId: string | null;
 }
 
@@ -58,15 +60,20 @@ export interface PaginatedPastConversationsResult {
  * Keeps conversations that never got a first message out of "history" — same
  * rule `globalConversationRepository` applies. NOT a single table: despite
  * `messages`' own doc comment claiming to be "unified... for all conversation
- * types", only `type: 'global'` (and, so far as this codebase shows, `type:
- * 'drive'`) content actually lands there — `type: 'page'` conversations
- * (including session-bound agent chats, which share the same page-agent send
- * path) write to the older `chat_messages` table instead, keyed by `pageId` +
- * a local `conversationId` grouping column (never an FK to `conversations.id`,
- * but the same value `conversations.id` holds for that row — see
- * `conversationRepository.conversationExists`, which queries it the same way).
- * Checking only `messages` here silently excluded every page-agent
- * conversation with real content from this listing (review finding).
+ * types", only `type: 'global'` content actually lands there — `type: 'page'`
+ * AND `type: 'client'` conversations write to the older `chat_messages` table
+ * instead (both share the same underlying send path,
+ * `saveMessageToDatabase`/`chatMessageRepository`). Checking only `messages`
+ * here silently excluded every one of those conversations from this listing
+ * (review finding).
+ *
+ * Matched on `chatMessages.conversationId` ALONE — no `pageId` join. A
+ * `type: 'client'` conversation's `chat_messages` rows can carry a DIFFERENT
+ * `pageId` per message (the v1 completions API lets each request target a
+ * different agent page; only `conversationId` scopes a thread), so a `pageId`
+ * equality would just never match for that type. `conversationId` is a
+ * cuid2 — already globally unique — so it never needed the extra key even
+ * for `type: 'page'`.
  */
 const hasActiveMessage = or(
   exists(
@@ -81,25 +88,46 @@ const hasActiveMessage = or(
       .from(chatMessages)
       .where(
         and(
-          eq(conversations.type, 'page'),
           eq(chatMessages.conversationId, conversations.id),
-          eq(chatMessages.pageId, conversations.contextId),
           eq(chatMessages.isActive, true),
+          sql`${chatMessages.status} != 'streaming'`,
         ),
       ),
   ),
 )!;
 
 /**
- * The sort/cursor key. NOT just `lastMessageAt`: unlike the global-chat
- * listing (which only ever lists conversations already known to have
- * messages), a brand-new agent-session conversation can have zero messages
- * yet — `lastMessageAt` null — and still needs a sensible recency position.
+ * The real "last activity" timestamp — NOT `conversations.lastMessageAt`,
+ * which nothing ever sets for `type: 'page'`/`type: 'client'` conversations
+ * (their send path writes only `chat_messages`; grepping every
+ * `.set({...lastMessageAt...})` call in this codebase turns up exactly two
+ * call sites, both in the global-assistant message routes). Sorting or
+ * displaying recency by `conversations.lastMessageAt` alone left every
+ * page-agent conversation permanently ordered by its CREATION time, however
+ * recently it was actually used (review finding). Mirrors
+ * `conversationRepository.listConversations`'s own `MAX(chat_messages."createdAt")
+ * GROUP BY "conversationId"` derivation, as a correlated subquery here since
+ * this listing needs ONE sortable expression across heterogeneous source
+ * tables. Falls back to `conversations.lastMessageAt` for `type: 'global'`
+ * rows (where that column IS the source of truth).
  */
-const sortKeyExpr = sql`COALESCE(${conversations.lastMessageAt}, ${conversations.createdAt})`;
+const recencyExpr = sql<Date | null>`COALESCE(
+  (SELECT MAX(${chatMessages.createdAt}) FROM chat_messages
+   WHERE ${chatMessages.conversationId} = ${conversations.id}
+     AND ${chatMessages.isActive} = true
+     AND ${chatMessages.status} != 'streaming'),
+  ${conversations.lastMessageAt}
+)`;
 
-/** `pages.driveId` for a page conversation, `agentSessions.driveId` for a session-bound one, the conversation's own contextId for a `type: 'drive'` one — else null (a driveless global-assistant conversation). */
-const resolvedDriveIdExpr = sql<string | null>`COALESCE(${pages.driveId}, ${agentSessions.driveId}, CASE WHEN ${conversations.type} = 'drive' THEN ${conversations.contextId} ELSE NULL END)`;
+/**
+ * The sort/cursor key. NOT just `recencyExpr`: a brand-new agent-session
+ * conversation can have zero messages yet — recency null — and still needs a
+ * sensible position (its own creation time).
+ */
+const sortKeyExpr = sql`COALESCE(${recencyExpr}, ${conversations.createdAt})`;
+
+/** `pages.driveId` for a page conversation, `agentSessions.driveId` for a session-bound one, the conversation's own contextId for a `type: 'client'` one (that column holds an optional driveId for API-managed conversations — see `buildCreateConversationPayload`) — else null (a driveless global-assistant conversation). */
+const resolvedDriveIdExpr = sql<string | null>`COALESCE(${pages.driveId}, ${agentSessions.driveId}, CASE WHEN ${conversations.type} = 'client' THEN ${conversations.contextId} ELSE NULL END)`;
 
 /**
  * Cursor pagination is unidirectional ("older than `cursor`") on purpose —
@@ -141,7 +169,7 @@ export async function listAllConversationsPaginated(
     conditions.push(sql`(
       (${conversations.type} = 'page' AND ${pages.driveId} = ${driveId})
       OR (${isNotNull(conversations.sessionId)} AND ${agentSessions.driveId} = ${driveId})
-      OR (${conversations.type} = 'drive' AND ${conversations.contextId} = ${driveId})
+      OR (${conversations.type} = 'client' AND ${conversations.contextId} = ${driveId})
     )`);
   }
 
@@ -165,7 +193,7 @@ export async function listAllConversationsPaginated(
       title: conversations.title,
       type: conversations.type,
       contextId: conversations.contextId,
-      lastMessageAt: conversations.lastMessageAt,
+      lastMessageAt: recencyExpr,
       createdAt: conversations.createdAt,
       sessionId: conversations.sessionId,
       sessionName: agentSessions.name,

--- a/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
@@ -41,8 +41,8 @@ export interface PastConversationRow {
 
 export interface ListAllConversationsPaginatedInput {
   limit?: number;
+  /** Always "older than this conversation" — see `listAllConversationsPaginated`'s doc comment for why there is no `after` direction. */
   cursor?: string;
-  direction?: 'before' | 'after';
 }
 
 export interface PaginatedPastConversationsResult {
@@ -50,7 +50,6 @@ export interface PaginatedPastConversationsResult {
   pagination: {
     hasMore: boolean;
     nextCursor: string | null;
-    prevCursor: string | null;
     limit: number;
   };
 }
@@ -74,11 +73,26 @@ const sortKeyExpr = sql`COALESCE(${conversations.lastMessageAt}, ${conversations
 /** `pages.driveId` for a page conversation, `agentSessions.driveId` for a session-bound one, the conversation's own contextId for a `type: 'drive'` one — else null (a driveless global-assistant conversation). */
 const resolvedDriveIdExpr = sql<string | null>`COALESCE(${pages.driveId}, ${agentSessions.driveId}, CASE WHEN ${conversations.type} = 'drive' THEN ${conversations.contextId} ELSE NULL END)`;
 
+/**
+ * Cursor pagination is unidirectional ("older than `cursor`") on purpose —
+ * not a `direction: 'before' | 'after'` toggle like
+ * `globalConversationRepository.listConversationsPaginated`'s. This listing's
+ * only consumer (`AgentsPastConversationsList`) never asks to go "forward":
+ * its Prev button replays an already-fetched, SWR-cached earlier page rather
+ * than re-querying the server. An `after` branch would need the ORDER BY
+ * direction inverted (ascending toward the cursor, then reversed back to
+ * descending for display) to return the page truly adjacent to the cursor —
+ * a real algorithm this listing has no caller to exercise or verify, so it
+ * doesn't exist here rather than existing unverified and wrong (caught in
+ * review: an earlier version reused the `>` comparator under an unchanged
+ * `ORDER BY ... DESC`, which returns the globally newest matches instead of
+ * the page adjacent to the cursor).
+ */
 export async function listAllConversationsPaginated(
   filter: { ownerId: string; driveId?: string },
   options: ListAllConversationsPaginatedInput = {},
 ): Promise<PaginatedPastConversationsResult> {
-  const { limit = 20, cursor, direction = 'before' } = options;
+  const { limit = 20, cursor } = options;
   const maxLimit = Math.min(Math.max(limit, 1), 100);
 
   const conditions = [
@@ -111,9 +125,8 @@ export async function listAllConversationsPaginated(
       .limit(1);
 
     if (cursorRow) {
-      const comparator = direction === 'before' ? sql`<` : sql`>`;
       conditions.push(
-        sql`(${sortKeyExpr} ${comparator} ${cursorRow.sortKey} OR (${sortKeyExpr} = ${cursorRow.sortKey} AND ${conversations.id} ${comparator} ${cursorRow.id}))`,
+        sql`(${sortKeyExpr} < ${cursorRow.sortKey} OR (${sortKeyExpr} = ${cursorRow.sortKey} AND ${conversations.id} < ${cursorRow.id}))`,
       );
     }
   }
@@ -159,7 +172,6 @@ export async function listAllConversationsPaginated(
     pagination: {
       hasMore,
       nextCursor: hasMore && page.length > 0 ? page[page.length - 1].conversationId : null,
-      prevCursor: page.length > 0 && cursor ? page[0].conversationId : null,
       limit: maxLimit,
     },
   };

--- a/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-conversations-runtime.ts
@@ -16,10 +16,10 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, desc, eq, exists, isNotNull, sql } from '@pagespace/db/operators';
+import { and, desc, eq, exists, isNotNull, or, sql } from '@pagespace/db/operators';
 import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { agentSessions } from '@pagespace/db/schema/agent-sessions';
-import { pages } from '@pagespace/db/schema/core';
+import { pages, chatMessages } from '@pagespace/db/schema/core';
 
 export interface PastConversationRow {
   conversationId: string;
@@ -54,13 +54,41 @@ export interface PaginatedPastConversationsResult {
   };
 }
 
-/** Keeps conversations that never got a first message out of "history" — same rule `globalConversationRepository` applies. */
-const hasActiveMessage = exists(
-  db
-    .select({ one: sql`1` })
-    .from(messages)
-    .where(and(eq(messages.conversationId, conversations.id), eq(messages.isActive, true))),
-);
+/**
+ * Keeps conversations that never got a first message out of "history" — same
+ * rule `globalConversationRepository` applies. NOT a single table: despite
+ * `messages`' own doc comment claiming to be "unified... for all conversation
+ * types", only `type: 'global'` (and, so far as this codebase shows, `type:
+ * 'drive'`) content actually lands there — `type: 'page'` conversations
+ * (including session-bound agent chats, which share the same page-agent send
+ * path) write to the older `chat_messages` table instead, keyed by `pageId` +
+ * a local `conversationId` grouping column (never an FK to `conversations.id`,
+ * but the same value `conversations.id` holds for that row — see
+ * `conversationRepository.conversationExists`, which queries it the same way).
+ * Checking only `messages` here silently excluded every page-agent
+ * conversation with real content from this listing (review finding).
+ */
+const hasActiveMessage = or(
+  exists(
+    db
+      .select({ one: sql`1` })
+      .from(messages)
+      .where(and(eq(messages.conversationId, conversations.id), eq(messages.isActive, true))),
+  ),
+  exists(
+    db
+      .select({ one: sql`1` })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(conversations.type, 'page'),
+          eq(chatMessages.conversationId, conversations.id),
+          eq(chatMessages.pageId, conversations.contextId),
+          eq(chatMessages.isActive, true),
+        ),
+      ),
+  ),
+)!;
 
 /**
  * The sort/cursor key. NOT just `lastMessageAt`: unlike the global-chat


### PR DESCRIPTION
## Summary
- Replace the Agents surface's static "Select a session" placeholder with a paginated list of every past conversation the user owns (sandbox-session conversations, plain page-agent chats, and the global assistant's own history), sorted newest-first — especially useful on mobile/iPad where the sidebar may not be open.
- New cursor-paginated `GET /api/agent-sessions/conversations`, backed by `listAllConversationsPaginated` (joins `conversations` + `agentSessions` + `pages`). Pagination is unidirectional ("older than cursor") — the only direction the list's Prev/Next actually need.
- Row clicks route through a pure, exhaustively-typed `resolveNavigationTarget`: session-bound conversations open in-place in the pane grid; plain page-agent conversations navigate to that agent's page; global-assistant conversations navigate to wherever the global assistant renders.
- `useResolvedConversation` gains an `initialConversationId`/`initialSessionId` deep-link path, and `AgentPageView` reads `?conversationId=`/`?sessionId=` once at mount to support opening an exact past conversation from the new list.
- Page-derived metadata (title, drive) is masked per-row via a batch permission check — app-admin status alone doesn't prove the requester can still view a page whose drive they've since lost access to.
- A failed page-transition fetch keeps the last successful page visible (via SWR's `keepPreviousData`) with an inline notice, rather than stranding the user on a dead-end error screen.

Rebased on top of master's recent cross-drive session-hosting work (`useSessionRecord`, `sessionDriveResolved` gating) — reconciled in the merge commit.

## Test plan
- [x] `bun run --filter web typecheck`
- [x] `bun run --filter web lint` (no new warnings)
- [x] `bun run --filter web build` (production build; confirms both `/dashboard/agents` and `/dashboard/[driveId]/agents` build as fully dynamic routes)
- [x] `bun run --filter web test -- src/components/agents src/app/api/agent-sessions src/lib/agent-sessions` (435 tests passing) — route-level tests (permission masking), runtime unit + real-Postgres integration tests (pagination math, `chat_messages` visibility, recency ordering, `type: 'client'` handling), and `AgentsSurface.test.tsx` coverage for the default list, drive-change reset, failed-fetch recovery, and the `unavailable`-navigation toast.
- [x] All CI checks green (Lint & TypeScript, Unit Tests, Security Test Suite, CodeQL, Static Security Analysis, Dependency Audit, Secret Scanning, CodeRabbit)
- [ ] Manual click-through in the browser as an admin with real history across all conversation kinds (not done in this environment — worth doing before merge)

## Review status
Addressed 5 findings from the automated Codex review, all verified against real Postgres where the fix touched SQL (confirmed each regression test **fails** on the pre-fix code before confirming it passes after):
- **P1**: `hasActiveMessage` only checked the `messages` table, but page-agent conversations (including session-bound ones) write to `chat_messages` instead — silently excluding every real page-agent conversation from the list.
- **P1**: `conversations.lastMessageAt` is never set for page-agent conversations either — the sort/cursor key and displayed recency both silently fell back to creation time. Now derived via a correlated subquery over `chat_messages`, mirroring `conversationRepository.listConversations`'s own approach.
- **P2**: page-permission leak on joined page metadata (app-admin status doesn't prove current page-view access) — fixed via batch permission check + masking.
- **P2**: broken `direction=after` cursor branch — removed rather than fixed, since nothing calls it (pagination is now unidirectional).
- **P2**: an undocumented `type: 'client'` conversation kind (API-managed, via `POST /api/v1/conversations`) wasn't handled — its `contextId` is a driveId (not a pageId), and its `chat_messages` rows carry no fixed `pageId`. Also uncovered that my own `type: 'drive'` handling was checking a type no production code path has ever written — corrected to `'client'`.

And 2 findings from CodeRabbit: stale pagination state on a `driveId` change (fixed via keyed remount); a missing-Suspense-boundary concern verified as a false positive for this app via an actual production build.

Also fixed proactively (self-review, confirmed broken by the `type: 'client'` investigation): an unresolvable page conversation, or any `client` conversation, previously fell back to opening it in the global assistant — confirmed that silently opens a permanently-blank thread (the global loader reads `messages`, which those types never populate). Replaced with an explicit `unavailable` navigation state (row stays visible, click shows an info toast instead of a broken destination).

All threads replied to with specifics; CodeRabbit's own re-scans independently verified and withdrew its two findings.

**Known limitation, not fixed in this PR — tracked in [#2295](https://github.com/2witstudios/PageSpace/issues/2295)**: clicking a *closed-in-session* conversation (deliberately still shown here as valid history) opens it in the pane grid; a **pre-existing** heuristic in `useAgentWorkspaceStore.openConversation` (shared by every pane-opening flow in the app, not new to this PR) can later silently reassign that pane if the same session is reopened through an unrelated path (e.g. the sidebar). No data loss and no access-control impact (confirmed: reading/writing a closed-in-session conversation's transcript isn't gated by that column at all) — just a transient pane-binding eviction, recoverable by reopening it from this list again. Fixing it properly means touching a heavily-tested shared store (`AgentPanes.test.tsx`, 39 existing tests) and deserves its own focused PR rather than a rushed change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8wpNHykqhf8i9nkMhonq5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a paginated list of past conversations to the Agents surface.
  * Added filtering by drive, timestamps, and conversation status.
  * Added navigation across panes, pages, drives, and global chat.
  * Added deep links that open specific conversations and sessions.
  * Added empty states and clearer handling for unavailable conversations.

* **Bug Fixes**
  * Improved conversation selection and navigation for incomplete or session-bound data.
  * Restricted conversation history to authorized content.

* **Tests**
  * Added coverage for history, deep links, pagination, permissions, and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
