### PR TITLE
feat(agents): header with New Drive/Agent/Session CTAs on Agents list

### DIFF
--- a/apps/web/src/components/agents/AgentsListHeader.tsx
+++ b/apps/web/src/components/agents/AgentsListHeader.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Plus } from 'lucide-react';
+import { useSWRConfig } from 'swr';
 
 import { Button } from '@/components/ui/button';
 import CreateDriveDialog from '@/components/layout/left-sidebar/CreateDriveDialog';
@@ -37,7 +38,14 @@ export default function AgentsListHeader({ driveId }: { driveId?: string }) {
 
   const [createDriveOpen, setCreateDriveOpen] = useState(false);
   const { agentsByDrive } = usePageAgents(undefined, { enabled: canSpawn });
-  const { openSpawn, paletteElement } = useSpawnSession(agentsByDrive);
+  const { mutate } = useSWRConfig();
+  const { openSpawn, paletteElement } = useSpawnSession(agentsByDrive, () => {
+    // Broad match: the sidebar's sessions key is drive-scoped or global
+    // depending on ITS OWN route, and this header doesn't know which is
+    // mounted alongside it — without this, a session spawned from here only
+    // shows up in the sidebar after its 20s poll.
+    void mutate((key) => typeof key === 'string' && key.startsWith('/api/agent-sessions'));
+  });
   const openQuickCreate = useUIStore((state) => state.openQuickCreate);
 
   // Which button opened the picker — decides what happens once a drive is

--- a/apps/web/src/components/agents/AgentsListHeader.tsx
+++ b/apps/web/src/components/agents/AgentsListHeader.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Plus } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import CreateDriveDialog from '@/components/layout/left-sidebar/CreateDriveDialog';
+import { useAuth } from '@/hooks/useAuth';
 import { useDriveStore } from '@/hooks/useDrive';
 import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
 import { useUIStore } from '@/stores/useUIStore';
@@ -19,20 +20,42 @@ import DrivePickerDialog from './DrivePickerDialog';
  * palette. Drive-scoped, "New Session"/"New Agent" act on this drive
  * directly; on the global console (no `driveId`) they open a drive picker
  * first, since neither creation path has anywhere else to put the result.
+ *
+ * "New Session" is hidden for non-admins, mirroring `AgentsSidebar`'s own
+ * `canSpawn` gate — sandboxes are admin-only everywhere else in this
+ * console, and showing the button here would be the one place that UI
+ * promise doesn't hold. "New Drive" and "New Agent" are ordinary
+ * page/drive creation, open to anyone with the underlying permission, same
+ * as `DrivesBrowser` and the Quick Create palette.
  */
 export default function AgentsListHeader({ driveId }: { driveId?: string }) {
   const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const canSpawn = user?.role === 'admin' && !authLoading;
   const drives = useDriveStore((state) => state.drives);
   const driveName = driveId ? (drives.find((drive) => drive.id === driveId)?.name ?? null) : null;
 
   const [createDriveOpen, setCreateDriveOpen] = useState(false);
-  const { agentsByDrive } = usePageAgents();
+  const { agentsByDrive } = usePageAgents(undefined, { enabled: canSpawn });
   const { openSpawn, paletteElement } = useSpawnSession(agentsByDrive);
   const openQuickCreate = useUIStore((state) => state.openQuickCreate);
 
   // Which button opened the picker — decides what happens once a drive is
   // picked. Null means the picker is closed.
   const [pickerFor, setPickerFor] = useState<'session' | 'agent' | null>(null);
+
+  // Quick Create resolves its own driveId from the route (`useParams()`),
+  // not from anything passed here — so a global-page "New Agent" must wait
+  // for THIS component's own `driveId` prop to reflect the just-navigated
+  // route before opening it, rather than opening in the same tick as
+  // `router.push` and racing the navigation.
+  const [pendingAgentDriveId, setPendingAgentDriveId] = useState<string | null>(null);
+  useEffect(() => {
+    if (pendingAgentDriveId && driveId === pendingAgentDriveId) {
+      openQuickCreate(null);
+      setPendingAgentDriveId(null);
+    }
+  }, [pendingAgentDriveId, driveId, openQuickCreate]);
 
   const handleNewSession = () => {
     if (driveId) {
@@ -57,11 +80,8 @@ export default function AgentsListHeader({ driveId }: { driveId?: string }) {
       return;
     }
     if (pickerFor === 'agent') {
-      // Quick Create resolves its own driveId from the route — unlike
-      // spawning a session, there's no override to pass it directly, so
-      // land on that drive's Agents page first.
+      setPendingAgentDriveId(pickedDriveId);
       router.push(`/dashboard/${pickedDriveId}/agents`);
-      openQuickCreate(null);
     }
   };
 
@@ -77,10 +97,12 @@ export default function AgentsListHeader({ driveId }: { driveId?: string }) {
           <Plus className="h-4 w-4 mr-1" />
           New Agent
         </Button>
-        <Button size="sm" onClick={handleNewSession}>
-          <Plus className="h-4 w-4 mr-1" />
-          New Session
-        </Button>
+        {canSpawn && (
+          <Button size="sm" onClick={handleNewSession}>
+            <Plus className="h-4 w-4 mr-1" />
+            New Session
+          </Button>
+        )}
       </div>
 
       <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />

--- a/apps/web/src/components/agents/AgentsListHeader.tsx
+++ b/apps/web/src/components/agents/AgentsListHeader.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import CreateDriveDialog from '@/components/layout/left-sidebar/CreateDriveDialog';
+import { useDriveStore } from '@/hooks/useDrive';
+import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
+import { useUIStore } from '@/stores/useUIStore';
+import { useSpawnSession } from './useSpawnSession';
+import DrivePickerDialog from './DrivePickerDialog';
+
+/**
+ * Header above the Agents console's past-conversations list: gives it a
+ * title and the three ways to start something new (a drive, an agent, a
+ * session) that today only exist buried in the sidebar or the page-type
+ * palette. Drive-scoped, "New Session"/"New Agent" act on this drive
+ * directly; on the global console (no `driveId`) they open a drive picker
+ * first, since neither creation path has anywhere else to put the result.
+ */
+export default function AgentsListHeader({ driveId }: { driveId?: string }) {
+  const router = useRouter();
+  const drives = useDriveStore((state) => state.drives);
+  const driveName = driveId ? (drives.find((drive) => drive.id === driveId)?.name ?? null) : null;
+
+  const [createDriveOpen, setCreateDriveOpen] = useState(false);
+  const { agentsByDrive } = usePageAgents();
+  const { openSpawn, paletteElement } = useSpawnSession(agentsByDrive);
+  const openQuickCreate = useUIStore((state) => state.openQuickCreate);
+
+  // Which button opened the picker — decides what happens once a drive is
+  // picked. Null means the picker is closed.
+  const [pickerFor, setPickerFor] = useState<'session' | 'agent' | null>(null);
+
+  const handleNewSession = () => {
+    if (driveId) {
+      openSpawn(driveId, driveName);
+      return;
+    }
+    setPickerFor('session');
+  };
+
+  const handleNewAgent = () => {
+    if (driveId) {
+      openQuickCreate(null);
+      return;
+    }
+    setPickerFor('agent');
+  };
+
+  const handleDrivePicked = (pickedDriveId: string, pickedDriveName: string) => {
+    setPickerFor(null);
+    if (pickerFor === 'session') {
+      openSpawn(pickedDriveId, pickedDriveName);
+      return;
+    }
+    if (pickerFor === 'agent') {
+      // Quick Create resolves its own driveId from the route — unlike
+      // spawning a session, there's no override to pass it directly, so
+      // land on that drive's Agents page first.
+      router.push(`/dashboard/${pickedDriveId}/agents`);
+      openQuickCreate(null);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between border-b border-border px-4 py-3">
+      <h2 className="text-sm font-semibold text-foreground">Agents</h2>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => setCreateDriveOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Drive
+        </Button>
+        <Button variant="outline" size="sm" onClick={handleNewAgent}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Agent
+        </Button>
+        <Button size="sm" onClick={handleNewSession}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Session
+        </Button>
+      </div>
+
+      <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />
+      {paletteElement}
+      <DrivePickerDialog
+        open={pickerFor !== null}
+        onOpenChange={(open) => !open && setPickerFor(null)}
+        onPick={handleDrivePicked}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -12,6 +12,7 @@ import { useSessionRecord } from './useSessionRecord';
 import AgentPanes from './panes/AgentPanes';
 import EmptyState from './EmptyState';
 import AgentsPastConversationsList from './AgentsPastConversationsList';
+import AgentsListHeader from './AgentsListHeader';
 
 /**
  * The Agents console: mounted for the lifetime of the route, whatever is
@@ -191,7 +192,12 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
         // naming a position in the PREVIOUS drive's ordering. Remounting via
         // `key` resets everything at once rather than chasing every piece of
         // state that would otherwise need its own reset effect (review).
-        <AgentsPastConversationsList key={driveId ?? 'global'} driveId={driveId} />
+        <div className="flex h-full flex-col">
+          <AgentsListHeader driveId={driveId} />
+          <div className="flex-1 min-h-0">
+            <AgentsPastConversationsList key={driveId ?? 'global'} driveId={driveId} />
+          </div>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/agents/DrivePickerDialog.tsx
+++ b/apps/web/src/components/agents/DrivePickerDialog.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Folder } from 'lucide-react';
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useDriveStore } from '@/hooks/useDrive';
+
+/**
+ * Picks a drive to create something in — the step "New session" and "New
+ * agent" need on the global Agents page, which has no drive of its own.
+ * Trashed drives are excluded, same as `AgentsSidebar`'s own drive roster.
+ */
+export default function DrivePickerDialog({
+  open,
+  onOpenChange,
+  onPick,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPick: (driveId: string, driveName: string) => void;
+}) {
+  const drives = useDriveStore((state) => state.drives).filter((drive) => !drive.isTrashed);
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Choose a drive"
+      description="Pick which drive to create this in"
+      showCloseButton={false}
+      className="max-w-[420px]"
+    >
+      <CommandInput placeholder="Search drives…" autoFocus />
+      <CommandList>
+        <CommandEmpty>No drives yet.</CommandEmpty>
+        <CommandGroup>
+          {drives.map((drive) => (
+            <CommandItem key={drive.id} value={drive.name} onSelect={() => onPick(drive.id, drive.name)}>
+              <Folder className="size-3.5" aria-hidden="true" />
+              <span className="truncate">{drive.name}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/components/agents/DrivePickerDialog.tsx
+++ b/apps/web/src/components/agents/DrivePickerDialog.tsx
@@ -39,10 +39,14 @@ export default function DrivePickerDialog({
     >
       <CommandInput placeholder="Search drives…" autoFocus />
       <CommandList>
-        <CommandEmpty>No drives yet.</CommandEmpty>
+        <CommandEmpty>No drives found.</CommandEmpty>
         <CommandGroup>
           {drives.map((drive) => (
-            <CommandItem key={drive.id} value={drive.name} onSelect={() => onPick(drive.id, drive.name)}>
+            <CommandItem
+              key={drive.id}
+              value={`${drive.id}-${drive.name}`}
+              onSelect={() => onPick(drive.id, drive.name)}
+            >
               <Folder className="size-3.5" aria-hidden="true" />
               <span className="truncate">{drive.name}</span>
             </CommandItem>

--- a/apps/web/src/components/agents/__tests__/AgentsListHeader.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsListHeader.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * The Agents console's list header — three CTAs (New Drive, New Agent, New
+ * Session) above what used to be a bare conversations list.
+ *
+ * The properties worth pinning:
+ * - "New Session" mirrors `AgentsSidebar`'s own admin gate: sandboxes are
+ *   admin-only everywhere else in this console, so a non-admin must not see
+ *   this button here either, even though "New Drive"/"New Agent" (ordinary
+ *   permission-gated actions, not admin-only) stay visible.
+ * - Drive-scoped, "New Session"/"New Agent" act on the current drive
+ *   directly. Global (no `driveId`), both go through a drive picker first —
+ *   neither creation path has anywhere else to put the result.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }));
+
+interface PageAgentsResult {
+  agentsByDrive: {
+    driveId: string;
+    driveName: string;
+    agentCount: number;
+    agents: { id: string; title: string | null; driveId: string }[];
+  }[];
+  isLoading: boolean;
+  isError: boolean;
+  mutate: () => void;
+}
+
+const AGENTS_BY_DRIVE: PageAgentsResult['agentsByDrive'] = [
+  {
+    driveId: 'drive-1',
+    driveName: 'Alpha',
+    agentCount: 1,
+    agents: [{ id: 'agent-1', title: 'Researcher', driveId: 'drive-1' }],
+  },
+];
+
+const defaultPageAgents = (_driveId?: string, _options?: { enabled?: boolean }): PageAgentsResult => ({
+  agentsByDrive: AGENTS_BY_DRIVE,
+  isLoading: false,
+  isError: false,
+  mutate: vi.fn(),
+});
+const mockUsePageAgents = vi.fn(defaultPageAgents);
+vi.mock('@/hooks/page-agents/usePageAgents', () => ({
+  usePageAgents: (driveId?: string, options?: { enabled?: boolean }) => mockUsePageAgents(driveId, options),
+}));
+
+import AgentsListHeader from '../AgentsListHeader';
+import { useDriveStore, type Drive } from '@/hooks/useDrive';
+import { useUIStore } from '@/stores/useUIStore';
+
+const driveFixture = (id: string, name: string): Drive => ({
+  id,
+  name,
+  slug: name.toLowerCase(),
+  ownerId: 'user-1',
+  isTrashed: false,
+  trashedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  isOwned: true,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUsePageAgents.mockReturnValue({ agentsByDrive: AGENTS_BY_DRIVE, isLoading: false, isError: false, mutate: vi.fn() });
+  mockUseAuth.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
+  useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha'), driveFixture('drive-2', 'Beta')] });
+  useUIStore.setState({ quickCreateOpen: false, quickCreateParentOverride: undefined });
+});
+
+describe('AgentsListHeader', () => {
+  test('drive-scoped, admin: renders the title and all three CTAs', () => {
+    render(<AgentsListHeader driveId="drive-1" />);
+
+    expect(screen.getByText('Agents')).toBeDefined();
+    expect(screen.getByRole('button', { name: /New Drive/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /New Agent/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /New Session/ })).toBeDefined();
+  });
+
+  test('non-admin: "New Session" is hidden, but "New Drive"/"New Agent" stay visible', () => {
+    mockUseAuth.mockReturnValue({ user: { role: 'user' }, isLoading: false });
+
+    render(<AgentsListHeader driveId="drive-1" />);
+
+    expect(screen.getByRole('button', { name: /New Drive/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /New Agent/ })).toBeDefined();
+    expect(screen.queryByRole('button', { name: /New Session/ })).toBeNull();
+    // The agent picker's roster is spawn-only data — a non-admin can't reach
+    // the palette that would use it, so the fetch is disabled entirely.
+    expect(mockUsePageAgents).toHaveBeenCalledWith(undefined, { enabled: false });
+  });
+
+  test('drive-scoped: "New Session" opens the spawn palette directly, scoped to this drive', async () => {
+    const user = userEvent.setup();
+    render(<AgentsListHeader driveId="drive-1" />);
+
+    await user.click(screen.getByRole('button', { name: /New Session/ }));
+
+    expect(await screen.findByText('Choose an agent to start a session with in Alpha')).toBeDefined();
+    expect(screen.getByText('Researcher')).toBeDefined();
+    // The global-only drive picker must never appear for a drive-scoped spawn.
+    // `CommandDialog`'s title/description render outside its Radix `DialogContent`
+    // (so it's queryable even while closed) — assert on the picker's actual
+    // content instead, which IS gated on `open`.
+    expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
+  });
+
+  test('drive-scoped: "New Agent" opens Quick Create scoped to the drive root', async () => {
+    const user = userEvent.setup();
+    render(<AgentsListHeader driveId="drive-1" />);
+
+    await user.click(screen.getByRole('button', { name: /New Agent/ }));
+
+    expect(useUIStore.getState().quickCreateOpen).toBe(true);
+    expect(useUIStore.getState().quickCreateParentOverride).toBeNull();
+  });
+
+  test('"New Drive" opens the create-drive dialog', async () => {
+    const user = userEvent.setup();
+    render(<AgentsListHeader driveId="drive-1" />);
+
+    await user.click(screen.getByRole('button', { name: /New Drive/ }));
+
+    expect(await screen.findByText('Create a new drive')).toBeDefined();
+  });
+
+  test('global (no driveId): "New Session" opens a drive picker first, then the spawn palette scoped to the pick', async () => {
+    const user = userEvent.setup();
+    render(<AgentsListHeader />);
+
+    await user.click(screen.getByRole('button', { name: /New Session/ }));
+    expect(await screen.findByText('Choose a drive')).toBeDefined();
+
+    await user.click(screen.getByText('Alpha'));
+
+    expect(await screen.findByText('Choose an agent to start a session with in Alpha')).toBeDefined();
+    expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
+  });
+
+  test('global (no driveId): "New Agent" opens a drive picker, then navigates into the picked drive without opening Quick Create until that drive is live', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<AgentsListHeader />);
+
+    await user.click(screen.getByRole('button', { name: /New Agent/ }));
+    expect(await screen.findByText('Choose a drive')).toBeDefined();
+
+    await user.click(screen.getByText('Beta'));
+
+    expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-2/agents');
+    // Quick Create must not open before the route (and thus QuickCreatePalette's
+    // own `useParams()`-derived driveId) has actually caught up — opening in
+    // the same tick as `router.push` would race a still-in-flight navigation.
+    expect(useUIStore.getState().quickCreateOpen).toBe(false);
+
+    // The parent (AgentsSurface) re-renders this component with the new
+    // driveId once the route lands — simulated here by re-rendering with the
+    // prop the real navigation would eventually produce.
+    rerender(<AgentsListHeader driveId="drive-2" />);
+
+    await waitFor(() => expect(useUIStore.getState().quickCreateOpen).toBe(true));
+  });
+});

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Bot, SquareTerminal } from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+  CommandDialog,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { post } from '@/lib/auth/auth-fetch';
+import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
+import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+import type { DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
+
+export type SpawnKind = 'agent' | 'shell' | 'assistant';
+
+/** What the palette's first step picked — drives the naming step's placeholder and spawn() call. */
+export interface SpawnPick {
+  kind: SpawnKind;
+  agentPageId: string | null;
+  /** The sensible default: the agent's title, "Shell", or "Global Assistant". */
+  label: string;
+}
+
+/**
+ * The session-spawn flow, shared by every place that starts a new agent
+ * session: the sidebar's search-header "+", each drive group's inline "+",
+ * and the Agents surface's own "New session" header CTA. Owns the two-step
+ * palette (pick a target, then name it) and the POST itself, so none of its
+ * callers duplicate the naming/landing/error-toast details.
+ *
+ * Takes the caller's own `agentsByDrive` (from `usePageAgents`) rather than
+ * fetching it internally — callers that already have one (the sidebar) don't
+ * pay for a second, differently-scoped fetch, and callers that don't (the
+ * header) fetch their own and pass it in.
+ *
+ * `onSpawned` is for callers that hold their own cache of sessions (the
+ * sidebar's `onChanged`) — it fires right before landing in the new session,
+ * same timing the sidebar's inline version used.
+ */
+export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: () => void) {
+  const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
+  const selectSession = useAgentSurfaceStore((state) => state.selectSession);
+
+  const [spawnTarget, setSpawnTarget] = useState<{ driveId: string | null; driveName: string | null } | null>(null);
+  // Set once a target (agent/shell/assistant) is picked in the palette's first
+  // step — its presence is what swaps the dialog to the naming step. Null
+  // driveId + kind 'assistant' is the only shape `openAssistantSpawn` ever
+  // produces (it skips the picker entirely).
+  const [spawnPick, setSpawnPick] = useState<SpawnPick | null>(null);
+  const [spawning, setSpawning] = useState(false);
+
+  const spawn = useCallback(
+    async (input: { driveId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
+      if (spawning) return;
+      setSpawning(true);
+      try {
+        if (input.kind === 'shell') {
+          const created = await post<{ session: { sessionId: string }; shellId: string; shellName: string }>(
+            '/api/agent-sessions',
+            { driveId: input.driveId, firstThing: 'shell', name: input.name },
+          );
+          setSpawnTarget(null);
+          setSpawnPick(null);
+          onSpawned?.();
+          // useAgentSurfaceStore has no shell concept — land by selecting the
+          // session there, then placing the pane directly on the workspace
+          // store, mirroring AgentPanes.tsx's handleReattachShell. The shell
+          // is named independently server-side (spawnShell, no name passed) —
+          // use its own name, not the session label, so the pane title
+          // matches the shell row shown in the sidebar.
+          selectSession(created.session.sessionId);
+          useAgentWorkspaceStore.getState().openConversation(created.session.sessionId, {
+            kind: 'terminal',
+            name: created.shellName,
+            targetId: created.shellId,
+            agentPageId: null,
+          });
+          return;
+        }
+        const created = await post<{ session: { sessionId: string }; conversationId: string }>(
+          '/api/agent-sessions',
+          { driveId: input.driveId, agentPageId: input.agentPageId, name: input.name },
+        );
+        setSpawnTarget(null);
+        setSpawnPick(null);
+        onSpawned?.();
+        // Land the user IN the new session's first conversation — no empty
+        // state is ever visible.
+        selectConversation({
+          sessionId: created.session.sessionId,
+          conversationId: created.conversationId,
+          agentId: input.agentPageId,
+        });
+      } catch (error) {
+        console.error('Failed to start a session:', error);
+        toast.error('Could not start a session', {
+          description: error instanceof Error ? error.message : 'Please try again.',
+        });
+      } finally {
+        setSpawning(false);
+      }
+    },
+    [spawning, onSpawned, selectConversation, selectSession],
+  );
+
+  // A drive group's "+" opens the picker first so the naming step's
+  // placeholder can reflect whichever agent/shell was chosen.
+  const openSpawn = useCallback((driveId: string, driveName: string | null) => {
+    setSpawnTarget({ driveId, driveName });
+    setSpawnPick(null);
+  }, []);
+
+  // The Assistant group has nothing to pick (the assistant IS the
+  // counterpart), so this skips straight to naming.
+  const openAssistantSpawn = useCallback(() => {
+    setSpawnTarget({ driveId: null, driveName: null });
+    setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' });
+  }, []);
+
+  const handleSubmitName = useCallback(
+    (name: string) => {
+      if (!spawnTarget || !spawnPick) return;
+      void spawn({ driveId: spawnTarget.driveId, agentPageId: spawnPick.agentPageId, kind: spawnPick.kind, name });
+    },
+    [spawn, spawnTarget, spawnPick],
+  );
+
+  const paletteAgents = useMemo(
+    () => (spawnTarget ? (agentsByDrive.find((entry) => entry.driveId === spawnTarget.driveId)?.agents ?? []) : []),
+    [agentsByDrive, spawnTarget],
+  );
+
+  const paletteElement = (
+    <SpawnSessionPalette
+      open={spawnTarget !== null}
+      driveName={spawnTarget?.driveName ?? null}
+      agents={paletteAgents}
+      pick={spawnPick}
+      spawning={spawning}
+      onOpenChange={(open) => {
+        if (open) return;
+        setSpawnTarget(null);
+        setSpawnPick(null);
+      }}
+      onPickTarget={setSpawnPick}
+      onSubmitName={handleSubmitName}
+    />
+  );
+
+  return { openSpawn, openAssistantSpawn, spawning, paletteElement };
+}
+
+/**
+ * The spawn palette for a new session, Raycast-style: search or arrow-key to
+ * a target and hit Enter — the same keyboard-first pattern `QuickCreatePalette`
+ * established for page creation, reused here so a future mouseless-navigation
+ * pass has one command-palette idiom to build on, not two. Two steps: pick a
+ * target (an agent, Shell, or Global Assistant — `openAssistantSpawn` skips
+ * straight here since it has nothing else to choose), then name the session.
+ * Naming is always the last step, even for a one-click assistant spawn, so
+ * every session gets a deliberate name.
+ */
+function SpawnSessionPalette({
+  open,
+  driveName,
+  agents,
+  pick,
+  spawning,
+  onOpenChange,
+  onPickTarget,
+  onSubmitName,
+}: {
+  open: boolean;
+  driveName: string | null;
+  agents: DriveWithAgents['agents'];
+  pick: SpawnPick | null;
+  spawning: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPickTarget: (pick: SpawnPick) => void;
+  onSubmitName: (name: string) => void;
+}) {
+  const [name, setName] = useState('');
+
+  // Blank by default every time a new naming step starts — a stale typed
+  // value from resolving one spawn must never prefill the next.
+  useEffect(() => {
+    if (open) setName('');
+  }, [open, pick]);
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={pick ? 'Name your session' : 'New session'}
+      description={
+        pick
+          ? `Leave blank to use "${pick.label}"`
+          : driveName
+            ? `Choose an agent to start a session with in ${driveName}`
+            : 'Choose an agent to start a session with'
+      }
+      showCloseButton={false}
+      className="max-w-[420px]"
+    >
+      {pick ? (
+        <form
+          className="p-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmitName(name);
+          }}
+        >
+          <input
+            autoFocus
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter') return;
+              event.preventDefault();
+              onSubmitName(name);
+            }}
+            placeholder={pick.label}
+            disabled={spawning}
+            className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </form>
+      ) : (
+        <>
+          <CommandInput placeholder="Search agents…" autoFocus />
+          <CommandList>
+            <CommandGroup>
+              <CommandItem
+                value="assistant-Global Assistant"
+                disabled={spawning}
+                onSelect={() => onPickTarget({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' })}
+              >
+                <Bot className="size-3.5" aria-hidden="true" />
+                <span className="truncate">Global Assistant</span>
+              </CommandItem>
+              {agents.map((agent) => (
+                <CommandItem
+                  key={agent.id}
+                  value={`${agent.id}-${agent.title ?? 'Agent'}`}
+                  disabled={spawning}
+                  onSelect={() => onPickTarget({ kind: 'agent', agentPageId: agent.id, label: agent.title ?? 'Agent' })}
+                >
+                  <Bot className="size-3.5" aria-hidden="true" />
+                  <span className="truncate">{agent.title ?? 'Agent'}</span>
+                </CommandItem>
+              ))}
+              <CommandItem
+                value="shell-Shell"
+                disabled={spawning}
+                onSelect={() => onPickTarget({ kind: 'shell', agentPageId: null, label: 'Shell' })}
+              >
+                <SquareTerminal className="size-3.5" aria-hidden="true" />
+                <span className="truncate">Shell</span>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </>
+      )}
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -217,6 +217,7 @@ function SpawnSessionPalette({
         >
           <input
             autoFocus
+            aria-label="Session name"
             value={name}
             onChange={(event) => setName(event.target.value)}
             onKeyDown={(event) => {

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,19 +2,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Bot, ChevronDown, ChevronRight, Folder, History, Loader2, Plus, Search, SquareTerminal, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Folder, History, Loader2, Plus, Search, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { useSWRConfig } from 'swr';
 
 import EndSessionDialog from '@/components/agents/EndSessionDialog';
+import { useSpawnSession } from '@/components/agents/useSpawnSession';
 import { Input } from '@/components/ui/input';
-import {
-  CommandDialog,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
 import { cn, isElectron } from '@/lib/utils';
 import type { SidebarProps } from './index';
 import DriveSwitcher from '@/components/layout/navbar/DriveSwitcher';
@@ -333,97 +327,23 @@ function SessionList({
     [groups, hasSearch],
   );
 
-  const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
-  const selectSession = useAgentSurfaceStore((state) => state.selectSession);
-  const [spawnTarget, setSpawnTarget] = useState<{ driveId: string | null; driveName: string | null } | null>(null);
-  // Set once a target (agent/shell/assistant) is picked in the palette's first
-  // step — its presence is what swaps the dialog to the naming step. Null
-  // driveId + kind 'assistant' is the only shape the Assistant group's "+"
-  // ever produces (it skips the picker entirely, see handleNewSession).
-  const [spawnPick, setSpawnPick] = useState<SpawnPick | null>(null);
-  const [spawning, setSpawning] = useState(false);
   const [createDriveOpen, setCreateDriveOpen] = useState(false);
-
-  const spawn = useCallback(
-    async (input: { driveId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
-      if (spawning) return;
-      setSpawning(true);
-      try {
-        if (input.kind === 'shell') {
-          const created = await post<{ session: { sessionId: string }; shellId: string; shellName: string }>(
-            '/api/agent-sessions',
-            { driveId: input.driveId, firstThing: 'shell', name: input.name },
-          );
-          setSpawnTarget(null);
-          setSpawnPick(null);
-          onChanged();
-          // useAgentSurfaceStore has no shell concept — land by selecting the
-          // session there, then placing the pane directly on the workspace
-          // store, mirroring AgentPanes.tsx's handleReattachShell. The shell
-          // is named independently server-side (spawnShell, no name passed) —
-          // use its own name, not the session label, so the pane title
-          // matches the shell row shown in the sidebar.
-          selectSession(created.session.sessionId);
-          useAgentWorkspaceStore.getState().openConversation(created.session.sessionId, {
-            kind: 'terminal',
-            name: created.shellName,
-            targetId: created.shellId,
-            agentPageId: null,
-          });
-          return;
-        }
-        const created = await post<{ session: { sessionId: string }; conversationId: string }>(
-          '/api/agent-sessions',
-          { driveId: input.driveId, agentPageId: input.agentPageId, name: input.name },
-        );
-        setSpawnTarget(null);
-        setSpawnPick(null);
-        onChanged();
-        // Land the user IN the new session's first conversation — no empty
-        // state is ever visible.
-        selectConversation({
-          sessionId: created.session.sessionId,
-          conversationId: created.conversationId,
-          agentId: input.agentPageId,
-        });
-      } catch (error) {
-        console.error('Failed to start a session:', error);
-        toast.error('Could not start a session', {
-          description: error instanceof Error ? error.message : 'Please try again.',
-        });
-      } finally {
-        setSpawning(false);
-      }
-    },
-    [spawning, onChanged, selectConversation, selectSession],
-  );
+  const { openSpawn, openAssistantSpawn, paletteElement } = useSpawnSession(agentsByDrive, onChanged);
 
   // Sessions are always deliberately named now — both groups open the same
   // naming step. The ASSISTANT group has nothing to pick (the assistant IS
   // the counterpart), so it skips straight to naming; a DRIVE group's "+"
   // opens the picker first so the naming step's placeholder can reflect
   // whichever agent/shell was chosen.
-  const handleNewSession = useCallback((groupDriveId: string, groupDriveName: string | null) => {
-    if (groupDriveId === ASSISTANT_GROUP_KEY) {
-      setSpawnTarget({ driveId: null, driveName: null });
-      setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' });
-      return;
-    }
-    setSpawnTarget({ driveId: groupDriveId, driveName: groupDriveName });
-    setSpawnPick(null);
-  }, []);
-
-  const handleSubmitName = useCallback(
-    (name: string) => {
-      if (!spawnTarget || !spawnPick) return;
-      void spawn({ driveId: spawnTarget.driveId, agentPageId: spawnPick.agentPageId, kind: spawnPick.kind, name });
+  const handleNewSession = useCallback(
+    (groupDriveId: string, groupDriveName: string | null) => {
+      if (groupDriveId === ASSISTANT_GROUP_KEY) {
+        openAssistantSpawn();
+        return;
+      }
+      openSpawn(groupDriveId, groupDriveName);
     },
-    [spawn, spawnTarget, spawnPick],
-  );
-
-  const paletteAgents = useMemo(
-    () => (spawnTarget ? (agentsByDrive.find((entry) => entry.driveId === spawnTarget.driveId)?.agents ?? []) : []),
-    [agentsByDrive, spawnTarget],
+    [openSpawn, openAssistantSpawn],
   );
 
   return (
@@ -460,20 +380,7 @@ function SessionList({
         </div>
       ))}
       {notice}
-      <SpawnSessionPalette
-        open={spawnTarget !== null}
-        driveName={spawnTarget?.driveName ?? null}
-        agents={paletteAgents}
-        pick={spawnPick}
-        spawning={spawning}
-        onOpenChange={(open) => {
-          if (open) return;
-          setSpawnTarget(null);
-          setSpawnPick(null);
-        }}
-        onPickTarget={setSpawnPick}
-        onSubmitName={handleSubmitName}
-      />
+      {paletteElement}
       {!driveId && <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />}
     </div>
   );
@@ -924,129 +831,5 @@ function SessionRow({
         </div>
       )}
     </div>
-  );
-}
-
-type SpawnKind = 'agent' | 'shell' | 'assistant';
-
-/** What the palette's first step picked — drives the naming step's placeholder and spawn() call. */
-interface SpawnPick {
-  kind: SpawnKind;
-  agentPageId: string | null;
-  /** The sensible default: the agent's title, "Shell", or "Global Assistant". */
-  label: string;
-}
-
-/**
- * The spawn palette for a new session, Raycast-style: search or arrow-key to
- * a target and hit Enter — the same keyboard-first pattern `QuickCreatePalette`
- * established for page creation, reused here so a future mouseless-navigation
- * pass has one command-palette idiom to build on, not two. Two steps: pick a
- * target (an agent, Shell, or Global Assistant — the ASSISTANT group's own
- * "+" skips straight here since it has nothing else to choose), then name the
- * session. Naming is always the last step, even for a one-click assistant
- * spawn, so every session gets a deliberate name.
- */
-function SpawnSessionPalette({
-  open,
-  driveName,
-  agents,
-  pick,
-  spawning,
-  onOpenChange,
-  onPickTarget,
-  onSubmitName,
-}: {
-  open: boolean;
-  driveName: string | null;
-  agents: DriveWithAgents['agents'];
-  pick: SpawnPick | null;
-  spawning: boolean;
-  onOpenChange: (open: boolean) => void;
-  onPickTarget: (pick: SpawnPick) => void;
-  onSubmitName: (name: string) => void;
-}) {
-  const [name, setName] = useState('');
-
-  // Blank by default every time a new naming step starts — a stale typed
-  // value from resolving one spawn must never prefill the next.
-  useEffect(() => {
-    if (open) setName('');
-  }, [open, pick]);
-
-  return (
-    <CommandDialog
-      open={open}
-      onOpenChange={onOpenChange}
-      title={pick ? 'Name your session' : 'New session'}
-      description={
-        pick
-          ? `Leave blank to use "${pick.label}"`
-          : driveName
-            ? `Choose an agent to start a session with in ${driveName}`
-            : 'Choose an agent to start a session with'
-      }
-      showCloseButton={false}
-      className="max-w-[420px]"
-    >
-      {pick ? (
-        <form
-          className="p-3"
-          onSubmit={(event) => {
-            event.preventDefault();
-            onSubmitName(name);
-          }}
-        >
-          <input
-            autoFocus
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== 'Enter') return;
-              event.preventDefault();
-              onSubmitName(name);
-            }}
-            placeholder={pick.label}
-            disabled={spawning}
-            className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-          />
-        </form>
-      ) : (
-        <>
-          <CommandInput placeholder="Search agents…" autoFocus />
-          <CommandList>
-            <CommandGroup>
-              <CommandItem
-                value="assistant-Global Assistant"
-                disabled={spawning}
-                onSelect={() => onPickTarget({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' })}
-              >
-                <Bot className="size-3.5" aria-hidden="true" />
-                <span className="truncate">Global Assistant</span>
-              </CommandItem>
-              {agents.map((agent) => (
-                <CommandItem
-                  key={agent.id}
-                  value={`${agent.id}-${agent.title ?? 'Agent'}`}
-                  disabled={spawning}
-                  onSelect={() => onPickTarget({ kind: 'agent', agentPageId: agent.id, label: agent.title ?? 'Agent' })}
-                >
-                  <Bot className="size-3.5" aria-hidden="true" />
-                  <span className="truncate">{agent.title ?? 'Agent'}</span>
-                </CommandItem>
-              ))}
-              <CommandItem
-                value="shell-Shell"
-                disabled={spawning}
-                onSelect={() => onPickTarget({ kind: 'shell', agentPageId: null, label: 'Shell' })}
-              >
-                <SquareTerminal className="size-3.5" aria-hidden="true" />
-                <span className="truncate">Shell</span>
-              </CommandItem>
-            </CommandGroup>
-          </CommandList>
-        </>
-      )}
-    </CommandDialog>
   );
 }

--- a/tasks/reviews/pu-header-for-agents-page.md
+++ b/tasks/reviews/pu-header-for-agents-page.md
@@ -12,6 +12,22 @@ recorded here per the review skill's fallback.
 - [x] MAJOR · `AgentsListHeader.tsx` · "New Agent" on the global (driveless) page called `router.push()` then `openQuickCreate(null)` in the same synchronous tick. `QuickCreatePalette` resolves its own `driveId` from `useParams()`, which only updates once the client-side navigation actually lands — a fast user (or slow route transition) could hit "Create" while `driveId` was still `undefined`, silently no-opping with no error shown. · What correct looks like: wait for the component's own `driveId` prop (sourced from the same route) to match the picked drive before opening Quick Create. — fixed in b2f69cee6
 - [x] MINOR · `apps/web/src/components/agents/` · The three new files (`AgentsListHeader.tsx`, `DrivePickerDialog.tsx`, `useSpawnSession.tsx`) shipped with zero dedicated tests, in a codebase with strong existing coverage for this exact console (`AgentsSidebar.test.tsx` alone has 57 tests). · What correct looks like: a test file covering the header's own branching (admin gate, drive-scoped vs global CTA behavior, drive-picker flow). — fixed in b2f69cee6 (`AgentsListHeader.test.tsx`, 7 tests)
 
+## Round 2: CodeRabbit + chatgpt-codex-connector (automated PR reviewers)
+
+8 review threads landed on the first pushed commit. 2 (from `chatgpt-codex-connector`)
+duplicated the two findings above (already fixed at that point) — replied confirming
+the fix, left open per the "don't auto-resolve what you fixed during the loop" rule.
+The other 6 (all CodeRabbit) were genuinely new:
+
+- [x] MINOR · `AgentsListHeader.tsx` · `useSpawnSession(agentsByDrive)` was called with no `onSpawned` — a session spawned from the header never revalidated the sidebar's `/api/agent-sessions` SWR key, so it only appeared there after the 20s poll. · Fixed in 221dbe1c3: passes an `onSpawned` that broad-matches and revalidates every `/api/agent-sessions*` key.
+- [x] MINOR · `DrivePickerDialog.tsx` · `CommandItem`'s `value={drive.name}` — two drives sharing a name collide in cmdk's filtering/selection. · Fixed in 221dbe1c3: `value={`${drive.id}-${drive.name}`}`, matching the id-based uniqueness pattern already used in `useSpawnSession`'s own agent/shell items.
+- [x] MINOR · `DrivePickerDialog.tsx` · `CommandEmpty`'s "No drives yet." text is wrong when the user has drives but a search just matches none. · Fixed in 221dbe1c3: "No drives found."
+- [x] MINOR · `useSpawnSession.tsx` · the naming-step `<input>` had no accessible name (placeholder-only). · Fixed in 221dbe1c3: `aria-label="Session name"`.
+- (2 threads already resolved by `coderabbitai[bot]` itself after detecting round-1 fixes — not resolved by this review.)
+
+All 8 threads now have a concrete reply from this branch; 6 are resolved (by
+CodeRabbit, not by us), 2 remain open by design for reviewer verification.
+
 ## Not flagged (considered and dismissed)
 
 - OWASP Top 10: not applicable — no new API routes, no new data storage, no new auth/crypto logic; every mutating action (`POST /api/drives`, `POST /api/agent-sessions`, `POST /api/pages`) already existed and is reused via its existing client caller.
@@ -20,4 +36,6 @@ recorded here per the review skill's fallback.
 
 ## Verdict
 
-0 blockers / 0 majors / 0 minors open ; 3 fixed (of 3 found)
+0 blockers / 0 majors / 0 minors open ; 7 fixed (of 7 found across both rounds).
+CI green (Lint & TypeScript Check, Unit Tests, CodeRabbit), 0 merge conflicts,
+mergeStateStatus CLEAN.

--- a/tasks/reviews/pu-header-for-agents-page.md
+++ b/tasks/reviews/pu-header-for-agents-page.md
@@ -1,0 +1,23 @@
+# Review: pu/header-for-agents-page (PR #2300)
+
+Self-review of `AgentsListHeader`, `useSpawnSession`, `DrivePickerDialog` (new)
+and `AgentsSurface.tsx`/`AgentsSidebar.tsx` (modified). No PageSpace board is
+connected to this repo's own task tracking (the global `pagespace` credential
+present in this environment belongs to an unrelated project), so findings are
+recorded here per the review skill's fallback.
+
+## Findings
+
+- [x] BLOCKER · `AgentsListHeader.tsx` · "New Session" rendered unconditionally for every user, but session spawning is admin-only everywhere else in the console (`AgentsSidebar`'s `canSpawn = isAdmin && !authLoading` hides its entire spawn UI; `GET /api/agent-sessions` 403s non-admins). A non-admin viewing the Agents page would see and could click a button the rest of the app deliberately hides from them. · What correct looks like: gate the button behind the same `isAdmin` check the sidebar uses. — fixed in b2f69cee6
+- [x] MAJOR · `AgentsListHeader.tsx` · "New Agent" on the global (driveless) page called `router.push()` then `openQuickCreate(null)` in the same synchronous tick. `QuickCreatePalette` resolves its own `driveId` from `useParams()`, which only updates once the client-side navigation actually lands — a fast user (or slow route transition) could hit "Create" while `driveId` was still `undefined`, silently no-opping with no error shown. · What correct looks like: wait for the component's own `driveId` prop (sourced from the same route) to match the picked drive before opening Quick Create. — fixed in b2f69cee6
+- [x] MINOR · `apps/web/src/components/agents/` · The three new files (`AgentsListHeader.tsx`, `DrivePickerDialog.tsx`, `useSpawnSession.tsx`) shipped with zero dedicated tests, in a codebase with strong existing coverage for this exact console (`AgentsSidebar.test.tsx` alone has 57 tests). · What correct looks like: a test file covering the header's own branching (admin gate, drive-scoped vs global CTA behavior, drive-picker flow). — fixed in b2f69cee6 (`AgentsListHeader.test.tsx`, 7 tests)
+
+## Not flagged (considered and dismissed)
+
+- OWASP Top 10: not applicable — no new API routes, no new data storage, no new auth/crypto logic; every mutating action (`POST /api/drives`, `POST /api/agent-sessions`, `POST /api/pages`) already existed and is reused via its existing client caller.
+- `useSpawnSession` returning a JSX element from a hook (`paletteElement`) is an unconventional but established, intentional pattern here (headless-dialog-via-hook), matching the minimal-diff extraction goal; not worth a bigger refactor for this PR's scope.
+- No loading-state guard on `DrivePickerDialog`'s drive list — matches the existing codebase convention (`AgentsPastConversationsList.tsx` reads `useDriveStore().drives` the same unguarded way); not a regression introduced by this PR.
+
+## Verdict
+
+0 blockers / 0 majors / 0 minors open ; 3 fixed (of 3 found)


### PR DESCRIPTION
## Summary
- Adds a header (`AgentsListHeader`) above the Agents console's past-conversations list, which previously started with no title or actions directly below the tab bar.
- Three CTAs: **New Drive** (reuses `CreateDriveDialog`), **New Session**, **New Agent** (reuses the Quick Create palette).
- Extracts the sidebar's session-spawn flow (`spawn`, `SpawnSessionPalette`, related state) out of `AgentsSidebar.tsx` into a shared `useSpawnSession` hook so the new header and the sidebar don't duplicate that logic. `AgentsSidebar.tsx` now consumes the same hook with no behavior change.
- On the global (driveless) `/dashboard/agents` page, New Session/New Agent open a new `DrivePickerDialog` first, since neither creation path has a drive to act on without one.
- "New Session" is hidden for non-admins, matching `AgentsSidebar`'s own admin-only gate for spawning sandboxes.

## Review
Self-reviewed and addressed CodeRabbit + chatgpt-codex-connector feedback across two rounds (7 findings fixed — admin gating, a driveId navigation race, missing SWR revalidation on spawn, a cmdk duplicate-value bug, empty-state copy, and an accessibility gap). Full findings log: `tasks/reviews/pu-header-for-agents-page.md`.

## Test plan
- [x] `bun run --filter web typecheck` — clean
- [x] `bun run --filter web lint` — clean, no new warnings
- [x] `bun run --filter web test -- src/components/agents/__tests__/AgentsSurface.test.tsx src/components/agents/__tests__/AgentsListHeader.test.tsx src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx` — 89/89 passing
- [x] CI: Lint & TypeScript Check, Unit Tests, CodeRabbit — all green
- [ ] Manual click-through: drive-scoped Agents page header renders + all three CTAs work; global Agents page header renders + drive-picker flow works for New Session/New Agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkHfnA78K8SA5ffNGguhuC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agents console controls for creating drives, agents, and sessions.
  * Added searchable drive selection for launching sessions and creating agents.
  * Added support for starting agent, shell, and assistant sessions.
  * Added session naming and direct navigation to newly created conversations or workspaces.
* **Improvements**
  * Centralized session creation across the Agents console and sidebar.
  * Added loading safeguards, refresh handling, and error notifications during session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
