### PR TITLE
fix(agents): persist Agents tab selection across tab switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **The Agents console's tab now shows "Agents" and remembers what was open when you switch away and back** —
+  the browser-style tab bar didn't recognize `/dashboard/agents` as a page at all, so its tab showed
+  "Drive" or "Untitled" instead of "Agents". Worse, the console keeps its selected session/conversation/panes
+  in the URL's query string (so clicking around never kills a live shell or streaming chat), but the tab bar
+  never carried that query string along — so switching to another tab and back always dropped the selection,
+  landing on "Select a session" even though the panes were still safely persisted underneath. Tabs now carry
+  their full address, the Agents route is registered with a proper title and icon, reactivating a different
+  tab pointing at the same Agents page now correctly re-reads its own selection, and the header's Back/Forward
+  buttons no longer get one step out of sync after the browser's own Back restores an earlier selection.
 - **Global Assistant is no longer unclickable right after splitting a pane in the Agents console** —
   a short pane's empty-pane picker could crush its "Shell"/"Global Assistant" choices under the
   "Agents" list below them, so the Global Assistant button visually collided with — and lost clicks

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Bot, Loader2 } from 'lucide-react';
 
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
@@ -37,6 +38,7 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
   const selectSession = useAgentSurfaceStore((state) => state.selectSession);
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const storeDriveId = useAgentSurfaceStore((state) => state.driveId);
+  const search = useSearchParams().toString();
 
   const { data: sessionData } = useSessionRecord(selectedSessionId);
   // Resolved vs. not — NOT the same question as "which drive". On the global
@@ -70,15 +72,29 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
     }
   }, [selectedSessionId, sessionData, selectSession]);
 
-  // Deep link, refresh, and Back are the same operation: read the URL. `popstate`
-  // needs nothing beyond re-reading it, because the browser has already restored
-  // the address by the time the event fires.
+  // Deep link, refresh, and any Next-router-driven navigation to this same
+  // route (mount included) all read the URL through `useSearchParams()` —
+  // which is what makes reactivating a DIFFERENT tab that also points at this
+  // pathname work: `router.push` there only changes the query string, so
+  // nothing here remounts, but `useSearchParams()` still updates and re-runs
+  // this effect (caught in review, P2 — without it, the panes kept showing
+  // whichever tab's selection was hydrated last, and picking a session could
+  // silently overwrite the WRONG tab's saved search).
   useEffect(() => {
-    hydrateFromSearch({ driveId });
+    hydrateFromSearch({ driveId, search });
+  }, [hydrateFromSearch, driveId, search]);
+
+  // The one address change `useSearchParams()` can't see: a raw
+  // `history.pushState` (this surface's own writes — see `useAgentSurfaceStore`)
+  // bypasses Next's router entirely, so a `popstate` restoring one of those
+  // entries needs its own listener re-reading `window.location` directly,
+  // because the browser has already restored the address by the time the
+  // event fires.
+  useEffect(() => {
     const onPopState = () => hydrateFromSearch();
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, [hydrateFromSearch, driveId]);
+  }, [hydrateFromSearch]);
 
   // The LATEST selection, read at completion time rather than trusted from a
   // closure captured before an await: `AgentPanes`' close DELETE can still be

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -86,12 +86,14 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
     hydrateFromSearch({ driveId, search });
   }, [hydrateFromSearch, driveId, search]);
 
-  // The one address change `useSearchParams()` can't see: a raw
-  // `history.pushState` (this surface's own writes — see `useAgentSurfaceStore`)
-  // bypasses Next's router entirely, so a `popstate` restoring one of those
-  // entries needs its own listener re-reading `window.location` directly,
-  // because the browser has already restored the address by the time the
-  // event fires.
+  // A second, independent path to the same read: this surface's own raw
+  // `history.pushState` writes (see `useAgentSurfaceStore`) do eventually
+  // reach `useSearchParams()` too (Next patches `pushState` globally and
+  // folds external calls into its router state), but that path is async
+  // (wrapped in a `startTransition`). A `popstate` listener reading
+  // `window.location` directly needs no such wait — the browser has already
+  // restored the address by the time the event fires — so Back feels instant
+  // rather than trailing a render behind.
   useEffect(() => {
     const onPopState = () => hydrateFromSearch();
     window.addEventListener('popstate', onPopState);

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -3,16 +3,30 @@
  *
  * Two structural properties and one rendering contract:
  *
- * - It hydrates its selection from the URL on mount (deep link, refresh) and
- *   re-hydrates on `popstate` (Back/Forward). Together those are what let
- *   selection live in the query string instead of the route, which is what
- *   lets this component stay mounted through every click.
+ * - It hydrates its selection from the URL on mount (deep link, refresh),
+ *   reactively on any Next-router-driven change to the query string on this
+ *   SAME route (`useSearchParams()` — e.g. reactivating a different tab that
+ *   also points here), and on `popstate` (Back/Forward, including one
+ *   restoring a raw `history.pushState` entry Next's router never saw).
+ *   Together those are what let selection live in the query string instead of
+ *   the route, which is what lets this component stay mounted through every
+ *   click.
  * - The centre is the SESSION's pane grid, keyed by the session id — switching
  *   sessions swaps the grid; nothing else about the shell changes.
  */
 import { useRef } from 'react';
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act, waitFor } from '@testing-library/react';
+
+// The global setup mock's `useSearchParams` is a static empty stub — fine for
+// most tests, but this surface now reads it reactively (see AgentsSurface.tsx),
+// and these tests drive scenarios entirely through `window.history.replaceState`.
+// Override it here to read the CURRENT location, same shape as the real hook.
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+  usePathname: vi.fn(() => window.location.pathname),
+  useSearchParams: vi.fn(() => new URLSearchParams(window.location.search)),
+}));
 
 vi.mock('../panes/AgentPanes', () => ({
   default: function MockAgentPanes({
@@ -128,6 +142,25 @@ describe('AgentsSurface', () => {
 
     expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-2');
     expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-2');
+  });
+
+  test('re-hydrates on a same-route query change with no popstate and no remount (caught in review, P2)', () => {
+    // What reactivating a DIFFERENT tab that also points at this pathname does:
+    // `router.push` changes only the query string, so nothing here remounts and
+    // no popstate fires — only `useSearchParams()` changing. Before this fix the
+    // panes kept showing whichever tab's selection was hydrated last.
+    window.history.replaceState({}, '', '/dashboard/agents?session=ses-1&c=conv-1&agent=agent-1');
+    const { rerender } = render(<AgentsSurface />);
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
+
+    act(() => {
+      window.history.replaceState({}, '', '/dashboard/agents?session=ses-2&c=conv-2&agent=agent-2');
+    });
+    rerender(<AgentsSurface />);
+
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-2');
+    expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-2');
+    expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-2');
   });
 
   test('stops listening for popstate once unmounted', () => {

--- a/apps/web/src/components/layout/tabs/TabBar.tsx
+++ b/apps/web/src/components/layout/tabs/TabBar.tsx
@@ -19,6 +19,7 @@ import {
 } from '@dnd-kit/sortable';
 import { Plus } from 'lucide-react';
 import { useTabsStore, selectHasMultipleTabs } from '@/stores/useTabsStore';
+import { toHref } from '@/lib/tabs/tab-navigation';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useIsTablet } from '@/hooks/useDeviceTier';
 import { TabItem } from './TabItem';
@@ -80,7 +81,7 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
     const tab = tabs.find(t => t.id === tabId);
     if (tab) {
       setActiveTab(tabId);
-      router.push(tab.path);
+      router.push(toHref(tab.path, tab.search));
     }
   }, [tabs, setActiveTab, router]);
 
@@ -104,7 +105,7 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
         // Prefer the tab at the same index, or the last one
         const newActiveIndex = Math.min(tabIndex, remainingTabs.length - 1);
         const newActiveTab = remainingTabs[newActiveIndex];
-        router.push(newActiveTab.path);
+        router.push(toHref(newActiveTab.path, newActiveTab.search));
       } else {
         // No tabs left, go to dashboard (closeTab creates a new dashboard tab)
         const driveId = params.driveId as string;
@@ -127,7 +128,7 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
         const state = useTabsStore.getState();
         const newActiveTab = state.tabs.find(t => t.id === state.activeTabId);
         if (newActiveTab) {
-          router.push(newActiveTab.path);
+          router.push(toHref(newActiveTab.path, newActiveTab.search));
         }
         return;
       }
@@ -139,7 +140,7 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
         const state = useTabsStore.getState();
         const newActiveTab = state.tabs.find(t => t.id === state.activeTabId);
         if (newActiveTab) {
-          router.push(newActiveTab.path);
+          router.push(toHref(newActiveTab.path, newActiveTab.search));
         }
         return;
       }

--- a/apps/web/src/components/layout/tabs/TabItem.tsx
+++ b/apps/web/src/components/layout/tabs/TabItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useMemo, type CSSProperties } from 'react';
-import { X, Pin, File, FileText, LayoutDashboard, CheckSquare, Activity, Users, Settings, Trash2, MessageSquare, Layout, Folder, Table, Inbox, Calendar, HardDrive, Link, UserPlus, User, Bell, Shield, LifeBuoy, PenSquare, Hash, MessageCircle, Workflow } from 'lucide-react';
+import { X, Pin, File, FileText, LayoutDashboard, CheckSquare, Activity, Users, Settings, Trash2, MessageSquare, Layout, Folder, Table, Inbox, Calendar, HardDrive, Link, UserPlus, User, Bell, Shield, LifeBuoy, PenSquare, Hash, MessageCircle, Workflow, Bot } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
@@ -58,6 +58,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   PenSquare,
   Hash,
   Workflow,
+  Bot,
 };
 
 export const TabItem = memo(function TabItem({

--- a/apps/web/src/hooks/__tests__/useTabSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useTabSync.test.ts
@@ -249,4 +249,81 @@ describe('useTabSync', () => {
       expect(state.tabs[0].historyIndex).toBe(2);
     });
   });
+
+  describe('history reconciliation (Back/Forward, caught in review: chatgpt-codex-connector P2)', () => {
+    it('given a query-only Back after two selections, should move the index back instead of appending a new entry', async () => {
+      const { createTab } = useTabsStore.getState();
+      createTab({ path: '/dashboard/agents' });
+
+      mockPathname.mockReturnValue('/dashboard/agents');
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
+      const { rerender } = renderHook(() => useTabSync());
+      await waitFor(() => {
+        expect(useTabsStore.getState().tabs[0].search).toBe('session=a');
+      });
+
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=b'));
+      rerender();
+      await waitFor(() => {
+        expect(useTabsStore.getState().tabs[0].search).toBe('session=b');
+      });
+
+      expect(useTabsStore.getState().tabs[0].history).toEqual([
+        '/dashboard/agents',
+        '/dashboard/agents?session=a',
+        '/dashboard/agents?session=b',
+      ]);
+      expect(useTabsStore.getState().tabs[0].historyIndex).toBe(2);
+
+      // What a native Back does (or a popstate replaying a raw `history.pushState`
+      // entry Next's router never pushed itself, e.g. the Agents surface's
+      // selection store): the address returns to one this tab already recorded.
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
+      rerender();
+
+      await waitFor(() => {
+        const tab = useTabsStore.getState().tabs[0];
+        expect(tab.search).toBe('session=a');
+        expect(tab.historyIndex).toBe(1);
+        // No new entry appended — the array is unchanged, just the index moved.
+        expect(tab.history).toEqual([
+          '/dashboard/agents',
+          '/dashboard/agents?session=a',
+          '/dashboard/agents?session=b',
+        ]);
+      });
+    });
+
+    it('given a query-only Forward back to the later entry, should move the index forward instead of appending', async () => {
+      const { createTab } = useTabsStore.getState();
+      createTab({ path: '/dashboard/agents' });
+
+      mockPathname.mockReturnValue('/dashboard/agents');
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
+      const { rerender } = renderHook(() => useTabSync());
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].search).toBe('session=a'));
+
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=b'));
+      rerender();
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].search).toBe('session=b'));
+
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
+      rerender();
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].historyIndex).toBe(1));
+
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=b'));
+      rerender();
+
+      await waitFor(() => {
+        const tab = useTabsStore.getState().tabs[0];
+        expect(tab.search).toBe('session=b');
+        expect(tab.historyIndex).toBe(2);
+        expect(tab.history).toEqual([
+          '/dashboard/agents',
+          '/dashboard/agents?session=a',
+          '/dashboard/agents?session=b',
+        ]);
+      });
+    });
+  });
 });

--- a/apps/web/src/hooks/__tests__/useTabSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useTabSync.test.ts
@@ -11,9 +11,11 @@ import type { ElectronAPI } from '@/types/electron';
 
 // Mock next/navigation
 const mockPathname = vi.fn(() => '/dashboard');
+const mockSearchParams = vi.fn(() => new URLSearchParams());
 const mockRouterReplace = vi.fn();
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
+  useSearchParams: () => mockSearchParams(),
   useRouter: () => ({
     replace: mockRouterReplace,
   }),
@@ -43,6 +45,7 @@ describe('useTabSync', () => {
     });
     mockLocalStorage.clear();
     mockPathname.mockReturnValue('/dashboard');
+    mockSearchParams.mockReturnValue(new URLSearchParams());
     window.electron = undefined;
     vi.clearAllMocks();
   });
@@ -91,6 +94,24 @@ describe('useTabSync', () => {
         expect(state.tabs).toHaveLength(1); // No new tab created
         expect(state.tabs[0].path).toBe('/dashboard/drive-1/page-1');
         expect(state.activeTabId).toBe(tabId); // Same tab
+      });
+    });
+
+    it('given a Next navigation to a path with a query string, should store it on the active tab', async () => {
+      const { createTab } = useTabsStore.getState();
+      createTab({ path: '/dashboard/agents' });
+      const tabId = useTabsStore.getState().activeTabId;
+
+      mockPathname.mockReturnValue('/dashboard/agents');
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=abc&c=def'));
+
+      renderHook(() => useTabSync());
+
+      await waitFor(() => {
+        const state = useTabsStore.getState();
+        expect(state.tabs[0].path).toBe('/dashboard/agents');
+        expect(state.tabs[0].search).toBe('session=abc&c=def');
+        expect(state.activeTabId).toBe(tabId);
       });
     });
 

--- a/apps/web/src/hooks/__tests__/useTabSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useTabSync.test.ts
@@ -250,7 +250,23 @@ describe('useTabSync', () => {
     });
   });
 
-  describe('history reconciliation (Back/Forward, caught in review: chatgpt-codex-connector P2)', () => {
+  describe('history reconciliation (Back/Forward, caught in review: chatgpt-codex-connector P2, refined after a follow-up review)', () => {
+    /**
+     * Simulates what a real browser does on Back/Forward: the address
+     * changes AND a `popstate` event fires. These tests mock `usePathname`/
+     * `useSearchParams` directly (no real navigation), so both steps have to
+     * be driven by hand — set the mocks to the restored address, THEN
+     * dispatch `popstate` so the hook's own listener sets its internal flag,
+     * THEN rerender so the effect observes the new pathname/search while that
+     * flag is still set.
+     */
+    const simulatePopStateTo = (rerender: () => void, path: string, search: string) => {
+      mockPathname.mockReturnValue(path);
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+      act(() => window.dispatchEvent(new PopStateEvent('popstate')));
+      rerender();
+    };
+
     it('given a query-only Back after two selections, should move the index back instead of appending a new entry', async () => {
       const { createTab } = useTabsStore.getState();
       createTab({ path: '/dashboard/agents' });
@@ -278,8 +294,7 @@ describe('useTabSync', () => {
       // What a native Back does (or a popstate replaying a raw `history.pushState`
       // entry Next's router never pushed itself, e.g. the Agents surface's
       // selection store): the address returns to one this tab already recorded.
-      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
-      rerender();
+      simulatePopStateTo(rerender, '/dashboard/agents', 'session=a');
 
       await waitFor(() => {
         const tab = useTabsStore.getState().tabs[0];
@@ -307,12 +322,10 @@ describe('useTabSync', () => {
       rerender();
       await waitFor(() => expect(useTabsStore.getState().tabs[0].search).toBe('session=b'));
 
-      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
-      rerender();
+      simulatePopStateTo(rerender, '/dashboard/agents', 'session=a');
       await waitFor(() => expect(useTabsStore.getState().tabs[0].historyIndex).toBe(1));
 
-      mockSearchParams.mockReturnValue(new URLSearchParams('session=b'));
-      rerender();
+      simulatePopStateTo(rerender, '/dashboard/agents', 'session=b');
 
       await waitFor(() => {
         const tab = useTabsStore.getState().tabs[0];
@@ -323,6 +336,75 @@ describe('useTabSync', () => {
           '/dashboard/agents?session=a',
           '/dashboard/agents?session=b',
         ]);
+      });
+    });
+
+    it('given a multi-step Back (e.g. a long-press history menu jump), should move the index directly there without truncating forward history', async () => {
+      const { createTab } = useTabsStore.getState();
+      createTab({ path: '/dashboard/agents' });
+
+      // Three navigations from the bare tab give 4 entries at indices 0-3:
+      // bare, 'session=a', 'session=b', 'session=c' — current index ends at 3.
+      mockPathname.mockReturnValue('/dashboard/agents');
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
+      const { rerender } = renderHook(() => useTabSync());
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].search).toBe('session=a'));
+
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=b'));
+      rerender();
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].search).toBe('session=b'));
+
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=c'));
+      rerender();
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].historyIndex).toBe(3));
+
+      // Jump straight from 'c' (index 3) to the BARE tab (index 0) — three
+      // steps in one popstate, skipping 'a' and 'b' entirely, exactly what a
+      // multi-entry Back does. The old adjacency-only check (comparing only
+      // historyIndex ± 1) could never recognize this and would have fallen
+      // through to a fresh push, truncating history at index 3.
+      simulatePopStateTo(rerender, '/dashboard/agents', '');
+
+      await waitFor(() => {
+        const tab = useTabsStore.getState().tabs[0];
+        expect(tab.search).toBe('');
+        expect(tab.historyIndex).toBe(0);
+        expect(tab.history).toEqual([
+          '/dashboard/agents',
+          '/dashboard/agents?session=a',
+          '/dashboard/agents?session=b',
+          '/dashboard/agents?session=c',
+        ]);
+      });
+    });
+
+    it('given an ordinary navigation with NO popstate that happens to match an existing entry, should still append a new step (no false positive)', async () => {
+      // The old adjacency-only heuristic inferred "this is a Back" purely from
+      // string equality, so an ORDINARY new navigation (a Link click,
+      // router.push from elsewhere) that coincidentally matched an adjacent
+      // history entry got misclassified as Back — corrupting historyIndex
+      // instead of appending. Gating on a real popstate fixes this: with none
+      // fired, a matching href must still be treated as a new step.
+      const { createTab } = useTabsStore.getState();
+      createTab({ path: '/dashboard/agents' });
+
+      mockPathname.mockReturnValue('/dashboard/agents');
+      mockSearchParams.mockReturnValue(new URLSearchParams('session=a'));
+      const { rerender } = renderHook(() => useTabSync());
+      await waitFor(() => expect(useTabsStore.getState().tabs[0].search).toBe('session=a'));
+
+      // No popstate dispatched here — this is an ordinary Next-router-driven
+      // navigation that happens to coincidentally match the current entry's
+      // predecessor string ('/dashboard/agents', the bare tab root).
+      mockSearchParams.mockReturnValue(new URLSearchParams());
+      rerender();
+
+      await waitFor(() => {
+        const tab = useTabsStore.getState().tabs[0];
+        expect(tab.search).toBe('');
+        // Appended as a NEW entry, not a reconciled jump back to index 0.
+        expect(tab.history).toEqual(['/dashboard/agents', '/dashboard/agents?session=a', '/dashboard/agents']);
+        expect(tab.historyIndex).toBe(2);
       });
     });
   });

--- a/apps/web/src/hooks/useTabSync.ts
+++ b/apps/web/src/hooks/useTabSync.ts
@@ -18,15 +18,35 @@ export function useTabSync() {
   const search = useSearchParams().toString();
   const router = useRouter();
   const lastSyncedHref = useRef<string | null>(null);
+  // Set by a REAL browser popstate — the one unambiguous signal that a URL
+  // change is Back/Forward rather than a new step, whether the destination
+  // was pushed by Next's router or by code that bypasses it entirely (e.g.
+  // the Agents surface's raw `history.pushState`). Consumed and cleared at
+  // the top of the sync effect below on the very next run, since popstate
+  // always fires and settles before Next re-renders with the new
+  // pathname/search (this is also why `AgentsSurface` re-reads the URL for
+  // its OWN store the same way, independently of this hook).
+  const isPopStateRef = useRef(false);
 
   const rehydrated = useTabsStore((state) => state.rehydrated);
   const setDesktopRestoreAttempted = useTabsStore((state) => state.setDesktopRestoreAttempted);
+
+  useEffect(() => {
+    const onPopState = () => { isPopStateRef.current = true; };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
 
   useEffect(() => {
     // Wait for store to rehydrate from localStorage
     if (!rehydrated) return;
 
     const href = toHref(pathname, search);
+    // Read-and-clear atomically so every branch below (bootstrap restore,
+    // early returns, new navigation) starts this run with a fresh flag
+    // regardless of which branch it takes.
+    const wasPopState = isPopStateRef.current;
+    isPopStateRef.current = false;
 
     const state = useTabsStore.getState();
     const hasTabs = state.tabs.length > 0;
@@ -81,22 +101,25 @@ export function useTabSync() {
       return;
     }
 
-    // A URL change isn't always a NEW step — a native Back/Forward (or one
-    // driven by code that bypasses Next's router, e.g. the Agents surface's
-    // raw `history.pushState`) can restore an address this tab already has in
-    // its own history, adjacent to its current position. Recognize that by
-    // adjacency instead of always pushing: otherwise Back re-adds the entry
-    // being returned TO as a new forward step, and this tab's own Back/Forward
-    // buttons end up one entry off from what the browser just did.
-    if (activeTab && activeTab.history[activeTab.historyIndex - 1] === href) {
-      currentState.goBackInActiveTab();
-      lastSyncedHref.current = href;
-      return;
-    }
-    if (activeTab && activeTab.history[activeTab.historyIndex + 1] === href) {
-      currentState.goForwardInActiveTab();
-      lastSyncedHref.current = href;
-      return;
+    // A URL change isn't always a NEW step — a real popstate (native
+    // Back/Forward, of any distance, e.g. a long-press-selected entry several
+    // steps away) restores an address that should already be SOMEWHERE in
+    // this tab's own history, whether it was pushed by Next's router or by
+    // code that bypasses it entirely (e.g. the Agents surface's raw
+    // `history.pushState`). Reconcile the index to match instead of pushing a
+    // new entry: pushing would truncate everything after the current index,
+    // silently discarding real forward history, and would leave this tab's
+    // own Back/Forward buttons one entry off from what the browser just did.
+    // Gated on an ACTUAL popstate (not just string adjacency) so an ordinary
+    // new navigation that happens to coincidentally match an existing entry
+    // still gets appended as a new step rather than misread as a jump back.
+    if (activeTab && wasPopState) {
+      const matchIndex = activeTab.history.indexOf(href);
+      if (matchIndex !== -1) {
+        currentState.setActiveTabHistoryIndex(matchIndex);
+        lastSyncedHref.current = href;
+        return;
+      }
     }
 
     // Navigate within the active tab

--- a/apps/web/src/hooks/useTabSync.ts
+++ b/apps/web/src/hooks/useTabSync.ts
@@ -19,13 +19,19 @@ export function useTabSync() {
   const router = useRouter();
   const lastSyncedHref = useRef<string | null>(null);
   // Set by a REAL browser popstate — the one unambiguous signal that a URL
-  // change is Back/Forward rather than a new step, whether the destination
-  // was pushed by Next's router or by code that bypasses it entirely (e.g.
-  // the Agents surface's raw `history.pushState`). Consumed and cleared at
-  // the top of the sync effect below on the very next run, since popstate
-  // always fires and settles before Next re-renders with the new
-  // pathname/search (this is also why `AgentsSurface` re-reads the URL for
-  // its OWN store the same way, independently of this hook).
+  // change is Back/Forward rather than a new step, regardless of whether the
+  // destination was pushed by Next's own router or by application code (e.g.
+  // the Agents surface's `history.pushState`; Next patches `pushState`
+  // globally to copy its internal history markers onto ANY push, so even
+  // those entries get the ordinary soft `usePathname`/`useSearchParams`
+  // update on Back — verified against next@15.5.18's app-router.js).
+  // Consumed and cleared at the top of the sync effect below on its very next
+  // run. Not given an expiry: the only way it could go unconsumed is a
+  // popstate landing on a href IDENTICAL to what's already showing (nothing
+  // for `pathname`/`search` to change, so the effect wouldn't re-run at all)
+  // — and every write path here (`commit()`'s own same-URL guard,
+  // `navigateInTab`'s no-op check) already prevents two ADJACENT history
+  // entries from ever being identical, so that state isn't reachable.
   const isPopStateRef = useRef(false);
 
   const rehydrated = useTabsStore((state) => state.rehydrated);
@@ -104,10 +110,10 @@ export function useTabSync() {
     // A URL change isn't always a NEW step — a real popstate (native
     // Back/Forward, of any distance, e.g. a long-press-selected entry several
     // steps away) restores an address that should already be SOMEWHERE in
-    // this tab's own history, whether it was pushed by Next's router or by
-    // code that bypasses it entirely (e.g. the Agents surface's raw
-    // `history.pushState`). Reconcile the index to match instead of pushing a
-    // new entry: pushing would truncate everything after the current index,
+    // this tab's own history, whether that entry was pushed by Next's router
+    // or by application code (e.g. the Agents surface's `history.pushState`).
+    // Reconcile the index to match instead of pushing a new entry: pushing
+    // would truncate everything after the current index,
     // silently discarding real forward history, and would leave this tab's
     // own Back/Forward buttons one entry off from what the browser just did.
     // Gated on an ACTUAL popstate (not just string adjacency) so an ordinary

--- a/apps/web/src/hooks/useTabSync.ts
+++ b/apps/web/src/hooks/useTabSync.ts
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useRef } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTabsStore, selectActiveTab } from '@/stores/useTabsStore';
+import { toHref } from '@/lib/tabs/tab-navigation';
 
 /**
  * Syncs URL navigation with the browser-style tabs store.
@@ -14,8 +15,9 @@ import { useTabsStore, selectActiveTab } from '@/stores/useTabsStore';
  */
 export function useTabSync() {
   const pathname = usePathname();
+  const search = useSearchParams().toString();
   const router = useRouter();
-  const lastSyncedPath = useRef<string | null>(null);
+  const lastSyncedHref = useRef<string | null>(null);
 
   const rehydrated = useTabsStore((state) => state.rehydrated);
   const setDesktopRestoreAttempted = useTabsStore((state) => state.setDesktopRestoreAttempted);
@@ -23,6 +25,8 @@ export function useTabSync() {
   useEffect(() => {
     // Wait for store to rehydrate from localStorage
     if (!rehydrated) return;
+
+    const href = toHref(pathname, search);
 
     const state = useTabsStore.getState();
     const hasTabs = state.tabs.length > 0;
@@ -43,28 +47,28 @@ export function useTabSync() {
 
       if (pathname === '/dashboard' && hasTabs) {
         const activeTab = selectActiveTab(useTabsStore.getState());
-        const restorePath = activeTab?.path;
+        const restoreHref = activeTab ? toHref(activeTab.path, activeTab.search) : undefined;
 
-        if (restorePath && restorePath !== '/dashboard') {
+        if (restoreHref && restoreHref !== '/dashboard') {
           // Guard against immediate re-runs (e.g. strict mode) before replace updates pathname.
           // Keep '/dashboard' marked as already handled so we don't sync it into tab history.
-          lastSyncedPath.current = pathname;
-          router.replace(restorePath);
+          lastSyncedHref.current = href;
+          router.replace(restoreHref);
           return;
         }
       }
     }
 
-    // Skip if we already synced this path
-    if (lastSyncedPath.current === pathname) return;
+    // Skip if we already synced this href
+    if (lastSyncedHref.current === href) return;
 
     // Re-read after potential healing / restore
     const currentState = useTabsStore.getState();
 
     // If no tabs exist, create one from current path
     if (currentState.tabs.length === 0) {
-      currentState.createTab({ path: pathname });
-      lastSyncedPath.current = pathname;
+      currentState.createTab({ path: pathname, search });
+      lastSyncedHref.current = href;
       return;
     }
 
@@ -72,13 +76,13 @@ export function useTabSync() {
     const activeTab = selectActiveTab(currentState);
 
     // If active tab already at this path, just update sync ref
-    if (activeTab?.path === pathname) {
-      lastSyncedPath.current = pathname;
+    if (activeTab?.path === pathname && activeTab?.search === search) {
+      lastSyncedHref.current = href;
       return;
     }
 
     // Navigate within the active tab
-    currentState.navigateInActiveTab(pathname);
-    lastSyncedPath.current = pathname;
-  }, [pathname, rehydrated, router, setDesktopRestoreAttempted]);
+    currentState.navigateInActiveTab(pathname, search);
+    lastSyncedHref.current = href;
+  }, [pathname, search, rehydrated, router, setDesktopRestoreAttempted]);
 }

--- a/apps/web/src/hooks/useTabSync.ts
+++ b/apps/web/src/hooks/useTabSync.ts
@@ -112,10 +112,10 @@ export function useTabSync() {
     // steps away) restores an address that should already be SOMEWHERE in
     // this tab's own history, whether that entry was pushed by Next's router
     // or by application code (e.g. the Agents surface's `history.pushState`).
-    // Reconcile the index to match instead of pushing a new entry: pushing
-    // would truncate everything after the current index,
-    // silently discarding real forward history, and would leave this tab's
-    // own Back/Forward buttons one entry off from what the browser just did.
+    // Reconcile the index to match rather than pushing a new entry, which
+    // would truncate everything after the current index — silently
+    // discarding real forward history — and leave this tab's own
+    // Back/Forward buttons one entry off from what the browser just did.
     // Gated on an ACTUAL popstate (not just string adjacency) so an ordinary
     // new navigation that happens to coincidentally match an existing entry
     // still gets appended as a new step rather than misread as a jump back.

--- a/apps/web/src/hooks/useTabSync.ts
+++ b/apps/web/src/hooks/useTabSync.ts
@@ -81,6 +81,24 @@ export function useTabSync() {
       return;
     }
 
+    // A URL change isn't always a NEW step — a native Back/Forward (or one
+    // driven by code that bypasses Next's router, e.g. the Agents surface's
+    // raw `history.pushState`) can restore an address this tab already has in
+    // its own history, adjacent to its current position. Recognize that by
+    // adjacency instead of always pushing: otherwise Back re-adds the entry
+    // being returned TO as a new forward step, and this tab's own Back/Forward
+    // buttons end up one entry off from what the browser just did.
+    if (activeTab && activeTab.history[activeTab.historyIndex - 1] === href) {
+      currentState.goBackInActiveTab();
+      lastSyncedHref.current = href;
+      return;
+    }
+    if (activeTab && activeTab.history[activeTab.historyIndex + 1] === href) {
+      currentState.goForwardInActiveTab();
+      lastSyncedHref.current = href;
+      return;
+    }
+
     // Navigate within the active tab
     currentState.navigateInActiveTab(pathname, search);
     lastSyncedHref.current = href;

--- a/apps/web/src/lib/tabs/__tests__/tab-navigation.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-navigation.test.ts
@@ -152,6 +152,25 @@ describe('tab-navigation', () => {
       expect(updated.historyIndex).toBe(1);
     });
 
+    it('given a search-only change (same path), should preserve cached metadata (caught in review: coderabbitai)', () => {
+      // title/pageType are keyed by page identity (the path), not the query
+      // string. Clearing them on every Agents selection commit (a
+      // search-only change on the SAME path) would force a redundant
+      // useTabMeta refetch and a "Loading..." flicker for no reason.
+      const tab = createTestTab({
+        path: '/dashboard/drive-1/page-1',
+        search: 'foo=a',
+        title: 'Page Title',
+        pageType: PageType.DOCUMENT,
+      });
+
+      const updated = navigateInTab(tab, '/dashboard/drive-1/page-1', 'foo=b');
+
+      expect(updated.search).toBe('foo=b');
+      expect(updated.title).toBe('Page Title');
+      expect(updated.pageType).toBe('DOCUMENT');
+    });
+
     it('given same path and same search, should not modify history', () => {
       const tab = createTestTab({
         path: '/dashboard/agents',
@@ -367,6 +386,21 @@ describe('tab-navigation', () => {
 
       expect(updated.title).toBeUndefined();
       expect(updated.pageType).toBeUndefined();
+    });
+
+    it('given a jump to an entry with the SAME path (search-only), should preserve cached metadata', () => {
+      const tab = createTestTab({
+        path: '/dashboard/agents',
+        search: 'session=b',
+        history: ['/dashboard/agents?session=a', '/dashboard/agents?session=b'],
+        historyIndex: 1,
+        title: 'Agents',
+      });
+
+      const updated = goToHistoryIndex(tab, 0);
+
+      expect(updated.search).toBe('session=a');
+      expect(updated.title).toBe('Agents');
     });
   });
 

--- a/apps/web/src/lib/tabs/__tests__/tab-navigation.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-navigation.test.ts
@@ -9,6 +9,7 @@ import {
   navigateInTab,
   goBack,
   goForward,
+  goToHistoryIndex,
   canGoBack,
   canGoForward,
   toHref,
@@ -279,6 +280,90 @@ describe('tab-navigation', () => {
       });
 
       const updated = goForward(tab);
+
+      expect(updated.title).toBeUndefined();
+      expect(updated.pageType).toBeUndefined();
+    });
+  });
+
+  describe('goToHistoryIndex', () => {
+    it('given an index several steps back, should jump directly there', () => {
+      const tab = createTestTab({
+        path: '/page-3',
+        history: ['/dashboard', '/page-1', '/page-2', '/page-3'],
+        historyIndex: 3,
+      });
+
+      const updated = goToHistoryIndex(tab, 0);
+
+      expect(updated.path).toBe('/dashboard');
+      expect(updated.historyIndex).toBe(0);
+      // The array itself is untouched — only the index moved.
+      expect(updated.history).toEqual(['/dashboard', '/page-1', '/page-2', '/page-3']);
+    });
+
+    it('given an index several steps forward, should jump directly there', () => {
+      const tab = createTestTab({
+        path: '/dashboard',
+        history: ['/dashboard', '/page-1', '/page-2', '/page-3'],
+        historyIndex: 0,
+      });
+
+      const updated = goToHistoryIndex(tab, 3);
+
+      expect(updated.path).toBe('/page-3');
+      expect(updated.historyIndex).toBe(3);
+    });
+
+    it('given the current index, should return unchanged', () => {
+      const tab = createTestTab({
+        path: '/page-1',
+        history: ['/dashboard', '/page-1'],
+        historyIndex: 1,
+      });
+
+      expect(goToHistoryIndex(tab, 1)).toBe(tab);
+    });
+
+    it('given an out-of-range index, should return unchanged', () => {
+      const tab = createTestTab({
+        path: '/dashboard',
+        history: ['/dashboard', '/page-1'],
+        historyIndex: 0,
+      });
+
+      expect(goToHistoryIndex(tab, -1)).toBe(tab);
+      expect(goToHistoryIndex(tab, 2)).toBe(tab);
+    });
+
+    it('given a search-carrying entry, should restore both path and search', () => {
+      const tab = createTestTab({
+        path: '/dashboard/agents',
+        search: 'session=c',
+        history: [
+          '/dashboard/agents?session=a',
+          '/dashboard/agents?session=b',
+          '/dashboard/agents?session=c',
+        ],
+        historyIndex: 2,
+      });
+
+      const updated = goToHistoryIndex(tab, 0);
+
+      expect(updated.path).toBe('/dashboard/agents');
+      expect(updated.search).toBe('session=a');
+    });
+
+    it('given cached metadata, should clear it when jumping', () => {
+      const tab = createTestTab({
+        path: '/page-2',
+        history: ['/dashboard', '/page-1', '/page-2'],
+        historyIndex: 2,
+        title: 'Page 2',
+        pageType: PageType.DOCUMENT,
+      });
+
+      const updated = goToHistoryIndex(tab, 0);
 
       expect(updated.title).toBeUndefined();
       expect(updated.pageType).toBeUndefined();

--- a/apps/web/src/lib/tabs/__tests__/tab-navigation.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-navigation.test.ts
@@ -11,6 +11,8 @@ import {
   goForward,
   canGoBack,
   canGoForward,
+  toHref,
+  fromHref,
   type Tab,
 } from '../tab-navigation';
 import { PageType } from '@pagespace/lib/utils/enums';
@@ -19,6 +21,7 @@ import { PageType } from '@pagespace/lib/utils/enums';
 const createTestTab = (overrides: Partial<Tab> = {}): Tab => ({
   id: overrides.id ?? 'tab-1',
   path: overrides.path ?? '/dashboard',
+  search: overrides.search ?? '',
   history: overrides.history ?? ['/dashboard'],
   historyIndex: overrides.historyIndex ?? 0,
   isPinned: overrides.isPinned ?? false,
@@ -131,9 +134,71 @@ describe('tab-navigation', () => {
       expect(updated.title).toBe('Page Title');
       expect(updated.pageType).toBe('DOCUMENT');
     });
+
+    it('given same path but different search, should update search and push a new history entry', () => {
+      const tab = createTestTab({
+        path: '/dashboard/agents',
+        search: 'session=a',
+        history: ['/dashboard/agents?session=a'],
+        historyIndex: 0,
+      });
+
+      const updated = navigateInTab(tab, '/dashboard/agents', 'session=b');
+
+      expect(updated.path).toBe('/dashboard/agents');
+      expect(updated.search).toBe('session=b');
+      expect(updated.history).toEqual(['/dashboard/agents?session=a', '/dashboard/agents?session=b']);
+      expect(updated.historyIndex).toBe(1);
+    });
+
+    it('given same path and same search, should not modify history', () => {
+      const tab = createTestTab({
+        path: '/dashboard/agents',
+        search: 'session=a',
+        history: ['/dashboard/agents?session=a'],
+        historyIndex: 0,
+      });
+
+      const updated = navigateInTab(tab, '/dashboard/agents', 'session=a');
+
+      expect(updated).toBe(tab);
+    });
+  });
+
+  describe('toHref / fromHref', () => {
+    it('given a search string, should join it onto the path with a ?', () => {
+      expect(toHref('/dashboard/agents', 'session=a')).toBe('/dashboard/agents?session=a');
+    });
+
+    it('given no search string, should return the bare path', () => {
+      expect(toHref('/dashboard/agents', '')).toBe('/dashboard/agents');
+    });
+
+    it('should round-trip through fromHref', () => {
+      expect(fromHref('/dashboard/agents?session=a&c=b')).toEqual({
+        path: '/dashboard/agents',
+        search: 'session=a&c=b',
+      });
+      expect(fromHref('/dashboard/agents')).toEqual({ path: '/dashboard/agents', search: '' });
+    });
   });
 
   describe('goBack', () => {
+    it('given tab with a search-carrying history entry, should restore both path and search', () => {
+      const tab = createTestTab({
+        path: '/dashboard/agents',
+        search: 'session=b',
+        history: ['/dashboard/agents?session=a', '/dashboard/agents?session=b'],
+        historyIndex: 1,
+      });
+
+      const updated = goBack(tab);
+
+      expect(updated.path).toBe('/dashboard/agents');
+      expect(updated.search).toBe('session=a');
+      expect(updated.historyIndex).toBe(0);
+    });
+
     it('given tab with history, should navigate to previous entry', () => {
       const tab = createTestTab({
         path: '/page-2',

--- a/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
@@ -87,6 +87,21 @@ describe('tab-title', () => {
       expect(result.pageId).toBeUndefined();
     });
 
+    it('given drive agents path, should return drive-agents type', () => {
+      const result = parseTabPath('/dashboard/drive-123/agents');
+
+      expect(result.type).toBe('drive-agents');
+      expect(result.driveId).toBe('drive-123');
+      expect(result.pageId).toBeUndefined();
+    });
+
+    it('given global agents path, should return dashboard-agents type', () => {
+      const result = parseTabPath('/dashboard/agents');
+
+      expect(result.type).toBe('dashboard-agents');
+      expect(result.driveId).toBeUndefined();
+    });
+
     it('given dms root, should return dms type', () => {
       const result = parseTabPath('/dashboard/dms');
 
@@ -465,6 +480,20 @@ describe('tab-title', () => {
       expect(meta!.iconName).toBe('Workflow');
     });
 
+    it('given drive-agents type, should return Agents title', () => {
+      const meta = getStaticTabMeta({ type: 'drive-agents', driveId: 'drive-123' });
+
+      expect(meta!.title).toBe('Agents');
+      expect(meta!.iconName).toBe('Bot');
+    });
+
+    it('given dashboard-agents type, should return Agents title', () => {
+      const meta = getStaticTabMeta({ type: 'dashboard-agents' });
+
+      expect(meta!.title).toBe('Agents');
+      expect(meta!.iconName).toBe('Bot');
+    });
+
     // Members sub-routes
     it('given drive-members-invite type, should return Invite Members title', () => {
       const meta = getStaticTabMeta({ type: 'drive-members-invite', driveId: 'drive-123' });
@@ -567,7 +596,7 @@ describe('tab-title', () => {
 describe('isDriveScopedPath', () => {
   const DRIVE_SECTIONS = [
     'tasks', 'activity', 'members', 'settings',
-    'trash', 'calendar', 'channels', 'files', 'workflows',
+    'trash', 'calendar', 'channels', 'files', 'workflows', 'agents',
   ];
 
   it('holds for the bare drive route and every drive section', () => {

--- a/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
@@ -612,7 +612,7 @@ describe('isDriveScopedPath', () => {
   // resolves to routeType 'page', which already carries the drive).
   it('does not claim page routes, global routes, or the drive list', () => {
     for (const path of ['/dashboard/drives', '/dashboard/tasks', '/dashboard/calendar',
-      '/dashboard/channels/c1', '/settings/account', '/dashboard']) {
+      '/dashboard/agents', '/dashboard/channels/c1', '/settings/account', '/dashboard']) {
       const parsed = parseTabPath(path);
       expect({ path, scoped: isDriveScopedPath(parsed) }).toEqual({ path, scoped: false });
     }

--- a/apps/web/src/lib/tabs/tab-navigation.ts
+++ b/apps/web/src/lib/tabs/tab-navigation.ts
@@ -71,6 +71,13 @@ export const navigateInTab = (tab: Tab, newPath: string, newSearch: string = '')
 
   // Truncate forward history when navigating from middle of history
   const truncatedHistory = tab.history.slice(0, tab.historyIndex + 1);
+  // title/pageType are keyed by page identity (the path), not the query
+  // string — a search-only change (e.g. the Agents surface's selection
+  // commits, mirrored here via updateActiveTabSearch) has nothing to
+  // invalidate. Clearing it anyway would force a redundant `useTabMeta`
+  // refetch and a brief "Loading..." flicker in the tab title for no reason
+  // (caught in review: coderabbitai).
+  const pathChanged = newPath !== tab.path;
 
   return {
     ...tab,
@@ -78,9 +85,8 @@ export const navigateInTab = (tab: Tab, newPath: string, newSearch: string = '')
     search: newSearch,
     history: [...truncatedHistory, toHref(newPath, newSearch)],
     historyIndex: truncatedHistory.length,
-    // Clear cached metadata so useTabMeta fetches fresh data for new path
-    title: undefined,
-    pageType: undefined,
+    title: pathChanged ? undefined : tab.title,
+    pageType: pathChanged ? undefined : tab.pageType,
   };
 };
 
@@ -100,14 +106,16 @@ export const goToHistoryIndex = (tab: Tab, index: number): Tab => {
   }
 
   const { path, search } = fromHref(tab.history[index]);
+  const pathChanged = path !== tab.path;
   return {
     ...tab,
     path,
     search,
     historyIndex: index,
-    // Clear cached metadata so useTabMeta fetches fresh data for navigated path
-    title: undefined,
-    pageType: undefined,
+    // Same reasoning as navigateInTab: only a path change invalidates the
+    // cached title/pageType.
+    title: pathChanged ? undefined : tab.title,
+    pageType: pathChanged ? undefined : tab.pageType,
   };
 };
 

--- a/apps/web/src/lib/tabs/tab-navigation.ts
+++ b/apps/web/src/lib/tabs/tab-navigation.ts
@@ -84,51 +84,15 @@ export const navigateInTab = (tab: Tab, newPath: string, newSearch: string = '')
   };
 };
 
-export const goBack = (tab: Tab): Tab => {
-  if (!canGoBack(tab)) {
-    return tab;
-  }
-
-  const newIndex = tab.historyIndex - 1;
-  const { path, search } = fromHref(tab.history[newIndex]);
-  return {
-    ...tab,
-    path,
-    search,
-    historyIndex: newIndex,
-    // Clear cached metadata so useTabMeta fetches fresh data for navigated path
-    title: undefined,
-    pageType: undefined,
-  };
-};
-
-export const goForward = (tab: Tab): Tab => {
-  if (!canGoForward(tab)) {
-    return tab;
-  }
-
-  const newIndex = tab.historyIndex + 1;
-  const { path, search } = fromHref(tab.history[newIndex]);
-  return {
-    ...tab,
-    path,
-    search,
-    historyIndex: newIndex,
-    // Clear cached metadata so useTabMeta fetches fresh data for navigated path
-    title: undefined,
-    pageType: undefined,
-  };
-};
-
 /**
  * Jump directly to an arbitrary position in this tab's own history — what a
  * real Back/Forward (of any distance, e.g. a long-press-selected entry
  * several steps away) resolves to once the destination href is found in
- * `history`. Unlike `goBack`/`goForward`, this isn't a ±1 step: it's how a
- * URL change gets RECONCILED against history that already contains it,
- * rather than re-pushed as a new entry (which would truncate everything
- * after the current index and silently discard real forward history).
- * A no-op for an out-of-range or already-current index.
+ * `history`. `goBack`/`goForward` are just this at a fixed ±1 step: this isn't
+ * a re-push, it's how a URL change gets RECONCILED against history that
+ * already contains it, rather than truncated and re-appended as a new entry
+ * (which would silently discard real forward history). A no-op for an
+ * out-of-range or already-current index.
  */
 export const goToHistoryIndex = (tab: Tab, index: number): Tab => {
   if (index < 0 || index >= tab.history.length || index === tab.historyIndex) {
@@ -146,6 +110,10 @@ export const goToHistoryIndex = (tab: Tab, index: number): Tab => {
     pageType: undefined,
   };
 };
+
+export const goBack = (tab: Tab): Tab => goToHistoryIndex(tab, tab.historyIndex - 1);
+
+export const goForward = (tab: Tab): Tab => goToHistoryIndex(tab, tab.historyIndex + 1);
 
 export const canGoBack = (tab: Tab): boolean => tab.historyIndex > 0;
 

--- a/apps/web/src/lib/tabs/tab-navigation.ts
+++ b/apps/web/src/lib/tabs/tab-navigation.ts
@@ -8,6 +8,9 @@ import type { PageType } from '@pagespace/lib/utils/enums';
 export interface Tab {
   id: string;
   path: string;
+  /** Raw query string, no leading `?`. `''` means none. */
+  search: string;
+  /** Full hrefs (`toHref` output), one per navigation step in this tab. */
   history: string[];
   historyIndex: number;
   isPinned: boolean;
@@ -19,10 +22,22 @@ export interface Tab {
 export interface CreateTabOptions {
   id?: string;
   path?: string;
+  search?: string;
   isPinned?: boolean;
   title?: string;
   pageType?: PageType;
 }
+
+/** Combine a pathname and a raw query string (no leading `?`) into an href. */
+export const toHref = (path: string, search: string): string => (search ? `${path}?${search}` : path);
+
+/** Split an href produced by `toHref` back into its pathname and raw query string. */
+export const fromHref = (href: string): { path: string; search: string } => {
+  const qIndex = href.indexOf('?');
+  return qIndex === -1
+    ? { path: href, search: '' }
+    : { path: href.slice(0, qIndex), search: href.slice(qIndex + 1) };
+};
 
 export interface TabMetaUpdate {
   title?: string;
@@ -34,21 +49,23 @@ const generateId = () => `tab-${Date.now()}-${Math.random().toString(36).slice(2
 export const createTab = ({
   id = generateId(),
   path = '/dashboard',
+  search = '',
   isPinned = false,
   title,
   pageType,
 }: CreateTabOptions = {}): Tab => ({
   id,
   path,
-  history: [path],
+  search,
+  history: [toHref(path, search)],
   historyIndex: 0,
   isPinned,
   title,
   pageType,
 });
 
-export const navigateInTab = (tab: Tab, newPath: string): Tab => {
-  if (newPath === tab.path) {
+export const navigateInTab = (tab: Tab, newPath: string, newSearch: string = ''): Tab => {
+  if (newPath === tab.path && newSearch === tab.search) {
     return tab;
   }
 
@@ -58,7 +75,8 @@ export const navigateInTab = (tab: Tab, newPath: string): Tab => {
   return {
     ...tab,
     path: newPath,
-    history: [...truncatedHistory, newPath],
+    search: newSearch,
+    history: [...truncatedHistory, toHref(newPath, newSearch)],
     historyIndex: truncatedHistory.length,
     // Clear cached metadata so useTabMeta fetches fresh data for new path
     title: undefined,
@@ -72,9 +90,11 @@ export const goBack = (tab: Tab): Tab => {
   }
 
   const newIndex = tab.historyIndex - 1;
+  const { path, search } = fromHref(tab.history[newIndex]);
   return {
     ...tab,
-    path: tab.history[newIndex],
+    path,
+    search,
     historyIndex: newIndex,
     // Clear cached metadata so useTabMeta fetches fresh data for navigated path
     title: undefined,
@@ -88,9 +108,11 @@ export const goForward = (tab: Tab): Tab => {
   }
 
   const newIndex = tab.historyIndex + 1;
+  const { path, search } = fromHref(tab.history[newIndex]);
   return {
     ...tab,
-    path: tab.history[newIndex],
+    path,
+    search,
     historyIndex: newIndex,
     // Clear cached metadata so useTabMeta fetches fresh data for navigated path
     title: undefined,

--- a/apps/web/src/lib/tabs/tab-navigation.ts
+++ b/apps/web/src/lib/tabs/tab-navigation.ts
@@ -120,6 +120,33 @@ export const goForward = (tab: Tab): Tab => {
   };
 };
 
+/**
+ * Jump directly to an arbitrary position in this tab's own history — what a
+ * real Back/Forward (of any distance, e.g. a long-press-selected entry
+ * several steps away) resolves to once the destination href is found in
+ * `history`. Unlike `goBack`/`goForward`, this isn't a ±1 step: it's how a
+ * URL change gets RECONCILED against history that already contains it,
+ * rather than re-pushed as a new entry (which would truncate everything
+ * after the current index and silently discard real forward history).
+ * A no-op for an out-of-range or already-current index.
+ */
+export const goToHistoryIndex = (tab: Tab, index: number): Tab => {
+  if (index < 0 || index >= tab.history.length || index === tab.historyIndex) {
+    return tab;
+  }
+
+  const { path, search } = fromHref(tab.history[index]);
+  return {
+    ...tab,
+    path,
+    search,
+    historyIndex: index,
+    // Clear cached metadata so useTabMeta fetches fresh data for navigated path
+    title: undefined,
+    pageType: undefined,
+  };
+};
+
 export const canGoBack = (tab: Tab): boolean => tab.historyIndex > 0;
 
 export const canGoForward = (tab: Tab): boolean => tab.historyIndex < tab.history.length - 1;

--- a/apps/web/src/lib/tabs/tab-title.ts
+++ b/apps/web/src/lib/tabs/tab-title.ts
@@ -20,6 +20,7 @@ export type PathType =
   | 'drive-channels'
   | 'drive-files'
   | 'drive-workflows'
+  | 'drive-agents'
   // Global dashboard routes
   | 'dashboard-tasks'
   | 'dashboard-activity'
@@ -28,6 +29,7 @@ export type PathType =
   | 'dashboard-connections'
   | 'dashboard-calendar'
   | 'dashboard-drives'
+  | 'dashboard-agents'
   // Direct Messages + Channels routes
   | 'dms'
   | 'dm'
@@ -67,10 +69,10 @@ export interface TabMeta {
 }
 
 // Global dashboard routes (not drive-specific)
-const GLOBAL_DASHBOARD_ROUTES = ['tasks', 'activity', 'storage', 'trash', 'connections', 'calendar', 'dms', 'channels', 'drives'] as const;
+const GLOBAL_DASHBOARD_ROUTES = ['tasks', 'activity', 'storage', 'trash', 'connections', 'calendar', 'dms', 'channels', 'drives', 'agents'] as const;
 
 // Drive-specific special routes
-const DRIVE_SPECIAL_ROUTES = ['tasks', 'activity', 'members', 'settings', 'trash', 'calendar', 'channels', 'files', 'workflows'] as const;
+const DRIVE_SPECIAL_ROUTES = ['tasks', 'activity', 'members', 'settings', 'trash', 'calendar', 'channels', 'files', 'workflows', 'agents'] as const;
 
 /**
  * Whether a parsed route is scoped to ONE drive at the drive level — the bare
@@ -190,6 +192,7 @@ export const parseTabPath = (path: string): ParsedPath => {
       connections: 'dashboard-connections',
       calendar: 'dashboard-calendar',
       drives: 'dashboard-drives',
+      agents: 'dashboard-agents',
     };
     return { type: globalTypeMap[secondSegment] };
   }
@@ -239,6 +242,7 @@ export const parseTabPath = (path: string): ParsedPath => {
       channels: 'drive-channels',
       files: 'drive-files',
       workflows: 'drive-workflows',
+      agents: 'drive-agents',
     };
     return {
       type: typeMap[thirdSegment],
@@ -301,6 +305,9 @@ export const getStaticTabMeta = (parsed: ParsedPath): TabMeta | null => {
     case 'dashboard-drives':
       return { title: 'Drives', iconName: 'Folder' };
 
+    case 'dashboard-agents':
+      return { title: 'Agents', iconName: 'Bot' };
+
     // Drive-specific routes
     case 'drive-tasks':
       return { title: 'Tasks', iconName: 'CheckSquare' };
@@ -335,6 +342,9 @@ export const getStaticTabMeta = (parsed: ParsedPath): TabMeta | null => {
 
     case 'drive-workflows':
       return { title: 'Workflows', iconName: 'Workflow' };
+
+    case 'drive-agents':
+      return { title: 'Agents', iconName: 'Bot' };
 
     // Direct Messages + Channels routes
     case 'dms':

--- a/apps/web/src/stores/__tests__/useTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/useTabsStore.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useTabsStore } from '../useTabsStore';
+import { useTabsStore, migrateTabsStorage } from '../useTabsStore';
 
 // Mock localStorage
 const mockLocalStorage = (() => {
@@ -136,6 +136,62 @@ describe('useTabsStore', () => {
       goForwardInActiveTab();
 
       expect(useTabsStore.getState().tabs[0].path).toBe('/page-2');
+    });
+  });
+
+  describe('setActiveTabHistoryIndex', () => {
+    it('given an index several steps away, should jump directly there without pushing a new entry', () => {
+      const { createTab, navigateInActiveTab, setActiveTabHistoryIndex } = useTabsStore.getState();
+
+      createTab({ path: '/page-1' });
+      navigateInActiveTab('/page-2');
+      navigateInActiveTab('/page-3');
+
+      setActiveTabHistoryIndex(0);
+
+      const tab = useTabsStore.getState().tabs[0];
+      expect(tab.path).toBe('/page-1');
+      expect(tab.historyIndex).toBe(0);
+      expect(tab.history).toEqual(['/page-1', '/page-2', '/page-3']);
+    });
+
+    it('given no active tab, should do nothing', () => {
+      const { setActiveTabHistoryIndex } = useTabsStore.getState();
+
+      setActiveTabHistoryIndex(0);
+
+      expect(useTabsStore.getState().tabs).toHaveLength(0);
+    });
+  });
+
+  describe('migrateTabsStorage (v0 -> v1: backfills Tab.search)', () => {
+    it('given a v0-shaped tab with no search field, should backfill an empty string', () => {
+      const v0State = {
+        activeTabId: 'tab-1',
+        tabs: [
+          { id: 'tab-1', path: '/dashboard/agents', history: ['/dashboard/agents'], historyIndex: 0, isPinned: false },
+        ],
+      };
+
+      const migrated = migrateTabsStorage(v0State, 0);
+
+      expect(migrated.tabs[0].search).toBe('');
+      expect(migrated.activeTabId).toBe('tab-1');
+    });
+
+    it('given an already-v1 state, should pass it through unchanged', () => {
+      const v1State = {
+        activeTabId: 'tab-1',
+        tabs: [
+          { id: 'tab-1', path: '/dashboard/agents', search: 'session=a', history: ['/dashboard/agents?session=a'], historyIndex: 0, isPinned: false },
+        ],
+      };
+
+      expect(migrateTabsStorage(v1State, 1)).toEqual(v1State);
+    });
+
+    it('given no persisted tabs at all, should not throw', () => {
+      expect(migrateTabsStorage({ activeTabId: null }, 0)).toEqual({ activeTabId: null, tabs: [] });
     });
   });
 

--- a/apps/web/src/stores/__tests__/useTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/useTabsStore.test.ts
@@ -193,6 +193,32 @@ describe('useTabsStore', () => {
     it('given no persisted tabs at all, should not throw', () => {
       expect(migrateTabsStorage({ activeTabId: null }, 0)).toEqual({ activeTabId: null, tabs: [] });
     });
+
+    // A hand-edited or partially-written `localStorage` blob is outside this
+    // app's control. A `migrate` that throws leaves zustand's persist
+    // rehydration promise rejected, `state?.setRehydrated()` never runs, and
+    // `rehydrated` stays false forever — freezing the whole tab bar with no
+    // visible error. These prove malformed shapes degrade to an empty tab
+    // list instead.
+    it('given a completely malformed persisted value (null), should fall back to an empty tab list', () => {
+      expect(migrateTabsStorage(null, 0)).toEqual({ activeTabId: null, tabs: [] });
+    });
+
+    it('given a persisted value that is a primitive, not an object, should fall back to an empty tab list', () => {
+      expect(migrateTabsStorage('corrupted', 0)).toEqual({ activeTabId: null, tabs: [] });
+      expect(migrateTabsStorage(42, 1)).toEqual({ activeTabId: null, tabs: [] });
+    });
+
+    it('given tabs present but not an array, should fall back to an empty tab list rather than throw', () => {
+      expect(migrateTabsStorage({ activeTabId: 'tab-1', tabs: 'not-an-array' }, 0)).toEqual({
+        activeTabId: 'tab-1',
+        tabs: [],
+      });
+    });
+
+    it('given a non-string activeTabId, should fall back to null', () => {
+      expect(migrateTabsStorage({ activeTabId: 12345, tabs: [] }, 1)).toEqual({ activeTabId: null, tabs: [] });
+    });
   });
 
   describe('duplicateTab', () => {

--- a/apps/web/src/stores/agents/__tests__/useAgentSurfaceStore.test.ts
+++ b/apps/web/src/stores/agents/__tests__/useAgentSurfaceStore.test.ts
@@ -24,6 +24,7 @@
 import { describe, test, expect, beforeEach, vi, afterEach } from 'vitest';
 import { useAgentSurfaceStore } from '../useAgentSurfaceStore';
 import { useLayoutStore } from '@/stores/useLayoutStore';
+import { useTabsStore } from '@/stores/useTabsStore';
 
 const resetStore = () => {
   useAgentSurfaceStore.setState({
@@ -286,6 +287,44 @@ describe('URL mirroring', () => {
     useAgentSurfaceStore.getState().selectSession('ses-1');
     expect(pushSpy).toHaveBeenCalledTimes(1);
     expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('tab sync', () => {
+  // `commit()` writes the URL with a raw `pushState`, which Next's router (and
+  // therefore `useTabSync`) never sees — so this is the one call site that must
+  // keep the browser-style tab bar's record of this tab's address truthful,
+  // otherwise switching tabs away and back lands on the bare route.
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeTabId: null });
+    useTabsStore.getState().createTab({ path: '/dashboard/agents' });
+  });
+
+  const activeTabSearch = () => {
+    const { tabs, activeTabId } = useTabsStore.getState();
+    return tabs.find((t) => t.id === activeTabId)?.search;
+  };
+
+  test('selecting a session updates the active tab', () => {
+    useAgentSurfaceStore.getState().selectSession('ses-1');
+    expect(activeTabSearch()).toBe('session=ses-1');
+  });
+
+  test('selecting a conversation updates the active tab', () => {
+    useAgentSurfaceStore.getState().selectConversation({
+      sessionId: 'ses-1',
+      conversationId: 'conv-1',
+      agentId: 'agent-1',
+    });
+    expect(activeTabSearch()).toBe('session=ses-1&c=conv-1&agent=agent-1');
+  });
+
+  test('re-selecting the same session (a no-op push) leaves the active tab search untouched', () => {
+    useAgentSurfaceStore.getState().selectSession('ses-1');
+    setLocation('/dashboard/agents?session=ses-1');
+    const tabsBefore = useTabsStore.getState().tabs;
+    useAgentSurfaceStore.getState().selectSession('ses-1');
+    expect(useTabsStore.getState().tabs).toBe(tabsBefore);
   });
 });
 

--- a/apps/web/src/stores/agents/useAgentSurfaceStore.ts
+++ b/apps/web/src/stores/agents/useAgentSurfaceStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import { buildAgentSelectionUrl, parseAgentSelection } from '@/lib/agents/agent-selection';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useTabsStore } from '@/stores/useTabsStore';
+import { fromHref } from '@/lib/tabs/tab-navigation';
 
 /**
  * What is selected on the Agents surface — and nothing else.
@@ -135,7 +136,7 @@ export const useAgentSurfaceStore = create<AgentSurfaceState>()((set, get) => {
     // async (wrapped in a `startTransition`). Set it directly here as well so
     // the tab bar's record of this tab's address is correct the instant this
     // selection commits, not just eventually.
-    useTabsStore.getState().updateActiveTabSearch(url.split('?')[1] ?? '');
+    useTabsStore.getState().updateActiveTabSearch(fromHref(url).search);
   };
 
   return {

--- a/apps/web/src/stores/agents/useAgentSurfaceStore.ts
+++ b/apps/web/src/stores/agents/useAgentSurfaceStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 import { buildAgentSelectionUrl, parseAgentSelection } from '@/lib/agents/agent-selection';
 import { useLayoutStore } from '@/stores/useLayoutStore';
+import { useTabsStore } from '@/stores/useTabsStore';
 
 /**
  * What is selected on the Agents surface — and nothing else.
@@ -127,6 +128,11 @@ export const useAgentSurfaceStore = create<AgentSurfaceState>()((set, get) => {
     });
     if (url === currentUrl()) return;
     window.history.pushState({}, '', url);
+    // `pushState` here bypasses Next's router, so `useTabSync` (which only ever
+    // sees Next-driven navigations) never observes this address change. Tell the
+    // browser-style tab bar directly so switching away and back restores this
+    // selection instead of landing on the bare route.
+    useTabsStore.getState().updateActiveTabSearch(url.split('?')[1] ?? '');
   };
 
   return {

--- a/apps/web/src/stores/agents/useAgentSurfaceStore.ts
+++ b/apps/web/src/stores/agents/useAgentSurfaceStore.ts
@@ -128,10 +128,13 @@ export const useAgentSurfaceStore = create<AgentSurfaceState>()((set, get) => {
     });
     if (url === currentUrl()) return;
     window.history.pushState({}, '', url);
-    // `pushState` here bypasses Next's router, so `useTabSync` (which only ever
-    // sees Next-driven navigations) never observes this address change. Tell the
-    // browser-style tab bar directly so switching away and back restores this
-    // selection instead of landing on the bare route.
+    // Next's own `pushState` patch does eventually fold this into its router
+    // state too (it copies its internal history markers onto any external
+    // push and dispatches a restore, which is what makes `useSearchParams()`
+    // in `AgentsSurface`/`useTabSync` react to this at all) — but that path is
+    // async (wrapped in a `startTransition`). Set it directly here as well so
+    // the tab bar's record of this tab's address is correct the instant this
+    // selection commits, not just eventually.
     useTabsStore.getState().updateActiveTabSearch(url.split('?')[1] ?? '');
   };
 

--- a/apps/web/src/stores/useTabsStore.ts
+++ b/apps/web/src/stores/useTabsStore.ts
@@ -9,6 +9,7 @@ import {
   navigateInTab as navigateInTabFn,
   goBack as goBackFn,
   goForward as goForwardFn,
+  goToHistoryIndex as goToHistoryIndexFn,
   updateTabMeta as updateTabMetaFn,
   canGoBack,
   canGoForward,
@@ -43,6 +44,7 @@ interface TabsState {
   navigateInActiveTab: (path: string, search?: string) => void;
   goBackInActiveTab: () => void;
   goForwardInActiveTab: () => void;
+  setActiveTabHistoryIndex: (index: number) => void;
   duplicateTab: (tabId: string) => void;
   updateActiveTabSearch: (search: string) => void;
   updateTabMeta: (tabId: string, meta: TabMetaUpdate) => void;
@@ -53,6 +55,28 @@ interface TabsState {
   selectCanGoBack: (state: TabsState) => boolean;
   selectCanGoForward: (state: TabsState) => boolean;
 }
+
+/** The shape `partialize` actually persists — not the full store. */
+type PersistedTabsState = { tabs: Tab[]; activeTabId: string | null };
+
+/**
+ * v1 added `Tab.search` (required). A tab persisted under v0 rehydrates
+ * without it (`undefined`, not `''`), which fails `navigateInTab`'s no-op
+ * check (`undefined !== ''`) on the very next same-path sync and pushes a
+ * spurious duplicate history entry — backfill it here instead. A standalone,
+ * exported function (rather than inline in the `persist()` config below) so
+ * it's directly unit-testable without needing to drive an actual rehydration.
+ */
+export const migrateTabsStorage = (persistedState: unknown, version: number): PersistedTabsState => {
+  const state = persistedState as { tabs?: Array<Partial<Tab> & Pick<Tab, 'id' | 'path' | 'history' | 'historyIndex' | 'isPinned'>>; activeTabId?: string | null };
+  if (version < 1) {
+    return {
+      activeTabId: state.activeTabId ?? null,
+      tabs: (state.tabs ?? []).map((tab) => ({ ...tab, search: tab.search ?? '' })),
+    };
+  }
+  return state as PersistedTabsState;
+};
 
 export const useTabsStore = create<TabsState>()(
   persist(
@@ -283,6 +307,19 @@ export const useTabsStore = create<TabsState>()(
         set({ tabs: newTabs });
       },
 
+      setActiveTabHistoryIndex: (index) => {
+        const { tabs, activeTabId } = get();
+        if (!activeTabId) return;
+
+        const tabIndex = tabs.findIndex(t => t.id === activeTabId);
+        if (tabIndex === -1) return;
+
+        const newTabs = [...tabs];
+        newTabs[tabIndex] = goToHistoryIndexFn(newTabs[tabIndex], index);
+
+        set({ tabs: newTabs });
+      },
+
       duplicateTab: (tabId) => {
         const { tabs } = get();
         const tab = tabs.find(t => t.id === tabId);
@@ -360,6 +397,8 @@ export const useTabsStore = create<TabsState>()(
     }),
     {
       name: 'tabs-storage',
+      version: 1,
+      migrate: migrateTabsStorage,
       partialize: (state) => ({
         tabs: state.tabs,
         activeTabId: state.activeTabId,

--- a/apps/web/src/stores/useTabsStore.ts
+++ b/apps/web/src/stores/useTabsStore.ts
@@ -39,11 +39,12 @@ interface TabsState {
   reorderTab: (fromIndex: number, toIndex: number) => void;
   pinTab: (tabId: string) => void;
   unpinTab: (tabId: string) => void;
-  navigateInTab: (tabId: string, path: string) => void;
-  navigateInActiveTab: (path: string) => void;
+  navigateInTab: (tabId: string, path: string, search?: string) => void;
+  navigateInActiveTab: (path: string, search?: string) => void;
   goBackInActiveTab: () => void;
   goForwardInActiveTab: () => void;
   duplicateTab: (tabId: string) => void;
+  updateActiveTabSearch: (search: string) => void;
   updateTabMeta: (tabId: string, meta: TabMetaUpdate) => void;
   updateTabMetaByPageId: (pageId: string, meta: TabMetaUpdate) => void;
 
@@ -239,21 +240,21 @@ export const useTabsStore = create<TabsState>()(
         set({ tabs: newTabs });
       },
 
-      navigateInTab: (tabId, path) => {
+      navigateInTab: (tabId, path, search = '') => {
         const { tabs } = get();
         const tabIndex = tabs.findIndex(t => t.id === tabId);
         if (tabIndex === -1) return;
 
         const newTabs = [...tabs];
-        newTabs[tabIndex] = navigateInTabFn(newTabs[tabIndex], path);
+        newTabs[tabIndex] = navigateInTabFn(newTabs[tabIndex], path, search);
 
         set({ tabs: newTabs });
       },
 
-      navigateInActiveTab: (path) => {
+      navigateInActiveTab: (path, search = '') => {
         const { activeTabId, navigateInTab } = get();
         if (!activeTabId) return;
-        navigateInTab(activeTabId, path);
+        navigateInTab(activeTabId, path, search);
       },
 
       goBackInActiveTab: () => {
@@ -287,7 +288,7 @@ export const useTabsStore = create<TabsState>()(
         const tab = tabs.find(t => t.id === tabId);
         if (!tab) return;
 
-        const newTab = createTabFn({ path: tab.path, title: tab.title, pageType: tab.pageType });
+        const newTab = createTabFn({ path: tab.path, search: tab.search, title: tab.title, pageType: tab.pageType });
         const tabIndex = tabs.findIndex(t => t.id === tabId);
 
         const newTabs = [...tabs];
@@ -297,6 +298,22 @@ export const useTabsStore = create<TabsState>()(
           tabs: newTabs,
           activeTabId: newTab.id,
         });
+      },
+
+      updateActiveTabSearch: (search) => {
+        const { activeTabId, tabs } = get();
+        if (!activeTabId) return;
+
+        const tabIndex = tabs.findIndex(t => t.id === activeTabId);
+        if (tabIndex === -1) return;
+
+        const tab = tabs[tabIndex];
+        if (tab.search === search) return;
+
+        const newTabs = [...tabs];
+        newTabs[tabIndex] = navigateInTabFn(tab, tab.path, search);
+
+        set({ tabs: newTabs });
       },
 
       updateTabMeta: (tabId, meta) => {

--- a/apps/web/src/stores/useTabsStore.ts
+++ b/apps/web/src/stores/useTabsStore.ts
@@ -66,16 +66,33 @@ type PersistedTabsState = { tabs: Tab[]; activeTabId: string | null };
  * spurious duplicate history entry — backfill it here instead. A standalone,
  * exported function (rather than inline in the `persist()` config below) so
  * it's directly unit-testable without needing to drive an actual rehydration.
+ *
+ * Defensive about the WHOLE persisted shape, not just the field being
+ * migrated: `localStorage` is outside this app's control (hand-edited,
+ * partially written, corrupted by an extension), and zustand's `persist`
+ * middleware has no fallback for a `migrate` that throws — the rehydration
+ * promise rejects, `onRehydrateStorage`'s callback below receives `undefined`
+ * instead of the store, `state?.setRehydrated()` silently no-ops via optional
+ * chaining, and `rehydrated` stays `false` forever — freezing the entire tab
+ * bar with no visible error (`useTabSync` no-ops on every render while
+ * `!rehydrated`). Always returning a well-formed `PersistedTabsState`, even
+ * from garbage input, is what prevents that class of failure.
  */
 export const migrateTabsStorage = (persistedState: unknown, version: number): PersistedTabsState => {
-  const state = persistedState as { tabs?: Array<Partial<Tab> & Pick<Tab, 'id' | 'path' | 'history' | 'historyIndex' | 'isPinned'>>; activeTabId?: string | null };
+  const state = (persistedState && typeof persistedState === 'object' ? persistedState : {}) as {
+    tabs?: unknown;
+    activeTabId?: unknown;
+  };
+  const rawTabs = Array.isArray(state.tabs) ? state.tabs : [];
+  const activeTabId = typeof state.activeTabId === 'string' ? state.activeTabId : null;
+
   if (version < 1) {
     return {
-      activeTabId: state.activeTabId ?? null,
-      tabs: (state.tabs ?? []).map((tab) => ({ ...tab, search: tab.search ?? '' })),
+      activeTabId,
+      tabs: rawTabs.map((tab) => ({ ...tab, search: tab?.search ?? '' })),
     };
   }
-  return state as PersistedTabsState;
+  return { activeTabId, tabs: rawTabs as Tab[] };
 };
 
 export const useTabsStore = create<TabsState>()(


### PR DESCRIPTION
## Summary
- The Agents console keeps its selection (session/conversation/agent — which panes are open) in the URL query string, written via a raw `history.pushState` so switching sessions/conversations never remounts or kills a live PTY/streaming chat. The generic browser-style tab bar never carried that query string along, so:
  - the Agents route had no entry in the tab-title registry, so its tab showed "Drive"/"Untitled" instead of "Agents"
  - switching away from the Agents tab and back always dropped `?session=&c=&agent=`, resetting the selection even though the pane grid layout was still safely persisted server-side/locally
- Registered `dashboard-agents`/`drive-agents` route types with a `Bot` icon so the tab is recognized correctly.
- Gave `Tab` a `search` field (history entries are now full hrefs via new `toHref`/`fromHref` helpers), threaded it through `useTabsStore`, `useTabSync` (now tracks `useSearchParams()` too), and `TabBar` (pushes the full href on tab (re)activation).
- Wired `useAgentSurfaceStore`'s raw `pushState` commit to also update the active tab's stored search, since that's the address change Next's router doesn't apply synchronously (see below).

### Round 2 — follow-up fixes from review (chatgpt-codex-connector, both P2)
- **Same-route tab reactivation didn't rehydrate the selection.** Two tabs pointing at the same Agents pathname with different selections: reactivating one only changes the query string via `router.push`, which `AgentsSurface` previously only re-read on mount or `popstate` — neither fires here. Fixed by having `AgentsSurface` track `useSearchParams()` reactively as a third hydration trigger.
- **Back appended a duplicate history entry instead of moving the index back.** First fix used adjacency in the tab's own history; superseded in round 3 below.
- Merged master (PR #2293, the past-conversations list) into this branch; resolved the one real conflict (an import list) and re-ran the full combined suite.

### Round 3 — independent adversarial self-review (before any human/bot re-reviewed round 2)
The adjacency-only Back/Forward fix had two real gaps, plus a separate persistence gap:
- **Multi-step jumps** landed on a non-adjacent entry and fell through to a fresh push, truncating real forward history.
- **False positives**: string-adjacency couldn't tell an actual Back apart from an ordinary navigation that happened to match the adjacent entry.
- Replaced with a real `popstate` listener as the disambiguating signal; only when it fires does `useTabSync` search the tab's FULL history for the destination and relocate the index directly there (new `goToHistoryIndex`/`setActiveTabHistoryIndex`).
- **Missing persist migration**: `Tab.search` is a new required field; a tab already in `localStorage` would rehydrate with `search: undefined` and push one spurious duplicate entry. Added a versioned migration (matching the existing `useMCPStore.ts` pattern).

### Round 4 — second independent adversarial review (targeting round 3's own new code)
- **(Real, fixed)** `migrateTabsStorage` threw on malformed persisted shapes (non-array `tabs`, `null`/primitive `persistedState`). zustand's `persist` has no fallback for a throwing `migrate` — the rehydration promise rejects, `state?.setRehydrated()` silently no-ops, and `rehydrated` stays `false` forever, freezing the whole tab bar with no visible error. Rewrote it to validate the whole shape and degrade to an empty tab list instead of throwing.
- **(Investigated, not accepted at face value)** A claim that the `popstate` flag could go stale because raw `pushState` "bypasses" Next's router. Traced this directly against the installed `next@15.5.18` source: Next patches `pushState`/`replaceState` globally and copies its internal history markers onto ANY external call, so `usePathname`/`useSearchParams` DO react to these entries and `onPopState` does not hard-reload for them. The scenario the review described requires two adjacent identical history entries, which existing no-op guards already prevent from being created — not reachable here. Did not add a timer-based flag expiry (it would race against React's `startTransition`-wrapped router update). Corrected three comments that had inaccurately described raw `pushState` as bypassing Next's router entirely.
- **(Nit, applied)** `goBack`/`goForward` now delegate to `goToHistoryIndex` instead of duplicating it.

## Test plan
- [x] `bun run typecheck --filter=web`
- [x] `eslint` on all changed files
- [x] Full relevant suite: 1704 tests passing across `src/components/agents`, `src/lib/agent-sessions`, `src/lib/tabs`, `src/stores`, `src/components/layout`
- [ ] Manual browser check: open Agents, select a session/conversation, switch to another tab and back, confirm the same panes are still showing and the tab is titled "Agents"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTEeQySqUKjEt2qpn3M2U