### PR TITLE
feat(agents): any page type as a pane in agent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ in favor of `pagespace mcp`, part of `@pagespace/cli`; see the
 ## Core Features
 
 ### AI Agent Infrastructure
-- **76 workspace tools** for AI to manipulate content directly. The same operation registry
+- **77 workspace tools** for AI to manipulate content directly. The same operation registry
   generates every `pagespace` CLI verb, SDK method, and MCP tool, so none of the three can drift
 - **Tool permissions**: Control what each AI can do in your workspace
 - **MCP protocol support**: Connect external AI tools like Claude Desktop, Cursor, and Claude Code

--- a/apps/marketing/src/app/docs/getting-started/page.tsx
+++ b/apps/marketing/src/app/docs/getting-started/page.tsx
@@ -79,7 +79,7 @@ AI Chat pages are specialized AI conversations with custom configuration:
 1. Right-click in the file tree and select **New AI Chat**
 2. Open the agent's settings to configure:
    - **System prompt**: custom instructions for the agent's behavior
-   - **Enabled tools**: which of the 76 workspace tools the agent can call
+   - **Enabled tools**: which of the 77 workspace tools the agent can call
    - **Read-only toggle**: when on, the agent can only read and search — no writes, no trash, no task updates
    - **Web search toggle**: enables the \`web_search\` tool
    - **Provider / Model**: which AI model powers this agent

--- a/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
@@ -70,6 +70,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { db } from '@pagespace/db/db';
 import * as dbOperators from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
 
 // ============================================================================
 // Test Fixtures
@@ -386,84 +387,70 @@ describe('GET /api/mentions/search', () => {
   // ==========================================================================
   // excludePageTypes — the inverse of pageType, for callers whose picker can't
   // render several types at all (the agent-pane "Pages" search, which excludes
-  // FOLDER/AI_CHAT). Applied per-row BEFORE the final slice(0, 10), so an
-  // excluded type occupying a top-10 slot doesn't shrink the visible list.
+  // FOLDER/AI_CHAT). Enforced in the SQL WHERE clause (`notInArray`), not an
+  // after-the-fetch in-memory filter — see the route's own comment on why:
+  // excluded types must never occupy a row of the DB's own
+  // `.limit(50)`/`.limit(20)` window in the first place, or the response could
+  // still shrink even with every returned row correctly filtered.
+  //
+  // The mocked `db.select` chain can't observe filtering (its `.where()` is a
+  // no-op passthrough, same limitation every other filter test in this file
+  // has), so these tests verify the WHERE-clause condition was actually built
+  // by spying on the real (unmocked) `notInArray` from `@pagespace/db/operators`
+  // — the same module the route imports it from — rather than asserting on a
+  // response shape the mock can't meaningfully vary.
   // ==========================================================================
   describe('excludePageTypes filter', () => {
     beforeEach(() => {
       vi.mocked(getUserDriveAccess).mockResolvedValue(true);
       vi.mocked(getUserAccessLevel).mockResolvedValue('VIEW' as never);
       vi.mocked(getDriveRecipientUserIds).mockResolvedValue([mockUserId]);
-    });
 
-    it('drops excluded types even when they occupy the top of the DB result window', async () => {
-      // Simulates the exact bug: the most-recently-updated rows are folders,
-      // which would otherwise starve a client-side-only filter down to zero
-      // even though a real, paneable page exists right behind them.
       const selectChain = {
         from: vi.fn().mockReturnThis(),
         where: vi.fn().mockReturnThis(),
-        // No `q=` in this request, so the route takes the "recent pages"
+        // No `q=` in these requests, so the route takes the "recent pages"
         // branch (`.orderBy(...).limit(20)`), not `.limit(50)` directly.
         orderBy: vi.fn().mockReturnThis(),
         limit: vi.fn().mockResolvedValue([
-          { id: 'folder-1', title: 'Projects', type: 'FOLDER', driveId: mockDriveId, mimeType: null },
-          { id: 'chat-1', title: 'Assistant', type: 'AI_CHAT', driveId: mockDriveId, mimeType: null },
           { id: 'doc-1', title: 'Roadmap', type: 'DOCUMENT', driveId: mockDriveId, mimeType: null },
         ]),
       };
       vi.mocked(db.select).mockReturnValue(selectChain as unknown as ReturnType<typeof db.select>);
+    });
+
+    it('pushes recognized types into notInArray against pages.type', async () => {
+      const notInArraySpy = vi.spyOn(dbOperators, 'notInArray');
 
       const request = new Request(
         `https://example.com/api/mentions/search?driveId=${mockDriveId}&types=page&excludePageTypes=FOLDER,AI_CHAT`
       );
       const response = await GET(request);
-      const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toHaveLength(1);
-      expect(body[0]).toMatchObject({ id: 'doc-1', data: { pageType: 'DOCUMENT' } });
+      expect(notInArraySpy).toHaveBeenCalledWith(pages.type, expect.arrayContaining(['FOLDER', 'AI_CHAT']));
     });
 
-    it('behaves like an unfiltered search when excludePageTypes is omitted', async () => {
-      const selectChain = {
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        orderBy: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockResolvedValue([
-          { id: 'folder-1', title: 'Projects', type: 'FOLDER', driveId: mockDriveId, mimeType: null },
-        ]),
-      };
-      vi.mocked(db.select).mockReturnValue(selectChain as unknown as ReturnType<typeof db.select>);
+    it('does not call notInArray when excludePageTypes is omitted (unfiltered, as before)', async () => {
+      const notInArraySpy = vi.spyOn(dbOperators, 'notInArray');
 
       const request = new Request(`https://example.com/api/mentions/search?driveId=${mockDriveId}&types=page`);
       const response = await GET(request);
-      const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toHaveLength(1);
-      expect(body[0]).toMatchObject({ id: 'folder-1' });
+      expect(notInArraySpy).not.toHaveBeenCalled();
     });
 
-    it('ignores unrecognized values rather than erroring', async () => {
-      const selectChain = {
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        orderBy: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockResolvedValue([
-          { id: 'doc-1', title: 'Roadmap', type: 'DOCUMENT', driveId: mockDriveId, mimeType: null },
-        ]),
-      };
-      vi.mocked(db.select).mockReturnValue(selectChain as unknown as ReturnType<typeof db.select>);
+    it('ignores unrecognized values rather than erroring, and never calls notInArray for them', async () => {
+      const notInArraySpy = vi.spyOn(dbOperators, 'notInArray');
 
       const request = new Request(
         `https://example.com/api/mentions/search?driveId=${mockDriveId}&types=page&excludePageTypes=NOT_A_REAL_TYPE`
       );
       const response = await GET(request);
-      const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toHaveLength(1);
+      expect(notInArraySpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
@@ -383,6 +383,90 @@ describe('GET /api/mentions/search', () => {
     });
   });
 
+  // ==========================================================================
+  // excludePageTypes — the inverse of pageType, for callers whose picker can't
+  // render several types at all (the agent-pane "Pages" search, which excludes
+  // FOLDER/AI_CHAT). Applied per-row BEFORE the final slice(0, 10), so an
+  // excluded type occupying a top-10 slot doesn't shrink the visible list.
+  // ==========================================================================
+  describe('excludePageTypes filter', () => {
+    beforeEach(() => {
+      vi.mocked(getUserDriveAccess).mockResolvedValue(true);
+      vi.mocked(getUserAccessLevel).mockResolvedValue('VIEW' as never);
+      vi.mocked(getDriveRecipientUserIds).mockResolvedValue([mockUserId]);
+    });
+
+    it('drops excluded types even when they occupy the top of the DB result window', async () => {
+      // Simulates the exact bug: the most-recently-updated rows are folders,
+      // which would otherwise starve a client-side-only filter down to zero
+      // even though a real, paneable page exists right behind them.
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        // No `q=` in this request, so the route takes the "recent pages"
+        // branch (`.orderBy(...).limit(20)`), not `.limit(50)` directly.
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([
+          { id: 'folder-1', title: 'Projects', type: 'FOLDER', driveId: mockDriveId, mimeType: null },
+          { id: 'chat-1', title: 'Assistant', type: 'AI_CHAT', driveId: mockDriveId, mimeType: null },
+          { id: 'doc-1', title: 'Roadmap', type: 'DOCUMENT', driveId: mockDriveId, mimeType: null },
+        ]),
+      };
+      vi.mocked(db.select).mockReturnValue(selectChain as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request(
+        `https://example.com/api/mentions/search?driveId=${mockDriveId}&types=page&excludePageTypes=FOLDER,AI_CHAT`
+      );
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({ id: 'doc-1', data: { pageType: 'DOCUMENT' } });
+    });
+
+    it('behaves like an unfiltered search when excludePageTypes is omitted', async () => {
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([
+          { id: 'folder-1', title: 'Projects', type: 'FOLDER', driveId: mockDriveId, mimeType: null },
+        ]),
+      };
+      vi.mocked(db.select).mockReturnValue(selectChain as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request(`https://example.com/api/mentions/search?driveId=${mockDriveId}&types=page`);
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({ id: 'folder-1' });
+    });
+
+    it('ignores unrecognized values rather than erroring', async () => {
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([
+          { id: 'doc-1', title: 'Roadmap', type: 'DOCUMENT', driveId: mockDriveId, mimeType: null },
+        ]),
+      };
+      vi.mocked(db.select).mockReturnValue(selectChain as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request(
+        `https://example.com/api/mentions/search?driveId=${mockDriveId}&types=page&excludePageTypes=NOT_A_REAL_TYPE`
+      );
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toHaveLength(1);
+    });
+  });
+
   describe('search term escaping', () => {
     it('escapes LIKE metacharacters in the search term before building the ilike condition (regression: over-matching fix)', async () => {
       vi.mocked(getUserDriveAccess).mockResolvedValue(true);

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -143,8 +143,30 @@ export async function GET(request: Request) {
   // Further restrict FILE results to image mime types — for image pickers
   // (OG image, favicon) that only want to offer uploaded pictures.
   const imageOnly = searchParams.get('imageOnly') === 'true';
+  // The inverse of pageType: drop specific types rather than narrow to one —
+  // for callers whose picker can't render several types at all (e.g. the
+  // agent-pane "Pages" search, which excludes FOLDER/AI_CHAT). Applied to
+  // EACH ROW before `suggestions` is built, i.e. before the final
+  // `.slice(0, 10)` below — excluding after that slice would silently shrink
+  // the visible list any time the top 10 by relevance/recency happened to
+  // include excluded types, even when plenty of eligible pages exist further
+  // down the ranking.
+  const rawExcludePageTypes = searchParams.get('excludePageTypes');
+  const excludePageTypesParam: Set<PageTypeEnum> = new Set(
+    (rawExcludePageTypes?.split(',') ?? []).filter((t): t is PageTypeEnum =>
+      (pageType.enumValues as readonly string[]).includes(t)
+    )
+  );
 
-  loggers.api.debug('[API] Search params', { query, driveId, crossDrive, types: typesParam, pageType: pageTypeParam, imageOnly });
+  loggers.api.debug('[API] Search params', {
+    query,
+    driveId,
+    crossDrive,
+    types: typesParam,
+    pageType: pageTypeParam,
+    imageOnly,
+    excludePageTypes: [...excludePageTypesParam],
+  });
   
   // For within-drive searches, driveId is required
   // For cross-drive searches, driveId is optional (searches all accessible drives)
@@ -332,6 +354,7 @@ export async function GET(request: Request) {
         // checker rather than widening that type to admit a value nothing
         // can produce.
         if (page.type === 'MACHINE') continue;
+        if (excludePageTypesParam.has(page.type)) continue;
 
         const accessLevel = await getUserAccessLevel(userId, page.id);
         if (!accessLevel) continue;

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -7,7 +7,7 @@ import { buildSearchAuditDetails } from '@pagespace/lib/audit/search-audit-detai
 import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { and, eq, ilike, inArray, desc, SQL } from '@pagespace/db/operators'
+import { and, eq, ilike, inArray, notInArray, desc, SQL } from '@pagespace/db/operators'
 import { decryptUserRows } from '@pagespace/lib/auth/user-repository'
 import { users } from '@pagespace/db/schema/auth'
 import { pages, drives, pageType, type PageTypeEnum } from '@pagespace/db/schema/core';
@@ -145,12 +145,13 @@ export async function GET(request: Request) {
   const imageOnly = searchParams.get('imageOnly') === 'true';
   // The inverse of pageType: drop specific types rather than narrow to one —
   // for callers whose picker can't render several types at all (e.g. the
-  // agent-pane "Pages" search, which excludes FOLDER/AI_CHAT). Applied to
-  // EACH ROW before `suggestions` is built, i.e. before the final
-  // `.slice(0, 10)` below — excluding after that slice would silently shrink
-  // the visible list any time the top 10 by relevance/recency happened to
-  // include excluded types, even when plenty of eligible pages exist further
-  // down the ranking.
+  // agent-pane "Pages" search, which excludes FOLDER/AI_CHAT). Enforced in
+  // the SQL WHERE clause below (`notInArray`), NOT as an after-the-fetch
+  // in-memory skip — excluded types must never occupy a row of the DB's own
+  // `.limit(50)`/`.limit(20)` window in the first place, or the final
+  // `.slice(0, 10)` (and that window itself) could still silently shrink the
+  // visible list any time excluded types dominated the ranking, even when
+  // plenty of eligible pages exist further down it.
   const rawExcludePageTypes = searchParams.get('excludePageTypes');
   const excludePageTypesParam: Set<PageTypeEnum> = new Set(
     (rawExcludePageTypes?.split(',') ?? []).filter((t): t is PageTypeEnum =>
@@ -335,6 +336,7 @@ export async function GET(request: Request) {
           searchCondition, // undefined when empty query = no filter = all pages
           eq(pages.isTrashed, false),
           pageTypeParam ? eq(pages.type, pageTypeParam) : undefined,
+          excludePageTypesParam.size > 0 ? notInArray(pages.type, [...excludePageTypesParam]) : undefined,
           imageOnly ? ilike(pages.mimeType, 'image/%') : undefined
         )
       );
@@ -354,7 +356,11 @@ export async function GET(request: Request) {
         // checker rather than widening that type to admit a value nothing
         // can produce.
         if (page.type === 'MACHINE') continue;
-        if (excludePageTypesParam.has(page.type)) continue;
+        // excludePageTypesParam is enforced in the WHERE clause above (SQL,
+        // not here) — excluded types never occupy a row in `pageResults` at
+        // all, so the DB's own `.limit(50)`/`.limit(20)` window is composed
+        // entirely of eligible candidates, not just whatever's left of it
+        // after an after-the-fact skip.
 
         const accessLevel = await getUserAccessLevel(userId, page.id);
         if (!accessLevel) continue;

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -552,6 +552,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
             </div>
           ) : (
             <SessionChat
+              sessionId={null}
               agent={agent}
               conversationId={current.conversationId}
               context="page"

--- a/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
+++ b/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
@@ -37,6 +37,7 @@ export default function AssistantSessionChat({
   return (
     <SessionChatView
       sessionId={sessionId}
+      conversationId={conversationId}
       chat={chat}
       name="Global Assistant"
       visionModel={currentModel || ''}

--- a/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
+++ b/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
@@ -17,11 +17,14 @@ import { SessionChatView } from './SessionChat';
 import { useAssistantSessionChat } from './useAssistantSessionChat';
 
 export default function AssistantSessionChat({
+  sessionId,
   conversationId,
   driveId,
   context,
   isReadOnly = false,
 }: {
+  /** This conversation's pane-hosting session — see `SessionChatViewProps.sessionId`. */
+  sessionId: string | null;
   conversationId: string;
   /** The session's own drive, when it has one — see `useAssistantSessionChat`'s doc. */
   driveId: string | null;
@@ -33,6 +36,7 @@ export default function AssistantSessionChat({
 
   return (
     <SessionChatView
+      sessionId={sessionId}
       chat={chat}
       name="Global Assistant"
       visionModel={currentModel || ''}

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -29,10 +29,13 @@ import { ChatMessagesArea } from '@/components/ai/shared/chat/ChatMessagesArea';
 import { Conversation, ConversationScrollButton } from '@/components/ai/ui/conversation';
 import { SidebarMessagesContent } from '@/components/layout/right-sidebar/ai-assistant/SidebarChatTab';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { useOpenPagePane } from '@/lib/ai/shared/hooks/useOpenPagePane';
 import type { AgentInfo } from '@/types/agent';
 import { useAgentSessionChat, type UseAgentSessionChatReturn } from './useAgentSessionChat';
 
 export interface SessionChatProps {
+  /** This conversation's pane-hosting session — null (the default) for a plain, session-less conversation. See `SessionChatViewProps.sessionId`. */
+  sessionId?: string | null;
   /** The fixed agent this conversation belongs to. */
   agent: AgentInfo;
   /** The thread — its session (and sandbox) resolves server-side from the row's binding. */
@@ -44,6 +47,7 @@ export interface SessionChatProps {
 }
 
 export default function SessionChat({
+  sessionId = null,
   agent,
   conversationId,
   context,
@@ -52,6 +56,7 @@ export default function SessionChat({
   const chat = useAgentSessionChat({ agent, conversationId });
   return (
     <SessionChatView
+      sessionId={sessionId}
       chat={chat}
       name={agent.title}
       visionModel={agent.aiModel || ''}
@@ -62,6 +67,14 @@ export default function SessionChat({
 }
 
 export interface SessionChatViewProps {
+  /**
+   * This conversation's pane-hosting session, or null for a plain
+   * session-less conversation — used only to react to `open_page_pane` tool
+   * calls by opening a pane in THIS session's grid (`useOpenPagePane`, itself
+   * a no-op when null). Not part of `chat`'s own state since it's a fact
+   * about where this surface is mounted, not about the conversation itself.
+   */
+  sessionId: string | null;
   /** The chat's whole state — from either pipeline's hook. */
   chat: UseAgentSessionChatReturn;
   /** The counterpart's display name (composer placeholder, compact-renderer label). */
@@ -73,6 +86,7 @@ export interface SessionChatViewProps {
 }
 
 export function SessionChatView({
+  sessionId,
   chat,
   name,
   visionModel,
@@ -82,6 +96,8 @@ export function SessionChatView({
   const [input, setInput] = useState('');
   const [showError, setShowError] = useState(true);
   const [undoMessageId, setUndoMessageId] = useState<string | null>(null);
+
+  useOpenPagePane({ sessionId, messages: chat.messages });
 
   const handleSendClick = useCallback(async () => {
     const text = input;

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -57,6 +57,7 @@ export default function SessionChat({
   return (
     <SessionChatView
       sessionId={sessionId}
+      conversationId={conversationId}
       chat={chat}
       name={agent.title}
       visionModel={agent.aiModel || ''}
@@ -75,6 +76,8 @@ export interface SessionChatViewProps {
    * about where this surface is mounted, not about the conversation itself.
    */
   sessionId: string | null;
+  /** This conversation's own id — see `useOpenPagePane`'s `excludeTargetId` doc. */
+  conversationId: string;
   /** The chat's whole state — from either pipeline's hook. */
   chat: UseAgentSessionChatReturn;
   /** The counterpart's display name (composer placeholder, compact-renderer label). */
@@ -87,6 +90,7 @@ export interface SessionChatViewProps {
 
 export function SessionChatView({
   sessionId,
+  conversationId,
   chat,
   name,
   visionModel,
@@ -97,7 +101,7 @@ export function SessionChatView({
   const [showError, setShowError] = useState(true);
   const [undoMessageId, setUndoMessageId] = useState<string | null>(null);
 
-  useOpenPagePane({ sessionId, messages: chat.messages });
+  useOpenPagePane({ sessionId, conversationId, messages: chat.messages });
 
   const handleSendClick = useCallback(async () => {
     const text = input;

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -787,7 +787,7 @@ export default function AgentPanes({
               isReadOnly={isReadOnly}
             />
           ) : surface.surface === 'page' ? (
-            <PagePaneView pageId={surface.pageId} driveId={driveId} />
+            <PagePaneView pageId={surface.pageId} />
           ) : (
             <Shell shellId={surface.shellId} name={pane.scope?.name} />
           )}

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -9,10 +9,13 @@
  * ```
  * SessionPanes (layout only, surfaces injected)
  *  └─ pane: PaneBar (identity + split/close) over
- *      picker   → PanePicker      (unbound — choose an agent, a shell, or
- *                                  reattach one already running)
+ *      picker   → PanePicker      (unbound — choose an agent, a shell, a
+ *                                  page, or reattach a shell already running)
  *      chat     → PaneChat        (a conversation IN this session)
  *      terminal → Shell           (a PTY on this session's sandbox)
+ *      page     → PagePaneView    (a PageSpace page — document, task list,
+ *                                  sheet, canvas, code, ... — rendered with
+ *                                  the same view the main content area uses)
  *      loading  → spinner         (bound, row not minted yet — never a
  *                                  speculative terminal)
  * ```
@@ -65,6 +68,7 @@ import {
   type SessionListEntry,
 } from './session-conversations';
 import PaneChat from './PaneChat';
+import PagePaneView from './PagePaneView';
 import Shell from '../shell/Shell';
 
 export interface AgentPanesProps {
@@ -684,6 +688,16 @@ export default function AgentPanes({
     [assignPane, sessionId],
   );
 
+  // A page binding addresses an existing page directly — unlike a
+  // conversation or a shell, there is nothing to mint server-side, so this is
+  // a single synchronous assignment (no loading state, no rollback path).
+  const handlePickPage = useCallback(
+    (paneId: string, pageId: string, title: string) => {
+      assignPane(sessionId, paneId, { kind: 'page', name: title, targetId: pageId, agentPageId: null });
+    },
+    [assignPane, sessionId],
+  );
+
   if (!workspace) {
     // The openConversation effect seeds the grid on the next tick.
     return (
@@ -743,6 +757,7 @@ export default function AgentPanes({
           {showPicker ? (
             <PanePicker
               agents={pickableAgents}
+              driveId={driveId}
               isLoading={agentsLoading}
               existingShells={reattachableShells}
               // The assistant identity path is live (AssistantSessionChat), so
@@ -756,6 +771,7 @@ export default function AgentPanes({
               onPickAgent={(agentPageId) => void handlePickAgent(pane.id, agentPageId)}
               onPickShell={() => void handlePickShell(pane.id)}
               onReattachShell={(shellId, name) => handleReattachShell(pane.id, shellId, name)}
+              onPickPage={(pageId, title) => handlePickPage(pane.id, pageId, title)}
             />
           ) : surface.surface === 'loading' ? (
             <div className="flex h-full items-center justify-center">
@@ -763,12 +779,15 @@ export default function AgentPanes({
             </div>
           ) : surface.surface === 'chat' ? (
             <PaneChat
+              sessionId={sessionId}
               conversationId={surface.conversationId}
               agentPageId={surface.agentPageId}
               driveId={driveId}
               context={chatContext}
               isReadOnly={isReadOnly}
             />
+          ) : surface.surface === 'page' ? (
+            <PagePaneView pageId={surface.pageId} driveId={driveId} />
           ) : (
             <Shell shellId={surface.shellId} name={pane.scope?.name} />
           )}

--- a/apps/web/src/components/agents/panes/PagePaneView.tsx
+++ b/apps/web/src/components/agents/panes/PagePaneView.tsx
@@ -58,7 +58,12 @@ async function fetcher(url: string): Promise<TreePage> {
 }
 
 export default function PagePaneView({ pageId }: PagePaneViewProps) {
-  const { data: page, error, isLoading } = useSWR<TreePage>(`/api/pages/${pageId}`, fetcher);
+  // Encoded — unlike every other `/api/pages/${pageId}` call site in the app
+  // (all sourced from the loaded tree or a URL param), this one can carry a
+  // pageId straight from an agent's `open_page_pane` tool call: a free-text
+  // string, not a validated id. A `/`, `?`, or `#` in it must not reroute or
+  // reshape this request; it should just 404 into the error state below.
+  const { data: page, error, isLoading } = useSWR<TreePage>(`/api/pages/${encodeURIComponent(pageId)}`, fetcher);
 
   if (isLoading) {
     return <Skeleton className="h-full w-full" />;

--- a/apps/web/src/components/agents/panes/PagePaneView.tsx
+++ b/apps/web/src/components/agents/panes/PagePaneView.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * A `'page'` pane's content: any non-container, non-chat page type rendered
+ * with the SAME view component the main content area uses
+ * (`CenterPanel.tsx`'s `PageContent`), so a document/task-list/sheet/etc. is
+ * exactly as editable in a pane as it is in the center panel.
+ *
+ * Deliberately NOT built on `usePageTree` — a pane has no reason to load the
+ * whole drive's tree just to look up one page. It fetches the page directly
+ * (`/api/pages/{pageId}`), the same fallback fetch `CenterPanel` already uses
+ * when a page isn't in the loaded tree. Access control is enforced entirely
+ * by that fetch and by each view's own data hooks — this component adds no
+ * permission check of its own, so an inaccessible pageId (including one an
+ * agent supplied via `open_page_pane`) just renders the permission-denied
+ * message below rather than leaking anything.
+ */
+
+import { AlertCircle } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import useSWR from 'swr';
+import { getPageTypeComponent, isPaneablePageType } from '@pagespace/lib/content/page-types.config';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { TreePage } from '@/hooks/usePageTree';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export interface PagePaneViewProps {
+  pageId: string;
+  /** The session's drive, for DocumentView's cross-drive socket scoping. Null for a global-assistant session. */
+  driveId: string | null;
+}
+
+// Lazily loaded, same as DocumentView's own MonacoEditor/RichEditor split —
+// a pane is a secondary surface, and FileViewer alone pulls in pdfjs-dist
+// (heavy, browser-only). Pane-safe views only: no FolderView (a tree browser,
+// not content) and no AgentPageView (would nest a chat conversation inside a
+// chat pane). `isPaneablePageType` is the same exclusion the picker's search
+// applies.
+const componentMap = {
+  DocumentView: dynamic(() => import('@/components/layout/middle-content/page-views/document/DocumentView'), { ssr: false }),
+  CodePageView: dynamic(() => import('@/components/layout/middle-content/page-views/code/CodePageView'), { ssr: false }),
+  CanvasPageView: dynamic(() => import('@/components/layout/middle-content/page-views/canvas/CanvasPageView'), { ssr: false }),
+  ChannelView: dynamic(() => import('@/components/layout/middle-content/page-views/channel/ChannelView'), { ssr: false }),
+  FileViewer: dynamic(() => import('@/components/layout/middle-content/page-views/file/FileViewer'), { ssr: false }),
+  SheetView: dynamic(() => import('@/components/layout/middle-content/page-views/sheet/SheetView'), { ssr: false }),
+  TaskListView: dynamic(() => import('@/components/layout/middle-content/page-views/task-list/TaskListView'), { ssr: false }),
+};
+
+async function fetcher(url: string): Promise<TreePage> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error ?? `Failed to load this page (${response.status})`);
+  }
+  const page = await response.json();
+  // The single-page fetch omits `aiChat` (only the tree endpoint's shape
+  // carries it) — patched the same way CenterPanel's own fallback fetch does.
+  return { ...page, aiChat: null };
+}
+
+export default function PagePaneView({ pageId, driveId }: PagePaneViewProps) {
+  const { data: page, error, isLoading } = useSWR<TreePage>(`/api/pages/${pageId}`, fetcher);
+
+  if (isLoading) {
+    return <Skeleton className="h-full w-full" />;
+  }
+
+  if (error || !page) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center text-muted-foreground">
+        <AlertCircle className="h-8 w-8" />
+        <p className="text-sm">{error instanceof Error ? error.message : 'This page could not be loaded.'}</p>
+      </div>
+    );
+  }
+
+  if (!isPaneablePageType(page.type)) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-sm text-muted-foreground">
+        This page type can&apos;t be opened in a pane.
+      </div>
+    );
+  }
+
+  const componentName = getPageTypeComponent(page.type);
+  const ViewComponent = componentMap[componentName as keyof typeof componentMap];
+
+  if (!ViewComponent) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-sm text-muted-foreground">
+        This page type isn&apos;t supported in a pane.
+      </div>
+    );
+  }
+
+  // Same calling-convention split as CenterPanel.tsx's PageContent: the
+  // pageId-only views fetch their own data; everything else still takes the
+  // full page object.
+  let pageComponent: React.ReactNode;
+  if (componentName === 'DocumentView') {
+    const DocumentView = componentMap.DocumentView;
+    pageComponent = <DocumentView key={`document-${page.id}`} pageId={page.id} driveId={driveId ?? undefined} />;
+  } else if (componentName === 'CodePageView') {
+    const CodePageView = componentMap.CodePageView;
+    pageComponent = <CodePageView key={`code-${page.id}`} pageId={page.id} />;
+  } else if (componentName === 'CanvasPageView') {
+    const CanvasPageView = componentMap.CanvasPageView;
+    pageComponent = <CanvasPageView key={`canvas-${page.id}`} pageId={page.id} />;
+  } else {
+    const Component = ViewComponent as React.ComponentType<{ page: TreePage }>;
+    pageComponent = <Component key={`${componentName}-${page.id}`} page={page} />;
+  }
+
+  return <div className="h-full">{pageComponent}</div>;
+}

--- a/apps/web/src/components/agents/panes/PagePaneView.tsx
+++ b/apps/web/src/components/agents/panes/PagePaneView.tsx
@@ -19,6 +19,7 @@
 import { AlertCircle } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import useSWR from 'swr';
+import type { ComponentType, ReactNode } from 'react';
 import { getPageTypeComponent, isPaneablePageType } from '@pagespace/lib/content/page-types.config';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import type { TreePage } from '@/hooks/usePageTree';
@@ -26,8 +27,6 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export interface PagePaneViewProps {
   pageId: string;
-  /** The session's drive, for DocumentView's cross-drive socket scoping. Null for a global-assistant session. */
-  driveId: string | null;
 }
 
 // Lazily loaded, same as DocumentView's own MonacoEditor/RichEditor split —
@@ -58,7 +57,7 @@ async function fetcher(url: string): Promise<TreePage> {
   return { ...page, aiChat: null };
 }
 
-export default function PagePaneView({ pageId, driveId }: PagePaneViewProps) {
+export default function PagePaneView({ pageId }: PagePaneViewProps) {
   const { data: page, error, isLoading } = useSWR<TreePage>(`/api/pages/${pageId}`, fetcher);
 
   if (isLoading) {
@@ -95,11 +94,15 @@ export default function PagePaneView({ pageId, driveId }: PagePaneViewProps) {
 
   // Same calling-convention split as CenterPanel.tsx's PageContent: the
   // pageId-only views fetch their own data; everything else still takes the
-  // full page object.
-  let pageComponent: React.ReactNode;
+  // full page object. DocumentView's driveId is the PAGE's own drive
+  // (`page.driveId`) — never the session's, which is null for a
+  // global-assistant session and would otherwise disable (or misroute)
+  // `usePageContentSocket`'s realtime updates for a page that always
+  // belongs to a real drive regardless of which kind of session opened it.
+  let pageComponent: ReactNode;
   if (componentName === 'DocumentView') {
     const DocumentView = componentMap.DocumentView;
-    pageComponent = <DocumentView key={`document-${page.id}`} pageId={page.id} driveId={driveId ?? undefined} />;
+    pageComponent = <DocumentView key={`document-${page.id}`} pageId={page.id} driveId={page.driveId} />;
   } else if (componentName === 'CodePageView') {
     const CodePageView = componentMap.CodePageView;
     pageComponent = <CodePageView key={`code-${page.id}`} pageId={page.id} />;
@@ -107,7 +110,7 @@ export default function PagePaneView({ pageId, driveId }: PagePaneViewProps) {
     const CanvasPageView = componentMap.CanvasPageView;
     pageComponent = <CanvasPageView key={`canvas-${page.id}`} pageId={page.id} />;
   } else {
-    const Component = ViewComponent as React.ComponentType<{ page: TreePage }>;
+    const Component = ViewComponent as ComponentType<{ page: TreePage }>;
     pageComponent = <Component key={`${componentName}-${page.id}`} page={page} />;
   }
 

--- a/apps/web/src/components/agents/panes/PagePaneView.tsx
+++ b/apps/web/src/components/agents/panes/PagePaneView.tsx
@@ -99,18 +99,19 @@ export default function PagePaneView({ pageId }: PagePaneViewProps) {
 
   // Same calling-convention split as CenterPanel.tsx's PageContent: the
   // pageId-only views fetch their own data; everything else still takes the
-  // full page object. DocumentView's driveId is the PAGE's own drive
-  // (`page.driveId`) — never the session's, which is null for a
-  // global-assistant session and would otherwise disable (or misroute)
-  // `usePageContentSocket`'s realtime updates for a page that always
-  // belongs to a real drive regardless of which kind of session opened it.
+  // full page object. DocumentView/CodePageView's driveId is the PAGE's own
+  // drive (`page.driveId`) — never the session's (null for a global-assistant
+  // session) or the route's (a pane has none, or the wrong one for a
+  // cross-drive page) — either of which would disable or misroute
+  // `usePageContentSocket`'s realtime updates for a page that always belongs
+  // to a real drive regardless of which kind of session opened it.
   let pageComponent: ReactNode;
   if (componentName === 'DocumentView') {
     const DocumentView = componentMap.DocumentView;
     pageComponent = <DocumentView key={`document-${page.id}`} pageId={page.id} driveId={page.driveId} />;
   } else if (componentName === 'CodePageView') {
     const CodePageView = componentMap.CodePageView;
-    pageComponent = <CodePageView key={`code-${page.id}`} pageId={page.id} />;
+    pageComponent = <CodePageView key={`code-${page.id}`} pageId={page.id} driveId={page.driveId} />;
   } else if (componentName === 'CanvasPageView') {
     const CanvasPageView = componentMap.CanvasPageView;
     pageComponent = <CanvasPageView key={`canvas-${page.id}`} pageId={page.id} />;

--- a/apps/web/src/components/agents/panes/PaneChat.tsx
+++ b/apps/web/src/components/agents/panes/PaneChat.tsx
@@ -19,12 +19,15 @@ import SessionChat from '../chat/SessionChat';
 import { useResolvedAgent } from '../useResolvedAgent';
 
 export default function PaneChat({
+  sessionId,
   conversationId,
   agentPageId,
   driveId,
   context = 'console',
   isReadOnly = false,
 }: {
+  /** This pane's session — threaded through so the chat surface can react to `open_page_pane` tool calls by opening a pane in THIS session's grid. */
+  sessionId: string;
   conversationId: string;
   agentPageId: string | null;
   /** This pane's session's own drive — `null` for a global-assistant session. Only the assistant branch needs it (an agent already carries its own `driveId`). */
@@ -40,6 +43,7 @@ export default function PaneChat({
   if (agentPageId === null) {
     return (
       <AssistantSessionChat
+        sessionId={sessionId}
         conversationId={conversationId}
         driveId={driveId}
         context={context}
@@ -56,5 +60,13 @@ export default function PaneChat({
     );
   }
 
-  return <SessionChat agent={agent} conversationId={conversationId} context={context} isReadOnly={isReadOnly} />;
+  return (
+    <SessionChat
+      sessionId={sessionId}
+      agent={agent}
+      conversationId={conversationId}
+      context={context}
+      isReadOnly={isReadOnly}
+    />
+  );
 }

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -59,6 +59,13 @@ async function searchPagesFetcher(url: string): Promise<PageSearchResult[]> {
   return Array.isArray(json) ? (json as PageSearchResult[]) : [];
 }
 
+/**
+ * The same exclusion `isPaneablePageType` applies, sent to `/api/mentions/search`
+ * as `excludePageTypes` so the endpoint drops these BEFORE its own 10-result
+ * cap, not after — see the `searchKey` comment in `PagesSection`.
+ */
+const PANE_UNSUPPORTED_TYPES_PARAM = `${PageType.FOLDER},${PageType.AI_CHAT}`;
+
 export interface PanePickerProps {
   agents: readonly PickableAgent[];
   /** This session's drive, to scope the Pages search — cross-drive when null (a global-assistant session). */
@@ -233,9 +240,15 @@ function PagesSection({
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query, 200);
 
+  // Excluded SERVER-SIDE, not just client-side: the endpoint caps its
+  // response to 10 suggestions before this component ever sees them, so
+  // filtering only after the fetch can silently shrink (even empty) the
+  // visible list whenever the top 10 by relevance/recency happen to include
+  // FOLDER/AI_CHAT pages, hiding eligible pages ranked just below them.
+  const excludeParam = `&excludePageTypes=${PANE_UNSUPPORTED_TYPES_PARAM}`;
   const searchKey = driveId
-    ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${encodeURIComponent(driveId)}&types=page`
-    : `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&crossDrive=true&types=page`;
+    ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${encodeURIComponent(driveId)}&types=page${excludeParam}`
+    : `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&crossDrive=true&types=page${excludeParam}`;
   // `isValidating`, not `isLoading`: with `keepPreviousData: true`, `isLoading`
   // is false for every key after the first once ANY data has loaded (SWR
   // shows the previous results while revalidating) — retyping after the

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -236,7 +236,12 @@ function PagesSection({
   const searchKey = driveId
     ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${encodeURIComponent(driveId)}&types=page`
     : `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&crossDrive=true&types=page`;
-  const { data: results = [], isLoading: searching } = useSWR(searchKey, searchPagesFetcher, {
+  // `isValidating`, not `isLoading`: with `keepPreviousData: true`, `isLoading`
+  // is false for every key after the first once ANY data has loaded (SWR
+  // shows the previous results while revalidating) — retyping after the
+  // first search would otherwise show stale results with no "Searching…"
+  // signal while the new request is in flight.
+  const { data: results = [], isValidating: searching } = useSWR(searchKey, searchPagesFetcher, {
     revalidateOnFocus: false,
     keepPreviousData: true,
   });
@@ -261,9 +266,10 @@ function PagesSection({
       {searching && query !== debouncedQuery ? (
         <p className="px-2 text-xs text-muted-foreground">Searching…</p>
       ) : pages.length === 0 ? (
-        <p className="px-2 text-xs text-muted-foreground">
-          {query ? 'No pages found.' : 'Type to search this drive’s pages.'}
-        </p>
+        // An empty query still fetches (the endpoint answers with the
+        // drive's most recently updated pages), so an empty result here
+        // means genuinely none — never "haven't typed yet".
+        <p className="px-2 text-xs text-muted-foreground">No pages found.</p>
       ) : (
         pages.map((page) => (
           <Button

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -13,9 +13,16 @@
  * the only thing that knows whether a pick should reuse an existing row.
  */
 
-import { useEffect, useRef } from 'react';
-import { Bot, TerminalSquare } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Bot, Search, TerminalSquare } from 'lucide-react';
+import useSWR from 'swr';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { isPaneablePageType } from '@pagespace/lib/content/page-types.config';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { PageTypeIcon } from '@/components/common/PageTypeIcon';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useDebounce } from '@/hooks/useDebounce';
 
 /** The picker needs a label and an id — never the whole agent record. */
 export interface PickableAgent {
@@ -36,8 +43,26 @@ export interface ReattachableShell {
   name: string;
 }
 
+/** One `/api/mentions/search` result — the shape both `PagePickerPopover` and `TriggerPagePicker` already fetch. */
+interface PageSearchResult {
+  id: string;
+  label: string;
+  type: 'page' | 'user';
+  description?: string;
+  data?: { pageType?: PageType };
+}
+
+async function searchPagesFetcher(url: string): Promise<PageSearchResult[]> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error('Failed to search pages');
+  const json: unknown = await response.json();
+  return Array.isArray(json) ? (json as PageSearchResult[]) : [];
+}
+
 export interface PanePickerProps {
   agents: readonly PickableAgent[];
+  /** This session's drive, to scope the Pages search — cross-drive when null (a global-assistant session). */
+  driveId?: string | null;
   /** No agents resolved yet — distinct from "this drive has none". */
   isLoading?: boolean;
   /**
@@ -66,10 +91,13 @@ export interface PanePickerProps {
   onPickShell(): void;
   /** Bind this pane to an already-running shell instead of spawning a new one. */
   onReattachShell?(shellId: string, name: string): void;
+  /** Bind this pane to a page — `title` is a display label, never an address. */
+  onPickPage?(pageId: string, title: string): void;
 }
 
 export default function PanePicker({
   agents,
+  driveId = null,
   isLoading = false,
   autoFocus = false,
   canPickAssistant = false,
@@ -77,6 +105,7 @@ export default function PanePicker({
   onPickAgent,
   onPickShell,
   onReattachShell,
+  onPickPage,
 }: PanePickerProps) {
   const firstRef = useRef<HTMLButtonElement>(null);
 
@@ -178,6 +207,81 @@ export default function PanePicker({
           ))}
         </div>
       ) : null}
+
+      {/* Search-as-you-type rather than a bounded list like Agents/Shells —
+          a drive can hold far more pages than agents, so there is no fixed
+          set to enumerate up front. */}
+      {onPickPage && <PagesSection driveId={driveId} onPickPage={onPickPage} />}
+    </div>
+  );
+}
+
+/**
+ * The "Pages" section: debounced search against the same `/api/mentions/search`
+ * endpoint `PagePickerPopover`/`TriggerPagePicker` already use, filtered to
+ * pane-safe types (`isPaneablePageType` — no FOLDER, no AI_CHAT). Its own
+ * component (rather than inline) so its `useSWR`/`useState` hooks stay
+ * independent of `PanePicker`'s own render.
+ */
+function PagesSection({
+  driveId,
+  onPickPage,
+}: {
+  driveId: string | null;
+  onPickPage(pageId: string, title: string): void;
+}) {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query, 200);
+
+  const searchKey = driveId
+    ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${encodeURIComponent(driveId)}&types=page`
+    : `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&crossDrive=true&types=page`;
+  const { data: results = [], isLoading: searching } = useSWR(searchKey, searchPagesFetcher, {
+    revalidateOnFocus: false,
+    keepPreviousData: true,
+  });
+
+  const pages = results.filter(
+    (result) => result.type === 'page' && isPaneablePageType(result.data?.pageType ?? PageType.DOCUMENT),
+  );
+
+  return (
+    <div className="flex shrink-0 flex-col gap-1">
+      <p className="shrink-0 pt-1 text-xs font-medium text-muted-foreground">Pages</p>
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search pages…"
+          className="h-8 pl-7 text-sm"
+          data-testid="pane-picker-page-search"
+        />
+      </div>
+      {searching && query !== debouncedQuery ? (
+        <p className="px-2 text-xs text-muted-foreground">Searching…</p>
+      ) : pages.length === 0 ? (
+        <p className="px-2 text-xs text-muted-foreground">
+          {query ? 'No pages found.' : 'Type to search this drive’s pages.'}
+        </p>
+      ) : (
+        pages.map((page) => (
+          <Button
+            key={page.id}
+            variant="ghost"
+            size="sm"
+            className="h-8 justify-start gap-2 px-2"
+            onClick={() => onPickPage(page.id, page.label)}
+            data-testid={`pick-page-${page.id}`}
+          >
+            <PageTypeIcon
+              type={page.data?.pageType ?? PageType.DOCUMENT}
+              className="size-3.5 shrink-0 text-muted-foreground"
+            />
+            <span className="truncate">{page.label}</span>
+          </Button>
+        ))
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/agents/panes/__tests__/PagePaneView.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/PagePaneView.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * PagePaneView — the pane-safe page-type dispatch. Leaf view components are
+ * mocked (this suite is the dispatch/loading/error wiring, not their
+ * internals, same convention as `AgentPanes.test.tsx`'s `PaneChat`/`Shell`
+ * mocks). A fresh `SWRConfig` cache per render keeps tests from bleeding into
+ * each other.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+
+const mockFetchWithAuth = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+}));
+
+vi.mock('@/components/layout/middle-content/page-views/document/DocumentView', () => ({
+  default: ({ pageId, driveId }: { pageId: string; driveId?: string }) => (
+    <div data-testid="document-view">
+      {pageId}:{driveId ?? 'no-drive'}
+    </div>
+  ),
+}));
+vi.mock('@/components/layout/middle-content/page-views/code/CodePageView', () => ({
+  default: ({ pageId }: { pageId: string }) => <div data-testid="code-view">{pageId}</div>,
+}));
+vi.mock('@/components/layout/middle-content/page-views/canvas/CanvasPageView', () => ({
+  default: ({ pageId }: { pageId: string }) => <div data-testid="canvas-view">{pageId}</div>,
+}));
+vi.mock('@/components/layout/middle-content/page-views/channel/ChannelView', () => ({
+  default: ({ page }: { page: { id: string } }) => <div data-testid="channel-view">{page.id}</div>,
+}));
+vi.mock('@/components/layout/middle-content/page-views/file/FileViewer', () => ({
+  default: ({ page }: { page: { id: string } }) => <div data-testid="file-view">{page.id}</div>,
+}));
+vi.mock('@/components/layout/middle-content/page-views/sheet/SheetView', () => ({
+  default: ({ page }: { page: { id: string } }) => <div data-testid="sheet-view">{page.id}</div>,
+}));
+vi.mock('@/components/layout/middle-content/page-views/task-list/TaskListView', () => ({
+  default: ({ page }: { page: { id: string } }) => <div data-testid="task-list-view">{page.id}</div>,
+}));
+
+import PagePaneView from '../PagePaneView';
+
+const jsonOk = (body: unknown) => ({ ok: true, json: async () => body });
+const jsonErr = (status: number, body: unknown = { error: 'nope' }) => ({ ok: false, status, json: async () => body });
+
+function renderPane(pageId = 'page-1') {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <PagePaneView pageId={pageId} />
+    </SWRConfig>,
+  );
+}
+
+describe('PagePaneView', () => {
+  it('shows a loading skeleton before the page fetch resolves', () => {
+    mockFetchWithAuth.mockReturnValue(new Promise(() => {})); // never resolves
+    const { container } = renderPane();
+    expect(container.querySelector('[class*="animate-pulse"]')).not.toBeNull();
+  });
+
+  it('shows an error message when the fetch fails', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonErr(403, { error: 'You do not have permission to view this page' }));
+    renderPane();
+    expect(await screen.findByText('You do not have permission to view this page')).toBeInTheDocument();
+  });
+
+  it('renders DocumentView with pageId + the PAGE\'s own driveId (not a session driveId)', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonOk({ id: 'page-1', type: 'DOCUMENT', driveId: 'drive-owning-the-page' }),
+    );
+    renderPane();
+    expect(await screen.findByTestId('document-view')).toHaveTextContent('page-1:drive-owning-the-page');
+  });
+
+  it('renders CodePageView with pageId only', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'CODE', driveId: 'drive-1' }));
+    renderPane();
+    expect(await screen.findByTestId('code-view')).toHaveTextContent('page-1');
+  });
+
+  it('renders CanvasPageView with pageId only', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'CANVAS', driveId: 'drive-1' }));
+    renderPane();
+    expect(await screen.findByTestId('canvas-view')).toHaveTextContent('page-1');
+  });
+
+  it('renders SheetView with the full page object', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'SHEET', driveId: 'drive-1' }));
+    renderPane();
+    expect(await screen.findByTestId('sheet-view')).toHaveTextContent('page-1');
+  });
+
+  it('renders TaskListView with the full page object', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'TASK_LIST', driveId: 'drive-1' }));
+    renderPane();
+    expect(await screen.findByTestId('task-list-view')).toHaveTextContent('page-1');
+  });
+
+  it('renders ChannelView with the full page object', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'CHANNEL', driveId: 'drive-1' }));
+    renderPane();
+    expect(await screen.findByTestId('channel-view')).toHaveTextContent('page-1');
+  });
+
+  it('renders FileViewer with the full page object', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'FILE', driveId: 'drive-1' }));
+    renderPane();
+    expect(await screen.findByTestId('file-view')).toHaveTextContent('page-1');
+  });
+
+  it('shows an unsupported message for FOLDER — a stale persisted scope must never crash', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'FOLDER', driveId: 'drive-1' }));
+    renderPane();
+    await waitFor(() => {
+      expect(screen.getByText(/can.t be opened in a pane/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an unsupported message for AI_CHAT — never nests a chat inside a chat pane', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'AI_CHAT', driveId: 'drive-1' }));
+    renderPane();
+    await waitFor(() => {
+      expect(screen.getByText(/can.t be opened in a pane/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/agents/panes/__tests__/PagePaneView.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/PagePaneView.test.tsx
@@ -22,7 +22,11 @@ vi.mock('@/components/layout/middle-content/page-views/document/DocumentView', (
   ),
 }));
 vi.mock('@/components/layout/middle-content/page-views/code/CodePageView', () => ({
-  default: ({ pageId }: { pageId: string }) => <div data-testid="code-view">{pageId}</div>,
+  default: ({ pageId, driveId }: { pageId: string; driveId?: string }) => (
+    <div data-testid="code-view">
+      {pageId}:{driveId ?? 'no-drive'}
+    </div>
+  ),
 }));
 vi.mock('@/components/layout/middle-content/page-views/canvas/CanvasPageView', () => ({
   default: ({ pageId }: { pageId: string }) => <div data-testid="canvas-view">{pageId}</div>,
@@ -74,10 +78,10 @@ describe('PagePaneView', () => {
     expect(await screen.findByTestId('document-view')).toHaveTextContent('page-1:drive-owning-the-page');
   });
 
-  it('renders CodePageView with pageId only', async () => {
-    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'CODE', driveId: 'drive-1' }));
+  it('renders CodePageView with pageId + the PAGE\'s own driveId (not a session/route driveId)', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonOk({ id: 'page-1', type: 'CODE', driveId: 'drive-owning-the-page' }));
     renderPane();
-    expect(await screen.findByTestId('code-view')).toHaveTextContent('page-1');
+    expect(await screen.findByTestId('code-view')).toHaveTextContent('page-1:drive-owning-the-page');
   });
 
   it('renders CanvasPageView with pageId only', async () => {

--- a/apps/web/src/components/agents/panes/pane-surface.ts
+++ b/apps/web/src/components/agents/panes/pane-surface.ts
@@ -25,7 +25,8 @@ export type PaneSurface =
   /** Bound, but the row it addresses does not exist yet. Hold. */
   | { surface: 'loading' }
   | { surface: 'terminal'; shellId: string }
-  | { surface: 'chat'; conversationId: string; agentPageId: string | null };
+  | { surface: 'chat'; conversationId: string; agentPageId: string | null }
+  | { surface: 'page'; pageId: string };
 
 export function resolvePaneSurface(scope: PaneScope | null): PaneSurface {
   if (scope === null) return { surface: 'picker' };
@@ -37,6 +38,9 @@ export function resolvePaneSurface(scope: PaneScope | null): PaneSurface {
 
   if (scope.kind === 'chat') return { surface: 'chat', conversationId: scope.targetId, agentPageId: scope.agentPageId };
   if (scope.kind === 'terminal') return { surface: 'terminal', shellId: scope.targetId };
+  // A page binding addresses an existing page directly — there is no mint to
+  // wait on, so this is reachable the very first render after assignment.
+  if (scope.kind === 'page') return { surface: 'page', pageId: scope.targetId };
 
   // A `kind` this module has never heard of — a stale persisted value that
   // predates a schema change, or a corrupted store slipping past

--- a/apps/web/src/components/ai/shared/chat/tool-calls/OpenPagePaneRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/OpenPagePaneRenderer.tsx
@@ -9,11 +9,15 @@ interface OpenPagePaneRendererProps {
 }
 
 /**
- * A completed `open_page_pane` call. Informational only — nothing to click:
- * the pane (if this conversation is running inside a session's grid) already
- * opened as a side effect of the tool result streaming in, and the tool's own
- * `execute` never knows whether any browser tab actually had a grid to act on
- * (see `page-pane-tools.ts`'s doc).
+ * A completed `open_page_pane` call. Informational only — nothing to click.
+ *
+ * Worded as a REQUEST ("Requested to open…"), never a confirmed outcome
+ * ("Opened…"): the tool's own `execute` acks unconditionally because the
+ * server has no visibility into any browser tab's pane-grid state (see
+ * `page-pane-tools.ts`'s doc) — in a plain, session-less conversation (or
+ * any surface with no mounted `useOpenPagePane`), this call is a genuine
+ * no-op, and claiming "Opened" here would tell the user something happened
+ * when nothing did.
  */
 export function OpenPagePaneRenderer({ pageId, title }: OpenPagePaneRendererProps) {
   if (!pageId) return null;
@@ -21,7 +25,7 @@ export function OpenPagePaneRenderer({ pageId, title }: OpenPagePaneRendererProp
     <div className="my-2 flex items-center gap-2 rounded-lg border bg-card px-3 py-2 text-sm shadow-sm">
       <PanelRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <span className="text-muted-foreground">
-        Opened <span className="font-medium text-foreground">{title ?? 'this page'}</span> in a pane
+        Requested to open <span className="font-medium text-foreground">{title ?? 'this page'}</span> in a pane
       </span>
     </div>
   );

--- a/apps/web/src/components/ai/shared/chat/tool-calls/OpenPagePaneRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/OpenPagePaneRenderer.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React from 'react';
+import { PanelRight } from 'lucide-react';
+
+interface OpenPagePaneRendererProps {
+  pageId?: string;
+  title?: string;
+}
+
+/**
+ * A completed `open_page_pane` call. Informational only — nothing to click:
+ * the pane (if this conversation is running inside a session's grid) already
+ * opened as a side effect of the tool result streaming in, and the tool's own
+ * `execute` never knows whether any browser tab actually had a grid to act on
+ * (see `page-pane-tools.ts`'s doc).
+ */
+export function OpenPagePaneRenderer({ pageId, title }: OpenPagePaneRendererProps) {
+  if (!pageId) return null;
+  return (
+    <div className="my-2 flex items-center gap-2 rounded-lg border bg-card px-3 py-2 text-sm shadow-sm">
+      <PanelRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span className="text-muted-foreground">
+        Opened <span className="font-medium text-foreground">{title ?? 'this page'}</span> in a pane
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -22,6 +22,7 @@ import { CalendarEventListRenderer } from './calendar/CalendarEventListRenderer'
 import { CalendarAvailabilityRenderer, type FreeSlot } from './calendar/CalendarAvailabilityRenderer';
 import { WorkflowListRenderer } from './workflow/WorkflowListRenderer';
 import { WorkflowCard, type WorkflowData } from './workflow/WorkflowCard';
+import { OpenPagePaneRenderer } from './OpenPagePaneRenderer';
 
 /**
  * Tool-call renderer registry.
@@ -430,6 +431,13 @@ export const toolRenderers: Record<string, ToolRenderer> = {
       pageType={parsedOutput.type as string | undefined}
       message={parsedOutput.message as string | undefined}
       errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  open_page_pane: ({ parsedOutput }) => (
+    <OpenPagePaneRenderer
+      pageId={parsedOutput.pageId as string | undefined}
+      title={parsedOutput.title as string | undefined}
     />
   ),
 

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useCallback, useRef, useState } from 'react';
+import React, { useEffect, useCallback, useRef, useState, useId } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Maximize2 } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -57,6 +57,10 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
   const hasInitializedRef = useRef(false);
   const isDirtyRef = useRef(false);
   const socket = useSocket();
+  // Distinguishes this mount from any other simultaneous mount of the SAME
+  // page (main center panel vs. an agent-session pane) — see DocumentView's
+  // identical fix for why the key must not be pageId alone.
+  const instanceId = useId();
 
   // Mirrors published_pages.themeBridgeEnabled so the View tab's live preview
   // matches what publishing produces. Shared with the header's
@@ -127,7 +131,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
 
   // Register editing state to prevent SWR revalidation during edits
   useEffect(() => {
-    const componentId = `canvas-${pageId}`;
+    const componentId = `canvas-${pageId}-${instanceId}`;
 
     if (documentState?.isDirty) {
       useEditingStore.getState().startEditing(componentId, 'document', {
@@ -141,7 +145,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
     return () => {
       useEditingStore.getState().endEditing(componentId);
     };
-  }, [documentState?.isDirty, pageId]);
+  }, [documentState?.isDirty, pageId, instanceId]);
 
   // Track isDirty in ref
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
@@ -4,8 +4,8 @@ import React, { useEffect, useState, useCallback, useRef, useId } from 'react';
 import dynamic from 'next/dynamic';
 import { useDocument } from '@/hooks/useDocument';
 import { motion, AnimatePresence } from 'motion/react';
-import { useSocket } from '@/hooks/useSocket';
-import { PageEventPayload } from '@/lib/websocket';
+import { usePageContentSocket } from '@/hooks/usePageContentSocket';
+import type { PageEventPayload } from '@/lib/websocket';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -23,6 +23,15 @@ import { useParams } from 'next/navigation';
 
 interface CodePageViewProps {
   pageId: string;
+  /**
+   * The page's own drive, for cross-drive socket updates — mirrors
+   * DocumentView's identical prop. Optional and falls back to the route's own
+   * `driveId` param for backward compat with callers inside a drive route
+   * (e.g. CenterPanel); a pane has no such route (or the wrong one, for a
+   * cross-drive page in a global-assistant session), so it must pass the
+   * fetched page's real driveId explicitly.
+   */
+  driveId?: string;
 }
 
 const MonacoEditor = dynamic(() => import('@/components/editors/MonacoEditor'), { ssr: false });
@@ -61,15 +70,14 @@ function detectLanguageFromTitle(title: string): string {
   return detectLanguageFromFilename(title);
 }
 
-const CodePageView = ({ pageId }: CodePageViewProps) => {
+const CodePageView = ({ pageId, driveId: driveIdProp }: CodePageViewProps) => {
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [language, setLanguage] = useState('plaintext');
   const isDirtyRef = useRef(false);
   const hasInitializedRef = useRef(false);
-  const socket = useSocket();
   const { user } = useAuth();
   const params = useParams();
-  const driveId = params.driveId as string;
+  const driveId = driveIdProp ?? (params.driveId as string);
   const { tree } = usePageTree(driveId);
   // Distinguishes this mount from any other simultaneous mount of the SAME
   // page (main center panel vs. an agent-session pane) — see DocumentView's
@@ -157,35 +165,29 @@ const CodePageView = ({ pageId }: CodePageViewProps) => {
     checkPermissions();
   }, [user?.id, pageId]);
 
-  // Listen for content updates from other sources
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleContentUpdate = async (eventData: PageEventPayload) => {
-      if (eventData.socketId && eventData.socketId === socket.id) {
-        return;
-      }
-
-      if (eventData.pageId === pageId) {
-        try {
-          const response = await fetchWithAuth(`/api/pages/${pageId}`);
-          if (response.ok) {
-            const updatedPage = await response.json();
-            if (updatedPage.content !== documentState?.content && !documentState?.isDirty) {
-              updateContentFromServer(updatedPage.content, updatedPage.revision);
-            }
-          }
-        } catch (error) {
-          console.error('Failed to fetch updated content:', error);
+  // Listen for content updates from other sources. Joins the PAGE's own
+  // drive room (not just whatever the route happens to be) — see
+  // DocumentView's identical usage: without this, a code page opened outside
+  // its own drive's route (a pane in the global-assistant console, or a
+  // cross-drive session) never receives live updates at all.
+  const handleContentUpdate = useCallback(async (_eventData: PageEventPayload) => {
+    try {
+      const response = await fetchWithAuth(`/api/pages/${pageId}`);
+      if (response.ok) {
+        const updatedPage = await response.json();
+        if (updatedPage.content !== documentState?.content && !documentState?.isDirty) {
+          updateContentFromServer(updatedPage.content, updatedPage.revision);
         }
       }
-    };
+    } catch (error) {
+      console.error('Failed to fetch updated content:', error);
+    }
+  }, [pageId, documentState?.content, documentState?.isDirty, updateContentFromServer]);
 
-    socket.on('page:content-updated', handleContentUpdate);
-    return () => {
-      socket.off('page:content-updated', handleContentUpdate);
-    };
-  }, [socket, pageId, documentState, updateContentFromServer]);
+  usePageContentSocket(pageId, driveId, {
+    onContentUpdated: handleContentUpdate,
+    enabled: !!driveId,
+  });
 
   // Handle content changes
   const handleContentChange = useCallback((newContent: string | undefined) => {

--- a/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef, useId } from 'react';
 import dynamic from 'next/dynamic';
 import { useDocument } from '@/hooks/useDocument';
 import { motion, AnimatePresence } from 'motion/react';
@@ -71,6 +71,10 @@ const CodePageView = ({ pageId }: CodePageViewProps) => {
   const params = useParams();
   const driveId = params.driveId as string;
   const { tree } = usePageTree(driveId);
+  // Distinguishes this mount from any other simultaneous mount of the SAME
+  // page (main center panel vs. an agent-session pane) — see DocumentView's
+  // identical fix for why the key must not be pageId alone.
+  const instanceId = useId();
 
   const {
     document: documentState,
@@ -112,7 +116,7 @@ const CodePageView = ({ pageId }: CodePageViewProps) => {
 
   // Register editing state when document is dirty
   useEffect(() => {
-    const componentId = `code-${pageId}`;
+    const componentId = `code-${pageId}-${instanceId}`;
 
     if (documentState?.isDirty && !isReadOnly) {
       useEditingStore.getState().startEditing(componentId, 'document', {
@@ -126,7 +130,7 @@ const CodePageView = ({ pageId }: CodePageViewProps) => {
     return () => {
       useEditingStore.getState().endEditing(componentId);
     };
-  }, [documentState?.isDirty, pageId, isReadOnly]);
+  }, [documentState?.isDirty, pageId, isReadOnly, instanceId]);
 
   // Check user permissions
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef, useId } from 'react';
 import dynamic from 'next/dynamic';
 import { useDocument } from '@/hooks/useDocument';
 import { Editor } from '@tiptap/react';
@@ -36,6 +36,12 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const isDirtyRef = useRef(false);
   const { user } = useAuth();
+  // Distinguishes this mount from any other simultaneous mount of the SAME
+  // page (e.g. the main center panel and an agent-session pane both showing
+  // it) — without this, both compute the identical `document-${pageId}` key
+  // and collide in useEditingStore's Map: whichever unmounts first calls
+  // endEditing and wipes the entry while the other is still dirty.
+  const instanceId = useId();
 
   const {
     document: documentState,
@@ -99,7 +105,7 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
 
   // Register editing state when document is dirty
   useEffect(() => {
-    const componentId = `document-${pageId}`;
+    const componentId = `document-${pageId}-${instanceId}`;
 
     if (documentState?.isDirty && !isReadOnly) {
       useEditingStore.getState().startEditing(componentId, 'document', {
@@ -113,7 +119,7 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
     return () => {
       useEditingStore.getState().endEditing(componentId);
     };
-  }, [documentState?.isDirty, pageId, isReadOnly]);
+  }, [documentState?.isDirty, pageId, isReadOnly, instanceId]);
 
   // Check user permissions
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { TreePage, usePageTree } from '@/hooks/usePageTree';
 import { useSocket } from '@/hooks/useSocket';
 import { useAuth } from '@/hooks/useAuth';
@@ -202,7 +202,12 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     isFormulaFocused,
     isDirty: !!documentState?.isDirty,
   });
-  useEditingSession(`sheet-${page.id}`, isEditingActive, 'document', {
+  // instanceId distinguishes this mount from any other simultaneous mount of
+  // the SAME page (main center panel vs. an agent-session pane) — without it,
+  // both compute the identical `sheet-${page.id}` key and collide in
+  // useEditingStore's Map (see DocumentView's identical fix).
+  const instanceId = useId();
+  useEditingSession(`sheet-${page.id}-${instanceId}`, isEditingActive, 'document', {
     pageId: page.id,
     componentName: 'SheetView',
   });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, memo, useMemo } from 'react';
+import { useState, useEffect, useId, useRef, useCallback, memo, useMemo } from 'react';
 import { type Editor } from '@tiptap/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
@@ -531,7 +531,12 @@ function TaskListView({ page }: TaskListViewProps) {
     })
   );
 
-  useEditingSession(page.id, !!editingTaskId, 'form', {
+  // instanceId distinguishes this mount from any other simultaneous mount of
+  // the SAME page (main center panel vs. an agent-session pane) — without it,
+  // both compute the identical `page.id` key and collide in useEditingStore's
+  // Map (see DocumentView's identical fix).
+  const instanceId = useId();
+  useEditingSession(`${page.id}-${instanceId}`, !!editingTaskId, 'form', {
     pageId: page.id,
     componentName: 'TaskListView',
   });

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -196,6 +196,7 @@ import { commandTools } from '../../tools/command-tools';
 import { skillTools } from '../../tools/skill-tools';
 import { formTools } from '../../tools/form-tools';
 import { imageGenerationTools } from '../../tools/image-generation-tools';
+import { pagePaneTools } from '../../tools/page-pane-tools';
 
 describe('ai-tools', () => {
   describe('pageSpaceTools aggregation', () => {
@@ -226,6 +227,7 @@ describe('ai-tools', () => {
         ...skillTools,
         ...formTools,
         ...imageGenerationTools,
+        ...pagePaneTools,
       });
     });
 
@@ -251,6 +253,7 @@ describe('ai-tools', () => {
         Object.keys(commandTools),
         Object.keys(formTools),
         Object.keys(imageGenerationTools),
+        Object.keys(pagePaneTools),
       ];
 
       const allKeys = moduleKeysets.flat();

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -21,6 +21,7 @@ import { commandTools } from '../tools/command-tools';
 import { skillTools } from '../tools/skill-tools';
 import { formTools } from '../tools/form-tools';
 import { imageGenerationTools } from '../tools/image-generation-tools';
+import { pagePaneTools } from '../tools/page-pane-tools';
 import { buildSandboxTools } from '../tools/sandbox-tools-runtime';
 import { buildGitSandboxTools } from '../tools/sandbox-git-tools-runtime';
 import { buildSessionTools } from '../tools/session-tools-runtime';
@@ -59,6 +60,7 @@ const TOOL_MODULES = {
   skills: skillTools,
   forms: formTools,
   imageGeneration: imageGenerationTools,
+  pagePane: pagePaneTools,
 } as const;
 
 // Flatten the module map into one ToolSet. No key collisions across modules — the

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useOpenPagePane.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useOpenPagePane.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import { useOpenPagePane } from '../useOpenPagePane';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+import { panesOf } from '@/stores/agent-workspace/pane-reducer';
+
+const store = () => useAgentWorkspaceStore.getState();
+const grid = (id = 'ses-1') => store().workspaces[id];
+
+const toolPart = (toolCallId: string, state: string, output?: unknown) => ({
+  type: 'tool-open_page_pane',
+  toolCallId,
+  state,
+  input: { pageId: 'page-1' },
+  ...(output !== undefined ? { output } : {}),
+});
+
+const msg = (id: string, role: UIMessage['role'], parts: unknown[] = []): UIMessage =>
+  ({ id, role, parts }) as UIMessage;
+
+beforeEach(() => {
+  useAgentWorkspaceStore.setState({ workspaces: {} });
+});
+
+describe('useOpenPagePane', () => {
+  it('opens a page pane for a NEWLY streamed completed call', () => {
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    // Split first so the lone chat pane isn't the only replaceable candidate —
+    // isolates "does it act on a new call" from the invoker-exclusion behavior
+    // covered separately below.
+    store().splitRight('ses-1', panesOf(grid())[0].id);
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: 'ses-1', conversationId: 'conv-1', messages }),
+      { initialProps: { messages: [msg('a1', 'assistant', [])] } },
+    );
+
+    rerender({
+      messages: [
+        msg('a1', 'assistant', [
+          toolPart('tc1', 'output-available', { opened: true, pageId: 'page-1', title: 'My Doc' }),
+        ]),
+      ],
+    });
+
+    const panes = panesOf(grid());
+    const pagePane = panes.find((p) => p.scope?.kind === 'page');
+    expect(pagePane?.scope?.targetId).toBe('page-1');
+    expect(pagePane?.scope?.name).toBe('My Doc');
+  });
+
+  it('does NOT act on a completed call already present on the FIRST render (history replay guard)', () => {
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    store().splitRight('ses-1', panesOf(grid())[0].id);
+    const before = panesOf(grid()).map((p) => p.scope);
+
+    renderHook(() =>
+      useOpenPagePane({
+        sessionId: 'ses-1',
+        conversationId: 'conv-1',
+        messages: [
+          msg('a1', 'assistant', [
+            toolPart('tc1', 'output-available', { opened: true, pageId: 'page-1', title: 'My Doc' }),
+          ]),
+        ],
+      }),
+    );
+
+    // A reopened/remounted conversation's own loaded history must not
+    // re-trigger the pane it already opened last time.
+    expect(panesOf(grid()).map((p) => p.scope)).toEqual(before);
+  });
+
+  it('never double-fires the same toolCallId across rerenders', () => {
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    store().splitRight('ses-1', panesOf(grid())[0].id);
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: 'ses-1', conversationId: 'conv-1', messages }),
+      { initialProps: { messages: [msg('a1', 'assistant', [])] } },
+    );
+    const completed = [
+      msg('a1', 'assistant', [
+        toolPart('tc1', 'output-available', { opened: true, pageId: 'page-1', title: 'My Doc' }),
+      ]),
+    ];
+    rerender({ messages: completed });
+    // Manually re-target the pane the tool call opened, then rerender with the
+    // SAME messages again — a naive re-scan would reopen/refocus page-1 and
+    // undo the user's own subsequent action.
+    const pagePane = panesOf(grid()).find((p) => p.scope?.kind === 'page')!;
+    store().assignPane('ses-1', pagePane.id, { kind: 'page', name: 'Other', targetId: 'page-2', agentPageId: null });
+    rerender({ messages: completed });
+
+    expect(panesOf(grid()).find((p) => p.id === pagePane.id)?.scope?.targetId).toBe('page-2');
+  });
+
+  it('never evicts the invoking chat pane — splits beside it instead (excludeTargetId)', () => {
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    const chatPane = panesOf(grid())[0];
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: 'ses-1', conversationId: 'conv-1', messages }),
+      { initialProps: { messages: [msg('a1', 'assistant', [])] } },
+    );
+    rerender({
+      messages: [
+        msg('a1', 'assistant', [
+          toolPart('tc1', 'output-available', { opened: true, pageId: 'page-1', title: 'My Doc' }),
+        ]),
+      ],
+    });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === chatPane.id)?.scope?.targetId).toBe('conv-1');
+    expect(panes.find((p) => p.scope?.targetId === 'page-1')).toBeDefined();
+  });
+
+  it('ignores tool parts that are not yet output-available', () => {
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    const before = panesOf(grid()).map((p) => p.scope);
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: 'ses-1', conversationId: 'conv-1', messages }),
+      { initialProps: { messages: [msg('a1', 'assistant', [])] } },
+    );
+    rerender({ messages: [msg('a1', 'assistant', [toolPart('tc1', 'input-available')])] });
+
+    expect(panesOf(grid()).map((p) => p.scope)).toEqual(before);
+  });
+
+  it('no-ops when sessionId is null (a plain, session-less conversation)', () => {
+    const { rerender } = renderHook(
+      ({ messages }: { messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: null, conversationId: 'conv-1', messages }),
+      { initialProps: { messages: [msg('a1', 'assistant', [])] } },
+    );
+    rerender({
+      messages: [
+        msg('a1', 'assistant', [
+          toolPart('tc1', 'output-available', { opened: true, pageId: 'page-1', title: 'My Doc' }),
+        ]),
+      ],
+    });
+
+    expect(useAgentWorkspaceStore.getState().workspaces).toEqual({});
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useOpenPagePane.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useOpenPagePane.test.ts
@@ -73,6 +73,69 @@ describe('useOpenPagePane', () => {
     expect(panesOf(grid()).map((p) => p.scope)).toEqual(before);
   });
 
+  it('does NOT replay a DIFFERENT conversation\'s already-completed call when the same pane switches to it (no remount)', () => {
+    // The pane-bar agent switcher rebinds a pane's conversationId IN PLACE —
+    // SessionChat/AssistantSessionChat are never keyed by conversationId, so
+    // this hook's refs must not treat conv-2's own history as "new" just
+    // because they were already seeded (by conv-1) before the switch.
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    store().splitRight('ses-1', panesOf(grid())[0].id);
+
+    const { rerender } = renderHook(
+      ({ conversationId, messages }: { conversationId: string; messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: 'ses-1', conversationId, messages }),
+      { initialProps: { conversationId: 'conv-1', messages: [msg('a1', 'assistant', [])] } },
+    );
+    // Seed conv-1 as already-history (matches the "history replay guard" test above).
+    rerender({
+      conversationId: 'conv-1',
+      messages: [
+        msg('a1', 'assistant', [
+          toolPart('tc1', 'output-available', { opened: true, pageId: 'page-1', title: 'Conv 1 Doc' }),
+        ]),
+      ],
+    });
+    const before = panesOf(grid()).map((p) => p.scope);
+
+    // Switch the SAME pane to conv-2, whose own last message already ends in
+    // a completed call — must be seeded as conv-2's history, not fired.
+    rerender({
+      conversationId: 'conv-2',
+      messages: [
+        msg('a2', 'assistant', [
+          toolPart('tc2', 'output-available', { opened: true, pageId: 'page-2', title: 'Conv 2 Doc' }),
+        ]),
+      ],
+    });
+
+    expect(panesOf(grid()).map((p) => p.scope)).toEqual(before);
+  });
+
+  it('still fires a genuinely NEW call after switching to a different conversation', () => {
+    store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
+    store().splitRight('ses-1', panesOf(grid())[0].id);
+
+    const { rerender } = renderHook(
+      ({ conversationId, messages }: { conversationId: string; messages: UIMessage[] }) =>
+        useOpenPagePane({ sessionId: 'ses-1', conversationId, messages }),
+      { initialProps: { conversationId: 'conv-1', messages: [msg('a1', 'assistant', [])] } },
+    );
+    // Switch to conv-2 with no completed call yet...
+    rerender({ conversationId: 'conv-2', messages: [msg('a2', 'assistant', [])] });
+    // ...then a NEW call streams in live for conv-2.
+    rerender({
+      conversationId: 'conv-2',
+      messages: [
+        msg('a2', 'assistant', [
+          toolPart('tc2', 'output-available', { opened: true, pageId: 'page-2', title: 'Conv 2 Doc' }),
+        ]),
+      ],
+    });
+
+    const pagePane = panesOf(grid()).find((p) => p.scope?.kind === 'page');
+    expect(pagePane?.scope?.targetId).toBe('page-2');
+  });
+
   it('never double-fires the same toolCallId across rerenders', () => {
     store().ensureWorkspace('ses-1', { kind: 'chat', name: 'Thread', targetId: 'conv-1', agentPageId: 'agent-1' });
     store().splitRight('ses-1', panesOf(grid())[0].id);

--- a/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
@@ -43,18 +43,34 @@ export function useOpenPagePane({
   messages: UIMessage[];
 }) {
   const handledRef = useRef<Set<string>>(new Set());
-  // Whether we've ever inspected a REAL last-assistant-message yet. `false`
-  // on the very first sighting means every already-`output-available` call
-  // found there is HISTORY (loaded on mount, a remount, or a reopened
-  // conversation) rather than something that just streamed in — reacting to
-  // it would re-open/re-focus a pane the user may have since closed or
-  // repurposed, on every remount, forever. Those are marked handled without
-  // being acted on; only a call that becomes `output-available` on a LATER
-  // run (a genuinely new stream) is acted on.
+  // Whether we've ever inspected a REAL last-assistant-message yet FOR THIS
+  // CONVERSATION. `false` on the very first sighting means every already-
+  // `output-available` call found there is HISTORY (loaded on mount, a
+  // remount, a reopened conversation, or — see `seenConversationIdRef` below
+  // — a DIFFERENT conversation the pane bar just switched this same pane to)
+  // rather than something that just streamed in; reacting to it would
+  // re-open/re-focus a pane the user may have since closed or repurposed.
+  // Those are marked handled without being acted on; only a call that
+  // becomes `output-available` on a LATER run (a genuinely new stream) is
+  // acted on.
   const hasSeededRef = useRef(false);
+  // `SessionChat`/`AssistantSessionChat` are never keyed by conversationId
+  // (`AgentPanes`'s pane-bar agent switcher rebinds the SAME pane's scope to
+  // a different conversation in place — `handleSwitchAgent` → `assignPane`),
+  // so this hook's refs can outlive the conversation they were seeded for.
+  // Without this reset, switching a pane from conversation A to a FRESH
+  // mount-free conversation B whose own history already ends in a completed
+  // `open_page_pane` call would read B's history through A's now-stale
+  // `hasSeededRef === true` and wrongly treat it as new.
+  const seenConversationIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!sessionId) return;
+    if (seenConversationIdRef.current !== conversationId) {
+      seenConversationIdRef.current = conversationId;
+      handledRef.current = new Set();
+      hasSeededRef.current = false;
+    }
     const last = messages[messages.length - 1];
     if (!last || last.role !== 'assistant') return;
 

--- a/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { UIMessage } from 'ai';
+import { OPEN_PAGE_PANE_TOOL_NAME, type OpenPagePaneOutput } from '@/lib/ai/tools/page-pane-tools';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+
+const TOOL_PART_TYPE = `tool-${OPEN_PAGE_PANE_TOOL_NAME}`;
+
+interface OpenPagePaneToolPart {
+  type: typeof TOOL_PART_TYPE;
+  toolCallId: string;
+  state?: string;
+  output?: OpenPagePaneOutput;
+}
+
+/**
+ * Reacts to a completed `open_page_pane` tool call by opening/focusing the
+ * page in THIS session's pane grid. Unlike `ask_user`, this tool's `execute`
+ * always resolves server-side (see `page-pane-tools.ts`'s doc for why), so
+ * there is no turn to unblock and no `addToolResult` round-trip — this hook
+ * is a pure reaction to the tool call's result already streaming down as
+ * part of the assistant message, exactly like any other rendered tool
+ * result. A per-mount seen-set is still needed so a rerender never reopens
+ * (or resplits) the pane for a call already handled.
+ */
+export function useOpenPagePane({
+  sessionId,
+  messages,
+}: {
+  /** Null for a plain, session-less conversation — there is no pane grid to open into, so the hook no-ops. */
+  sessionId: string | null;
+  messages: UIMessage[];
+}) {
+  const handledRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!sessionId) return;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return;
+
+    for (const part of last.parts ?? []) {
+      if (part.type !== TOOL_PART_TYPE) continue;
+      const toolPart = part as unknown as OpenPagePaneToolPart;
+      if (toolPart.state !== 'output-available' || !toolPart.output?.opened) continue;
+      if (handledRef.current.has(toolPart.toolCallId)) continue;
+      handledRef.current.add(toolPart.toolCallId);
+
+      useAgentWorkspaceStore.getState().openPage(sessionId, {
+        kind: 'page',
+        name: toolPart.output.title ?? 'Page',
+        targetId: toolPart.output.pageId,
+        agentPageId: null,
+      });
+    }
+  }, [sessionId, messages]);
+}

--- a/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
@@ -23,21 +23,43 @@ interface OpenPagePaneToolPart {
  * part of the assistant message, exactly like any other rendered tool
  * result. A per-mount seen-set is still needed so a rerender never reopens
  * (or resplits) the pane for a call already handled.
+ *
+ * `conversationId` is passed to `openPage` as `excludeTargetId`: this
+ * conversation's OWN pane must never be the one the tool call replaces — a
+ * pane grid with only this one chat pane open would otherwise satisfy
+ * `focusOrAssignScope`'s "replaceable" check and evict the very conversation
+ * that just asked to show its work, which is backwards. The store instead
+ * splits a new pane beside it.
  */
 export function useOpenPagePane({
   sessionId,
+  conversationId,
   messages,
 }: {
   /** Null for a plain, session-less conversation — there is no pane grid to open into, so the hook no-ops. */
   sessionId: string | null;
+  /** This conversation's own id — excluded from replacement (see doc above). */
+  conversationId: string;
   messages: UIMessage[];
 }) {
   const handledRef = useRef<Set<string>>(new Set());
+  // Whether we've ever inspected a REAL last-assistant-message yet. `false`
+  // on the very first sighting means every already-`output-available` call
+  // found there is HISTORY (loaded on mount, a remount, or a reopened
+  // conversation) rather than something that just streamed in — reacting to
+  // it would re-open/re-focus a pane the user may have since closed or
+  // repurposed, on every remount, forever. Those are marked handled without
+  // being acted on; only a call that becomes `output-available` on a LATER
+  // run (a genuinely new stream) is acted on.
+  const hasSeededRef = useRef(false);
 
   useEffect(() => {
     if (!sessionId) return;
     const last = messages[messages.length - 1];
     if (!last || last.role !== 'assistant') return;
+
+    const isFirstSighting = !hasSeededRef.current;
+    hasSeededRef.current = true;
 
     for (const part of last.parts ?? []) {
       if (part.type !== TOOL_PART_TYPE) continue;
@@ -45,13 +67,18 @@ export function useOpenPagePane({
       if (toolPart.state !== 'output-available' || !toolPart.output?.opened) continue;
       if (handledRef.current.has(toolPart.toolCallId)) continue;
       handledRef.current.add(toolPart.toolCallId);
+      if (isFirstSighting) continue;
 
-      useAgentWorkspaceStore.getState().openPage(sessionId, {
-        kind: 'page',
-        name: toolPart.output.title ?? 'Page',
-        targetId: toolPart.output.pageId,
-        agentPageId: null,
-      });
+      useAgentWorkspaceStore.getState().openPage(
+        sessionId,
+        {
+          kind: 'page',
+          name: toolPart.output.title ?? 'Page',
+          targetId: toolPart.output.pageId,
+          agentPageId: null,
+        },
+        { excludeTargetId: conversationId },
+      );
     }
-  }, [sessionId, messages]);
+  }, [sessionId, conversationId, messages]);
 }

--- a/apps/web/src/lib/ai/tools/page-pane-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-pane-tools.ts
@@ -1,0 +1,51 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const OPEN_PAGE_PANE_TOOL_NAME = 'open_page_pane';
+
+export const openPagePaneInputSchema = z
+  .object({
+    /** The page to show — a real pageId from list_pages/create_page/read_page/etc, never a guess. */
+    pageId: z.string().min(1),
+    /** Display label for the pane header only — never an address. Omit if unknown. */
+    title: z.string().min(1).max(200).optional(),
+  })
+  .strict();
+
+export type OpenPagePaneInput = z.infer<typeof openPagePaneInputSchema>;
+
+export const openPagePaneOutputSchema = z.object({
+  opened: z.literal(true),
+  pageId: z.string(),
+  title: z.string().optional(),
+});
+
+export type OpenPagePaneOutput = z.infer<typeof openPagePaneOutputSchema>;
+
+/**
+ * Signals the UI to open (or focus) `pageId` in a pane beside this
+ * conversation — the highest-value moment is right after editing a page with
+ * the page tools, so the user sees the result without hunting for it in the
+ * sidebar.
+ *
+ * `execute` always acks `opened: true` and returns immediately — the server
+ * has no visibility into any browser tab's UI state (a pane grid is
+ * client-local, never synced — see `agent-workspace/useAgentWorkspaceStore.ts`),
+ * so it cannot know, and must not claim to know, whether any pane actually
+ * appeared. The real effect is a CLIENT-SIDE reaction: `useOpenPagePane`
+ * watches the conversation's message stream for a completed call to this tool
+ * and opens/focuses the pane itself. Outside a session's pane grid (a plain
+ * conversation, or no client currently rendering one), the call is a
+ * harmless no-op — never a hung turn, because it always resolves here, not
+ * client-side.
+ */
+export const pagePaneTools = {
+  open_page_pane: tool({
+    description:
+      'Open (or focus, if already open) a PageSpace page in a pane beside this conversation, so the user can see your work without ' +
+      'hunting for it in the sidebar. Most useful right after reading/editing a page with your page tools. ' +
+      'Only has a visible effect inside an agent session with an open pane grid; elsewhere it is a harmless no-op.',
+    inputSchema: openPagePaneInputSchema,
+    execute: async ({ pageId, title }): Promise<OpenPagePaneOutput> => ({ opened: true, pageId, title }),
+  }),
+};

--- a/apps/web/src/lib/ai/tools/page-pane-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-pane-tools.ts
@@ -12,8 +12,6 @@ export const openPagePaneInputSchema = z
   })
   .strict();
 
-export type OpenPagePaneInput = z.infer<typeof openPagePaneInputSchema>;
-
 export const openPagePaneOutputSchema = z.object({
   opened: z.literal(true),
   pageId: z.string(),

--- a/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
@@ -3,10 +3,11 @@
  * transition aimed at a grid that is gone. The layout rules themselves are the
  * reducer's, and are tested there.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
 import { useAgentWorkspaceStore } from '../useAgentWorkspaceStore';
 import { panesOf } from '../pane-reducer';
+import { useEditingStore } from '@/stores/useEditingStore';
 
 const scope = (name = 'Planning'): PaneScope => ({
   kind: 'chat',
@@ -274,6 +275,110 @@ describe('openConversation — selection means SHOW it (review M1)', () => {
     expect(panes).toHaveLength(2);
     expect(panes.find((p) => p.id === inFlightPane.id)?.scope?.targetId).toBeNull();
     expect(panes.find((p) => p.scope?.targetId === 'conv-2')).toBeDefined();
+  });
+});
+
+describe('openPage — the page-pane sibling of openConversation', () => {
+  const page = (targetId: string, name = 'Doc'): PaneScope => ({
+    kind: 'page',
+    name,
+    targetId,
+    agentPageId: null,
+  });
+  const conv = (targetId: string, name = 'Thread'): PaneScope => ({
+    kind: 'chat',
+    name,
+    targetId,
+    agentPageId: 'agent-1',
+  });
+
+  afterEach(() => {
+    useEditingStore.getState().clearAllSessions();
+  });
+
+  it('with no workspace, seeds the opening grid on the page (ensure semantics)', () => {
+    store().openPage('ses-1', page('page-1'));
+    expect(panesOf(grid())).toHaveLength(1);
+    expect(panesOf(grid())[0].scope?.targetId).toBe('page-1');
+  });
+
+  it('focuses the pane already showing the page instead of duplicating it', () => {
+    store().openPage('ses-1', page('page-1'));
+    const first = panesOf(grid())[0];
+    store().splitRight('ses-1', first.id);
+    const second = panesOf(grid()).find((p) => p.id !== first.id)!;
+    store().assignPane('ses-1', second.id, page('page-2'));
+
+    store().openPage('ses-1', page('page-1'));
+    expect(grid().activePaneId).toBe(first.id);
+    expect(panesOf(grid())).toHaveLength(2);
+  });
+
+  it('replaces an unseen page in the ACTIVE pane, same as a conversation would', () => {
+    store().openPage('ses-1', page('page-1'));
+    const paneId = panesOf(grid())[0].id;
+    store().openPage('ses-1', page('page-2'));
+    expect(panesOf(grid())).toHaveLength(1);
+    expect(panesOf(grid())[0].id).toBe(paneId);
+    expect(panesOf(grid())[0].scope?.targetId).toBe('page-2');
+  });
+
+  it('never replaces a page pane with unsaved edits — it splits beside it instead', () => {
+    store().openPage('ses-1', page('page-1'));
+    const dirtyPane = panesOf(grid())[0];
+    // A real dirty registration, keyed the way DocumentView/etc actually key it
+    // (pageId carried in metadata, a useId()-suffixed componentId — the store's
+    // guard reads metadata.pageId, never the componentId string itself).
+    useEditingStore.getState().startEditing('document-page-1-:r1:', 'document', { pageId: 'page-1' });
+
+    store().openPage('ses-1', page('page-2'));
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === dirtyPane.id)?.scope?.targetId).toBe('page-1');
+    expect(panes.find((p) => p.scope?.targetId === 'page-2')).toBeDefined();
+  });
+
+  it('stops treating a page as dirty once its editing session ends', () => {
+    store().openPage('ses-1', page('page-1'));
+    const onlyPane = panesOf(grid())[0];
+    useEditingStore.getState().startEditing('document-page-1-:r1:', 'document', { pageId: 'page-1' });
+    useEditingStore.getState().endEditing('document-page-1-:r1:');
+
+    store().openPage('ses-1', page('page-2'));
+
+    expect(panesOf(grid())).toHaveLength(1);
+    expect(panesOf(grid())[0].id).toBe(onlyPane.id);
+    expect(panesOf(grid())[0].scope?.targetId).toBe('page-2');
+  });
+
+  it('never replaces the pane the caller excluded (the open_page_pane tool\'s own invoking chat)', () => {
+    // A lone chat pane — exactly the shape a real agent session starts with —
+    // must not be evicted by its OWN tool call opening a page beside it.
+    store().ensureWorkspace('ses-1', conv('conv-1'));
+    const chatPane = panesOf(grid())[0];
+
+    store().openPage('ses-1', page('page-1'), { excludeTargetId: 'conv-1' });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === chatPane.id)?.scope?.targetId).toBe('conv-1');
+    expect(panes.find((p) => p.scope?.targetId === 'page-1')).toBeDefined();
+  });
+
+  it('still replaces a DIFFERENT replaceable pane when excludeTargetId only protects the invoker', () => {
+    store().ensureWorkspace('ses-1', conv('conv-1'));
+    const chatPane = panesOf(grid())[0];
+    store().splitRight('ses-1', chatPane.id);
+    const otherPane = panesOf(grid()).find((p) => p.id !== chatPane.id)!;
+    store().assignPane('ses-1', otherPane.id, page('page-1'));
+
+    store().openPage('ses-1', page('page-2'), { excludeTargetId: 'conv-1' });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === chatPane.id)?.scope?.targetId).toBe('conv-1');
+    expect(panes.find((p) => p.id === otherPane.id)?.scope?.targetId).toBe('page-2');
   });
 });
 

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
+import { useEditingStore } from '@/stores/useEditingStore';
 import {
   newWorkspace,
   paneShowing,
@@ -61,11 +62,16 @@ interface AgentWorkspaceState {
   openConversation(sessionId: string, scope: PaneScope): void;
   /**
    * Make a PAGE visible in the session's grid — the page-pane sibling of
-   * `openConversation`, sharing its exact focus-or-replace-or-split policy.
-   * Used both by the picker's "Pages" section and by the agent-driven
-   * `open_page_pane` tool's client-side resolution.
+   * `openConversation`, sharing its focus-or-replace-or-split policy (with
+   * two extra guards `openConversation` doesn't need, since a page pane can
+   * hold unsaved edits and can itself BE the conversation that asked to open
+   * it): a pane is never replaceable while its page has an active dirty
+   * `useEditingStore` session, and `excludeTargetId` (the invoking
+   * conversation's own id, for the agent-driven `open_page_pane` path) is
+   * never replaced either — both fall through to a split instead. Used by
+   * the picker's "Pages" section and by `useOpenPagePane`'s resolution.
    */
-  openPage(sessionId: string, scope: PaneScope): void;
+  openPage(sessionId: string, scope: PaneScope, options?: { excludeTargetId?: string }): void;
   splitRight(sessionId: string, fromPaneId: string): void;
   splitDown(sessionId: string, fromPaneId: string): void;
   /**
@@ -123,10 +129,29 @@ function updateWorkspace(
 }
 
 /**
+ * Is `pane` a PAGE pane whose target currently has unsaved edits? Checked
+ * against `useEditingStore` by pageId (not by the pane's own id — the
+ * editing-store componentId carries a per-mount `useId()` suffix the pane
+ * model knows nothing about), so a dirty document/canvas/sheet page is never
+ * silently overwritten by `focusOrAssignScope`'s replace path (only 'document'
+ * and 'form' session types count as dirty for this purpose — see
+ * `useEditingStore.isAnyEditing`'s identical set).
+ */
+function isPaneDirty(pane: PaneState): boolean {
+  if (pane.scope?.kind !== 'page' || pane.scope.targetId === null) return false;
+  const targetPageId = pane.scope.targetId;
+  return useEditingStore
+    .getState()
+    .getActiveSessions()
+    .some((session) => (session.type === 'document' || session.type === 'form') && session.metadata?.pageId === targetPageId);
+}
+
+/**
  * Shared by `openConversation` and `openPage`: make `scope`'s target VISIBLE
  * in the session's grid. Focus the pane already showing it; otherwise replace
  * a replaceable pane (unbound, or bound to a resolved non-terminal row —
- * never a running terminal, which has no reattach UI); otherwise split the
+ * never a running terminal, which has no reattach UI; never one with unsaved
+ * edits; never `options.excludeTargetId`, when given); otherwise split the
  * active pane right. Scope-kind-agnostic: a chat scope and a page scope
  * follow the identical policy, which is why one function serves both.
  */
@@ -134,6 +159,7 @@ function focusOrAssignScope(
   set: (fn: (state: AgentWorkspaceState) => Partial<AgentWorkspaceState>) => void,
   sessionId: string,
   scope: PaneScope,
+  options?: { excludeTargetId?: string },
 ) {
   const state = useAgentWorkspaceStore.getState();
   const workspace = state.workspaces[sessionId];
@@ -154,15 +180,22 @@ function focusOrAssignScope(
   // row. A pane whose mint is still in flight (`targetId === null`) is
   // EXCLUDED even though its kind isn't terminal: landing a different
   // selection there now means the mint's own success callback later
-  // overwrites it with the stale pick (review low-batch #1).
+  // overwrites it with the stale pick (review low-batch #1). Also excluded:
+  // a pane with unsaved edits (`isPaneDirty`), and — when the caller passed
+  // `excludeTargetId` — the pane already showing THAT target (the
+  // `open_page_pane` tool's own invoking conversation must never be evicted
+  // by its own tool call; it should get a split beside it instead).
   const isReplaceable = (pane: PaneState) =>
-    pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null);
+    (pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null)) &&
+    !isPaneDirty(pane) &&
+    (options?.excludeTargetId === undefined || pane.scope?.targetId !== options.excludeTargetId);
   const replaceable = active && isReplaceable(active) ? active : panes.find(isReplaceable);
   if (replaceable) {
     state.assignPane(sessionId, replaceable.id, scope);
     return;
   }
-  // Every pane is a running terminal — open beside them.
+  // Nothing replaceable (every pane is a running terminal, dirty, or the
+  // excluded invoker) — open beside them instead of losing anything.
   set(
     (current) =>
       updateWorkspace(current, sessionId, (w) => {
@@ -195,7 +228,7 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
 
       openConversation: (sessionId, scope) => focusOrAssignScope(set, sessionId, scope),
 
-      openPage: (sessionId, scope) => focusOrAssignScope(set, sessionId, scope),
+      openPage: (sessionId, scope, options) => focusOrAssignScope(set, sessionId, scope, options),
 
       splitRight: (sessionId, fromPaneId) =>
         set(

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -59,6 +59,13 @@ interface AgentWorkspaceState {
    * the active pane right.
    */
   openConversation(sessionId: string, scope: PaneScope): void;
+  /**
+   * Make a PAGE visible in the session's grid — the page-pane sibling of
+   * `openConversation`, sharing its exact focus-or-replace-or-split policy.
+   * Used both by the picker's "Pages" section and by the agent-driven
+   * `open_page_pane` tool's client-side resolution.
+   */
+  openPage(sessionId: string, scope: PaneScope): void;
   splitRight(sessionId: string, fromPaneId: string): void;
   splitDown(sessionId: string, fromPaneId: string): void;
   /**
@@ -115,6 +122,56 @@ function updateWorkspace(
   return { workspaces: { ...state.workspaces, [sessionId]: next } };
 }
 
+/**
+ * Shared by `openConversation` and `openPage`: make `scope`'s target VISIBLE
+ * in the session's grid. Focus the pane already showing it; otherwise replace
+ * a replaceable pane (unbound, or bound to a resolved non-terminal row —
+ * never a running terminal, which has no reattach UI); otherwise split the
+ * active pane right. Scope-kind-agnostic: a chat scope and a page scope
+ * follow the identical policy, which is why one function serves both.
+ */
+function focusOrAssignScope(
+  set: (fn: (state: AgentWorkspaceState) => Partial<AgentWorkspaceState>) => void,
+  sessionId: string,
+  scope: PaneScope,
+) {
+  const state = useAgentWorkspaceStore.getState();
+  const workspace = state.workspaces[sessionId];
+  if (!workspace) {
+    state.ensureWorkspace(sessionId, scope);
+    return;
+  }
+  if (scope.targetId !== null) {
+    const showing = paneShowing(workspace, scope.targetId);
+    if (showing) {
+      state.selectPane(sessionId, showing.id);
+      return;
+    }
+  }
+  const panes = panesOf(workspace);
+  const active = panes.find((pane) => pane.id === workspace.activePaneId);
+  // Replaceable = unbound (picker), or bound to a resolved, non-terminal
+  // row. A pane whose mint is still in flight (`targetId === null`) is
+  // EXCLUDED even though its kind isn't terminal: landing a different
+  // selection there now means the mint's own success callback later
+  // overwrites it with the stale pick (review low-batch #1).
+  const isReplaceable = (pane: PaneState) =>
+    pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null);
+  const replaceable = active && isReplaceable(active) ? active : panes.find(isReplaceable);
+  if (replaceable) {
+    state.assignPane(sessionId, replaceable.id, scope);
+    return;
+  }
+  // Every pane is a running terminal — open beside them.
+  set(
+    (current) =>
+      updateWorkspace(current, sessionId, (w) => {
+        const split = splitRightIn(w, w.activePaneId, mintId('col'), mintId('pane'));
+        return assignPaneIn(split, split.activePaneId, scope);
+      }) ?? {},
+  );
+}
+
 export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
   persist(
     (set) => ({
@@ -136,43 +193,9 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
           };
         }),
 
-      openConversation: (sessionId, scope) => {
-        const state = useAgentWorkspaceStore.getState();
-        const workspace = state.workspaces[sessionId];
-        if (!workspace) {
-          state.ensureWorkspace(sessionId, scope);
-          return;
-        }
-        if (scope.targetId !== null) {
-          const showing = paneShowing(workspace, scope.targetId);
-          if (showing) {
-            state.selectPane(sessionId, showing.id);
-            return;
-          }
-        }
-        const panes = panesOf(workspace);
-        const active = panes.find((pane) => pane.id === workspace.activePaneId);
-        // Replaceable = unbound (picker), or bound to a resolved, non-terminal
-        // row. A pane whose mint is still in flight (`targetId === null`) is
-        // EXCLUDED even though its kind isn't terminal: landing a different
-        // selection there now means the mint's own success callback later
-        // overwrites it with the stale pick (review low-batch #1).
-        const isReplaceable = (pane: PaneState) =>
-          pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null);
-        const replaceable = active && isReplaceable(active) ? active : panes.find(isReplaceable);
-        if (replaceable) {
-          state.assignPane(sessionId, replaceable.id, scope);
-          return;
-        }
-        // Every pane is a running terminal — open beside them.
-        set(
-          (current) =>
-            updateWorkspace(current, sessionId, (w) => {
-              const split = splitRightIn(w, w.activePaneId, mintId('col'), mintId('pane'));
-              return assignPaneIn(split, split.activePaneId, scope);
-            }) ?? {},
-        );
-      },
+      openConversation: (sessionId, scope) => focusOrAssignScope(set, sessionId, scope),
+
+      openPage: (sessionId, scope) => focusOrAssignScope(set, sessionId, scope),
 
       splitRight: (sessionId, fromPaneId) =>
         set(

--- a/packages/lib/src/agent-sessions/__tests__/contract.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/contract.test.ts
@@ -271,11 +271,13 @@ describe('shellSendPayloadSchema', () => {
 });
 
 describe('paneScopeSchema', () => {
-  it('should offer BOTH surfaces — a pane that can only be a terminal makes panes pointless', () => {
+  it('should offer every surface — a pane that can only be a terminal makes panes pointless', () => {
     // The regression this guards: `SHELL_AGENT_TYPES` being PTY-only was read as
     // "the whole pane surface is PTY-only", which removed the ability to open an
     // agent conversation in a pane and left splitting with nothing to split into.
-    expect([...PANE_KINDS].sort()).toEqual(['chat', 'terminal']);
+    // `'page'` extends this the same way: a page pane addresses an existing
+    // PageSpace page directly, so a pane surface still isn't just PTY-only.
+    expect([...PANE_KINDS].sort()).toEqual(['chat', 'page', 'terminal']);
   });
 
   it('should bind a chat pane to a conversation and its agent', () => {

--- a/packages/lib/src/agent-sessions/contract.ts
+++ b/packages/lib/src/agent-sessions/contract.ts
@@ -75,9 +75,14 @@ export type ShellAgentType = z.infer<typeof shellAgentTypeSchema>;
  * a pane is the one place that has to talk about both.
  *
  * `'chat'` addresses a conversation (one thread among the session's many —
- * invariant 1); `'terminal'` addresses a `shellId`.
+ * invariant 1); `'terminal'` addresses a `shellId`; `'page'` addresses a
+ * PageSpace pageId — any non-container, non-chat page type (a document, task
+ * list, sheet, canvas, code file, ...), rendered read/write via the same
+ * page-type dispatch the main content area uses. Unlike `'chat'`/`'terminal'`,
+ * a `'page'` binding mints no row anywhere: the target already exists as a
+ * page, so binding it is a pure client-side assignment.
  */
-export const PANE_KINDS = ['chat', 'terminal'] as const;
+export const PANE_KINDS = ['chat', 'terminal', 'page'] as const;
 
 export const paneKindSchema = z.enum(PANE_KINDS);
 export type PaneKind = z.infer<typeof paneKindSchema>;
@@ -91,7 +96,7 @@ export const paneScopeSchema = z.object({
   kind: paneKindSchema,
   /** Display label — the conversation title or the shell name. Never an address. */
   name: z.string(),
-  /** The conversationId (chat) or shellId (terminal) this pane is bound to. */
+  /** The conversationId (chat), shellId (terminal), or pageId (page) this pane is bound to. */
   targetId: z.string().min(1).nullable(),
   /**
    * Which agent the conversation belongs to, for a `'chat'` pane. Null for a

--- a/packages/lib/src/content/page-types.config.ts
+++ b/packages/lib/src/content/page-types.config.ts
@@ -292,6 +292,17 @@ export function isCodePage(type: PageType): boolean {
   return type === PageType.CODE;
 }
 
+/**
+ * Can this page type be opened as an agent-session PANE (as opposed to only
+ * the main content area)? Excludes `FOLDER` (a tree browser, not content to
+ * edit) and `AI_CHAT` (would nest a chat conversation inside a chat pane) —
+ * every other type has a real standalone editor/viewer that makes sense
+ * beside a conversation.
+ */
+export function isPaneablePageType(type: PageType): boolean {
+  return type !== PageType.FOLDER && type !== PageType.AI_CHAT;
+}
+
 export function getCreatablePageTypes(): PageType[] {
   return Object.values(PAGE_TYPE_CONFIGS).filter(c => !c.experimental).map(c => c.type);
 }


### PR DESCRIPTION
## Summary
- Adds a `'page'` pane kind alongside `chat`/`terminal` so any non-container, non-chat page type (document, task list, sheet, canvas, code, channel, file) can be opened and edited in an agent session's pane grid.
- `PagePaneView` dispatches through the same page-type config `CenterPanel` uses, lazily loading each view via `next/dynamic` (keeps `pdfjs-dist` and other heavy editors out of every pane bundle).
- `PanePicker` gets a debounced "Pages" search section (backed by `/api/mentions/search`, now with a server-side `excludePageTypes` param so FOLDER/AI_CHAT never occupy a slot in its capped result window); `AgentPanes`/`useAgentWorkspaceStore` gain the wiring (`handlePickPage`, `openPage`, sharing `openConversation`'s focus-or-replace-or-split policy) — extended with a dirty-page guard (never silently replaces a pane with unsaved edits) and an `excludeTargetId` guard (never evicts the conversation that itself asked to open a page).
- Fixes a real editing-store key collision: `DocumentView`/`CodePageView`/`CanvasPageView`/`SheetView`/`TaskListView` now suffix their `useEditingStore` registration with `useId()`, so the same page open in the main center panel *and* a pane can no longer clobber each other's dirty-state entry.
- New `open_page_pane` tool lets an agent surface a page pane itself — its `execute()` always acks (the server has no visibility into any browser tab's pane-grid state, which is purely client-local), and a new `useOpenPagePane` hook reacts to the completed result by opening/focusing the pane in the conversation's own session, with guards against replaying historical calls on remount, on a pane-bar conversation switch, and against evicting the invoking conversation. Registered as an ordinary workspace tool (77th), with a rich tool-call card (`OpenPagePaneRenderer`) that describes the action taken ("Requested to open…"), not a claimed outcome.
- `CodePageView` now accepts an optional `driveId` (falls back to the route param, so `CenterPanel`'s existing call site is unaffected) and joins its page's own drive room via `usePageContentSocket`, matching `DocumentView` — needed because a pane can host a code page outside its own drive's route entirely.

### Follow-up commits (post-review, in order)
- `3d4eee4c3` — CI fixes (a knip dead-code finding, a stale `PANE_KINDS` exhaustiveness test) + every first-round Codex/CodeRabbit finding: the invoking-chat eviction bug, the tool-call history-replay bug, a wrong `driveId` passed to `DocumentView`, a missing dirty-pane guard, missing `ReactNode`/`ComponentType` imports, an `isLoading`/`isValidating` SWR bug in the picker.
- `201e1b489` — a second, self-found history-replay instance: switching a pane's bound conversation in place (no remount) could replay a *different* conversation's own history.
- `881ef0847` — URL-encoded the agent-suppliable `pageId` in `PagePaneView`'s fetch.
- `4361529e4` — merged master after sibling PR #2299 ("pane-level Chat/History/Settings tabs") pulled chat rendering into a new `ChatPane` component; resolved the one conflict and threaded `sessionId` into `ChatPane`'s own `PaneChat` call.
- `07af1c482` — a second `@codex review` pass found three more real issues, all fixed: `CodePageView`'s missing driveId/socket-room join, `OpenPagePaneRenderer` overclaiming "Opened" when the tool's ack can't actually know that, and the mentions-search truncation gap in `PanePicker`'s search.
- `99085867a` — CodeRabbit follow-up: pushed the `excludePageTypes` fix into the actual SQL `WHERE` clause (my prior commit only fixed it before the final `.slice(0,10)`, not before the earlier DB-level `.limit(50/20)` fetch).

## Test plan
- [x] `bun run typecheck` / `bun run lint` / `bun run knip:check` (web, @pagespace/lib) — clean throughout
- [x] Full `@pagespace/lib` suite (8682 tests) and the full touched `web` surface (panes/store/hooks/tool-registry/API routes/mentions-search/code view — 198+ tests in the final sweep alone, `AgentPanes.test.tsx`'s 65 post-merge) — all green
- [x] Doc-count guard (`tool-registry-docs.test.ts`) — updated README.md and marketing docs from 76 → 77 workspace tools
- [x] Branch merged with master (post-#2299) — `MERGEABLE`, `CLEAN`, all 10 CI checks green as of `99085867a`
- [x] Two independent review passes (CodeRabbit + `@codex review`) both re-verified and withdrew/resolved every finding they raised
- [ ] Manual: open an agent session, split a pane, search and open a document/task-list/sheet via the new "Pages" section; ask an agent to call `open_page_pane` after editing a page and confirm the pane opens without manual interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaXkcqLXNPp9AnbJVntWqD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI agents can now open supported pages directly in workspace panes.
  * Pane selection supports searching for and opening pages alongside chats and terminals.
  * Existing pages are focused when already open, while new pages open in available panes.
* **Bug Fixes**
  * Improved editing reliability when the same page is open in multiple panes.
  * Prevented duplicate page openings from repeated AI tool results.
* **Documentation**
  * Updated the documented workspace tool count from 76 to 77.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
