### PR TITLE
feat(agents): pane-level Chat/History/Settings tabs (+ history-deleted-send fix)

### DIFF
--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/__tests__/route.test.ts
@@ -58,7 +58,7 @@ describe('POST /api/agent-sessions/[sessionId]/conversations/[conversationId]/re
   it('reopens a closed listing', async () => {
     const response = await post();
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ ok: true });
+    expect(await response.json()).toEqual({ ok: true, alreadyOpen: false });
     expect(mockReopenConversationInSession).toHaveBeenCalledWith({
       conversationId: CONVERSATION_ID,
       sessionId: SESSION_ID,
@@ -73,6 +73,11 @@ describe('POST /api/agent-sessions/[sessionId]/conversations/[conversationId]/re
     mockReopenConversationInSession.mockResolvedValue('already_open');
     const response = await post();
     expect(response.status).toBe(200);
+    // Distinguishes a no-op from a genuine transition — a caller that races
+    // this response with a supersession must know whether it's safe to roll
+    // the listing back out (review finding — chatgpt-codex-connector on
+    // PR #2299, round 15).
+    expect(await response.json()).toEqual({ ok: true, alreadyOpen: true });
     expect(mockAuditRequest).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ eventType: 'data.write' }),

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/reopen/route.ts
@@ -74,5 +74,13 @@ export async function POST(request: Request, context: RouteContext) {
     });
   }
 
-  return NextResponse.json({ ok: true });
+  // `alreadyOpen` (outcome === 'already_open'): this call did NOT transition
+  // the listing — it was already open (e.g. a different pane, tab, or an
+  // agent switch that left it open but unshown). The caller needs this to
+  // know whether it's safe to roll the listing back out if THIS request
+  // turns out to be superseded — doing so unconditionally would close a
+  // listing the request never actually opened, possibly still in use
+  // elsewhere (review finding — chatgpt-codex-connector on PR #2299,
+  // round 15).
+  return NextResponse.json({ ok: true, alreadyOpen: outcome === 'already_open' });
 }

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -68,19 +68,28 @@ vi.mock('@pagespace/db/db', () => {
     pageTreeScope: null,
     revision: 0,
   };
+  const dbLike = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => {
+          const result = Promise.resolve([pageRow]);
+          return Object.assign(result, {
+            orderBy: vi.fn().mockResolvedValue([]),
+            limit: vi.fn().mockResolvedValue([]),
+            // The route's atomic active-conversation re-check
+            // (`.where(...).for('update').limit(1)`) — active by default,
+            // this suite isn't about that race.
+            for: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ isActive: true }]) })),
+          });
+        }),
+      })),
+    })),
+  };
   return {
     db: {
-      select: vi.fn(() => ({
-        from: vi.fn(() => ({
-          where: vi.fn(() => {
-            const result = Promise.resolve([pageRow]);
-            return Object.assign(result, {
-              orderBy: vi.fn().mockResolvedValue([]),
-              limit: vi.fn().mockResolvedValue([]),
-            });
-          }),
-        })),
-      })),
+      ...dbLike,
+      // A transaction runs its callback against the same db-like shape.
+      transaction: vi.fn(async (callback: (tx: typeof dbLike) => Promise<unknown>) => callback(dbLike)),
     },
   };
 });

--- a/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
@@ -77,19 +77,28 @@ vi.mock('@pagespace/db/db', () => {
     sandboxEnabled: true,
     revision: 0,
   };
+  const dbLike = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => {
+          const result = Promise.resolve([pageRow]);
+          return Object.assign(result, {
+            orderBy: vi.fn().mockResolvedValue([]),
+            limit: vi.fn().mockResolvedValue([]),
+            // The route's atomic active-conversation re-check
+            // (`.where(...).for('update').limit(1)`) — active by default,
+            // this suite isn't about that race.
+            for: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ isActive: true }]) })),
+          });
+        }),
+      })),
+    })),
+  };
   return {
     db: {
-      select: vi.fn(() => ({
-        from: vi.fn(() => ({
-          where: vi.fn(() => {
-            const result = Promise.resolve([pageRow]);
-            return Object.assign(result, {
-              orderBy: vi.fn().mockResolvedValue([]),
-              limit: vi.fn().mockResolvedValue([]),
-            });
-          }),
-        })),
-      })),
+      ...dbLike,
+      // A transaction runs its callback against the same db-like shape.
+      transaction: vi.fn(async (callback: (tx: typeof dbLike) => Promise<unknown>) => callback(dbLike)),
     },
   };
 });

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -100,8 +100,19 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 
-vi.mock('@pagespace/db/db', () => ({
-  db: {
+// Read dynamically (not closure-captured) by the `for('update').limit()` mock
+// below, so a test can simulate a concurrent History-delete committing
+// between the route's early ownership check and its late, lock-guarded
+// re-check — flip false, call POST, flip back in the next test's beforeEach.
+const mockConversationActiveAtLockTime = vi.hoisted(() => ({ current: true }));
+
+vi.mock('@pagespace/db/db', () => {
+  // Reused inside `transaction()`'s callback too — `tx` needs the identical
+  // shape as `db` since `saveMessageToDatabase`'s `dbClient` override (and
+  // the route's own locked active-conversation SELECT, run immediately
+  // before the first message's persist) run against whichever one the
+  // caller passed in.
+  const makeDbLike = () => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
@@ -111,22 +122,39 @@ vi.mock('@pagespace/db/db', () => ({
           ) => Promise.resolve([mockDbRow]).then(resolve, reject),
           orderBy: vi.fn().mockResolvedValue([]),
           limit: vi.fn().mockResolvedValue([{ displayName: 'Profile User', drivePrompt: null }]),
+          // The route's atomic active-conversation re-check — active by
+          // default so the happy-path tests below don't each need their
+          // own override.
+          for: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([{ isActive: mockConversationActiveAtLockTime.current }])),
+          })),
         })),
       })),
     })),
     // Server Stream Durability epic PR 2: assistant placeholder row insert at stream start.
     insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
-  },
-  // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
-  // exactly as before. Its own retry/degrade behavior is covered by
-  // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
-  getAdvisoryLockPool: vi.fn(() => ({
-    connect: vi.fn(async () => ({
-      query: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
-      release: vi.fn(),
+  });
+
+  const dbLike = makeDbLike();
+  // A transaction runs its callback against a FRESH db-like object, same as
+  // a real transaction's `tx` is a distinct client from `db`.
+  const transaction = vi.fn(async (callback: (tx: ReturnType<typeof makeDbLike>) => Promise<unknown>) => {
+    return callback(makeDbLike());
+  });
+
+  return {
+    db: { ...dbLike, transaction },
+    // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
+    // exactly as before. Its own retry/degrade behavior is covered by
+    // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
+    getAdvisoryLockPool: vi.fn(() => ({
+      connect: vi.fn(async () => ({
+        query: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
+        release: vi.fn(),
+      })),
     })),
-  })),
-}));
+  };
+});
 
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), ne: vi.fn(), and: vi.fn() }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id' } }));
@@ -134,6 +162,9 @@ vi.mock('@pagespace/db/schema/core', () => ({
   chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt' },
   pages: { id: 'id' },
   drives: { id: 'id', drivePrompt: 'drivePrompt' },
+}));
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: { id: 'id', isActive: 'isActive' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
   userProfiles: { userId: 'userId', displayName: 'displayName' },
@@ -387,6 +418,7 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     mockGetConversation.mockResolvedValue(null);
     mockHasConflictingMessageOwner.mockResolvedValue(false);
     mockTakeOverConversationStreams.mockResolvedValue({ aborted: [], reconciled: [] });
+    mockConversationActiveAtLockTime.current = true;
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     mockCreateStreamLifecycle.mockResolvedValue({
       pushPart: mockLifecyclePushPart,
@@ -559,6 +591,26 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
 
       expect(response.status).not.toBe(404);
       expect(mockCreateStreamLifecycle).toHaveBeenCalled();
+    });
+
+    // The race the isActive: false check above cannot catch on its own: the
+    // conversation looks active at the EARLY ownership check (this test's
+    // mockGetConversation), but a concurrent History-delete commits sometime
+    // in the credit-gate/mention/command-resolution work that follows —
+    // before saveMessageToDatabase runs. The atomic, lock-guarded re-check
+    // immediately adjacent to that write (not the early snapshot) is what
+    // must catch this (review finding — chatgpt-codex-connector and
+    // coderabbitai on PR #2299).
+    it('given the conversation looked active at the early check but a concurrent History-delete committed before the message write, should 404 and never invoke the lifecycle', async () => {
+      mockGetConversation.mockResolvedValue({
+        id: CONV_ID, userId: 'user-1', isShared: false, contextId: 'page-1', isActive: true,
+      });
+      mockConversationActiveAtLockTime.current = false;
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).toBe(404);
+      expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -105,6 +105,11 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 // between the route's early ownership check and its late, lock-guarded
 // re-check — flip false, call POST, flip back in the next test's beforeEach.
 const mockConversationActiveAtLockTime = vi.hoisted(() => ({ current: true }));
+// Separate from the flag above: false simulates NO row at all (the eager
+// createConversation() call for a brand-new conversation failed, tolerated
+// as best-effort) rather than a row that exists and is explicitly inactive
+// — the two must be told apart (round 10 review finding).
+const mockConversationRowExistsAtLockTime = vi.hoisted(() => ({ current: true }));
 
 vi.mock('@pagespace/db/db', () => {
   // Reused inside `transaction()`'s callback too — `tx` needs the identical
@@ -126,7 +131,13 @@ vi.mock('@pagespace/db/db', () => {
           // default so the happy-path tests below don't each need their
           // own override.
           for: vi.fn(() => ({
-            limit: vi.fn(() => Promise.resolve([{ isActive: mockConversationActiveAtLockTime.current }])),
+            limit: vi.fn(() =>
+              Promise.resolve(
+                mockConversationRowExistsAtLockTime.current
+                  ? [{ isActive: mockConversationActiveAtLockTime.current }]
+                  : [],
+              ),
+            ),
           })),
         })),
       })),
@@ -420,6 +431,7 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     mockHasConflictingMessageOwner.mockResolvedValue(false);
     mockTakeOverConversationStreams.mockResolvedValue({ aborted: [], reconciled: [] });
     mockConversationActiveAtLockTime.current = true;
+    mockConversationRowExistsAtLockTime.current = true;
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     mockCreateStreamLifecycle.mockResolvedValue({
       pushPart: mockLifecyclePushPart,
@@ -654,6 +666,26 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
 
       await POST(makeRequest({ conversationId: CONV_ID }));
 
+      expect(loggers.ai.warn).not.toHaveBeenCalledWith(
+        'AI Chat API: skipped placeholder assistant row, conversation no longer active',
+        expect.anything(),
+      );
+    });
+
+    // round 10 review finding — chatgpt-codex-connector on PR #2299: a
+    // brand-new conversation's eager createConversation() call (tolerated
+    // best-effort) can fail, leaving NO row in `conversations` at all —
+    // distinct from a row that exists and was explicitly deactivated by a
+    // History delete. Treating "no row" the same as "inactive" here would
+    // silently drop the assistant's reply while the user's own message
+    // (saved via the unguarded new-conversation path) still persists.
+    it('given a brand-new conversation whose eager createConversation() call failed (no row exists), should NOT skip the placeholder insert', async () => {
+      mockGetConversation.mockResolvedValue(null); // brand-new — no existing row
+      mockConversationRowExistsAtLockTime.current = false;
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).not.toBe(404);
       expect(loggers.ai.warn).not.toHaveBeenCalledWith(
         'AI Chat API: skipped placeholder assistant row, conversation no longer active',
         expect.anything(),
@@ -1058,6 +1090,31 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
         userId: null,
         role: 'assistant',
       });
+    });
+
+    // round 10 review finding — chatgpt-codex-connector on PR #2299: a
+    // brand-new conversation's eager createConversation() call is tolerated
+    // best-effort (see that call site) — if it fails, NO row exists in
+    // `conversations` at all, distinct from a row that exists and was
+    // explicitly deactivated. saveTerminalAssistantMessage's own atomic
+    // re-check must not treat the two the same, or the assistant's reply
+    // silently vanishes (streamed to the user, gone on refresh) while their
+    // own message — saved via the unguarded new-conversation path — sticks.
+    it('given no conversations row exists at execute-end time (brand-new conversation, failed eager create), should still persist the assistant reply', async () => {
+      mockGetConversation.mockResolvedValue(null); // brand-new — no existing row
+      mockConversationRowExistsAtLockTime.current = false;
+      mockCreateStreamLifecycle.mockResolvedValueOnce({
+        pushPart: mockLifecyclePushPart,
+        finish: mockLifecycleFinish,
+        getBufferedParts: vi.fn().mockReturnValue([{ type: 'text', text: 'server reply' }]),
+      });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      const saveCalls = mockSaveMessageToDatabase.mock.calls;
+      const assistantSave = saveCalls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
+      expect(assistantSave).toBeDefined();
     });
 
     // CodeRabbit review: this used to be a "should NOT persist" test — but skipping the

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -532,6 +532,34 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
       expect(response.status).not.toBe(403);
       expect(mockCreateStreamLifecycle).toHaveBeenCalled();
     });
+
+    // A conversation whose CANONICAL row is history-deleted (isActive: false) must never
+    // accept a new message: the send would appear to succeed while the row stays excluded
+    // from every open/closed session listing, leaving the new transcript unreachable once
+    // the stale pane refreshes (review finding — chatgpt-codex-connector on PR #2296, filed
+    // after History-delete was changed to deactivate the canonical row, not just its
+    // messages).
+    it('given an existing conversation row that is isActive: false (history-deleted), should 404 and never invoke the lifecycle', async () => {
+      mockGetConversation.mockResolvedValue({
+        id: CONV_ID, userId: 'user-1', isShared: false, contextId: 'page-1', isActive: false,
+      });
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).toBe(404);
+      expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
+    });
+
+    it('given an existing conversation row that is isActive: true, should NOT be rejected on that basis', async () => {
+      mockGetConversation.mockResolvedValue({
+        id: CONV_ID, userId: 'user-1', isShared: false, contextId: 'page-1', isActive: true,
+      });
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).not.toBe(404);
+      expect(mockCreateStreamLifecycle).toHaveBeenCalled();
+    });
   });
 
   // AC5 — takeover, never 409. This route called takeOverConversationStreams and NOTHING asserted

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -110,6 +110,13 @@ const mockConversationActiveAtLockTime = vi.hoisted(() => ({ current: true }));
 // as best-effort) rather than a row that exists and is explicitly inactive
 // — the two must be told apart (round 10 review finding).
 const mockConversationRowExistsAtLockTime = vi.hoisted(() => ({ current: true }));
+// The round-12 in-transaction claim insert (`.insert(conversations).values(...)
+// .onConflictDoNothing().returning(...)`), reached only when the flag above is
+// false. Defaults to "this insert won, row is active" so the round-10/11
+// no-row tests keep proceeding normally; a test simulating a concurrent
+// winner sets this to `[]` (conflict — nothing returned) and relies on the
+// `for('update').limit()` mock above for the follow-up winner re-select.
+const mockConversationClaimInsertRows = vi.hoisted(() => ({ current: [{ isActive: true }] as Array<{ isActive: boolean }> }));
 
 vi.mock('@pagespace/db/db', () => {
   // Reused inside `transaction()`'s callback too — `tx` needs the identical
@@ -142,8 +149,34 @@ vi.mock('@pagespace/db/db', () => {
         })),
       })),
     })),
-    // Server Stream Durability epic PR 2: assistant placeholder row insert at stream start.
-    insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+    // Server Stream Durability epic PR 2: assistant placeholder row insert at
+    // stream start (a plain, directly-awaited insert). Round 12's in-
+    // transaction claim insert for a missing conversations row additionally
+    // chains `.onConflictDoNothing().returning(...)` off the same `values()`
+    // call — the returned object supports both: awaiting it directly
+    // resolves like the plain insert, and it also exposes the chain.
+    insert: vi.fn(() => ({
+      values: vi.fn(() => {
+        const chain = {
+          then: <T>(
+            resolve?: ((value: undefined) => T | PromiseLike<T>) | null,
+            reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
+          ) => Promise.resolve(undefined).then(resolve, reject),
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() => {
+              const rows = mockConversationClaimInsertRows.current;
+              // An empty result means a CONCURRENT insert won the conflict —
+              // which by definition means a row exists now, for the
+              // production code's own follow-up winner re-select (via the
+              // same for('update').limit() mock above) to find.
+              if (rows.length === 0) mockConversationRowExistsAtLockTime.current = true;
+              return Promise.resolve(rows);
+            }),
+          })),
+        };
+        return chain;
+      }),
+    })),
   });
 
   const dbLike = makeDbLike();
@@ -432,6 +465,7 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     mockTakeOverConversationStreams.mockResolvedValue({ aborted: [], reconciled: [] });
     mockConversationActiveAtLockTime.current = true;
     mockConversationRowExistsAtLockTime.current = true;
+    mockConversationClaimInsertRows.current = [{ isActive: true }];
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     mockCreateStreamLifecycle.mockResolvedValue({
       pushPart: mockLifecyclePushPart,
@@ -641,6 +675,36 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
       mockGetConversation.mockResolvedValue(null); // legacy: no row at the early check
       mockConversationRowExistsAtLockTime.current = true; // ...but the eager create found/made one
       mockConversationActiveAtLockTime.current = false; // ...and it's now inactive
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).toBe(404);
+      expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
+    });
+
+    // round 12 review finding — chatgpt-codex-connector on PR #2299: `FOR
+    // UPDATE` on a SELECT that returns zero rows locks nothing at all — the
+    // round 10/11 "no row → proceed" tolerance closed the wrong-rejection
+    // bug but reopened a DIFFERENT one: with nothing locked, a concurrent
+    // create-then-delete for the same conversationId had no serialization
+    // to catch it. The write must now claim/create the row INSIDE this same
+    // transaction so something is actually locked before proceeding.
+    it('given no row exists and this transaction wins the claim-insert, should proceed (not reject)', async () => {
+      mockGetConversation.mockResolvedValue(null);
+      mockConversationRowExistsAtLockTime.current = false;
+      mockConversationClaimInsertRows.current = [{ isActive: true }]; // this insert wins
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).not.toBe(404);
+      expect(mockCreateStreamLifecycle).toHaveBeenCalled();
+    });
+
+    it('given no row exists and a CONCURRENT insert wins the claim race, should re-check the winner and 404 if it is inactive', async () => {
+      mockGetConversation.mockResolvedValue(null);
+      mockConversationRowExistsAtLockTime.current = false; // no row at the FIRST select
+      mockConversationClaimInsertRows.current = []; // conflict — someone else's insert won
+      mockConversationActiveAtLockTime.current = false; // ...and the winner's row is inactive
 
       const response = await POST(makeRequest({ conversationId: CONV_ID }));
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -337,6 +337,7 @@ import { authenticateRequestWithOptions } from '@/lib/auth';
 import type { SessionAuthResult } from '@/lib/auth';
 import { MAX_BROWSER_SESSION_ID_LENGTH } from '@/lib/ai/core/browser-session-id-validation';
 import { createStreamAbortController } from '@/lib/ai/core/stream-abort-registry';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /** A signal that reports aborted=true — simulates onAbort having already fired. */
 const abortedSignal = (): AbortSignal => {
@@ -611,6 +612,52 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
 
       expect(response.status).toBe(404);
       expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
+    });
+  });
+
+  // The user-message write's atomic re-check above only covers that ONE write. The
+  // 'streaming' placeholder row inserted right after createStreamLifecycle resolves is a
+  // SEPARATE, later write, with its own window for a concurrent History-delete to land in
+  // between (review finding — chatgpt-codex-connector on PR #2299, round 7).
+  describe('assistant placeholder row (stream start) — atomic re-check', () => {
+    it('given the conversation looked active through the message write but a concurrent History-delete commits before the placeholder insert, should skip the insert without failing the request', async () => {
+      mockGetConversation.mockResolvedValue({
+        id: CONV_ID, userId: 'user-1', isShared: false, contextId: 'page-1', isActive: true,
+      });
+      mockCreateStreamLifecycle.mockImplementationOnce(async () => {
+        // The user-message write above already ran (and saw isActive: true) by this
+        // point — flipping here simulates the delete committing in the window between
+        // that write and this stream-start placeholder insert.
+        mockConversationActiveAtLockTime.current = false;
+        return {
+          pushPart: mockLifecyclePushPart,
+          finish: mockLifecycleFinish,
+          getBufferedParts: vi.fn().mockReturnValue([]),
+        };
+      });
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      // Best-effort, same as an insert failure: the generation still proceeds.
+      expect(response.status).not.toBe(404);
+      expect(mockCreateStreamLifecycle).toHaveBeenCalled();
+      expect(loggers.ai.warn).toHaveBeenCalledWith(
+        'AI Chat API: skipped placeholder assistant row, conversation no longer active',
+        expect.objectContaining({ conversationId: CONV_ID }),
+      );
+    });
+
+    it('given the conversation is still active at placeholder-insert time, should NOT skip (no false-positive warning)', async () => {
+      mockGetConversation.mockResolvedValue({
+        id: CONV_ID, userId: 'user-1', isShared: false, contextId: 'page-1', isActive: true,
+      });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(loggers.ai.warn).not.toHaveBeenCalledWith(
+        'AI Chat API: skipped placeholder assistant row, conversation no longer active',
+        expect.anything(),
+      );
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -625,6 +625,28 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
       expect(response.status).toBe(404);
       expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
     });
+
+    // round 11 review finding — chatgpt-codex-connector on PR #2299: a LEGACY
+    // conversation (messages exist, but no `conversations` row — the early
+    // ownership check's mockGetConversation resolves null, same as a
+    // genuinely brand-new one) has its row created by the EAGER, best-effort
+    // createConversation() call a few lines below that check. The guard used
+    // to be gated on the early null snapshot and skip the lock entirely for
+    // this case — missing the window between that eager create succeeding
+    // and this write, where a concurrent History-delete could land with
+    // nothing to catch it. The guard now always runs; a row that exists NOW
+    // (even though the early snapshot found none) and is inactive must still
+    // 404.
+    it('given a legacy conversation whose row the eager createConversation() call just produced, but a concurrent History-delete then deactivated it before this write, should 404', async () => {
+      mockGetConversation.mockResolvedValue(null); // legacy: no row at the early check
+      mockConversationRowExistsAtLockTime.current = true; // ...but the eager create found/made one
+      mockConversationActiveAtLockTime.current = false; // ...and it's now inactive
+
+      const response = await POST(makeRequest({ conversationId: CONV_ID }));
+
+      expect(response.status).toBe(404);
+      expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
+    });
   });
 
   // The user-message write's atomic re-check above only covers that ONE write. The

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -235,7 +235,18 @@ export async function POST(request: Request) {
         .where(eq(conversations.id, args.conversationId))
         .for('update')
         .limit(1);
-      if (!row?.isActive) return false;
+      // `row` is undefined for a brand-new conversation whose eager
+      // `createConversation()` call (above, before generation started)
+      // failed — deliberately tolerated there (best-effort/non-fatal, see
+      // that call site) so the user's own message still saves and
+      // generation still proceeds. Treating "no row" the same as
+      // "explicitly inactive" here would then silently drop the assistant's
+      // reply too: the user sees it stream in, then loses it on refresh
+      // while their own prompt remains (review finding — chatgpt-codex-
+      // connector on PR #2299). Only skip when a row exists AND is
+      // explicitly inactive (a real History-delete) — an absent row is not
+      // that, it's the same tolerated gap the user message already crossed.
+      if (row && !row.isActive) return false;
       await saveMessageToDatabase({ ...args, ...(mentionNotify && { mentionNotify }), dbClient: tx });
       return true;
     });
@@ -1523,7 +1534,13 @@ export async function POST(request: Request) {
                 .where(eq(conversations.id, conversationId!))
                 .for('update')
                 .limit(1);
-              if (!row?.isActive) return false;
+              // See saveTerminalAssistantMessage's own comment above: `row`
+              // undefined means the eager createConversation() call earlier
+              // in this request failed (tolerated, best-effort) — not that
+              // History deleted it. Only an explicitly inactive row is a
+              // real delete (review finding — chatgpt-codex-connector on
+              // PR #2299, round 10).
+              if (row && !row.isActive) return false;
               await tx.insert(chatMessages).values({
                 id: serverAssistantMessageId!,
                 pageId: chatId!,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -43,6 +43,20 @@ import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPP
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+/**
+ * The conversation was still active at the ownership check far above, but a
+ * concurrent History-delete committed sometime in the (long, I/O-heavy) gap
+ * between that check and the user-message persist below. Thrown from inside
+ * the short, tightly-scoped transaction that re-verifies immediately
+ * adjacent to the write — see that call site's own comment.
+ */
+class ConversationHistoryDeletedError extends Error {
+  constructor() {
+    super('Conversation has been deleted from history');
+    this.name = 'ConversationHistoryDeletedError';
+  }
+}
 // canUserViewPage stays user-level here: it gates mention-notification RECIPIENTS
 // (other users), not the requesting principal.
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
@@ -94,6 +108,7 @@ import { db } from '@pagespace/db/db'
 import { eq, and, ne } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { chatMessages, pages, drives } from '@pagespace/db/schema/core';
+import { conversations } from '@pagespace/db/schema/conversations';
 import { userProfiles } from '@pagespace/db/schema/members';
 import { createId, isCuid } from '@paralleldrive/cuid2';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -703,17 +718,54 @@ export async function POST(request: Request) {
 
         loggers.ai.debug('AI Chat API: Saving user message immediately', { id: messageId, contentLength: messageContent.length });
 
-        await saveMessageToDatabase({
-          messageId,
-          pageId: chatId,
-          conversationId,
-          userId,
-          role: 'user',
-          content: messageContent,
-          toolCalls: undefined,
-          toolResults: undefined,
-          uiMessage: userMessage,
-        });
+        if (existingConversation) {
+          // Atomic re-check immediately adjacent to the write: `existingConversation`
+          // was read (and validated active) far above, but the credit-gate check,
+          // @mention processing, and command resolution in between all do their own
+          // unrelated I/O — plenty of room for a concurrent History-delete to commit
+          // in that gap. A `SELECT ... FOR UPDATE` + the insert in ONE short
+          // transaction (not wrapping any of the intervening work, which must never
+          // run inside an open transaction) closes that window rather than trusting
+          // the stale earlier read (review finding — chatgpt-codex-connector on PR
+          // #2299). Gated on `existingConversation`: a brand-new conversation has no
+          // row to race against yet (or, per the eager-create call above, may have
+          // none at all — that failure is explicitly tolerated/non-fatal there, and
+          // this check must not turn it into a hard rejection).
+          await db.transaction(async (tx) => {
+            const [row] = await tx
+              .select({ isActive: conversations.isActive })
+              .from(conversations)
+              .where(eq(conversations.id, conversationId!))
+              .for('update')
+              .limit(1);
+            if (!row?.isActive) throw new ConversationHistoryDeletedError();
+
+            await saveMessageToDatabase({
+              messageId,
+              pageId: chatId!,
+              conversationId: conversationId!,
+              userId: userId!,
+              role: 'user',
+              content: messageContent,
+              toolCalls: undefined,
+              toolResults: undefined,
+              uiMessage: userMessage,
+              dbClient: tx,
+            });
+          });
+        } else {
+          await saveMessageToDatabase({
+            messageId,
+            pageId: chatId,
+            conversationId,
+            userId,
+            role: 'user',
+            content: messageContent,
+            toolCalls: undefined,
+            toolResults: undefined,
+            uiMessage: userMessage,
+          });
+        }
 
         // Fire-and-forget: title derivation must never fail or delay the chat
         // response, matching how createConversation above is treated as
@@ -762,6 +814,9 @@ export async function POST(request: Request) {
             .catch((err) => loggers.ai.error('AI Chat: Failed to expand mentions', err as Error));
         }
       } catch (error) {
+        if (error instanceof ConversationHistoryDeletedError) {
+          return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+        }
         loggers.ai.error('AI Chat API: Failed to save user message', error as Error);
         return NextResponse.json({
           error: 'Failed to save message to database',

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -754,54 +754,47 @@ export async function POST(request: Request) {
 
         loggers.ai.debug('AI Chat API: Saving user message immediately', { id: messageId, contentLength: messageContent.length });
 
-        if (existingConversation) {
-          // Atomic re-check immediately adjacent to the write: `existingConversation`
-          // was read (and validated active) far above, but the credit-gate check,
-          // @mention processing, and command resolution in between all do their own
-          // unrelated I/O — plenty of room for a concurrent History-delete to commit
-          // in that gap. A `SELECT ... FOR UPDATE` + the insert in ONE short
-          // transaction (not wrapping any of the intervening work, which must never
-          // run inside an open transaction) closes that window rather than trusting
-          // the stale earlier read (review finding — chatgpt-codex-connector on PR
-          // #2299). Gated on `existingConversation`: a brand-new conversation has no
-          // row to race against yet (or, per the eager-create call above, may have
-          // none at all — that failure is explicitly tolerated/non-fatal there, and
-          // this check must not turn it into a hard rejection).
-          await db.transaction(async (tx) => {
-            const [row] = await tx
-              .select({ isActive: conversations.isActive })
-              .from(conversations)
-              .where(eq(conversations.id, conversationId!))
-              .for('update')
-              .limit(1);
-            if (!row?.isActive) throw new ConversationHistoryDeletedError();
+        // Atomic re-check immediately adjacent to the write: `existingConversation`
+        // (if any) was read far above, but the credit-gate check, @mention
+        // processing, and command resolution in between all do their own
+        // unrelated I/O — plenty of room for a concurrent History-delete to commit
+        // in that gap. A `SELECT ... FOR UPDATE` + the insert in ONE short
+        // transaction (not wrapping any of the intervening work, which must never
+        // run inside an open transaction) closes that window rather than trusting
+        // the stale earlier read (review finding — chatgpt-codex-connector on PR
+        // #2299).
+        //
+        // Unconditional — NOT gated on `existingConversation` (that snapshot
+        // predates the eager createConversation() call a few lines up, and
+        // stayed null for BOTH "genuinely no row anywhere yet" and "a LEGACY
+        // conversation whose row that eager call just created": skipping the
+        // lock for the second case let a concurrent History-delete land between
+        // that create and this write with nothing to catch it — review finding,
+        // round 11). `row` undefined here means no row exists even now (the
+        // eager create's own failure, tolerated/non-fatal there) — not a
+        // History-delete, so only an explicitly inactive row blocks the write.
+        await db.transaction(async (tx) => {
+          const [row] = await tx
+            .select({ isActive: conversations.isActive })
+            .from(conversations)
+            .where(eq(conversations.id, conversationId!))
+            .for('update')
+            .limit(1);
+          if (row && !row.isActive) throw new ConversationHistoryDeletedError();
 
-            await saveMessageToDatabase({
-              messageId,
-              pageId: chatId!,
-              conversationId: conversationId!,
-              userId: userId!,
-              role: 'user',
-              content: messageContent,
-              toolCalls: undefined,
-              toolResults: undefined,
-              uiMessage: userMessage,
-              dbClient: tx,
-            });
-          });
-        } else {
           await saveMessageToDatabase({
             messageId,
-            pageId: chatId,
-            conversationId,
-            userId,
+            pageId: chatId!,
+            conversationId: conversationId!,
+            userId: userId!,
             role: 'user',
             content: messageContent,
             toolCalls: undefined,
             toolResults: undefined,
             uiMessage: userMessage,
+            dbClient: tx,
           });
-        }
+        });
 
         // Fire-and-forget: title derivation must never fail or delay the chat
         // response, matching how createConversation above is treated as

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1507,19 +1507,44 @@ export async function POST(request: Request) {
         // itself still proceeds.
         if (!streamLifecycle.preAborted) {
           try {
-            await db.insert(chatMessages).values({
-              id: serverAssistantMessageId!,
-              pageId: chatId!,
-              conversationId: conversationId!,
-              role: 'assistant',
-              content: '',
-              toolCalls: null,
-              toolResults: null,
-              isActive: true,
-              userId: null,
-              sourceAgentId: null,
-              status: 'streaming',
+            // Same atomic re-check as saveTerminalAssistantMessage above: a History delete
+            // permitted between the user-message write and here would otherwise let this
+            // best-effort insert plant an isActive:true 'streaming' row under a conversation
+            // already gone from every listing — and since the row is BRAND NEW here (not yet
+            // existing for saveTerminalAssistantMessage's own isActive check to catch via its
+            // upsert), that later check finding the conversation inactive would just skip its
+            // update, leaving this row stuck at 'streaming' forever. Visible again, permanently
+            // "in progress", the moment this PR's reopen feature brings the conversation back
+            // (review finding — chatgpt-codex-connector on PR #2299).
+            const conversationActive = await db.transaction(async (tx) => {
+              const [row] = await tx
+                .select({ isActive: conversations.isActive })
+                .from(conversations)
+                .where(eq(conversations.id, conversationId!))
+                .for('update')
+                .limit(1);
+              if (!row?.isActive) return false;
+              await tx.insert(chatMessages).values({
+                id: serverAssistantMessageId!,
+                pageId: chatId!,
+                conversationId: conversationId!,
+                role: 'assistant',
+                content: '',
+                toolCalls: null,
+                toolResults: null,
+                isActive: true,
+                userId: null,
+                sourceAgentId: null,
+                status: 'streaming',
+              });
+              return true;
             });
+            if (!conversationActive) {
+              loggers.ai.warn('AI Chat API: skipped placeholder assistant row, conversation no longer active', {
+                messageId: serverAssistantMessageId,
+                conversationId,
+              });
+            }
           } catch (error) {
             loggers.ai.warn('AI Chat API: placeholder assistant row INSERT failed', {
               messageId: serverAssistantMessageId,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -213,8 +213,33 @@ export async function POST(request: Request) {
     args: Omit<Parameters<typeof saveMessageToDatabase>[0], 'mentionNotify'>,
   ): Promise<void> => {
     const mentionNotify = mentionNotifyFor(args.content);
-    await saveMessageToDatabase({ ...args, ...(mentionNotify && { mentionNotify }) });
-    if (mentionNotify) mentionNotified = true;
+    // The SAME atomic re-check the user's own message write uses, applied
+    // here too: the earlier lock only covers the moment the user's message
+    // was persisted, and model generation between then and THIS terminal
+    // write can run for seconds — plenty of room for a History delete
+    // (permitted the whole time; nothing else in this route blocks it mid-
+    // generation) to land in between. Without this, the assistant's reply
+    // persists as an ACTIVE message beneath a conversation already excluded
+    // from every session listing — generation the user cancelled by
+    // deleting the conversation, billed and answered into a transcript
+    // they can no longer reach (review finding — chatgpt-codex-connector on
+    // PR #2299). A deleted conversation silently drops the reply rather
+    // than persisting it as orphaned; the provider call itself already
+    // happened and is billed/tracked independently of this write via the
+    // usual trackUsage path, which this does not touch — only what gets
+    // WRITTEN to the (now-gone) conversation's transcript.
+    const persisted = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({ isActive: conversations.isActive })
+        .from(conversations)
+        .where(eq(conversations.id, args.conversationId))
+        .for('update')
+        .limit(1);
+      if (!row?.isActive) return false;
+      await saveMessageToDatabase({ ...args, ...(mentionNotify && { mentionNotify }), dbClient: tx });
+      return true;
+    });
+    if (persisted && mentionNotify) mentionNotified = true;
   };
   // Captured by the inner catch (createUIMessageStream construction failure) BEFORE it calls
   // lifecycle.finish() — finish() deletes the multicast registry entry getBufferedParts() reads

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -547,6 +547,21 @@ export async function POST(request: Request) {
           return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
         }
       } else {
+        // A history-deleted row (`conversations.isActive: false`) must never
+        // accept a new message — the send would appear to succeed while the
+        // canonical row stays excluded from both open and closed session
+        // listings, leaving the new transcript unreachable after the stale
+        // pane refreshes. This is reachable now that History-delete
+        // deactivates the CANONICAL row (not just its messages) while a
+        // conversation can still be open in another pane or browser tab
+        // (review finding — chatgpt-codex-connector on PR #2296).
+        if (existingConversation.isActive === false) {
+          loggers.ai.warn('AI Chat API: rejected send to a history-deleted conversation', {
+            userId,
+            requestConversationId,
+          });
+          return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+        }
         const ownsIt = existingConversation.userId === userId;
         const isSharedConversation = existingConversation.isShared === true;
         // contextId is nullable in the schema (null for global conversations), so only

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -770,9 +770,7 @@ export async function POST(request: Request) {
         // conversation whose row that eager call just created": skipping the
         // lock for the second case let a concurrent History-delete land between
         // that create and this write with nothing to catch it — review finding,
-        // round 11). `row` undefined here means no row exists even now (the
-        // eager create's own failure, tolerated/non-fatal there) — not a
-        // History-delete, so only an explicitly inactive row blocks the write.
+        // round 11).
         await db.transaction(async (tx) => {
           const [row] = await tx
             .select({ isActive: conversations.isActive })
@@ -780,7 +778,53 @@ export async function POST(request: Request) {
             .where(eq(conversations.id, conversationId!))
             .for('update')
             .limit(1);
-          if (row && !row.isActive) throw new ConversationHistoryDeletedError();
+
+          if (row) {
+            if (!row.isActive) throw new ConversationHistoryDeletedError();
+          } else {
+            // `FOR UPDATE` on zero rows locks nothing — if the eager
+            // createConversation() call above hasn't landed a row yet (raced
+            // with a concurrent request, or failed), there is nothing here
+            // yet for the lock to serialize against: a concurrent create
+            // (this request's own eager call, or another request's) plus a
+            // History-delete could still interleave between here and the
+            // message insert below, unguarded. Idempotently claim/create the
+            // row IN THIS transaction instead — same create-then-select-the-
+            // winner pattern resolveOrCreateConversation already uses for
+            // the global route — so something is always actually locked
+            // before the write proceeds (review finding — chatgpt-codex-
+            // connector on PR #2299, round 12). Mirrors createConversation's
+            // own insert shape/defaults exactly, since a caller landing here
+            // supplied no `opts`.
+            const [created] = await tx
+              .insert(conversations)
+              .values({
+                id: conversationId!,
+                userId: userId!,
+                type: 'page',
+                contextId: chatId!,
+                isShared: false,
+                sessionId: null,
+                title: null,
+                updatedAt: new Date(),
+              })
+              .onConflictDoNothing()
+              .returning({ isActive: conversations.isActive });
+
+            if (created) {
+              if (!created.isActive) throw new ConversationHistoryDeletedError();
+            } else {
+              // A concurrent insert won the race — re-select, locked, same
+              // reasoning as the initial SELECT above.
+              const [winner] = await tx
+                .select({ isActive: conversations.isActive })
+                .from(conversations)
+                .where(eq(conversations.id, conversationId!))
+                .for('update')
+                .limit(1);
+              if (!winner?.isActive) throw new ConversationHistoryDeletedError();
+            }
+          }
 
           await saveMessageToDatabase({
             messageId,

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
@@ -142,6 +142,7 @@ vi.mock('../resolve-or-create-conversation', () => ({
     isNew: false,
   }),
   ConversationOwnershipError: class ConversationOwnershipError extends Error {},
+  ConversationHistoryDeletedError: class ConversationHistoryDeletedError extends Error {},
 }));
 vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'id', drivePrompt: 'drivePrompt' } }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { __label: 'users', id: 'id', name: 'name', subscriptionTier: 'subscriptionTier' } }));
@@ -304,7 +305,7 @@ vi.mock('@/lib/ai/core/compaction/prepare-context', () => ({
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import type { SessionAuthResult } from '@/lib/auth';
-import { resolveOrCreateConversation } from '../resolve-or-create-conversation';
+import { resolveOrCreateConversation, ConversationHistoryDeletedError } from '../resolve-or-create-conversation';
 
 const mockAuth = (): SessionAuthResult => ({
   userId: 'user-1',
@@ -352,5 +353,16 @@ describe('POST /api/ai/global/[id]/messages — conversation identity resolution
     await POST(makeRequest({}), makeContext());
 
     expect(resolveOrCreateConversation).toHaveBeenCalledWith('user-1', 'url-conv-id');
+  });
+
+  // The lazy-create race fallback can resolve to a history-deleted row (see
+  // resolve-or-create-conversation.test.ts for the mechanism) — the route must
+  // translate that into the same 404 an ownership mismatch gets, not a 500.
+  it('given resolveOrCreateConversation rejects with ConversationHistoryDeletedError, should 404', async () => {
+    vi.mocked(resolveOrCreateConversation).mockRejectedValueOnce(new ConversationHistoryDeletedError());
+
+    const response = await POST(makeRequest({}), makeContext());
+
+    expect(response.status).toBe(404);
   });
 });

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -94,28 +94,41 @@ const mockUserProfile = { displayName: 'Display User' };
 const mockAuthUser = { name: 'Auth User', subscriptionTier: 'free' };
 
 vi.mock('@pagespace/db/db', () => {
-  const select = vi.fn(() => ({
-    from: vi.fn((table: unknown) => {
-      const tableLabel = table as { __label?: string } | undefined;
-      const isUsers = tableLabel?.__label === 'users';
-      return {
-        where: vi.fn(() => ({
-          then: <T>(
-            resolve?: ((value: unknown[]) => T | PromiseLike<T>) | null,
-            reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
-          ) => Promise.resolve(isUsers ? [mockAuthUser] : [mockConversation]).then(resolve, reject),
-          orderBy: vi.fn().mockResolvedValue([]),
-          limit: vi.fn().mockResolvedValue(isUsers ? [mockAuthUser] : [mockUserProfile]),
-        })),
-      };
-    }),
-  }));
-  const insert = vi.fn(() => ({
-    values: vi.fn(() => ({
-      onConflictDoUpdate: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'msg-1' }]) })),
-    })),
-  }));
-  const update = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }));
+  // Reused inside `transaction()`'s callback too — see the identical
+  // pattern (and its own doc) in stream-socket-events.test.ts's db mock.
+  const makeDbLike = () => {
+    const select = vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        const tableLabel = table as { __label?: string } | undefined;
+        const isUsers = tableLabel?.__label === 'users';
+        const isConversations = tableLabel?.__label === 'conversations';
+        return {
+          where: vi.fn(() => ({
+            then: <T>(
+              resolve?: ((value: unknown[]) => T | PromiseLike<T>) | null,
+              reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
+            ) => Promise.resolve(isUsers ? [mockAuthUser] : [mockConversation]).then(resolve, reject),
+            orderBy: vi.fn().mockResolvedValue([]),
+            limit: vi.fn().mockResolvedValue(isUsers ? [mockAuthUser] : [mockUserProfile]),
+            for: vi.fn(() => ({
+              limit: vi.fn().mockResolvedValue(isConversations ? [{ isActive: true }] : [mockConversation]),
+            })),
+          })),
+        };
+      }),
+    }));
+    const insert = vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'msg-1' }]) })),
+      })),
+    }));
+    const update = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }));
+    return { select, insert, update };
+  };
+  const dbLike = makeDbLike();
+  const transaction = vi.fn(async (callback: (tx: ReturnType<typeof makeDbLike>) => Promise<unknown>) => {
+    return callback(makeDbLike());
+  });
   // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
   // exactly as before. Its own retry/degrade behavior is covered by
   // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
@@ -125,7 +138,7 @@ vi.mock('@pagespace/db/db', () => {
       release: vi.fn(),
     })),
   }));
-  return { db: { select, insert, update }, getAdvisoryLockPool };
+  return { db: { ...dbLike, transaction }, getAdvisoryLockPool };
 });
 
 vi.mock('@pagespace/db/operators', () => ({
@@ -139,11 +152,12 @@ vi.mock('../resolve-or-create-conversation', () => ({
     isNew: false,
   }),
   ConversationOwnershipError: class ConversationOwnershipError extends Error {},
+  ConversationHistoryDeletedError: class ConversationHistoryDeletedError extends Error {},
 }));
 vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'id', drivePrompt: 'drivePrompt' } }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { __label: 'users', id: 'id', name: 'name', subscriptionTier: 'subscriptionTier' } }));
 vi.mock('@pagespace/db/schema/conversations', () => ({
-  conversations: { id: 'id', userId: 'userId', isActive: 'isActive', lastMessageAt: 'lastMessageAt', updatedAt: 'updatedAt', title: 'title' },
+  conversations: { __label: 'conversations', id: 'id', userId: 'userId', isActive: 'isActive', lastMessageAt: 'lastMessageAt', updatedAt: 'updatedAt', title: 'title' },
   messages: { conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt', id: 'id' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
@@ -16,7 +16,12 @@ vi.mock('@pagespace/db/schema/conversations', () => ({
   },
 }));
 
-import { resolveOrCreateConversation, ConversationOwnershipError, ConversationBindingConflictError } from '../resolve-or-create-conversation';
+import {
+  resolveOrCreateConversation,
+  ConversationOwnershipError,
+  ConversationBindingConflictError,
+  ConversationHistoryDeletedError,
+} from '../resolve-or-create-conversation';
 
 const makeDb = (selectResult: object[], insertResult: object[] = []) => ({
   select: vi.fn().mockReturnValue({
@@ -125,6 +130,41 @@ describe('resolveOrCreateConversation', () => {
     const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
     expect(result).toEqual({ conversation: winner, isNew: true });
     expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  // The initial SELECT filters isActive: true, so a history-deleted row reads as "no
+  // existing row" and falls into this same insert-then-conflict path — the INSERT
+  // collides with the inactive row's id, onConflictDoNothing swallows it, and the
+  // fallback "who won the race" select has no isActive filter of its own. Without this
+  // guard it would silently hand back the STALE INACTIVE row mislabeled isNew: true,
+  // letting a caller resume sending into a conversation excluded from every session
+  // listing (review finding — chatgpt-codex-connector on PR #2296, the same class of
+  // bug fixed on the page-agent send route via an explicit isActive check).
+  it('given the conflict winner is a history-deleted (isActive: false) row, throws ConversationHistoryDeletedError', async () => {
+    const deletedWinner = { ...CONV, isActive: false };
+    const db = {
+      select: vi.fn()
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        })
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([deletedWinner]) }),
+          }),
+        }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    };
+    await expect(
+      resolveOrCreateConversation('user1', 'conv1', db as never)
+    ).rejects.toThrow(ConversationHistoryDeletedError);
   });
 });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
@@ -23,14 +23,22 @@ import {
   ConversationHistoryDeletedError,
 } from '../resolve-or-create-conversation';
 
-const makeDb = (selectResult: object[], insertResult: object[] = []) => ({
-  select: vi.fn().mockReturnValue({
-    from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(selectResult),
+// The real query chain is `.select().from().where().for('update').limit()` —
+// row-locked so a caller wrapping this in an explicit transaction can
+// serialize against a concurrent History-delete (see resolve-or-create-
+// conversation.ts's own doc on the `.for('update')` calls).
+const selectChain = (result: object[]) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn().mockReturnValue({
+      for: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(result),
       }),
     }),
   }),
+});
+
+const makeDb = (selectResult: object[], insertResult: object[] = []) => ({
+  select: vi.fn().mockReturnValue(selectChain(selectResult)),
   insert: vi.fn().mockReturnValue({
     values: vi.fn().mockReturnValue({
       onConflictDoNothing: vi.fn().mockReturnValue({
@@ -61,13 +69,7 @@ describe('resolveOrCreateConversation', () => {
   it('given existing conversation owned by a different user, throws ConversationOwnershipError', async () => {
     const otherUserConv = { ...CONV, userId: 'user2' };
     const db = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([otherUserConv]),
-          }),
-        }),
-      }),
+      select: vi.fn().mockReturnValue(selectChain([otherUserConv])),
       insert: vi.fn(),
     };
     await expect(
@@ -108,17 +110,9 @@ describe('resolveOrCreateConversation', () => {
     const db = {
       select: vi.fn()
         // First call: no existing row (triggers insert path)
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
-          }),
-        })
+        .mockReturnValueOnce(selectChain([]))
         // Second call: fallback select finds the winner
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([winner]) }),
-          }),
-        }),
+        .mockReturnValueOnce(selectChain([winner])),
       insert: vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
           onConflictDoNothing: vi.fn().mockReturnValue({
@@ -144,16 +138,8 @@ describe('resolveOrCreateConversation', () => {
     const deletedWinner = { ...CONV, isActive: false };
     const db = {
       select: vi.fn()
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
-          }),
-        })
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([deletedWinner]) }),
-          }),
-        }),
+        .mockReturnValueOnce(selectChain([]))
+        .mockReturnValueOnce(selectChain([deletedWinner])),
       insert: vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
           onConflictDoNothing: vi.fn().mockReturnValue({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -556,7 +556,7 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
       // Best-effort, same as an insert failure: the generation still proceeds.
       expect(response.status).not.toBe(404);
       expect(mockCreateStreamLifecycle).toHaveBeenCalled();
-      expect(loggers.ai.warn).toHaveBeenCalledWith(
+      expect(loggers.api.warn).toHaveBeenCalledWith(
         'Global AI messages API: skipped placeholder assistant row, conversation no longer active',
         expect.objectContaining({ conversationId: 'conv-1' }),
       );
@@ -565,7 +565,7 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
     it('given the conversation is still active at placeholder-insert time, should NOT skip (no false-positive warning)', async () => {
       await POST(makeRequest(), makeContext());
 
-      expect(loggers.ai.warn).not.toHaveBeenCalledWith(
+      expect(loggers.api.warn).not.toHaveBeenCalledWith(
         'Global AI messages API: skipped placeholder assistant row, conversation no longer active',
         expect.anything(),
       );

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -405,6 +405,7 @@ import { MAX_BROWSER_SESSION_ID_LENGTH } from '@/lib/ai/core/browser-session-id-
 import { createStreamAbortController } from '@/lib/ai/core/stream-abort-registry';
 import { db } from '@pagespace/db/db';
 import { conversations } from '@pagespace/db/schema/conversations';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /** A signal that reports aborted=true — simulates onAbort having already fired. */
 const abortedSignal = (): AbortSignal => {
@@ -529,6 +530,45 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
 
       expect(response.status).toBe(404);
       expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
+    });
+  });
+
+  // The user-message write's atomic re-check above only covers that ONE write. The
+  // 'streaming' placeholder row inserted right after createStreamLifecycle resolves is a
+  // SEPARATE, later write, with its own window for a concurrent History-delete to land in
+  // between (review finding — chatgpt-codex-connector on PR #2299, round 7).
+  describe('assistant placeholder row (stream start) — atomic re-check', () => {
+    it('given the conversation looked active through the message write but a concurrent History-delete commits before the placeholder insert, should skip the insert without failing the request', async () => {
+      mockCreateStreamLifecycle.mockImplementationOnce(async () => {
+        // The user-message write above already ran (and saw isActive: true) by this
+        // point — flipping here simulates the delete committing in the window between
+        // that write and this stream-start placeholder insert.
+        mockConversationActiveAtLockTime.current = false;
+        return {
+          pushPart: mockLifecyclePushPart,
+          finish: mockLifecycleFinish,
+          getBufferedParts: vi.fn().mockReturnValue([]),
+        };
+      });
+
+      const response = await POST(makeRequest(), makeContext());
+
+      // Best-effort, same as an insert failure: the generation still proceeds.
+      expect(response.status).not.toBe(404);
+      expect(mockCreateStreamLifecycle).toHaveBeenCalled();
+      expect(loggers.ai.warn).toHaveBeenCalledWith(
+        'Global AI messages API: skipped placeholder assistant row, conversation no longer active',
+        expect.objectContaining({ conversationId: 'conv-1' }),
+      );
+    });
+
+    it('given the conversation is still active at placeholder-insert time, should NOT skip (no false-positive warning)', async () => {
+      await POST(makeRequest(), makeContext());
+
+      expect(loggers.ai.warn).not.toHaveBeenCalledWith(
+        'Global AI messages API: skipped placeholder assistant row, conversation no longer active',
+        expect.anything(),
+      );
     });
   });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -94,37 +94,74 @@ const mockConversation = {
 const mockUserProfile = { displayName: 'Display User' };
 const mockAuthUser = { name: 'Auth User' };
 
+// Read dynamically (not closure-captured) by the `for('update').limit()` mock
+// below, so a test can simulate a concurrent History-delete committing
+// between resolveOrCreateConversation's earlier resolve and the route's
+// late, lock-guarded re-check — flip false, call POST, reset in beforeEach.
+const mockConversationActiveAtLockTime = vi.hoisted(() => ({ current: true }));
+
 vi.mock('@pagespace/db/db', () => {
-  const select = vi.fn(() => ({
-    from: vi.fn((table: unknown) => {
-      const tableLabel = table as { __label?: string } | undefined;
-      const isUsers = tableLabel?.__label === 'users';
-      return {
-        where: vi.fn(() => ({
-          then: <T>(
-            resolve?: ((value: unknown[]) => T | PromiseLike<T>) | null,
-            reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
-          ) => Promise.resolve([mockConversation]).then(resolve, reject),
-          orderBy: vi.fn().mockResolvedValue([]),
-          limit: vi.fn().mockResolvedValue(isUsers ? [mockAuthUser] : [mockUserProfile]),
+  // Reused inside `transaction()`'s callback too — `tx` needs the identical
+  // shape as `db` since `saveGlobalAssistantMessageToDatabase`'s `dbClient`
+  // override (and the route's own locked SELECT) run against whichever one
+  // the caller passed in.
+  const makeDbLike = () => {
+    const select = vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        const tableLabel = table as { __label?: string } | undefined;
+        const isUsers = tableLabel?.__label === 'users';
+        const isConversations = tableLabel?.__label === 'conversations';
+        return {
+          where: vi.fn(() => ({
+            then: <T>(
+              resolve?: ((value: unknown[]) => T | PromiseLike<T>) | null,
+              reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
+            ) => Promise.resolve([mockConversation]).then(resolve, reject),
+            orderBy: vi.fn().mockResolvedValue([]),
+            limit: vi.fn().mockResolvedValue(isUsers ? [mockAuthUser] : [mockUserProfile]),
+            // The route's atomic active-conversation re-check
+            // (`.where(...).for('update').limit(1)`, run inside a
+            // transaction right before the first message's persist) —
+            // active by default so the happy-path tests below don't each
+            // need their own override.
+            for: vi.fn(() => ({
+              limit: vi.fn(() =>
+                Promise.resolve(
+                  isConversations ? [{ isActive: mockConversationActiveAtLockTime.current }] : [mockConversation],
+                ),
+              ),
+            })),
+          })),
+        };
+      }),
+    }));
+
+    const insert = vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{ id: 'msg-1' }]),
         })),
-      };
-    }),
-  }));
-
-  const insert = vi.fn(() => ({
-    values: vi.fn(() => ({
-      onConflictDoUpdate: vi.fn(() => ({
-        returning: vi.fn().mockResolvedValue([{ id: 'msg-1' }]),
       })),
-    })),
-  }));
+    }));
 
-  const update = vi.fn(() => ({
-    set: vi.fn(() => ({
-      where: vi.fn().mockResolvedValue(undefined),
-    })),
-  }));
+    const update = vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue(undefined),
+      })),
+    }));
+
+    return { select, insert, update };
+  };
+
+  const dbLike = makeDbLike();
+  // A transaction runs its callback against a FRESH db-like object (its own
+  // mock-call history), same as a real transaction's `tx` is a distinct
+  // client from `db` — tests asserting call counts on the outer `db` mock
+  // (e.g. `db.update`) stay accurate; assertions that need calls made
+  // *inside* a transaction read from this.
+  const transaction = vi.fn(async (callback: (tx: ReturnType<typeof makeDbLike>) => Promise<unknown>) => {
+    return callback(makeDbLike());
+  });
 
   // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
   // exactly as before. Its own retry/degrade behavior is covered by
@@ -137,7 +174,7 @@ vi.mock('@pagespace/db/db', () => {
   }));
 
   return {
-    db: { select, insert, update },
+    db: { ...dbLike, transaction },
     getAdvisoryLockPool,
   };
 });
@@ -160,6 +197,7 @@ vi.mock('../resolve-or-create-conversation', () => ({
     isNew: false,
   }),
   ConversationOwnershipError: class ConversationOwnershipError extends Error {},
+  ConversationHistoryDeletedError: class ConversationHistoryDeletedError extends Error {},
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -171,7 +209,7 @@ vi.mock('@pagespace/db/schema/auth', () => ({
 }));
 
 vi.mock('@pagespace/db/schema/conversations', () => ({
-  conversations: { id: 'id', userId: 'userId', isActive: 'isActive', lastMessageAt: 'lastMessageAt', updatedAt: 'updatedAt', title: 'title' },
+  conversations: { __label: 'conversations', id: 'id', userId: 'userId', isActive: 'isActive', lastMessageAt: 'lastMessageAt', updatedAt: 'updatedAt', title: 'title' },
   messages: { conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt', id: 'id' },
 }));
 
@@ -416,6 +454,7 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
     vi.clearAllMocks();
     captured.createUIMessageStreamOptions = {};
     captured.streamTextOptions = {};
+    mockConversationActiveAtLockTime.current = true;
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     mockCreateStreamLifecycle.mockResolvedValue({
       pushPart: mockLifecyclePushPart,
@@ -470,6 +509,26 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
       );
       expect(mockTakeOverConversationStreams.mock.invocationCallOrder[0])
         .toBeLessThan(mockCreateStreamLifecycle.mock.invocationCallOrder[0]);
+    });
+  });
+
+  // resolveOrCreateConversation resolved this conversation as active (the
+  // mocked `resolve-or-create-conversation` module always returns
+  // isActive: true), but the credit-gate check, @mention processing, and
+  // command resolution that follow all do their own unrelated I/O — plenty
+  // of room for a concurrent History-delete to commit before
+  // saveGlobalAssistantMessageToDatabase runs. The atomic, lock-guarded
+  // re-check immediately adjacent to that write is what must catch this,
+  // not the earlier resolve (review finding — chatgpt-codex-connector and
+  // coderabbitai on PR #2299).
+  describe('atomic re-check before the first message write', () => {
+    it('given a concurrent History-delete committed after resolution but before the write, should 404 and never invoke the lifecycle', async () => {
+      mockConversationActiveAtLockTime.current = false;
+
+      const response = await POST(makeRequest(), makeContext());
+
+      expect(response.status).toBe(404);
+      expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
@@ -24,6 +24,26 @@ export class ConversationBindingConflictError extends Error {
   }
 }
 
+/**
+ * The id resolves to a row, but it has been history-deleted
+ * (`isActive: false`) — reachable via the concurrent-insert fallback below:
+ * the initial SELECT filters `isActive: true` (so a history-deleted row
+ * reads as "does not exist"), the INSERT then collides on the id's primary
+ * key and is swallowed by `onConflictDoNothing`, and the fallback SELECT
+ * that resolves "who won the race" has no `isActive` filter at all — so it
+ * silently returns the STALE INACTIVE row, mislabeled `isNew: true`, and
+ * the caller would persist a new message beneath a conversation excluded
+ * from every session listing (same class of bug as the page-agent send
+ * route's missing isActive check — review finding, chatgpt-codex-connector
+ * on PR #2296).
+ */
+export class ConversationHistoryDeletedError extends Error {
+  constructor() {
+    super('Conversation has been deleted from history');
+    this.name = 'ConversationHistoryDeletedError';
+  }
+}
+
 // CUID2 format: starts with lowercase letter, followed by 1–31 lowercase alphanumeric chars.
 const CUID2_RE = /^[a-z][a-z0-9]{1,31}$/;
 
@@ -108,6 +128,7 @@ export async function resolveOrCreateConversation(
     .limit(1);
 
   if (!winner) throw new Error(`Failed to resolve conversation ${conversationId}`);
+  if (!winner.isActive) throw new ConversationHistoryDeletedError();
   if (winner.userId !== userId) throw new ConversationOwnershipError();
   if (opts?.sessionId !== undefined && winner.sessionId !== opts.sessionId) {
     // The racing insert won without our binding — same refusal as any other

--- a/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
@@ -86,6 +86,17 @@ export async function resolveOrCreateConversation(
     throw new ConversationOwnershipError();
   }
 
+  // `FOR UPDATE` — a no-op standalone (each statement is its own implicit
+  // transaction), but when the caller wraps this call in an explicit
+  // `db.transaction()` alongside the first message's persist, it locks the
+  // row for the transaction's duration: a concurrent History-delete's
+  // `UPDATE conversations SET isActive = false ...` on the SAME row blocks
+  // until this transaction commits (or, if the delete's UPDATE landed
+  // first, this SELECT blocks until IT commits and then correctly re-reads
+  // isActive: false). Without this, the isActive check and the message
+  // insert are two independent statements with an unguarded gap between
+  // them — exactly the race this exists to close (review finding —
+  // chatgpt-codex-connector and coderabbitai on PR #2299).
   const [existing] = await db
     .select()
     .from(conversations)
@@ -93,6 +104,7 @@ export async function resolveOrCreateConversation(
       eq(conversations.id, conversationId),
       eq(conversations.isActive, true),
     ))
+    .for('update')
     .limit(1);
 
   if (existing) {
@@ -120,11 +132,13 @@ export async function resolveOrCreateConversation(
 
   if (created) return { conversation: created, isNew: true };
 
-  // A concurrent insert won the race — select the winner.
+  // A concurrent insert won the race — select the winner. Locked for the same
+  // reason as the initial SELECT above.
   const [winner] = await db
     .select()
     .from(conversations)
     .where(eq(conversations.id, conversationId))
+    .for('update')
     .limit(1);
 
   if (!winner) throw new Error(`Failed to resolve conversation ${conversationId}`);

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -1248,17 +1248,40 @@ CONVERSATION TYPE: ${conversation.type.toUpperCase()}${conversation.contextId ? 
         // itself still proceeds.
         if (!streamLifecycle.preAborted) {
           try {
-            await db.insert(messages).values({
-              id: serverAssistantMessageId,
-              conversationId,
-              userId,
-              role: 'assistant',
-              content: '',
-              toolCalls: null,
-              toolResults: null,
-              isActive: true,
-              status: 'streaming',
+            // Same atomic re-check as saveTerminalGlobalAssistantMessage: a History delete
+            // permitted between the user-message write and here would otherwise let this
+            // best-effort insert plant an isActive:true 'streaming' row under a conversation
+            // already gone from every listing — and since the row is BRAND NEW here, the later
+            // terminal-write check finding the conversation inactive would just skip its
+            // update, leaving this row stuck at 'streaming' forever, visible again the moment
+            // the conversation is reopened (review finding — chatgpt-codex-connector on PR #2299).
+            const conversationActive = await db.transaction(async (tx) => {
+              const [row] = await tx
+                .select({ isActive: conversations.isActive })
+                .from(conversations)
+                .where(eq(conversations.id, conversationId))
+                .for('update')
+                .limit(1);
+              if (!row?.isActive) return false;
+              await tx.insert(messages).values({
+                id: serverAssistantMessageId,
+                conversationId,
+                userId,
+                role: 'assistant',
+                content: '',
+                toolCalls: null,
+                toolResults: null,
+                isActive: true,
+                status: 'streaming',
+              });
+              return true;
             });
+            if (!conversationActive) {
+              loggers.ai.warn('Global AI messages API: skipped placeholder assistant row, conversation no longer active', {
+                messageId: serverAssistantMessageId,
+                conversationId,
+              });
+            }
           } catch (error) {
             loggers.ai.warn('Global AI messages API: placeholder assistant row INSERT failed', {
               messageId: serverAssistantMessageId,

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -1277,13 +1277,13 @@ CONVERSATION TYPE: ${conversation.type.toUpperCase()}${conversation.contextId ? 
               return true;
             });
             if (!conversationActive) {
-              loggers.ai.warn('Global AI messages API: skipped placeholder assistant row, conversation no longer active', {
+              loggers.api.warn('Global AI messages API: skipped placeholder assistant row, conversation no longer active', {
                 messageId: serverAssistantMessageId,
                 conversationId,
               });
             }
           } catch (error) {
-            loggers.ai.warn('Global AI messages API: placeholder assistant row INSERT failed', {
+            loggers.api.warn('Global AI messages API: placeholder assistant row INSERT failed', {
               messageId: serverAssistantMessageId,
               conversationId,
               error: error instanceof Error ? error.message : 'unknown',

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -93,7 +93,11 @@ import {
   withCacheBreakpoints,
 } from '@/lib/ai/core/prompt-assembly';
 import { prepareHistoryForModel, finishModelRequest } from '@/lib/ai/core/context-assembly';
-import { resolveOrCreateConversation, ConversationOwnershipError } from './resolve-or-create-conversation';
+import {
+  resolveOrCreateConversation,
+  ConversationOwnershipError,
+  ConversationHistoryDeletedError,
+} from './resolve-or-create-conversation';
 import { deriveConversationTitle } from '@/lib/repositories/derive-conversation-title';
 
 // Allow streaming responses up to 5 minutes
@@ -333,7 +337,7 @@ export async function POST(
     try {
       ({ conversation, isNew: conversationIsNew } = await resolveOrCreateConversation(userId, conversationId));
     } catch (e) {
-      if (e instanceof ConversationOwnershipError) {
+      if (e instanceof ConversationOwnershipError || e instanceof ConversationHistoryDeletedError) {
         return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
       }
       throw e;

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -274,6 +274,39 @@ export async function POST(
   // pre-generation exit (auth/permission/provider/save failure) doesn't strand the
   // reservation against the user's balance + in-flight cap until the cron sweeps it.
   let holdHandedOff = false;
+  // The SAME atomic re-check the user's own message write uses (this
+  // route's own earlier `db.transaction` around the FIRST message), applied
+  // here too: that lock only covers the moment the user's message was
+  // persisted, and model generation between then and a TERMINAL write can
+  // run for seconds — plenty of room for a History delete (permitted the
+  // whole time; nothing else in this route blocks it mid-generation) to
+  // land in between. Without this, the assistant's reply persists as an
+  // ACTIVE message beneath a conversation already excluded from every
+  // session listing — generation the user cancelled by deleting the
+  // conversation, answered into a transcript they can no longer reach
+  // (review finding — chatgpt-codex-connector on PR #2299, filed against
+  // the page-agent chat route's identical gap; the same class of bug here
+  // too). A deleted conversation silently drops the reply rather than
+  // persisting it as orphaned; the provider call itself already happened
+  // and is billed/tracked independently via the usual trackUsage path,
+  // which this does not touch — only what gets WRITTEN to the (now-gone)
+  // conversation's transcript. One shared choke point (all 3 terminal-write
+  // sites below route through it) rather than three separate re-checks.
+  const saveTerminalGlobalAssistantMessage = async (
+    args: Parameters<typeof saveGlobalAssistantMessageToDatabase>[0],
+  ): Promise<boolean> => {
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({ isActive: conversations.isActive })
+        .from(conversations)
+        .where(eq(conversations.id, args.conversationId))
+        .for('update')
+        .limit(1);
+      if (!row?.isActive) return false;
+      await saveGlobalAssistantMessageToDatabase({ ...args, dbClient: tx });
+      return true;
+    });
+  };
   try {
     loggers.api.debug('Global Assistant Chat API: Starting request processing', {});
 
@@ -1387,7 +1420,7 @@ CONVERSATION TYPE: ${conversation.type.toUpperCase()}${conversation.contextId ? 
           const aborted = isRunAborted({ agentRun, abortSignal });
           const payload = buildAssistantPersistencePayload(serverAssistantMessageId, bufferedParts);
           try {
-            await saveGlobalAssistantMessageToDatabase({
+            await saveTerminalGlobalAssistantMessage({
               messageId: serverAssistantMessageId,
               conversationId,
               userId,
@@ -1452,7 +1485,7 @@ CONVERSATION TYPE: ${conversation.type.toUpperCase()}${conversation.contextId ? 
               toolResultsCount: extractedToolResults.length,
             });
 
-            await saveGlobalAssistantMessageToDatabase({
+            await saveTerminalGlobalAssistantMessage({
               messageId,
               conversationId,
               userId,
@@ -1592,7 +1625,7 @@ CONVERSATION TYPE: ${conversation.type.toUpperCase()}${conversation.contextId ? 
     if (!assistantMessagePersisted && cleanupContext && lifecycle && !lifecycle.preAborted) {
       try {
         const payload = buildAssistantPersistencePayload(cleanupContext.serverAssistantMessageId, bufferedPartsAtError);
-        await saveGlobalAssistantMessageToDatabase({
+        await saveTerminalGlobalAssistantMessage({
           messageId: cleanupContext.serverAssistantMessageId,
           conversationId: cleanupContext.conversationId,
           userId: cleanupContext.userId,

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -514,15 +514,34 @@ export async function POST(
 
         loggers.api.debug('Global Assistant Chat API: Saving user message immediately', { id: messageId, contentLength: messageContent.length });
         
-        await saveGlobalAssistantMessageToDatabase({
-          messageId,
-          conversationId,
-          userId,
-          role: 'user',
-          content: messageContent,
-          toolCalls: undefined,
-          toolResults: undefined,
-          uiMessage: userMessage, // Pass UIMessage to preserve part ordering
+        // Atomic re-check immediately adjacent to the write: `resolveOrCreateConversation`
+        // resolved this conversation as active well above, but the credit-gate check,
+        // @mention processing, and command resolution in between all do their own
+        // unrelated I/O — plenty of room for a concurrent History-delete to commit in
+        // that gap. A `SELECT ... FOR UPDATE` + the insert in ONE short transaction (not
+        // wrapping any of the intervening work, which must never run inside an open
+        // transaction) closes that window rather than trusting the stale earlier read
+        // (review finding — chatgpt-codex-connector and coderabbitai on PR #2299).
+        await db.transaction(async (tx) => {
+          const [row] = await tx
+            .select({ isActive: conversations.isActive })
+            .from(conversations)
+            .where(eq(conversations.id, conversationId))
+            .for('update')
+            .limit(1);
+          if (!row?.isActive) throw new ConversationHistoryDeletedError();
+
+          await saveGlobalAssistantMessageToDatabase({
+            messageId,
+            conversationId,
+            userId,
+            role: 'user',
+            content: messageContent,
+            toolCalls: undefined,
+            toolResults: undefined,
+            uiMessage: userMessage, // Pass UIMessage to preserve part ordering
+            dbClient: tx,
+          });
         });
 
         auditRequest(request, { eventType: 'data.write', userId, resourceType: 'global_chat_message', resourceId: conversationId, details: {
@@ -553,6 +572,9 @@ export async function POST(
         
         loggers.api.debug('Global Assistant Chat API: User message saved to database', {});
       } catch (error) {
+        if (error instanceof ConversationHistoryDeletedError) {
+          return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+        }
         loggers.api.error('Global Assistant Chat API: Failed to save user message', error as Error);
         return NextResponse.json({
           error: 'Failed to save message to database',

--- a/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
@@ -66,6 +66,7 @@ const mockConversationSummary = (overrides: Partial<{
   contextId: string | null;
   lastMessageAt: Date;
   createdAt: Date;
+  sessionId: string | null;
 }> = {}) => ({
   id: overrides.id ?? 'conv_123',
   title: overrides.title ?? 'Test Conversation',
@@ -73,6 +74,7 @@ const mockConversationSummary = (overrides: Partial<{
   contextId: overrides.contextId ?? null,
   lastMessageAt: overrides.lastMessageAt ?? new Date(),
   createdAt: overrides.createdAt ?? new Date(),
+  sessionId: overrides.sessionId ?? null,
 });
 
 const createRequest = () =>

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -51,6 +51,7 @@ import { AgentIntegrationsPanel } from '@/components/ai/page-agents/AgentIntegra
 import { PageWebhooksDialog } from '@/components/shared/PageWebhooksDialog';
 import { useProviderSettings } from '@/lib/ai/shared/hooks/useProviderSettings';
 import { useConversations } from '@/lib/ai/shared/hooks/useConversations';
+import { useAgentConfig } from '@/lib/ai/shared/hooks/useAgentConfig';
 import { buildAgentSelectionUrl } from '@/lib/agents/agent-selection';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useAuth } from '@/hooks/useAuth';
@@ -68,7 +69,6 @@ import AgentPanes from './panes/AgentPanes';
 import { agentSessionsKey, isAgentSessionsKey, type SessionListEntry } from './panes/session-conversations';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import type { TreePage } from '@/hooks/usePageTree';
-import type { AgentConfig } from '@/lib/ai/shared/chat-types';
 
 export interface AgentPageViewProps {
   page: TreePage;
@@ -162,32 +162,16 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
     window.history.replaceState({}, '', url.toString());
   }, [searchParams]);
   const [webhooksOpen, setWebhooksOpen] = useState(false);
-  const [agentConfig, setAgentConfig] = useState<AgentConfig | null>(null);
+  // SWR-backed and keyed by `page.id` — shared with every pane showing this
+  // agent's Settings tab (see `useAgentConfig`'s own doc), not a private
+  // per-instance fetch.
+  const { config: agentConfig, setConfig: setAgentConfig } = useAgentConfig(page.id);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
   const agentSettingsRef = useRef<PageAgentSettingsTabRef>(null);
 
   const isReadOnly = usePermissionsCheck(page.id, user?.id);
 
   const { agent, isLoading: agentLoading, error: agentError, retry: retryAgent } = useResolvedAgent(page.id);
-
-  // The Settings tab's data: PageAgentSettingsTab renders its loading state
-  // until `config` arrives, so this fetch is what makes Settings (and Save)
-  // work at all — the AiChatView effect this page's rewrite dropped, restored.
-  useEffect(() => {
-    const controller = new AbortController();
-    (async () => {
-      try {
-        const response = await fetchWithAuth(`/api/pages/${page.id}/agent-config`, {
-          signal: controller.signal,
-        });
-        if (response.ok) setAgentConfig(await response.json());
-      } catch (error) {
-        if (controller.signal.aborted) return;
-        console.error('Failed to load agent config:', error);
-      }
-    })();
-    return () => controller.abort();
-  }, [page.id]);
 
   const {
     selectedProvider,

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -165,7 +165,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // SWR-backed and keyed by `page.id` — shared with every pane showing this
   // agent's Settings tab (see `useAgentConfig`'s own doc), not a private
   // per-instance fetch.
-  const { config: agentConfig, setConfig: setAgentConfig } = useAgentConfig(page.id);
+  const { config: agentConfig, setConfig: setAgentConfig, revalidate: revalidateAgentConfig } = useAgentConfig(page.id);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
   const agentSettingsRef = useRef<PageAgentSettingsTabRef>(null);
 
@@ -565,6 +565,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
             driveId={page.driveId}
             config={agentConfig}
             onConfigUpdate={setAgentConfig}
+            onConfigRevalidate={revalidateAgentConfig}
             selectedProvider={selectedProvider}
             selectedModel={selectedModel}
             onProviderChange={setSelectedProvider}

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -140,6 +140,14 @@ vi.mock('@/lib/ai/shared/hooks/useConversations', () => ({
   },
 }));
 
+// The hook's OWN fetch/shared-cache behavior is covered by useAgentConfig.test.ts
+// directly — this suite only needs to verify AgentPageView WIRES it correctly
+// (calls it with page.id, passes the result through to the Settings tab).
+const mockUseAgentConfig = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/ai/shared/hooks/useAgentConfig', () => ({
+  useAgentConfig: (...args: unknown[]) => mockUseAgentConfig(...args),
+}));
+
 vi.mock('@/components/ai/page-agents', () => ({
   PageAgentSettingsTab: ({ config }: { config: unknown }) => (
     <div data-testid="page-agent-settings-tab" data-has-config={String(config !== null)} />
@@ -198,6 +206,7 @@ beforeEach(() => {
   // one test's override (the global-assistant-session test below) can never
   // leak into whichever test happens to run next.
   mockUseSWR.mockReturnValue({ data: undefined });
+  mockUseAgentConfig.mockReturnValue({ config: null, setConfig: vi.fn() });
   resolvedConversation.current = { resolved: null, isLoading: true };
   authState.current = { user: { id: 'user-1', role: 'admin' } };
   conversationsState.current = {
@@ -345,15 +354,19 @@ describe('AgentPageView', () => {
     // The rewrite once dropped this fetch entirely — PageAgentSettingsTab
     // shows its loading state until config arrives, so a page that never
     // fetches it has a Settings tab that never works (codex review, P1).
+    // Now sourced from the SWR-backed useAgentConfig hook (shared with every
+    // pane showing this agent's Settings tab, see useAgentConfig.test.ts for
+    // its own fetch/cache-sharing behavior) — this suite only verifies
+    // AgentPageView wires it with the right pageId and threads the result
+    // through to the Settings tab.
+    mockUseAgentConfig.mockReturnValue({
+      config: { systemPrompt: '', enabledTools: [], availableTools: [] },
+      setConfig: vi.fn(),
+    });
     resolveTo({ conversationId: 'conv-1', sessionId: null });
     render(<AgentPageView page={pageFixture()} />);
 
-    await waitFor(() =>
-      expect(mockFetchWithAuth).toHaveBeenCalledWith(
-        '/api/pages/agent-1/agent-config',
-        expect.objectContaining({ signal: expect.anything() }),
-      ),
-    );
+    expect(mockUseAgentConfig).toHaveBeenCalledWith('agent-1');
     await userEvent.click(screen.getByRole('tab', { name: /settings/i }));
     await waitFor(() =>
       expect(screen.getByTestId('page-agent-settings-tab')).toHaveAttribute('data-has-config', 'true'),

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -659,6 +659,18 @@ export default function AgentPanes({
             `/api/agent-sessions/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversationId)}/reopen`,
             {},
           );
+          // The SAME race applies to this compensating reopen itself: the
+          // pane that caused the check above to pass can move on to
+          // something else before this call's own response arrives,
+          // leaving the conversation orphaned again with nothing left to
+          // notice. Re-check once more and, if so, clean up again — this
+          // recurses rather than loops, so it naturally terminates the
+          // moment the grid stops churning through this exact conversation
+          // (review finding — chatgpt-codex-connector on PR #2299,
+          // round 18).
+          if (!isConversationShownSomewhere(conversationId)) {
+            await cleanupOrphanedConversation(conversationId);
+          }
         }
       } catch (error) {
         console.error('Failed to clean up an orphaned conversation:', error);

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -515,18 +515,6 @@ export default function AgentPanes({
   const handleClosePane = useCallback(
     (paneId: string) => {
       if (!workspace) return;
-      // Supersede any pending mint/reopen for this pane the instant a close
-      // is initiated — none of the close branches below otherwise touch
-      // this paneId's token, so a History reopen still in flight when the
-      // user closes the pane would stay "current" and either try to
-      // assignPane onto a pane that's about to be gone (no-op, leaving an
-      // invisible open listing that consumes a session cap slot forever),
-      // or — if it resolves before this close's own DELETE — silently
-      // repurpose the pane the user just asked to close. Bumping the token
-      // here routes that stale completion into the existing orphan-cleanup
-      // path (rounds 8-9) instead (review finding — chatgpt-codex-connector
-      // on PR #2299, round 10).
-      beginPaneAssign(paneId);
       const pane = panesOf(workspace).find((p) => p.id === paneId);
       const decision = decideClosePane({
         panes: panesOf(workspace),
@@ -539,9 +527,40 @@ export default function AgentPanes({
       if (decision.action === 'end-session') {
         // Emptying the session ends it — ask first, same as the sidebar's
         // identical act, and don't touch the grid until the user confirms.
+        // Deliberately no beginPaneAssign here: the user can still CANCEL
+        // this dialog, in which case nothing about this pane actually
+        // changes, and bumping the token regardless would invalidate a
+        // pending mint/reopen for a close that never happened (same class
+        // of bug as the noop case below). If the user DOES confirm,
+        // confirmEndSession tears down the whole workspace via
+        // forgetWorkspace — at that point the existing paneStillLoading
+        // shape-check already correctly detects this pane is gone, with no
+        // token needed.
         beginEndSessionConfirm(paneId);
         return;
       }
+
+      // Only reachable once a decision ACTUALLY commits to altering this
+      // pane below — supersede any pending mint/reopen for it here, not
+      // before the noop/end-session checks above. Bumping it unconditionally
+      // at the top of this function (the original round-10 fix) invalidated
+      // a pending mint even when the close turned out to be a no-op (the
+      // grid-last pane's listing hadn't resolved yet) or was later cancelled
+      // — the mint's own completion then treated itself as superseded and
+      // discarded its result without ever moving the pane out of its
+      // loading state, leaving it stuck spinning forever for a close that
+      // never actually happened (review finding — chatgpt-codex-connector
+      // on PR #2299, round 23). None of the branches below otherwise touch
+      // this paneId's token themselves, so a History reopen still in flight
+      // when the user closes the pane would stay "current" and either try
+      // to assignPane onto a pane that's about to be gone (no-op, leaving
+      // an invisible open listing that consumes a session cap slot
+      // forever), or — if it resolves before this close's own DELETE —
+      // silently repurpose the pane the user just asked to close. Bumping
+      // the token here routes that stale completion into the existing
+      // orphan-cleanup path (rounds 8-9) instead (review finding —
+      // chatgpt-codex-connector on PR #2299, round 10).
+      beginPaneAssign(paneId);
 
       if (decision.action === 'close-pane') {
         closePane(sessionId, paneId);
@@ -1366,7 +1385,7 @@ function ChatPane({
     enabled: activeTab === 'history',
   });
 
-  const { config: agentConfig, setConfig: setAgentConfig } = useAgentConfig(scope.agentPageId);
+  const { config: agentConfig, setConfig: setAgentConfig, revalidate: revalidateAgentConfig } = useAgentConfig(scope.agentPageId);
   const {
     selectedProvider,
     setSelectedProvider,
@@ -1534,6 +1553,7 @@ function ChatPane({
               driveId={agent.driveId}
               config={agentConfig}
               onConfigUpdate={setAgentConfig}
+              onConfigRevalidate={revalidateAgentConfig}
               selectedProvider={selectedProvider}
               selectedModel={selectedModel}
               onProviderChange={setSelectedProvider}

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -626,10 +626,26 @@ export default function AgentPanes({
    * DIFFERENT session, is never subject to this session's cap/listing at
    * all — no server call needed, straight to `assignPane` (the same client-
    * only mechanism `openConversation`/`handleSwitchAgent`'s focus branch
-   * already use to point a pane at an existing conversationId).
+   * already use to point a pane at an existing conversationId). Verified
+   * against the sandbox/tool-execution layer too (review question —
+   * chatgpt-codex-connector on PR #2299): tool calls resolve their sandbox
+   * from the CONVERSATION ROW's own persisted `sessionId`
+   * (`findSessionForConversation`, a fresh DB read keyed only on
+   * `conversationId`), never from which pane grid happens to display it —
+   * so a foreign-session or unbound conversation opened here can never
+   * execute tools against the wrong session's sandbox.
+   *
+   * Returns whether the pick actually landed — `false` on a failed reopen,
+   * so the caller (the pane's own tab-switch) can stay on History rather
+   * than following a pick that never happened (review finding —
+   * chatgpt-codex-connector on PR #2299).
    */
   const handlePickHistoryConversation = useCallback(
-    async (paneId: string, agentPageId: string | null, conversation: { id: string; title: string | null; sessionId: string | null }) => {
+    async (
+      paneId: string,
+      agentPageId: string | null,
+      conversation: { id: string; title: string | null; sessionId: string | null },
+    ): Promise<boolean> => {
       if (conversation.sessionId === sessionId) {
         try {
           await post(
@@ -641,12 +657,35 @@ export default function AgentPanes({
           toast.error('Could not reopen this conversation', {
             description: error instanceof Error ? error.message : 'Please try again.',
           });
-          return;
+          return false;
         }
         // Instant-freshness nudge, same as every other listing-changing
         // action here — the sidebar's own open list otherwise lags until its
         // next poll.
         void mutate(isAgentSessionsKey);
+      }
+      // Already showing in another pane in THIS grid — focus it rather than
+      // mounting a second, independently interactive surface for the same
+      // transcript (review finding — chatgpt-codex-connector on PR #2299;
+      // the same dedup `openConversation`'s own focus branch enforces
+      // elsewhere, applied here since this path assigns directly rather
+      // than going through that store action).
+      const existingPane = workspace
+        ? panesOf(workspace).find(
+            (p) => p.id !== paneId && p.scope?.kind === 'chat' && p.scope.targetId === conversation.id,
+          )
+        : undefined;
+      if (existingPane) {
+        // Deferred: the click that triggered this pick originated INSIDE
+        // paneId's own DOM subtree, and `ChatPane`'s outer `group/pane` div
+        // still has its own bubble-phase `onClick={onSelectPane}` — a plain
+        // synchronous `selectPane` here would run before that handler and
+        // get immediately clobbered back to paneId once bubbling reaches it
+        // (caught in testing: `activePaneId` kept reverting to the pane the
+        // pick was made FROM). A macrotask runs after the entire bubble
+        // phase has finished, so this is the call that actually wins.
+        setTimeout(() => selectPane(sessionId, existingPane.id), 0);
+        return true;
       }
       assignPane(sessionId, paneId, {
         kind: 'chat',
@@ -654,8 +693,36 @@ export default function AgentPanes({
         targetId: conversation.id,
         agentPageId,
       });
+      return true;
     },
-    [sessionId, assignPane],
+    [sessionId, assignPane, workspace, selectPane],
+  );
+
+  /**
+   * A pane's History tab deleting a conversation (`softDeleteConversation`
+   * deactivates the CANONICAL row, not just this pane's own listing) —
+   * every pane in THIS grid still pointing at that id, whichever pane's
+   * History tab the delete came from, is left showing a dead transcript:
+   * switching it back to Chat would render nothing sendable (the row now
+   * 404s per the send-route's own isActive guard) with no obvious way out.
+   * Reset each one to the picker — the simplest, safe recovery; the user
+   * explicitly picks what's next rather than a guessed replacement (review
+   * finding — chatgpt-codex-connector on PR #2299).
+   */
+  const handleHistoryDeleteConversation = useCallback(
+    (deletedConversationId: string) => {
+      if (!workspace) return;
+      const affectedPanes = panesOf(workspace).filter(
+        (p) => p.scope?.kind === 'chat' && p.scope.targetId === deletedConversationId,
+      );
+      for (const pane of affectedPanes) {
+        resetPane(sessionId, pane.id);
+      }
+      if (affectedPanes.length > 0) {
+        void mutate(isAgentSessionsKey);
+      }
+    },
+    [workspace, sessionId, resetPane],
   );
 
   // The pane bar selector's switch — focus-or-mint, decided by the pure
@@ -765,8 +832,9 @@ export default function AgentPanes({
           onClose={() => handleClosePane(pane.id)}
           onCreateNewFromHistory={() => void handlePickAgent(pane.id, pane.scope!.agentPageId)}
           onPickHistoryConversation={(conversation) =>
-            void handlePickHistoryConversation(pane.id, pane.scope!.agentPageId, conversation)
+            handlePickHistoryConversation(pane.id, pane.scope!.agentPageId, conversation)
           }
+          onHistoryDeleteConversation={handleHistoryDeleteConversation}
         />
       );
     }
@@ -886,6 +954,7 @@ function ChatPane({
   onClose,
   onCreateNewFromHistory,
   onPickHistoryConversation,
+  onHistoryDeleteConversation,
 }: {
   /** Always `kind: 'chat'` at the call site — `PaneScope` isn't a discriminated union, so this stays the full type. */
   scope: PaneScope;
@@ -912,7 +981,10 @@ function ChatPane({
   onSplitDown: () => void;
   onClose: () => void;
   onCreateNewFromHistory: () => void;
-  onPickHistoryConversation: (conversation: { id: string; title: string | null; sessionId: string | null }) => void;
+  /** Resolves to whether the pick actually landed — false on a failed reopen. */
+  onPickHistoryConversation: (conversation: { id: string; title: string | null; sessionId: string | null }) => Promise<boolean>;
+  /** A History delete's canonical-row deactivation reaches every pane showing that id, not just this one — the container resets each affected pane. */
+  onHistoryDeleteConversation: (conversationId: string) => void;
 }) {
   const { user } = useAuth();
   const { agent } = useResolvedAgent(scope.agentPageId);
@@ -973,10 +1045,19 @@ function ChatPane({
   );
 
   const handleSelectHistoryConversation = useCallback(
-    (id: string) => {
+    async (id: string) => {
       const picked = conversations.find((c) => c.id === id);
-      onPickHistoryConversation({ id, title: picked?.title ?? null, sessionId: picked?.sessionId ?? null });
-      setActiveTab('chat');
+      // Only follow the pick to Chat once it actually landed — a failed
+      // reopen (session full, deleted, access changed) leaves the pane
+      // untouched, and switching tabs anyway would show the OLD pane
+      // content as if the pick had succeeded (review finding —
+      // chatgpt-codex-connector on PR #2299).
+      const landed = await onPickHistoryConversation({
+        id,
+        title: picked?.title ?? null,
+        sessionId: picked?.sessionId ?? null,
+      });
+      if (landed) setActiveTab('chat');
     },
     [conversations, onPickHistoryConversation],
   );
@@ -1026,7 +1107,13 @@ function ChatPane({
                   e.stopPropagation();
                   settingsRef.current?.submitForm();
                 }}
-                disabled={isSettingsSaving}
+                // `PageAgentSettingsTab` registers `submitForm` before its own
+                // config-loaded check returns, and its form defaults contain
+                // an EMPTY prompt/tool list — clicking Save before agentConfig
+                // arrives would PATCH those defaults over the agent's real
+                // config (review finding — chatgpt-codex-connector on PR
+                // #2299).
+                disabled={isSettingsSaving || agentConfig === null}
                 className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
               >
                 {isSettingsSaving ? <Loader2 className="size-3 animate-spin" aria-hidden="true" /> : <Save className="size-3" aria-hidden="true" />}
@@ -1064,7 +1151,10 @@ function ChatPane({
             currentConversationId={conversationId}
             onSelectConversation={handleSelectHistoryConversation}
             onCreateNew={handleCreateNewFromHistory}
-            onDeleteConversation={(id) => void deleteConversation(id)}
+            onDeleteConversation={(id) => {
+              void deleteConversation(id);
+              onHistoryDeleteConversation(id);
+            }}
             onToggleShare={toggleConversationShare}
             isLoading={conversationsLoading}
           />

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -163,6 +163,26 @@ export default function AgentPanes({
     return () => paneAssignTokens.current.get(paneId) === token;
   }, []);
 
+  // Two more races the pane-token above can't catch on its own, since it's
+  // scoped per PANE while these are scoped per CONVERSATION (review finding
+  // — chatgpt-codex-connector on PR #2299, round 8):
+  //
+  // 1. The SAME conversation picked twice (same pane or two panes) can have
+  //    the OLDER reopen resolve first while the NEWER one is still in
+  //    flight — at that instant no pane shows it yet, so the older (stale)
+  //    request's "is anyone showing this?" check reads false-orphaned and
+  //    closes the conversation the newer request is about to legitimately
+  //    land. Tracked as an in-flight count per conversationId; the rollback
+  //    below only fires once nothing else is still reopening the same id.
+  const pendingReopenCounts = useRef(new Map<string, number>());
+  // 2. A reopen can commit server-side, then have its OWN response delayed
+  //    long enough for the SAME conversation to be deleted from History (a
+  //    different pane, or the same one) before the reopen's completion
+  //    assigns it — landing a pane on a transcript that already 404s on
+  //    send. `handleHistoryDeleteConversation` marks the id here; the
+  //    reopen completion checks-and-consumes it right before assigning.
+  const historyDeletedDuringReopen = useRef(new Set<string>());
+
   // The picker's agent list. A drive session offers only that drive's agents;
   // a global-assistant session (driveId null) has no home drive to filter by,
   // so it offers every agent the caller can access, across all their drives —
@@ -674,12 +694,23 @@ export default function AgentPanes({
     ): Promise<boolean> => {
       const isCurrent = beginPaneAssign(paneId);
       if (conversation.sessionId === sessionId) {
+        pendingReopenCounts.current.set(conversation.id, (pendingReopenCounts.current.get(conversation.id) ?? 0) + 1);
+        // Exactly-once decrement regardless of which exit path below runs.
+        let reopenSettled = false;
+        const settleReopen = () => {
+          if (reopenSettled) return;
+          reopenSettled = true;
+          const next = (pendingReopenCounts.current.get(conversation.id) ?? 1) - 1;
+          if (next <= 0) pendingReopenCounts.current.delete(conversation.id);
+          else pendingReopenCounts.current.set(conversation.id, next);
+        };
         try {
           await post(
             `/api/agent-sessions/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversation.id)}/reopen`,
             {},
           );
         } catch (error) {
+          settleReopen();
           // A newer pick (or agent switch) on this pane already superseded
           // this one — its own outcome, success or failure, is no longer
           // this pane's concern, and surfacing an error toast for a request
@@ -691,6 +722,7 @@ export default function AgentPanes({
           });
           return false;
         }
+        settleReopen();
         if (!isCurrent()) {
           // The reopen SUCCEEDED server-side (closedInSessionAt cleared, a
           // cap slot consumed) after a newer pick or agent mint already
@@ -709,14 +741,30 @@ export default function AgentPanes({
           // reopened, currently-visible conversation back out from under
           // whichever pane is showing it. Read live state across every pane
           // in the grid (not just this one) before deciding (review finding
-          // — chatgpt-codex-connector on PR #2299).
+          // — chatgpt-codex-connector on PR #2299). That alone still misses
+          // the case where the NEWER request hasn't landed yet (still
+          // in-flight) when the older one resolves — nothing shows it YET,
+          // but something is about to. Check the in-flight count too (round
+          // 8 review finding): only clean up when no reopen for this same
+          // conversation is still pending anywhere.
           const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
-          const stillOrphaned =
-            !liveWorkspace ||
-            !panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversation.id);
-          if (stillOrphaned) {
+          const shownSomewhere =
+            !!liveWorkspace &&
+            panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversation.id);
+          const anotherReopenPending = pendingReopenCounts.current.has(conversation.id);
+          if (!shownSomewhere && !anotherReopenPending) {
             void cleanupOrphanedConversation(conversation.id);
           }
+          return false;
+        }
+        if (historyDeletedDuringReopen.current.delete(conversation.id)) {
+          // This reopen's HTTP round trip was still in flight when the SAME
+          // conversation was deleted from History (possibly from a
+          // different pane) — the reopen may have already committed
+          // server-side before that delete landed, so assigning now would
+          // bind this pane to a transcript that already 404s on send.
+          // Treated like a superseded pick: no assignment, stay put (review
+          // finding — chatgpt-codex-connector on PR #2299, round 8).
           return false;
         }
         // Instant-freshness nudge, same as every other listing-changing
@@ -779,6 +827,13 @@ export default function AgentPanes({
    */
   const handleHistoryDeleteConversation = useCallback(
     (deletedConversationId: string) => {
+      // Marked unconditionally (not just when a pane is currently affected
+      // below): a History pick's reopen for this exact id can be mid-flight
+      // right now, having already committed server-side, with its
+      // completion still to come — that completion checks and consumes this
+      // mark before assigning (review finding — chatgpt-codex-connector on
+      // PR #2299, round 8).
+      historyDeletedDuringReopen.current.add(deletedConversationId);
       // Read fresh at call time, not the `workspace` this callback closed
       // over — this always runs after the DELETE's own async round trip,
       // during which the user could have already reassigned an affected

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -499,6 +499,18 @@ export default function AgentPanes({
   const handleClosePane = useCallback(
     (paneId: string) => {
       if (!workspace) return;
+      // Supersede any pending mint/reopen for this pane the instant a close
+      // is initiated — none of the close branches below otherwise touch
+      // this paneId's token, so a History reopen still in flight when the
+      // user closes the pane would stay "current" and either try to
+      // assignPane onto a pane that's about to be gone (no-op, leaving an
+      // invisible open listing that consumes a session cap slot forever),
+      // or — if it resolves before this close's own DELETE — silently
+      // repurpose the pane the user just asked to close. Bumping the token
+      // here routes that stale completion into the existing orphan-cleanup
+      // path (rounds 8-9) instead (review finding — chatgpt-codex-connector
+      // on PR #2299, round 10).
+      beginPaneAssign(paneId);
       const pane = panesOf(workspace).find((p) => p.id === paneId);
       const decision = decideClosePane({
         panes: panesOf(workspace),
@@ -547,6 +559,7 @@ export default function AgentPanes({
       closeConversationListing,
       assignPane,
       beginEndSessionConfirm,
+      beginPaneAssign,
     ],
   );
 

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -630,11 +630,16 @@ export default function AgentPanes({
       // Also supersedes any pending `handlePickHistoryConversation` call for
       // this pane — a slow reopen resolving after the user has since minted
       // a different agent into this same pane must not overwrite it (review
-      // finding — chatgpt-codex-connector on PR #2299). This mint has its
-      // OWN, separate staleness guard below (`paneStillLoading`); bumping
-      // the shared token here just extends that same protection to the
-      // OTHER call path.
-      beginPaneAssign(paneId);
+      // finding — chatgpt-codex-connector on PR #2299). Captured (not
+      // discarded) so THIS call can tell a genuinely stale completion of
+      // ITSELF apart from a same-shaped sibling: two mints started back to
+      // back before either settles install the SAME indistinguishable
+      // loading scope, so `paneStillLoading`'s shape check alone can't tell
+      // them apart — the older one's catch could restore over the newer
+      // one's still-pending success, which then finds itself "superseded"
+      // and cleans up its own just-created row (review finding — chatgpt-
+      // codex-connector on PR #2299, round 14).
+      const isCurrent = beginPaneAssign(paneId);
       const conversationId = createId();
       // Captured BEFORE the loading-state overwrite below — a failed mint
       // then restores THIS instead of always falling back to the picker.
@@ -649,6 +654,17 @@ export default function AgentPanes({
       const priorScope = liveWorkspaceAtStart
         ? (panesOf(liveWorkspaceAtStart).find((p) => p.id === paneId)?.scope ?? null)
         : null;
+      // The pane's LOADING scope (targetId null) doesn't identify the prior
+      // conversation, so a History-delete of it while this mint is pending
+      // can't reset this pane the normal way — capture its delete
+      // generation now and re-check before restoring, so a since-deleted
+      // prior conversation is never resurrected onto a pane whose sends
+      // would just 404 (review finding — chatgpt-codex-connector on PR
+      // #2299, round 14).
+      const priorScopeConversationId = priorScope?.kind === 'chat' ? priorScope.targetId : null;
+      const priorScopeDeleteGenerationAtStart = priorScopeConversationId
+        ? (historyDeleteGenerations.current.get(priorScopeConversationId) ?? 0)
+        : 0;
       // Bind first, render after: the pane goes to `loading` (kind set, target
       // null) while the mint is in flight — never a speculative surface.
       assignPane(sessionId, paneId, { kind: 'chat', name: 'New conversation', targetId: null, agentPageId });
@@ -665,12 +681,14 @@ export default function AgentPanes({
             sessionId,
           });
         }
-        if (!paneStillLoading(paneId, { kind: 'chat', agentPageId })) {
-          // The pane closed mid-mint, OR a grid-last close already rebound it
-          // to another open listing while this request was in flight. Either
-          // way, the row was already created server-side — clean it up
-          // rather than leaving an orphaned, unbound thread (or clobbering
-          // the rebind with this now-abandoned mint's result).
+        if (!isCurrent() || !paneStillLoading(paneId, { kind: 'chat', agentPageId })) {
+          // Either a NEWER call for this same pane superseded this one
+          // (isCurrent false — round 14), or the pane closed mid-mint, or a
+          // grid-last close already rebound it to another open listing
+          // while this request was in flight. Either way, the row was
+          // already created server-side — clean it up rather than leaving
+          // an orphaned, unbound thread (or clobbering a newer assignment
+          // with this now-abandoned mint's result).
           void cleanupOrphanedConversation(conversationId);
           return false;
         }
@@ -700,9 +718,16 @@ export default function AgentPanes({
         // Same rebind-survives rule as the success path above: a rejected
         // mint must not reset a pane a grid-last close already rebound to
         // something else while this request was in flight (caught in
-        // review — the earlier fix only guarded the success path).
-        if (paneStillLoading(paneId, { kind: 'chat', agentPageId })) {
-          if (priorScope) {
+        // review — the earlier fix only guarded the success path). Also
+        // gated on `isCurrent()` (round 14) — a NEWER call for this same
+        // pane already owns whatever happens to it now; this stale one must
+        // not restore over that in-flight sibling.
+        if (isCurrent() && paneStillLoading(paneId, { kind: 'chat', agentPageId })) {
+          const priorScopeStillValid =
+            !priorScopeConversationId ||
+            (historyDeleteGenerations.current.get(priorScopeConversationId) ?? 0) ===
+              priorScopeDeleteGenerationAtStart;
+          if (priorScope && priorScopeStillValid) {
             assignPane(sessionId, paneId, priorScope);
           } else {
             resetPane(sessionId, paneId);

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -199,6 +199,22 @@ export default function AgentPanes({
   //    independently compares its own captured start value against the
   //    current one — no consumption, so no reader ever misses it.
   const historyDeleteGenerations = useRef(new Map<string, number>());
+  // 3. New Conversation from History captures the pane's PRIOR scope so a
+  //    failed mint can restore it (round 13) — but re-reading "the live
+  //    scope right now" at the start of EVERY call breaks the moment two
+  //    mints for the SAME pane overlap: the second call's "live scope" is
+  //    already the FIRST call's loading sentinel, not the true original.
+  //    A failed second call would then "restore" that sentinel, leaving the
+  //    pane stuck spinning forever. Captured ONCE per paneId (only by
+  //    whichever mint is first to start while none is in flight) and reused
+  //    by every overlapping sibling; reference-counted so the entry clears
+  //    once every overlapping mint for that pane has settled, letting a
+  //    LATER, non-overlapping mint capture fresh state again (review
+  //    finding — chatgpt-codex-connector on PR #2299, round 15).
+  const pendingMintCounts = useRef(new Map<string, number>());
+  const priorScopeBeforeMint = useRef(
+    new Map<string, { scope: PaneScope | null; deleteGenerationAtStart: number }>(),
+  );
 
   // The picker's agent list. A drive session offers only that drive's agents;
   // a global-assistant session (driveId null) has no home drive to filter by,
@@ -641,30 +657,55 @@ export default function AgentPanes({
       // codex-connector on PR #2299, round 14).
       const isCurrent = beginPaneAssign(paneId);
       const conversationId = createId();
-      // Captured BEFORE the loading-state overwrite below — a failed mint
-      // then restores THIS instead of always falling back to the picker.
-      // For the normal "pick from an empty picker" call site this is
-      // already null (restoring null IS today's reset-to-picker behavior),
-      // but "New Conversation" picked from a pane's own History tab starts
-      // from a pane already showing a real, working conversation — losing
-      // that to a blank picker on a transient failure (session full,
-      // network drop) is a real regression the user did not ask for
+      // Captured ONLY when no mint is already in flight for this pane — a
+      // failed mint then restores THIS instead of always falling back to
+      // the picker. For the normal "pick from an empty picker" call site
+      // this is already null (restoring null IS today's reset-to-picker
+      // behavior), but "New Conversation" picked from a pane's own History
+      // tab starts from a pane already showing a real, working conversation
+      // — losing that to a blank picker on a transient failure (session
+      // full, network drop) is a real regression the user did not ask for
       // (review finding — chatgpt-codex-connector on PR #2299, round 13).
-      const liveWorkspaceAtStart = useAgentWorkspaceStore.getState().workspaces[sessionId];
-      const priorScope = liveWorkspaceAtStart
-        ? (panesOf(liveWorkspaceAtStart).find((p) => p.id === paneId)?.scope ?? null)
-        : null;
-      // The pane's LOADING scope (targetId null) doesn't identify the prior
-      // conversation, so a History-delete of it while this mint is pending
-      // can't reset this pane the normal way — capture its delete
-      // generation now and re-check before restoring, so a since-deleted
-      // prior conversation is never resurrected onto a pane whose sends
-      // would just 404 (review finding — chatgpt-codex-connector on PR
-      // #2299, round 14).
+      // Reused (not re-captured) by any OVERLAPPING sibling mint for this
+      // same pane — re-reading "the live scope now" on every call would see
+      // an earlier sibling's own loading sentinel, not the true original
+      // (review finding — chatgpt-codex-connector on PR #2299, round 15).
+      if (!priorScopeBeforeMint.current.has(paneId)) {
+        const liveWorkspaceAtStart = useAgentWorkspaceStore.getState().workspaces[sessionId];
+        const capturedScope = liveWorkspaceAtStart
+          ? (panesOf(liveWorkspaceAtStart).find((p) => p.id === paneId)?.scope ?? null)
+          : null;
+        // The pane's LOADING scope (targetId null) doesn't identify the
+        // prior conversation, so a History-delete of it while this mint is
+        // pending can't reset this pane the normal way — capture its
+        // delete generation now and re-check before restoring, so a
+        // since-deleted prior conversation is never resurrected onto a
+        // pane whose sends would just 404 (review finding — chatgpt-codex-
+        // connector on PR #2299, round 14).
+        const capturedConversationId = capturedScope?.kind === 'chat' ? capturedScope.targetId : null;
+        const deleteGenerationAtStart = capturedConversationId
+          ? (historyDeleteGenerations.current.get(capturedConversationId) ?? 0)
+          : 0;
+        priorScopeBeforeMint.current.set(paneId, { scope: capturedScope, deleteGenerationAtStart });
+      }
+      pendingMintCounts.current.set(paneId, (pendingMintCounts.current.get(paneId) ?? 0) + 1);
+      const { scope: priorScope, deleteGenerationAtStart: priorScopeDeleteGenerationAtStart } =
+        priorScopeBeforeMint.current.get(paneId)!;
       const priorScopeConversationId = priorScope?.kind === 'chat' ? priorScope.targetId : null;
-      const priorScopeDeleteGenerationAtStart = priorScopeConversationId
-        ? (historyDeleteGenerations.current.get(priorScopeConversationId) ?? 0)
-        : 0;
+      // Exactly-once decrement regardless of exit path; clears the shared
+      // capture only once every overlapping mint for this pane has settled.
+      let mintSettled = false;
+      const settleMint = () => {
+        if (mintSettled) return;
+        mintSettled = true;
+        const next = (pendingMintCounts.current.get(paneId) ?? 1) - 1;
+        if (next <= 0) {
+          pendingMintCounts.current.delete(paneId);
+          priorScopeBeforeMint.current.delete(paneId);
+        } else {
+          pendingMintCounts.current.set(paneId, next);
+        }
+      };
       // Bind first, render after: the pane goes to `loading` (kind set, target
       // null) while the mint is in flight — never a speculative surface.
       assignPane(sessionId, paneId, { kind: 'chat', name: 'New conversation', targetId: null, agentPageId });
@@ -681,6 +722,7 @@ export default function AgentPanes({
             sessionId,
           });
         }
+        settleMint();
         if (!isCurrent() || !paneStillLoading(paneId, { kind: 'chat', agentPageId })) {
           // Either a NEWER call for this same pane superseded this one
           // (isCurrent false — round 14), or the pane closed mid-mint, or a
@@ -711,6 +753,7 @@ export default function AgentPanes({
         void mutate(isAgentSessionsKey);
         return true;
       } catch (error) {
+        settleMint();
         console.error('Failed to start a conversation in this pane:', error);
         toast.error('Could not start a conversation', {
           description: error instanceof Error ? error.message : 'Please try again.',
@@ -793,8 +836,9 @@ export default function AgentPanes({
           else pendingReopenCounts.current.set(conversation.id, next);
           return next;
         };
+        let reopenResult: { ok: boolean; alreadyOpen: boolean };
         try {
-          await post(
+          reopenResult = await post<{ ok: boolean; alreadyOpen: boolean }>(
             `/api/agent-sessions/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversation.id)}/reopen`,
             {},
           );
@@ -840,7 +884,16 @@ export default function AgentPanes({
           // whichever pane is showing it. Read live state across every pane
           // in the grid (not just this one) before deciding (review finding
           // — chatgpt-codex-connector on PR #2299).
-          if (isShownSomewhere()) return false;
+          //
+          // And only when THIS request actually transitioned the listing:
+          // the reopen runtime returns `already_open` (folded into the same
+          // `{ ok: true }` shape client-side used to see) when the
+          // conversation was already open elsewhere (another pane/tab, or
+          // an agent switch that left it open unshown) — this request never
+          // opened it, so rolling it back would close a listing still in
+          // use for a no-op this request didn't cause (review finding —
+          // chatgpt-codex-connector on PR #2299, round 15).
+          if (reopenResult.alreadyOpen || isShownSomewhere()) return false;
           if (remaining > 0) {
             // Something else is still reopening this same conversationId —
             // premature to clean up (that request might land it). Defer:
@@ -936,6 +989,15 @@ export default function AgentPanes({
         deletedConversationId,
         (historyDeleteGenerations.current.get(deletedConversationId) ?? 0) + 1,
       );
+      // Instant-freshness nudge, unconditional — the canonical row is gone
+      // from the session's listing regardless of whether any pane in THIS
+      // grid happens to be showing it right now. Scoping this to "only when
+      // a pane was affected" left every OTHER consumer of the cached
+      // listing (handleSwitchAgent's focus branch, a close decision's
+      // fallback) trusting a stale row for up to the poll interval —
+      // binding a pane to a transcript that already 404s on send (review
+      // finding — chatgpt-codex-connector on PR #2299, round 15).
+      void mutate(isAgentSessionsKey);
       // Read fresh at call time, not the `workspace` this callback closed
       // over — this always runs after the DELETE's own async round trip,
       // during which the user could have already reassigned an affected
@@ -950,9 +1012,6 @@ export default function AgentPanes({
       );
       for (const pane of affectedPanes) {
         resetPane(sessionId, pane.id);
-      }
-      if (affectedPanes.length > 0) {
-        void mutate(isAgentSessionsKey);
       }
     },
     [sessionId, resetPane],

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -626,7 +626,7 @@ export default function AgentPanes({
   );
 
   const handlePickAgent = useCallback(
-    async (paneId: string, agentPageId: string | null) => {
+    async (paneId: string, agentPageId: string | null): Promise<boolean> => {
       // Also supersedes any pending `handlePickHistoryConversation` call for
       // this pane — a slow reopen resolving after the user has since minted
       // a different agent into this same pane must not overwrite it (review
@@ -636,6 +636,19 @@ export default function AgentPanes({
       // OTHER call path.
       beginPaneAssign(paneId);
       const conversationId = createId();
+      // Captured BEFORE the loading-state overwrite below — a failed mint
+      // then restores THIS instead of always falling back to the picker.
+      // For the normal "pick from an empty picker" call site this is
+      // already null (restoring null IS today's reset-to-picker behavior),
+      // but "New Conversation" picked from a pane's own History tab starts
+      // from a pane already showing a real, working conversation — losing
+      // that to a blank picker on a transient failure (session full,
+      // network drop) is a real regression the user did not ask for
+      // (review finding — chatgpt-codex-connector on PR #2299, round 13).
+      const liveWorkspaceAtStart = useAgentWorkspaceStore.getState().workspaces[sessionId];
+      const priorScope = liveWorkspaceAtStart
+        ? (panesOf(liveWorkspaceAtStart).find((p) => p.id === paneId)?.scope ?? null)
+        : null;
       // Bind first, render after: the pane goes to `loading` (kind set, target
       // null) while the mint is in flight — never a speculative surface.
       assignPane(sessionId, paneId, { kind: 'chat', name: 'New conversation', targetId: null, agentPageId });
@@ -659,7 +672,7 @@ export default function AgentPanes({
           // rather than leaving an orphaned, unbound thread (or clobbering
           // the rebind with this now-abandoned mint's result).
           void cleanupOrphanedConversation(conversationId);
-          return;
+          return false;
         }
         assignPane(sessionId, paneId, { kind: 'chat', name: 'New conversation', targetId: conversationId, agentPageId });
         // Local optimistic update for THIS component's own switch/close
@@ -678,6 +691,7 @@ export default function AgentPanes({
         // orphaned conversation that holds a cap slot forever (caught in
         // review).
         void mutate(isAgentSessionsKey);
+        return true;
       } catch (error) {
         console.error('Failed to start a conversation in this pane:', error);
         toast.error('Could not start a conversation', {
@@ -688,8 +702,13 @@ export default function AgentPanes({
         // something else while this request was in flight (caught in
         // review — the earlier fix only guarded the success path).
         if (paneStillLoading(paneId, { kind: 'chat', agentPageId })) {
-          resetPane(sessionId, paneId);
+          if (priorScope) {
+            assignPane(sessionId, paneId, priorScope);
+          } else {
+            resetPane(sessionId, paneId);
+          }
         }
+        return false;
       }
     },
     [assignPane, resetPane, sessionId, paneStillLoading, cleanupOrphanedConversation, recordMintedConversation, beginPaneAssign],
@@ -1019,7 +1038,7 @@ export default function AgentPanes({
           onSplitRight={() => splitRight(sessionId, pane.id)}
           onSplitDown={() => splitDown(sessionId, pane.id)}
           onClose={() => handleClosePane(pane.id)}
-          onCreateNewFromHistory={() => void handlePickAgent(pane.id, pane.scope!.agentPageId)}
+          onCreateNewFromHistory={() => handlePickAgent(pane.id, pane.scope!.agentPageId)}
           onPickHistoryConversation={(conversation) =>
             handlePickHistoryConversation(pane.id, pane.scope!.agentPageId, conversation)
           }
@@ -1169,7 +1188,8 @@ function ChatPane({
   onSplitRight: () => void;
   onSplitDown: () => void;
   onClose: () => void;
-  onCreateNewFromHistory: () => void;
+  /** Resolves to whether the mint actually landed — false on a failed create. */
+  onCreateNewFromHistory: () => Promise<boolean>;
   /** Resolves to whether the pick actually landed — false on a failed reopen. */
   onPickHistoryConversation: (conversation: { id: string; title: string | null; sessionId: string | null }) => Promise<boolean>;
   /** A History delete's canonical-row deactivation reaches every pane showing that id, not just this one — the container resets each affected pane. */
@@ -1263,9 +1283,16 @@ function ChatPane({
     [conversations, onPickHistoryConversation],
   );
 
-  const handleCreateNewFromHistory = useCallback(() => {
-    onCreateNewFromHistory();
-    setActiveTab('chat');
+  const handleCreateNewFromHistory = useCallback(async () => {
+    // Only follow to Chat once the mint actually landed — same discipline
+    // as handleSelectHistoryConversation above. A failed create (session
+    // full, permission changed, network drop) now restores this pane's
+    // PRIOR scope internally (handlePickAgent), so staying on History here
+    // shows that restored, still-working conversation underneath rather
+    // than switching to a blank/lost pane (review finding — chatgpt-codex-
+    // connector on PR #2299, round 13).
+    const landed = await onCreateNewFromHistory();
+    if (landed) setActiveTab('chat');
   }, [onCreateNewFromHistory]);
 
   return (

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -163,9 +163,9 @@ export default function AgentPanes({
     return () => paneAssignTokens.current.get(paneId) === token;
   }, []);
 
-  // Two more races the pane-token above can't catch on its own, since it's
-  // scoped per PANE while these are scoped per CONVERSATION (review finding
-  // — chatgpt-codex-connector on PR #2299, round 8):
+  // Races the pane-token above can't catch on its own, since it's scoped
+  // per PANE while these are scoped per CONVERSATION (review findings —
+  // chatgpt-codex-connector on PR #2299, rounds 8-9):
   //
   // 1. The SAME conversation picked twice (same pane or two panes) can have
   //    the OLDER reopen resolve first while the NEWER one is still in
@@ -174,14 +174,31 @@ export default function AgentPanes({
   //    closes the conversation the newer request is about to legitimately
   //    land. Tracked as an in-flight count per conversationId; the rollback
   //    below only fires once nothing else is still reopening the same id.
+  //
+  //    That alone still drops the ball when the LAST settler is the one
+  //    that FAILS: an earlier (superseded) reopen for the same id can
+  //    succeed-but-defer its own rollback because this one was still
+  //    pending — if this one then rejects instead of landing it, nothing
+  //    is left to finish that deferred cleanup. `deferredReopenSuccess`
+  //    marks that case; whichever request is the LAST to settle for a
+  //    given conversationId (by count reaching zero) is responsible for
+  //    checking it and finishing the cleanup if still nothing shows it.
   const pendingReopenCounts = useRef(new Map<string, number>());
+  const deferredReopenSuccess = useRef(new Set<string>());
   // 2. A reopen can commit server-side, then have its OWN response delayed
   //    long enough for the SAME conversation to be deleted from History (a
   //    different pane, or the same one) before the reopen's completion
   //    assigns it — landing a pane on a transcript that already 404s on
-  //    send. `handleHistoryDeleteConversation` marks the id here; the
-  //    reopen completion checks-and-consumes it right before assigning.
-  const historyDeletedDuringReopen = useRef(new Set<string>());
+  //    send. A single consumable flag isn't enough here either: TWO panes
+  //    concurrently reopening the same conversation both need to observe
+  //    the same delete, but a boolean/Set entry consumed by whichever
+  //    completion checks it first would leave the second one blind. A
+  //    per-conversationId generation counter instead: each reopen captures
+  //    the generation at start, `handleHistoryDeleteConversation` bumps it
+  //    on delete, and every completion (however many are in flight)
+  //    independently compares its own captured start value against the
+  //    current one — no consumption, so no reader ever misses it.
+  const historyDeleteGenerations = useRef(new Map<string, number>());
 
   // The picker's agent list. A drive session offers only that drive's agents;
   // a global-assistant session (driveId null) has no home drive to filter by,
@@ -694,15 +711,30 @@ export default function AgentPanes({
     ): Promise<boolean> => {
       const isCurrent = beginPaneAssign(paneId);
       if (conversation.sessionId === sessionId) {
+        const isShownSomewhere = () => {
+          const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
+          return (
+            !!liveWorkspace &&
+            panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversation.id)
+          );
+        };
         pendingReopenCounts.current.set(conversation.id, (pendingReopenCounts.current.get(conversation.id) ?? 0) + 1);
+        // Captured BEFORE the request starts — compared, never consumed, so
+        // every concurrent reopen for this same conversationId independently
+        // notices a delete that happened anywhere during its own flight
+        // (round 9 review finding).
+        const deleteGenerationAtStart = historyDeleteGenerations.current.get(conversation.id) ?? 0;
         // Exactly-once decrement regardless of which exit path below runs.
+        // Returns the count still outstanding AFTER this one settles, so the
+        // caller can tell whether it was the LAST one for this conversationId.
         let reopenSettled = false;
         const settleReopen = () => {
-          if (reopenSettled) return;
+          if (reopenSettled) return pendingReopenCounts.current.get(conversation.id) ?? 0;
           reopenSettled = true;
           const next = (pendingReopenCounts.current.get(conversation.id) ?? 1) - 1;
           if (next <= 0) pendingReopenCounts.current.delete(conversation.id);
           else pendingReopenCounts.current.set(conversation.id, next);
+          return next;
         };
         try {
           await post(
@@ -710,7 +742,16 @@ export default function AgentPanes({
             {},
           );
         } catch (error) {
-          settleReopen();
+          const remaining = settleReopen();
+          // I was the LAST outstanding reopen for this conversationId, and
+          // an EARLIER (superseded) request already reopened it server-side
+          // but deferred its own cleanup because I was still pending —
+          // nothing else will ever revisit that now that I've failed
+          // instead of landing it. Finish the job it punted on (round 9
+          // review finding — chatgpt-codex-connector on PR #2299).
+          if (remaining <= 0 && deferredReopenSuccess.current.delete(conversation.id) && !isShownSomewhere()) {
+            void cleanupOrphanedConversation(conversation.id);
+          }
           // A newer pick (or agent switch) on this pane already superseded
           // this one — its own outcome, success or failure, is no longer
           // this pane's concern, and surfacing an error toast for a request
@@ -722,7 +763,7 @@ export default function AgentPanes({
           });
           return false;
         }
-        settleReopen();
+        const remaining = settleReopen();
         if (!isCurrent()) {
           // The reopen SUCCEEDED server-side (closedInSessionAt cleared, a
           // cap slot consumed) after a newer pick or agent mint already
@@ -741,23 +782,23 @@ export default function AgentPanes({
           // reopened, currently-visible conversation back out from under
           // whichever pane is showing it. Read live state across every pane
           // in the grid (not just this one) before deciding (review finding
-          // — chatgpt-codex-connector on PR #2299). That alone still misses
-          // the case where the NEWER request hasn't landed yet (still
-          // in-flight) when the older one resolves — nothing shows it YET,
-          // but something is about to. Check the in-flight count too (round
-          // 8 review finding): only clean up when no reopen for this same
-          // conversation is still pending anywhere.
-          const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
-          const shownSomewhere =
-            !!liveWorkspace &&
-            panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversation.id);
-          const anotherReopenPending = pendingReopenCounts.current.has(conversation.id);
-          if (!shownSomewhere && !anotherReopenPending) {
+          // — chatgpt-codex-connector on PR #2299).
+          if (isShownSomewhere()) return false;
+          if (remaining > 0) {
+            // Something else is still reopening this same conversationId —
+            // premature to clean up (that request might land it). Defer:
+            // whichever reopen is the LAST to settle for this id is
+            // responsible for finishing this check (round 9 review finding).
+            deferredReopenSuccess.current.add(conversation.id);
+          } else {
             void cleanupOrphanedConversation(conversation.id);
           }
           return false;
         }
-        if (historyDeletedDuringReopen.current.delete(conversation.id)) {
+        // I'm the one landing this — any deferred-cleanup marker left by an
+        // earlier superseded request for this id is moot now.
+        deferredReopenSuccess.current.delete(conversation.id);
+        if ((historyDeleteGenerations.current.get(conversation.id) ?? 0) !== deleteGenerationAtStart) {
           // This reopen's HTTP round trip was still in flight when the SAME
           // conversation was deleted from History (possibly from a
           // different pane) — the reopen may have already committed
@@ -827,13 +868,17 @@ export default function AgentPanes({
    */
   const handleHistoryDeleteConversation = useCallback(
     (deletedConversationId: string) => {
-      // Marked unconditionally (not just when a pane is currently affected
+      // Bumped unconditionally (not just when a pane is currently affected
       // below): a History pick's reopen for this exact id can be mid-flight
-      // right now, having already committed server-side, with its
-      // completion still to come — that completion checks and consumes this
-      // mark before assigning (review finding — chatgpt-codex-connector on
-      // PR #2299, round 8).
-      historyDeletedDuringReopen.current.add(deletedConversationId);
+      // right now, possibly from more than one pane at once, having already
+      // committed server-side, with its completion(s) still to come — each
+      // one independently compares its own captured start value against
+      // this counter before assigning (review finding — chatgpt-codex-
+      // connector on PR #2299, rounds 8-9).
+      historyDeleteGenerations.current.set(
+        deletedConversationId,
+        (historyDeleteGenerations.current.get(deletedConversationId) ?? 0) + 1,
+      );
       // Read fresh at call time, not the `workspace` this callback closed
       // over — this always runs after the DELETE's own async round trip,
       // during which the user could have already reassigned an affected

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -691,7 +691,18 @@ export default function AgentPanes({
           });
           return false;
         }
-        if (!isCurrent()) return false;
+        if (!isCurrent()) {
+          // The reopen SUCCEEDED server-side (closedInSessionAt cleared, a
+          // cap slot consumed) after a newer pick or agent mint already
+          // superseded this one on the same pane — returning early without
+          // undoing that leaves an invisible open listing occupying a slot
+          // no pane shows, which can make a LATER reopen fail as "session
+          // full" for no visible reason. Close it right back out, the same
+          // way an orphaned mint is cleaned up above (review finding —
+          // chatgpt-codex-connector on PR #2299).
+          void cleanupOrphanedConversation(conversation.id);
+          return false;
+        }
         // Instant-freshness nudge, same as every other listing-changing
         // action here — the sidebar's own open list otherwise lags until its
         // next poll.
@@ -703,9 +714,16 @@ export default function AgentPanes({
       // transcript (review finding — chatgpt-codex-connector on PR #2299;
       // the same dedup `openConversation`'s own focus branch enforces
       // elsewhere, applied here since this path assigns directly rather
-      // than going through that store action).
-      const existingPane = workspace
-        ? panesOf(workspace).find(
+      // than going through that store action). Read FRESH, not the
+      // `workspace` this callback closed over: two panes racing to reopen
+      // the SAME closed conversation each run this check after their own
+      // await, so a stale pre-request snapshot could make BOTH miss the
+      // other's just-completed assignment and independently assign — the
+      // exact duplicate this check exists to prevent (review finding —
+      // chatgpt-codex-connector on PR #2299).
+      const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
+      const existingPane = liveWorkspace
+        ? panesOf(liveWorkspace).find(
             (p) => p.id !== paneId && p.scope?.kind === 'chat' && p.scope.targetId === conversation.id,
           )
         : undefined;
@@ -729,7 +747,7 @@ export default function AgentPanes({
       });
       return true;
     },
-    [sessionId, assignPane, workspace, selectPane, beginPaneAssign],
+    [sessionId, assignPane, selectPane, beginPaneAssign, cleanupOrphanedConversation],
   );
 
   /**

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1001,6 +1001,18 @@ function ChatPane({
 
   const [activeTab, setActiveTab] = useState<PaneChatTab>('chat');
 
+  // A pane's agent can change under it (the AISelector switch) without
+  // remounting this component. Settings belongs to the OLD agent — showing
+  // it (or leaving `activeTab: 'settings'` set) after switching to a
+  // DIFFERENT agent presents that agent's config as if requested, and
+  // switching to the Assistant (no Settings tab at all) leaves the body on
+  // its final "not agentPageId or no agent" branch, a spinner that never
+  // resolves since neither condition can ever become true again for this
+  // scope (review finding — coderabbitai on PR #2299).
+  useEffect(() => {
+    setActiveTab('chat');
+  }, [scope.agentPageId]);
+
   const {
     conversations,
     isLoading: conversationsLoading,
@@ -1152,8 +1164,16 @@ function ChatPane({
             onSelectConversation={handleSelectHistoryConversation}
             onCreateNew={handleCreateNewFromHistory}
             onDeleteConversation={(id) => {
-              void deleteConversation(id);
-              onHistoryDeleteConversation(id);
+              // Only rebind panes once the delete actually succeeded — a
+              // refused delete (the never-empty guard's 409, e.g.) or a
+              // network failure both leave the conversation exactly as it
+              // was server-side, and resetting live panes for it anyway
+              // would discard a working pane binding for nothing (review
+              // finding — chatgpt-codex-connector and coderabbitai on PR
+              // #2299).
+              void deleteConversation(id).then((succeeded) => {
+                if (succeeded) onHistoryDeleteConversation(id);
+              });
             }}
             onToggleShare={toggleConversationShare}
             isLoading={conversationsLoading}

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -622,6 +622,19 @@ export default function AgentPanes({
     onSessionEnded?.();
   }, [pendingEndClose, sessionId, forgetWorkspace, closeTerminalShell, onSessionEnded]);
 
+  // Shared by cleanupOrphanedConversation's own post-DELETE recheck below and
+  // handlePickHistoryConversation's rollback decision.
+  const isConversationShownSomewhere = useCallback(
+    (conversationId: string) => {
+      const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
+      return (
+        !!liveWorkspace &&
+        panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversationId)
+      );
+    },
+    [sessionId],
+  );
+
   const cleanupOrphanedConversation = useCallback(
     async (conversationId: string) => {
       // Best-effort: the pane that wanted this is already gone, so a failure
@@ -634,11 +647,24 @@ export default function AgentPanes({
         await del(
           `/api/agent-sessions/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversationId)}`,
         );
+        // This DELETE can be delayed (a slow network) long enough for a
+        // LATER, independent pick of this exact conversation to land in a
+        // pane before it reaches the server — closing a listing that is now
+        // visibly displayed. Re-check right after the delete resolves and
+        // compensate by reopening it back rather than leaving the pane
+        // pointed at a transcript that would 404 on send (review finding —
+        // chatgpt-codex-connector on PR #2299, round 17).
+        if (isConversationShownSomewhere(conversationId)) {
+          await post(
+            `/api/agent-sessions/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversationId)}/reopen`,
+            {},
+          );
+        }
       } catch (error) {
         console.error('Failed to clean up an orphaned conversation:', error);
       }
     },
-    [sessionId],
+    [sessionId, isConversationShownSomewhere],
   );
 
   const handlePickAgent = useCallback(
@@ -811,13 +837,7 @@ export default function AgentPanes({
     ): Promise<boolean> => {
       const isCurrent = beginPaneAssign(paneId);
       if (conversation.sessionId === sessionId) {
-        const isShownSomewhere = () => {
-          const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
-          return (
-            !!liveWorkspace &&
-            panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversation.id)
-          );
-        };
+        const isShownSomewhere = () => isConversationShownSomewhere(conversation.id);
         pendingReopenCounts.current.set(conversation.id, (pendingReopenCounts.current.get(conversation.id) ?? 0) + 1);
         // Captured BEFORE the request starts — compared, never consumed, so
         // every concurrent reopen for this same conversationId independently
@@ -978,7 +998,7 @@ export default function AgentPanes({
       });
       return true;
     },
-    [sessionId, assignPane, selectPane, beginPaneAssign, cleanupOrphanedConversation],
+    [sessionId, assignPane, selectPane, beginPaneAssign, cleanupOrphanedConversation, isConversationShownSomewhere],
   );
 
   /**

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -700,7 +700,23 @@ export default function AgentPanes({
           // full" for no visible reason. Close it right back out, the same
           // way an orphaned mint is cleaned up above (review finding —
           // chatgpt-codex-connector on PR #2299).
-          void cleanupOrphanedConversation(conversation.id);
+          //
+          // BUT only when it's genuinely orphaned: the same conversation
+          // picked twice in quick succession can have the NEWER request's
+          // reopen resolve first and legitimately land in a pane (this one
+          // or another), with this now-stale request's reopen resolving
+          // second. Unconditionally closing here would rip that just-
+          // reopened, currently-visible conversation back out from under
+          // whichever pane is showing it. Read live state across every pane
+          // in the grid (not just this one) before deciding (review finding
+          // — chatgpt-codex-connector on PR #2299).
+          const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
+          const stillOrphaned =
+            !liveWorkspace ||
+            !panesOf(liveWorkspace).some((p) => p.scope?.kind === 'chat' && p.scope.targetId === conversation.id);
+          if (stillOrphaned) {
+            void cleanupOrphanedConversation(conversation.id);
+          }
           return false;
         }
         // Instant-freshness nudge, same as every other listing-changing

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -893,7 +893,23 @@ export default function AgentPanes({
           // opened it, so rolling it back would close a listing still in
           // use for a no-op this request didn't cause (review finding —
           // chatgpt-codex-connector on PR #2299, round 15).
-          if (reopenResult.alreadyOpen || isShownSomewhere()) return false;
+          const shownSomewhere = isShownSomewhere();
+          // The LAST settler for this conversationId is responsible for
+          // finishing a SIBLING's deferred cleanup regardless of THIS
+          // request's own outcome — an `alreadyOpen` no-op response still
+          // needs to drain it if nothing else is left pending, or an
+          // earlier request that genuinely transitioned the listing (and
+          // deferred because this one was still in flight) leaks an
+          // invisible open listing forever, since nothing else will ever
+          // revisit it (review finding — chatgpt-codex-connector on PR
+          // #2299, round 16).
+          const hadDeferredSibling = remaining <= 0 && deferredReopenSuccess.current.delete(conversation.id);
+          if (shownSomewhere) return false;
+          if (hadDeferredSibling) {
+            void cleanupOrphanedConversation(conversation.id);
+            return false;
+          }
+          if (reopenResult.alreadyOpen) return false;
           if (remaining > 0) {
             // Something else is still reopening this same conversationId —
             // premature to clean up (that request might land it). Defer:

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -145,6 +145,24 @@ export default function AgentPanes({
   const replaceConversation = useAgentWorkspaceStore((state) => state.replaceConversation);
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
 
+  // The latest "assign this pane to conversation X" request per pane —
+  // bumped by every such request (a History pick, an agent mint) so an
+  // OLDER one's async completion (a slow reopen, a slow mint) can detect
+  // it's been superseded and skip applying its now-stale result. A pane id
+  // is reused across a pane's whole lifetime (split/close mint new ids, but
+  // WITHIN one pane's life the id is stable), so a plain per-paneId counter
+  // is enough — no cleanup needed, a closed pane's entry is simply never
+  // read again (review finding — chatgpt-codex-connector on PR #2299: two
+  // rapid History picks, or a History pick raced by an agent switch, could
+  // resolve out of order and let network timing pick the visible
+  // transcript).
+  const paneAssignTokens = useRef(new Map<string, number>());
+  const beginPaneAssign = useCallback((paneId: string) => {
+    const token = (paneAssignTokens.current.get(paneId) ?? 0) + 1;
+    paneAssignTokens.current.set(paneId, token);
+    return () => paneAssignTokens.current.get(paneId) === token;
+  }, []);
+
   // The picker's agent list. A drive session offers only that drive's agents;
   // a global-assistant session (driveId null) has no home drive to filter by,
   // so it offers every agent the caller can access, across all their drives —
@@ -559,6 +577,14 @@ export default function AgentPanes({
 
   const handlePickAgent = useCallback(
     async (paneId: string, agentPageId: string | null) => {
+      // Also supersedes any pending `handlePickHistoryConversation` call for
+      // this pane — a slow reopen resolving after the user has since minted
+      // a different agent into this same pane must not overwrite it (review
+      // finding — chatgpt-codex-connector on PR #2299). This mint has its
+      // OWN, separate staleness guard below (`paneStillLoading`); bumping
+      // the shared token here just extends that same protection to the
+      // OTHER call path.
+      beginPaneAssign(paneId);
       const conversationId = createId();
       // Bind first, render after: the pane goes to `loading` (kind set, target
       // null) while the mint is in flight — never a speculative surface.
@@ -616,7 +642,7 @@ export default function AgentPanes({
         }
       }
     },
-    [assignPane, resetPane, sessionId, paneStillLoading, cleanupOrphanedConversation, recordMintedConversation],
+    [assignPane, resetPane, sessionId, paneStillLoading, cleanupOrphanedConversation, recordMintedConversation, beginPaneAssign],
   );
 
   /**
@@ -646,6 +672,7 @@ export default function AgentPanes({
       agentPageId: string | null,
       conversation: { id: string; title: string | null; sessionId: string | null },
     ): Promise<boolean> => {
+      const isCurrent = beginPaneAssign(paneId);
       if (conversation.sessionId === sessionId) {
         try {
           await post(
@@ -653,17 +680,24 @@ export default function AgentPanes({
             {},
           );
         } catch (error) {
+          // A newer pick (or agent switch) on this pane already superseded
+          // this one — its own outcome, success or failure, is no longer
+          // this pane's concern, and surfacing an error toast for a request
+          // the user has already moved past would be confusing.
+          if (!isCurrent()) return false;
           console.error('Failed to reopen conversation:', error);
           toast.error('Could not reopen this conversation', {
             description: error instanceof Error ? error.message : 'Please try again.',
           });
           return false;
         }
+        if (!isCurrent()) return false;
         // Instant-freshness nudge, same as every other listing-changing
         // action here — the sidebar's own open list otherwise lags until its
         // next poll.
         void mutate(isAgentSessionsKey);
       }
+      if (!isCurrent()) return false;
       // Already showing in another pane in THIS grid — focus it rather than
       // mounting a second, independently interactive surface for the same
       // transcript (review finding — chatgpt-codex-connector on PR #2299;
@@ -695,7 +729,7 @@ export default function AgentPanes({
       });
       return true;
     },
-    [sessionId, assignPane, workspace, selectPane],
+    [sessionId, assignPane, workspace, selectPane, beginPaneAssign],
   );
 
   /**
@@ -711,8 +745,16 @@ export default function AgentPanes({
    */
   const handleHistoryDeleteConversation = useCallback(
     (deletedConversationId: string) => {
-      if (!workspace) return;
-      const affectedPanes = panesOf(workspace).filter(
+      // Read fresh at call time, not the `workspace` this callback closed
+      // over — this always runs after the DELETE's own async round trip,
+      // during which the user could have already reassigned an affected
+      // pane to something else. Resetting based on the STALE pre-DELETE
+      // snapshot would discard that newer selection even though the pane
+      // no longer shows the deleted conversation at all (review finding —
+      // chatgpt-codex-connector on PR #2299).
+      const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
+      if (!liveWorkspace) return;
+      const affectedPanes = panesOf(liveWorkspace).filter(
         (p) => p.scope?.kind === 'chat' && p.scope.targetId === deletedConversationId,
       );
       for (const pane of affectedPanes) {
@@ -722,7 +764,7 @@ export default function AgentPanes({
         void mutate(isAgentSessionsKey);
       }
     },
-    [workspace, sessionId, resetPane],
+    [sessionId, resetPane],
   );
 
   // The pane bar selector's switch — focus-or-mint, decided by the pure

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -35,10 +35,9 @@
  * session already has that isn't currently shown anywhere.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createId } from '@paralleldrive/cuid2';
-import { Loader2, Settings } from 'lucide-react';
+import { History, Loader2, MessageSquare, Save, Settings } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
@@ -50,6 +49,11 @@ import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
 import { useAuth } from '@/hooks/useAuth';
 import { useConversationActiveStream } from '@/hooks/useActiveStream';
 import { AISelector } from '@/components/ai/shared';
+import { useConversations } from '@/lib/ai/shared/hooks/useConversations';
+import { useAgentConfig } from '@/lib/ai/shared/hooks/useAgentConfig';
+import { useProviderSettings } from '@/lib/ai/shared/hooks/useProviderSettings';
+import { PageAgentHistoryTab, PageAgentSettingsTab, type PageAgentSettingsTabRef } from '@/components/ai/page-agents';
+import { cn } from '@/lib/utils';
 import EndSessionDialog from '../EndSessionDialog';
 import { useResolvedAgent } from '../useResolvedAgent';
 import SessionPanes from './SessionPanes';
@@ -615,6 +619,45 @@ export default function AgentPanes({
     [assignPane, resetPane, sessionId, paneStillLoading, cleanupOrphanedConversation, recordMintedConversation],
   );
 
+  /**
+   * A pane's own History tab picking a past conversation — assign it to THIS
+   * pane, reopening it into the session's listing first when it's bound to
+   * THIS session and closed. A conversation that is unbound, or bound to a
+   * DIFFERENT session, is never subject to this session's cap/listing at
+   * all — no server call needed, straight to `assignPane` (the same client-
+   * only mechanism `openConversation`/`handleSwitchAgent`'s focus branch
+   * already use to point a pane at an existing conversationId).
+   */
+  const handlePickHistoryConversation = useCallback(
+    async (paneId: string, agentPageId: string | null, conversation: { id: string; title: string | null; sessionId: string | null }) => {
+      if (conversation.sessionId === sessionId) {
+        try {
+          await post(
+            `/api/agent-sessions/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversation.id)}/reopen`,
+            {},
+          );
+        } catch (error) {
+          console.error('Failed to reopen conversation:', error);
+          toast.error('Could not reopen this conversation', {
+            description: error instanceof Error ? error.message : 'Please try again.',
+          });
+          return;
+        }
+        // Instant-freshness nudge, same as every other listing-changing
+        // action here — the sidebar's own open list otherwise lags until its
+        // next poll.
+        void mutate(isAgentSessionsKey);
+      }
+      assignPane(sessionId, paneId, {
+        kind: 'chat',
+        name: conversation.title || 'Conversation',
+        targetId: conversation.id,
+        agentPageId,
+      });
+    },
+    [sessionId, assignPane],
+  );
+
   // The pane bar selector's switch — focus-or-mint, decided by the pure
   // module above. Focusing reuses the store's dedup-aware `openConversation`
   // (the same conversation never shows in two panes at once — review M1);
@@ -695,6 +738,39 @@ export default function AgentPanes({
 
   const renderPane = ({ pane, isActive, canSplit }: { pane: PaneState; isActive: boolean; canSplit: boolean }) => {
     const surface = resolvePaneSurface(pane.scope);
+
+    // A chat pane owns real Chat/History/Settings tabs and the state that
+    // switches between them — pulled into its own component (not inlined
+    // here) for the same reason `ChatPaneIdentity`/`ChatPane`'s predecessor
+    // was: hooks cannot run inside a render-prop map across a pane count
+    // that changes on every split/close.
+    if (pane.scope?.kind === 'chat') {
+      return (
+        <ChatPane
+          scope={pane.scope}
+          surface={surface}
+          isActive={isActive}
+          canSplit={canSplit}
+          pickableAgents={pickableAgents}
+          agentsLoading={agentsLoading}
+          conversationsReady={sessionKnownToConversationsCache}
+          driveId={driveId}
+          sessionId={sessionId}
+          chatContext={chatContext}
+          isReadOnly={isReadOnly}
+          onSelectAgent={(nextAgentPageId) => handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)}
+          onSelectPane={() => selectPane(sessionId, pane.id)}
+          onSplitRight={() => splitRight(sessionId, pane.id)}
+          onSplitDown={() => splitDown(sessionId, pane.id)}
+          onClose={() => handleClosePane(pane.id)}
+          onCreateNewFromHistory={() => void handlePickAgent(pane.id, pane.scope!.agentPageId)}
+          onPickHistoryConversation={(conversation) =>
+            void handlePickHistoryConversation(pane.id, pane.scope!.agentPageId, conversation)
+          }
+        />
+      );
+    }
+
     // Unbound (scope null) is the only picker shape now — `resetPane` is the
     // one path back to it, so there is no longer a bound-but-empty sentinel
     // to also treat as one (issue #2263, finding 5).
@@ -711,19 +787,7 @@ export default function AgentPanes({
         <PaneBar
           isActive={isActive}
           identity={
-            pane.scope?.kind === 'chat' ? (
-              <ChatPaneIdentity
-                scope={pane.scope}
-                surface={surface}
-                pickableAgents={pickableAgents}
-                agentsLoading={agentsLoading}
-                conversationsReady={sessionKnownToConversationsCache}
-                driveId={driveId}
-                onSelectAgent={(nextAgentPageId) =>
-                  handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)
-                }
-              />
-            ) : pane.scope ? (
+            pane.scope ? (
               <PaneSessionIdentity name={pane.scope.name || 'pane'} />
             ) : (
               <span className="text-muted-foreground">New pane</span>
@@ -761,17 +825,9 @@ export default function AgentPanes({
             <div className="flex h-full items-center justify-center">
               <Loader2 className="size-4 animate-spin text-muted-foreground" />
             </div>
-          ) : surface.surface === 'chat' ? (
-            <PaneChat
-              conversationId={surface.conversationId}
-              agentPageId={surface.agentPageId}
-              driveId={driveId}
-              context={chatContext}
-              isReadOnly={isReadOnly}
-            />
-          ) : (
+          ) : surface.surface === 'terminal' ? (
             <Shell shellId={surface.shellId} name={pane.scope?.name} />
-          )}
+          ) : null}
         </div>
       </div>
     );
@@ -792,31 +848,50 @@ export default function AgentPanes({
   );
 }
 
+type PaneChatTab = 'chat' | 'history' | 'settings';
+
 /**
- * A chat pane's bar identity: the `/development` AISelector, restored as a
- * first-class pane bar control (a pane-close-lifecycle audit follow-up). Own
- * component (rather than inline in `renderPane`) so its hooks — resolving the
- * pane's agent, reading whether it's streaming — obey the rules of hooks
- * across a pane count that changes on every split/close.
+ * A chat pane, in full: the bar identity (AISelector + Chat/History/Settings
+ * tab strip) AND the body those tabs switch between. One component, not two,
+ * because the tabs live in the bar but the state they drive has to reach the
+ * body below it — `renderPane` itself cannot hold that state (a plain
+ * function invoked per pane, not a component; hooks would violate their own
+ * rules across a pane count that changes on every split/close), so this is
+ * the pane-bar-plus-body wrapper every OTHER pane kind's inline JSX in
+ * `renderPane` also uses, just pulled out for this one kind's own hooks.
  *
- * `pickableAgents` is what scopes the dropdown to the session's own drive
- * (or to nothing, for a global-assistant session — see `AISelector`'s
- * `agents` override): the same list the split picker already offers, so a
- * pane's selector and "Split → pick an agent" never disagree about what's
- * choosable here.
+ * History and Settings reuse the SAME hooks (`useConversations`,
+ * `useAgentConfig`) the page's own `AgentPageView` tabs use — the whole
+ * point (raised in review on PR #2296/#2299) being that a pane and the page
+ * view are not two parallel implementations of "this agent's history/
+ * settings": they are the same SWR-keyed data, so two panes on the same
+ * agent (or a pane and the page view) can never silently drift.
  */
-function ChatPaneIdentity({
+function ChatPane({
   scope,
   surface,
+  isActive,
+  canSplit,
   pickableAgents,
   agentsLoading,
   conversationsReady,
   driveId,
+  sessionId,
+  chatContext,
+  isReadOnly,
   onSelectAgent,
+  onSelectPane,
+  onSplitRight,
+  onSplitDown,
+  onClose,
+  onCreateNewFromHistory,
+  onPickHistoryConversation,
 }: {
   /** Always `kind: 'chat'` at the call site — `PaneScope` isn't a discriminated union, so this stays the full type. */
   scope: PaneScope;
   surface: PaneSurface;
+  isActive: boolean;
+  canSplit: boolean;
   pickableAgents: PickableAgent[];
   agentsLoading: boolean;
   /**
@@ -828,7 +903,16 @@ function ChatPaneIdentity({
    */
   conversationsReady: boolean;
   driveId: string | null;
+  sessionId: string;
+  chatContext?: 'page' | 'console';
+  isReadOnly: boolean;
   onSelectAgent: (agentPageId: string | null) => void;
+  onSelectPane: () => void;
+  onSplitRight: () => void;
+  onSplitDown: () => void;
+  onClose: () => void;
+  onCreateNewFromHistory: () => void;
+  onPickHistoryConversation: (conversation: { id: string; title: string | null; sessionId: string | null }) => void;
 }) {
   const { user } = useAuth();
   const { agent } = useResolvedAgent(scope.agentPageId);
@@ -841,33 +925,216 @@ function ChatPaneIdentity({
   // Mid-mint (the row isn't there yet), mid-stream, or the switch decision's
   // own data doesn't know this session yet: none of these have anything
   // safe to switch against.
-  const disabled = surface.surface === 'loading' || activeStream !== undefined || !conversationsReady;
+  const disabledAgentSwitch = surface.surface === 'loading' || activeStream !== undefined || !conversationsReady;
+
+  const [activeTab, setActiveTab] = useState<PaneChatTab>('chat');
+
+  const {
+    conversations,
+    isLoading: conversationsLoading,
+    deleteConversation,
+  } = useConversations({
+    agentId: scope.agentPageId,
+    currentConversationId: conversationId,
+    // Only fetched while History is actually showing — same lazy-load
+    // discipline `AgentPageView`'s own History tab uses.
+    enabled: activeTab === 'history',
+  });
+
+  const { config: agentConfig, setConfig: setAgentConfig } = useAgentConfig(scope.agentPageId);
+  const {
+    selectedProvider,
+    setSelectedProvider,
+    selectedModel,
+    setSelectedModel,
+    isProviderConfigured,
+  } = useProviderSettings(scope.agentPageId ? { pageId: scope.agentPageId } : {});
+  const [isSettingsSaving, setIsSettingsSaving] = useState(false);
+  const settingsRef = useRef<PageAgentSettingsTabRef>(null);
+
+  const toggleConversationShare = useCallback(
+    async (targetConversationId: string, isShared: boolean) => {
+      if (scope.agentPageId === null) return;
+      try {
+        const response = await fetchWithAuth(
+          `/api/ai/page-agents/${scope.agentPageId}/conversations/${targetConversationId}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isShared }),
+          },
+        );
+        if (!response.ok) console.error('Failed to update conversation sharing');
+      } catch (error) {
+        console.error('Failed to update conversation sharing:', error);
+      }
+    },
+    [scope.agentPageId],
+  );
+
+  const handleSelectHistoryConversation = useCallback(
+    (id: string) => {
+      const picked = conversations.find((c) => c.id === id);
+      onPickHistoryConversation({ id, title: picked?.title ?? null, sessionId: picked?.sessionId ?? null });
+      setActiveTab('chat');
+    },
+    [conversations, onPickHistoryConversation],
+  );
+
+  const handleCreateNewFromHistory = useCallback(() => {
+    onCreateNewFromHistory();
+    setActiveTab('chat');
+  }, [onCreateNewFromHistory]);
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-0.5">
-      <AISelector
-        selectedAgent={scope.agentPageId === null ? null : agent}
-        onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
-        driveId={driveId ?? undefined}
-        agents={pickableAgents}
-        agentsLoading={agentsLoading}
-        disabled={disabled}
-        className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
+    <div
+      className="group/pane flex h-full min-h-0 flex-col"
+      onClick={onSelectPane}
+      // Tabbing into any control inside a pane (the chat input, a close
+      // button) must activate it too — a click is not the only way in.
+      onFocusCapture={onSelectPane}
+    >
+      <PaneBar
+        isActive={isActive}
+        identity={
+          <div className="flex min-w-0 flex-1 items-center gap-0.5">
+            <AISelector
+              selectedAgent={scope.agentPageId === null ? null : agent}
+              onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
+              driveId={driveId ?? undefined}
+              agents={pickableAgents}
+              agentsLoading={agentsLoading}
+              disabled={disabledAgentSwitch}
+              className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
+            />
+            <PaneChatTabStrip
+              activeTab={activeTab}
+              onSelectTab={setActiveTab}
+              // The Assistant (agentPageId null) has no page, so no Settings —
+              // every other pane's agent does.
+              showSettings={scope.agentPageId !== null}
+              agentTitle={agent?.title ?? 'Agent'}
+            />
+          </div>
+        }
+        actions={
+          <>
+            {activeTab === 'settings' && scope.agentPageId !== null && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  settingsRef.current?.submitForm();
+                }}
+                disabled={isSettingsSaving}
+                className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+              >
+                {isSettingsSaving ? <Loader2 className="size-3 animate-spin" aria-hidden="true" /> : <Save className="size-3" aria-hidden="true" />}
+                Save
+              </button>
+            )}
+            <PaneSplitCloseActions
+              canSplit={canSplit}
+              canClose
+              onSplitRight={onSplitRight}
+              onSplitDown={onSplitDown}
+              onClose={onClose}
+            />
+          </>
+        }
       />
-      {/* The Assistant (agentPageId null) has no page, so no Settings — every
-          other pane's agent does. `/p/[pageId]` resolves the drive-scoped
-          URL without this component needing to know it. */}
-      {scope.agentPageId !== null && (
-        <Link
-          href={`/p/${scope.agentPageId}?tab=settings`}
-          aria-label={`${agent?.title ?? 'Agent'} settings`}
-          title="Agent settings"
-          className="flex shrink-0 items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Settings className="size-3" aria-hidden="true" />
-        </Link>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {activeTab === 'chat' ? (
+          surface.surface === 'loading' ? (
+            <div className="flex h-full items-center justify-center">
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : surface.surface === 'chat' ? (
+            <PaneChat
+              conversationId={surface.conversationId}
+              agentPageId={surface.agentPageId}
+              driveId={driveId}
+              context={chatContext}
+              isReadOnly={isReadOnly}
+            />
+          ) : null
+        ) : activeTab === 'history' ? (
+          <PageAgentHistoryTab
+            conversations={conversations}
+            currentConversationId={conversationId}
+            onSelectConversation={handleSelectHistoryConversation}
+            onCreateNew={handleCreateNewFromHistory}
+            onDeleteConversation={(id) => void deleteConversation(id)}
+            onToggleShare={toggleConversationShare}
+            isLoading={conversationsLoading}
+          />
+        ) : scope.agentPageId !== null && agent ? (
+          <div className="h-full overflow-auto">
+            <PageAgentSettingsTab
+              ref={settingsRef}
+              pageId={scope.agentPageId}
+              driveId={agent.driveId}
+              config={agentConfig}
+              onConfigUpdate={setAgentConfig}
+              selectedProvider={selectedProvider}
+              selectedModel={selectedModel}
+              onProviderChange={setSelectedProvider}
+              onModelChange={setSelectedModel}
+              isProviderConfigured={isProviderConfigured}
+              onSavingChange={setIsSettingsSaving}
+            />
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The tab strip itself — icon-only (a pane bar is 30px tall, no room for
+ * `AgentPageView`'s spacious text pills), tooltipped/aria-labeled for the
+ * text a mouse-hover or screen reader still needs.
+ */
+function PaneChatTabStrip({
+  activeTab,
+  onSelectTab,
+  showSettings,
+  agentTitle,
+}: {
+  activeTab: PaneChatTab;
+  onSelectTab: (tab: PaneChatTab) => void;
+  showSettings: boolean;
+  agentTitle: string;
+}) {
+  const tabButton = (tab: PaneChatTab, label: string, Icon: typeof MessageSquare) => (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={activeTab === tab}
+      aria-label={label}
+      title={label}
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelectTab(tab);
+      }}
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground',
+        activeTab === tab && 'bg-accent text-foreground',
       )}
+    >
+      <Icon className="size-3" aria-hidden="true" />
+    </button>
+  );
+
+  return (
+    <div role="tablist" className="flex shrink-0 items-center gap-0.5">
+      {tabButton('chat', 'Chat', MessageSquare)}
+      {tabButton('history', 'History', History)}
+      {showSettings && tabButton('settings', `${agentTitle} settings`, Settings)}
     </div>
   );
 }

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1108,6 +1108,51 @@ describe('AgentPanes', () => {
       );
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 7): the
+    // rollback above must not fire when the SAME conversation was picked
+    // twice and the NEWER pick's reopen wins the race, legitimately landing
+    // in a pane before the older (now-stale) reopen resolves — closing it
+    // back out would rip a currently-visible conversation out of its pane.
+    it('does not roll back a stale reopen when a newer pick already landed the same conversation', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-slow', title: 'Slow chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveSlowReopen!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveSlowReopen = resolve)))
+        .mockResolvedValueOnce({});
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      // First pick of conv-slow — still pending, stays on History.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-slow' }));
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
+
+      // Second pick of the SAME conversation, on the SAME pane, before the
+      // first resolves — its own reopen resolves immediately and legitimately
+      // lands it in the pane.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-slow' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-slow'));
+
+      // NOW the first (stale) reopen resolves — must NOT close conv-slow,
+      // since a pane is currently showing it.
+      resolveSlowReopen({});
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).toBe('conv-slow');
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-slow');
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: History-delete
     // deactivates the CANONICAL row, not just the deleting pane's own
     // listing — every pane showing that id (in this grid), whichever pane's

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1534,6 +1534,75 @@ describe('AgentPanes', () => {
       );
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 18): the
+    // SAME race that motivates the compensating reopen above applies to
+    // that compensating reopen itself — if IT is slow, the pane that made
+    // it necessary can move on again before it lands, leaving the
+    // conversation orphaned a second time with nothing left to notice.
+    it('recursively re-checks and cleans up again if the pane moves on before the compensating reopen itself lands', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([
+            { id: 'conv-recurse', title: 'Recurse', sessionId: 'ses-1' },
+            { id: 'conv-unbound', title: 'Unbound', sessionId: null },
+          ]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveFirstReopen!: (value: unknown) => void;
+      let resolveFirstDelete!: (value: unknown) => void;
+      let resolveCompensatingReopen!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveFirstReopen = resolve))) // first pick
+        .mockResolvedValueOnce({ ok: true, alreadyOpen: false }) // fresh second pick
+        .mockReturnValueOnce(new Promise((resolve) => (resolveCompensatingReopen = resolve))); // compensating reopen
+      mockDel
+        .mockReturnValueOnce(new Promise((resolve) => (resolveFirstDelete = resolve))) // first cleanup DELETE
+        .mockResolvedValueOnce(undefined); // second (recursive) cleanup DELETE
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-recurse' })); // reopen #1, pending
+
+      await user.click(await screen.findByRole('button', { name: 'select-conv-unbound' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-unbound'));
+
+      // Reopen #1 resolves, genuinely orphaned — DIRECT cleanup, DELETE
+      // pending.
+      resolveFirstReopen({ ok: true, alreadyOpen: false });
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-recurse'));
+
+      // A fresh pick lands it back while that first DELETE is pending.
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-recurse' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-recurse'));
+
+      // First DELETE resolves — triggers a compensating reopen, pending.
+      resolveFirstDelete(undefined);
+      await waitFor(() =>
+        expect(
+          mockPost.mock.calls.filter((c) => c[0] === '/api/agent-sessions/ses-1/conversations/conv-recurse/reopen'),
+        ).toHaveLength(3),
+      );
+
+      // WHILE that compensating reopen is still pending, the pane moves on
+      // to something else again.
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-unbound' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-unbound'));
+
+      // The compensating reopen resolves — must recheck and, since nothing
+      // shows conv-recurse anymore, clean it up AGAIN.
+      resolveCompensatingReopen({ ok: true, alreadyOpen: false });
+      await waitFor(() =>
+        expect(
+          mockDel.mock.calls.filter((c) => c[0] === '/api/agent-sessions/ses-1/conversations/conv-recurse'),
+        ).toHaveLength(2),
+      );
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299 (round 8): a
     // reopen can commit server-side and then have its OWN response delayed
     // long enough for the SAME conversation to be deleted from History

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1375,6 +1375,55 @@ describe('AgentPanes', () => {
       expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-already-open');
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 16): the
+    // round-15 alreadyOpen early-return skipped the "am I the last settler,
+    // do I need to finish a SIBLING's deferred cleanup" check entirely —
+    // an alreadyOpen no-op response for the LAST pending reopen left an
+    // earlier request's genuine (but deferred) transition orphaned forever.
+    it("given the last-to-settle reopen reports alreadyOpen, still drains an earlier sibling's deferred cleanup", async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([
+            { id: 'conv-shared-16', title: 'Shared', sessionId: 'ses-1' },
+            { id: 'conv-other-16', title: 'Other', sessionId: null },
+          ]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveOlder!: (value: unknown) => void;
+      let resolveNewer!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveOlder = resolve)))
+        .mockReturnValueOnce(new Promise((resolve) => (resolveNewer = resolve)));
+      mockDel.mockResolvedValue(undefined);
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-shared-16' })); // older, pending
+      await user.click(await screen.findByRole('button', { name: 'select-conv-shared-16' })); // newer, pending, supersedes older
+      // A third pick (unbound — no reopen call of its own) supersedes the
+      // newer reopen too.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-other-16' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-other-16'));
+
+      // Older resolves first, genuinely transitioning the listing —
+      // deferred, since the newer reopen is still pending.
+      resolveOlder({ ok: true, alreadyOpen: false });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-shared-16');
+
+      // The newer (LAST to settle) reports alreadyOpen — its OWN outcome is
+      // a no-op, but it must still drain the older's deferred cleanup.
+      resolveNewer({ ok: true, alreadyOpen: true });
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-shared-16'),
+      );
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299 (round 8): the
     // "is anyone showing this?" rollback check above still misses the case
     // where the newer reopen for the SAME conversation hasn't LANDED yet

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1249,6 +1249,113 @@ describe('AgentPanes', () => {
       expect(pane?.scope?.targetId).not.toBe('conv-doomed-live');
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 9): the
+    // Set-based mark above is a SINGLE consumable flag — fine for one
+    // pending reopen, but TWO panes concurrently reopening the same closed
+    // conversation both need to observe the same delete, and whichever
+    // completion checks first would consume it, leaving the second one
+    // blind and assigning a deleted conversation anyway.
+    it('rejects EVERY pending reopen for a conversation deleted from History, not just the first to check', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-shared', title: 'Shared chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveA!: (value: unknown) => void;
+      let resolveB!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveA = resolve)))
+        .mockReturnValueOnce(new Promise((resolve) => (resolveB = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      const secondPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+
+      const user = userEvent.setup();
+      const historyTabs = await screen.findAllByRole('tab', { name: /history/i });
+      await user.click(historyTabs[0]);
+      await user.click(historyTabs[1]);
+
+      // Both panes reopen the SAME conversation — both pending.
+      const selectButtonsFirst = await screen.findAllByRole('button', { name: 'select-conv-shared' });
+      await user.click(selectButtonsFirst[0]);
+      const selectButtonsSecond = await screen.findAllByRole('button', { name: 'select-conv-shared' });
+      await user.click(selectButtonsSecond[1]);
+
+      // Deleted from History while BOTH reopens are still in flight.
+      const deleteButtons = await screen.findAllByRole('button', { name: 'delete-conv-shared' });
+      await user.click(deleteButtons[0]);
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(
+          '/api/ai/page-agents/agent-1/conversations/conv-shared',
+          { method: 'DELETE' },
+        ),
+      );
+
+      // Both delayed reopens resolve — NEITHER pane may end up bound to the
+      // deleted conversation.
+      resolveA({});
+      resolveB({});
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const finalPanes = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns.flatMap((c) => c.panes);
+      expect(finalPanes.find((p) => p.id === firstPaneId)?.scope?.targetId).not.toBe('conv-shared');
+      expect(finalPanes.find((p) => p.id === secondPaneId)?.scope?.targetId).not.toBe('conv-shared');
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299 (round 9): the
+    // round-8 fix deferred cleanup when another reopen for the same
+    // conversation was still pending, on the assumption that request would
+    // either land it (fine) or fail leaving cleanup moot (WRONG — a failed
+    // final request leaves the earlier successful-but-deferred reopen
+    // dangling forever, since nothing else will ever revisit it).
+    it('cleans up an earlier successful-but-deferred reopen when the final pending reopen for it fails', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-orphan', title: 'Orphan chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveOlder!: (value: unknown) => void;
+      let rejectNewer!: (reason: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveOlder = resolve)))
+        .mockReturnValueOnce(new Promise((_resolve, reject) => (rejectNewer = reject)));
+      mockDel.mockResolvedValue(undefined);
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      // Two picks of the same conversation on the same pane — the second
+      // supersedes the first's token.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-orphan' }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-orphan' }));
+
+      // The OLDER (now-superseded) reopen resolves successfully first —
+      // deferred, since the newer one is still pending and nothing shows it
+      // yet.
+      resolveOlder({});
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-orphan');
+
+      // The NEWER (current) reopen then fails outright — nothing else will
+      // ever revisit the older one's dangling server-side success; the
+      // failing settle must finish that deferred cleanup itself.
+      rejectNewer(new Error('network down'));
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-orphan'),
+      );
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: History-delete
     // deactivates the CANONICAL row, not just the deleting pane's own
     // listing — every pane showing that id (in this grid), whichever pane's

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -683,6 +683,108 @@ describe('AgentPanes', () => {
       expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 14): two
+    // mints for the SAME pane install the identical, indistinguishable
+    // loading scope — without a per-call token, the OLDER one's failure
+    // could restore over the NEWER one's still-pending (and about to
+    // succeed) mint, which then finds itself "superseded" and discards its
+    // own just-created row.
+    it('given New Conversation is clicked twice before either settles, an older rejection does not clobber the still-pending newer mint', async () => {
+      let rejectOlder!: (reason: unknown) => void;
+      let resolveNewer!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((_resolve, reject) => (rejectOlder = reject)))
+        .mockReturnValueOnce(new Promise((resolve) => (resolveNewer = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' })); // older, pending
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' })); // newer, pending
+
+      // The OLDER mint rejects first — must be a no-op (superseded), not a
+      // restore, since the newer mint is still pending and about to land.
+      rejectOlder(new Error('transient'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // The NEWER mint then succeeds — must land normally.
+      resolveNewer({});
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).toBe('new-id-2');
+      });
+      // Not cleaned up as if it had been superseded.
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/new-id-2');
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299 (round 14): the
+    // pane's captured priorScope can itself go stale — if the conversation
+    // it points at is deleted from History (elsewhere) while this mint is
+    // still pending, restoring it on failure would bind the pane to a
+    // transcript that already 404s on send.
+    it('given the prior conversation is deleted from History while New Conversation is pending and the mint then fails, resets to the picker instead of restoring the deleted conversation', async () => {
+      // Inline fixture — `conversationsFixture` below is scoped to a
+      // different (later) describe block.
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return jsonOk({
+            conversations: [
+              {
+                id: 'conv-1',
+                title: 'Conversation',
+                preview: '',
+                createdAt: new Date('2026-01-01').toISOString(),
+                updatedAt: new Date('2026-01-01').toISOString(),
+                messageCount: 1,
+                sessionId: null,
+                lastMessage: { role: 'user', timestamp: new Date('2026-01-01').toISOString() },
+              },
+            ],
+          });
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let rejectMint!: (reason: unknown) => void;
+      mockPost.mockReturnValue(new Promise((_resolve, reject) => (rejectMint = reject)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      // Confirm the History list (including conv-1) has actually loaded
+      // before starting the mint below.
+      await screen.findByRole('button', { name: 'delete-conv-1' });
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' })); // mint pending
+
+      // The prior conversation (conv-1) is deleted from History while the
+      // mint above is still pending — the pane's own scope is the generic
+      // loading sentinel at this point, so the delete's own affected-panes
+      // scan can't identify and reset this pane directly.
+      await user.click(await screen.findByRole('button', { name: 'delete-conv-1' }));
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/ai/page-agents/agent-1/conversations/conv-1', { method: 'DELETE' }),
+      );
+
+      // NOW the mint fails — must NOT restore the pane to the just-deleted
+      // conv-1; falls back to the picker instead.
+      rejectMint(new Error('quota exceeded'));
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).not.toBe('conv-1');
+      });
+    });
+
     it('a pane closed mid-mint does not resurrect once the POST resolves, and the orphaned row is cleaned up', async () => {
       let resolvePost!: (value: unknown) => void;
       mockPost.mockReturnValue(new Promise((resolve) => (resolvePost = resolve)));

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1103,6 +1103,76 @@ describe('AgentPanes', () => {
       });
     });
 
+    // review finding — chatgpt-codex-connector and coderabbitai on PR #2299:
+    // deleteConversation used to resolve regardless of outcome, so a REFUSED
+    // delete (the never-empty guard's 409) still reset every pane showing
+    // it, discarding a working binding for a conversation the server never
+    // actually deleted.
+    it('does NOT reset panes when the History delete is refused (a 409)', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-doomed', title: 'Doomed chat', sessionId: null }]);
+        }
+        if (url === '/api/ai/page-agents/agent-1/conversations/conv-doomed') {
+          return { ok: false, json: async () => ({ error: 'last conversation', reason: 'last_conversation' }) };
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      const secondPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+      act(() =>
+        useAgentWorkspaceStore.getState().assignPane('ses-1', secondPaneId, {
+          kind: 'chat',
+          name: 'Doomed chat',
+          targetId: 'conv-doomed',
+          agentPageId: 'agent-1',
+        }),
+      );
+
+      const user = userEvent.setup();
+      const historyTabs = await screen.findAllByRole('tab', { name: /history/i });
+      await user.click(historyTabs[0]);
+      await user.click(await screen.findByRole('button', { name: 'delete-conv-doomed' }));
+
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(
+          '/api/ai/page-agents/agent-1/conversations/conv-doomed',
+          expect.objectContaining({ method: 'DELETE' }),
+        ),
+      );
+      const secondPaneAfter = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id === secondPaneId);
+      expect(secondPaneAfter?.scope?.targetId).toBe('conv-doomed');
+    });
+
+    // review finding — coderabbitai on PR #2299: `showSettings` hides the tab
+    // once agentPageId becomes null, but a stuck `activeTab: 'settings'` fell
+    // through to a spinner branch that could never resolve for the Assistant.
+    it('resets away from the Settings tab when the pane switches to a different agent', async () => {
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+      mockPost.mockResolvedValue({});
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /researcher settings/i }));
+      await screen.findByTestId('pane-settings-tab');
+
+      await user.click(await findEnabledSelector(/Researcher/));
+      await user.click(await screen.findByRole('menuitem', { name: /Writer/ }));
+
+      await waitFor(() => expect(screen.getAllByTestId('pane-chat').length).toBeGreaterThan(0));
+      expect(screen.queryByTestId('pane-settings-tab')).not.toBeInTheDocument();
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: PageAgentSettingsTab
     // registers submitForm before its own config-loaded check returns, and its
     // form defaults contain an empty prompt/tool list — clicking Save before

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1143,6 +1143,14 @@ describe('AgentPanes', () => {
       // NOW the first (stale) reopen resolves — must NOT close conv-slow,
       // since a pane is currently showing it.
       resolveSlowReopen({});
+      // Flush the stale completion's own continuation — without this, the
+      // waitFor below can pass on its first attempt (the pane already shows
+      // conv-slow from the SECOND pick) before the rollback guard even runs,
+      // making the assertion below pass trivially (review finding —
+      // coderabbitai on PR #2299, round 12).
+      await act(async () => {
+        await Promise.resolve();
+      });
       await waitFor(() => {
         const pane = useAgentWorkspaceStore
           .getState()

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1091,7 +1091,10 @@ describe('AgentPanes', () => {
       await user.click(await screen.findByRole('button', { name: 'select-conv-fast' }));
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-fast'));
 
-      // NOW the stale reopen resolves — must be ignored.
+      // NOW the stale reopen resolves — must be ignored, AND rolled back:
+      // it succeeded server-side (closedInSessionAt cleared, a cap slot
+      // consumed) for a pick nothing shows anymore, which could otherwise
+      // make a later reopen fail as "session full" for no visible reason.
       resolveSlowReopen({});
       await waitFor(() => {
         const pane = useAgentWorkspaceStore
@@ -1100,6 +1103,9 @@ describe('AgentPanes', () => {
           .find((p) => p.id === paneId);
         expect(pane?.scope?.targetId).toBe('conv-fast');
       });
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-slow'),
+      );
     });
 
     // review finding — chatgpt-codex-connector on PR #2299: History-delete

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -724,6 +724,45 @@ describe('AgentPanes', () => {
       expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/new-id-2');
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 15): the
+    // round-13 restore-on-failure fix re-read "the pane's live scope" fresh
+    // at the start of EVERY mint call — for a SECOND overlapping mint,
+    // that live scope is already the FIRST mint's own loading sentinel, not
+    // the true original conversation. A failed second mint then "restored"
+    // that sentinel, leaving the pane stuck spinning forever.
+    it('given New Conversation is clicked twice before either settles and BOTH fail, restores the TRUE original conversation, not an intermediate loading sentinel', async () => {
+      let rejectOlder!: (reason: unknown) => void;
+      let rejectNewer!: (reason: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((_resolve, reject) => (rejectOlder = reject)))
+        .mockReturnValueOnce(new Promise((_resolve, reject) => (rejectNewer = reject)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' })); // older, pending
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' })); // newer, pending
+
+      // The OLDER mint rejects first — superseded, no-op.
+      rejectOlder(new Error('transient'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // The NEWER (current) mint then ALSO rejects — must restore the
+      // ORIGINAL conv-1, not the older mint's own loading sentinel.
+      rejectNewer(new Error('session full'));
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).toBe('conv-1');
+      });
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299 (round 14): the
     // pane's captured priorScope can itself go stale — if the conversation
     // it points at is deleted from History (elsewhere) while this mint is
@@ -1296,6 +1335,44 @@ describe('AgentPanes', () => {
         expect(pane?.scope?.targetId).toBe('conv-slow');
       });
       expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-slow');
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299 (round 15): the
+    // reopen endpoint returns the same { ok: true } shape for a genuine
+    // transition AND a no-op ("already_open" — the conversation was already
+    // open elsewhere, e.g. another pane/tab, or an agent switch that left
+    // it open unshown). Rolling back a superseded pick unconditionally
+    // could close a listing this request never actually opened.
+    it('does not roll back a superseded reopen whose response reports alreadyOpen (a no-op, not a transition)', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([
+            { id: 'conv-already-open', title: 'Already open', sessionId: 'ses-1' },
+            { id: 'conv-other', title: 'Other', sessionId: null },
+          ]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveReopen!: (value: unknown) => void;
+      mockPost.mockReturnValueOnce(new Promise((resolve) => (resolveReopen = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-already-open' })); // pending
+
+      // Superseded by picking a DIFFERENT conversation on the same pane.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-other' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-other'));
+
+      // The stale reopen resolves reporting alreadyOpen — this request
+      // never transitioned the listing, so no cleanup DELETE should fire.
+      resolveReopen({ ok: true, alreadyOpen: true });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-already-open');
     });
 
     // review finding — chatgpt-codex-connector on PR #2299 (round 8): the

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1060,6 +1060,48 @@ describe('AgentPanes', () => {
       expect(screen.queryByTestId('pane-chat')).not.toBeInTheDocument();
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299: a slow reopen's
+    // completion, arriving after the user has already picked something else
+    // on the SAME pane, must not overwrite that newer choice.
+    it('ignores a stale reopen completion superseded by a second pick on the same pane', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([
+            { id: 'conv-slow', title: 'Slow chat', sessionId: 'ses-1' },
+            { id: 'conv-fast', title: 'Fast chat', sessionId: null },
+          ]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveSlowReopen!: (value: unknown) => void;
+      mockPost.mockReturnValue(new Promise((resolve) => (resolveSlowReopen = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      // Starts the slow reopen — still pending, so the pane stays on History
+      // (per the previous fix) rather than following it to Chat.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-slow' }));
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
+
+      // A second pick on the SAME pane, before the first resolves — no
+      // reopen needed (unbound), so it lands immediately.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-fast' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-fast'));
+
+      // NOW the stale reopen resolves — must be ignored.
+      resolveSlowReopen({});
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).toBe('conv-fast');
+      });
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: History-delete
     // deactivates the CANONICAL row, not just the deleting pane's own
     // listing — every pane showing that id (in this grid), whichever pane's
@@ -1151,6 +1193,75 @@ describe('AgentPanes', () => {
         .workspaces['ses-1'].columns.flatMap((c) => c.panes)
         .find((p) => p.id === secondPaneId);
       expect(secondPaneAfter?.scope?.targetId).toBe('conv-doomed');
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299: reading the
+    // workspace SNAPSHOT captured when the callback was created (rather than
+    // fresh at completion time) meant a pane reassigned WHILE the DELETE was
+    // in flight still got reset based on its old, no-longer-current binding.
+    it('does not reset a pane that was reassigned to something else while the History delete was in flight', async () => {
+      let resolveDelete!: () => void;
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-doomed', title: 'Doomed chat', sessionId: null }]);
+        }
+        if (url === '/api/ai/page-agents/agent-1/conversations/conv-doomed') {
+          return new Promise((resolve) => (resolveDelete = () => resolve({ ok: true })));
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      const secondPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+      act(() =>
+        useAgentWorkspaceStore.getState().assignPane('ses-1', secondPaneId, {
+          kind: 'chat',
+          name: 'Doomed chat',
+          targetId: 'conv-doomed',
+          agentPageId: 'agent-1',
+        }),
+      );
+
+      const user = userEvent.setup();
+      const historyTabs = await screen.findAllByRole('tab', { name: /history/i });
+      await user.click(historyTabs[0]);
+      await user.click(await screen.findByRole('button', { name: 'delete-conv-doomed' }));
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(
+          '/api/ai/page-agents/agent-1/conversations/conv-doomed',
+          expect.objectContaining({ method: 'DELETE' }),
+        ),
+      );
+
+      // The user reassigns the SECOND pane to something else while the
+      // DELETE is still pending.
+      act(() =>
+        useAgentWorkspaceStore.getState().assignPane('ses-1', secondPaneId, {
+          kind: 'chat',
+          name: 'Something else',
+          targetId: 'conv-something-else',
+          agentPageId: 'agent-1',
+        }),
+      );
+
+      // NOW the delete resolves — must not clobber the newer assignment.
+      // No `affectedPanes` remain (the pane no longer shows conv-doomed),
+      // so nothing else to await on directly — poll the pane's own scope
+      // instead, giving the delete's `.then()` chain time to run and
+      // confirming it stays put once it has.
+      resolveDelete();
+      await waitFor(() => {
+        const secondPaneAfter = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === secondPaneId);
+        expect(secondPaneAfter?.scope?.targetId).toBe('conv-something-else');
+      });
     });
 
     // review finding — coderabbitai on PR #2299: `showSettings` hides the tab

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -651,6 +651,55 @@ describe('AgentPanes', () => {
       expect(await screen.findAllByTestId('pane-picker')).toHaveLength(1);
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 23): the
+    // round-10 fix bumped the closing pane's assignment token BEFORE
+    // deciding what the close actually does — including when the decision
+    // turns out to be a no-op (the grid-last pane's session-conversation
+    // listing hasn't resolved yet, so decideClosePane can't safely act).
+    // Invalidating a pending mint's token for a close that never actually
+    // happened left the mint's own completion treating itself as
+    // superseded, discarding its result without ever moving the pane out
+    // of its loading state — stuck spinning forever for nothing.
+    it('does not invalidate a pending mint when closing turns out to be a no-op (listing not yet resolved)', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url.includes('/api/agent-sessions')) {
+          // Never resolves — closeDecisionListing stays null the whole test.
+          return new Promise(() => {});
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveMint!: (value: unknown) => void;
+      mockPost.mockReturnValue(new Promise((resolve) => (resolveMint = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' })); // mint pending
+
+      // Close the pane WHILE the mint is pending and the listing hasn't
+      // resolved — the grid's only pane, so this is a no-op (nothing to
+      // fall back to is confirmed yet).
+      await user.click(screen.getByLabelText('Close pane'));
+      // Still there — a no-op close doesn't remove anything.
+      expect(
+        useAgentWorkspaceStore.getState().workspaces['ses-1'].columns.flatMap((c) => c.panes),
+      ).toHaveLength(1);
+
+      // The mint then succeeds — must land normally, not be discarded as
+      // "superseded" by the no-op close attempt.
+      resolveMint({});
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).toBe('new-id-1');
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/new-id-1');
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299 (round 13): unlike
     // the picker-flow test above (nothing to lose), "New Conversation" picked
     // from a pane's OWN History tab starts from a pane already showing a

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -78,14 +78,17 @@ vi.mock('@/components/ai/page-agents', () => ({
   PageAgentHistoryTab: ({
     conversations,
     onSelectConversation,
+    onCreateNew,
     onDeleteConversation,
   }: {
     conversations: Array<{ id: string; title: string | null; sessionId: string | null }>;
     onSelectConversation: (id: string) => void;
+    onCreateNew: () => void;
     onDeleteConversation: (id: string) => void;
   }) => (
     <div data-testid="pane-history-tab">
       {conversations.length} conversations
+      <button onClick={() => onCreateNew()}>create-new-from-history</button>
       {conversations.map((c) => (
         <div key={c.id}>
           <button onClick={() => onSelectConversation(c.id)}>select-{c.id}</button>
@@ -646,6 +649,38 @@ describe('AgentPanes', () => {
         expect(newPane.scope).toBeNull();
       });
       expect(await screen.findAllByTestId('pane-picker')).toHaveLength(1);
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299 (round 13): unlike
+    // the picker-flow test above (nothing to lose), "New Conversation" picked
+    // from a pane's OWN History tab starts from a pane already showing a
+    // real, working conversation. The unconditional reset-to-picker on
+    // failure lost that conversation to a blank picker for no reason — a
+    // transient failure (session full, network drop) should not cost the
+    // user a working conversation they never asked to leave.
+    it('given "New Conversation" from History fails, restores the prior working conversation instead of resetting to the picker', async () => {
+      mockPost.mockRejectedValue(new Error('session full'));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
+      await user.click(await screen.findByRole('button', { name: 'create-new-from-history' }));
+
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        // Restored to the ORIGINAL working conversation, not reset to a
+        // blank picker and not left on the failed mint's loading sentinel.
+        expect(pane?.scope?.targetId).toBe('conv-1');
+      });
+      // Stayed on History — the failed create never landed, so the tab
+      // switch to Chat that would follow a successful one never fires.
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
     });
 
     it('a pane closed mid-mint does not resurrect once the POST resolves, and the orphaned row is cleaned up', async () => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -75,8 +75,24 @@ vi.mock('../../shell/Shell', () => ({
 // react-hook-form for the latter — exercising it for real here would test
 // a different component's own test file's job).
 vi.mock('@/components/ai/page-agents', () => ({
-  PageAgentHistoryTab: ({ conversations }: { conversations: Array<{ id: string }> }) => (
-    <div data-testid="pane-history-tab">{conversations.length} conversations</div>
+  PageAgentHistoryTab: ({
+    conversations,
+    onSelectConversation,
+    onDeleteConversation,
+  }: {
+    conversations: Array<{ id: string; title: string | null; sessionId: string | null }>;
+    onSelectConversation: (id: string) => void;
+    onDeleteConversation: (id: string) => void;
+  }) => (
+    <div data-testid="pane-history-tab">
+      {conversations.length} conversations
+      {conversations.map((c) => (
+        <div key={c.id}>
+          <button onClick={() => onSelectConversation(c.id)}>select-{c.id}</button>
+          <button onClick={() => onDeleteConversation(c.id)}>delete-{c.id}</button>
+        </div>
+      ))}
+    </div>
   ),
   PageAgentSettingsTab: ({ pageId, config }: { pageId: string; config: unknown }) => (
     <div data-testid="pane-settings-tab" data-page-id={pageId} data-has-config={String(config !== null)} />
@@ -952,6 +968,168 @@ describe('AgentPanes', () => {
 
       expect(await screen.findByTestId('pane-chat')).toBeInTheDocument();
       expect(screen.queryByTestId('pane-history-tab')).not.toBeInTheDocument();
+    });
+
+    const conversationsFixture = (entries: Array<{ id: string; title: string; sessionId: string | null }>) =>
+      jsonOk({
+        conversations: entries.map((e) => ({
+          id: e.id,
+          title: e.title,
+          preview: '',
+          createdAt: new Date('2026-01-01').toISOString(),
+          updatedAt: new Date('2026-01-01').toISOString(),
+          messageCount: 1,
+          sessionId: e.sessionId,
+          lastMessage: { role: 'user', timestamp: new Date('2026-01-01').toISOString() },
+        })),
+      });
+
+    // review finding — chatgpt-codex-connector on PR #2299: picking a History
+    // entry already open in another pane bypassed the store's deduplicating
+    // openConversation path, mounting a second independently interactive
+    // surface for the same transcript.
+    it('focuses an existing pane instead of duplicating it when the picked History conversation is already open elsewhere', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-other', title: 'Other chat', sessionId: null }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      const secondPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+      act(() =>
+        useAgentWorkspaceStore.getState().assignPane('ses-1', secondPaneId, {
+          kind: 'chat',
+          name: 'Other chat',
+          targetId: 'conv-other',
+          agentPageId: 'agent-1',
+        }),
+      );
+
+      const user = userEvent.setup();
+      // Pane bar and its pane's body are siblings under the same `group/pane`
+      // container — locate the pane bar whose OWN pane currently renders
+      // conv-1 (the first pane), rather than assuming DOM/array order lines
+      // up with pane creation order.
+      const bars = screen.getAllByTestId('pane-bar');
+      const firstPaneBar = bars.find((bar) =>
+        within(bar.parentElement as HTMLElement).queryByTestId('pane-chat')?.textContent === 'conv-1',
+      )!;
+      await user.click(within(firstPaneBar).getByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-other' }));
+
+      await waitFor(() =>
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId).toBe(secondPaneId),
+      );
+      // The first pane's own binding is untouched — no duplicate was created there.
+      const firstPaneAfter = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id === firstPaneId);
+      expect(firstPaneAfter?.scope?.targetId).toBe('conv-1');
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299: switching to Chat
+    // immediately (fire-and-forget) after starting an async reopen showed the
+    // OLD pane content as if a failed pick had succeeded.
+    it('stays on the History tab when reopening a same-session conversation fails, rather than following the failed pick to Chat', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-closed', title: 'Closed chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      mockPost.mockRejectedValue(new Error('session full'));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-closed' }));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-closed/reopen', {}),
+      );
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
+      expect(screen.queryByTestId('pane-chat')).not.toBeInTheDocument();
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299: History-delete
+    // deactivates the CANONICAL row, not just the deleting pane's own
+    // listing — every pane showing that id (in this grid), whichever pane's
+    // History tab the delete came from, must be reset rather than left
+    // pointing at a transcript that now 404s on send.
+    it("resets every pane showing a conversation deleted from another pane's History tab back to the picker", async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-doomed', title: 'Doomed chat', sessionId: null }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      const secondPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+      act(() =>
+        useAgentWorkspaceStore.getState().assignPane('ses-1', secondPaneId, {
+          kind: 'chat',
+          name: 'Doomed chat',
+          targetId: 'conv-doomed',
+          agentPageId: 'agent-1',
+        }),
+      );
+
+      const user = userEvent.setup();
+      const historyTabs = await screen.findAllByRole('tab', { name: /history/i });
+      await user.click(historyTabs[0]);
+      await user.click(await screen.findByRole('button', { name: 'delete-conv-doomed' }));
+
+      await waitFor(() => {
+        const secondPaneAfter = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === secondPaneId);
+        expect(secondPaneAfter?.scope).toBeNull();
+      });
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299: PageAgentSettingsTab
+    // registers submitForm before its own config-loaded check returns, and its
+    // form defaults contain an empty prompt/tool list — clicking Save before
+    // agentConfig arrives would PATCH those defaults over the agent's real
+    // config.
+    it('disables the Save button until the agent config has finished loading', async () => {
+      let resolveConfig!: () => void;
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/pages/agent-1/agent-config') {
+          return new Promise((resolve) => {
+            resolveConfig = () => resolve(jsonOk({ systemPrompt: '', enabledTools: [], availableTools: [] }));
+          });
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const settingsTab = await screen.findByRole('tab', { name: /researcher settings/i });
+      await userEvent.click(settingsTab);
+      await screen.findByTestId('pane-settings-tab');
+
+      const saveButton = screen.getByRole('button', { name: /save/i });
+      expect(saveButton).toBeDisabled();
+
+      resolveConfig();
+      await waitFor(() => expect(saveButton).not.toBeDisabled());
     });
 
     it("is disabled until THIS session's entry appears in the switch decision's own data", async () => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1356,6 +1356,82 @@ describe('AgentPanes', () => {
       );
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 10): none
+    // of the close branches touched the closing pane's assignment token, so
+    // a History reopen still in flight for that exact pane stayed "current"
+    // even after the pane was gone — either no-oping assignPane onto a
+    // removed pane (leaving an invisible open listing that consumes a
+    // session cap slot forever) or, if it resolved before the close's own
+    // effect, silently repurposing the pane the user just asked to close.
+    it('cancels a pending History reopen when its own pane is closed before the reopen resolves', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-closed-mid-close', title: 'Closed chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveReopen!: (value: unknown) => void;
+      mockPost.mockReturnValue(new Promise((resolve) => (resolveReopen = resolve)));
+      mockDel.mockResolvedValue(undefined);
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+      const secondPaneId = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id !== firstPaneId)!.id;
+      // History needs an agent context to know whose conversations to list —
+      // give the second pane one without landing a conversation of its own
+      // yet (the same "agent picked, mint still pending" shape handlePickAgent
+      // itself produces).
+      act(() =>
+        useAgentWorkspaceStore
+          .getState()
+          .assignPane('ses-1', secondPaneId, { kind: 'chat', name: 'Conversation', targetId: null, agentPageId: 'agent-1' }),
+      );
+
+      const user = userEvent.setup();
+      // Correlate the SECOND pane's own DOM subtree by content rather than
+      // array/DOM order (unreliable — a `pane-bar` and its pane body are
+      // siblings under one `group/pane` container; the first pane is the
+      // only one ever showing "conv-1").
+      await waitFor(() => expect(screen.getAllByTestId('pane-bar')).toHaveLength(2));
+      const secondPaneContainer = screen
+        .getAllByTestId('pane-bar')
+        .map((bar) => bar.parentElement!)
+        .find((container) => !container.textContent?.includes('conv-1'))!;
+
+      await user.click(within(secondPaneContainer).getByRole('tab', { name: /history/i }));
+      await user.click(
+        await within(secondPaneContainer).findByRole('button', { name: 'select-conv-closed-mid-close' }),
+      );
+
+      // Close that SAME (second) pane while the reopen is still in flight —
+      // a pure layout close (unbound pane, another pane still in the grid),
+      // no DELETE of its own.
+      await user.click(within(secondPaneContainer).getByLabelText('Close pane'));
+      await waitFor(() =>
+        expect(
+          useAgentWorkspaceStore.getState().workspaces['ses-1'].columns.flatMap((c) => c.panes),
+        ).toHaveLength(1),
+      );
+
+      // NOW the reopen resolves — must not repurpose (there is no pane left
+      // to assign to) and must clean up the now-invisible open listing it
+      // left behind server-side.
+      resolveReopen({});
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-closed-mid-close'),
+      );
+      // The surviving (first) pane was never touched by any of this.
+      const survivingPane = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id === firstPaneId);
+      expect(survivingPane?.scope?.targetId).not.toBe('conv-closed-mid-close');
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: History-delete
     // deactivates the CANONICAL row, not just the deleting pane's own
     // listing — every pane showing that id (in this grid), whichever pane's

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -69,6 +69,19 @@ vi.mock('../PaneChat', () => ({
 vi.mock('../../shell/Shell', () => ({
   default: ({ shellId }: { shellId: string }) => <div data-testid="pane-shell">{shellId}</div>,
 }));
+// Leaf renderers for the pane's History/Settings tabs — same philosophy as
+// PaneChat/Shell above: this suite is the pane's own tab-switching wiring,
+// not PageAgentHistoryTab/PageAgentSettingsTab's internals (867 lines of
+// react-hook-form for the latter — exercising it for real here would test
+// a different component's own test file's job).
+vi.mock('@/components/ai/page-agents', () => ({
+  PageAgentHistoryTab: ({ conversations }: { conversations: Array<{ id: string }> }) => (
+    <div data-testid="pane-history-tab">{conversations.length} conversations</div>
+  ),
+  PageAgentSettingsTab: ({ pageId, config }: { pageId: string; config: unknown }) => (
+    <div data-testid="pane-settings-tab" data-page-id={pageId} data-has-config={String(config !== null)} />
+  ),
+}));
 
 import AgentPanes from '../AgentPanes';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
@@ -904,21 +917,41 @@ describe('AgentPanes', () => {
       expect(await screen.findByRole('button', { name: /Researcher/ })).toBeInTheDocument();
     });
 
-    it("links to the pane's agent settings — the console's only Settings entry point", async () => {
+    it("has a Settings tab for the pane's agent, which switches the pane body to the settings form", async () => {
       renderPanes();
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
 
-      const settingsLink = await screen.findByRole('link', { name: /researcher settings/i });
-      expect(settingsLink).toHaveAttribute('href', '/p/agent-1?tab=settings');
+      const settingsTab = await screen.findByRole('tab', { name: /researcher settings/i });
+      await userEvent.click(settingsTab);
+
+      expect(await screen.findByTestId('pane-settings-tab')).toHaveAttribute('data-page-id', 'agent-1');
+      expect(screen.queryByTestId('pane-chat')).not.toBeInTheDocument();
     });
 
-    it('hides the settings link for the Assistant (no agent page, so no settings)', async () => {
+    it('hides the Settings tab for the Assistant (no agent page, so no settings)', async () => {
       renderPanes({
         initialConversation: { conversationId: 'conv-1', agentPageId: null, name: 'Assistant' },
       });
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
 
-      expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: /settings/i })).not.toBeInTheDocument();
+    });
+
+    it('has a History tab that switches the pane body to the conversation list, and back to Chat on selection', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      const historyTab = await screen.findByRole('tab', { name: /history/i });
+      await userEvent.click(historyTab);
+
+      expect(await screen.findByTestId('pane-history-tab')).toBeInTheDocument();
+      expect(screen.queryByTestId('pane-chat')).not.toBeInTheDocument();
+
+      const chatTab = screen.getByRole('tab', { name: /^chat$/i });
+      await userEvent.click(chatTab);
+
+      expect(await screen.findByTestId('pane-chat')).toBeInTheDocument();
+      expect(screen.queryByTestId('pane-history-tab')).not.toBeInTheDocument();
     });
 
     it("is disabled until THIS session's entry appears in the switch decision's own data", async () => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1473,6 +1473,67 @@ describe('AgentPanes', () => {
       expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-race');
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 17): the
+    // cleanup DELETE itself can be delayed long enough for a LATER,
+    // independent pick of the exact same conversation to land in a pane
+    // before it reaches the server — closing a listing that is now visibly
+    // displayed. cleanupOrphanedConversation must recheck after its own
+    // DELETE resolves and compensate (reopen it back) if so.
+    it('compensates by reopening a conversation that landed in a pane while its own delayed cleanup DELETE was still in flight', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([
+            { id: 'conv-compensate', title: 'Compensate', sessionId: 'ses-1' },
+            { id: 'conv-unbound', title: 'Unbound', sessionId: null },
+          ]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveFirstReopen!: (value: unknown) => void;
+      let resolveDelete!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveFirstReopen = resolve))) // first pick
+        .mockResolvedValueOnce({ ok: true, alreadyOpen: false }); // second (fresh) pick
+      mockDel.mockReturnValueOnce(new Promise((resolve) => (resolveDelete = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-compensate' })); // reopen #1, pending
+
+      // Superseded by an unbound pick — no network call, lands instantly.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-unbound' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-unbound'));
+
+      // Reopen #1 resolves — genuinely orphaned (nothing shows it, nothing
+      // else pending for this id) — triggers a DIRECT cleanup, DELETE
+      // pending.
+      resolveFirstReopen({ ok: true, alreadyOpen: false });
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-compensate'));
+
+      // WHILE that DELETE is still in flight, a fresh pick of the SAME
+      // conversation lands it back in the pane (back to History first —
+      // landing conv-unbound switched the tab to Chat).
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-compensate' }));
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-compensate'));
+
+      // NOW the delayed cleanup DELETE resolves — must compensate by
+      // reopening the conversation it just closed back out, since a pane
+      // is now showing it.
+      resolveDelete(undefined);
+      // 2 reopen calls happened already (the first pick, the fresh second
+      // pick) — the compensating call is a THIRD.
+      await waitFor(() =>
+        expect(
+          mockPost.mock.calls.filter(
+            (c) => c[0] === '/api/agent-sessions/ses-1/conversations/conv-compensate/reopen',
+          ),
+        ).toHaveLength(3),
+      );
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299 (round 8): a
     // reopen can commit server-side and then have its OWN response delayed
     // long enough for the SAME conversation to be deleted from History

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1153,6 +1153,102 @@ describe('AgentPanes', () => {
       expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-slow');
     });
 
+    // review finding — chatgpt-codex-connector on PR #2299 (round 8): the
+    // "is anyone showing this?" rollback check above still misses the case
+    // where the newer reopen for the SAME conversation hasn't LANDED yet
+    // when the older one resolves — nothing shows it yet, but something is
+    // about to. The rollback must also check for a still-in-flight reopen.
+    it('does not close a conversation when an older reopen resolves first while a newer reopen for the same conversation is still pending', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-race', title: 'Race chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveOlder!: (value: unknown) => void;
+      let resolveNewer!: (value: unknown) => void;
+      mockPost
+        .mockReturnValueOnce(new Promise((resolve) => (resolveOlder = resolve)))
+        .mockReturnValueOnce(new Promise((resolve) => (resolveNewer = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      // Both picks fire before either reopen resolves — neither has landed.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-race' }));
+      await user.click(await screen.findByRole('button', { name: 'select-conv-race' }));
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
+
+      // The OLDER reopen resolves first. No pane shows conv-race yet, but
+      // the newer request is still in flight — must not close it.
+      resolveOlder({});
+      await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-race');
+
+      // The newer reopen resolves too — legitimately lands it.
+      resolveNewer({});
+      await waitFor(() => {
+        const pane = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id === paneId);
+        expect(pane?.scope?.targetId).toBe('conv-race');
+      });
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/conversations/conv-race');
+    });
+
+    // review finding — chatgpt-codex-connector on PR #2299 (round 8): a
+    // reopen can commit server-side and then have its OWN response delayed
+    // long enough for the SAME conversation to be deleted from History
+    // before the completion assigns it — landing a pane on a transcript
+    // that already 404s on send.
+    it('does not assign a pane to a conversation deleted from History while its reopen was still in flight', async () => {
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (url === '/api/ai/page-agents/agent-1/conversations') {
+          return conversationsFixture([{ id: 'conv-doomed-live', title: 'Doomed live chat', sessionId: 'ses-1' }]);
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      let resolveReopen!: (value: unknown) => void;
+      mockPost.mockReturnValue(new Promise((resolve) => (resolveReopen = resolve)));
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('tab', { name: /history/i }));
+      // Reopen starts and commits server-side but its response is delayed.
+      await user.click(await screen.findByRole('button', { name: 'select-conv-doomed-live' }));
+      expect(screen.getByTestId('pane-history-tab')).toBeInTheDocument();
+
+      // The SAME conversation is deleted from History before the reopen
+      // above completes.
+      await user.click(await screen.findByRole('button', { name: 'delete-conv-doomed-live' }));
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(
+          '/api/ai/page-agents/agent-1/conversations/conv-doomed-live',
+          { method: 'DELETE' },
+        ),
+      );
+
+      // NOW the delayed reopen resolves — must NOT assign the pane to the
+      // just-deleted conversation.
+      resolveReopen({});
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const pane = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+        .find((p) => p.id === paneId);
+      expect(pane?.scope?.targetId).not.toBe('conv-doomed-live');
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: History-delete
     // deactivates the CANONICAL row, not just the deleting pane's own
     // listing — every pane showing that id (in this grid), whichever pane's

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -218,6 +218,12 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   // surface for the same agent just saved, and its update arrived here via
   // the shared SWR cache."
   const justSavedOwnConfigRef = useRef(false);
+  // Set the first time THIS instance's own provider/model controls are
+  // touched — distinguishes "the user explicitly picked this here" from
+  // "still whatever useProviderSettings loaded on mount, possibly stale
+  // relative to a sibling's later save" (see onSubmit below, round 18).
+  const providerTouchedRef = useRef(false);
+  const modelTouchedRef = useRef(false);
 
   // Reset form when config changes — but NOT when this surface has its own
   // unsaved edits from an EXTERNAL update (a different pane's Settings tab
@@ -315,11 +321,22 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     setIsSaving(true);
     onSavingChange?.(true);
     try {
-      // Include the current provider and model from props
+      // `selectedProvider`/`selectedModel` are OWNED by the parent's own
+      // useProviderSettings() instance — a separate, per-mount hook with no
+      // shared cache (unlike useAgentConfig). If this instance never
+      // touched the provider/model controls itself, its copy can be stale
+      // relative to a SIBLING Settings surface for the same agent that
+      // just saved a provider change: submitting the stale prop here would
+      // silently revert that sibling's save the moment this instance saves
+      // anything else. Prefer the shared config's value in that case; only
+      // this instance's OWN explicit selection overrides it (review
+      // finding — chatgpt-codex-connector on PR #2299, round 18).
+      const resolvedProvider = providerTouchedRef.current ? selectedProvider : (config?.aiProvider || selectedProvider);
+      const resolvedModel = modelTouchedRef.current ? selectedModel : (config?.aiModel || selectedModel);
       const requestData = {
         ...data,
-        aiProvider: selectedProvider,
-        aiModel: selectedModel,
+        aiProvider: resolvedProvider,
+        aiModel: resolvedModel,
         includeDrivePrompt: data.includeDrivePrompt,
         agentDefinition: data.agentDefinition,
         visibleToGlobalAssistant: data.visibleToGlobalAssistant,
@@ -332,8 +349,8 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       const updatedConfig = {
         ...config,
         ...data,
-        aiProvider: selectedProvider,
-        aiModel: selectedModel,
+        aiProvider: resolvedProvider,
+        aiModel: resolvedModel,
         includeDrivePrompt: data.includeDrivePrompt,
         agentDefinition: data.agentDefinition,
         visibleToGlobalAssistant: data.visibleToGlobalAssistant,
@@ -355,6 +372,21 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       onSavingChange?.(false);
     }
   }, [pageId, config, onConfigUpdate, selectedProvider, selectedModel, onSavingChange]);
+
+  const handleProviderSelectChange = useCallback(
+    (provider: string) => {
+      providerTouchedRef.current = true;
+      onProviderChange(provider);
+    },
+    [onProviderChange],
+  );
+  const handleModelSelectChange = useCallback(
+    (model: string) => {
+      modelTouchedRef.current = true;
+      onModelChange(model);
+    },
+    [onModelChange],
+  );
 
   // Expose form submission to parent component
   useImperativeHandle(ref, () => ({
@@ -444,7 +476,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
               {/* Provider Selector */}
               <div>
                 <label className="text-sm font-medium mb-2 block">AI Provider</label>
-                <Select value={selectedProvider} onValueChange={onProviderChange}>
+                <Select value={selectedProvider} onValueChange={handleProviderSelectChange}>
                   <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>
@@ -467,7 +499,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
               {/* Model Selector */}
               <div>
                 <label className="text-sm font-medium mb-2 block">Model</label>
-                <Select value={selectedModel} onValueChange={onModelChange}>
+                <Select value={selectedModel} onValueChange={handleModelSelectChange}>
                   <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -350,42 +350,45 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       const providerOrModelTouched = providerTouchedRef.current || modelTouchedRef.current;
       const resolvedProvider = providerOrModelTouched ? selectedProvider : (config?.aiProvider || selectedProvider);
       const resolvedModel = providerOrModelTouched ? selectedModel : (config?.aiModel || selectedModel);
-      // Every OTHER field: only what THIS instance's form actually has a
-      // pending edit for (react-hook-form's own dirtyFields) should
-      // override the freshest config. This surface's reset effect above
-      // deliberately keeps its old form snapshot while dirty, so anything
-      // NOT edited here can be stale relative to a sibling's own save of
-      // that same field — submitting the whole form regardless would
-      // silently revert it (review finding — chatgpt-codex-connector on
-      // PR #2299, round 20).
-      const mergedFields = {
-        systemPrompt: dirtyFields.systemPrompt ? data.systemPrompt : (config?.systemPrompt ?? data.systemPrompt),
-        enabledTools: dirtyFields.enabledTools ? data.enabledTools : (config?.enabledTools ?? data.enabledTools),
-        includeDrivePrompt: dirtyFields.includeDrivePrompt
-          ? data.includeDrivePrompt
-          : (config?.includeDrivePrompt ?? data.includeDrivePrompt),
-        agentDefinition: dirtyFields.agentDefinition ? data.agentDefinition : (config?.agentDefinition ?? data.agentDefinition),
-        visibleToGlobalAssistant: dirtyFields.visibleToGlobalAssistant
-          ? data.visibleToGlobalAssistant
-          : (config?.visibleToGlobalAssistant ?? data.visibleToGlobalAssistant),
-        includePageTree: dirtyFields.includePageTree ? data.includePageTree : (config?.includePageTree ?? data.includePageTree),
-        pageTreeScope: dirtyFields.pageTreeScope ? data.pageTreeScope : (config?.pageTreeScope ?? data.pageTreeScope),
-        toolExposureMode: dirtyFields.toolExposureMode ? data.toolExposureMode : (config?.toolExposureMode ?? data.toolExposureMode),
-        sandboxEnabled: dirtyFields.sandboxEnabled ? data.sandboxEnabled : (config?.sandboxEnabled ?? data.sandboxEnabled),
-      };
+      // Every OTHER field: send ONLY what THIS instance's form actually has
+      // a pending edit for (react-hook-form's own dirtyFields) — a SPARSE
+      // PATCH, omitting untouched fields entirely rather than merging in a
+      // value copied from this instance's own (possibly already-stale)
+      // config snapshot. The route already applies each field only `if
+      // (field !== undefined)`, so an omitted field is left untouched
+      // server-side. Round 20's "merge from local config" still raced: two
+      // surfaces saving different fields close enough together that
+      // neither's SWR update had reached the other yet would both submit
+      // the SAME stale snapshot for their own "unedited" fields, and
+      // whichever PATCH landed second would stomp the first's just-saved
+      // change. Never sending a field this instance didn't touch removes
+      // that race entirely (review finding — chatgpt-codex-connector on
+      // PR #2299, round 21).
+      const dirtyPatch: Partial<FormData> = {};
+      if (dirtyFields.systemPrompt) dirtyPatch.systemPrompt = data.systemPrompt;
+      if (dirtyFields.enabledTools) dirtyPatch.enabledTools = data.enabledTools;
+      if (dirtyFields.includeDrivePrompt) dirtyPatch.includeDrivePrompt = data.includeDrivePrompt;
+      if (dirtyFields.agentDefinition) dirtyPatch.agentDefinition = data.agentDefinition;
+      if (dirtyFields.visibleToGlobalAssistant) dirtyPatch.visibleToGlobalAssistant = data.visibleToGlobalAssistant;
+      if (dirtyFields.includePageTree) dirtyPatch.includePageTree = data.includePageTree;
+      if (dirtyFields.pageTreeScope) dirtyPatch.pageTreeScope = data.pageTreeScope;
+      if (dirtyFields.toolExposureMode) dirtyPatch.toolExposureMode = data.toolExposureMode;
+      if (dirtyFields.sandboxEnabled) dirtyPatch.sandboxEnabled = data.sandboxEnabled;
       const requestData = {
-        ...mergedFields,
-        aiProvider: resolvedProvider,
-        aiModel: resolvedModel,
+        ...dirtyPatch,
+        ...(providerOrModelTouched && { aiProvider: resolvedProvider, aiModel: resolvedModel }),
       };
 
       await patch(`/api/pages/${pageId}/agent-config`, requestData);
 
+      // The LOCAL optimistic cache update is display-only (never sent to
+      // the server above), so merging with the freshest config here is
+      // safe — this just makes sure THIS instance's own edits are visible
+      // immediately without waiting on a revalidation round trip.
       const updatedConfig = {
         ...config,
-        ...mergedFields,
-        aiProvider: resolvedProvider,
-        aiModel: resolvedModel,
+        ...dirtyPatch,
+        ...(providerOrModelTouched && { aiProvider: resolvedProvider, aiModel: resolvedModel }),
       } as AgentConfig;
       // This save's own values should always become this instance's new
       // clean baseline, even though the form is (still, momentarily) dirty
@@ -468,12 +471,17 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     [config, sandboxEnabled]
   );
 
+  // shouldDirty: true — without it, dirtyFields.enabledTools stays false
+  // even though the displayed selection changed, so onSubmit's dirty-only
+  // merge below would silently discard the bulk selection and resubmit
+  // the stale config value instead (review finding — chatgpt-codex-
+  // connector on PR #2299, round 21).
   const handleSelectAllTools = () => {
-    setValue('enabledTools', visibleTools.map(tool => tool.name));
+    setValue('enabledTools', visibleTools.map(tool => tool.name), { shouldDirty: true });
   };
 
   const handleDeselectAllTools = () => {
-    setValue('enabledTools', []);
+    setValue('enabledTools', [], { shouldDirty: true });
   };
 
   // Register with useEditingStore while dirty so SWR doesn't revalidate this

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo, useRef, useId } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
@@ -125,6 +125,10 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   isProviderConfigured,
   onSavingChange
 }, ref) => {
+  // Stable per-MOUNT identifier — distinguishes this instance from another
+  // Settings surface for the SAME agent mounted elsewhere (see the
+  // useEditingStore registration below, round 20).
+  const mountId = useId();
   const [isSaving, setIsSaving] = useState(false);
   const [membership, setMembership] = useState<AgentMembership | null | undefined>(undefined);
   const [membershipUserRole, setMembershipUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
@@ -211,7 +215,11 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
 
   // Read early (moved up from its original spot near the useEditingStore
   // registration below) so the reset effect right below can gate on it.
-  const { isDirty: formIsDirty } = useFormState({ control });
+  // `dirtyFields` additionally lets onSubmit tell "the user actually
+  // edited this field in THIS instance" apart from "still whatever this
+  // instance's own (possibly now-stale) form snapshot happens to hold" —
+  // see onSubmit below, round 20.
+  const { isDirty: formIsDirty, dirtyFields } = useFormState({ control });
   // Set right before THIS instance's own save propagates the new config
   // into the shared cache (onSubmit below) — distinguishes "my own save,
   // whose values I want as my new clean baseline" from "a SIBLING Settings
@@ -331,31 +339,53 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       // anything else. Prefer the shared config's value in that case; only
       // this instance's OWN explicit selection overrides it (review
       // finding — chatgpt-codex-connector on PR #2299, round 18).
-      const resolvedProvider = providerTouchedRef.current ? selectedProvider : (config?.aiProvider || selectedProvider);
-      const resolvedModel = modelTouchedRef.current ? selectedModel : (config?.aiModel || selectedModel);
+      //
+      // Provider and model are a COUPLED pair — a model must belong to its
+      // provider — so they are resolved from the SAME source together, not
+      // independently: touching only the model here while a sibling
+      // changed the provider must not combine this instance's (stale-
+      // provider) model with the sibling's new provider, an invalid pair
+      // the route rejects with a 400 (review finding — chatgpt-codex-
+      // connector on PR #2299, round 20).
+      const providerOrModelTouched = providerTouchedRef.current || modelTouchedRef.current;
+      const resolvedProvider = providerOrModelTouched ? selectedProvider : (config?.aiProvider || selectedProvider);
+      const resolvedModel = providerOrModelTouched ? selectedModel : (config?.aiModel || selectedModel);
+      // Every OTHER field: only what THIS instance's form actually has a
+      // pending edit for (react-hook-form's own dirtyFields) should
+      // override the freshest config. This surface's reset effect above
+      // deliberately keeps its old form snapshot while dirty, so anything
+      // NOT edited here can be stale relative to a sibling's own save of
+      // that same field — submitting the whole form regardless would
+      // silently revert it (review finding — chatgpt-codex-connector on
+      // PR #2299, round 20).
+      const mergedFields = {
+        systemPrompt: dirtyFields.systemPrompt ? data.systemPrompt : (config?.systemPrompt ?? data.systemPrompt),
+        enabledTools: dirtyFields.enabledTools ? data.enabledTools : (config?.enabledTools ?? data.enabledTools),
+        includeDrivePrompt: dirtyFields.includeDrivePrompt
+          ? data.includeDrivePrompt
+          : (config?.includeDrivePrompt ?? data.includeDrivePrompt),
+        agentDefinition: dirtyFields.agentDefinition ? data.agentDefinition : (config?.agentDefinition ?? data.agentDefinition),
+        visibleToGlobalAssistant: dirtyFields.visibleToGlobalAssistant
+          ? data.visibleToGlobalAssistant
+          : (config?.visibleToGlobalAssistant ?? data.visibleToGlobalAssistant),
+        includePageTree: dirtyFields.includePageTree ? data.includePageTree : (config?.includePageTree ?? data.includePageTree),
+        pageTreeScope: dirtyFields.pageTreeScope ? data.pageTreeScope : (config?.pageTreeScope ?? data.pageTreeScope),
+        toolExposureMode: dirtyFields.toolExposureMode ? data.toolExposureMode : (config?.toolExposureMode ?? data.toolExposureMode),
+        sandboxEnabled: dirtyFields.sandboxEnabled ? data.sandboxEnabled : (config?.sandboxEnabled ?? data.sandboxEnabled),
+      };
       const requestData = {
-        ...data,
+        ...mergedFields,
         aiProvider: resolvedProvider,
         aiModel: resolvedModel,
-        includeDrivePrompt: data.includeDrivePrompt,
-        agentDefinition: data.agentDefinition,
-        visibleToGlobalAssistant: data.visibleToGlobalAssistant,
-        includePageTree: data.includePageTree,
-        pageTreeScope: data.pageTreeScope,
       };
 
       await patch(`/api/pages/${pageId}/agent-config`, requestData);
 
       const updatedConfig = {
         ...config,
-        ...data,
+        ...mergedFields,
         aiProvider: resolvedProvider,
         aiModel: resolvedModel,
-        includeDrivePrompt: data.includeDrivePrompt,
-        agentDefinition: data.agentDefinition,
-        visibleToGlobalAssistant: data.visibleToGlobalAssistant,
-        includePageTree: data.includePageTree,
-        pageTreeScope: data.pageTreeScope,
       } as AgentConfig;
       // This save's own values should always become this instance's new
       // clean baseline, even though the form is (still, momentarily) dirty
@@ -381,7 +411,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       setIsSaving(false);
       onSavingChange?.(false);
     }
-  }, [pageId, config, onConfigUpdate, selectedProvider, selectedModel, onSavingChange]);
+  }, [pageId, config, onConfigUpdate, selectedProvider, selectedModel, onSavingChange, dirtyFields]);
 
   const handleProviderSelectChange = useCallback(
     (provider: string) => {
@@ -448,16 +478,23 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
 
   // Register with useEditingStore while dirty so SWR doesn't revalidate this
   // page mid-edit and clobber unsaved changes. (formIsDirty is declared
-  // earlier, above the config-reset effect it also gates.)
+  // earlier, above the config-reset effect it also gates.) Keyed by a
+  // per-MOUNT id (mountId, below), not just pageId: two Settings surfaces
+  // for the SAME agent otherwise register the identical key, and either
+  // one saving/unmounting deletes the shared Map entry out from under the
+  // OTHER — a still-dirty sibling then silently drops out of
+  // isAnyEditing(), letting SWR revalidation and other editing-paused
+  // background work resume while it still has unsaved edits (review
+  // finding — chatgpt-codex-connector on PR #2299, round 20).
   useEffect(() => {
-    const componentId = `page-agent-settings-${pageId}`;
+    const componentId = `page-agent-settings-${pageId}-${mountId}`;
     if (formIsDirty) {
       useEditingStore.getState().startEditing(componentId, 'form', { pageId });
     } else {
       useEditingStore.getState().endEditing(componentId);
     }
     return () => { useEditingStore.getState().endEditing(componentId); };
-  }, [formIsDirty, pageId]);
+  }, [formIsDirty, pageId, mountId]);
 
   if (!config) {
     return (

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
@@ -209,24 +209,42 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     }
   });
 
-  // Reset form when config changes
+  // Read early (moved up from its original spot near the useEditingStore
+  // registration below) so the reset effect right below can gate on it.
+  const { isDirty: formIsDirty } = useFormState({ control });
+  // Set right before THIS instance's own save propagates the new config
+  // into the shared cache (onSubmit below) — distinguishes "my own save,
+  // whose values I want as my new clean baseline" from "a SIBLING Settings
+  // surface for the same agent just saved, and its update arrived here via
+  // the shared SWR cache."
+  const justSavedOwnConfigRef = useRef(false);
+
+  // Reset form when config changes — but NOT when this surface has its own
+  // unsaved edits from an EXTERNAL update (a different pane's Settings tab
+  // for the SAME agent saving propagates through the shared config cache
+  // `useAgentConfig` — see AgentPanes.tsx — and this effect used to reset
+  // unconditionally, silently discarding whatever the user was mid-typing
+  // here). Always resets for THIS instance's own save (justSavedOwnConfigRef)
+  // — its own newly-saved values become the new clean baseline as before
+  // (review finding — chatgpt-codex-connector on PR #2299, round 17).
   useEffect(() => {
-    if (config) {
-      reset({
-        systemPrompt: config.systemPrompt,
-        enabledTools: config.enabledTools,
-        aiProvider: config.aiProvider || selectedProvider || '',
-        aiModel: config.aiModel || selectedModel || '',
-        includeDrivePrompt: config.includeDrivePrompt ?? false,
-        agentDefinition: config.agentDefinition || '',
-        visibleToGlobalAssistant: config.visibleToGlobalAssistant ?? true,
-        includePageTree: config.includePageTree ?? false,
-        pageTreeScope: config.pageTreeScope ?? 'children',
-        toolExposureMode: config.toolExposureMode ?? 'upfront',
-        sandboxEnabled: config.sandboxEnabled ?? false,
-      });
-    }
-  }, [config, reset, selectedProvider, selectedModel]);
+    if (!config) return;
+    if (formIsDirty && !justSavedOwnConfigRef.current) return;
+    justSavedOwnConfigRef.current = false;
+    reset({
+      systemPrompt: config.systemPrompt,
+      enabledTools: config.enabledTools,
+      aiProvider: config.aiProvider || selectedProvider || '',
+      aiModel: config.aiModel || selectedModel || '',
+      includeDrivePrompt: config.includeDrivePrompt ?? false,
+      agentDefinition: config.agentDefinition || '',
+      visibleToGlobalAssistant: config.visibleToGlobalAssistant ?? true,
+      includePageTree: config.includePageTree ?? false,
+      pageTreeScope: config.pageTreeScope ?? 'children',
+      toolExposureMode: config.toolExposureMode ?? 'upfront',
+      sandboxEnabled: config.sandboxEnabled ?? false,
+    });
+  }, [config, reset, selectedProvider, selectedModel, formIsDirty]);
 
   // Fetch Ollama models dynamically
   const fetchOllamaModels = useCallback(async () => {
@@ -322,6 +340,11 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
         includePageTree: data.includePageTree,
         pageTreeScope: data.pageTreeScope,
       } as AgentConfig;
+      // This save's own values should always become this instance's new
+      // clean baseline, even though the form is (still, momentarily) dirty
+      // when the reset effect runs — the dirty-guard above only exists to
+      // protect against a DIFFERENT (sibling) surface's external update.
+      justSavedOwnConfigRef.current = true;
       onConfigUpdate(updatedConfig);
       toast.success('Agent configuration saved successfully');
     } catch (error) {
@@ -382,8 +405,8 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   };
 
   // Register with useEditingStore while dirty so SWR doesn't revalidate this
-  // page mid-edit and clobber unsaved changes.
-  const { isDirty: formIsDirty } = useFormState({ control });
+  // page mid-edit and clobber unsaved changes. (formIsDirty is declared
+  // earlier, above the config-reset effect it also gates.)
   useEffect(() => {
     const componentId = `page-agent-settings-${pageId}`;
     if (formIsDirty) {

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -17,6 +17,7 @@ import { getRoleColorClasses } from '@/lib/utils';
 import { AgentDrivesCard } from './AgentDrivesCard';
 import { SANDBOX_TOOL_NAMES } from '@/lib/ai/core/tool-filtering';
 import { useEditingStore } from '@/stores/useEditingStore';
+import { useAgentMembership } from '@/lib/ai/shared/hooks/useAgentMembership';
 
 interface AgentConfig {
   systemPrompt: string;
@@ -32,17 +33,6 @@ interface AgentConfig {
   pageTreeScope?: 'children' | 'drive';
   toolExposureMode?: 'upfront' | 'search';
   sandboxEnabled?: boolean;
-}
-
-interface AgentMembership {
-  role: string;
-  customRole: { id: string; name: string; color: string | null } | null;
-}
-
-interface DriveRole {
-  id: string;
-  name: string;
-  color?: string | null;
 }
 
 interface PageAgentSettingsTabProps {
@@ -137,66 +127,21 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   // useEditingStore registration below, round 20).
   const mountId = useId();
   const [isSaving, setIsSaving] = useState(false);
-  const [membership, setMembership] = useState<AgentMembership | null | undefined>(undefined);
-  const [membershipUserRole, setMembershipUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
-  const [driveRoles, setDriveRoles] = useState<DriveRole[]>([]);
-  const [membershipSaving, setMembershipSaving] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadMembership() {
-      try {
-        const [membersRes, rolesRes] = await Promise.all([
-          fetchWithAuth(`/api/drives/${driveId}/agents/members`),
-          fetchWithAuth(`/api/drives/${driveId}/roles`),
-        ]);
-        if (cancelled) return;
-        if (membersRes.ok) {
-          const data = await membersRes.json();
-          const entry = (data.agentMembers ?? []).find(
-            (m: { agentPageId: string }) => m.agentPageId === pageId,
-          );
-          setMembership(entry ? { role: entry.role, customRole: entry.customRole } : null);
-          setMembershipUserRole(data.currentUserRole ?? 'MEMBER');
-        } else {
-          setMembership(null);
-        }
-        if (rolesRes.ok) {
-          const data = await rolesRes.json();
-          setDriveRoles(data.roles ?? []);
-        }
-      } catch {
-        if (!cancelled) setMembership(null);
-      }
-    }
-    loadMembership();
-    return () => { cancelled = true; };
-  }, [pageId, driveId]);
+  // Shared across every mounted Settings surface for this agent (keyed by
+  // driveId in SWR's cache) — see useAgentMembership for why a per-instance
+  // useState here previously let two Settings surfaces for the same agent
+  // drift out of sync.
+  const { membership, membershipUserRole, driveRoles, updateRole, isSaving: membershipSaving } =
+    useAgentMembership(driveId, pageId);
 
   const handleMembershipRoleChange = useCallback(async (value: string) => {
-    setMembershipSaving(true);
     try {
-      const body: { role: 'MEMBER' | 'ADMIN'; customRoleId: string | null } =
-        value === 'ADMIN'
-          ? { role: 'ADMIN', customRoleId: null }
-          : value === 'MEMBER'
-          ? { role: 'MEMBER', customRoleId: null }
-          : { role: 'MEMBER', customRoleId: value };
-      await patch(`/api/drives/${driveId}/agents/${pageId}`, body);
-      const customRole = body.customRoleId
-        ? (driveRoles.find((r) => r.id === body.customRoleId) ?? null)
-        : null;
-      setMembership({
-        role: body.role,
-        customRole: customRole ? { id: customRole.id, name: customRole.name, color: customRole.color ?? null } : null,
-      });
+      await updateRole(value);
       toast.success('Role updated');
     } catch {
       toast.error('Failed to update role');
-    } finally {
-      setMembershipSaving(false);
     }
-  }, [driveId, pageId, driveRoles]);
+  }, [updateRole]);
 
   // Dynamic Ollama models state
   const [ollamaModels, setOllamaModels] = useState<Record<string, string> | null>(null);
@@ -239,6 +184,21 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   // relative to a sibling's later save" (see onSubmit below, round 18).
   const providerTouchedRef = useRef(false);
   const modelTouchedRef = useRef(false);
+
+  // What to actually SHOW in the provider/model Selects — same resolution
+  // as onSubmit's resolvedProvider/resolvedModel (this instance's own
+  // untouched selection defers to the shared config), but read at render
+  // time rather than only at submit time. Without this, an untouched
+  // instance kept rendering its stale `selectedProvider`/`selectedModel`
+  // prop (owned by a separate, non-shared useProviderSettings() per mount)
+  // even after a SIBLING Settings surface for the same agent saved a
+  // different provider — the save itself was already correct (onSubmit's
+  // own resolution prevented the stale prop from being submitted), but the
+  // display never caught up (review finding — chatgpt-codex-connector on
+  // PR #2299, round 26, thread r3694897525).
+  const providerOrModelTouched = providerTouchedRef.current || modelTouchedRef.current;
+  const displayedProvider = providerOrModelTouched ? selectedProvider : (config?.aiProvider || selectedProvider);
+  const displayedModel = providerOrModelTouched ? selectedModel : (config?.aiModel || selectedModel);
 
   // Reset form when config changes — but NOT when this surface has its own
   // unsaved edits from an EXTERNAL update (a different pane's Settings tab
@@ -321,15 +281,20 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     }
   }, [lmstudioModels]);
 
-  // Get models for the current provider (dynamic for Ollama and LM Studio, static for others)
+  // Get models for the DISPLAYED provider (dynamic for Ollama and LM Studio,
+  // static for others) — must match displayedProvider, not selectedProvider:
+  // an untouched instance can be displaying a sibling's saved provider (see
+  // displayedProvider above) while selectedProvider still holds this
+  // instance's own stale value, and listing the wrong provider's models
+  // would offer a model that doesn't belong to the shown provider.
   const getCurrentProviderModels = (): Record<string, string> => {
-    if (selectedProvider === 'ollama' && ollamaModels) {
+    if (displayedProvider === 'ollama' && ollamaModels) {
       return ollamaModels;
     }
-    if (selectedProvider === 'lmstudio' && lmstudioModels) {
+    if (displayedProvider === 'lmstudio' && lmstudioModels) {
       return lmstudioModels;
     }
-    return AI_PROVIDERS[selectedProvider as keyof typeof AI_PROVIDERS]?.models || {};
+    return AI_PROVIDERS[displayedProvider as keyof typeof AI_PROVIDERS]?.models || {};
   };
 
   const onSubmit = useCallback(async (data: FormData) => {
@@ -465,20 +430,22 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     isSaving
   }), [handleSubmit, onSubmit, isSaving]);
 
-  // Eagerly fetch models when provider is Ollama or LM Studio
+  // Eagerly fetch models for the DISPLAYED provider (see displayedProvider
+  // above) when it's Ollama or LM Studio — must match what's actually
+  // rendered, not this instance's own possibly-stale selectedProvider.
   useEffect(() => {
-    if (selectedProvider === 'ollama' && !ollamaModels) {
+    if (displayedProvider === 'ollama' && !ollamaModels) {
       fetchOllamaModels().catch(() => {
         console.debug('Initial Ollama model fetch failed');
       });
     }
-    if (selectedProvider === 'lmstudio' && !lmstudioModels) {
+    if (displayedProvider === 'lmstudio' && !lmstudioModels) {
       fetchLMStudioModels().catch(() => {
         console.debug('Initial LM Studio model fetch failed');
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedProvider]); // Only selectedProvider - fetch functions are stable, models checked inline
+  }, [displayedProvider]); // Only displayedProvider - fetch functions are stable, models checked inline
 
   // Watch enabledTools for the count display
   const enabledTools = watch('enabledTools', []);
@@ -557,7 +524,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
               {/* Provider Selector */}
               <div>
                 <label className="text-sm font-medium mb-2 block">AI Provider</label>
-                <Select value={selectedProvider} onValueChange={handleProviderSelectChange}>
+                <Select value={displayedProvider} onValueChange={handleProviderSelectChange}>
                   <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>
@@ -580,13 +547,13 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
               {/* Model Selector */}
               <div>
                 <label className="text-sm font-medium mb-2 block">Model</label>
-                <Select value={selectedModel} onValueChange={handleModelSelectChange}>
+                <Select value={displayedModel} onValueChange={handleModelSelectChange}>
                   <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectGroup>
-                      <SelectLabel>{AI_PROVIDERS[selectedProvider as keyof typeof AI_PROVIDERS]?.name} Models</SelectLabel>
+                      <SelectLabel>{AI_PROVIDERS[displayedProvider as keyof typeof AI_PROVIDERS]?.name} Models</SelectLabel>
                       {Object.entries(getCurrentProviderModels()).map(([key, name]) => (
                         <SelectItem key={key} value={key}>
                           {name}

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -52,6 +52,10 @@ interface PageAgentSettingsTabProps {
   /** Accepts a plain value OR an updater `(current) => next` — see onSubmit
    * below for why the updater form matters (round 22). */
   onConfigUpdate: (config: AgentConfig | ((current: AgentConfig | undefined) => AgentConfig)) => void;
+  /** Re-fetches the shared config cache to reconcile it with the server's
+   * ground truth — see onSubmit below for why the optimistic update above
+   * isn't always enough on its own (round 23). */
+  onConfigRevalidate: () => void;
   selectedProvider: string;
   selectedModel: string;
   onProviderChange: (provider: string) => void;
@@ -120,6 +124,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   driveId,
   config,
   onConfigUpdate,
+  onConfigRevalidate,
   selectedProvider,
   selectedModel,
   onProviderChange,
@@ -417,6 +422,16 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
         ...patchThisSave,
         ...providerModelPatch,
       } as AgentConfig));
+      // The optimistic merge above is instant but not the last word: a
+      // sibling surface PATCHing the SAME field concurrently can have its
+      // OWN response arrive after this one despite its write having
+      // committed FIRST in the DB (HTTP response order need not match
+      // write order) — merging alone can't tell the two apart, since both
+      // completions look identical from here. Re-fetching lets the cache
+      // reconcile to whatever the server actually holds once any
+      // overlapping sibling save has also had a chance to land (review
+      // finding — chatgpt-codex-connector on PR #2299, round 23).
+      onConfigRevalidate();
       toast.success('Agent configuration saved successfully');
     } catch (error) {
       console.error('Error saving agent configuration:', error);
@@ -425,7 +440,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       setIsSaving(false);
       onSavingChange?.(false);
     }
-  }, [pageId, config, onConfigUpdate, selectedProvider, selectedModel, onSavingChange, dirtyFields]);
+  }, [pageId, config, onConfigUpdate, onConfigRevalidate, selectedProvider, selectedModel, onSavingChange, dirtyFields]);
 
   const handleProviderSelectChange = useCallback(
     (provider: string) => {

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -49,7 +49,9 @@ interface PageAgentSettingsTabProps {
   pageId: string;
   driveId: string;
   config: AgentConfig | null;
-  onConfigUpdate: (config: AgentConfig) => void;
+  /** Accepts a plain value OR an updater `(current) => next` — see onSubmit
+   * below for why the updater form matters (round 22). */
+  onConfigUpdate: (config: AgentConfig | ((current: AgentConfig | undefined) => AgentConfig)) => void;
   selectedProvider: string;
   selectedModel: string;
   onProviderChange: (provider: string) => void;
@@ -381,15 +383,20 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
 
       await patch(`/api/pages/${pageId}/agent-config`, requestData);
 
-      // The LOCAL optimistic cache update is display-only (never sent to
-      // the server above), so merging with the freshest config here is
-      // safe — this just makes sure THIS instance's own edits are visible
-      // immediately without waiting on a revalidation round trip.
-      const updatedConfig = {
-        ...config,
-        ...dirtyPatch,
-        ...(providerOrModelTouched && { aiProvider: resolvedProvider, aiModel: resolvedModel }),
-      } as AgentConfig;
+      // Updater form — merges against whatever the SHARED SWR cache
+      // actually holds at the moment this runs, not the `config` this
+      // closure captured when onSubmit was created. Two surfaces saving
+      // DIFFERENT fields concurrently each hold their OWN stale closure
+      // from before either save started; whichever finishes last spreading
+      // that closure as a plain value would publish a snapshot missing the
+      // other's meanwhile-arrived change, making it disappear from every
+      // mounted consumer even though both sparse PATCHes above persisted
+      // correctly server-side (review finding — chatgpt-codex-connector on
+      // PR #2299, round 22).
+      const patchThisSave = dirtyPatch;
+      const providerModelPatch = providerOrModelTouched
+        ? { aiProvider: resolvedProvider, aiModel: resolvedModel }
+        : {};
       // This save's own values should always become this instance's new
       // clean baseline, even though the form is (still, momentarily) dirty
       // when the reset effect runs — the dirty-guard above only exists to
@@ -405,7 +412,11 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       // chatgpt-codex-connector on PR #2299, round 19).
       providerTouchedRef.current = false;
       modelTouchedRef.current = false;
-      onConfigUpdate(updatedConfig);
+      onConfigUpdate((current) => ({
+        ...current,
+        ...patchThisSave,
+        ...providerModelPatch,
+      } as AgentConfig));
       toast.success('Agent configuration saved successfully');
     } catch (error) {
       console.error('Error saving agent configuration:', error);

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -362,6 +362,16 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       // when the reset effect runs — the dirty-guard above only exists to
       // protect against a DIFFERENT (sibling) surface's external update.
       justSavedOwnConfigRef.current = true;
+      // Cleared here, not left true forever: `config.aiProvider`/`aiModel`
+      // now correctly reflect what THIS instance just chose (onConfigUpdate
+      // below), so "prefer the shared config" is exactly as correct for
+      // this instance's own just-saved value as it is for reacting to a
+      // LATER sibling's save. Leaving these true past this point would
+      // permanently pin onSubmit to this instance's local snapshot and
+      // revert every subsequent sibling save forever (review finding —
+      // chatgpt-codex-connector on PR #2299, round 19).
+      providerTouchedRef.current = false;
+      modelTouchedRef.current = false;
       onConfigUpdate(updatedConfig);
       toast.success('Agent configuration saved successfully');
     } catch (error) {

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -525,6 +525,7 @@ export async function saveMessageToDatabase({
   sourceAgentId,
   mentionNotify,
   status = 'complete',
+  dbClient = db,
 }: {
   messageId: string;
   pageId: string;
@@ -546,6 +547,14 @@ export async function saveMessageToDatabase({
    * See Server Stream Durability epic PR 2.
    */
   status?: 'complete' | 'interrupted';
+  /**
+   * Override the connection this write runs on — a caller that already
+   * opened a transaction (e.g. to hold a row lock across an active-
+   * conversation check and this insert, atomically) passes its `tx` here so
+   * the insert runs on the SAME connection/transaction rather than a second,
+   * unlocked one. Defaults to the plain module `db`.
+   */
+  dbClient?: typeof db;
 }) {
   try {
     let structuredContent = content;
@@ -582,7 +591,7 @@ export async function saveMessageToDatabase({
     // still pass the conversationId check and overwrite that assistant reply's content —
     // content-spoofing an AI response within a conversation the client already has access
     // to write to (ids aren't secret; they're visible in the conversation's own history).
-    const result = await db.insert(chatMessages)
+    const result = await dbClient.insert(chatMessages)
       .values({
         id: messageId,
         pageId,
@@ -700,6 +709,7 @@ export async function saveGlobalAssistantMessageToDatabase({
   toolResults,
   uiMessage,
   status = 'complete',
+  dbClient = db,
 }: {
   messageId: string;
   conversationId: string;
@@ -712,6 +722,8 @@ export async function saveGlobalAssistantMessageToDatabase({
   /** Terminal status for a formerly-'streaming' placeholder row. See saveMessageToDatabase's
    * param doc for the full rationale — same contract, mirrored for the global assistant table. */
   status?: 'complete' | 'interrupted';
+  /** See saveMessageToDatabase's own doc — same override, same purpose. */
+  dbClient?: typeof db;
 }) {
   try {
     let structuredContent = content;
@@ -732,7 +744,7 @@ export async function saveGlobalAssistantMessageToDatabase({
     // DID silently overwrite another conversation's content on a colliding id — the
     // `where` closes that too, plus the same same-conversation role-spoofing gap
     // (a 'user'-role save whose id collides with an existing 'assistant' row).
-    const result = await db.insert(messages)
+    const result = await dbClient.insert(messages)
       .values({
         id: messageId,
         conversationId,

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
@@ -3,6 +3,7 @@ import { createElement, type ReactNode } from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { SWRConfig } from 'swr';
 import { useAgentConfig } from '../useAgentConfig';
+import type { AgentConfig } from '../../chat-types';
 
 vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn() }));
 
@@ -103,6 +104,42 @@ describe('useAgentConfig', () => {
 
     await waitFor(() => expect(r1.current.config?.systemPrompt).toBe('config-for-1'));
     await waitFor(() => expect(r2.current.config?.systemPrompt).toBe('config-for-2'));
+  });
+
+  // review finding — chatgpt-codex-connector on PR #2299, round 22:
+  // PageAgentSettingsTab's onSubmit used to build its cache update from a
+  // `config` value closed over when the save STARTED — two sibling saves
+  // for different fields could each publish a snapshot missing the
+  // other's meanwhile-arrived change. setConfig now also accepts an
+  // updater, applied against whatever the cache actually holds when SWR's
+  // own mutate runs it, not a stale closure.
+  it('setConfig accepts an updater function that merges against the LIVE cache value, not a stale closure', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ systemPrompt: 'original', enabledTools: [], availableTools: [], aiProvider: 'openai' }),
+    });
+
+    const { result } = renderHook(() => useAgentConfig('agent-1'), { wrapper });
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    // Simulates two "sibling saves" of DIFFERENT fields, each an updater
+    // over whatever is live at apply time rather than a value closed over
+    // from before either save started.
+    act(() => {
+      result.current.setConfig((current) => ({ ...current, systemPrompt: 'saved-by-a' }) as AgentConfig);
+    });
+    act(() => {
+      result.current.setConfig((current) => ({ ...current, aiProvider: 'anthropic' }) as AgentConfig);
+    });
+
+    // Both merges applied — the second updater saw the first's change via
+    // the live cache, not a stale closure that would have reverted it.
+    expect(result.current.config).toEqual({
+      systemPrompt: 'saved-by-a',
+      enabledTools: [],
+      availableTools: [],
+      aiProvider: 'anthropic',
+    });
   });
 
   // The global assistant has no page — a pane hosting it must still be able

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { useAgentConfig } from '../useAgentConfig';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn() }));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+const mockFetchWithAuth = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
+
+// A fresh cache per test (`provider: () => new Map()`) — the module-scope SWR
+// cache is otherwise shared across tests and would let one test's config leak
+// into the next's assertions for the same pageId.
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
+
+describe('useAgentConfig', () => {
+  beforeEach(() => {
+    mockFetchWithAuth.mockReset();
+  });
+
+  it('fetches from /api/pages/{pageId}/agent-config, keyed by pageId', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ systemPrompt: 'be helpful', enabledTools: [], availableTools: [] }),
+    });
+
+    const { result } = renderHook(() => useAgentConfig('agent-1'), { wrapper });
+
+    expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/pages/agent-1/agent-config');
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    expect(result.current.config).toEqual({ systemPrompt: 'be helpful', enabledTools: [], availableTools: [] });
+  });
+
+  it('starts with config: null before the fetch resolves', () => {
+    mockFetchWithAuth.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useAgentConfig('agent-1'), { wrapper });
+
+    expect(result.current.config).toBeNull();
+  });
+
+  // The whole point of this hook: two consumers of the SAME pageId share ONE
+  // cache entry. A save from one instance's setConfig must be visible in the
+  // other WITHOUT a second fetch — that's what makes Settings a single
+  // source of truth across N panes showing the same agent.
+  it('setConfig writes through the SHARED cache — a second hook instance for the same pageId sees the update with no additional fetch', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ systemPrompt: 'original', enabledTools: [], availableTools: [] }),
+    });
+
+    const cache = new Map();
+    const sharedWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(SWRConfig, { value: { provider: () => cache } }, children);
+
+    const first = renderHook(() => useAgentConfig('agent-1'), { wrapper: sharedWrapper });
+    await waitFor(() => expect(first.result.current.config?.systemPrompt).toBe('original'));
+
+    act(() => {
+      first.result.current.setConfig({ systemPrompt: 'saved', enabledTools: [], availableTools: [] });
+    });
+    expect(first.result.current.config?.systemPrompt).toBe('saved');
+
+    const fetchCallsBeforeSecondMount = mockFetchWithAuth.mock.calls.length;
+    const second = renderHook(() => useAgentConfig('agent-1'), { wrapper: sharedWrapper });
+
+    expect(second.result.current.config?.systemPrompt).toBe('saved');
+    expect(mockFetchWithAuth.mock.calls.length).toBe(fetchCallsBeforeSecondMount);
+  });
+
+  it('setConfig does not trigger a revalidating refetch (the caller already has the server-fresh value)', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ systemPrompt: 'original', enabledTools: [], availableTools: [] }),
+    });
+
+    const { result } = renderHook(() => useAgentConfig('agent-1'), { wrapper });
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    const callsAfterInitialLoad = mockFetchWithAuth.mock.calls.length;
+
+    act(() => {
+      result.current.setConfig({ systemPrompt: 'saved', enabledTools: [], availableTools: [] });
+    });
+
+    expect(mockFetchWithAuth.mock.calls.length).toBe(callsAfterInitialLoad);
+  });
+
+  it('two different pageIds are independent cache entries', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => ({
+        systemPrompt: url.includes('agent-1') ? 'config-for-1' : 'config-for-2',
+        enabledTools: [],
+        availableTools: [],
+      }),
+    }));
+
+    const { result: r1 } = renderHook(() => useAgentConfig('agent-1'), { wrapper });
+    const { result: r2 } = renderHook(() => useAgentConfig('agent-2'), { wrapper });
+
+    await waitFor(() => expect(r1.current.config?.systemPrompt).toBe('config-for-1'));
+    await waitFor(() => expect(r2.current.config?.systemPrompt).toBe('config-for-2'));
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
@@ -104,4 +104,14 @@ describe('useAgentConfig', () => {
     await waitFor(() => expect(r1.current.config?.systemPrompt).toBe('config-for-1'));
     await waitFor(() => expect(r2.current.config?.systemPrompt).toBe('config-for-2'));
   });
+
+  // The global assistant has no page — a pane hosting it must still be able
+  // to call this hook unconditionally (stable hook order across an agent
+  // switch within the same pane instance) without issuing a request.
+  it('given pageId: null (the global assistant), never fetches and config stays null', async () => {
+    const { result } = renderHook(() => useAgentConfig(null), { wrapper });
+
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    expect(result.current.config).toBeNull();
+  });
 });

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentConfig.test.ts
@@ -89,6 +89,42 @@ describe('useAgentConfig', () => {
     expect(mockFetchWithAuth.mock.calls.length).toBe(callsAfterInitialLoad);
   });
 
+  // review finding — chatgpt-codex-connector on PR #2299, round 23: two
+  // sibling surfaces PATCHing the SAME field race not just on which save
+  // STARTS first, but on which HTTP RESPONSE arrives first — that need not
+  // match DB-write order. Merging optimistic updates alone can't tell the
+  // two apart; revalidate() lets the cache reconcile to server ground
+  // truth.
+  it('revalidate() re-fetches and replaces the cache with the server response', async () => {
+    mockFetchWithAuth
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ systemPrompt: 'original', enabledTools: [], availableTools: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ systemPrompt: 'ground-truth-from-server', enabledTools: [], availableTools: [] }),
+      });
+
+    const { result } = renderHook(() => useAgentConfig('agent-1'), { wrapper });
+    await waitFor(() => expect(result.current.config?.systemPrompt).toBe('original'));
+
+    // An optimistic update that (in the real bug) could be wrong relative
+    // to a sibling's out-of-order response.
+    act(() => {
+      result.current.setConfig({ systemPrompt: 'optimistic-guess', enabledTools: [], availableTools: [] });
+    });
+    expect(result.current.config?.systemPrompt).toBe('optimistic-guess');
+
+    await act(async () => {
+      result.current.revalidate();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.config?.systemPrompt).toBe('ground-truth-from-server'));
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(2);
+  });
+
   it('two different pageIds are independent cache entries', async () => {
     mockFetchWithAuth.mockImplementation(async (url: string) => ({
       ok: true,

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentMembership.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentMembership.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { useAgentMembership } from '../useAgentMembership';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn(), patch: vi.fn() }));
+
+import { fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
+
+const mockFetchWithAuth = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
+const mockPatch = patch as unknown as ReturnType<typeof vi.fn>;
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
+
+function membersResponse(role: string) {
+  return {
+    ok: true,
+    json: async () => ({
+      agentMembers: [{ agentPageId: 'agent-1', role, customRole: null }],
+      currentUserRole: 'ADMIN',
+    }),
+  };
+}
+const rolesResponse = { ok: true, json: async () => ({ roles: [] }) };
+
+describe('useAgentMembership', () => {
+  beforeEach(() => {
+    mockFetchWithAuth.mockReset();
+    mockPatch.mockReset();
+  });
+
+  it('fetches members + roles for the drive and resolves this agent\'s membership', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) =>
+      url.includes('/roles') ? rolesResponse : membersResponse('MEMBER'),
+    );
+
+    const { result } = renderHook(() => useAgentMembership('drive-1', 'agent-1'), { wrapper });
+
+    expect(result.current.membership).toBeUndefined();
+    await waitFor(() => expect(result.current.membership).not.toBeUndefined());
+    expect(result.current.membership).toEqual({ role: 'MEMBER', customRole: null });
+    expect(result.current.membershipUserRole).toBe('ADMIN');
+  });
+
+  // The whole point of this hook: two Settings surfaces for the SAME agent
+  // must share one members fetch, and a role change from one must be
+  // visible in the other without a manual local merge.
+  it('updateRole revalidates the SHARED cache — a second hook instance for the same agent sees the new role with no extra local state', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) =>
+      url.includes('/roles') ? rolesResponse : membersResponse('MEMBER'),
+    );
+    mockPatch.mockResolvedValue({ success: true });
+
+    const cache = new Map();
+    const sharedWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(SWRConfig, { value: { provider: () => cache } }, children);
+
+    const first = renderHook(() => useAgentMembership('drive-1', 'agent-1'), { wrapper: sharedWrapper });
+    await waitFor(() => expect(first.result.current.membership?.role).toBe('MEMBER'));
+
+    // After the PATCH resolves, the members endpoint reflects the new role.
+    mockFetchWithAuth.mockImplementation(async (url: string) =>
+      url.includes('/roles') ? rolesResponse : membersResponse('ADMIN'),
+    );
+
+    await act(async () => {
+      await first.result.current.updateRole('ADMIN');
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/drives/drive-1/agents/agent-1', {
+      role: 'ADMIN',
+      customRoleId: null,
+    });
+
+    const second = renderHook(() => useAgentMembership('drive-1', 'agent-1'), { wrapper: sharedWrapper });
+    await waitFor(() => expect(second.result.current.membership?.role).toBe('ADMIN'));
+    expect(first.result.current.membership?.role).toBe('ADMIN');
+  });
+
+  it('a custom role id sends customRoleId and MEMBER role', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) =>
+      url.includes('/roles') ? rolesResponse : membersResponse('MEMBER'),
+    );
+    mockPatch.mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useAgentMembership('drive-1', 'agent-1'), { wrapper });
+    await waitFor(() => expect(result.current.membership).not.toBeUndefined());
+
+    await act(async () => {
+      await result.current.updateRole('custom-role-id');
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/drives/drive-1/agents/agent-1', {
+      role: 'MEMBER',
+      customRoleId: 'custom-role-id',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
@@ -151,7 +151,7 @@ describe('useConversations deleteConversation', () => {
     mockFetchWithAuth.mockReset();
   });
 
-  it('given the DELETE succeeds, resolves true and invalidates the SWR cache', async () => {
+  it('given the DELETE succeeds, resolves true and notifies the parent', async () => {
     mockFetchWithAuth.mockResolvedValue({ ok: true });
     const onConversationDelete = vi.fn();
     const { result } = renderHook(() =>

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
@@ -141,3 +141,72 @@ describe('useConversations createConversation', () => {
     });
   });
 });
+
+// A caller reacting to the deletion (resetting UI bound to this
+// conversationId) needs to tell success from failure — the previous version
+// resolved regardless of outcome, with no signal either way (review finding
+// — chatgpt-codex-connector and coderabbitai on PR #2299).
+describe('useConversations deleteConversation', () => {
+  beforeEach(() => {
+    mockFetchWithAuth.mockReset();
+  });
+
+  it('given the DELETE succeeds, resolves true and invalidates the SWR cache', async () => {
+    mockFetchWithAuth.mockResolvedValue({ ok: true });
+    const onConversationDelete = vi.fn();
+    const { result } = renderHook(() =>
+      useConversations({
+        agentId: 'agent-1',
+        currentConversationId: 'conv-1',
+        enabled: false,
+        onConversationDelete,
+      })
+    );
+
+    const succeeded = await act(() => result.current.deleteConversation('conv-1'));
+
+    expect(succeeded).toBe(true);
+    expect(onConversationDelete).toHaveBeenCalledWith('conv-1');
+  });
+
+  it('given the DELETE is refused (e.g. a 409), resolves false, surfaces the server-provided reason, and does NOT notify the parent', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'This is the only open conversation in its session.' }),
+    });
+    const onConversationDelete = vi.fn();
+    const { result } = renderHook(() =>
+      useConversations({
+        agentId: 'agent-1',
+        currentConversationId: 'conv-1',
+        enabled: false,
+        onConversationDelete,
+      })
+    );
+
+    const { toast } = await import('sonner');
+    const succeeded = await act(() => result.current.deleteConversation('conv-1'));
+
+    expect(succeeded).toBe(false);
+    expect(onConversationDelete).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('This is the only open conversation in its session.');
+  });
+
+  it('given the DELETE request throws (network failure), resolves false and does NOT notify the parent', async () => {
+    mockFetchWithAuth.mockRejectedValue(new Error('network down'));
+    const onConversationDelete = vi.fn();
+    const { result } = renderHook(() =>
+      useConversations({
+        agentId: 'agent-1',
+        currentConversationId: 'conv-1',
+        enabled: false,
+        onConversationDelete,
+      })
+    );
+
+    const succeeded = await act(() => result.current.deleteConversation('conv-1'));
+
+    expect(succeeded).toBe(false);
+    expect(onConversationDelete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { createElement } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
 import { useConversations } from '../useConversations';
 
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
@@ -208,5 +210,60 @@ describe('useConversations deleteConversation', () => {
 
     expect(succeeded).toBe(false);
     expect(onConversationDelete).not.toHaveBeenCalled();
+  });
+});
+
+// round 13 review finding — chatgpt-codex-connector on PR #2299: the
+// Assistant pane's History tab (agentId null) fetched the LEGACY, bare-array
+// `/api/ai/global` endpoint and read `data.conversations` from it — which is
+// undefined on a bare array, so the list was always empty regardless of what
+// conversations actually existed.
+describe('useConversations global-mode conversation list', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
+
+  beforeEach(() => {
+    mockFetchWithAuth.mockReset();
+  });
+
+  it('given agentId is null, fetches the PAGINATED endpoint (not the legacy bare array) and returns a non-empty list', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        conversations: [
+          { id: 'conv-a', title: 'Chat A', lastMessageAt: '2026-01-02T00:00:00.000Z', createdAt: '2026-01-01T00:00:00.000Z', sessionId: null },
+        ],
+        pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 },
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useConversations({ agentId: null, currentConversationId: null, enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.conversations).toHaveLength(1));
+    expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/ai/global?paginated=true');
+    expect(result.current.conversations[0]).toMatchObject({ id: 'conv-a', title: 'Chat A' });
+  });
+
+  it('given a global conversation with a null title, falls back to a display placeholder rather than crashing', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        conversations: [
+          { id: 'conv-b', title: null, lastMessageAt: null, createdAt: '2026-01-01T00:00:00.000Z', sessionId: null },
+        ],
+        pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 20 },
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useConversations({ agentId: null, currentConversationId: null, enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.conversations).toHaveLength(1));
+    expect(result.current.conversations[0].title).toBeTruthy();
   });
 });

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useConversations.test.ts
@@ -243,7 +243,7 @@ describe('useConversations global-mode conversation list', () => {
     );
 
     await waitFor(() => expect(result.current.conversations).toHaveLength(1));
-    expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/ai/global?paginated=true');
+    expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/ai/global?paginated=true&limit=100');
     expect(result.current.conversations[0]).toMatchObject({ id: 'conv-a', title: 'Chat A' });
   });
 

--- a/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
@@ -2,7 +2,7 @@
  * useAgentConfig - Shared, SWR-backed hook for a page agent's config.
  *
  * SWR's cache is keyed by URL, so every mounted consumer of the SAME
- * `pageId` — the page's own Settings tab, and now every pane showing that
+ * `pageId` — the page's own Settings tab, and every pane showing that
  * agent — reads the identical cache entry: one fetch, one in-flight state,
  * one value. `setConfig` writes through that SAME cache (no revalidate,
  * since the caller already has the server's own fresh response — see
@@ -12,13 +12,19 @@
  * Settings tab, cannot be shadowed by a stale copy held in another (the gap
  * a per-instance `useState` fetch would have: two panes on the same agent
  * would otherwise each hold their own independent snapshot).
+ *
+ * `pageId: null` — the global assistant, which has no page and so no
+ * config to fetch — disables the SWR key entirely (mirrors `useConversations`'s
+ * own `enabled`/null-key pattern), so a pane hosting the assistant can call
+ * this hook unconditionally (stable hook order across an agent switch)
+ * without ever issuing a request.
  */
 import useSWR from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import type { AgentConfig } from '../chat-types';
 
-function agentConfigKey(pageId: string): string {
-  return `/api/pages/${pageId}/agent-config`;
+function agentConfigKey(pageId: string | null): string | null {
+  return pageId === null ? null : `/api/pages/${pageId}/agent-config`;
 }
 
 interface UseAgentConfigResult {
@@ -26,7 +32,7 @@ interface UseAgentConfigResult {
   setConfig: (next: AgentConfig) => void;
 }
 
-export function useAgentConfig(pageId: string): UseAgentConfigResult {
+export function useAgentConfig(pageId: string | null): UseAgentConfigResult {
   const { data, mutate } = useSWR<AgentConfig>(
     agentConfigKey(pageId),
     async (url) => {

--- a/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
@@ -45,6 +45,20 @@ interface UseAgentConfigResult {
    * `null`, for "no value yet", since it's passed straight through.)
    */
   setConfig: (next: AgentConfig | ((current: AgentConfig | undefined) => AgentConfig)) => void;
+  /**
+   * Re-fetches and reconciles the cache with whatever the server actually
+   * holds right now. Needed because `setConfig`'s optimistic updates can
+   * still end up wrong for a reason merging alone can't fix: two mounted
+   * surfaces PATCHing the SAME field with different values race not just
+   * on which save STARTS first, but on which HTTP response ARRIVES first
+   * — that need not match DB-write order (the earlier write can have the
+   * slower response). Whichever completion applies last here wins the
+   * cache regardless of which write actually landed last in the DB. Call
+   * this after a save to let the fetch settle the cache to ground truth
+   * once any overlapping sibling save has also had a chance to land
+   * (review finding — chatgpt-codex-connector on PR #2299, round 23).
+   */
+  revalidate: () => void;
 }
 
 export function useAgentConfig(pageId: string | null): UseAgentConfigResult {
@@ -65,6 +79,11 @@ export function useAgentConfig(pageId: string | null): UseAgentConfigResult {
       // through so the updater form runs against whatever the cache
       // actually holds when it executes.
       void mutate(next, { revalidate: false });
+    },
+    // No-argument mutate() re-fetches the key and replaces the cache with
+    // the response — SWR's own revalidate primitive.
+    revalidate: () => {
+      void mutate();
     },
   };
 }

--- a/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
@@ -29,7 +29,22 @@ function agentConfigKey(pageId: string | null): string | null {
 
 interface UseAgentConfigResult {
   config: AgentConfig | null;
-  setConfig: (next: AgentConfig) => void;
+  /**
+   * Accepts a plain value OR an updater `(current) => next` — the updater
+   * form reads the LIVE SWR cache value at the moment it actually runs,
+   * not whatever `config` a caller's closure captured when it was created.
+   * Two mounted consumers of the SAME pageId saving DIFFERENT fields
+   * concurrently each hold their own stale closure of `config` from
+   * before either save started; whichever finishes last spreading that
+   * closure into a plain value here would publish a snapshot missing the
+   * other's meanwhile-arrived change, making it disappear from the shared
+   * cache (and every mounted consumer) even though both sparse PATCHes
+   * persisted correctly server-side (review finding — chatgpt-codex-
+   * connector on PR #2299, round 22 — see PageAgentSettingsTab's onSubmit).
+   * (Matches SWR's own MutatorCallback signature — `undefined`, not
+   * `null`, for "no value yet", since it's passed straight through.)
+   */
+  setConfig: (next: AgentConfig | ((current: AgentConfig | undefined) => AgentConfig)) => void;
 }
 
 export function useAgentConfig(pageId: string | null): UseAgentConfigResult {
@@ -46,6 +61,9 @@ export function useAgentConfig(pageId: string | null): UseAgentConfigResult {
   return {
     config: data ?? null,
     setConfig: (next) => {
+      // SWR's own mutate natively accepts either shape — passed straight
+      // through so the updater form runs against whatever the cache
+      // actually holds when it executes.
       void mutate(next, { revalidate: false });
     },
   };

--- a/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAgentConfig.ts
@@ -1,0 +1,46 @@
+/**
+ * useAgentConfig - Shared, SWR-backed hook for a page agent's config.
+ *
+ * SWR's cache is keyed by URL, so every mounted consumer of the SAME
+ * `pageId` — the page's own Settings tab, and now every pane showing that
+ * agent — reads the identical cache entry: one fetch, one in-flight state,
+ * one value. `setConfig` writes through that SAME cache (no revalidate,
+ * since the caller already has the server's own fresh response — see
+ * `PageAgentSettingsTab`'s `onSubmit`, which PATCHes itself and hands back
+ * the persisted result), so a save from ANY one consumer is instantly
+ * visible in every other one — a save in one pane, or the page's own
+ * Settings tab, cannot be shadowed by a stale copy held in another (the gap
+ * a per-instance `useState` fetch would have: two panes on the same agent
+ * would otherwise each hold their own independent snapshot).
+ */
+import useSWR from 'swr';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { AgentConfig } from '../chat-types';
+
+function agentConfigKey(pageId: string): string {
+  return `/api/pages/${pageId}/agent-config`;
+}
+
+interface UseAgentConfigResult {
+  config: AgentConfig | null;
+  setConfig: (next: AgentConfig) => void;
+}
+
+export function useAgentConfig(pageId: string): UseAgentConfigResult {
+  const { data, mutate } = useSWR<AgentConfig>(
+    agentConfigKey(pageId),
+    async (url) => {
+      const response = await fetchWithAuth(url);
+      if (!response.ok) throw new Error('Failed to load agent config');
+      return response.json();
+    },
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+
+  return {
+    config: data ?? null,
+    setConfig: (next) => {
+      void mutate(next, { revalidate: false });
+    },
+  };
+}

--- a/apps/web/src/lib/ai/shared/hooks/useAgentMembership.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAgentMembership.ts
@@ -1,0 +1,116 @@
+/**
+ * useAgentMembership - Shared, SWR-backed hook for an agent's drive
+ * membership (role + custom role) and the drive's available roles.
+ *
+ * Mirrors useAgentConfig's reasoning: SWR's cache is keyed by URL, so every
+ * mounted Settings surface for agents in the SAME drive shares one fetch of
+ * `/api/drives/{driveId}/agents/members` and one fetch of
+ * `/api/drives/{driveId}/roles`. Without this, each PageAgentSettingsTab
+ * instance held its own `useState`-backed snapshot loaded once on mount —
+ * two Settings surfaces for the SAME agent (an ordinary scenario: two panes
+ * both open to that agent's Settings tab) would drift the moment either one
+ * changed the role, since the change only ever touched the mounting
+ * instance's own local state (review finding — chatgpt-codex-connector on
+ * PR #2299, round 27, thread r3695144705).
+ */
+import { useState } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
+
+interface AgentMemberRow {
+  agentPageId: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+  customRole: { id: string; name: string; color: string | null } | null;
+}
+
+interface AgentMembersResponse {
+  agentMembers: AgentMemberRow[];
+  currentUserRole: 'OWNER' | 'ADMIN' | 'MEMBER';
+}
+
+export interface DriveRole {
+  id: string;
+  name: string;
+  color?: string | null;
+}
+
+interface RolesResponse {
+  roles: DriveRole[];
+}
+
+export interface AgentMembership {
+  role: string;
+  customRole: { id: string; name: string; color: string | null } | null;
+}
+
+function membersKey(driveId: string): string {
+  return `/api/drives/${driveId}/agents/members`;
+}
+
+function rolesKey(driveId: string): string {
+  return `/api/drives/${driveId}/roles`;
+}
+
+interface UseAgentMembershipResult {
+  /** `undefined` while loading, `null` if the agent has no explicit role. */
+  membership: AgentMembership | null | undefined;
+  membershipUserRole: 'OWNER' | 'ADMIN' | 'MEMBER';
+  driveRoles: DriveRole[];
+  updateRole: (value: string) => Promise<void>;
+  isSaving: boolean;
+}
+
+export function useAgentMembership(driveId: string, pageId: string): UseAgentMembershipResult {
+  const [isSaving, setIsSaving] = useState(false);
+
+  const { data: membersData, mutate: mutateMembers } = useSWR<AgentMembersResponse>(
+    membersKey(driveId),
+    async (url) => {
+      const response = await fetchWithAuth(url);
+      if (!response.ok) throw new Error('Failed to load agent members');
+      return response.json();
+    },
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+
+  const { data: rolesData } = useSWR<RolesResponse>(
+    rolesKey(driveId),
+    async (url) => {
+      const response = await fetchWithAuth(url);
+      if (!response.ok) throw new Error('Failed to load drive roles');
+      return response.json();
+    },
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+
+  const entry = membersData?.agentMembers.find((m) => m.agentPageId === pageId);
+  const membership: AgentMembership | null | undefined =
+    membersData === undefined ? undefined : entry ? { role: entry.role, customRole: entry.customRole } : null;
+
+  const updateRole = async (value: string) => {
+    setIsSaving(true);
+    try {
+      const body: { role: 'MEMBER' | 'ADMIN'; customRoleId: string | null } =
+        value === 'ADMIN'
+          ? { role: 'ADMIN', customRoleId: null }
+          : value === 'MEMBER'
+          ? { role: 'MEMBER', customRoleId: null }
+          : { role: 'MEMBER', customRoleId: value };
+      await patch(`/api/drives/${driveId}/agents/${pageId}`, body);
+      // Revalidate the SHARED members cache (rather than a local optimistic
+      // merge) so every mounted Settings surface for this agent — not just
+      // the one that made the change — sees the new role.
+      await mutateMembers();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    membership,
+    membershipUserRole: membersData?.currentUserRole ?? 'MEMBER',
+    driveRoles: rolesData?.roles ?? [],
+    updateRole,
+    isSaving,
+  };
+}

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -23,6 +23,31 @@ import type { OptimisticConversationEntry } from '@/stores/useOptimisticConversa
 // value when no optimistic entries exist (prevents unnecessary re-renders).
 const EMPTY_OPTIMISTIC: OptimisticConversationEntry[] = [];
 
+/** The shape `/api/ai/global?paginated=true` actually returns per conversation
+ * (globalConversationRepository.ConversationSummary, serialized over JSON). */
+interface GlobalConversationSummary {
+  id: string;
+  title: string | null;
+  lastMessageAt: string | null;
+  createdAt: string;
+  sessionId: string | null;
+}
+
+/** Bridges GlobalConversationSummary to RawConversationData — see the cacheKey
+ * comment below for why this exists. */
+function adaptGlobalConversationSummary(raw: GlobalConversationSummary): RawConversationData {
+  return {
+    id: raw.id,
+    title: raw.title ?? 'New conversation',
+    preview: '',
+    createdAt: raw.createdAt,
+    updatedAt: raw.lastMessageAt ?? raw.createdAt,
+    messageCount: 0,
+    sessionId: raw.sessionId,
+    lastMessage: { role: '', timestamp: raw.lastMessageAt ?? raw.createdAt },
+  };
+}
+
 interface UseConversationsOptions {
   /**
    * For agent mode: the agent/page ID
@@ -97,11 +122,17 @@ export function useConversations({
   // store can be addressed across hook-mount lifetimes (e.g. when a
   // chat:conversation_added broadcast arrives while the history tab is
   // closed).
+  //
+  // Global mode uses the PAGINATED endpoint (`?paginated=true`), not the
+  // legacy bare-array one: the legacy shape has no `.conversations` wrapper
+  // at all, so this hook's `data?.conversations` read silently resolved to
+  // nothing and the Assistant's History tab was always empty (review
+  // finding — chatgpt-codex-connector on PR #2299, round 13).
   const cacheKey = useMemo(
     () =>
       isAgentMode
         ? `/api/ai/page-agents/${agentId}/conversations`
-        : `/api/ai/global`,
+        : `/api/ai/global?paginated=true`,
     [isAgentMode, agentId],
   );
   // SWR key for conversations list — null disables the SWR fetch.
@@ -113,7 +144,16 @@ export function useConversations({
     async (url) => {
       const response = await fetchWithAuth(url);
       if (!response.ok) throw new Error('Failed to load conversations');
-      return response.json();
+      const json = await response.json();
+      if (isAgentMode) return json; // already { conversations: RawConversationData[] }
+      // The paginated global endpoint's ConversationSummary is narrower than
+      // RawConversationData — no preview/messageCount/lastMessage (those
+      // require a join this repository doesn't do yet). Adapted here with
+      // safe placeholders so the list renders at all rather than staying
+      // empty; a richer summary query is a scoped follow-up, not required
+      // to fix the reported bug (the list being empty).
+      const summaries = (json.conversations ?? []) as GlobalConversationSummary[];
+      return { conversations: summaries.map(adaptGlobalConversationSummary) };
     },
     {
       // Only pause revalidation after initial load - never block the first fetch

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -55,8 +55,8 @@ interface UseConversationsResult {
   loadConversation: (conversationId: string) => Promise<void>;
   /** Create a new conversation */
   createConversation: () => Promise<string | null>;
-  /** Delete a conversation */
-  deleteConversation: (conversationId: string) => Promise<void>;
+  /** Delete a conversation. Resolves to whether it actually succeeded — a refused delete (e.g. a 409) or a network failure both resolve `false`, never throw. */
+  deleteConversation: (conversationId: string) => Promise<boolean>;
   /** Refresh conversations list */
   refreshConversations: () => void;
   /**
@@ -258,9 +258,16 @@ export function useConversations({
     return conversationId;
   }, [isAgentMode, agentId, swrKey, onConversationCreate]);
 
-  // Delete a conversation
+  // Delete a conversation. Returns whether it actually succeeded — a caller
+  // that reacts to the deletion (e.g. resetting UI bound to this
+  // conversationId) must not do so on a REFUSED delete (a 409, e.g. "this
+  // is the session's only open listing") or a network failure, both of
+  // which leave the conversation exactly as it was server-side (review
+  // finding — chatgpt-codex-connector and coderabbitai on PR #2299: the
+  // previous version resolved regardless of outcome, with no way for a
+  // caller to tell success from failure).
   const deleteConversation = useCallback(
-    async (conversationId: string) => {
+    async (conversationId: string): Promise<boolean> => {
       try {
         const deleteUrl = isAgentMode
           ? `/api/ai/page-agents/${agentId}/conversations/${conversationId}`
@@ -268,20 +275,35 @@ export function useConversations({
 
         const response = await fetchWithAuth(deleteUrl, { method: 'DELETE' });
 
-        if (response.ok) {
-          // Invalidate SWR cache
-          if (swrKey) {
-            mutate(swrKey);
+        if (!response.ok) {
+          // Surface WHY — a 409 is a real, intentional refusal (not a
+          // transient failure), and silently doing nothing left it
+          // invisible to the user.
+          let message = 'Failed to delete conversation';
+          try {
+            const body = await response.json();
+            if (typeof body?.error === 'string') message = body.error;
+          } catch {
+            // Non-JSON error body — fall back to the generic message.
           }
-
-          // If deleting current conversation, notify parent
-          if (conversationId === currentConversationId) {
-            onConversationDelete?.(conversationId);
-          }
+          toast.error(message);
+          return false;
         }
+
+        // Invalidate SWR cache
+        if (swrKey) {
+          mutate(swrKey);
+        }
+
+        // If deleting current conversation, notify parent
+        if (conversationId === currentConversationId) {
+          onConversationDelete?.(conversationId);
+        }
+        return true;
       } catch (error) {
         console.error('Failed to delete conversation:', error);
         toast.error('Failed to delete conversation');
+        return false;
       }
     },
     [isAgentMode, agentId, swrKey, currentConversationId, onConversationDelete]

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -127,12 +127,17 @@ export function useConversations({
   // legacy bare-array one: the legacy shape has no `.conversations` wrapper
   // at all, so this hook's `data?.conversations` read silently resolved to
   // nothing and the Assistant's History tab was always empty (review
-  // finding — chatgpt-codex-connector on PR #2299, round 13).
+  // finding — chatgpt-codex-connector on PR #2299, round 13). `limit=100`
+  // (the route's own max) rather than its 20 default — this hook has no
+  // load-more path (same pre-existing limitation the page-agent History
+  // listing already has at its own default page size), so widening the
+  // single page is the safe mitigation; true pagination is a separate,
+  // larger scoped change (review finding, round 14).
   const cacheKey = useMemo(
     () =>
       isAgentMode
         ? `/api/ai/page-agents/${agentId}/conversations`
-        : `/api/ai/global?paginated=true`,
+        : `/api/ai/global?paginated=true&limit=100`,
     [isAgentMode, agentId],
   );
   // SWR key for conversations list — null disables the SWR fetch.

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -439,12 +439,18 @@ describe('conversationRepository.softDeleteConversation', () => {
     // vice versa (a second review finding on the same fix: chatgpt-codex-
     // connector on PR #2296).
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-    // Two separate UPDATEs: chat_messages (unchanged, pre-existing behavior)
-    // THEN conversations — same order the fix was added in, verified via the
-    // table argument each db.update() call received.
+    // Two separate UPDATEs: conversations FIRST, then chat_messages — the
+    // canonical row is locked before the message sweep, or a concurrent
+    // send's own FOR UPDATE re-check (apps/web/src/app/api/ai/chat/route.ts)
+    // could acquire that lock in the window between them, observe
+    // isActive: true, and commit a new active message a moment before this
+    // transaction tombstones the conversation (review finding — chatgpt-
+    // codex-connector on PR #2299, filed after the original chatMessages-
+    // then-conversations order shipped on PR #2296). Verified via the table
+    // argument each db.update() call received.
     expect(mockDb.update).toHaveBeenCalledTimes(2);
-    expect(mockDb.update).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'chatMessages.id' }));
-    expect(mockDb.update).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: 'conversations.id' }));
+    expect(mockDb.update).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'conversations.id' }));
+    expect(mockDb.update).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: 'chatMessages.id' }));
     expect(setMock).toHaveBeenNthCalledWith(1, { isActive: false });
     expect(setMock).toHaveBeenNthCalledWith(2, { isActive: false });
     expect(mockInvalidateCompaction).toHaveBeenCalledWith('conv_deleted', { source: 'page', pageId: 'agent_1' });

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -374,7 +374,39 @@ export const conversationRepository = {
     // active-message precondition the route checks, stranding the row in
     // the inconsistent state this pairing exists to eliminate (review
     // finding — chatgpt-codex-connector on PR #2296).
+    //
+    // The CONVERSATIONS row first, THEN its messages — not the other order.
+    // The page-agent chat route's own atomic active-conversation re-check
+    // (agent-sessions-runtime's sibling, apps/web/src/app/api/ai/chat/
+    // route.ts) takes `SELECT ... FOR UPDATE` on THIS conversations row
+    // before persisting a message. If this transaction touched
+    // `chatMessages` first, that lock stays free for the whole message
+    // sweep — a concurrent send can acquire it, read `isActive: true`
+    // (still true, since this transaction hasn't reached the conversations
+    // UPDATE yet), insert a new active message, and commit, ALL before this
+    // transaction finally tombstones the conversation a moment later. The
+    // new message then survives as an active row under a now-inactive
+    // conversation — exactly the same class of bug the FOR UPDATE guard
+    // exists to prevent, just reachable through this transaction's own
+    // internal ordering rather than the read-then-write gap that guard
+    // already closes (review finding — chatgpt-codex-connector on PR
+    // #2299). Acquiring the conversations lock FIRST here means a
+    // concurrent send's own FOR UPDATE blocks for this transaction's WHOLE
+    // duration, including the message sweep — there is no window left.
     await db.transaction(async (tx) => {
+      await tx
+        .update(conversations)
+        .set({ isActive: false })
+        .where(eq(conversations.id, conversationId));
+      // Mirrors `globalConversationRepository.softDeleteConversation`'s
+      // pattern, and matches `conversations.isActive`'s own doc comment
+      // ("history soft-delete"). Every reader that gates on
+      // `conversations.isActive` (agent-sessions-runtime.ts's session
+      // listings/caps, the v1/MCP conversations API, the compliance
+      // retention purge) previously kept treating a page conversation
+      // deleted from History as live forever — including, most concretely,
+      // letting the agents console's reopen affordance resurrect one with
+      // no messages left.
       await tx
         .update(chatMessages)
         .set({ isActive: false })
@@ -382,19 +414,6 @@ export const conversationRepository = {
           eq(chatMessages.pageId, agentId),
           eq(chatMessages.conversationId, conversationId)
         ));
-      // The canonical row itself, not just its messages — mirrors
-      // `globalConversationRepository.softDeleteConversation`'s pattern, and
-      // matches `conversations.isActive`'s own doc comment ("history soft-
-      // delete"). Every reader that gates on `conversations.isActive`
-      // (agent-sessions-runtime.ts's session listings/caps, the v1/MCP
-      // conversations API, the compliance retention purge) previously kept
-      // treating a page conversation deleted from History as live forever —
-      // including, most concretely, letting the agents console's reopen
-      // affordance resurrect one with no messages left.
-      await tx
-        .update(conversations)
-        .set({ isActive: false })
-        .where(eq(conversations.id, conversationId));
     });
     // Whole conversation cleared — any summary is stale; the tombstone also
     // guards against a first compaction that may still be in flight.

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -19,14 +19,14 @@ export interface ConversationSummary {
   contextId: string | null;
   lastMessageAt: Date | null;
   createdAt: Date;
+  /** Null for a plain (non-session) conversation. */
+  sessionId: string | null;
 }
 
 export interface Conversation extends ConversationSummary {
   userId: string;
   isActive: boolean;
   updatedAt: Date;
-  /** Null for a plain (non-session) conversation. */
-  sessionId: string | null;
   /** Set when closed out of its session's listing; null while open (or never session-bound). */
   closedInSessionAt: Date | null;
 }
@@ -223,6 +223,7 @@ export const globalConversationRepository = {
         contextId: conversations.contextId,
         lastMessageAt: conversations.lastMessageAt,
         createdAt: conversations.createdAt,
+        sessionId: conversations.sessionId,
       })
       .from(conversations)
       .where(and(
@@ -292,6 +293,7 @@ export const globalConversationRepository = {
         contextId: conversations.contextId,
         lastMessageAt: conversations.lastMessageAt,
         createdAt: conversations.createdAt,
+        sessionId: conversations.sessionId,
       })
       .from(conversations)
       .where(and(...conditions))
@@ -359,6 +361,7 @@ export const globalConversationRepository = {
         contextId: conversations.contextId,
         lastMessageAt: conversations.lastMessageAt,
         createdAt: conversations.createdAt,
+        sessionId: conversations.sessionId,
       })
       .from(conversations)
       .where(and(


### PR DESCRIPTION
## Summary

Continuation of #2296 (merged) on a fresh branch: the one review finding that
hadn't been addressed before the merge, plus a follow-up feature requested
during that PR's review — Chat/History/Settings as real tabs inside each
console pane, sharing state with the page's own `AgentPageView` tabs rather
than duplicating them.

## What's in this PR

- **Reject sends to history-deleted conversations**, closed atomically. A
  conversation still open in another pane or browser tab when it's deleted
  from History could previously keep accepting messages — the send appeared
  to succeed but the row stayed excluded from every session listing. Fixed
  on both send paths, then hardened against a TOCTOU race: the active-
  conversation check now runs as a `SELECT ... FOR UPDATE` immediately
  adjacent to the write, inside a short transaction (never wrapping the
  credit-gate/mention/command work around it).

- **`useAgentConfig`**: a new SWR-backed hook replacing `AgentPageView`'s
  bespoke `useEffect`+`useState` fetch for the agent Settings config. SWR's
  URL-keyed cache makes this a genuine single source of truth — every
  consumer of the same `pageId` shares one cache entry, so a save from any
  one of them is instantly visible everywhere else.

- **Chat | History | Settings as real tabs inside every console pane**
  (`ChatPane` in `AgentPanes.tsx`, replacing `ChatPaneIdentity`). Reuses the
  exact same `useConversations`/`useAgentConfig` hooks and
  `PageAgentHistoryTab`/`PageAgentSettingsTab` components the page's own
  tabs use — a pane and the page view showing the same agent are two views
  onto one cache entry, never two copies that can drift. Picking a History
  entry reopens it first only when bound to THIS session; focuses an
  existing pane instead of duplicating one if already open elsewhere; stays
  on History until the pick actually lands. Deleting from History resets
  every pane in the grid still showing that conversation. Save is disabled
  until the agent config has actually loaded.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] Full relevant suite passing, including new hook-level coverage
      (`useAgentConfig.test.ts`, real SWR via a scoped `SWRConfig`), race
      regression tests (a concurrent History-delete committing between the
      active-conversation check and the message write), and pane-tab
      regression tests (Settings-disabled-while-loading, focus-not-
      duplicate, stay-on-History-on-failed-reopen, rebind-on-delete)
- [ ] Manual click-through in a live browser (not completed in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PofpNe4dkeFdFrN3TjhVFd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added integrated Chat, History, and Settings tabs to agent panes.
  - Added shared, cached agent configuration loading.
  - Reopen responses now indicate whether a conversation was already open.
  - Improved conversation reopening, duplicate-pane focusing, and deletion handling.

- **Bug Fixes**
  - Prevented messages from being saved after conversations are deleted or deactivated.
  - Deleted or inactive conversations now return a clear not-found response.
  - Improved reliability during concurrent conversation updates and pane interactions.
  - Conversation deletion now reports success or failure more clearly.

- **Tests**
  - Expanded coverage for pane tabs, history, deletion, configuration, and concurrent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->