### PR TITLE
fix(agents): sidebar scrollbar, pane-picker overlap, Global Assistant in drive spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Global Assistant is no longer unclickable right after splitting a pane in the Agents console** —
+  a short pane's empty-pane picker could crush its "Shell"/"Global Assistant" choices under the
+  "Agents" list below them, so the Global Assistant button visually collided with — and lost clicks
+  to — the section beneath it. The picker's sections no longer shrink below their own content.
+- **The Agents console's session list no longer shows a distracting scrollbar** — the sidebar's
+  left-hand session list now scrolls without ever painting a scrollbar, matching the rest of the
+  console's chrome-free feel.
+- **A Global Assistant conversation started from the global Agents dashboard now keeps the right
+  drive's context** — picking Global Assistant for a specific drive from `/dashboard/agents` (rather
+  than that drive's own Agents page) minted a session correctly scoped to that drive, but the
+  assistant itself had no way to know which drive it was in — it derived that from the current page,
+  and the Agents console never navigates as you click between sessions. It now reads the drive
+  straight from its own session instead.
 - **A database outage no longer takes the whole platform down with it** — when Postgres
   became unreachable (as in the recent OOM stalls), the rate limiter denied every request
   platform-wide, turning a database incident into a total outage. Production now degrades to
@@ -53,6 +66,11 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Start a session with Global Assistant directly from a drive** — clicking "+" on a drive in the
+  Agents console now offers Global Assistant alongside that drive's own agents and Shell, first in
+  the list. The new session is filed under that drive, same as any agent session, rather than only
+  being reachable as a driveless global session. Its default name now also reads "Global Assistant"
+  (was "Assistant") everywhere a session or conversation goes unnamed.
 - **Rotate a webhook secret in place** — the Incoming Webhooks dialog (and
   `POST /api/pages/[pageId]/webhooks/[id]/rotate`) now mints a fresh signing secret for the **same
   webhook URL**, so replacing a lost or leaked secret no longer means deleting the webhook and

--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -203,12 +203,12 @@ describe('POST /api/agent-sessions — spawn', () => {
     // the absence is structural.
   });
 
-  it('spawns a GLOBAL-ASSISTANT session from the both-null shape, auto-naming it "Assistant"', async () => {
+  it('spawns a GLOBAL-ASSISTANT session from the both-null shape, auto-naming it "Global Assistant"', async () => {
     const response = await spawn({});
     expect(response.status).toBe(201);
     const body = await response.json();
     expect(typeof body.conversationId).toBe('string');
-    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null, name: 'Assistant' });
+    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null, name: 'Global Assistant' });
     // The first conversation is an assistant thread: no agent page.
     expect(mockCreateConversationInSession).toHaveBeenCalledWith(
       expect.objectContaining({ agentPageId: null, sessionId: 'ses-new' }),
@@ -220,11 +220,25 @@ describe('POST /api/agent-sessions — spawn', () => {
     );
   });
 
-  it('refuses the half-specified shapes — an agent needs its drive, a drive needs an agent', async () => {
-    for (const body of [{ driveId: 'drive-1' }, { agentPageId: 'agent-1' }]) {
-      const response = await spawn(body);
-      expect(response.status).toBe(400);
-    }
+  it('spawns a DRIVE session from the drive-only shape, first conversation is the assistant', async () => {
+    const response = await spawn({ driveId: 'drive-1' });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(typeof body.conversationId).toBe('string');
+    expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: 'drive-1', name: 'Global Assistant' });
+    expect(mockCreateConversationInSession).toHaveBeenCalledWith(
+      expect.objectContaining({ agentPageId: null, sessionId: 'ses-new' }),
+    );
+    // The access decision saw the DRIVE subject, not the global one.
+    expect(mockCheckAccessForSubject).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ driveId: 'drive-1' }),
+    );
+  });
+
+  it('refuses the one unresolvable shape — an agent without its drive', async () => {
+    const response = await spawn({ agentPageId: 'agent-1' });
+    expect(response.status).toBe(400);
     expect(mockSpawnSession).not.toHaveBeenCalled();
   });
 
@@ -469,11 +483,11 @@ describe('POST /api/agent-sessions — blank name auto-generates a unique one', 
     );
   });
 
-  it('given a blank name for the global-assistant shape, should derive the base label "Assistant"', async () => {
+  it('given a blank name for the global-assistant shape, should derive the base label "Global Assistant"', async () => {
     const response = await spawn({});
     expect(response.status).toBe(201);
     expect(mockSpawnSession).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'Assistant' }),
+      expect.objectContaining({ name: 'Global Assistant' }),
     );
   });
 

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -118,10 +118,17 @@ export async function GET(request: Request) {
  *
  * One act, per the lifecycle invariant: a session is born with its first
  * thing, so this creates the workspace row AND that first thing already bound
- * to it. Two shapes, matching the two session kinds:
+ * to it. Three shapes:
  *
  * - `{ driveId, agentPageId }` — a DRIVE session, first conversation with that
  *   drive agent.
+ * - `{ driveId }` (`agentPageId` null/omitted) — a DRIVE session whose first
+ *   conversation is the assistant instead of a specific agent. The
+ *   conversation and access layers don't care whether a null-agent
+ *   conversation's session has a drive (`createConversationInSession`'s
+ *   `agentPageId: null` branch and `decideAgentSessionAccess` both key only
+ *   on `driveId`) — a drive session can already host such a conversation via
+ *   the split-pane picker, this just allows it as the FIRST thing too.
  * - `{}` (both null/omitted) — a GLOBAL-ASSISTANT session: no drive, first
  *   conversation is a `type: 'global'` assistant thread. Owner-only by the
  *   access decision (there is no drive whose membership could admit anyone
@@ -133,13 +140,13 @@ export async function GET(request: Request) {
  * (`provisionSessionSandbox` + `spawnShell`) rather than reimplementing it.
  * Omitted/anything else behaves exactly as before — the conversation path.
  *
- * Half-specified shapes are refused: an agent without its drive is
- * unresolvable, and a drive without an agent would mint an empty session —
- * UNLESS `firstThing: 'shell'`, whose first thing needs no agent.
+ * Only one shape is refused: an `agentPageId` without a `driveId` is
+ * unresolvable (which drive's agent?) — UNLESS `firstThing: 'shell'`, whose
+ * first thing needs no agent at all.
  *
  * A blank/omitted `name` is not left null: it is auto-derived from the spawn
- * target (the agent's title, "Shell", or "Assistant") and made unique among
- * the owner's own existing session names before the row is inserted.
+ * target (the agent's title, "Shell", or "Global Assistant") and made unique
+ * among the owner's own existing session names before the row is inserted.
  *
  * Spawn itself is instant and free: NO sandbox is provisioned for the
  * conversation path. `firstThing: 'shell'` is the exception — opening a shell
@@ -166,13 +173,14 @@ export async function POST(request: Request) {
   const rawName = typeof body.name === 'string' ? body.name.trim() : '';
   const wantsShellFirst = body.firstThing === 'shell';
 
-  if (!wantsShellFirst && (driveId === null) !== (agentPageId === null)) {
-    // Half-specified: an agent without its drive is unresolvable, and a drive
-    // without an agent would mint an empty session. Both-null is the
-    // global-assistant spawn; both-present is the drive spawn. A shell-first
-    // spawn needs no agent, so it is exempt from this shape check.
+  if (!wantsShellFirst && driveId === null && agentPageId !== null) {
+    // The only truly unresolvable shape: an agent without its drive. Every
+    // other combination is valid — both-present (drive session with that
+    // agent), drive-only (drive session, assistant-first), and both-null
+    // (global-assistant session). A shell-first spawn needs no agent, so it
+    // is exempt from this check entirely.
     return NextResponse.json(
-      { error: 'A session needs a drive and an agent to start with, or neither for the assistant' },
+      { error: 'An agent needs its drive to start a session' },
       { status: 400 },
     );
   }
@@ -259,7 +267,7 @@ export async function POST(request: Request) {
   if (rawName.length > 0) {
     name = rawName.slice(0, MAX_SESSION_NAME_LENGTH);
   } else {
-    const baseLabel = wantsShellFirst ? 'Shell' : agentPageId !== null ? (agentTitle ?? 'Agent') : 'Assistant';
+    const baseLabel = wantsShellFirst ? 'Shell' : agentPageId !== null ? (agentTitle ?? 'Agent') : 'Global Assistant';
     const existingSessions = await listSessions({ ownerId: auth.userId });
     const existingNames = existingSessions.map((session) => session.name);
     name = nextUniqueSessionName(baseLabel, existingNames).slice(0, MAX_SESSION_NAME_LENGTH);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -723,6 +723,16 @@ svg.lucide {
     background-color: hsl(var(--accent));
   }
 
+  /* Fully hidden scrollbar — scrolling still works, the bar never renders */
+  .scrollbar-none {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* legacy Edge */
+  }
+
+  .scrollbar-none::-webkit-scrollbar {
+    display: none; /* Chrome/Safari/Electron */
+  }
+
   /* SVG Color Utilities - for dark mode support in SVG elements */
   .svg-bg {
     fill: var(--background);

--- a/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
+++ b/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
@@ -18,14 +18,17 @@ import { useAssistantSessionChat } from './useAssistantSessionChat';
 
 export default function AssistantSessionChat({
   conversationId,
+  driveId,
   context,
   isReadOnly = false,
 }: {
   conversationId: string;
+  /** The session's own drive, when it has one — see `useAssistantSessionChat`'s doc. */
+  driveId: string | null;
   context: 'page' | 'console';
   isReadOnly?: boolean;
 }) {
-  const chat = useAssistantSessionChat({ conversationId });
+  const chat = useAssistantSessionChat({ conversationId, driveId });
   const currentModel = useAssistantSettingsStore((state) => state.currentModel);
 
   return (

--- a/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
@@ -1,0 +1,178 @@
+/**
+ * useAssistantSessionChat Hook Tests.
+ *
+ * Behavior under test: which `contextRef` a send carries. The Agents console
+ * never navigates as sessions/panes are clicked, and `agents` isn't even a
+ * route `buildContextRef` recognizes as drive-scoped (see `tab-title.ts`) —
+ * so the pathname can never tell this hook which drive a DRIVE-SCOPED
+ * session's Global Assistant conversation belongs to. The session's own
+ * `driveId` (known statically by whoever mounts this hook) must win over
+ * pathname parsing whenever the session has one; pathname parsing remains
+ * the only signal for a driveless global-assistant session, which has none.
+ *
+ * renderHook, auth-fetch mocked, real swr, real conversation-messages store —
+ * same minimal-mock strategy as `useAgentSessionChat.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+
+const { mockFetchWithAuth } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+}));
+
+const chat = vi.hoisted(() => ({
+  capturedConfigs: [] as Array<Record<string, unknown>>,
+  instance: {
+    sendMessage: vi.fn(),
+    regenerate: vi.fn(),
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+    clearError: vi.fn(),
+    addToolResult: vi.fn(),
+  },
+}));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: vi.fn((config: Record<string, unknown> | undefined) => {
+    if (config && typeof config.id === 'string') chat.capturedConfigs.push(config);
+    return {
+      messages: [] as UIMessage[],
+      status: 'ready' as const,
+      error: undefined,
+      ...chat.instance,
+    };
+  }),
+}));
+
+const loaders = vi.hoisted(() => ({
+  loadGlobalConversationMessages: vi.fn(async () => {}),
+  loadOlderGlobalConversationMessages: vi.fn(async () => {}),
+}));
+vi.mock('@/hooks/conversationMessagesLoaders', () => loaders);
+
+vi.mock('@/hooks/useActiveStream', () => ({
+  useActiveStream: () => ({ streams: [] }),
+  useConversationActiveStream: () => undefined,
+}));
+
+const route = vi.hoisted(() => ({ pathname: '/dashboard/agents' }));
+vi.mock('next/navigation', () => ({
+  usePathname: () => route.pathname,
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1', name: 'Test User', email: 'test@example.com' } }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+// Real `useGlobalChatConversation` throws outside a `GlobalChatProvider` —
+// this hook doesn't mount one, only reads the rejoin callback off it.
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  useGlobalChatConversation: () => ({ rejoinGlobalStream: vi.fn() }),
+}));
+
+import { useDriveStore, type Drive } from '@/hooks/useDrive';
+import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { useAssistantSessionChat } from '../useAssistantSessionChat';
+
+function ids(slug: string) {
+  return { conversationId: `conv-${slug}` };
+}
+
+function driveFixture(id: string, name: string): Drive {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase(),
+    ownerId: 'user-1',
+    isTrashed: false,
+    trashedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    isOwned: true,
+  };
+}
+
+function sentBody() {
+  const [, options] = chat.instance.sendMessage.mock.calls.at(-1) as [
+    UIMessage,
+    { body?: Record<string, unknown> },
+  ];
+  return options.body;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chat.capturedConfigs.length = 0;
+  route.pathname = '/dashboard/agents';
+  useConversationMessagesStore.setState({ byConversationId: {} });
+  useDriveStore.setState({ drives: [driveFixture('drive-1', 'Engineering')] });
+  mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({}) });
+});
+
+describe('useAssistantSessionChat — contextRef', () => {
+  it("sends routeType 'drive' with the SESSION's own driveId when the session has one, ignoring the pathname entirely", async () => {
+    const { conversationId } = ids('drive-scoped');
+    conversationMessagesActions.seedConversation(conversationId);
+    // The global console route — buildContextRef alone would resolve this to
+    // routeType 'other' (agents isn't a route it recognizes at all).
+    route.pathname = '/dashboard/agents';
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: 'drive-1' }));
+    await act(async () => {
+      await result.current.handleSend('hello');
+    });
+
+    await waitFor(() => expect(chat.instance.sendMessage).toHaveBeenCalledTimes(1));
+    expect(sentBody()).toEqual(
+      expect.objectContaining({ contextRef: { routeType: 'drive', driveId: 'drive-1' } }),
+    );
+  });
+
+  it('still uses the session driveId even while standing on an UNRELATED page in a different drive', async () => {
+    const { conversationId } = ids('drive-scoped-elsewhere');
+    conversationMessagesActions.seedConversation(conversationId);
+    useDriveStore.setState({
+      drives: [driveFixture('drive-1', 'Engineering'), driveFixture('drive-2', 'Design')],
+    });
+    // Main view is showing a page in drive-2; this pane's session is drive-1's.
+    route.pathname = '/dashboard/drive-2/some-page';
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: 'drive-1' }));
+    await act(async () => {
+      await result.current.handleSend('put this here');
+    });
+
+    await waitFor(() => expect(chat.instance.sendMessage).toHaveBeenCalledTimes(1));
+    expect(sentBody()).toEqual(
+      expect.objectContaining({ contextRef: { routeType: 'drive', driveId: 'drive-1' } }),
+    );
+  });
+
+  it('falls back to the pathname-derived context for a DRIVELESS global-assistant session', async () => {
+    const { conversationId } = ids('driveless');
+    conversationMessagesActions.seedConversation(conversationId);
+    route.pathname = '/dashboard/drive-1/page-1';
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
+    await act(async () => {
+      await result.current.handleSend('hello');
+    });
+
+    await waitFor(() => expect(chat.instance.sendMessage).toHaveBeenCalledTimes(1));
+    expect(sentBody()).toEqual(
+      expect.objectContaining({
+        contextRef: { routeType: 'page', pageId: 'page-1', driveId: 'drive-1' },
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -41,7 +41,7 @@ import {
   buildChatConfig,
   buildGlobalChatRequestBody,
 } from '@/lib/ai/shared';
-import { buildContextRef } from '@/lib/ai/shared/buildContextRef';
+import { buildContextRef, type ContextRef } from '@/lib/ai/shared/buildContextRef';
 import { buildUserMessage } from '@/lib/ai/streams/buildUserMessage';
 import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimisticSendOnFailure';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
@@ -65,9 +65,20 @@ import type { UseAgentSessionChatReturn } from './useAgentSessionChat';
 
 export function useAssistantSessionChat({
   conversationId,
+  driveId,
 }: {
   /** The assistant conversation this pane is mounted for — fixed for the hook's life. */
   conversationId: string;
+  /**
+   * The session's own drive, when it has one — `null` for a driveless
+   * global-assistant session. Takes priority over the pathname-derived
+   * context below: the Agents console never navigates as panes/sessions are
+   * clicked (`AgentsSidebar`'s whole design), and `agents` isn't even a
+   * route `buildContextRef` recognizes as drive-scoped (see `tab-title.ts`),
+   * so pathname parsing can never see this session's drive — the session
+   * itself is the only reliable source.
+   */
+  driveId: string | null;
 }): UseAgentSessionChatReturn {
   const pathname = usePathname();
   const { user } = useAuth();
@@ -159,7 +170,7 @@ export function useAssistantSessionChat({
       const trimmed = text.trim();
       if (!trimmed || !conversationId) return false;
 
-      const contextRef = buildContextRef(pathname, drives);
+      const contextRef: ContextRef = driveId ? { routeType: 'drive', driveId } : buildContextRef(pathname, drives);
       if (!(await prepareSend(conversationId))) {
         toast.error(HANDOFF_REFUSED_MESSAGE);
         return false;
@@ -191,6 +202,7 @@ export function useAssistantSessionChat({
     },
     [
       conversationId,
+      driveId,
       pathname,
       drives,
       prepareSend,

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -764,6 +764,7 @@ export default function AgentPanes({
             <PaneChat
               conversationId={surface.conversationId}
               agentPageId={surface.agentPageId}
+              driveId={driveId}
               context={chatContext}
               isReadOnly={isReadOnly}
             />

--- a/apps/web/src/components/agents/panes/PaneChat.tsx
+++ b/apps/web/src/components/agents/panes/PaneChat.tsx
@@ -21,11 +21,14 @@ import { useResolvedAgent } from '../useResolvedAgent';
 export default function PaneChat({
   conversationId,
   agentPageId,
+  driveId,
   context = 'console',
   isReadOnly = false,
 }: {
   conversationId: string;
   agentPageId: string | null;
+  /** This pane's session's own drive — `null` for a global-assistant session. Only the assistant branch needs it (an agent already carries its own `driveId`). */
+  driveId: string | null;
   /** Which message renderer to use — the page grid hosts the full one. */
   context?: 'page' | 'console';
   isReadOnly?: boolean;
@@ -35,7 +38,14 @@ export default function PaneChat({
   const { agent, isLoading } = useResolvedAgent(agentPageId);
 
   if (agentPageId === null) {
-    return <AssistantSessionChat conversationId={conversationId} context={context} isReadOnly={isReadOnly} />;
+    return (
+      <AssistantSessionChat
+        conversationId={conversationId}
+        driveId={driveId}
+        context={context}
+        isReadOnly={isReadOnly}
+      />
+    );
   }
 
   if (isLoading || !agent) {

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -91,7 +91,17 @@ export default function PanePicker({
     >
       <p className="shrink-0 text-xs font-medium text-muted-foreground">Open in this pane</p>
 
-      <div className="flex min-h-0 flex-col gap-1">
+      {/* `shrink-0`, not `min-h-0`: none of this picker's sub-lists scroll on
+          their own (the root `overflow-auto` above is the only scroll
+          region), so a sub-list must never be allowed to shrink below its
+          buttons' height — `min-h-0` on a non-scrolling flex item just lets
+          the outer column crush it under space pressure while its buttons
+          (already `shrink-0` via the Button component) refuse to shrink,
+          which pushes their overflow into the next section instead of
+          scrolling — exactly what made a short split pane's "Global
+          Assistant" button visually collide with "Agents" and eat its
+          clicks. */}
+      <div className="flex shrink-0 flex-col gap-1">
         <Button
           ref={firstRef}
           variant="ghost"
@@ -122,7 +132,7 @@ export default function PanePicker({
           the drive's agents since reattaching an existing thing outranks
           spawning a new one. */}
       {existingShells.length > 0 && (
-        <div className="flex min-h-0 flex-col gap-1">
+        <div className="flex shrink-0 flex-col gap-1">
           <p className="shrink-0 pt-1 text-xs font-medium text-muted-foreground">Reattach a shell</p>
           {existingShells.map((shell) => (
             <Button
@@ -148,7 +158,7 @@ export default function PanePicker({
           Loading agents…
         </p>
       ) : agents.length > 0 ? (
-        <div className="flex min-h-0 flex-col gap-1">
+        <div className="flex shrink-0 flex-col gap-1">
           <p className="shrink-0 pt-1 text-xs font-medium text-muted-foreground">Agents</p>
           {agents.map((agent) => (
             <Button

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -7,7 +7,6 @@ import { toast } from 'sonner';
 import useSWR from 'swr';
 
 import EndSessionDialog from '@/components/agents/EndSessionDialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Input } from '@/components/ui/input';
 import {
   CommandDialog,
@@ -111,7 +110,7 @@ export default function AgentsSidebar({ className }: SidebarProps) {
 
         <PrimaryNavigation driveId={driveId} />
 
-        <ScrollArea className="flex-1 min-h-0">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none">
           <div className="space-y-0.5">
             <SessionList
               authLoading={authLoading}
@@ -126,7 +125,7 @@ export default function AgentsSidebar({ className }: SidebarProps) {
               onChanged={() => void retrySessions()}
             />
           </div>
-        </ScrollArea>
+        </div>
 
         {driveId ? <DriveFooter canManage={canManage} /> : <DashboardFooter />}
       </div>
@@ -381,7 +380,7 @@ function SessionList({
   const handleNewSession = useCallback((groupDriveId: string, groupDriveName: string | null) => {
     if (groupDriveId === ASSISTANT_GROUP_KEY) {
       setSpawnTarget({ driveId: null, driveName: null });
-      setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Assistant' });
+      setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' });
       return;
     }
     setSpawnTarget({ driveId: groupDriveId, driveName: groupDriveName });
@@ -690,7 +689,7 @@ function SessionRow({
           {session.conversations.map((conversation) => {
             const agentName =
               conversation.agentPageId === null
-                ? 'Assistant'
+                ? 'Global Assistant'
                 : (agentNamesById.get(conversation.agentPageId) ?? 'Agent');
             const label = conversation.title ? `${agentName} — ${conversation.title}` : agentName;
             return (
@@ -746,7 +745,7 @@ type SpawnKind = 'agent' | 'shell' | 'assistant';
 interface SpawnPick {
   kind: SpawnKind;
   agentPageId: string | null;
-  /** The sensible default: the agent's title, "Shell", or "Assistant". */
+  /** The sensible default: the agent's title, "Shell", or "Global Assistant". */
   label: string;
 }
 
@@ -755,8 +754,8 @@ interface SpawnPick {
  * a target and hit Enter — the same keyboard-first pattern `QuickCreatePalette`
  * established for page creation, reused here so a future mouseless-navigation
  * pass has one command-palette idiom to build on, not two. Two steps: pick a
- * target (an agent, Shell, or — for the ASSISTANT group, which skips straight
- * here since it has nothing else to choose — Assistant), then name the
+ * target (an agent, Shell, or Global Assistant — the ASSISTANT group's own
+ * "+" skips straight here since it has nothing else to choose), then name the
  * session. Naming is always the last step, even for a one-click assistant
  * spawn, so every session gets a deliberate name.
  */
@@ -829,6 +828,14 @@ function SpawnSessionPalette({
           <CommandInput placeholder="Search agents…" autoFocus />
           <CommandList>
             <CommandGroup>
+              <CommandItem
+                value="assistant-Global Assistant"
+                disabled={spawning}
+                onSelect={() => onPickTarget({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' })}
+              >
+                <Bot className="size-3.5" aria-hidden="true" />
+                <span className="truncate">Global Assistant</span>
+              </CommandItem>
               {agents.map((agent) => (
                 <CommandItem
                   key={agent.id}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -373,7 +373,7 @@ describe('AgentsSidebar', () => {
       expect(screen.queryByText(/—/)).toBeNull();
     });
 
-    test('falls back to "Assistant" for a null agentPageId, and "Agent" for an unknown one', async () => {
+    test('falls back to "Global Assistant" for a null agentPageId, and "Agent" for an unknown one', async () => {
       respondWithSessions([
         {
           ...SESSION,
@@ -388,7 +388,7 @@ describe('AgentsSidebar', () => {
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
 
-      expect(screen.getByText('Assistant')).toBeDefined();
+      expect(screen.getByText('Global Assistant')).toBeDefined();
       expect(screen.getByText('Agent')).toBeDefined();
     });
   });
@@ -453,6 +453,32 @@ describe('AgentsSidebar', () => {
       // Landed IN the first conversation — no empty-session state is visible.
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-new');
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
+    });
+
+    test('the drive palette also offers Global Assistant, first — picking it spawns a session in THIS drive with no agent', async () => {
+      mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, conversationId: 'conv-new' });
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Global Assistant'));
+
+      const nameInput = await screen.findByPlaceholderText('Global Assistant');
+      expect(nameInput).toHaveValue('');
+      await user.type(nameInput, '{Enter}');
+
+      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+      // Drive-scoped, not the global assistant group: driveId stays 'drive-1'.
+      expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {
+        driveId: 'drive-1',
+        agentPageId: null,
+        name: '',
+      });
+      await waitFor(() =>
+        expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-new'),
+      );
+      expect(useAgentSurfaceStore.getState().selectedAgentId).toBeNull();
     });
 
     test('spawning a shell-first session names its terminal pane from the SHELL\'s own auto-assigned name, not the session label', async () => {
@@ -782,7 +808,7 @@ describe('AgentsSidebar', () => {
       // now, so an unscoped query would be ambiguous.
       await user.click(within(groupContainer('Global Assistant')).getByRole('button', { name: /^New session/i }));
 
-      const nameInput = await screen.findByPlaceholderText('Assistant');
+      const nameInput = await screen.findByPlaceholderText('Global Assistant');
       expect(nameInput).toHaveValue('');
       await user.type(nameInput, '{Enter}');
 


### PR DESCRIPTION
## Summary
- Hide the Agents sidebar's session-list scrollbar entirely (new `.scrollbar-none` utility) instead of the Radix `ScrollArea`'s always-visible overlay bar, which collided with row "+" buttons.
- Fix `PanePicker`'s split-pane overlap: its sub-list wrappers used `min-h-0` on non-scrolling flex boxes, letting a short pane crush them while their `shrink-0` buttons refused to shrink — pushing "Global Assistant" past its box and stealing clicks from "Agents" below. Switched to `shrink-0`.
- Offer Global Assistant as the first pick in a drive's "+" spawn palette, landing the new session under that drive (loosened the session-spawn validation gate, which previously only allowed a driveless assistant spawn even though drive-scoped assistant conversations were already supported everywhere else — via the pane picker and the access/conversation layers).
- Default naming: "Assistant" → "Global Assistant" for the auto-named session label, the naming-step placeholder, and the expanded-conversation fallback.
- **(Review follow-up)** Thread the session's own `driveId` into the Global Assistant's chat request context instead of deriving it from the pathname. Turned out `agents` isn't a route `buildContextRef`/`tab-title.ts` recognizes as drive-scoped at all, so a Global Assistant conversation inside an agent session never got its drive's prompt/page-tree scope from any entry point (pre-existing, not introduced by this PR, but the new spawn-palette path made it reachable in one more way). See the review thread for detail.
- Added a `CHANGELOG.md` entry (manual, matching this repo's convention — the `changelog:generate` script is known-stale).

## Test plan
- [x] `bun run typecheck` (apps/web) — clean
- [x] `route.test.ts` — 34/34 passing, including new tests for the drive-scoped assistant spawn and the narrowed validation gate
- [x] `AgentsSidebar.test.tsx` — 48/48 passing, including a new test for picking Global Assistant from a drive's "+"
- [x] `PanePicker.test.tsx`, `AgentPanes.test.tsx`, `SessionPanes.test.tsx` — 65/65 passing
- [x] `useAssistantSessionChat.test.ts` (new) — covers the driveId-override and the driveless fallback
- [x] `bun run test:unit` (full monorepo lib + web suite) — 15502/15503 passing; the 1 failure (`grouping.test.ts` midnight-boundary case) is a pre-existing, unrelated TZ-environment flake (fails under local CDT, passes under UTC), not touched by this PR
- [x] `bun run test:security` — 44/50 suites passing; the 6 failures match this repo's known pre-existing baseline (deleted Login/Signup/Mobile-Login routes, excluded Session Service/Device Auth/Permissions suites) — confirmed identical failure set, nothing new
- [x] `bun run lint` (repo-wide build+lint) — clean
- [x] Verified no merge conflicts / branch fully up to date with `master`
- [ ] Manual: confirm no scrollbar renders on `/dashboard/agents`'s left sidebar, at rest or on hover
- [ ] Manual: split a pane and confirm "Global Assistant" is clickable and doesn't collide with "Agents"
- [ ] Manual: click "+" on a drive, pick Global Assistant, confirm the new session lands under that drive
- [ ] Manual: from the global `/dashboard/agents` view, spawn Global Assistant for a specific drive and confirm the assistant has that drive's context (page tree / system prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMC7fGVwuwyD7NChEaQobP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Start Global Assistant sessions scoped to a specific drive.
  - Global Assistant now uses the associated drive for conversation context.
  - Global sessions are named “Global Assistant” by default.

- **Bug Fixes**
  - Improved pane picker spacing so options remain accessible in smaller panes.
  - Hidden scrollbars in the Agents session list while preserving scrolling.
  - Fixed drive context when viewing a session from a different drive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->