### PR TITLE
fix(agents): AI_CHAT page scroll + duplicate pane chrome

### DIFF
--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -506,7 +506,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
                 name: 'Conversation',
               }}
               chatContext="page"
-              hostAgentPageId={page.id}
+              hostConversationId={current.conversationId}
               isReadOnly={isReadOnly}
               onSessionEnded={() => void handleCreateNew()}
               onConversationClosed={handleConversationClosed}

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -506,6 +506,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
                 name: 'Conversation',
               }}
               chatContext="page"
+              hostAgentPageId={page.id}
               isReadOnly={isReadOnly}
               onSessionEnded={() => void handleCreateNew()}
               onConversationClosed={handleConversationClosed}

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -75,6 +75,7 @@ vi.mock('../panes/AgentPanes', () => ({
     driveId,
     initialConversation,
     chatContext,
+    hostAgentPageId,
     isReadOnly,
     onConversationClosed,
   }: {
@@ -82,6 +83,7 @@ vi.mock('../panes/AgentPanes', () => ({
     driveId: string | null;
     initialConversation: { conversationId: string };
     chatContext?: string;
+    hostAgentPageId?: string | null;
     isReadOnly?: boolean;
     onConversationClosed?: (event: { conversationId: string; next: string | null; nextAgentPageId: string | null }) => void;
   }) => {
@@ -93,6 +95,7 @@ vi.mock('../panes/AgentPanes', () => ({
       <div
         data-testid="agent-panes"
         data-chat-context={chatContext}
+        data-host-agent-page-id={hostAgentPageId ?? ''}
         data-readonly={String(!!isReadOnly)}
         data-drive-id={driveId ?? ''}
       >
@@ -250,6 +253,10 @@ describe('AgentPageView', () => {
 
     await waitFor(() => expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-1/conv-1'));
     expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-chat-context', 'page');
+    // The page's own id — lets the grid tell "the pane matching this page's
+    // own agent" (duplicate chrome, dropped) apart from any other pane
+    // (a split on a different agent, which keeps its own selector/tabs).
+    expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-host-agent-page-id', 'agent-1');
     // Defaults to the agent page's own drive while the session record is
     // unresolved — correct for the overwhelming common case.
     expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-drive-id', 'drive-1');

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -75,7 +75,7 @@ vi.mock('../panes/AgentPanes', () => ({
     driveId,
     initialConversation,
     chatContext,
-    hostAgentPageId,
+    hostConversationId,
     isReadOnly,
     onConversationClosed,
   }: {
@@ -83,7 +83,7 @@ vi.mock('../panes/AgentPanes', () => ({
     driveId: string | null;
     initialConversation: { conversationId: string };
     chatContext?: string;
-    hostAgentPageId?: string | null;
+    hostConversationId?: string | null;
     isReadOnly?: boolean;
     onConversationClosed?: (event: { conversationId: string; next: string | null; nextAgentPageId: string | null }) => void;
   }) => {
@@ -95,7 +95,7 @@ vi.mock('../panes/AgentPanes', () => ({
       <div
         data-testid="agent-panes"
         data-chat-context={chatContext}
-        data-host-agent-page-id={hostAgentPageId ?? ''}
+        data-host-conversation-id={hostConversationId ?? ''}
         data-readonly={String(!!isReadOnly)}
         data-drive-id={driveId ?? ''}
       >
@@ -253,10 +253,11 @@ describe('AgentPageView', () => {
 
     await waitFor(() => expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-1/conv-1'));
     expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-chat-context', 'page');
-    // The page's own id — lets the grid tell "the pane matching this page's
-    // own agent" (duplicate chrome, dropped) apart from any other pane
-    // (a split on a different agent, which keeps its own selector/tabs).
-    expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-host-agent-page-id', 'agent-1');
+    // The page's own current conversation — lets the grid tell "the pane
+    // showing exactly this conversation" (duplicate chrome, dropped) apart
+    // from any other pane (a split on a different conversation — even of the
+    // SAME agent — which keeps its own selector/tabs).
+    expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-host-conversation-id', 'conv-1');
     // Defaults to the agent page's own drive while the session record is
     // unresolved — correct for the overwhelming common case.
     expect(screen.getByTestId('agent-panes')).toHaveAttribute('data-drive-id', 'drive-1');

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -146,7 +146,7 @@ export function SessionChatView({
         </div>
       )}
 
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden flex flex-col">
         {showLoading ? (
           <div data-testid="session-chat-loading" className="flex h-full items-center justify-center">
             <Loader2 className="size-4 animate-spin text-muted-foreground" />

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -103,6 +103,13 @@ export interface AgentPanesProps {
    * the full renderer, the console with the compact one. Layout is identical.
    */
   chatContext?: 'page' | 'console';
+  /**
+   * The page hosting this grid, when it's an AI_CHAT page's own embedded grid — the pane
+   * bound to THIS agent is showing the same conversation the page's own header already
+   * identifies, so its pane bar drops the (duplicate) selector/tab-strip down to a plain
+   * label. Undefined for the console, which has no single hosting page.
+   */
+  hostAgentPageId?: string | null;
   /** Read-only viewers get history but no send/edit/delete/retry in any chat pane. */
   isReadOnly?: boolean;
 }
@@ -136,6 +143,7 @@ export default function AgentPanes({
   onSessionEnded,
   onConversationClosed,
   chatContext = 'console',
+  hostAgentPageId,
   isReadOnly = false,
 }: AgentPanesProps) {
   const workspace = useAgentWorkspaceStore((state) => state.workspaces[sessionId]);
@@ -1197,6 +1205,7 @@ export default function AgentPanes({
           driveId={driveId}
           sessionId={sessionId}
           chatContext={chatContext}
+          hostAgentPageId={hostAgentPageId}
           isReadOnly={isReadOnly}
           onSelectAgent={(nextAgentPageId) => handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)}
           onSelectPane={() => selectPane(sessionId, pane.id)}
@@ -1323,6 +1332,7 @@ function ChatPane({
   driveId,
   sessionId,
   chatContext,
+  hostAgentPageId,
   isReadOnly,
   onSelectAgent,
   onSelectPane,
@@ -1351,6 +1361,8 @@ function ChatPane({
   driveId: string | null;
   sessionId: string;
   chatContext?: 'page' | 'console';
+  /** The page hosting this grid — see `AgentPanesProps.hostAgentPageId`'s own doc. */
+  hostAgentPageId?: string | null;
   isReadOnly: boolean;
   onSelectAgent: (agentPageId: string | null) => void;
   onSelectPane: () => void;
@@ -1475,25 +1487,36 @@ function ChatPane({
       <PaneBar
         isActive={isActive}
         identity={
-          <div className="flex min-w-0 flex-1 items-center gap-0.5">
-            <AISelector
-              selectedAgent={scope.agentPageId === null ? null : agent}
-              onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
-              driveId={driveId ?? undefined}
-              agents={pickableAgents}
-              agentsLoading={agentsLoading}
-              disabled={disabledAgentSwitch}
-              className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
-            />
-            <PaneChatTabStrip
-              activeTab={activeTab}
-              onSelectTab={setActiveTab}
-              // The Assistant (agentPageId null) has no page, so no Settings —
-              // every other pane's agent does.
-              showSettings={scope.agentPageId !== null}
-              agentTitle={agent?.title ?? 'Agent'}
-            />
-          </div>
+          scope.agentPageId !== null && scope.agentPageId === hostAgentPageId ? (
+            // This pane is showing the SAME conversation the hosting AI_CHAT
+            // page's own header already identifies (Chat/History/Settings
+            // pills, agent name) — a second selector + tab-strip here would
+            // just be duplicate chrome for the identical thing. Drop to the
+            // same plain, non-interactive label the other pane kinds
+            // (terminal, page, picker) already use; split/close (below,
+            // unaffected) is still this pane bar's job.
+            <PaneSessionIdentity name={agent?.title ?? 'Agent'} />
+          ) : (
+            <div className="flex min-w-0 flex-1 items-center gap-0.5">
+              <AISelector
+                selectedAgent={scope.agentPageId === null ? null : agent}
+                onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
+                driveId={driveId ?? undefined}
+                agents={pickableAgents}
+                agentsLoading={agentsLoading}
+                disabled={disabledAgentSwitch}
+                className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
+              />
+              <PaneChatTabStrip
+                activeTab={activeTab}
+                onSelectTab={setActiveTab}
+                // The Assistant (agentPageId null) has no page, so no Settings —
+                // every other pane's agent does.
+                showSettings={scope.agentPageId !== null}
+                agentTitle={agent?.title ?? 'Agent'}
+              />
+            </div>
+          )
         }
         actions={
           <>

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -104,12 +104,17 @@ export interface AgentPanesProps {
    */
   chatContext?: 'page' | 'console';
   /**
-   * The page hosting this grid, when it's an AI_CHAT page's own embedded grid — the pane
-   * bound to THIS agent is showing the same conversation the page's own header already
-   * identifies, so its pane bar drops the (duplicate) selector/tab-strip down to a plain
-   * label. Undefined for the console, which has no single hosting page.
+   * The conversation the HOSTING AI_CHAT page's own header is currently showing, when
+   * this is that page's own embedded grid — the one pane bound to exactly this
+   * conversation is displaying the same thing the page's own selector/Chat/History/
+   * Settings chrome already identifies, so its pane bar drops to a plain label instead.
+   * Deliberately keyed by CONVERSATION, not agent: a split pane the user pointed at the
+   * same agent but a DIFFERENT conversation (via the picker) is still a distinct thing
+   * the page's own header isn't showing — it keeps its full selector/tab-strip, since
+   * that's its only in-grid way to be managed. Undefined for the console, which has no
+   * single hosting page.
    */
-  hostAgentPageId?: string | null;
+  hostConversationId?: string | null;
   /** Read-only viewers get history but no send/edit/delete/retry in any chat pane. */
   isReadOnly?: boolean;
 }
@@ -143,7 +148,7 @@ export default function AgentPanes({
   onSessionEnded,
   onConversationClosed,
   chatContext = 'console',
-  hostAgentPageId,
+  hostConversationId,
   isReadOnly = false,
 }: AgentPanesProps) {
   const workspace = useAgentWorkspaceStore((state) => state.workspaces[sessionId]);
@@ -1205,7 +1210,7 @@ export default function AgentPanes({
           driveId={driveId}
           sessionId={sessionId}
           chatContext={chatContext}
-          hostAgentPageId={hostAgentPageId}
+          hostConversationId={hostConversationId}
           isReadOnly={isReadOnly}
           onSelectAgent={(nextAgentPageId) => handleSwitchAgent(pane.id, pane.scope!.agentPageId, nextAgentPageId)}
           onSelectPane={() => selectPane(sessionId, pane.id)}
@@ -1332,7 +1337,7 @@ function ChatPane({
   driveId,
   sessionId,
   chatContext,
-  hostAgentPageId,
+  hostConversationId,
   isReadOnly,
   onSelectAgent,
   onSelectPane,
@@ -1361,8 +1366,8 @@ function ChatPane({
   driveId: string | null;
   sessionId: string;
   chatContext?: 'page' | 'console';
-  /** The page hosting this grid — see `AgentPanesProps.hostAgentPageId`'s own doc. */
-  hostAgentPageId?: string | null;
+  /** The hosting page's own current conversation — see `AgentPanesProps.hostConversationId`'s own doc. */
+  hostConversationId?: string | null;
   isReadOnly: boolean;
   onSelectAgent: (agentPageId: string | null) => void;
   onSelectPane: () => void;
@@ -1487,14 +1492,18 @@ function ChatPane({
       <PaneBar
         isActive={isActive}
         identity={
-          scope.agentPageId !== null && scope.agentPageId === hostAgentPageId ? (
+          conversationId !== null && conversationId === hostConversationId ? (
             // This pane is showing the SAME conversation the hosting AI_CHAT
             // page's own header already identifies (Chat/History/Settings
             // pills, agent name) — a second selector + tab-strip here would
-            // just be duplicate chrome for the identical thing. Drop to the
-            // same plain, non-interactive label the other pane kinds
-            // (terminal, page, picker) already use; split/close (below,
-            // unaffected) is still this pane bar's job.
+            // just be duplicate chrome for the identical thing. Matched by
+            // CONVERSATION, not agent: a split pane pointed at the same
+            // agent but a DIFFERENT conversation is still something the
+            // page's own header isn't showing, so it keeps its full
+            // selector/tab-strip below. Drop to the same plain,
+            // non-interactive label the other pane kinds (terminal, page,
+            // picker) already use; split/close (below, unaffected) is still
+            // this pane bar's job.
             <PaneSessionIdentity name={agent?.title ?? 'Agent'} />
           ) : (
             <div className="flex min-w-0 flex-1 items-center gap-0.5">

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1158,6 +1158,51 @@ describe('AgentPanes', () => {
       expect(await screen.findByRole('button', { name: /Researcher/ })).toBeInTheDocument();
     });
 
+    describe('hostConversationId — the hosting AI_CHAT page drops duplicate chrome for its own pane only', () => {
+      it('drops to a plain label (no selector, no tab strip) when this pane IS the host conversation, keeping split/close', async () => {
+        renderPanes({ hostConversationId: 'conv-1' });
+        await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+        expect(screen.queryByRole('button', { name: /Researcher/ })).not.toBeInTheDocument();
+        expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Split right')).toBeInTheDocument();
+        expect(screen.getByLabelText('Close pane')).toBeInTheDocument();
+      });
+
+      // Review finding: matching by AGENT instead of CONVERSATION would also
+      // collapse a split pane the user deliberately pointed at a SECOND,
+      // distinct conversation of the same agent — silently stripping its
+      // only in-grid way to be retargeted (AISelector) or to reach its own
+      // History/Settings (PaneChatTabStrip), even though the page's own
+      // header isn't showing that conversation. Matching by conversation id
+      // instead keeps that pane fully functional.
+      it('keeps its own selector + tab strip for a split pane on a DIFFERENT conversation of the SAME agent as the host', async () => {
+        renderPanes({ hostConversationId: 'conv-1' });
+        await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+        const firstPaneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+        act(() => useAgentWorkspaceStore.getState().splitRight('ses-1', firstPaneId));
+        const secondPaneId = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes)
+          .find((p) => p.id !== firstPaneId)!.id;
+        act(() =>
+          useAgentWorkspaceStore.getState().assignPane('ses-1', secondPaneId, {
+            kind: 'chat',
+            name: 'Other conversation',
+            targetId: 'conv-other',
+            agentPageId: 'agent-1',
+          }),
+        );
+
+        await waitFor(() => expect(screen.getAllByTestId('pane-chat')).toHaveLength(2));
+        // Exactly one match each — the FIRST (host) pane stays a plain label;
+        // only the SECOND (different conversation) pane still has these.
+        expect(screen.getByRole('button', { name: /Researcher/ })).toBeInTheDocument();
+        expect(screen.getByRole('tablist')).toBeInTheDocument();
+      });
+    });
+
     it("has a Settings tab for the pane's agent, which switches the pane body to the settings form", async () => {
       renderPanes();
       await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());


### PR DESCRIPTION
## Summary
- Fix `AI_CHAT` page conversations being stuck at the top / unable to scroll: `SessionChat`'s wrapper div for the `context: 'page'` branch was missing `flex flex-col`, so `ChatMessagesArea`'s `flex-1`/`min-h-0` sizing had no flex parent to size against and got clipped instead of scrolling.
- Fix duplicate chrome on a session-bound `AI_CHAT` page: the pane showing the exact conversation the page's own header already displays (Chat/History/Settings tabs) previously showed a second, full copy of that same chrome — an agent selector, Chat/History/Settings tab strip, and Save button — in its pane bar. That one pane now drops to a plain name label (split/close unaffected). Matched by **conversation id**, not agent id: a split pane pointed at a *different* conversation — even of the same agent — keeps its full selector/tabs, since that's its only in-grid way to be managed (caught in an independent self-review pass, see `c7c507fdc`).

## Test plan
- [x] `bun run --filter web typecheck`
- [x] `bun run knip:check` (within baseline)
- [x] `eslint` on all touched files (clean)
- [x] `bun run --filter web test -- SessionChat AgentPanes AgentPageView AgentsSurface` (149 tests passing, including new coverage for the host-pane-vs-split-pane distinction)
- [x] CI green on both commits (`ci / Unit Tests`, `ci / Lint & TypeScript Check`)
- [ ] Manual: open an `AI_CHAT` page as a non-admin/pre-session conversation and confirm it scrolls
- [ ] Manual: open an `AI_CHAT` page as an admin on a session-bound conversation, confirm scrolling and that the host pane shows only a plain label + split/close
- [ ] Manual: split that grid onto a *different* conversation (same or different agent) and confirm it keeps its full selector/tabs
- [ ] Manual: confirm the agents console/sidebar (`AgentsSurface`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFDr8672nxS2tVrTCLbdfN