### PR TITLE
fix(agents): AI_CHAT page scroll, reopen closed conversations, settings link

### DIFF
--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+/**
+ * The session-scoped conversation-reopen route — the undo of the sibling
+ * `[conversationId]` route's DELETE. What matters here: the uniform 404 for
+ * an unreachable session AND for a conversation this session does not own
+ * (or was history-deleted), the 429 + human message on the cap, and that an
+ * idempotent re-reopen (already_open) still answers 200 without a fresh
+ * audit write — mirrors `[conversationId]/__tests__/route.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockAuthenticateRequest, mockAuditRequest, mockCheckSessionAccess, mockReopenConversationInSession } =
+  vi.hoisted(() => ({
+    mockAuthenticateRequest: vi.fn(),
+    mockAuditRequest: vi.fn(),
+    mockCheckSessionAccess: vi.fn(),
+    mockReopenConversationInSession: vi.fn(),
+  }));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => result != null && typeof result === 'object' && 'error' in result,
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: vi.fn(), warn: vi.fn() } },
+}));
+vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
+  checkSessionAccess: (...args: unknown[]) => mockCheckSessionAccess(...args),
+  reopenConversationInSession: (...args: unknown[]) => mockReopenConversationInSession(...args),
+}));
+
+import { POST } from '../route';
+
+const AUTH_USER = { userId: 'user-1', role: 'admin' };
+const SESSION_ID = 'ses-1';
+const CONVERSATION_ID = 'conv-1';
+
+const params = { params: Promise.resolve({ sessionId: SESSION_ID, conversationId: CONVERSATION_ID }) };
+const post = () =>
+  POST(
+    new Request(`http://localhost/api/agent-sessions/${SESSION_ID}/conversations/${CONVERSATION_ID}/reopen`, {
+      method: 'POST',
+    }),
+    params,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH_USER);
+  mockCheckSessionAccess.mockResolvedValue({ allowed: true });
+  mockReopenConversationInSession.mockResolvedValue('reopened');
+});
+
+describe('POST /api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen', () => {
+  it('reopens a closed listing', async () => {
+    const response = await post();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(mockReopenConversationInSession).toHaveBeenCalledWith({
+      conversationId: CONVERSATION_ID,
+      sessionId: SESSION_ID,
+    });
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ op: 'reopen_conversation' }) }),
+    );
+  });
+
+  it('an idempotent re-reopen (already_open) still answers 200, with no fresh data.write audit', async () => {
+    mockReopenConversationInSession.mockResolvedValue('already_open');
+    const response = await post();
+    expect(response.status).toBe(200);
+    expect(mockAuditRequest).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write' }),
+    );
+  });
+
+  it('404s an unknown session — same shape whether it never existed or is denied', async () => {
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'session_not_found' });
+    const response = await post();
+    expect(response.status).toBe(404);
+    expect(mockReopenConversationInSession).not.toHaveBeenCalled();
+  });
+
+  it('404s a session the requester cannot reach, but still audits the denial', async () => {
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
+    const response = await post();
+    expect(response.status).toBe(404);
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'authz.access.denied' }),
+    );
+  });
+
+  it('404s a conversation this session does not own (not_in_session) — session access alone is not enough', async () => {
+    mockReopenConversationInSession.mockResolvedValue('not_in_session');
+    const response = await post();
+    expect(response.status).toBe(404);
+  });
+
+  it('404s a history-deleted conversation — nothing left to restore, same shape as not-found', async () => {
+    mockReopenConversationInSession.mockResolvedValue('history_deleted');
+    const response = await post();
+    expect(response.status).toBe(404);
+  });
+
+  it("429s a session already at MAX_SESSION_CONVERSATIONS, as a quota refusal with the shared human message", async () => {
+    mockReopenConversationInSession.mockResolvedValue('session_full');
+    const response = await post();
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.error).toMatch(/maximum number of conversations/i);
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited' }),
+    );
+  });
+
+  it('500s a thrown failure with a human error', async () => {
+    mockReopenConversationInSession.mockRejectedValue(new Error('db exploded'));
+    const response = await post();
+    expect(response.status).toBe(500);
+  });
+
+  it('given an auth failure, should return the auth error untouched', async () => {
+    const error = new Response(null, { status: 401 });
+    mockAuthenticateRequest.mockResolvedValue({ error });
+    const response = await post();
+    expect(response.status).toBe(401);
+    expect(mockCheckSessionAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/route.ts
@@ -1,0 +1,78 @@
+/**
+ * Reopen ONE conversation back INTO its session's listing — the undo of the
+ * sibling `[conversationId]` route's DELETE.
+ *
+ * POST → 200 { ok: true } — the console's "History" affordance: a closed
+ * listing is invisible to `GET /api/agent-sessions` (see
+ * `listSessionConversationsBulk`'s doc) but its transcript is untouched, so
+ * this is how a user gets back to a conversation they closed a pane on. It
+ * never touches history — same as the close route, this stamps/clears
+ * `conversations.closedInSessionAt` only.
+ *
+ * Subject to the same `MAX_SESSION_CONVERSATIONS` ceiling the create route
+ * enforces (`session_full` → the shared 429), because reopening occupies an
+ * open-listing slot exactly like minting a new conversation does.
+ *
+ * Gated by the same ordinary session access check the close route uses —
+ * this is a routine write, not a capability-gated act.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkSessionAccess, reopenConversationInSession } from '@/lib/agent-sessions/agent-sessions-runtime';
+import { sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
+import { sessionConversationLimitExceeded } from '@/lib/agent-sessions/quota-response';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const ROUTE = 'agent-sessions/[sessionId]/conversations/[conversationId]/reopen';
+
+type RouteContext = { params: Promise<{ sessionId: string; conversationId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+  const { sessionId, conversationId } = await context.params;
+
+  const access = await checkSessionAccess(auth.userId, sessionId);
+  if (!access.allowed) {
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE);
+  }
+
+  let outcome: Awaited<ReturnType<typeof reopenConversationInSession>>;
+  try {
+    outcome = await reopenConversationInSession({ conversationId, sessionId });
+  } catch (error) {
+    loggers.api.error(
+      'Session conversation reopen failed',
+      error instanceof Error ? error : undefined,
+      { sessionId, conversationId },
+    );
+    return NextResponse.json({ error: 'Could not reopen this conversation' }, { status: 500 });
+  }
+
+  if (outcome === 'not_in_session' || outcome === 'history_deleted') {
+    // Same "nothing here" shape whether the id never existed, names a
+    // conversation some OTHER session owns, or was history-deleted — an
+    // id-guessing caller learns nothing either way.
+    return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+  }
+
+  if (outcome === 'session_full') {
+    return sessionConversationLimitExceeded(request, auth.userId, sessionId, ROUTE);
+  }
+
+  if (outcome === 'reopened') {
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'agent_session',
+      resourceId: sessionId,
+      details: { op: 'reopen_conversation', conversationId },
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/closed/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/closed/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+/**
+ * A session's CLOSED conversations — the reopen affordance's source list.
+ * What matters here: the uniform 404 for an unreachable session (same shape
+ * as every WRITE route in this family — `sessionNotFoundOrDenied`, not the
+ * GET-`[sessionId]`-only `{ session: null }`/200 convention), and that the
+ * runtime's listing passes through untouched.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockAuthenticateRequest, mockAuditRequest, mockCheckSessionAccess, mockListClosedSessionConversations } =
+  vi.hoisted(() => ({
+    mockAuthenticateRequest: vi.fn(),
+    mockAuditRequest: vi.fn(),
+    mockCheckSessionAccess: vi.fn(),
+    mockListClosedSessionConversations: vi.fn(),
+  }));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => result != null && typeof result === 'object' && 'error' in result,
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
+  checkSessionAccess: (...args: unknown[]) => mockCheckSessionAccess(...args),
+  listClosedSessionConversations: (...args: unknown[]) => mockListClosedSessionConversations(...args),
+}));
+
+import { GET } from '../route';
+
+const AUTH_USER = { userId: 'user-1', role: 'admin' };
+const SESSION_ID = 'ses-1';
+const CONVERSATIONS = [{ conversationId: 'conv-1', title: 'Old chat', agentPageId: 'agent-1', lastMessageAt: null }];
+
+const params = { params: Promise.resolve({ sessionId: SESSION_ID }) };
+const get = () => GET(new Request(`http://localhost/api/agent-sessions/${SESSION_ID}/conversations/closed`), params);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH_USER);
+  mockCheckSessionAccess.mockResolvedValue({ allowed: true });
+  mockListClosedSessionConversations.mockResolvedValue(CONVERSATIONS);
+});
+
+describe('GET /api/agent-sessions/[sessionId]/conversations/closed', () => {
+  it('returns the session\'s closed conversations', async () => {
+    const response = await get();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ conversations: CONVERSATIONS });
+    expect(mockListClosedSessionConversations).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('returns an empty list, not an error, when the session has nothing closed', async () => {
+    mockListClosedSessionConversations.mockResolvedValue([]);
+    const response = await get();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ conversations: [] });
+  });
+
+  it('404s an unknown session — same shape whether it never existed or is denied (this family\'s write-route convention, not GET [sessionId]\'s own { session: null })', async () => {
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'session_not_found' });
+    const response = await get();
+    expect(response.status).toBe(404);
+    expect(mockListClosedSessionConversations).not.toHaveBeenCalled();
+  });
+
+  it('404s a session the requester cannot reach, but still audits the denial', async () => {
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
+    const response = await get();
+    expect(response.status).toBe(404);
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'authz.access.denied' }),
+    );
+  });
+
+  it('given an auth failure, should return the auth error untouched', async () => {
+    const error = new Response(null, { status: 401 });
+    mockAuthenticateRequest.mockResolvedValue({ error });
+    const response = await get();
+    expect(response.status).toBe(401);
+    expect(mockCheckSessionAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/closed/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/closed/route.ts
@@ -1,0 +1,40 @@
+/**
+ * A session's CLOSED conversations — the source list for the console's
+ * "History" affordance (the reopen route's picker). A closed listing never
+ * appears in `GET /api/agent-sessions` (see `listSessionConversationsBulk`'s
+ * doc); this is the one read that surfaces them so a user can find and
+ * reopen a conversation they closed a pane on.
+ *
+ * GET → 200 { conversations: SessionConversationEntry[] } — newest activity
+ * first, capped at `MAX_SESSION_CONVERSATIONS` (see
+ * `listClosedSessionConversations`'s doc for why: older history belongs to
+ * the agent's own page History tab, not this session-scoped list).
+ *
+ * Gated by the same ordinary session access check every conversation route
+ * in this family uses — a read, not a capability-gated act.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { checkSessionAccess, listClosedSessionConversations } from '@/lib/agent-sessions/agent-sessions-runtime';
+import { sessionNotFoundOrDenied } from '@/lib/agent-sessions/session-unavailable-response';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+const ROUTE = 'agent-sessions/[sessionId]/conversations/closed';
+
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+  const { sessionId } = await context.params;
+
+  const access = await checkSessionAccess(auth.userId, sessionId);
+  if (!access.allowed) {
+    return sessionNotFoundOrDenied(request, auth.userId, sessionId, access.reason, ROUTE);
+  }
+
+  const conversations = await listClosedSessionConversations(sessionId);
+  return NextResponse.json({ conversations });
+}

--- a/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
@@ -41,9 +41,19 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
 }));
 
+vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
+  countOpenConversationsForSession: vi.fn(),
+  // Pass-through: these DELETE-route tests are about the guard-then-delete
+  // sequence at the call site, not lock contention (that's
+  // `agent-sessions-runtime`'s own test suite).
+  withSessionListingLock: vi.fn((_sessionId: string, fn: () => Promise<unknown>) => fn()),
+}));
+
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { countOpenConversationsForSession, withSessionListingLock } from '@/lib/agent-sessions/agent-sessions-runtime';
 
 // Test fixtures
 const mockUserId = 'user_123';
@@ -72,6 +82,8 @@ const mockConversation = (overrides: Partial<{
   createdAt: Date;
   updatedAt: Date;
   isActive: boolean;
+  sessionId: string | null;
+  closedInSessionAt: Date | null;
 }> = {}) => ({
   id: overrides.id ?? mockConversationId,
   userId: overrides.userId ?? mockUserId,
@@ -82,6 +94,8 @@ const mockConversation = (overrides: Partial<{
   createdAt: overrides.createdAt ?? new Date(),
   updatedAt: overrides.updatedAt ?? new Date(),
   isActive: overrides.isActive ?? true,
+  sessionId: overrides.sessionId ?? null,
+  closedInSessionAt: overrides.closedInSessionAt ?? null,
 });
 
 const createContext = (id: string) => ({
@@ -304,10 +318,20 @@ describe('DELETE /api/ai/global/[id]', () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
     vi.mocked(isAuthError).mockReturnValue(false);
 
+    // Default: a plain (non-session-bound) conversation
+    vi.mocked(globalConversationRepository.getConversationById).mockResolvedValue(
+      mockConversation()
+    );
+
     // Default: delete succeeds
     vi.mocked(globalConversationRepository.softDeleteConversation).mockResolvedValue(
       mockConversation({ isActive: false })
     );
+
+    // Default: irrelevant unless the conversation fixture overrides
+    // sessionId — a plenty-large count so the never-empty guard never
+    // trips by accident in tests that don't care about it.
+    vi.mocked(countOpenConversationsForSession).mockResolvedValue(5);
   });
 
   describe('authentication', () => {
@@ -326,7 +350,7 @@ describe('DELETE /api/ai/global/[id]', () => {
 
   describe('conversation not found', () => {
     it('should return 404 when conversation does not exist', async () => {
-      vi.mocked(globalConversationRepository.softDeleteConversation).mockResolvedValue(null);
+      vi.mocked(globalConversationRepository.getConversationById).mockResolvedValue(null);
 
       const request = createDeleteRequest(mockConversationId);
       const context = createContext(mockConversationId);
@@ -336,6 +360,7 @@ describe('DELETE /api/ai/global/[id]', () => {
 
       expect(response.status).toBe(404);
       expect(body.error).toBe('Conversation not found');
+      expect(globalConversationRepository.softDeleteConversation).not.toHaveBeenCalled();
     });
   });
 
@@ -361,6 +386,95 @@ describe('DELETE /api/ai/global/[id]', () => {
         mockUserId,
         mockConversationId
       );
+    });
+
+    it('does not take the session lock for a plain (non-session-bound) conversation', async () => {
+      const request = createDeleteRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+
+      await DELETE(request, context);
+
+      expect(withSessionListingLock).not.toHaveBeenCalled();
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the session never-empty guard and reopen race (review findings: chatgpt-codex-connector on PR #2296)', () => {
+    it("refuses to delete a session-bound conversation that is its session's LAST open listing", async () => {
+      vi.mocked(globalConversationRepository.getConversationById).mockResolvedValue(
+        mockConversation({ sessionId: 'ses_1', closedInSessionAt: null })
+      );
+      vi.mocked(countOpenConversationsForSession).mockResolvedValue(1);
+
+      const request = createDeleteRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+      const response = await DELETE(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.reason).toBe('last_conversation');
+      expect(globalConversationRepository.softDeleteConversation).not.toHaveBeenCalled();
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ eventType: 'security.rate.limited' }),
+      );
+    });
+
+    it('allows deleting a session-bound conversation when another open listing remains in the same session', async () => {
+      vi.mocked(globalConversationRepository.getConversationById).mockResolvedValue(
+        mockConversation({ sessionId: 'ses_1', closedInSessionAt: null })
+      );
+      vi.mocked(countOpenConversationsForSession).mockResolvedValue(2);
+
+      const request = createDeleteRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(globalConversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockUserId, mockConversationId);
+    });
+
+    it('takes the session lock (but not the never-empty guard) for a conversation ALREADY closed out of its session — a closed delete must still serialize against a concurrent reopen', async () => {
+      vi.mocked(globalConversationRepository.getConversationById).mockResolvedValue(
+        mockConversation({ sessionId: 'ses_1', closedInSessionAt: new Date('2026-01-01') })
+      );
+
+      const request = createDeleteRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(globalConversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockUserId, mockConversationId);
+      expect(withSessionListingLock).toHaveBeenCalledWith('ses_1', expect.any(Function));
+    });
+
+    it('still soft-deletes a row whose session was cleared between the pre-lock read and the lock-held read — detached is not the same as history-deleted', async () => {
+      vi.mocked(globalConversationRepository.getConversationById)
+        .mockResolvedValueOnce(mockConversation({ sessionId: 'ses_1', closedInSessionAt: null }))
+        .mockResolvedValueOnce(mockConversation({ sessionId: null, closedInSessionAt: null }));
+
+      const request = createDeleteRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(globalConversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockUserId, mockConversationId);
+    });
+
+    it('is idempotent when a concurrent request already deleted the row before this one entered the lock', async () => {
+      vi.mocked(globalConversationRepository.getConversationById)
+        .mockResolvedValueOnce(mockConversation({ sessionId: 'ses_1', closedInSessionAt: null }))
+        .mockResolvedValueOnce(null);
+
+      const request = createDeleteRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(globalConversationRepository.softDeleteConversation).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
@@ -96,6 +96,8 @@ const mockConversation = (overrides: Partial<{
   lastMessageAt: new Date(),
   createdAt: new Date(),
   updatedAt: new Date(),
+  sessionId: null,
+  closedInSessionAt: null,
 });
 
 const mockMessage = (overrides: Partial<{

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -3,6 +3,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
+import { countOpenConversationsForSession, withSessionListingLock } from '@/lib/agent-sessions/agent-sessions-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -106,15 +107,67 @@ export async function DELETE(
 
     const { id } = await context.params;
 
-    const deletedConversation = await globalConversationRepository.softDeleteConversation(
-      userId,
-      id
-    );
-
-    if (!deletedConversation) {
+    const conversation = await globalConversationRepository.getConversationById(userId, id);
+    if (!conversation) {
       return NextResponse.json({
         error: 'Conversation not found'
       }, { status: 404 });
+    }
+
+    // A global-assistant conversation can be session-bound exactly like a
+    // page-agent one (`createConversationInSession`'s `createGlobalConversation`
+    // arm), so it shares the same never-empty invariant AND the same
+    // reopen race: deleting it here while a reopen POST
+    // (`/api/agent-sessions/[sessionId]/conversations/[id]/reopen`) is in
+    // flight could otherwise commit `isActive: false` right as the reopen's
+    // unguarded `isActive` read passes, leaving a "reopened" conversation
+    // invisible to every session listing (review finding —
+    // chatgpt-codex-connector on PR #2296, same class of bug already fixed
+    // on the sibling page-agent route). Every session-bound deletion here
+    // takes the identical `withSessionListingLock` and re-reads the row's
+    // live state inside it, rather than trusting this pre-lock read.
+    if (conversation.sessionId) {
+      const sessionId = conversation.sessionId;
+      const outcome = await withSessionListingLock(sessionId, async () => {
+        const fresh = await globalConversationRepository.getConversationById(userId, id);
+        if (!fresh) {
+          // Already history-deleted by a concurrent request.
+          return 'already_deleted' as const;
+        }
+        // Only weigh the never-empty guard while still bound to THIS
+        // session — a row detached by a since-deleted session
+        // (`sessionId` is `ON DELETE SET NULL`) holds no listing slot to
+        // protect, but is still an active conversation that must be
+        // deleted.
+        if (fresh.sessionId === sessionId && fresh.closedInSessionAt === null) {
+          const openCount = await countOpenConversationsForSession(sessionId);
+          if (openCount <= 1) return 'last_conversation' as const;
+        }
+        await globalConversationRepository.softDeleteConversation(userId, id);
+        return 'deleted' as const;
+      });
+
+      if (outcome === 'last_conversation') {
+        auditRequest(request, {
+          eventType: 'security.rate.limited',
+          userId,
+          resourceType: 'global_chat',
+          resourceId: id,
+          details: { reason: 'last_session_conversation', sessionId, method: 'DELETE' },
+          riskScore: 0,
+        });
+        return NextResponse.json(
+          {
+            error: 'This is the only open conversation in its session — close the pane (or end the session) instead of deleting it from History.',
+            reason: 'last_conversation',
+          },
+          { status: 409 },
+        );
+      }
+      // 'already_deleted' falls through to the success response below —
+      // idempotent from the caller's point of view.
+    } else {
+      await globalConversationRepository.softDeleteConversation(userId, id);
     }
 
     auditRequest(request, { eventType: 'data.delete', userId, resourceType: 'global_chat', resourceId: id, details: {

--- a/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
@@ -88,6 +88,8 @@ const mockConversation = (overrides: Partial<{
   lastMessageAt: new Date(),
   createdAt: new Date(),
   updatedAt: new Date(),
+  sessionId: null,
+  closedInSessionAt: null,
 });
 
 const mockUsageLog = (overrides: Partial<{

--- a/apps/web/src/app/api/ai/global/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/__tests__/route.test.ts
@@ -92,6 +92,8 @@ const mockConversation = (overrides: Partial<{
   createdAt: overrides.createdAt ?? new Date(),
   updatedAt: overrides.updatedAt ?? new Date(),
   isActive: overrides.isActive ?? true,
+  sessionId: null,
+  closedInSessionAt: null,
 });
 
 const createGetRequest = () =>

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -69,6 +69,11 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 }));
 vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   countOpenConversationsForSession: vi.fn(),
+  // Real semantics for the mock: just run `fn` — the route's own tests
+  // aren't about lock contention (that's `agent-sessions-runtime`'s own
+  // test suite), only about the guard-then-delete sequence being atomic
+  // AT THE CALL SITE, which a pass-through faithfully exercises.
+  withSessionListingLock: vi.fn((_sessionId: string, fn: () => Promise<unknown>) => fn()),
 }));
 
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
@@ -77,7 +82,7 @@ import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastAiConversationAdded, broadcastAiConversationDeleted } from '@/lib/websocket/socket-utils';
-import { countOpenConversationsForSession } from '@/lib/agent-sessions/agent-sessions-runtime';
+import { countOpenConversationsForSession, withSessionListingLock } from '@/lib/agent-sessions/agent-sessions-runtime';
 
 // Test fixtures
 const mockUserId = 'user_123';
@@ -486,6 +491,9 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
         expect.anything(),
         expect.objectContaining({ eventType: 'security.rate.limited' }),
       );
+      // The count-then-refuse decision ran under the SAME per-session lock
+      // create/close/reopen serialize under — not a bare unlocked read.
+      expect(withSessionListingLock).toHaveBeenCalledWith('ses_1', expect.any(Function));
     });
 
     it('allows deleting a session-bound conversation when another open listing remains in the same session', async () => {
@@ -515,6 +523,7 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
       expect(response.status).toBe(200);
       expect(countOpenConversationsForSession).not.toHaveBeenCalled();
       expect(conversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockAgentId, mockConversationId);
+      expect(withSessionListingLock).not.toHaveBeenCalled();
     });
 
     it('does not weigh the guard for a plain (non-session-bound) conversation', async () => {
@@ -528,6 +537,7 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
 
       expect(response.status).toBe(200);
       expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(withSessionListingLock).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -67,12 +67,17 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
 }));
+vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
+  countOpenConversationsForSession: vi.fn(),
+}));
 
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastAiConversationAdded, broadcastAiConversationDeleted } from '@/lib/websocket/socket-utils';
+import { countOpenConversationsForSession } from '@/lib/agent-sessions/agent-sessions-runtime';
 
 // Test fixtures
 const mockUserId = 'user_123';
@@ -100,7 +105,9 @@ const mockAgent = () => ({
   driveId: mockDriveId,
 });
 
-const mockConversationRow = (overrides: Partial<{ userId: string; isShared: boolean }> = {}) => ({
+const mockConversationRow = (
+  overrides: Partial<{ userId: string; isShared: boolean; sessionId: string | null; closedInSessionAt: Date | null }> = {},
+) => ({
   id: mockConversationId,
   userId: mockUserId,
   type: 'page',
@@ -439,6 +446,11 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
 
     // Default: audit log succeeds
     vi.mocked(conversationRepository.logConversationDeletion).mockResolvedValue(undefined);
+
+    // Default: irrelevant unless the conversation row overrides sessionId —
+    // a plenty-large count so the never-empty guard never trips by accident
+    // in tests that don't care about it.
+    vi.mocked(countOpenConversationsForSession).mockResolvedValue(5);
   });
 
   describe('authentication', () => {
@@ -452,6 +464,70 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
       const response = await DELETE(request, context);
 
       expect(response.status).toBe(401);
+    });
+  });
+
+  describe("the session never-empty guard (review finding: chatgpt-codex-connector on PR #2296)", () => {
+    it("refuses to delete a session-bound conversation that is its session's LAST open listing", async () => {
+      vi.mocked(conversationRepository.getConversation).mockResolvedValue(
+        mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null }),
+      );
+      vi.mocked(countOpenConversationsForSession).mockResolvedValue(1);
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.reason).toBe('last_conversation');
+      expect(conversationRepository.softDeleteConversation).not.toHaveBeenCalled();
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ eventType: 'security.rate.limited' }),
+      );
+    });
+
+    it('allows deleting a session-bound conversation when another open listing remains in the same session', async () => {
+      vi.mocked(conversationRepository.getConversation).mockResolvedValue(
+        mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null }),
+      );
+      vi.mocked(countOpenConversationsForSession).mockResolvedValue(2);
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(conversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockAgentId, mockConversationId);
+    });
+
+    it('does not weigh the guard at all for a conversation ALREADY closed out of its session — it holds no open slot to protect', async () => {
+      vi.mocked(conversationRepository.getConversation).mockResolvedValue(
+        mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: new Date('2026-01-01') }),
+      );
+      vi.mocked(countOpenConversationsForSession).mockResolvedValue(0);
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(conversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockAgentId, mockConversationId);
+    });
+
+    it('does not weigh the guard for a plain (non-session-bound) conversation', async () => {
+      vi.mocked(conversationRepository.getConversation).mockResolvedValue(
+        mockConversationRow({ sessionId: null }),
+      );
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -111,7 +111,7 @@ const mockAgent = () => ({
 });
 
 const mockConversationRow = (
-  overrides: Partial<{ userId: string; isShared: boolean; sessionId: string | null; closedInSessionAt: Date | null }> = {},
+  overrides: Partial<{ userId: string; isShared: boolean; sessionId: string | null; closedInSessionAt: Date | null; isActive: boolean }> = {},
 ) => ({
   id: mockConversationId,
   userId: mockUserId,
@@ -510,7 +510,7 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
       expect(conversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockAgentId, mockConversationId);
     });
 
-    it('does not weigh the guard at all for a conversation ALREADY closed out of its session — it holds no open slot to protect', async () => {
+    it('does not weigh the never-empty guard for a conversation ALREADY closed out of its session — it holds no open slot to protect — but STILL serializes under the session lock', async () => {
       vi.mocked(conversationRepository.getConversation).mockResolvedValue(
         mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: new Date('2026-01-01') }),
       );
@@ -523,7 +523,14 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
       expect(response.status).toBe(200);
       expect(countOpenConversationsForSession).not.toHaveBeenCalled();
       expect(conversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockAgentId, mockConversationId);
-      expect(withSessionListingLock).not.toHaveBeenCalled();
+      // A CLOSED conversation's delete is not exempt from the lock — only
+      // from the never-empty guard's count check. Without the lock, this
+      // delete could interleave with a concurrent reopen's own lock-held
+      // critical section and leave `isActive: false` with
+      // `closedInSessionAt: null` — "reopened" but invisible to every
+      // session listing (review finding — chatgpt-codex-connector on PR
+      // #2296, filed after the previous round's open-only guard).
+      expect(withSessionListingLock).toHaveBeenCalledWith('ses_1', expect.any(Function));
     });
 
     it('does not weigh the guard for a plain (non-session-bound) conversation', async () => {
@@ -538,6 +545,42 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
       expect(response.status).toBe(200);
       expect(countOpenConversationsForSession).not.toHaveBeenCalled();
       expect(withSessionListingLock).not.toHaveBeenCalled();
+    });
+
+    it('re-reads the row INSIDE the lock rather than trusting the pre-lock snapshot — a since-reopened conversation still trips the never-empty guard even though the outer read saw it closed', async () => {
+      // The pre-lock snapshot (read for ownership/audit purposes) sees the
+      // conversation closed; a concurrent reopen commits between that read
+      // and the lock being acquired, so the FRESH read taken inside the
+      // lock — the only one this route's decision actually uses — must see
+      // it open and weigh the guard, or a stale-snapshot bypass would let a
+      // since-reopened conversation slip past it.
+      vi.mocked(conversationRepository.getConversation)
+        .mockResolvedValueOnce(mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: new Date('2026-01-01') }))
+        .mockResolvedValueOnce(mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null }));
+      vi.mocked(countOpenConversationsForSession).mockResolvedValue(1);
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.reason).toBe('last_conversation');
+      expect(conversationRepository.softDeleteConversation).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when a concurrent request already history-deleted the row before this one entered the lock', async () => {
+      vi.mocked(conversationRepository.getConversation)
+        .mockResolvedValueOnce(mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null }))
+        .mockResolvedValueOnce(mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null, isActive: false }));
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(conversationRepository.softDeleteConversation).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -569,6 +569,26 @@ describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', 
       expect(conversationRepository.softDeleteConversation).not.toHaveBeenCalled();
     });
 
+    it('still soft-deletes a row whose session was cleared between the pre-lock read and the lock-held read — detached is not the same as history-deleted', async () => {
+      // `conversations.sessionId` is `ON DELETE SET NULL`: a session
+      // deleted between the two reads leaves this row active but detached.
+      // The prior version folded "sessionId no longer matches" into
+      // "already deleted" and silently skipped the soft-delete, so a
+      // detached-but-active conversation was reported as removed while
+      // staying in History (review finding — coderabbitai on PR #2296).
+      vi.mocked(conversationRepository.getConversation)
+        .mockResolvedValueOnce(mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null }))
+        .mockResolvedValueOnce(mockConversationRow({ sessionId: null, closedInSessionAt: null }));
+
+      const request = createRequest(mockAgentId, mockConversationId, 'DELETE');
+      const context = createContext(mockAgentId, mockConversationId);
+      const response = await DELETE(request, context);
+
+      expect(response.status).toBe(200);
+      expect(countOpenConversationsForSession).not.toHaveBeenCalled();
+      expect(conversationRepository.softDeleteConversation).toHaveBeenCalledWith(mockAgentId, mockConversationId);
+    });
+
     it('is idempotent when a concurrent request already history-deleted the row before this one entered the lock', async () => {
       vi.mocked(conversationRepository.getConversation)
         .mockResolvedValueOnce(mockConversationRow({ sessionId: 'ses_1', closedInSessionAt: null }))

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -3,6 +3,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrin
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { countOpenConversationsForSession } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { broadcastAiConversationAdded, broadcastAiConversationRenamed, broadcastAiConversationDeleted } from '@/lib/websocket/socket-utils';
 import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
 import { maskIdentifier } from '@/lib/logging/mask';
@@ -216,6 +217,37 @@ export async function DELETE(
         { error: 'Insufficient permissions to delete this conversation' },
         { status: 403 }
       );
+    }
+
+    // History-deleting a session-bound conversation now also deactivates its
+    // CANONICAL row (`softDeleteConversation` below) — which, unlike the
+    // console's own "Close" action, does not go through
+    // `closeConversationInSessionWith`'s never-empty guard. Refusing here
+    // when this is the session's LAST open listing keeps that same
+    // invariant true regardless of which route emptied it (review finding —
+    // chatgpt-codex-connector on PR #2296): an active session left with a
+    // live sandbox and zero reachable conversations is worse than a plain
+    // 409 telling the user to close the pane (which offers to end the
+    // session) or delete history from a different conversation first.
+    if (conversationRow?.sessionId && conversationRow.closedInSessionAt === null) {
+      const openCount = await countOpenConversationsForSession(conversationRow.sessionId);
+      if (openCount <= 1) {
+        auditRequest(request, {
+          eventType: 'security.rate.limited',
+          userId: auth.userId,
+          resourceType: 'page_agent_conversation',
+          resourceId: conversationId,
+          details: { reason: 'last_session_conversation', agentId, sessionId: conversationRow.sessionId, method: 'DELETE' },
+          riskScore: 0,
+        });
+        return NextResponse.json(
+          {
+            error: 'This is the only open conversation in its session — close the pane (or end the session) instead of deleting it from History.',
+            reason: 'last_conversation',
+          },
+          { status: 409 },
+        );
+      }
     }
 
     // Get conversation metadata before deletion for audit log

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -251,12 +251,19 @@ export async function DELETE(
       const sessionId = conversationRow.sessionId;
       const outcome = await withSessionListingLock(sessionId, async () => {
         const fresh = await conversationRepository.getConversation(conversationId);
-        if (!fresh || fresh.sessionId !== sessionId || !fresh.isActive) {
-          // Already history-deleted by a concurrent request (or no longer
-          // bound to this session) — nothing left to guard or delete.
+        if (!fresh || !fresh.isActive) {
+          // Already history-deleted by a concurrent request — nothing left
+          // to guard or delete.
           return 'already_deleted' as const;
         }
-        if (fresh.closedInSessionAt === null) {
+        // A row whose session was cleared (`conversations.sessionId` is
+        // `ON DELETE SET NULL`) is still an active conversation that must
+        // be deleted — it's merely detached from `sessionId`'s cap, not
+        // history-deleted. Only weigh the never-empty guard when the row is
+        // STILL bound to the session this lock is keyed on (review finding
+        // — coderabbitai on PR #2296: the prior version folded "detached"
+        // into "already deleted" and silently skipped the soft-delete).
+        if (fresh.sessionId === sessionId && fresh.closedInSessionAt === null) {
           // Still open — occupies a listing slot, so the never-empty guard applies.
           const openCount = await countOpenConversationsForSession(sessionId);
           if (openCount <= 1) return 'last_conversation' as const;

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -231,15 +231,36 @@ export async function DELETE(
     // left with a live sandbox and zero reachable conversations is worse
     // than a plain 409 telling the user to close the pane (which offers to
     // end the session) or delete history from a different conversation
-    // first. The count-then-delete pair runs inside `withSessionListingLock`
-    // — the SAME per-session lock create/close/reopen already serialize
-    // under — so this can never race one of them into reading a stale count
-    // (review findings — chatgpt-codex-connector on PR #2296).
-    if (conversationRow?.sessionId && conversationRow.closedInSessionAt === null) {
+    // first.
+    //
+    // EVERY session-bound deletion takes the lock — not just open-listing
+    // ones — and re-reads the row's live state once inside it, rather than
+    // branching on `conversationRow`'s pre-lock snapshot. An already-CLOSED
+    // conversation still needs the lock: without it, this delete could
+    // interleave with a concurrent reopen's own lock-held critical section
+    // arbitrarily (they'd never even contend for the same lock), so a delete
+    // racing a reopen could commit `isActive: false` right as the reopen's
+    // stale-free `isActive` read passed, letting the reopen's UPDATE clear
+    // `closedInSessionAt` on a row that never got a listing slot back —
+    // "reopened successfully" but invisible to every session listing (review
+    // finding — chatgpt-codex-connector on PR #2296, filed after the
+    // previous round's open-only guard). Re-reading inside the lock also
+    // means a stale pre-lock snapshot can never smuggle a since-reopened
+    // conversation past the never-empty guard.
+    if (conversationRow?.sessionId) {
       const sessionId = conversationRow.sessionId;
       const outcome = await withSessionListingLock(sessionId, async () => {
-        const openCount = await countOpenConversationsForSession(sessionId);
-        if (openCount <= 1) return 'last_conversation' as const;
+        const fresh = await conversationRepository.getConversation(conversationId);
+        if (!fresh || fresh.sessionId !== sessionId || !fresh.isActive) {
+          // Already history-deleted by a concurrent request (or no longer
+          // bound to this session) — nothing left to guard or delete.
+          return 'already_deleted' as const;
+        }
+        if (fresh.closedInSessionAt === null) {
+          // Still open — occupies a listing slot, so the never-empty guard applies.
+          const openCount = await countOpenConversationsForSession(sessionId);
+          if (openCount <= 1) return 'last_conversation' as const;
+        }
         await conversationRepository.softDeleteConversation(agentId, conversationId);
         return 'deleted' as const;
       });
@@ -261,10 +282,11 @@ export async function DELETE(
           { status: 409 },
         );
       }
+      // 'already_deleted' falls through to the success response below —
+      // idempotent from the caller's point of view, since the end state
+      // (isActive: false) is exactly what a DELETE asks for.
     } else {
-      // Not session-bound (or already closed out of its session, so it
-      // holds no open slot to protect) — no lock needed, nothing to
-      // serialize against.
+      // Not session-bound at all — no listing to protect, no lock needed.
       await conversationRepository.softDeleteConversation(agentId, conversationId);
     }
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -3,7 +3,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrin
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
-import { countOpenConversationsForSession } from '@/lib/agent-sessions/agent-sessions-runtime';
+import { countOpenConversationsForSession, withSessionListingLock } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { broadcastAiConversationAdded, broadcastAiConversationRenamed, broadcastAiConversationDeleted } from '@/lib/websocket/socket-utils';
 import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
 import { maskIdentifier } from '@/lib/logging/mask';
@@ -219,25 +219,38 @@ export async function DELETE(
       );
     }
 
+    // Get conversation metadata before deletion for audit log
+    const metadata = await conversationRepository.getConversationMetadata(agentId, conversationId);
+
     // History-deleting a session-bound conversation now also deactivates its
     // CANONICAL row (`softDeleteConversation` below) — which, unlike the
     // console's own "Close" action, does not go through
     // `closeConversationInSessionWith`'s never-empty guard. Refusing here
     // when this is the session's LAST open listing keeps that same
-    // invariant true regardless of which route emptied it (review finding —
-    // chatgpt-codex-connector on PR #2296): an active session left with a
-    // live sandbox and zero reachable conversations is worse than a plain
-    // 409 telling the user to close the pane (which offers to end the
-    // session) or delete history from a different conversation first.
+    // invariant true regardless of which route emptied it: an active session
+    // left with a live sandbox and zero reachable conversations is worse
+    // than a plain 409 telling the user to close the pane (which offers to
+    // end the session) or delete history from a different conversation
+    // first. The count-then-delete pair runs inside `withSessionListingLock`
+    // — the SAME per-session lock create/close/reopen already serialize
+    // under — so this can never race one of them into reading a stale count
+    // (review findings — chatgpt-codex-connector on PR #2296).
     if (conversationRow?.sessionId && conversationRow.closedInSessionAt === null) {
-      const openCount = await countOpenConversationsForSession(conversationRow.sessionId);
-      if (openCount <= 1) {
+      const sessionId = conversationRow.sessionId;
+      const outcome = await withSessionListingLock(sessionId, async () => {
+        const openCount = await countOpenConversationsForSession(sessionId);
+        if (openCount <= 1) return 'last_conversation' as const;
+        await conversationRepository.softDeleteConversation(agentId, conversationId);
+        return 'deleted' as const;
+      });
+
+      if (outcome === 'last_conversation') {
         auditRequest(request, {
           eventType: 'security.rate.limited',
           userId: auth.userId,
           resourceType: 'page_agent_conversation',
           resourceId: conversationId,
-          details: { reason: 'last_session_conversation', agentId, sessionId: conversationRow.sessionId, method: 'DELETE' },
+          details: { reason: 'last_session_conversation', agentId, sessionId, method: 'DELETE' },
           riskScore: 0,
         });
         return NextResponse.json(
@@ -248,13 +261,12 @@ export async function DELETE(
           { status: 409 },
         );
       }
+    } else {
+      // Not session-bound (or already closed out of its session, so it
+      // holds no open slot to protect) — no lock needed, nothing to
+      // serialize against.
+      await conversationRepository.softDeleteConversation(agentId, conversationId);
     }
-
-    // Get conversation metadata before deletion for audit log
-    const metadata = await conversationRepository.getConversationMetadata(agentId, conversationId);
-
-    // Soft-delete all messages in the conversation
-    await conversationRepository.softDeleteConversation(agentId, conversationId);
 
     // Audit log the deletion for security and compliance
     await conversationRepository.logConversationDeletion({

--- a/apps/web/src/app/p/[pageId]/page.tsx
+++ b/apps/web/src/app/p/[pageId]/page.tsx
@@ -23,7 +23,7 @@ export default async function PageRedirect({ params, searchParams }: PageProps) 
   // query params the destination page itself interprets.
   const query = new URLSearchParams(
     Object.entries(await searchParams).flatMap(([key, value]): [string, string][] =>
-      value === undefined ? [] : (Array.isArray(value) ? value : [value]).map((v) => [key, v]),
+      value === undefined ? [] : (typeof value === 'string' ? [value] : value).map((v): [string, string] => [key, v]),
     ),
   ).toString();
 

--- a/apps/web/src/app/p/[pageId]/page.tsx
+++ b/apps/web/src/app/p/[pageId]/page.tsx
@@ -9,28 +9,39 @@ import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 
 interface PageProps {
   params: Promise<{ pageId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 /**
  * Page redirect route - navigates to the correct dashboard URL for a page
  * This allows mentions to link directly to a page ID without knowing the driveId
  */
-export default async function PageRedirect({ params }: PageProps) {
+export default async function PageRedirect({ params, searchParams }: PageProps) {
   const { pageId } = await params;
+  // Forwarded verbatim (e.g. `?tab=settings` from the agents console's
+  // Settings link) — this route only resolves the driveId, it must not drop
+  // query params the destination page itself interprets.
+  const query = new URLSearchParams(
+    Object.entries(await searchParams).flatMap(([key, value]): [string, string][] =>
+      value === undefined ? [] : (Array.isArray(value) ? value : [value]).map((v) => [key, v]),
+    ),
+  ).toString();
 
   // Get session token from cookies
   const cookieStore = await cookies();
   const cookieHeader = cookieStore.toString();
   const sessionToken = getSessionFromCookies(cookieHeader);
 
+  const callbackUrl = query ? `/p/${pageId}?${query}` : `/p/${pageId}`;
+
   if (!sessionToken) {
-    redirect(`/auth/signin?callbackUrl=/p/${pageId}`);
+    redirect(`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   }
 
   // Validate the session token — only a browser session may drive this redirect.
   const session = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!session) {
-    redirect(`/auth/signin?callbackUrl=/p/${pageId}`);
+    redirect(`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   }
 
   const userId = session.userId;
@@ -52,5 +63,5 @@ export default async function PageRedirect({ params }: PageProps) {
   }
 
   // Redirect to the full dashboard URL
-  redirect(`/dashboard/${page.driveId}/${pageId}`);
+  redirect(query ? `/dashboard/${page.driveId}/${pageId}?${query}` : `/dashboard/${page.driveId}/${pageId}`);
 }

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -80,32 +80,39 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // (drive membership + code-execution) on every spawn.
   const canUseSessions = user?.role === 'admin';
 
-  // A deep link from the Agents surface's past-conversations list
-  // (`?conversationId=&sessionId=`) — one-time intent, not durable state like
-  // the Agents surface's own `?session=`/`?c=`/`?agent=`, so it's captured
-  // once at mount and never re-read afterward (a later History-tab pick or
-  // "new conversation" is not fighting a stale URL param).
+  // Deep links into this page — one-time intent, not durable state like the
+  // Agents surface's own `?session=`/`?c=`/`?agent=`, so every one of these is
+  // captured once at mount and never re-read afterward (a later History-tab
+  // pick, "new conversation", or tab click is not fighting a stale URL param):
+  // - `?conversationId=&sessionId=` — the Agents surface's past-conversations list
+  // - `?tab=` — the agents console's per-pane Settings link (via `/p/[pageId]`,
+  //   which forwards the query string verbatim)
   const searchParams = useSearchParams();
   const initialConversationIdRef = useRef(searchParams.get('conversationId') ?? undefined);
   const initialSessionIdRef = useRef(searchParams.get('sessionId'));
+  const initialTab = searchParams.get('tab');
+  const hadDeepLinkParams =
+    initialConversationIdRef.current !== undefined || initialSessionIdRef.current !== null || initialTab !== null;
 
   // Consume-once, for real: strip the params from the URL immediately after
-  // capturing them. Left in place, a refresh after the user later switches
-  // to a DIFFERENT conversation (History tab, "new") would remount this
-  // component, re-read the same stale `conversationId` from the URL, and
-  // silently reopen the original deep-linked thread instead of respecting
-  // where the user actually navigated to (review finding — this was
-  // previously dismissed as "cosmetic", but it's a real functional bug on
-  // refresh, not just an untidy address bar).
+  // capturing them. Left in place, a refresh after the user later switches to
+  // a DIFFERENT conversation (History tab, "new") or tab would remount this
+  // component, re-read the same stale params from the URL, and silently
+  // reopen the original deep-linked thread/tab instead of respecting where
+  // the user actually navigated to (review finding — this was previously
+  // dismissed as "cosmetic", but it's a real functional bug on refresh, not
+  // just an untidy address bar).
   useEffect(() => {
-    if (initialConversationIdRef.current === undefined) return;
+    if (!hadDeepLinkParams) return;
     const url = new URL(window.location.href);
     url.searchParams.delete('conversationId');
     url.searchParams.delete('sessionId');
+    url.searchParams.delete('tab');
     window.history.replaceState({}, '', url.toString());
-    // Deliberately empty deps: this runs once, immediately after the refs
-    // above captured their values on this same mount — never re-runs for
-    // this component instance.
+    // Deliberately empty deps: this runs once, immediately after the refs/
+    // values above captured their values on this same mount — never re-runs
+    // for this component instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const { resolved: initialResolved } = useResolvedConversation(page.id, {
@@ -138,7 +145,9 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   const { data: sessionData } = useSessionRecord(current?.sessionId ?? null);
   const panesDriveId = sessionData?.session ? sessionData.session.driveId : page.driveId;
 
-  const [activeTab, setActiveTab] = useState<string>('chat');
+  const [activeTab, setActiveTab] = useState<string>(
+    initialTab === 'history' || initialTab === 'settings' ? initialTab : 'chat',
+  );
   const [webhooksOpen, setWebhooksOpen] = useState(false);
   const [agentConfig, setAgentConfig] = useState<AgentConfig | null>(null);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -80,39 +80,32 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // (drive membership + code-execution) on every spawn.
   const canUseSessions = user?.role === 'admin';
 
-  // Deep links into this page — one-time intent, not durable state like the
-  // Agents surface's own `?session=`/`?c=`/`?agent=`, so every one of these is
-  // captured once at mount and never re-read afterward (a later History-tab
-  // pick, "new conversation", or tab click is not fighting a stale URL param):
-  // - `?conversationId=&sessionId=` — the Agents surface's past-conversations list
-  // - `?tab=` — the agents console's per-pane Settings link (via `/p/[pageId]`,
-  //   which forwards the query string verbatim)
+  // A deep link from the Agents surface's past-conversations list
+  // (`?conversationId=&sessionId=`) — one-time intent, not durable state like
+  // the Agents surface's own `?session=`/`?c=`/`?agent=`, so it's captured
+  // once at mount and never re-read afterward (a later History-tab pick or
+  // "new conversation" is not fighting a stale URL param).
   const searchParams = useSearchParams();
   const initialConversationIdRef = useRef(searchParams.get('conversationId') ?? undefined);
   const initialSessionIdRef = useRef(searchParams.get('sessionId'));
-  const initialTab = searchParams.get('tab');
-  const hadDeepLinkParams =
-    initialConversationIdRef.current !== undefined || initialSessionIdRef.current !== null || initialTab !== null;
 
   // Consume-once, for real: strip the params from the URL immediately after
-  // capturing them. Left in place, a refresh after the user later switches to
-  // a DIFFERENT conversation (History tab, "new") or tab would remount this
-  // component, re-read the same stale params from the URL, and silently
-  // reopen the original deep-linked thread/tab instead of respecting where
-  // the user actually navigated to (review finding — this was previously
-  // dismissed as "cosmetic", but it's a real functional bug on refresh, not
-  // just an untidy address bar).
+  // capturing them. Left in place, a refresh after the user later switches
+  // to a DIFFERENT conversation (History tab, "new") would remount this
+  // component, re-read the same stale `conversationId` from the URL, and
+  // silently reopen the original deep-linked thread instead of respecting
+  // where the user actually navigated to (review finding — this was
+  // previously dismissed as "cosmetic", but it's a real functional bug on
+  // refresh, not just an untidy address bar).
   useEffect(() => {
-    if (!hadDeepLinkParams) return;
+    if (initialConversationIdRef.current === undefined) return;
     const url = new URL(window.location.href);
     url.searchParams.delete('conversationId');
     url.searchParams.delete('sessionId');
-    url.searchParams.delete('tab');
     window.history.replaceState({}, '', url.toString());
-    // Deliberately empty deps: this runs once, immediately after the refs/
-    // values above captured their values on this same mount — never re-runs
-    // for this component instance.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Deliberately empty deps: this runs once, immediately after the refs
+    // above captured their values on this same mount — never re-runs for
+    // this component instance.
   }, []);
 
   const { resolved: initialResolved } = useResolvedConversation(page.id, {
@@ -145,9 +138,29 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   const { data: sessionData } = useSessionRecord(current?.sessionId ?? null);
   const panesDriveId = sessionData?.session ? sessionData.session.driveId : page.driveId;
 
-  const [activeTab, setActiveTab] = useState<string>(
-    initialTab === 'history' || initialTab === 'settings' ? initialTab : 'chat',
-  );
+  // `?tab=` deep-links here (the agents console's per-pane Settings link, via
+  // `/p/[pageId]`, which forwards the query string verbatim). Seeded once at
+  // mount (a lazy initializer, so a fresh navigation lands on the right tab
+  // with no flash of "chat" first) AND re-synced by the effect below on every
+  // subsequent `searchParams` change: clicking that link while THIS SAME
+  // `AgentPageView` instance is already mounted — its own Chat tab hosts a
+  // pane for its own agent, so the pane bar's Settings link can point right
+  // back at the page it's already showing — is a query-only navigation Next
+  // does not remount for, so a mount-only read would silently no-op (review
+  // finding — chatgpt-codex-connector on PR #2296).
+  const [activeTab, setActiveTab] = useState<string>(() => {
+    const tab = searchParams.get('tab');
+    return tab === 'history' || tab === 'settings' ? tab : 'chat';
+  });
+
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab !== 'history' && tab !== 'settings') return;
+    setActiveTab(tab);
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tab');
+    window.history.replaceState({}, '', url.toString());
+  }, [searchParams]);
   const [webhooksOpen, setWebhooksOpen] = useState(false);
   const [agentConfig, setAgentConfig] = useState<AgentConfig | null>(null);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -744,4 +744,56 @@ describe('AgentPageView', () => {
       expect(window.location.search).toBe('');
     });
   });
+
+  describe('the console\'s Settings link (?tab=) — review finding: chatgpt-codex-connector on PR #2296', () => {
+    it('lands on the requested tab on a fresh mount', () => {
+      resolveTo({ conversationId: 'conv-1', sessionId: null });
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=settings') as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?tab=settings');
+
+      render(<AgentPageView page={pageFixture()} />);
+
+      expect(screen.getByRole('tab', { name: /settings/i })).toHaveAttribute('data-state', 'active');
+    });
+
+    it('strips ?tab= from the URL after consuming it', () => {
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=history') as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?tab=history');
+
+      render(<AgentPageView page={pageFixture()} />);
+
+      expect(new URL(window.location.href).searchParams.has('tab')).toBe(false);
+    });
+
+    it('re-syncs the tab when the SAME mounted instance receives a new ?tab= — a query-only navigation Next does not remount for', () => {
+      // The pane-bar link points at THIS agent's own page: when the user is
+      // already on it (this page's own Chat tab can host a pane for its own
+      // agent), clicking Settings is a query-only navigation to the exact
+      // same route — Next keeps the component instance mounted, so a
+      // mount-only read of `?tab=` would silently no-op.
+      resolveTo({ conversationId: 'conv-1', sessionId: null });
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1');
+
+      const { rerender } = render(<AgentPageView page={pageFixture()} />);
+      expect(screen.getByRole('tab', { name: /^chat/i })).toHaveAttribute('data-state', 'active');
+
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=settings') as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?tab=settings');
+      rerender(<AgentPageView page={pageFixture()} />);
+
+      expect(screen.getByRole('tab', { name: /settings/i })).toHaveAttribute('data-state', 'active');
+      expect(new URL(window.location.href).searchParams.has('tab')).toBe(false);
+    });
+
+    it('ignores an unrecognized ?tab= value rather than crashing or clearing the current tab', () => {
+      resolveTo({ conversationId: 'conv-1', sessionId: null });
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=nonsense') as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?tab=nonsense');
+
+      render(<AgentPageView page={pageFixture()} />);
+
+      expect(screen.getByRole('tab', { name: /^chat/i })).toHaveAttribute('data-state', 'active');
+    });
+  });
 });

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -786,6 +786,36 @@ describe('AgentPageView', () => {
       expect(new URL(window.location.href).searchParams.has('tab')).toBe(false);
     });
 
+    it('re-applies a repeat ?tab=settings navigation even after the user has since clicked away — coderabbitai raised this as a distinct case from a differing tab value', async () => {
+      // CodeRabbit's scenario: the URL goes from `tab=settings` to `tab=settings`
+      // AGAIN while mounted (not `history` → `settings`, a genuinely repeated
+      // value) — e.g. the user clicks the pane's Settings link, manually
+      // switches to Chat, then clicks that SAME Settings link a second time.
+      // The fix doesn't track "did the value change from its last observed
+      // value" — it applies whatever valid `tab` is present on every
+      // `searchParams` identity change (which Next produces on every real
+      // navigation, including a repeat), so this needs no special-casing.
+      resolveTo({ conversationId: 'conv-1', sessionId: null });
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=settings') as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?tab=settings');
+
+      const { rerender } = render(<AgentPageView page={pageFixture()} />);
+      expect(screen.getByRole('tab', { name: /settings/i })).toHaveAttribute('data-state', 'active');
+
+      // The user navigates away locally (a plain tab click, not a URL change).
+      await userEvent.click(screen.getByRole('tab', { name: /^chat/i }));
+      expect(screen.getByRole('tab', { name: /^chat/i })).toHaveAttribute('data-state', 'active');
+
+      // A second, independent navigation arrives carrying the SAME `tab=settings`
+      // value (a fresh `URLSearchParams` instance, exactly as a real Next
+      // navigation produces even for a repeated value).
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=settings') as ReturnType<typeof useSearchParams>);
+      window.history.replaceState({}, '', '/dashboard/drive-1/page-1?tab=settings');
+      rerender(<AgentPageView page={pageFixture()} />);
+
+      expect(screen.getByRole('tab', { name: /settings/i })).toHaveAttribute('data-state', 'active');
+    });
+
     it('ignores an unrecognized ?tab= value rather than crashing or clearing the current tab', () => {
       resolveTo({ conversationId: 'conv-1', sessionId: null });
       vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams('tab=nonsense') as ReturnType<typeof useSearchParams>);

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -36,8 +36,9 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { createId } from '@paralleldrive/cuid2';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Settings } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
@@ -843,14 +844,30 @@ function ChatPaneIdentity({
   const disabled = surface.surface === 'loading' || activeStream !== undefined || !conversationsReady;
 
   return (
-    <AISelector
-      selectedAgent={scope.agentPageId === null ? null : agent}
-      onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
-      driveId={driveId ?? undefined}
-      agents={pickableAgents}
-      agentsLoading={agentsLoading}
-      disabled={disabled}
-      className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
-    />
+    <div className="flex min-w-0 flex-1 items-center gap-0.5">
+      <AISelector
+        selectedAgent={scope.agentPageId === null ? null : agent}
+        onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
+        driveId={driveId ?? undefined}
+        agents={pickableAgents}
+        agentsLoading={agentsLoading}
+        disabled={disabled}
+        className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
+      />
+      {/* The Assistant (agentPageId null) has no page, so no Settings — every
+          other pane's agent does. `/p/[pageId]` resolves the drive-scoped
+          URL without this component needing to know it. */}
+      {scope.agentPageId !== null && (
+        <Link
+          href={`/p/${scope.agentPageId}?tab=settings`}
+          aria-label={`${agent?.title ?? 'Agent'} settings`}
+          title="Agent settings"
+          className="flex shrink-0 items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Settings className="size-3" aria-hidden="true" />
+        </Link>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -904,6 +904,23 @@ describe('AgentPanes', () => {
       expect(await screen.findByRole('button', { name: /Researcher/ })).toBeInTheDocument();
     });
 
+    it("links to the pane's agent settings — the console's only Settings entry point", async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const settingsLink = await screen.findByRole('link', { name: /researcher settings/i });
+      expect(settingsLink).toHaveAttribute('href', '/p/agent-1?tab=settings');
+    });
+
+    it('hides the settings link for the Assistant (no agent page, so no settings)', async () => {
+      renderPanes({
+        initialConversation: { conversationId: 'conv-1', agentPageId: null, name: 'Assistant' },
+      });
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument();
+    });
+
     it("is disabled until THIS session's entry appears in the switch decision's own data", async () => {
       let resolveSessions!: () => void;
       mockFetchWithAuth.mockImplementation(async (url: string) => {

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -122,7 +122,9 @@ export default function AgentsSidebar({ className }: SidebarProps) {
               hasError={!!sessionsError}
               onRetry={() => void retrySessions()}
               agentsByDrive={agentsByDrive}
-              onChanged={() => void retrySessions()}
+              onChanged={(updater) =>
+                void (updater ? retrySessions(updater, { revalidate: false }) : retrySessions())
+              }
             />
           </div>
         </div>
@@ -147,6 +149,23 @@ interface SessionListEntry {
   conversations: SessionConversationEntry[];
   shells: Array<{ shellId: string; name: string }>;
 }
+
+type SessionsCacheData = { sessions: SessionListEntry[] } | undefined;
+
+/**
+ * The sessions list changed — plain `onChanged()` just revalidates. Passing
+ * an `updater` instead applies it to the cache LOCALLY first (no
+ * `revalidate`), the same optimistic-write discipline `AgentPanes.tsx`'s
+ * `recordMintedConversation`/`recordClosedConversation` already use on this
+ * identical SWR key (`agentSessionsKey(driveId)` — same string as this
+ * sidebar's own `sessionsKey`, so it's the same cache entry): a reopen needs
+ * this cache to already contain the reopened conversation the instant
+ * `openConversation` focuses its pane, not after the next revalidation
+ * lands, or a pane closed before then reads `decideClosePane`'s
+ * "resolved-but-absent" fallback and never issues the close DELETE (review
+ * finding — chatgpt-codex-connector on PR #2296).
+ */
+type OnSessionsChanged = (updater?: (current: SessionsCacheData) => SessionsCacheData) => void;
 
 async function sessionsFetcher(url: string): Promise<{ sessions: SessionListEntry[] }> {
   const response = await fetchWithAuth(url);
@@ -231,7 +250,7 @@ function SessionList({
   hasError: boolean;
   onRetry: () => void;
   agentsByDrive: DriveWithAgents[];
-  onChanged: () => void;
+  onChanged: OnSessionsChanged;
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const trimmedQuery = searchQuery.trim();
@@ -532,7 +551,7 @@ function SessionRow({
   agentNamesById,
 }: {
   session: SessionListEntry;
-  onChanged: () => void;
+  onChanged: OnSessionsChanged;
   agentNamesById: Map<string, string>;
 }) {
   const selectedSessionId = useAgentSurfaceStore((state) => state.selectedSessionId);
@@ -654,11 +673,29 @@ function SessionRow({
         await post(
           `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations/${encodeURIComponent(conversation.conversationId)}/reopen`,
         );
-        // Drop it from the closed list and refresh the open list — it now
-        // belongs in both places (the second matters even before the poll
-        // catches up, or the row a user just reopened looks like a no-op).
+        // Drop it from the closed list and add it to the open list LOCALLY,
+        // synchronously — not just a revalidate. `openConversation` below
+        // focuses this conversation's pane immediately, and `AgentPanes`'
+        // close-pane decision reads this SAME cache (`agentSessionsKey`,
+        // this sidebar's `sessionsKey` is the identical string) to decide
+        // whether closing that pane should also issue the session-scoped
+        // DELETE. A plain revalidate is a network round trip behind that —
+        // closing the pane before it lands reads "no listing found" and
+        // silently skips the DELETE, leaving the reopened conversation
+        // consuming a cap slot forever (review finding —
+        // chatgpt-codex-connector on PR #2296). Mirrors `AgentPanes.tsx`'s
+        // own `recordMintedConversation`/`recordClosedConversation`.
         void retryClosed();
-        onChanged();
+        onChanged((current) => {
+          if (!current) return current;
+          return {
+            sessions: current.sessions.map((s) =>
+              s.sessionId === session.sessionId
+                ? { ...s, conversations: [conversation, ...s.conversations] }
+                : s,
+            ),
+          };
+        });
         setExpanded(true);
         openConversation(conversation);
       } catch (error) {

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, Folder, Plus, Search, SquareTerminal, X } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Folder, History, Loader2, Plus, Search, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 
@@ -151,6 +151,12 @@ interface SessionListEntry {
 async function sessionsFetcher(url: string): Promise<{ sessions: SessionListEntry[] }> {
   const response = await fetchWithAuth(url);
   if (!response.ok) throw new Error(`Failed to list sessions (${response.status})`);
+  return response.json();
+}
+
+async function closedConversationsFetcher(url: string): Promise<{ conversations: SessionConversationEntry[] }> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to list closed conversations (${response.status})`);
   return response.json();
 }
 
@@ -537,8 +543,24 @@ function SessionRow({
   const [expanded, setExpanded] = useState(false);
   const [confirmingEnd, setConfirmingEnd] = useState(false);
   const [ending, setEnding] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  const [reopeningId, setReopeningId] = useState<string | null>(null);
   const isSelected = selectedSessionId === session.sessionId;
   const isRunning = session.sandboxStatus === 'running' || session.sandboxStatus === 'starting';
+
+  // Closed conversations — the reopen affordance's source list. Fetched only
+  // once the user actually opens History (not on every session row's mount),
+  // since most sessions are browsed without ever needing it.
+  const {
+    data: closedData,
+    error: closedError,
+    isLoading: closedLoading,
+    mutate: retryClosed,
+  } = useSWR<{ conversations: SessionConversationEntry[] }>(
+    showHistory ? `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations/closed` : null,
+    closedConversationsFetcher,
+    { revalidateOnFocus: false },
+  );
 
   const openConversation = useCallback(
     (conversation: SessionConversationEntry) => {
@@ -625,6 +647,49 @@ function SessionRow({
     [onChanged, session.sessionId],
   );
 
+  const reopenConversation = useCallback(
+    async (conversation: SessionConversationEntry) => {
+      setReopeningId(conversation.conversationId);
+      try {
+        await post(
+          `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations/${encodeURIComponent(conversation.conversationId)}/reopen`,
+        );
+        // Drop it from the closed list and refresh the open list — it now
+        // belongs in both places (the second matters even before the poll
+        // catches up, or the row a user just reopened looks like a no-op).
+        void retryClosed();
+        onChanged();
+        setExpanded(true);
+        openConversation(conversation);
+      } catch (error) {
+        if (error instanceof ApiRequestError && error.status === 404) {
+          // Someone else (or another tab) already history-deleted it —
+          // stale row in this list; drop it rather than leave a dead click.
+          void retryClosed();
+          return;
+        }
+        console.error('Failed to reopen this conversation:', error);
+        toast.error('Could not reopen this conversation', {
+          description: error instanceof Error ? error.message : 'Please try again.',
+        });
+      } finally {
+        setReopeningId(null);
+      }
+    },
+    [onChanged, openConversation, retryClosed, session.sessionId],
+  );
+
+  const conversationLabel = useCallback(
+    (conversation: SessionConversationEntry) => {
+      const agentName =
+        conversation.agentPageId === null
+          ? 'Global Assistant'
+          : (agentNamesById.get(conversation.agentPageId) ?? 'Agent');
+      return conversation.title ? `${agentName} — ${conversation.title}` : agentName;
+    },
+    [agentNamesById],
+  );
+
   const menuItems: RowMenuItem[] = useMemo(
     () => [
       {
@@ -686,39 +751,32 @@ function SessionRow({
 
       {expanded && (
         <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">
-          {session.conversations.map((conversation) => {
-            const agentName =
-              conversation.agentPageId === null
-                ? 'Global Assistant'
-                : (agentNamesById.get(conversation.agentPageId) ?? 'Agent');
-            const label = conversation.title ? `${agentName} — ${conversation.title}` : agentName;
-            return (
-              <RowMenu
-                key={conversation.conversationId}
-                items={[
-                  {
-                    label: 'Close',
-                    icon: X,
-                    onSelect: () => void closeConversation(conversation.conversationId),
-                    destructive: true,
-                  },
-                ]}
-                menuLabel="Conversation actions"
-                className={cn(
-                  'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
-                  selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
-                )}
+          {session.conversations.map((conversation) => (
+            <RowMenu
+              key={conversation.conversationId}
+              items={[
+                {
+                  label: 'Close',
+                  icon: X,
+                  onSelect: () => void closeConversation(conversation.conversationId),
+                  destructive: true,
+                },
+              ]}
+              menuLabel="Conversation actions"
+              className={cn(
+                'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
+                selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
+              )}
+            >
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center text-left"
+                onClick={() => openConversation(conversation)}
               >
-                <button
-                  type="button"
-                  className="flex min-w-0 flex-1 items-center text-left"
-                  onClick={() => openConversation(conversation)}
-                >
-                  <span className="truncate">{label}</span>
-                </button>
-              </RowMenu>
-            );
-          })}
+                <span className="truncate">{conversationLabel(conversation)}</span>
+              </button>
+            </RowMenu>
+          ))}
           {session.shells.map((shell) => (
             <button
               key={shell.shellId}
@@ -732,6 +790,55 @@ function SessionRow({
           ))}
           {session.conversations.length === 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">No conversations</div>
+          )}
+
+          <button
+            type="button"
+            aria-expanded={showHistory}
+            className="flex min-w-0 w-full items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+            onClick={() => setShowHistory((value) => !value)}
+          >
+            {showHistory ? <ChevronDown className="size-3 shrink-0" /> : <ChevronRight className="size-3 shrink-0" />}
+            <History className="size-3 shrink-0" aria-hidden="true" />
+            <span className="truncate">History</span>
+          </button>
+
+          {showHistory && (
+            <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">
+              {closedLoading && (
+                <div className="flex items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground">
+                  <Loader2 className="size-3 shrink-0 animate-spin" aria-hidden="true" />
+                  Loading history…
+                </div>
+              )}
+              {closedError && !closedLoading && (
+                <button
+                  type="button"
+                  className="px-2 py-1 text-left text-xs text-destructive hover:underline"
+                  onClick={() => void retryClosed()}
+                >
+                  Failed to load history — retry
+                </button>
+              )}
+              {!closedLoading && !closedError && (closedData?.conversations.length ?? 0) === 0 && (
+                <div className="px-2 py-1 text-xs text-muted-foreground">No closed conversations</div>
+              )}
+              {closedData?.conversations.map((conversation) => (
+                <button
+                  key={conversation.conversationId}
+                  type="button"
+                  disabled={reopeningId === conversation.conversationId}
+                  className="flex min-w-0 w-full items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+                  onClick={() => void reopenConversation(conversation)}
+                  title="Reopen this conversation"
+                >
+                  {reopeningId === conversation.conversationId ? (
+                    <Loader2 className="size-3 shrink-0 animate-spin" aria-hidden="true" />
+                  ) : null}
+                  <span className="truncate">{conversationLabel(conversation)}</span>
+                </button>
+              ))}
+            </div>
           )}
         </div>
       )}

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { Bot, ChevronDown, ChevronRight, Folder, History, Loader2, Plus, Search, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 
 import EndSessionDialog from '@/components/agents/EndSessionDialog';
 import { Input } from '@/components/ui/input';
@@ -33,6 +33,7 @@ import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspa
 import { fetchWithAuth, post, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
+import { agentSessionsKey } from '@/components/agents/panes/session-conversations';
 
 /**
  * The Agents console's left sidebar: **Drive → Session → conversations.**
@@ -559,6 +560,11 @@ function SessionRow({
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const selectSession = useAgentSurfaceStore((state) => state.selectSession);
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
+  // Scoped to whatever cache provider this tree renders under (matching
+  // whichever cache `useSWR` calls nearby actually read) — the bare `mutate`
+  // import from `'swr'` only ever targets the true default cache, silently
+  // missing a scoped one if this ever renders under a custom `SWRConfig`.
+  const { mutate: scopedMutate } = useSWRConfig();
   const [expanded, setExpanded] = useState(false);
   const [confirmingEnd, setConfirmingEnd] = useState(false);
   const [ending, setEnding] = useState(false);
@@ -676,26 +682,48 @@ function SessionRow({
         // Drop it from the closed list and add it to the open list LOCALLY,
         // synchronously — not just a revalidate. `openConversation` below
         // focuses this conversation's pane immediately, and `AgentPanes`'
-        // close-pane decision reads this SAME cache (`agentSessionsKey`,
-        // this sidebar's `sessionsKey` is the identical string) to decide
-        // whether closing that pane should also issue the session-scoped
-        // DELETE. A plain revalidate is a network round trip behind that —
-        // closing the pane before it lands reads "no listing found" and
-        // silently skips the DELETE, leaving the reopened conversation
-        // consuming a cap slot forever (review finding —
+        // close-pane decision reads `agentSessionsKey(session.driveId)` to
+        // decide whether closing that pane should also issue the
+        // session-scoped DELETE. A plain revalidate is a network round trip
+        // behind that — closing the pane before it lands reads "no listing
+        // found" and silently skips the DELETE, leaving the reopened
+        // conversation consuming a cap slot forever (review finding —
         // chatgpt-codex-connector on PR #2296). Mirrors `AgentPanes.tsx`'s
         // own `recordMintedConversation`/`recordClosedConversation`.
         void retryClosed();
-        onChanged((current) => {
+        // Idempotent — de-dupes by conversationId before prepending, not a
+        // plain prepend. `onChanged` and the `scopedMutate` call below can
+        // both land on the SAME cache entry (whenever this sidebar's own
+        // key already equals `agentSessionsKey(session.driveId)`, the
+        // common drive-scoped-view case) — a plain prepend applied twice to
+        // the same underlying data would insert the conversation twice.
+        const insertReopened = (current: SessionsCacheData): SessionsCacheData => {
           if (!current) return current;
           return {
             sessions: current.sessions.map((s) =>
               s.sessionId === session.sessionId
-                ? { ...s, conversations: [conversation, ...s.conversations] }
+                ? {
+                    ...s,
+                    conversations: [
+                      conversation,
+                      ...s.conversations.filter((c) => c.conversationId !== conversation.conversationId),
+                    ],
+                  }
                 : s,
             ),
           };
-        });
+        };
+        onChanged(insertReopened);
+        // `agentSessionsKey(session.driveId)` is the SAME string as this
+        // sidebar's own `sessionsKey` only when the sidebar is itself
+        // drive-scoped to that same drive. In the GLOBAL console
+        // (`/dashboard/agents`, no driveId in the route) a drive-bound
+        // session's own key differs from this sidebar's `/api/agent-sessions`
+        // — `onChanged` above never reaches it, so `AgentPanes` (which reads
+        // exactly this key) would still miss the reopened conversation. Safe
+        // to call unconditionally: when the two keys coincide (drive-scoped
+        // view), this is a harmless duplicate of the same insert.
+        void scopedMutate(agentSessionsKey(session.driveId), insertReopened, { revalidate: false });
         setExpanded(true);
         openConversation(conversation);
       } catch (error) {
@@ -713,7 +741,7 @@ function SessionRow({
         setReopeningId(null);
       }
     },
-    [onChanged, openConversation, retryClosed, session.sessionId],
+    [onChanged, openConversation, retryClosed, scopedMutate, session.sessionId, session.driveId],
   );
 
   const conversationLabel = useCallback(

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -584,7 +584,17 @@ function SessionRow({
   } = useSWR<{ conversations: SessionConversationEntry[] }>(
     showHistory ? `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations/closed` : null,
     closedConversationsFetcher,
-    { revalidateOnFocus: false },
+    {
+      revalidateOnFocus: false,
+      // Same modest poll as the main sessions list — a conversation closed
+      // from elsewhere (AgentPanes, another tab) while History is already
+      // open must eventually appear here too, not just on the next
+      // collapse/re-expand (review finding — chatgpt-codex-connector on PR
+      // #2296). The explicit `retryClosed()` call in `closeConversation`
+      // below covers the immediate case (closed from THIS row's own visible
+      // open list); this poll is the catch-all for every other source.
+      refreshInterval: 20_000,
+    },
   );
 
   const openConversation = useCallback(
@@ -654,6 +664,12 @@ function SessionRow({
           `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations/${encodeURIComponent(conversationId)}`,
         );
         onChanged();
+        // The just-closed conversation belongs in History now — a no-op if
+        // that section isn't open (its SWR key is `null` then), but if it
+        // IS open the user should see it appear immediately, not wait for
+        // the next poll (review finding — chatgpt-codex-connector on PR
+        // #2296).
+        void retryClosed();
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 409) {
           // The session's LAST open listing — the server is the authority on
@@ -669,7 +685,7 @@ function SessionRow({
         });
       }
     },
-    [onChanged, session.sessionId],
+    [onChanged, retryClosed, session.sessionId],
   );
 
   const reopenConversation = useCallback(

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -676,6 +676,77 @@ describe('AgentsSidebar', () => {
     });
   });
 
+  describe('history (reopening a closed conversation)', () => {
+    const CLOSED_CONVERSATION = { conversationId: 'conv-closed', title: 'Old chat', agentPageId: 'agent-1' };
+
+    const respondWithSessionsAndClosed = (
+      sessions: SessionFixture[],
+      closed: { conversationId: string; title: string | null; agentPageId: string | null }[],
+    ) => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/conversations/closed')) {
+          return { ok: true, json: async () => ({ conversations: closed }) };
+        }
+        return { ok: true, json: async () => ({ sessions }) };
+      });
+    };
+
+    test('opening History fetches and lists the session\'s closed conversations', async () => {
+      respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+
+      expect(await screen.findByText('Researcher — Old chat')).toBeDefined();
+      expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/closed');
+    });
+
+    test('an empty history says so rather than showing nothing', async () => {
+      respondWithSessionsAndClosed([SESSION], []);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+
+      expect(await screen.findByText(/no closed conversations/i)).toBeDefined();
+    });
+
+    test('clicking a closed conversation POSTs reopen and selects it, same as an open one', async () => {
+      respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
+      mockPost.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+      await user.click(await screen.findByText('Researcher — Old chat'));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-closed/reopen'),
+      );
+      expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
+      expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-closed');
+      expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
+    });
+
+    test('a reopen failure shows an error toast and leaves selection untouched', async () => {
+      respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
+      mockPost.mockRejectedValue(new ApiRequestError('boom', 500));
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+      await user.click(await screen.findByText('Researcher — Old chat'));
+
+      await waitFor(() => expect(mockPost).toHaveBeenCalled());
+      expect(useAgentSurfaceStore.getState().selectedConversationId).not.toBe('conv-closed');
+    });
+  });
+
   describe('global mode', () => {
     beforeEach(() => {
       mockUseParams.mockReturnValue({});

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -735,6 +735,35 @@ describe('AgentsSidebar', () => {
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
     });
 
+    test('reopening inserts into the open conversations list synchronously — before any sessions-list revalidation lands (review finding: chatgpt-codex-connector on PR #2296)', async () => {
+      // AgentPanes' close-pane decision reads this SAME sessions cache to
+      // decide whether closing a pane should issue the server-side DELETE.
+      // If the cache only updated via a network revalidation, a pane closed
+      // before that fetch resolves would read "no listing found" and skip
+      // the DELETE — this proves the insert happens locally, synchronously.
+      respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
+      mockPost.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+      const sessionsListCallsBefore = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => url === '/api/agent-sessions?driveId=drive-1',
+      ).length;
+
+      await user.click(await screen.findByText('Researcher — Old chat'));
+      await waitFor(() => expect(mockPost).toHaveBeenCalled());
+
+      // Now showing in the (still-expanded) open conversations section too —
+      // present without any additional sessions-list fetch.
+      expect(screen.getAllByText('Researcher — Old chat').length).toBeGreaterThan(0);
+      const sessionsListCallsAfter = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => url === '/api/agent-sessions?driveId=drive-1',
+      ).length;
+      expect(sessionsListCallsAfter).toBe(sessionsListCallsBefore);
+    });
+
     test('a non-404 reopen failure shows an error toast and leaves selection untouched', async () => {
       respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
       mockPost.mockRejectedValue(new ApiRequestError('boom', 500));

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -21,7 +21,8 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SWRConfig } from 'swr';
+import useSWR, { SWRConfig } from 'swr';
+import { agentSessionsKey } from '@/components/agents/panes/session-conversations';
 
 const mockPush = vi.fn();
 const mockUseAuth = vi.fn();
@@ -158,6 +159,25 @@ const renderSidebar = () =>
       <AgentsSidebar />
     </SWRConfig>,
   );
+
+/**
+ * Reads the exact cache key `AgentPanes` reads (`agentSessionsKey(driveId)`)
+ * — mounted alongside `AgentsSidebar` in the SAME `SWRConfig` to prove a
+ * reopen's optimistic write lands in the key the pane grid actually
+ * consumes, not just the sidebar's own (which differs from it in the
+ * global console when the session belongs to a real drive).
+ */
+function DriveCacheProbe({ driveId }: { driveId: string }) {
+  const { data } = useSWR<{ sessions: SessionFixture[] }>(agentSessionsKey(driveId), async (url: string) => {
+    const res = await mockFetchWithAuth(url);
+    return res.json();
+  });
+  const conversationIds = (data?.sessions ?? [])
+    .flatMap((s) => s.conversations)
+    .map((c) => c.conversationId)
+    .join(',');
+  return <div data-testid="drive-cache-probe">{conversationIds}</div>;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -762,6 +782,35 @@ describe('AgentsSidebar', () => {
         ([url]) => url === '/api/agent-sessions?driveId=drive-1',
       ).length;
       expect(sessionsListCallsAfter).toBe(sessionsListCallsBefore);
+    });
+
+    test('in the GLOBAL console, also updates the drive-scoped cache AgentPanes actually reads — not just this sidebar\'s own global key (review finding: chatgpt-codex-connector on PR #2296)', async () => {
+      // Global console: this sidebar's own key is '/api/agent-sessions' (no
+      // driveId), but SESSION belongs to a real drive ('drive-1') —
+      // AgentPanes reads `agentSessionsKey('drive-1')` specifically, a
+      // DIFFERENT cache entry than this sidebar's own in this mode.
+      mockUseParams.mockReturnValue({});
+      window.history.replaceState({}, '', '/dashboard/agents');
+      useAgentSurfaceStore.setState({ driveId: null });
+      respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
+      mockPost.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <AgentsSidebar />
+          <DriveCacheProbe driveId="drive-1" />
+        </SWRConfig>,
+      );
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+      await user.click(await screen.findByText('Researcher — Old chat'));
+      await waitFor(() => expect(mockPost).toHaveBeenCalled());
+
+      await waitFor(() =>
+        expect(screen.getByTestId('drive-cache-probe').textContent).toContain('conv-closed'),
+      );
     });
 
     test('a non-404 reopen failure shows an error toast and leaves selection untouched', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -99,6 +99,9 @@ vi.mock('../PrimaryNavigation', () => ({ default: () => <div /> }));
 vi.mock('../DriveFooter', () => ({ default: () => <div /> }));
 vi.mock('../DashboardFooter', () => ({ default: () => <div /> }));
 
+const mockToastError = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => mockToastError(...args) } }));
+
 import { within } from '@testing-library/react';
 import { ApiRequestError } from '@/lib/auth/auth-fetch';
 import AgentsSidebar, { resolveListNotice } from '../AgentsSidebar';
@@ -732,7 +735,7 @@ describe('AgentsSidebar', () => {
       expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
     });
 
-    test('a reopen failure shows an error toast and leaves selection untouched', async () => {
+    test('a non-404 reopen failure shows an error toast and leaves selection untouched', async () => {
       respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
       mockPost.mockRejectedValue(new ApiRequestError('boom', 500));
       const user = userEvent.setup();
@@ -743,6 +746,31 @@ describe('AgentsSidebar', () => {
       await user.click(await screen.findByText('Researcher — Old chat'));
 
       await waitFor(() => expect(mockPost).toHaveBeenCalled());
+      expect(mockToastError).toHaveBeenCalledWith(
+        'Could not reopen this conversation',
+        expect.objectContaining({ description: 'boom' }),
+      );
+      expect(useAgentSurfaceStore.getState().selectedConversationId).not.toBe('conv-closed');
+    });
+
+    test('a 404 (someone else already history-deleted it) refetches the closed list silently, WITHOUT a toast', async () => {
+      // A stale row — the server is the authority on whether it's still
+      // there to reopen. No toast: this is routine staleness, not a failure
+      // the user did anything wrong to cause.
+      respondWithSessionsAndClosed([SESSION], [CLOSED_CONVERSATION]);
+      mockPost.mockRejectedValue(new ApiRequestError('not found', 404));
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+      const fetchesBeforeClick = mockFetchWithAuth.mock.calls.length;
+      await user.click(await screen.findByText('Researcher — Old chat'));
+
+      await waitFor(() => expect(mockPost).toHaveBeenCalled());
+      // `retryClosed()` re-fetches the closed list so the stale row can drop out.
+      await waitFor(() => expect(mockFetchWithAuth.mock.calls.length).toBeGreaterThan(fetchesBeforeClick));
+      expect(mockToastError).not.toHaveBeenCalled();
       expect(useAgentSurfaceStore.getState().selectedConversationId).not.toBe('conv-closed');
     });
   });

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -654,6 +654,53 @@ describe('AgentsSidebar', () => {
       await waitFor(() => expect(mockFetchWithAuth.mock.calls.length).toBeGreaterThan(fetchesBefore));
     });
 
+    test("also refreshes an already-open History list — otherwise the just-closed conversation is absent until collapse/re-expand (review finding: chatgpt-codex-connector on PR #2296)", async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/conversations/closed')) {
+          return { ok: true, json: async () => ({ conversations: [] }) };
+        }
+        return { ok: true, json: async () => ({ sessions: [SESSION] }) };
+      });
+      mockDel.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('History'));
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/closed'),
+      );
+      const closedListFetchesBefore = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => url === '/api/agent-sessions/ses-1/conversations/closed',
+      ).length;
+
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
+      await user.click(await screen.findByText('Close'));
+      await waitFor(() => expect(mockDel).toHaveBeenCalled());
+
+      await waitFor(() => {
+        const closedListFetchesAfter = mockFetchWithAuth.mock.calls.filter(
+          ([url]) => url === '/api/agent-sessions/ses-1/conversations/closed',
+        ).length;
+        expect(closedListFetchesAfter).toBeGreaterThan(closedListFetchesBefore);
+      });
+    });
+
+    test('does not error when History is closed (its SWR key is null) — the retryClosed() call is a safe no-op', async () => {
+      mockDel.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
+      await user.click(await screen.findByText('Close'));
+
+      await waitFor(() => expect(mockDel).toHaveBeenCalled());
+      expect(
+        mockFetchWithAuth.mock.calls.some(([url]) => url === '/api/agent-sessions/ses-1/conversations/closed'),
+      ).toBe(false);
+    });
+
     test('the 3-dots dropdown "Close" drives the same DELETE', async () => {
       mockDel.mockResolvedValue(undefined);
       const user = userEvent.setup();

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -815,6 +815,10 @@ describe('AgentsSidebar', () => {
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       await user.click(await screen.findByText('History'));
+      // The History row already renders this same label before the reopen
+      // — count it so the assertion below proves an INSERT, not just
+      // presence (which would pass even if the open-list insert never ran).
+      const labelsBefore = screen.getAllByText('Researcher — Old chat').length;
       const sessionsListCallsBefore = mockFetchWithAuth.mock.calls.filter(
         ([url]) => url === '/api/agent-sessions?driveId=drive-1',
       ).length;
@@ -824,7 +828,9 @@ describe('AgentsSidebar', () => {
 
       // Now showing in the (still-expanded) open conversations section too —
       // present without any additional sessions-list fetch.
-      expect(screen.getAllByText('Researcher — Old chat').length).toBeGreaterThan(0);
+      await waitFor(() =>
+        expect(screen.getAllByText('Researcher — Old chat').length).toBeGreaterThan(labelsBefore),
+      );
       const sessionsListCallsAfter = mockFetchWithAuth.mock.calls.filter(
         ([url]) => url === '/api/agent-sessions?driveId=drive-1',
       ).length;
@@ -889,12 +895,22 @@ describe('AgentsSidebar', () => {
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       await user.click(await screen.findByText('History'));
-      const fetchesBeforeClick = mockFetchWithAuth.mock.calls.length;
+      const closedListFetchesBefore = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => url === '/api/agent-sessions/ses-1/conversations/closed',
+      ).length;
       await user.click(await screen.findByText('Researcher — Old chat'));
 
       await waitFor(() => expect(mockPost).toHaveBeenCalled());
-      // `retryClosed()` re-fetches the closed list so the stale row can drop out.
-      await waitFor(() => expect(mockFetchWithAuth.mock.calls.length).toBeGreaterThan(fetchesBeforeClick));
+      // `retryClosed()` re-fetches the closed list so the stale row can drop
+      // out — filtered to that URL specifically, since an unrelated
+      // sessions-list revalidation would otherwise satisfy a bare "any
+      // fetch happened" assertion without ever re-fetching the closed list.
+      await waitFor(() => {
+        const closedListFetchesAfter = mockFetchWithAuth.mock.calls.filter(
+          ([url]) => url === '/api/agent-sessions/ses-1/conversations/closed',
+        ).length;
+        expect(closedListFetchesAfter).toBeGreaterThan(closedListFetchesBefore);
+      });
       expect(mockToastError).not.toHaveBeenCalled();
       expect(useAgentSurfaceStore.getState().selectedConversationId).not.toBe('conv-closed');
     });

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -363,9 +363,20 @@ export default function CenterPanel() {
             onRefresh={pageRefresh.refresh}
             disabled={!pageRefresh.canRefresh}
           >
-            <CustomScrollArea className="h-full">
-              <PageContent pageId={activePageId} />
-            </CustomScrollArea>
+            {pageRefresh.managesOwnScroll ? (
+              // Chat-shaped pages (AI_CHAT, CHANNEL) own their scroll region
+              // end to end. Wrapping them in another `overflow-auto` area
+              // stacks two independent scroll containers over the same
+              // content — the outer one wins the wheel/touch gesture and the
+              // inner message list stops scrolling.
+              <div className="h-full overflow-hidden">
+                <PageContent pageId={activePageId} />
+              </div>
+            ) : (
+              <CustomScrollArea className="h-full">
+                <PageContent pageId={activePageId} />
+              </CustomScrollArea>
+            )}
           </PullToRefresh>
         </div>
       </div>

--- a/apps/web/src/hooks/__tests__/usePageRefresh.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageRefresh.test.ts
@@ -1,0 +1,117 @@
+/**
+ * usePageRefresh — specifically `managesOwnScroll`, the signal `CenterPanel`
+ * uses to skip its own `overflow-auto` wrapper for AI_CHAT/CHANNEL pages
+ * (they manage their own internal scroll; double-wrapping breaks it, see
+ * `CenterPanel.tsx`).
+ *
+ * The property under test: a page not yet in the tree (freshly created, or a
+ * deep link) still renders via `CenterPanel`'s `/api/pages/${pageId}`
+ * fallback fetch — this hook must reach the SAME page-type conclusion via its
+ * own mirrored fallback, not silently default to "unknown" and double-wrap a
+ * fallback-rendered chat page's scroll until it happens to land in the tree
+ * (review finding — chatgpt-codex-connector on PR #2296).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockUseParams = vi.fn<() => { driveId?: string; pageId?: string }>(() => ({}));
+const mockUsePathname = vi.fn(() => '/dashboard/drive-1/page-1');
+vi.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+  usePathname: () => mockUsePathname(),
+}));
+
+const mockUsePageTree = vi.fn();
+vi.mock('../usePageTree', () => ({
+  usePageTree: (...args: unknown[]) => mockUsePageTree(...args),
+}));
+
+const mockFetchWithAuth = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+}));
+
+import { usePageRefresh } from '../usePageRefresh';
+
+const treePageFixture = (overrides: Partial<{ id: string; type: string }> = {}) => ({
+  id: 'page-1',
+  title: 'Fixture',
+  type: 'DOCUMENT',
+  driveId: 'drive-1',
+  children: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseParams.mockReturnValue({ driveId: 'drive-1', pageId: 'page-1' });
+  mockUsePathname.mockReturnValue('/dashboard/drive-1/page-1');
+  mockUsePageTree.mockReturnValue({ tree: [], isLoading: false, mutate: vi.fn() });
+  mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => treePageFixture() });
+});
+
+describe('usePageRefresh — managesOwnScroll', () => {
+  it('is true for an AI_CHAT page already present in the tree', () => {
+    mockUsePageTree.mockReturnValue({
+      tree: [treePageFixture({ type: 'AI_CHAT' })],
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    const { result } = renderHook(() => usePageRefresh());
+
+    expect(result.current.managesOwnScroll).toBe(true);
+    // Fallback fetch must not fire when the tree already answered.
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('is false for a DOCUMENT page already present in the tree', () => {
+    mockUsePageTree.mockReturnValue({
+      tree: [treePageFixture({ type: 'DOCUMENT' })],
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    const { result } = renderHook(() => usePageRefresh());
+
+    expect(result.current.managesOwnScroll).toBe(false);
+  });
+
+  it('is true for an AI_CHAT page NOT yet in the tree, once the fallback fetch resolves', async () => {
+    // Empty tree (settled, not loading) — the page is missing, exactly the
+    // shape a freshly created page or a deep link produces.
+    mockUsePageTree.mockReturnValue({ tree: [], isLoading: false, mutate: vi.fn() });
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => treePageFixture({ type: 'AI_CHAT' }),
+    });
+
+    const { result } = renderHook(() => usePageRefresh());
+
+    // Before the fallback resolves, the hook has no page-type answer yet —
+    // it must not default to "false" (that would be the double-wrap bug,
+    // just delayed instead of permanent).
+    await waitFor(() => expect(result.current.managesOwnScroll).toBe(true));
+    expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/pages/page-1');
+  });
+
+  it('does not fetch the fallback while the tree is still loading', () => {
+    mockUsePageTree.mockReturnValue({ tree: [], isLoading: true, mutate: vi.fn() });
+
+    renderHook(() => usePageRefresh());
+
+    // A page absent from a tree that hasn't finished its FIRST load is not
+    // yet "missing" — it just hasn't arrived. Fetching now would race the
+    // tree's own request for the same answer.
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch the fallback when there is no pageId', () => {
+    mockUseParams.mockReturnValue({ driveId: 'drive-1' });
+    mockUsePageTree.mockReturnValue({ tree: [], isLoading: false, mutate: vi.fn() });
+
+    renderHook(() => usePageRefresh());
+
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/usePageRefresh.ts
+++ b/apps/web/src/hooks/usePageRefresh.ts
@@ -13,6 +13,14 @@ export interface PageRefreshConfig {
   refresh: () => Promise<void>;
   /** Reason why refresh is disabled (for debugging/UI hints) */
   disabledReason?: string;
+  /**
+   * True for page types (AI_CHAT, CHANNEL) that own their own internal scroll
+   * region and fill the container exactly — `CenterPanel` must not also wrap
+   * them in its own `overflow-auto` scroll area, or the two independent
+   * scroll containers fight and the inner one stops receiving wheel/touch
+   * scroll input.
+   */
+  managesOwnScroll: boolean;
 }
 
 /**
@@ -43,8 +51,14 @@ export function usePageRefresh(): PageRefreshConfig {
   // Create a stable no-op function
   const noOp = useCallback(async () => {}, []);
 
+  // Chat-shaped pages own their scroll end to end; see `managesOwnScroll` on
+  // `PageRefreshConfig`. Computed once here so it can be merged onto every
+  // branch below without repeating the check in each one.
+  const managesOwnScroll =
+    currentPage?.type === PageType.AI_CHAT || currentPage?.type === PageType.CHANNEL;
+
   // Determine refresh configuration based on page type and route
-  const config = useMemo<PageRefreshConfig>(() => {
+  const config = useMemo<Omit<PageRefreshConfig, 'managesOwnScroll'>>(() => {
     // Settings pages - can refresh settings data
     if (pathname.endsWith('/settings') || pathname.endsWith('/settings/mcp')) {
       return {
@@ -132,5 +146,5 @@ export function usePageRefresh(): PageRefreshConfig {
     };
   }, [currentPage, pathname, refreshTree, noOp]);
 
-  return config;
+  return { ...config, managesOwnScroll };
 }

--- a/apps/web/src/hooks/usePageRefresh.ts
+++ b/apps/web/src/hooks/usePageRefresh.ts
@@ -2,9 +2,17 @@
 
 import { useCallback, useMemo } from 'react';
 import { useParams, usePathname } from 'next/navigation';
+import useSWR from 'swr';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { usePageTree, TreePage } from './usePageTree';
 import { findNodeAndParent } from '@/lib/tree/tree-utils';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+const fallbackPageFetcher = (url: string) =>
+  fetchWithAuth(url).then((r) => {
+    if (!r.ok) throw new Error('Failed to fetch');
+    return r.json();
+  });
 
 export interface PageRefreshConfig {
   /** Whether pull-to-refresh is available for this page */
@@ -33,14 +41,30 @@ export function usePageRefresh(): PageRefreshConfig {
   const driveId = params.driveId as string | undefined;
   const pageId = params.pageId as string | undefined;
 
-  const { tree, mutate } = usePageTree(driveId);
+  const { tree, isLoading: isTreeLoading, mutate } = usePageTree(driveId);
 
   // Find the current page in the tree
-  const currentPage = useMemo<TreePage | null>(() => {
+  const treePage = useMemo<TreePage | null>(() => {
     if (!pageId || !tree) return null;
     const result = findNodeAndParent(tree, pageId);
     return result?.node ?? null;
   }, [pageId, tree]);
+
+  // A page the tree hasn't caught up to yet (freshly created, or a deep
+  // link) still renders — `CenterPanel`'s `PageContent` falls back to
+  // `/api/pages/${pageId}` for exactly this case. Mirrored here with the
+  // same gate (tree settled, page id present, not already found) so THIS
+  // hook's page-type decision — specifically `managesOwnScroll` — agrees
+  // with what's actually on screen instead of defaulting to "unknown" and
+  // silently double-wrapping a fallback-rendered AI_CHAT/CHANNEL page's
+  // self-managed scroll in `CenterPanel`'s outer `CustomScrollArea` until
+  // the page happens to land in the tree (review finding —
+  // chatgpt-codex-connector on PR #2296).
+  const { data: fallbackPage } = useSWR<TreePage>(
+    !isTreeLoading && !!pageId && !treePage ? `/api/pages/${pageId}` : null,
+    fallbackPageFetcher,
+  );
+  const currentPage = treePage ?? fallbackPage ?? null;
 
   // Create a stable refresh function for the page tree
   const refreshTree = useCallback(async () => {

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
@@ -125,6 +125,13 @@ describe('create/reopen — the open-listing cap serializes across BOTH operatio
     if (createResult.status === 'rejected') {
       expect(createResult.reason).toBeInstanceOf(SessionFullError);
     }
+    // Unlike create, reopen never REJECTS for a cap refusal — it RETURNS
+    // 'session_full'. `isRefused` above treats any rejection as a
+    // legitimate cap refusal, so a reopen rejecting for an unrelated reason
+    // (e.g. `SessionListingLockBusyError`) would silently pass as "refused"
+    // here without this explicit fulfilled check (review finding —
+    // coderabbitai on PR #2296).
+    expect(reopenResult.status).toBe('fulfilled');
     if (reopenResult.status === 'fulfilled') {
       expect(reopenResult.value === 'reopened' || reopenResult.value === 'session_full').toBe(true);
     }

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The per-session open-listing cap (`MAX_SESSION_CONVERSATIONS`) under REAL
+ * concurrency — a mocked-DB unit test can prove the pure decision logic, but
+ * "does the advisory lock actually serialize two genuinely concurrent
+ * transactions" needs a real Postgres, since that's exactly the property a
+ * mock can't exercise.
+ *
+ * The bug this guards (review finding, chatgpt-codex-connector on PR #2296):
+ * `createConversationInSession` and `reopenConversationInSession` both count
+ * open listings against the same cap, but only `reopenConversationInSession`
+ * (and `closeConversationInSession`) took the per-session advisory lock.
+ * A create racing a reopen for the session's LAST open slot could both read
+ * the count before either wrote, and both succeed — exceeding the cap.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable —
+ * mirrors `agent-sessions-conversations-runtime.integration.test.ts` in this
+ * same directory.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq, and, isNull, count } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { agentSessions } from '@pagespace/db/schema/agent-sessions';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { factories } from '@pagespace/db/test/factories';
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
+import {
+  createConversationInSession,
+  reopenConversationInSession,
+} from '../agent-sessions-runtime';
+import { SessionFullError } from '../create-conversation-in-session';
+
+let dbAvailable = false;
+
+describe('create/reopen — the open-listing cap serializes across BOTH operations, under real concurrency', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  async function openCountFor(sessionId: string): Promise<number> {
+    const [row] = await db
+      .select({ n: count() })
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.sessionId, sessionId),
+          eq(conversations.isActive, true),
+          isNull(conversations.closedInSessionAt),
+        ),
+      );
+    return row?.n ?? 0;
+  }
+
+  it('a create racing a reopen for the session\'s LAST slot: exactly one wins, the count never exceeds the cap', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Race Agent' });
+    const [session] = await db.insert(agentSessions).values({ id: createId(), driveId: drive.id, ownerId: owner.id }).returning();
+
+    // Bring the session to exactly ONE slot below the cap with plain rows
+    // (bypassing the create path — this test is about the cap's own
+    // serialization, not about creation itself).
+    const filler = Array.from({ length: MAX_SESSION_CONVERSATIONS - 1 }, () => ({
+      id: createId(),
+      userId: owner.id,
+      type: 'page' as const,
+      contextId: agentPage.id,
+      sessionId: session.id,
+      isActive: true,
+    }));
+    await db.insert(conversations).values(filler);
+
+    // The ONE closed conversation available to reopen — contends for the
+    // same last slot the concurrent create is also trying to claim.
+    const closedConversationId = createId();
+    await db.insert(conversations).values({
+      id: closedConversationId,
+      userId: owner.id,
+      type: 'page',
+      contextId: agentPage.id,
+      sessionId: session.id,
+      isActive: true,
+      closedInSessionAt: new Date(),
+    });
+
+    expect(await openCountFor(session.id)).toBe(MAX_SESSION_CONVERSATIONS - 1);
+
+    const newConversationId = createId();
+    const [createResult, reopenResult] = await Promise.allSettled([
+      createConversationInSession({
+        conversationId: newConversationId,
+        userId: owner.id,
+        agentPageId: agentPage.id,
+        sessionId: session.id,
+      }),
+      reopenConversationInSession({ conversationId: closedConversationId, sessionId: session.id }),
+    ]);
+
+    // Exactly one of the two must have been refused — never both succeeding
+    // (that would exceed the cap) and never both refused (the session
+    // legitimately had room for one more). Mutually exclusive by
+    // construction: a refusal is EITHER a rejection (create's `SessionFullError`)
+    // OR a fulfilled 'session_full' (reopen's refusal return value) — never
+    // both counted for the same outcome.
+    const isRefused = (o: PromiseSettledResult<unknown>) =>
+      o.status === 'rejected' || (o.status === 'fulfilled' && o.value === 'session_full');
+    const outcomes = [createResult, reopenResult];
+    const refused = outcomes.filter(isRefused);
+    const succeeded = outcomes.filter((o) => !isRefused(o));
+    expect(succeeded).toHaveLength(1);
+    expect(refused).toHaveLength(1);
+
+    // The refused side must be refused for the RIGHT reason (the cap), not
+    // some unrelated failure masking a real bug.
+    if (createResult.status === 'rejected') {
+      expect(createResult.reason).toBeInstanceOf(SessionFullError);
+    }
+    if (reopenResult.status === 'fulfilled') {
+      expect(reopenResult.value === 'reopened' || reopenResult.value === 'session_full').toBe(true);
+    }
+
+    // The load-bearing assertion: the real, final row count in the database
+    // is exactly at the cap — never over it.
+    expect(await openCountFor(session.id)).toBe(MAX_SESSION_CONVERSATIONS);
+  }, 20_000);
+});

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
@@ -29,6 +29,7 @@ import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-sp
 import {
   createConversationInSession,
   reopenConversationInSession,
+  listClosedSessionConversations,
 } from '../agent-sessions-runtime';
 import { SessionFullError } from '../create-conversation-in-session';
 
@@ -132,4 +133,54 @@ describe('create/reopen — the open-listing cap serializes across BOTH operatio
     // is exactly at the cap — never over it.
     expect(await openCountFor(session.id)).toBe(MAX_SESSION_CONVERSATIONS);
   }, 20_000);
+});
+
+describe('listClosedSessionConversations — NULLS LAST (review finding: coderabbitai on PR #2296)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('sorts a closed conversation that never received a message LAST, not first — Postgres DESC sorts NULLs first by default', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Sort Agent' });
+    const [session] = await db.insert(agentSessions).values({ id: createId(), driveId: drive.id, ownerId: owner.id }).returning();
+
+    // Closed, never messaged — `lastMessageAt` stays NULL.
+    const neverMessaged = createId();
+    await db.insert(conversations).values({
+      id: neverMessaged, userId: owner.id, type: 'page', contextId: agentPage.id, sessionId: session.id,
+      isActive: true, closedInSessionAt: new Date(),
+    });
+
+    // Closed, with real (older) activity.
+    const older = createId();
+    await db.insert(conversations).values({
+      id: older, userId: owner.id, type: 'page', contextId: agentPage.id, sessionId: session.id,
+      isActive: true, closedInSessionAt: new Date(), lastMessageAt: new Date('2020-01-01'),
+    });
+
+    // Closed, with real (newer) activity.
+    const newer = createId();
+    await db.insert(conversations).values({
+      id: newer, userId: owner.id, type: 'page', contextId: agentPage.id, sessionId: session.id,
+      isActive: true, closedInSessionAt: new Date(), lastMessageAt: new Date('2026-01-01'),
+    });
+
+    const result = await listClosedSessionConversations(session.id);
+    const order = result.map((c) => c.conversationId);
+
+    // Newest-activity-first among the real rows, and the never-messaged row
+    // LAST — not first, which is what a plain `DESC` (no `NULLS LAST`) would
+    // have produced, silently pushing it ahead of `older` and `newer` and
+    // able to crowd them out of the MAX_SESSION_CONVERSATIONS cap.
+    expect(order).toEqual([newer, older, neverMessaged]);
+  });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/reopen-conversation-in-session.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/reopen-conversation-in-session.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The session→conversation listing-reopen decision — the property under test
+ * is the cap guard (a session already at `MAX_SESSION_CONVERSATIONS` open
+ * listings refuses a reopen) plus idempotency (reopening an already-open
+ * listing, or racing another reopen, is success, never an error), mirroring
+ * `close-conversation-in-session.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
+import {
+  reopenConversationInSessionWith,
+  type ReopenConversationInSessionDeps,
+} from '../reopen-conversation-in-session';
+
+let deps: {
+  findConversation: ReturnType<typeof vi.fn>;
+  countOpenConversations: ReturnType<typeof vi.fn>;
+  reopenConversation: ReturnType<typeof vi.fn>;
+};
+
+const input = { conversationId: 'conv-1', sessionId: 'ses-1' };
+const run = () => reopenConversationInSessionWith(deps as ReopenConversationInSessionDeps, input);
+
+beforeEach(() => {
+  deps = {
+    findConversation: vi.fn(async () => ({
+      sessionId: 'ses-1',
+      closedInSessionAt: new Date('2026-01-01'),
+      isActive: true,
+    })),
+    countOpenConversations: vi.fn(async () => 1),
+    reopenConversation: vi.fn(async () => 'reopened' as const),
+  };
+});
+
+describe('reopenConversationInSessionWith', () => {
+  it('reopens a closed conversation when the session has room', async () => {
+    await expect(run()).resolves.toBe('reopened');
+    expect(deps.reopenConversation).toHaveBeenCalledWith('conv-1');
+  });
+
+  it('given no such row, should answer not_in_session', async () => {
+    deps.findConversation.mockResolvedValue(null);
+    await expect(run()).resolves.toBe('not_in_session');
+    expect(deps.countOpenConversations).not.toHaveBeenCalled();
+    expect(deps.reopenConversation).not.toHaveBeenCalled();
+  });
+
+  it("given the row belongs to a DIFFERENT session, should answer not_in_session — same shape as no such row", async () => {
+    deps.findConversation.mockResolvedValue({
+      sessionId: 'ses-other',
+      closedInSessionAt: new Date('2026-01-01'),
+      isActive: true,
+    });
+    await expect(run()).resolves.toBe('not_in_session');
+    expect(deps.reopenConversation).not.toHaveBeenCalled();
+  });
+
+  it('given a row bound to no session at all (sessionId null), should answer not_in_session', async () => {
+    deps.findConversation.mockResolvedValue({ sessionId: null, closedInSessionAt: new Date('2026-01-01'), isActive: true });
+    await expect(run()).resolves.toBe('not_in_session');
+  });
+
+  it('given a history-deleted target (isActive false), should answer history_deleted WITHOUT weighing the cap', async () => {
+    deps.findConversation.mockResolvedValue({ sessionId: 'ses-1', closedInSessionAt: new Date('2026-01-01'), isActive: false });
+    await expect(run()).resolves.toBe('history_deleted');
+    expect(deps.countOpenConversations).not.toHaveBeenCalled();
+    expect(deps.reopenConversation).not.toHaveBeenCalled();
+  });
+
+  describe('the cap guard', () => {
+    it('refuses to reopen when the session already holds MAX_SESSION_CONVERSATIONS open listings', async () => {
+      deps.countOpenConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS);
+      await expect(run()).resolves.toBe('session_full');
+      expect(deps.reopenConversation).not.toHaveBeenCalled();
+    });
+
+    it('allows reopening with room for exactly one more', async () => {
+      deps.countOpenConversations.mockResolvedValue(MAX_SESSION_CONVERSATIONS - 1);
+      await expect(run()).resolves.toBe('reopened');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('reopening an already-open conversation is a no-op success, not an error', async () => {
+      deps.findConversation.mockResolvedValue({ sessionId: 'ses-1', closedInSessionAt: null, isActive: true });
+      await expect(run()).resolves.toBe('already_open');
+      // Already open — no need to weigh the cap or write anything.
+      expect(deps.countOpenConversations).not.toHaveBeenCalled();
+      expect(deps.reopenConversation).not.toHaveBeenCalled();
+    });
+
+    it('a race that reopens the row between the check and the write folds into already_open', async () => {
+      deps.reopenConversation.mockResolvedValue('noop');
+      await expect(run()).resolves.toBe('already_open');
+    });
+  });
+});

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -299,6 +299,47 @@ export async function createConversationInSession(input: {
 }
 
 /**
+ * The read half of the close/reopen deps — `findConversation` and
+ * `countOpenConversations` are IDENTICAL between the two (both weigh the same
+ * "is this row open" fact), and the cap's symmetry between close and reopen
+ * depends on them staying that way: one copy drifting from the other would
+ * silently unbalance which listings count toward `MAX_SESSION_CONVERSATIONS`.
+ * One definition, shared, rather than two that must be kept in lockstep by
+ * hand (review finding — coderabbitai on PR #2296). Takes `tx` (or plain
+ * `db`) so both callers' advisory-lock transaction is what these queries run
+ * on.
+ */
+function sessionListingReadDeps(tx: typeof db) {
+  return {
+    findConversation: async (conversationId: string) => {
+      const [row] = await tx
+        .select({
+          sessionId: conversations.sessionId,
+          closedInSessionAt: conversations.closedInSessionAt,
+          isActive: conversations.isActive,
+        })
+        .from(conversations)
+        .where(eq(conversations.id, conversationId))
+        .limit(1);
+      return row ?? null;
+    },
+    countOpenConversations: async (sessionId: string) => {
+      const [row] = await tx
+        .select({ n: count() })
+        .from(conversations)
+        .where(
+          and(
+            eq(conversations.sessionId, sessionId),
+            eq(conversations.isActive, true),
+            isNull(conversations.closedInSessionAt),
+          ),
+        );
+      return row?.n ?? 0;
+    },
+  };
+}
+
+/**
  * Close a conversation OUT of its session's listing — the transactional
  * wiring for `close-conversation-in-session.ts`'s pure decision. A per-session
  * advisory lock (the `agent-sessions-store.ts` `createIfUnderLimit` pattern)
@@ -317,31 +358,7 @@ export async function closeConversationInSession(input: {
     );
     return closeConversationInSessionWith(
       {
-        findConversation: async (conversationId) => {
-          const [row] = await tx
-            .select({
-              sessionId: conversations.sessionId,
-              closedInSessionAt: conversations.closedInSessionAt,
-              isActive: conversations.isActive,
-            })
-            .from(conversations)
-            .where(eq(conversations.id, conversationId))
-            .limit(1);
-          return row ?? null;
-        },
-        countOpenConversations: async (sessionId) => {
-          const [row] = await tx
-            .select({ n: count() })
-            .from(conversations)
-            .where(
-              and(
-                eq(conversations.sessionId, sessionId),
-                eq(conversations.isActive, true),
-                isNull(conversations.closedInSessionAt),
-              ),
-            );
-          return row?.n ?? 0;
-        },
+        ...sessionListingReadDeps(tx),
         closeConversation: async (conversationId) => {
           const updated = await tx
             .update(conversations)
@@ -373,31 +390,7 @@ export async function reopenConversationInSession(input: {
     );
     return reopenConversationInSessionWith(
       {
-        findConversation: async (conversationId) => {
-          const [row] = await tx
-            .select({
-              sessionId: conversations.sessionId,
-              closedInSessionAt: conversations.closedInSessionAt,
-              isActive: conversations.isActive,
-            })
-            .from(conversations)
-            .where(eq(conversations.id, conversationId))
-            .limit(1);
-          return row ?? null;
-        },
-        countOpenConversations: async (sessionId) => {
-          const [row] = await tx
-            .select({ n: count() })
-            .from(conversations)
-            .where(
-              and(
-                eq(conversations.sessionId, sessionId),
-                eq(conversations.isActive, true),
-                isNull(conversations.closedInSessionAt),
-              ),
-            );
-          return row?.n ?? 0;
-        },
+        ...sessionListingReadDeps(tx),
         reopenConversation: async (conversationId) => {
           const updated = await tx
             .update(conversations)

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -18,7 +18,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, count, eq, inArray, isNull, isNotNull, sql, desc } from '@pagespace/db/operators';
+import { and, count, eq, inArray, isNull, isNotNull, sql } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { users } from '@pagespace/db/schema/auth';
 import { checkAgentSessionConcurrency } from '@pagespace/lib/services/sandbox/quota';
@@ -438,7 +438,12 @@ export async function listClosedSessionConversations(sessionId: string): Promise
         isNotNull(conversations.closedInSessionAt),
       ),
     )
-    .orderBy(desc(conversations.lastMessageAt))
+    // `lastMessageAt` is nullable, and Postgres sorts NULLs FIRST for a plain
+    // DESC order — without NULLS LAST, a closed conversation that never got a
+    // message would rank ABOVE genuinely recent ones and could crowd them out
+    // of the LIMIT below, contradicting "newest activity first" (review
+    // finding — coderabbitai on PR #2296).
+    .orderBy(sql`${conversations.lastMessageAt} DESC NULLS LAST`)
     .limit(MAX_SESSION_CONVERSATIONS);
 
   return rows.map((row) => ({

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -18,7 +18,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, count, eq, inArray, isNull, sql } from '@pagespace/db/operators';
+import { and, count, eq, inArray, isNull, isNotNull, sql, desc } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { users } from '@pagespace/db/schema/auth';
 import { checkAgentSessionConcurrency } from '@pagespace/lib/services/sandbox/quota';
@@ -76,6 +76,10 @@ import {
   closeConversationInSessionWith,
   type CloseConversationOutcome,
 } from '@/lib/agent-sessions/close-conversation-in-session';
+import {
+  reopenConversationInSessionWith,
+  type ReopenConversationOutcome,
+} from '@/lib/agent-sessions/reopen-conversation-in-session';
 
 export { isCodeExecutionEnabled };
 
@@ -332,6 +336,101 @@ export async function closeConversationInSession(input: {
       input,
     );
   });
+}
+
+/**
+ * Reopen a conversation OUT of "closed" and back into its session's
+ * listing — the transactional wiring for `reopen-conversation-in-session.ts`'s
+ * pure decision. Same per-session advisory lock as `closeConversationInSession`
+ * (same lock key), so a reopen can never race a close — or another reopen —
+ * of the same session's listings.
+ */
+export async function reopenConversationInSession(input: {
+  conversationId: string;
+  sessionId: string;
+}): Promise<ReopenConversationOutcome> {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${'agent-session-conversations:' + input.sessionId}))`,
+    );
+    return reopenConversationInSessionWith(
+      {
+        findConversation: async (conversationId) => {
+          const [row] = await tx
+            .select({
+              sessionId: conversations.sessionId,
+              closedInSessionAt: conversations.closedInSessionAt,
+              isActive: conversations.isActive,
+            })
+            .from(conversations)
+            .where(eq(conversations.id, conversationId))
+            .limit(1);
+          return row ?? null;
+        },
+        countOpenConversations: async (sessionId) => {
+          const [row] = await tx
+            .select({ n: count() })
+            .from(conversations)
+            .where(
+              and(
+                eq(conversations.sessionId, sessionId),
+                eq(conversations.isActive, true),
+                isNull(conversations.closedInSessionAt),
+              ),
+            );
+          return row?.n ?? 0;
+        },
+        reopenConversation: async (conversationId) => {
+          const updated = await tx
+            .update(conversations)
+            .set({ closedInSessionAt: null })
+            .where(and(eq(conversations.id, conversationId), isNotNull(conversations.closedInSessionAt)))
+            .returning({ id: conversations.id });
+          return updated.length > 0 ? 'reopened' : 'noop';
+        },
+      },
+      input,
+    );
+  });
+}
+
+/**
+ * A session's CLOSED conversations — the reopen affordance's listing. Mirrors
+ * `listSessionConversationsBulk`'s shape and cap for a single session, with
+ * the closed/open predicate flipped: `isActive` still gates history-deleted
+ * rows out, but `closedInSessionAt` must be SET rather than null. Newest
+ * activity first, capped at {@link MAX_SESSION_CONVERSATIONS} — history
+ * beyond that is reachable through the agent's own page History tab, not
+ * this session-scoped reopen list.
+ */
+export async function listClosedSessionConversations(sessionId: string): Promise<SessionConversationEntry[]> {
+  const rows = await db
+    .select({
+      conversationId: conversations.id,
+      title: conversations.title,
+      type: conversations.type,
+      contextId: conversations.contextId,
+      lastMessageAt: conversations.lastMessageAt,
+    })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.sessionId, sessionId),
+        eq(conversations.isActive, true),
+        isNotNull(conversations.closedInSessionAt),
+      ),
+    )
+    .orderBy(desc(conversations.lastMessageAt))
+    .limit(MAX_SESSION_CONVERSATIONS);
+
+  return rows.map((row) => ({
+    conversationId: row.conversationId,
+    title: row.title,
+    // Same mapping `listSessionConversationsBulk` uses: `contextId` is only
+    // meaningful as an agent page id for a 'page' conversation.
+    agentPageId: row.type === 'page' ? row.contextId : null,
+    lastMessageAt: row.lastMessageAt,
+  }));
 }
 
 /**

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -17,7 +17,8 @@
  * wrappers that return result unions — never throws — for the routes to map.
  */
 
-import { db } from '@pagespace/db/db';
+import { db, getAdvisoryLockPool } from '@pagespace/db/db';
+import { withAdvisoryLock } from '@pagespace/db/advisory-lock';
 import { and, count, eq, inArray, isNull, isNotNull, sql } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { users } from '@pagespace/db/schema/auth';
@@ -213,6 +214,68 @@ export async function checkSessionEndAccess(
 // Lifecycle
 // ---------------------------------------------------------------------------
 
+const SESSION_LISTING_LOCK_MAX_RETRIES = 5;
+const SESSION_LISTING_LOCK_RETRY_DELAY_MS = 200;
+
+function sessionListingLockKey(sessionId: string): string {
+  return 'agent-session-conversations:' + sessionId;
+}
+
+/** Every retry was met with `lock_busy` — the caller's remedy is a plain retry, not a silent unlocked write. */
+export class SessionListingLockBusyError extends Error {
+  constructor(sessionId: string) {
+    super(`Could not acquire the session-listing lock for ${sessionId} after ${SESSION_LISTING_LOCK_MAX_RETRIES} retries`);
+    this.name = 'SessionListingLockBusyError';
+  }
+}
+
+/**
+ * Serializes every operation that consumes or frees a session's open-listing
+ * slot — create, close, reopen, and (via this same export) the page-agent
+ * History delete route's own never-empty guard — via a session-level
+ * advisory lock on a DEDICATED connection (`getAdvisoryLockPool`), never
+ * `db.transaction`. A transaction would hold the MAIN pool's connection for
+ * `fn`'s whole duration; `fn` here always needs a SECOND connection from
+ * that same pool (every dependency — `conversationRepository.*`,
+ * `resolveOrCreateConversation` — uses the plain, unwrapped `db`), so a
+ * `DB_POOL_MAX=1` deployment, or a burst of calls equal to any pool size,
+ * would deadlock every caller waiting on a connection the held transaction
+ * was never going to release (review finding — chatgpt-codex-connector on
+ * PR #2296; this is exactly the hazard `db.ts`'s own doc comment on
+ * `getAdvisoryLockPool` warns a session-level lock holder must avoid). The
+ * dedicated lock pool sidesteps it entirely: the lock connection and `fn`'s
+ * own connection(s) are never drawn from the same pool.
+ *
+ * `withAdvisoryLock` TRIES the lock (fails fast on contention) rather than
+ * blocking the way `pg_advisory_xact_lock` did — retried a bounded few
+ * times here. Unlike `start-generation-exclusive.ts`'s BEST-EFFORT
+ * degrade-to-unlocked fallback for a duplicate-generation guard, exhausting
+ * retries here throws (`SessionListingLockBusyError`): an unlocked
+ * create/close/reopen/delete is exactly the cap-violating race this lock
+ * exists to prevent, so "proceed anyway" can never be this caller's answer.
+ */
+export async function withSessionListingLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+  const pool = getAdvisoryLockPool();
+  const lockKey = sessionListingLockKey(sessionId);
+
+  let attemptsMade = 0;
+  for (;;) {
+    const attempt = await withAdvisoryLock(pool, lockKey, fn);
+
+    if (attempt.outcome === 'acquired') return attempt.result;
+
+    if (attempt.outcome === 'connection_error') {
+      throw attempt.error instanceof Error ? attempt.error : new Error(String(attempt.error));
+    }
+
+    attemptsMade += 1;
+    if (attemptsMade > SESSION_LISTING_LOCK_MAX_RETRIES) {
+      throw new SessionListingLockBusyError(sessionId);
+    }
+    await new Promise((resolve) => setTimeout(resolve, SESSION_LISTING_LOCK_RETRY_DELAY_MS));
+  }
+}
+
 /**
  * Create a conversation BORN INTO a session. Decision logic lives in the pure
  * module (`create-conversation-in-session.ts`) — this is only its production
@@ -225,18 +288,14 @@ export async function checkSessionEndAccess(
  * when the id cannot be claimed WITH this binding — foreign owner, legacy
  * message-owner conflict, or an existing row whose binding disagrees.
  *
- * Wrapped in the SAME per-session advisory lock `closeConversationInSession`/
- * `reopenConversationInSession` take (same key: every operation that consumes
- * or frees an open-listing slot serializes against every other one). Without
- * this, a create racing a reopen could both read the cap's count before
- * either writes, and both succeed — two operations each individually under
- * `MAX_SESSION_CONVERSATIONS`, together over it (caught in review — the
- * advisory lock previously only coordinated close/reopen against each other,
- * not against create). The lock only needs to be HELD for the duration of
- * this call, not used for the actual reads/writes below (the deps still go
- * through the repository's own `db`) — Postgres advisory locks gate
- * concurrent CALLERS of the guarded code, independent of which connection
- * the guarded code's own queries run on.
+ * Wrapped in the SAME per-session listing lock `closeConversationInSession`/
+ * `reopenConversationInSession` take — see `withSessionListingLock`'s own
+ * doc for why that's a dedicated-pool advisory lock, never `db.transaction`.
+ * Without this serialization at all, a create racing a reopen could both
+ * read the cap's count before either writes, and both succeed — two
+ * operations each individually under `MAX_SESSION_CONVERSATIONS`, together
+ * over it (caught in review — the lock previously only coordinated
+ * close/reopen against each other, not against create).
  */
 export async function createConversationInSession(input: {
   conversationId: string;
@@ -247,11 +306,8 @@ export async function createConversationInSession(input: {
   /** Display label written at birth (a spawned worker's name). */
   title?: string | null;
 }): Promise<void> {
-  return db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext(${'agent-session-conversations:' + input.sessionId}))`,
-    );
-    return createConversationInSessionWith(
+  return withSessionListingLock(input.sessionId, () =>
+    createConversationInSessionWith(
       {
         createPageConversation: ({ conversationId, userId, agentPageId, sessionId, title }) =>
           conversationRepository.createConversation(conversationId, userId, agentPageId, {
@@ -294,8 +350,8 @@ export async function createConversationInSession(input: {
         },
       },
       input,
-    );
-  });
+    ),
+  );
 }
 
 /**
@@ -305,14 +361,14 @@ export async function createConversationInSession(input: {
  * depends on them staying that way: one copy drifting from the other would
  * silently unbalance which listings count toward `MAX_SESSION_CONVERSATIONS`.
  * One definition, shared, rather than two that must be kept in lockstep by
- * hand (review finding — coderabbitai on PR #2296). Takes `tx` (or plain
- * `db`) so both callers' advisory-lock transaction is what these queries run
- * on.
+ * hand (review finding — coderabbitai on PR #2296). Always the plain `db` —
+ * `withSessionListingLock`'s lock is on a separate dedicated connection, not
+ * a transaction these reads need to share.
  */
-function sessionListingReadDeps(tx: typeof db) {
+function sessionListingReadDeps() {
   return {
     findConversation: async (conversationId: string) => {
-      const [row] = await tx
+      const [row] = await db
         .select({
           sessionId: conversations.sessionId,
           closedInSessionAt: conversations.closedInSessionAt,
@@ -324,7 +380,7 @@ function sessionListingReadDeps(tx: typeof db) {
       return row ?? null;
     },
     countOpenConversations: async (sessionId: string) => {
-      const [row] = await tx
+      const [row] = await db
         .select({ n: count() })
         .from(conversations)
         .where(
@@ -340,9 +396,8 @@ function sessionListingReadDeps(tx: typeof db) {
 }
 
 /**
- * Close a conversation OUT of its session's listing — the transactional
- * wiring for `close-conversation-in-session.ts`'s pure decision. A per-session
- * advisory lock (the `agent-sessions-store.ts` `createIfUnderLimit` pattern)
+ * Close a conversation OUT of its session's listing — the wiring for
+ * `close-conversation-in-session.ts`'s pure decision. `withSessionListingLock`
  * serializes concurrent closes of THIS session's listings, so two racing
  * closes of the last two open conversations cannot both read "more than one
  * open" and both succeed — the second sees the first's write and gets
@@ -352,15 +407,12 @@ export async function closeConversationInSession(input: {
   conversationId: string;
   sessionId: string;
 }): Promise<CloseConversationOutcome> {
-  return db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext(${'agent-session-conversations:' + input.sessionId}))`,
-    );
-    return closeConversationInSessionWith(
+  return withSessionListingLock(input.sessionId, () =>
+    closeConversationInSessionWith(
       {
-        ...sessionListingReadDeps(tx),
+        ...sessionListingReadDeps(),
         closeConversation: async (conversationId) => {
-          const updated = await tx
+          const updated = await db
             .update(conversations)
             .set({ closedInSessionAt: new Date() })
             .where(and(eq(conversations.id, conversationId), isNull(conversations.closedInSessionAt)))
@@ -369,30 +421,27 @@ export async function closeConversationInSession(input: {
         },
       },
       input,
-    );
-  });
+    ),
+  );
 }
 
 /**
  * Reopen a conversation OUT of "closed" and back into its session's
- * listing — the transactional wiring for `reopen-conversation-in-session.ts`'s
- * pure decision. Same per-session advisory lock as `closeConversationInSession`
- * (same lock key), so a reopen can never race a close — or another reopen —
- * of the same session's listings.
+ * listing — the wiring for `reopen-conversation-in-session.ts`'s pure
+ * decision. Same `withSessionListingLock` key as `closeConversationInSession`,
+ * so a reopen can never race a close — or another reopen — of the same
+ * session's listings.
  */
 export async function reopenConversationInSession(input: {
   conversationId: string;
   sessionId: string;
 }): Promise<ReopenConversationOutcome> {
-  return db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext(${'agent-session-conversations:' + input.sessionId}))`,
-    );
-    return reopenConversationInSessionWith(
+  return withSessionListingLock(input.sessionId, () =>
+    reopenConversationInSessionWith(
       {
-        ...sessionListingReadDeps(tx),
+        ...sessionListingReadDeps(),
         reopenConversation: async (conversationId) => {
-          const updated = await tx
+          const updated = await db
             .update(conversations)
             .set({ closedInSessionAt: null })
             .where(and(eq(conversations.id, conversationId), isNotNull(conversations.closedInSessionAt)))
@@ -401,8 +450,8 @@ export async function reopenConversationInSession(input: {
         },
       },
       input,
-    );
-  });
+    ),
+  );
 }
 
 /**

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -224,6 +224,19 @@ export async function checkSessionEndAccess(
  * Throws `ConversationUnavailableError` (message `conversation_unavailable`)
  * when the id cannot be claimed WITH this binding — foreign owner, legacy
  * message-owner conflict, or an existing row whose binding disagrees.
+ *
+ * Wrapped in the SAME per-session advisory lock `closeConversationInSession`/
+ * `reopenConversationInSession` take (same key: every operation that consumes
+ * or frees an open-listing slot serializes against every other one). Without
+ * this, a create racing a reopen could both read the cap's count before
+ * either writes, and both succeed — two operations each individually under
+ * `MAX_SESSION_CONVERSATIONS`, together over it (caught in review — the
+ * advisory lock previously only coordinated close/reopen against each other,
+ * not against create). The lock only needs to be HELD for the duration of
+ * this call, not used for the actual reads/writes below (the deps still go
+ * through the repository's own `db`) — Postgres advisory locks gate
+ * concurrent CALLERS of the guarded code, independent of which connection
+ * the guarded code's own queries run on.
  */
 export async function createConversationInSession(input: {
   conversationId: string;
@@ -234,50 +247,55 @@ export async function createConversationInSession(input: {
   /** Display label written at birth (a spawned worker's name). */
   title?: string | null;
 }): Promise<void> {
-  return createConversationInSessionWith(
-    {
-      createPageConversation: ({ conversationId, userId, agentPageId, sessionId, title }) =>
-        conversationRepository.createConversation(conversationId, userId, agentPageId, {
-          sessionId,
-          title: title ?? undefined,
-        }),
-      createGlobalConversation: async ({ conversationId, userId, sessionId, title }) => {
-        await resolveOrCreateConversation(userId, conversationId, undefined, {
-          sessionId,
-          title: title ?? undefined,
-        });
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${'agent-session-conversations:' + input.sessionId}))`,
+    );
+    return createConversationInSessionWith(
+      {
+        createPageConversation: ({ conversationId, userId, agentPageId, sessionId, title }) =>
+          conversationRepository.createConversation(conversationId, userId, agentPageId, {
+            sessionId,
+            title: title ?? undefined,
+          }),
+        createGlobalConversation: async ({ conversationId, userId, sessionId, title }) => {
+          await resolveOrCreateConversation(userId, conversationId, undefined, {
+            sessionId,
+            title: title ?? undefined,
+          });
+        },
+        findConversation: async (conversationId) => {
+          const row = await conversationRepository.getConversation(conversationId);
+          if (!row) return null;
+          return { userId: row.userId, type: row.type, contextId: row.contextId, sessionId: row.sessionId };
+        },
+        findAgentDriveId: async (agentPageId) => {
+          const agent = await conversationRepository.getAiAgent(agentPageId);
+          return agent?.driveId ?? null;
+        },
+        findSessionDriveId: async (sessionId) => {
+          const row = await findSessionRecord(sessionId);
+          return row ? { driveId: row.driveId } : null;
+        },
+        countActiveConversations: async (sessionId) => {
+          const [row] = await db
+            .select({ n: count() })
+            .from(conversations)
+            .where(
+              and(
+                eq(conversations.sessionId, sessionId),
+                eq(conversations.isActive, true),
+                // A conversation closed OUT of the session's listing no longer
+                // holds a cap slot — closing one frees room for another.
+                isNull(conversations.closedInSessionAt),
+              ),
+            );
+          return row?.n ?? 0;
+        },
       },
-      findConversation: async (conversationId) => {
-        const row = await conversationRepository.getConversation(conversationId);
-        if (!row) return null;
-        return { userId: row.userId, type: row.type, contextId: row.contextId, sessionId: row.sessionId };
-      },
-      findAgentDriveId: async (agentPageId) => {
-        const agent = await conversationRepository.getAiAgent(agentPageId);
-        return agent?.driveId ?? null;
-      },
-      findSessionDriveId: async (sessionId) => {
-        const row = await findSessionRecord(sessionId);
-        return row ? { driveId: row.driveId } : null;
-      },
-      countActiveConversations: async (sessionId) => {
-        const [row] = await db
-          .select({ n: count() })
-          .from(conversations)
-          .where(
-            and(
-              eq(conversations.sessionId, sessionId),
-              eq(conversations.isActive, true),
-              // A conversation closed OUT of the session's listing no longer
-              // holds a cap slot — closing one frees room for another.
-              isNull(conversations.closedInSessionAt),
-            ),
-          );
-        return row?.n ?? 0;
-      },
-    },
-    input,
-  );
+      input,
+    );
+  });
 }
 
 /**

--- a/apps/web/src/lib/agent-sessions/reopen-conversation-in-session.ts
+++ b/apps/web/src/lib/agent-sessions/reopen-conversation-in-session.ts
@@ -1,0 +1,74 @@
+/**
+ * Reopen a conversation back INTO its session's listing — the undo of
+ * `closeConversationInSessionWith`. Restores `conversations.closedInSessionAt`
+ * to null so the thread reappears in the sidebar and can host a pane again.
+ * Never touches history (`isActive`) — a history-deleted thread is not
+ * reachable this way, same as it is excluded from the open listing.
+ *
+ * Reopening occupies a listing slot exactly like minting a new conversation
+ * does (`createConversationInSessionWith`'s `countActiveConversations` and
+ * this decision's `countOpenConversations` count the identical set: ACTIVE
+ * rows with `closedInSessionAt IS NULL`) — so a session already holding
+ * `MAX_SESSION_CONVERSATIONS` open listings refuses a reopen the same way it
+ * refuses a new conversation, rather than silently exceeding the cap the
+ * create path enforces.
+ *
+ * Pure decision logic over injected deps, per the repo rule that
+ * branching which decides lifecycle/access lives in a testable module —
+ * `agent-sessions-runtime.ts` only wires the production deps, wrapping the
+ * whole decision in the same per-session transaction + advisory lock
+ * `closeConversationInSessionWith`'s wiring uses, so a reopen can never race
+ * a close (or another reopen) of the same session's listings.
+ */
+
+import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
+
+export type ReopenConversationOutcome =
+  | 'reopened'
+  | 'already_open'
+  | 'not_in_session'
+  | 'history_deleted'
+  | 'session_full';
+
+export interface ReopenConversationInSessionDeps {
+  /** Row facts for the foreign-session and idempotency checks. Same shape `closeConversationInSessionWith` reads. */
+  findConversation: (conversationId: string) => Promise<{
+    sessionId: string | null;
+    closedInSessionAt: Date | null;
+    isActive: boolean;
+  } | null>;
+  /**
+   * OPEN (not yet closed) conversations already counted against this
+   * session — the cap's input. Must be read AFTER the lock is held (the
+   * runtime wiring's job), or two concurrent reopens could both read
+   * "room for one more" and both succeed, exceeding the cap.
+   */
+  countOpenConversations: (sessionId: string) => Promise<number>;
+  /**
+   * The guarded UPDATE: clear `closedInSessionAt` WHERE it is still set.
+   * `'noop'` means a race already reopened it between the idempotency check
+   * above and this write — folded into `already_open`, not an error.
+   */
+  reopenConversation: (conversationId: string) => Promise<'reopened' | 'noop'>;
+}
+
+export async function reopenConversationInSessionWith(
+  deps: ReopenConversationInSessionDeps,
+  { conversationId, sessionId }: { conversationId: string; sessionId: string },
+): Promise<ReopenConversationOutcome> {
+  const row = await deps.findConversation(conversationId);
+  if (row === null || row.sessionId !== sessionId) return 'not_in_session';
+  // A history-deleted target is gone regardless of `closedInSessionAt` —
+  // there is no listing left to restore (mirrors the close side's own
+  // isActive check, which excludes these from `countOpenConversations` too).
+  if (!row.isActive) return 'history_deleted';
+  if (row.closedInSessionAt === null) return 'already_open';
+
+  // Only checked once the row is confirmed CLOSED, so a retry of an
+  // already-open conversation never trips the cap on its own way out.
+  const openCount = await deps.countOpenConversations(sessionId);
+  if (openCount >= MAX_SESSION_CONVERSATIONS) return 'session_full';
+
+  const outcome = await deps.reopenConversation(conversationId);
+  return outcome === 'reopened' ? 'reopened' : 'already_open';
+}

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -74,6 +74,11 @@ vi.mock('@pagespace/db/schema/monitoring', () => ({
   userActivities: { userId: 'userActivities.userId' },
 }));
 
+const mockInvalidateCompaction = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/ai/core/compaction/compaction-repository', () => ({
+  invalidate: (...args: unknown[]) => mockInvalidateCompaction(...args),
+}));
+
 import { conversationRepository } from '../conversation-repository';
 import { db } from '@pagespace/db/db';
 
@@ -412,5 +417,25 @@ describe('conversationRepository.setConversationShared', () => {
     expect(setMock).toHaveBeenCalledWith(
       expect.objectContaining({ isShared: false })
     );
+  });
+});
+
+describe('conversationRepository.softDeleteConversation', () => {
+  it("deactivates the canonical conversations row, not just its chat_messages — review finding (chatgpt-codex-connector on PR #2296): every reader gating on conversations.isActive (session listings/caps, the v1/MCP API, retention purge) previously kept treating a page conversation deleted from History as live forever", async () => {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mockDb.update = vi.fn().mockReturnValue({ set: setMock });
+
+    await conversationRepository.softDeleteConversation('agent_1', 'conv_deleted');
+
+    // Two separate UPDATEs: chat_messages (unchanged, pre-existing behavior)
+    // THEN conversations — same order the fix was added in, verified via the
+    // table argument each db.update() call received.
+    expect(mockDb.update).toHaveBeenCalledTimes(2);
+    expect(mockDb.update).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'chatMessages.id' }));
+    expect(mockDb.update).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: 'conversations.id' }));
+    expect(setMock).toHaveBeenNthCalledWith(1, { isActive: false });
+    expect(setMock).toHaveBeenNthCalledWith(2, { isActive: false });
+    expect(mockInvalidateCompaction).toHaveBeenCalledWith('conv_deleted', { source: 'page', pageId: 'agent_1' });
   });
 });

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -23,8 +23,12 @@ const mockUpdateChain = vi.hoisted(() => ({
 
 const mockExecute = vi.hoisted(() => vi.fn());
 
-vi.mock('@pagespace/db/db', () => ({
-  db: {
+// `tx` supports the identical `.select`/`.update`/etc. surface `db` does —
+// the transaction mock invokes its callback with `db` itself, so a test's
+// `mockDb.update = vi.fn()...` override applies transparently whether the
+// real code runs its writes directly or inside `db.transaction(async (tx) => ...)`.
+vi.mock('@pagespace/db/db', () => {
+  const db = {
     select: vi.fn(() => mockSelectChain),
     insert: vi.fn(() => mockInsertChain),
     update: vi.fn(() => mockUpdateChain),
@@ -32,8 +36,10 @@ vi.mock('@pagespace/db/db', () => ({
     query: {
       pages: { findFirst: vi.fn() },
     },
-  },
-}));
+    transaction: vi.fn((callback: (tx: unknown) => unknown) => callback(db)),
+  };
+  return { db };
+});
 
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ kind: 'eq', field, value })),
@@ -428,6 +434,11 @@ describe('conversationRepository.softDeleteConversation', () => {
 
     await conversationRepository.softDeleteConversation('agent_1', 'conv_deleted');
 
+    // Both UPDATEs run inside ONE transaction — a partial failure between
+    // them must never leave messages inactive but the row still active, or
+    // vice versa (a second review finding on the same fix: chatgpt-codex-
+    // connector on PR #2296).
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     // Two separate UPDATEs: chat_messages (unchanged, pre-existing behavior)
     // THEN conversations — same order the fix was added in, verified via the
     // table argument each db.update() call received.
@@ -437,5 +448,21 @@ describe('conversationRepository.softDeleteConversation', () => {
     expect(setMock).toHaveBeenNthCalledWith(1, { isActive: false });
     expect(setMock).toHaveBeenNthCalledWith(2, { isActive: false });
     expect(mockInvalidateCompaction).toHaveBeenCalledWith('conv_deleted', { source: 'page', pageId: 'agent_1' });
+  });
+
+  it('does not touch conversations.isActive at all if the chat_messages update throws — the transaction rolls back atomically', async () => {
+    const failingWhere = vi.fn().mockRejectedValue(new Error('db exploded'));
+    const setMock = vi.fn().mockReturnValue({ where: failingWhere });
+    mockDb.update = vi.fn().mockReturnValue({ set: setMock });
+
+    await expect(conversationRepository.softDeleteConversation('agent_1', 'conv_deleted')).rejects.toThrow(
+      'db exploded',
+    );
+
+    // Only the FIRST update (chat_messages) was even attempted — the second
+    // (conversations) never ran, matching real transaction semantics where
+    // a throw inside the callback aborts before any later statement.
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateCompaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -368,27 +368,34 @@ export const conversationRepository = {
    * Soft-delete a conversation (mark all messages as inactive)
    */
   async softDeleteConversation(agentId: string, conversationId: string): Promise<void> {
-    await db
-      .update(chatMessages)
-      .set({ isActive: false })
-      .where(and(
-        eq(chatMessages.pageId, agentId),
-        eq(chatMessages.conversationId, conversationId)
-      ));
-    // The canonical row itself, not just its messages — mirrors
-    // `globalConversationRepository.softDeleteConversation`'s pattern, and
-    // matches `conversations.isActive`'s own doc comment ("history soft-
-    // delete"). Every reader that gates on `conversations.isActive`
-    // (agent-sessions-runtime.ts's session listings/caps, the v1/MCP
-    // conversations API, the compliance retention purge) previously kept
-    // treating a page conversation deleted from History as live forever —
-    // including, most concretely, letting the agents console's reopen
-    // affordance resurrect one with no messages left (review finding —
-    // chatgpt-codex-connector on PR #2296).
-    await db
-      .update(conversations)
-      .set({ isActive: false })
-      .where(eq(conversations.id, conversationId));
+    // Both UPDATEs in one transaction — a failure between them must not
+    // leave messages inactive but the canonical row still active (or vice
+    // versa): a retry after a partial failure would fail whatever
+    // active-message precondition the route checks, stranding the row in
+    // the inconsistent state this pairing exists to eliminate (review
+    // finding — chatgpt-codex-connector on PR #2296).
+    await db.transaction(async (tx) => {
+      await tx
+        .update(chatMessages)
+        .set({ isActive: false })
+        .where(and(
+          eq(chatMessages.pageId, agentId),
+          eq(chatMessages.conversationId, conversationId)
+        ));
+      // The canonical row itself, not just its messages — mirrors
+      // `globalConversationRepository.softDeleteConversation`'s pattern, and
+      // matches `conversations.isActive`'s own doc comment ("history soft-
+      // delete"). Every reader that gates on `conversations.isActive`
+      // (agent-sessions-runtime.ts's session listings/caps, the v1/MCP
+      // conversations API, the compliance retention purge) previously kept
+      // treating a page conversation deleted from History as live forever —
+      // including, most concretely, letting the agents console's reopen
+      // affordance resurrect one with no messages left.
+      await tx
+        .update(conversations)
+        .set({ isActive: false })
+        .where(eq(conversations.id, conversationId));
+    });
     // Whole conversation cleared — any summary is stale; the tombstone also
     // guards against a first compaction that may still be in flight.
     await invalidateCompaction(conversationId, { source: 'page', pageId: agentId });

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -375,6 +375,20 @@ export const conversationRepository = {
         eq(chatMessages.pageId, agentId),
         eq(chatMessages.conversationId, conversationId)
       ));
+    // The canonical row itself, not just its messages — mirrors
+    // `globalConversationRepository.softDeleteConversation`'s pattern, and
+    // matches `conversations.isActive`'s own doc comment ("history soft-
+    // delete"). Every reader that gates on `conversations.isActive`
+    // (agent-sessions-runtime.ts's session listings/caps, the v1/MCP
+    // conversations API, the compliance retention purge) previously kept
+    // treating a page conversation deleted from History as live forever —
+    // including, most concretely, letting the agents console's reopen
+    // affordance resurrect one with no messages left (review finding —
+    // chatgpt-codex-connector on PR #2296).
+    await db
+      .update(conversations)
+      .set({ isActive: false })
+      .where(eq(conversations.id, conversationId));
     // Whole conversation cleared — any summary is stale; the tombstone also
     // guards against a first compaction that may still be in flight.
     await invalidateCompaction(conversationId, { source: 'page', pageId: agentId });

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -25,6 +25,10 @@ export interface Conversation extends ConversationSummary {
   userId: string;
   isActive: boolean;
   updatedAt: Date;
+  /** Null for a plain (non-session) conversation. */
+  sessionId: string | null;
+  /** Set when closed out of its session's listing; null while open (or never session-bound). */
+  closedInSessionAt: Date | null;
 }
 
 export interface CreateConversationInput {


### PR DESCRIPTION
## Summary
- Fixes AI_CHAT pages (opened as a page, not in the console pane grid) being unscrollable — `CenterPanel` was double-wrapping chat's self-managed scroll region in its own `overflow-auto` `CustomScrollArea`. Added `managesOwnScroll` to `usePageRefresh()` (true for AI_CHAT/CHANNEL, and now also resolved for a page not yet in the tree via the same `/api/pages/${pageId}` fallback `CenterPanel` itself uses) and skip the redundant wrapper for those page types.
- Fixes the agents console permanently hiding a conversation once its pane is closed (`closedInSessionAt` excludes it from the sidebar with no way back). Adds a symmetric reopen path (`reopen-conversation-in-session.ts`, mirroring the existing close decision's cap/lock discipline), `GET .../conversations/closed` + `POST .../conversations/[id]/reopen` routes, and a History section in `AgentsSidebar` to list and reopen them.
- Adds a Settings entry point to the console — a link on each pane that opens the agent's Settings tab (`/p/[pageId]?tab=settings`, which `AgentPageView` now reads to land directly on Settings, and re-syncs if the same instance receives the param again via a query-only navigation).

## Review history
This PR went through six rounds of automated review (chatgpt-codex-connector, coderabbitai) plus independent adversarial passes — every finding was verified against current code and either fixed or confirmed already-handled with a regression test proving it:
- **Race condition**: `createConversationInSession` wasn't under the same per-session advisory lock as close/reopen, so a create racing a reopen for a session's last open slot could both succeed, exceeding `MAX_SESSION_CONVERSATIONS`. Fixed, with a real-Postgres concurrency test (`agent-sessions-runtime.integration.test.ts`) firing both simultaneously.
- **Tab-sync bug**: the pane bar's Settings link only worked on a fresh mount; a query-only navigation to an already-mounted `AgentPageView` silently no-opped. Fixed with a reactive effect + regression tests, including the exact "identical value re-navigated" edge case CodeRabbit raised.
- **Scroll-fix gap**: `usePageRefresh` didn't account for a page CenterPanel renders via its tree-fallback fetch (a freshly-created or deep-linked page). Fixed by mirroring that same fallback fetch.
- **NULL-sort bug**: the closed-conversations list ordered by `desc(lastMessageAt)`, but Postgres sorts NULLs first — a never-messaged closed conversation could crowd out real activity from the capped History list. Fixed with `NULLS LAST`.
- **Non-atomic soft-delete**: `softDeleteConversation` only deactivated `chatMessages`, leaving `conversations.isActive` stale, and its two updates weren't transactional. Fixed — both updates now run in one `db.transaction`, and the conversation row is deactivated too.
- **History-emptying a session**: deleting a conversation from History bypassed the never-empty guard `closeConversationInSession` enforces, so History could empty an active session down to zero reachable conversations. Fixed with the same guard (409 + `reason: 'last_conversation'`) on the DELETE route.
- **Drive-scoped cache miss / duplicate-insert on reopen**: reopening from the drive-scoped view (`/dashboard/agents`) only updated the session-scoped SWR cache, and calling both the session- and drive-scoped updaters could double-insert the same conversation. Fixed with a scoped `mutate` call and an idempotent (de-duping) cache updater.
- **History going stale after a pane close**: closing a pane didn't refresh an already-open History list, so a just-closed conversation wouldn't appear there until an unrelated refresh. Fixed.
- **Pool-starvation deadlock (P1)**: the session-listing lock used `db.transaction()` + `pg_advisory_xact_lock`, pinning the main pool's connection for the transaction's duration while its own callback (via `conversationRepository`/global `db`) needed a *second* connection from that same pool — a real deadlock under `DB_POOL_MAX=1` or a pool-size burst. Replaced with `withSessionListingLock`, built on this codebase's existing `withAdvisoryLock` primitive against the dedicated `getAdvisoryLockPool()` (structurally separate from the main pool), with bounded retry-then-throw instead of silent degrade-to-unlocked. Applied across create/close/reopen.
- **Unserialized History-deletion guard (P2)**: the never-empty guard's count-then-delete used the explicitly lock-free `countOpenConversationsForSession`, so two racing History deletes (or one racing the normal close route) could both read a stale open count and both empty the session. Fixed by running the guard inside the same `withSessionListingLock` create/close/reopen already serialize under.
- Plus: DRY'd the duplicated close/reopen read-deps, tightened a type in the query-forwarding redirect, and extended sidebar tests to assert the actual toast + a dedicated 404 case.

Merged with master's PR #2297 (`pu/session-refresh-persist`, an unrelated tab-history/back-forward fix) — zero textual conflicts (`git merge-tree` confirmed clean before merging), re-verified with a full local validation pass afterward.

## Test plan
- [x] `bunx tsc --noEmit` clean across the whole app
- [x] `eslint` clean on all changed files (only pre-existing warnings in untouched files)
- [x] 798 unit tests passing across the affected suites (agents console, agent-sessions API + lib, usePageRefresh, conversation-repository)
- [x] 2 real-Postgres integration tests passing (`scripts/test-with-db.sh` DB): the cap-race concurrency test (re-verified against the new lock mechanism) and the NULLS-LAST ordering test
- [x] All CI checks green (Lint & TypeScript, Unit Tests, Security Test Suite, Dependency Audit, CodeQL, Static Security Analysis, Secret Scanning)
- [ ] Manual click-through in a live browser (not completed in this session — no seeded admin credentials / DB hostname reachable from a host-run dev server in this worktree; recommend a quick smoke test before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PofpNe4dkeFdFrN3TjhVFd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added History views for agent sessions, including lazy loading, empty/error states, retry support, and reopening closed conversations.
  - Added direct links to agent settings from conversation panes.
  - Added URL support for opening agent pages on Chat, History, or Settings tabs.
  - Preserved query parameters during page redirects and authentication flows.

- **Improvements**
  - Improved scrolling behavior on chat and channel pages.
  - Reopening conversations now refreshes lists and selects the restored conversation automatically.
  - Prevented deletion of the last active conversation in a session.
  - Improved consistency when conversations are deleted or reopened concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
