### PR TITLE
fix(agents): wire ask_user answering into session/pane chat

### DIFF
--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -24,6 +24,7 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ChatInput } from '@/components/ai/chat/input';
 import { UndoAiChangesDialog } from '@/components/ai/shared/chat';
+import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 import { ChatMessagesArea } from '@/components/ai/shared/chat/ChatMessagesArea';
 import { Conversation, ConversationScrollButton } from '@/components/ai/ui/conversation';
@@ -128,6 +129,7 @@ export function SessionChatView({
     chat.isMessagesLoading && chat.messages.length === 0 && chat.remoteStreams.length === 0;
 
   return (
+    <AskUserAnswerProvider value={chat.askUserAnswering}>
     <div
       data-testid="session-chat"
       className="@container flex h-full min-w-0 min-h-0 flex-col bg-background"
@@ -225,5 +227,6 @@ export function SessionChatView({
         />
       )}
     </div>
+    </AskUserAnswerProvider>
   );
 }

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -129,7 +129,10 @@ export function SessionChatView({
     chat.isMessagesLoading && chat.messages.length === 0 && chat.remoteStreams.length === 0;
 
   return (
-    <AskUserAnswerProvider value={chat.askUserAnswering}>
+    // isReadOnly viewers get no answer plumbing at all — same as rendering
+    // outside a chat surface entirely — so AskUserQuestionCard's options and
+    // Submit stay disabled instead of letting a viewer attempt a 403'd resume.
+    <AskUserAnswerProvider value={isReadOnly ? null : chat.askUserAnswering}>
     <div
       data-testid="session-chat"
       className="@container flex h-full min-w-0 min-h-0 flex-col bg-background"

--- a/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
+++ b/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { AgentInfo } from '@/types/agent';
+import { useAskUserAnswerContext } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 
 const chatState = vi.hoisted(() => ({
   current: {} as Record<string, unknown>,
@@ -20,7 +21,10 @@ vi.mock('../useAgentSessionChat', () => ({
 }));
 
 vi.mock('@/components/ai/shared/chat/ChatMessagesArea', () => ({
-  ChatMessagesArea: () => <div data-testid="chat-messages-area" />,
+  ChatMessagesArea: () => {
+    const ctx = useAskUserAnswerContext();
+    return <div data-testid="chat-messages-area" data-ask-user-ctx={ctx ? 'present' : 'absent'} />;
+  },
 }));
 
 vi.mock('@/components/layout/right-sidebar/ai-assistant/SidebarChatTab', () => ({
@@ -167,6 +171,22 @@ describe('SessionChat', () => {
     const input = screen.getByTestId('chat-input') as HTMLInputElement;
     expect(input.disabled).toBe(true);
     expect(input.placeholder).toBe('View only');
+  });
+
+  it('provides ask_user answering context to the message renderer when not read-only', () => {
+    render(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />);
+    expect(screen.getByTestId('chat-messages-area')).toHaveAttribute('data-ask-user-ctx', 'present');
+  });
+
+  // The bug this covers (Codex P2, PR #2303): the provider ignored `isReadOnly`, so a
+  // viewer without edit permission could still submit ask_user answers — enabling
+  // options/Submit that would 403 (or actually resume a global-assistant pane) despite
+  // the surface showing "View only".
+  it('withholds ask_user answering context from the message renderer in read-only mode', () => {
+    render(
+      <SessionChat agent={agentFixture()} conversationId="conv-1" context="page" isReadOnly />,
+    );
+    expect(screen.getByTestId('chat-messages-area')).toHaveAttribute('data-ask-user-ctx', 'absent');
   });
 
   it('shows the error banner when an error cause is present', () => {

--- a/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
+++ b/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
@@ -98,6 +98,7 @@ function baseChatState(overrides: Record<string, unknown> = {}) {
     hasMoreOlder: false,
     errorCause: null,
     dismissError: vi.fn(),
+    askUserAnswering: { answerableToolCallIds: new Set<string>(), submitAnswers: vi.fn() },
     ...overrides,
   };
 }

--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -73,8 +73,19 @@ vi.mock('@/hooks/useAgentChannelMultiplayer', () => ({
   ),
 }));
 
+const activeStream = vi.hoisted(() => ({
+  remoteStreams: [] as Array<{
+    messageId: string;
+    pageId: string;
+    conversationId: string;
+    triggeredBy: { userId: string; displayName: string };
+    parts: unknown[];
+    isOwn: boolean;
+    startedAt?: string;
+  }>,
+}));
 vi.mock('@/hooks/useActiveStream', () => ({
-  useActiveStream: () => ({ streams: [] }),
+  useActiveStream: () => ({ streams: activeStream.remoteStreams }),
   useConversationActiveStream: () => undefined,
 }));
 
@@ -119,6 +130,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   chat.capturedConfigs.length = 0;
   multiplayer.calls.length = 0;
+  activeStream.remoteStreams = [];
   useConversationMessagesStore.setState({ byConversationId: {} });
   mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({}) });
 });
@@ -274,5 +286,39 @@ describe('useAgentSessionChat', () => {
     const [callArgs] = chat.instance.addToolResult.mock.calls[0] as [{ toolCallId: string; tool: string }];
     expect(callArgs.toolCallId).toBe('tc-1');
     expect(callArgs.tool).toBe('ask_user');
+  });
+
+  // Codex review, PR #2303 (P1): displayIsStreaming is own-stream-only (what Stop is
+  // scoped to). A REMOTE collaborator's stream leaves it false while renderedMessages
+  // filters their in-flight message out, so a stale ask_user prompt from before their
+  // run started would otherwise stay answerable — submitting it invokes addToolResult,
+  // whose server-side takeover aborts the collaborator's still-running generation.
+  it('given a remote collaborator is streaming in this conversation, does not mark a stale ask_user answerable', async () => {
+    const { agent, conversationId } = ids('ask-user-remote-stream');
+    const generation = conversationMessagesActions.startLoad(conversationId);
+    conversationMessagesActions.applyLoad(conversationId, generation, [
+      {
+        id: 'm-ask-1',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-ask_user', toolCallId: 'tc-1', state: 'input-available', input: { questions: [] } },
+        ],
+      } as unknown as UIMessage,
+    ]);
+    activeStream.remoteStreams = [
+      {
+        messageId: 'm-remote-1',
+        pageId: agent.id,
+        conversationId,
+        triggeredBy: { userId: 'other-user', displayName: 'Other User' },
+        parts: [],
+        isOwn: false,
+        startedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const { result } = renderHook(() => useAgentSessionChat({ agent, conversationId }));
+
+    expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(false);
   });
 });

--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -240,4 +240,39 @@ describe('useAgentSessionChat', () => {
       expect(loaders.loadOlderAgentConversationMessages).toHaveBeenCalledWith(agent.id, conversationId),
     );
   });
+
+  // The bug this covers: SessionChat (agent pages + every pane in AgentPanes) never wired
+  // useAnswerAskUser/AskUserAnswerProvider in, so an ask_user card rendered there was
+  // permanently non-interactive regardless of the tool part's own state.
+  it('given a pending ask_user on the last assistant message, marks it answerable and submitting it re-invokes the chat via addToolResult', async () => {
+    const { agent, conversationId } = ids('ask-user');
+    const generation = conversationMessagesActions.startLoad(conversationId);
+    conversationMessagesActions.applyLoad(conversationId, generation, [
+      {
+        id: 'm-ask-1',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-ask_user', toolCallId: 'tc-1', state: 'input-available', input: { questions: [] } },
+        ],
+      } as unknown as UIMessage,
+    ]);
+
+    const { result } = renderHook(() => useAgentSessionChat({ agent, conversationId }));
+
+    await waitFor(() =>
+      expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(true),
+    );
+
+    await act(async () => {
+      result.current.askUserAnswering.submitAnswers('tc-1', { answers: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(chat.instance.addToolResult).toHaveBeenCalledTimes(1));
+    const [callArgs] = chat.instance.addToolResult.mock.calls[0] as [{ toolCallId: string; tool: string }];
+    expect(callArgs.toolCallId).toBe('tc-1');
+    expect(callArgs.tool).toBe('ask_user');
+  });
 });

--- a/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
@@ -176,3 +176,40 @@ describe('useAssistantSessionChat — contextRef', () => {
     );
   });
 });
+
+describe('useAssistantSessionChat — ask_user answering', () => {
+  // The bug this covers: SessionChat (the global assistant in a session pane, agentPageId
+  // null) never wired useAnswerAskUser/AskUserAnswerProvider in, so an ask_user card there
+  // was permanently non-interactive regardless of the tool part's own state.
+  it('given a pending ask_user on the last assistant message, marks it answerable and submitting it re-invokes the chat via addToolResult', async () => {
+    const { conversationId } = ids('ask-user');
+    const generation = conversationMessagesActions.startLoad(conversationId);
+    conversationMessagesActions.applyLoad(conversationId, generation, [
+      {
+        id: 'm-ask-1',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-ask_user', toolCallId: 'tc-1', state: 'input-available', input: { questions: [] } },
+        ],
+      } as unknown as UIMessage,
+    ]);
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
+
+    await waitFor(() =>
+      expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(true),
+    );
+
+    await act(async () => {
+      result.current.askUserAnswering.submitAnswers('tc-1', { answers: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(chat.instance.addToolResult).toHaveBeenCalledTimes(1));
+    const [callArgs] = chat.instance.addToolResult.mock.calls[0] as [{ toolCallId: string; tool: string }];
+    expect(callArgs.toolCallId).toBe('tc-1');
+    expect(callArgs.tool).toBe('ask_user');
+  });
+});

--- a/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
@@ -55,8 +55,19 @@ const loaders = vi.hoisted(() => ({
 }));
 vi.mock('@/hooks/conversationMessagesLoaders', () => loaders);
 
+const activeStream = vi.hoisted(() => ({
+  remoteStreams: [] as Array<{
+    messageId: string;
+    pageId: string;
+    conversationId: string;
+    triggeredBy: { userId: string; displayName: string };
+    parts: unknown[];
+    isOwn: boolean;
+    startedAt?: string;
+  }>,
+}));
 vi.mock('@/hooks/useActiveStream', () => ({
-  useActiveStream: () => ({ streams: [] }),
+  useActiveStream: () => ({ streams: activeStream.remoteStreams }),
   useConversationActiveStream: () => undefined,
 }));
 
@@ -114,6 +125,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   chat.capturedConfigs.length = 0;
   route.pathname = '/dashboard/agents';
+  activeStream.remoteStreams = [];
   useConversationMessagesStore.setState({ byConversationId: {} });
   useDriveStore.setState({ drives: [driveFixture('drive-1', 'Engineering')] });
   mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({}) });
@@ -211,5 +223,39 @@ describe('useAssistantSessionChat — ask_user answering', () => {
     const [callArgs] = chat.instance.addToolResult.mock.calls[0] as [{ toolCallId: string; tool: string }];
     expect(callArgs.toolCallId).toBe('tc-1');
     expect(callArgs.tool).toBe('ask_user');
+  });
+
+  // Codex review, PR #2303 (P1): displayIsStreaming is own-stream-only (what Stop is
+  // scoped to). A REMOTE collaborator's stream leaves it false while renderedMessages
+  // filters their in-flight message out, so a stale ask_user prompt from before their
+  // run started would otherwise stay answerable — submitting it invokes addToolResult,
+  // whose server-side takeover aborts the collaborator's still-running generation.
+  it('given a remote collaborator is streaming in this conversation, does not mark a stale ask_user answerable', async () => {
+    const { conversationId } = ids('ask-user-remote-stream');
+    const generation = conversationMessagesActions.startLoad(conversationId);
+    conversationMessagesActions.applyLoad(conversationId, generation, [
+      {
+        id: 'm-ask-1',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-ask_user', toolCallId: 'tc-1', state: 'input-available', input: { questions: [] } },
+        ],
+      } as unknown as UIMessage,
+    ]);
+    activeStream.remoteStreams = [
+      {
+        messageId: 'm-remote-1',
+        pageId: 'global',
+        conversationId,
+        triggeredBy: { userId: 'other-user', displayName: 'Other User' },
+        parts: [],
+        isOwn: false,
+        startedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
+
+    expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(false);
   });
 });

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -207,10 +207,18 @@ export function useAgentSessionChat({
   // decided by whether the ask_user part sits on the conversation's LAST message, and
   // remote edits/deletes/messages update the store, not useChat's local array.
   // isConversationBusy replaces status==='ready' — see selectAnswerableAskUserToolCallIds.
+  //
+  // Deliberately NOT displayIsStreaming (own-stream-only, what Stop is scoped to): a
+  // REMOTE collaborator's stream leaves displayIsStreaming false while renderedMessages
+  // filters out their in-flight message, so the conversation's last SETTLED message can
+  // still be a stale ask_user prompt from before their run started. Submitting it would
+  // invoke addToolResult, whose server-side per-conversation takeover aborts their
+  // generation and resumes the stale prompt (Codex review, PR #2303).
+  const isConversationBusyForAskUser = displayIsStreaming || remoteStreams.some((s) => !s.isOwn);
   const askUserAnswering = useAnswerAskUser({
     conversationId,
     renderedMessages,
-    isConversationBusy: displayIsStreaming,
+    isConversationBusy: isConversationBusyForAskUser,
     setMessages,
     addToolResult,
     wrapSend,

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -34,9 +34,11 @@ import {
   useConversationSendHandoff,
   HANDOFF_REFUSED_MESSAGE,
   useChatErrorCause,
+  useAnswerAskUser,
   buildChatConfig,
   type AIErrorCause,
 } from '@/lib/ai/shared';
+import type { UseAnswerAskUserResult } from '@/lib/ai/shared/hooks/useAnswerAskUser';
 import { buildContextRef } from '@/lib/ai/shared/buildContextRef';
 import { buildSessionChatRequestBody } from '@/lib/agents/build-session-chat-request';
 import { buildUserMessage } from '@/lib/ai/streams/buildUserMessage';
@@ -87,6 +89,7 @@ export interface UseAgentSessionChatReturn {
   hasMoreOlder: boolean;
   errorCause: AIErrorCause | null;
   dismissError: () => void;
+  askUserAnswering: UseAnswerAskUserResult;
 }
 
 export function useAgentSessionChat({
@@ -114,7 +117,7 @@ export function useAgentSessionChat({
     });
   }, [transport, conversationId]);
 
-  const { sendMessage, status, error, clearError, regenerate, setMessages, stop } = useChat(
+  const { sendMessage, status, error, clearError, regenerate, setMessages, stop, addToolResult } = useChat(
     chatConfig ?? {},
   );
   const isStreaming = status === 'submitted' || status === 'streaming';
@@ -169,12 +172,57 @@ export function useAgentSessionChat({
   const imageGenEnabled = useAssistantSettingsStore((state) => state.imageGenEnabled);
   const writeMode = useAssistantSettingsStore((state) => state.writeMode);
 
+  // Shared by handleSend and the ask_user answer path (submitting an answer
+  // re-invokes the chat with the same per-request body a fresh send would use).
+  const buildBody = useCallback(
+    () =>
+      buildSessionChatRequestBody({
+        agentId: agent.id,
+        conversationId,
+        isReadOnly: !writeMode,
+        webSearchEnabled,
+        imageGenEnabled,
+        provider: agent.aiProvider,
+        model: agent.aiModel,
+        systemPrompt: agent.systemPrompt,
+        enabledTools: agent.enabledTools,
+        contextRef: buildContextRef(pathname, drives),
+      }),
+    [
+      agent.id,
+      agent.aiProvider,
+      agent.aiModel,
+      agent.systemPrompt,
+      agent.enabledTools,
+      conversationId,
+      writeMode,
+      webSearchEnabled,
+      imageGenEnabled,
+      pathname,
+      drives,
+    ],
+  );
+
+  // renderedMessages (selector output), not useChat's raw `messages`: "answerable" is
+  // decided by whether the ask_user part sits on the conversation's LAST message, and
+  // remote edits/deletes/messages update the store, not useChat's local array.
+  // isConversationBusy replaces status==='ready' — see selectAnswerableAskUserToolCallIds.
+  const askUserAnswering = useAnswerAskUser({
+    conversationId,
+    renderedMessages,
+    isConversationBusy: displayIsStreaming,
+    setMessages,
+    addToolResult,
+    wrapSend,
+    buildBody,
+    prepareSend,
+  });
+
   const handleSend = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed || !conversationId) return false;
 
-      const contextRef = buildContextRef(pathname, drives);
       if (!(await prepareSend(conversationId))) {
         toast.error(HANDOFF_REFUSED_MESSAGE);
         return false;
@@ -184,44 +232,13 @@ export function useAgentSessionChat({
       conversationMessagesActions.addOptimisticSend(conversationId, userMessage);
 
       rollbackOptimisticSendOnFailure(
-        () =>
-          wrapSend(() =>
-            sendMessage(userMessage, {
-              body: buildSessionChatRequestBody({
-                agentId: agent.id,
-                conversationId,
-                isReadOnly: !writeMode,
-                webSearchEnabled,
-                imageGenEnabled,
-                provider: agent.aiProvider,
-                model: agent.aiModel,
-                systemPrompt: agent.systemPrompt,
-                enabledTools: agent.enabledTools,
-                contextRef,
-              }),
-            }),
-          ),
+        () => wrapSend(() => sendMessage(userMessage, { body: buildBody() })),
         conversationId,
         userMessage.id,
       );
       return true;
     },
-    [
-      conversationId,
-      pathname,
-      drives,
-      prepareSend,
-      wrapSend,
-      sendMessage,
-      agent.id,
-      agent.aiProvider,
-      agent.aiModel,
-      agent.systemPrompt,
-      agent.enabledTools,
-      writeMode,
-      webSearchEnabled,
-      imageGenEnabled,
-    ],
+    [conversationId, prepareSend, wrapSend, sendMessage, buildBody],
   );
 
   const handleStop = useStopStream({
@@ -292,5 +309,6 @@ export function useAgentSessionChat({
     hasMoreOlder,
     errorCause,
     dismissError,
+    askUserAnswering,
   };
 }

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -38,6 +38,7 @@ import {
   useConversationSendHandoff,
   HANDOFF_REFUSED_MESSAGE,
   useChatErrorCause,
+  useAnswerAskUser,
   buildChatConfig,
   buildGlobalChatRequestBody,
 } from '@/lib/ai/shared';
@@ -110,7 +111,7 @@ export function useAssistantSessionChat({
     });
   }, [transport, conversationId]);
 
-  const { sendMessage, status, error, clearError, regenerate, setMessages, stop } = useChat(
+  const { sendMessage, status, error, clearError, regenerate, setMessages, stop, addToolResult } = useChat(
     chatConfig ?? {},
   );
   const isStreaming = status === 'submitted' || status === 'streaming';
@@ -165,12 +166,53 @@ export function useAssistantSessionChat({
   const currentProvider = useAssistantSettingsStore((state) => state.currentProvider);
   const currentModel = useAssistantSettingsStore((state) => state.currentModel);
 
+  // Shared by handleSend and the ask_user answer path (submitting an answer
+  // re-invokes the chat with the same per-request body a fresh send would use).
+  const buildBody = useCallback(() => {
+    const contextRef: ContextRef = driveId ? { routeType: 'drive', driveId } : buildContextRef(pathname, drives);
+    return buildGlobalChatRequestBody({
+      conversationId,
+      isReadOnly: !writeMode,
+      webSearchEnabled,
+      imageGenEnabled,
+      showPageTree,
+      contextRef,
+      selectedProvider: currentProvider,
+      selectedModel: currentModel,
+    });
+  }, [
+    conversationId,
+    driveId,
+    pathname,
+    drives,
+    writeMode,
+    webSearchEnabled,
+    imageGenEnabled,
+    showPageTree,
+    currentProvider,
+    currentModel,
+  ]);
+
+  // renderedMessages (selector output), not useChat's raw `messages`: "answerable" is
+  // decided by whether the ask_user part sits on the conversation's LAST message, and
+  // remote edits/deletes/messages update the store, not useChat's local array.
+  // isConversationBusy replaces status==='ready' — see selectAnswerableAskUserToolCallIds.
+  const askUserAnswering = useAnswerAskUser({
+    conversationId,
+    renderedMessages,
+    isConversationBusy: displayIsStreaming,
+    setMessages,
+    addToolResult,
+    wrapSend,
+    buildBody,
+    prepareSend,
+  });
+
   const handleSend = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed || !conversationId) return false;
 
-      const contextRef: ContextRef = driveId ? { routeType: 'drive', driveId } : buildContextRef(pathname, drives);
       if (!(await prepareSend(conversationId))) {
         toast.error(HANDOFF_REFUSED_MESSAGE);
         return false;
@@ -180,41 +222,13 @@ export function useAssistantSessionChat({
       conversationMessagesActions.addOptimisticSend(conversationId, userMessage);
 
       rollbackOptimisticSendOnFailure(
-        () =>
-          wrapSend(() =>
-            sendMessage(userMessage, {
-              body: buildGlobalChatRequestBody({
-                conversationId,
-                isReadOnly: !writeMode,
-                webSearchEnabled,
-                imageGenEnabled,
-                showPageTree,
-                contextRef,
-                selectedProvider: currentProvider,
-                selectedModel: currentModel,
-              }),
-            }),
-          ),
+        () => wrapSend(() => sendMessage(userMessage, { body: buildBody() })),
         conversationId,
         userMessage.id,
       );
       return true;
     },
-    [
-      conversationId,
-      driveId,
-      pathname,
-      drives,
-      prepareSend,
-      wrapSend,
-      sendMessage,
-      writeMode,
-      webSearchEnabled,
-      imageGenEnabled,
-      showPageTree,
-      currentProvider,
-      currentModel,
-    ],
+    [conversationId, prepareSend, wrapSend, sendMessage, buildBody],
   );
 
   const handleStop = useStopStream({
@@ -287,5 +301,6 @@ export function useAssistantSessionChat({
     hasMoreOlder,
     errorCause,
     dismissError,
+    askUserAnswering,
   };
 }

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -197,10 +197,18 @@ export function useAssistantSessionChat({
   // decided by whether the ask_user part sits on the conversation's LAST message, and
   // remote edits/deletes/messages update the store, not useChat's local array.
   // isConversationBusy replaces status==='ready' — see selectAnswerableAskUserToolCallIds.
+  //
+  // Deliberately NOT displayIsStreaming (own-stream-only, what Stop is scoped to): a
+  // REMOTE collaborator's stream leaves displayIsStreaming false while renderedMessages
+  // filters out their in-flight message, so the conversation's last SETTLED message can
+  // still be a stale ask_user prompt from before their run started. Submitting it would
+  // invoke addToolResult, whose server-side per-conversation takeover aborts their
+  // generation and resumes the stale prompt (Codex review, PR #2303).
+  const isConversationBusyForAskUser = displayIsStreaming || remoteStreams.some((s) => !s.isOwn);
   const askUserAnswering = useAnswerAskUser({
     conversationId,
     renderedMessages,
-    isConversationBusy: displayIsStreaming,
+    isConversationBusy: isConversationBusyForAskUser,
     setMessages,
     addToolResult,
     wrapSend,


### PR DESCRIPTION
## Summary
- Fixes `ask_user` questions being permanently non-interactive in agent-session panes (`AgentPanes`) and in `AgentPageView`'s session-less chat.
- Wires `useAnswerAskUser` + `AskUserAnswerProvider` into the shared `useAgentSessionChat`/`useAssistantSessionChat` → `SessionChatView` pipeline, matching how `GlobalAssistantView` and `SidebarChatTab` already do it.

## Root cause
`useAnswerAskUser`/`useAskUserAnsweringStore` (#2112) replaced the old `useAskUserAnswering` hook and fixed its answerability logic, but only got wired into two of the four chat surfaces: `GlobalAssistantView.tsx` and `SidebarChatTab.tsx`. The shared agent-session chat pipeline — `useAgentSessionChat`/`useAssistantSessionChat` → `SessionChatView`, rendered by `AgentPageView` directly and by every pane in `AgentPanes` (`PaneChat` → `SessionChat`/`AssistantSessionChat`) — never got the same wiring.

`AskUserAnswerContext` defaults to `null` when unwrapped (by design, so read-only/historical renderers stay non-interactive). With no provider, `useAskUserAnswerContext()` returned `null` inside `AskUserQuestionCard`, so `isAnswerable` was unconditionally `false` — every `ask_user` card in an agent session or pane rendered "Waiting for a response…" forever, regardless of the tool part's actual state.

## Changes
- `useAgentSessionChat.ts` / `useAssistantSessionChat.ts`: call `useAnswerAskUser` with the hook's own `renderedMessages`/`isConversationBusy` (`displayIsStreaming`)/`setMessages`/`addToolResult`/`wrapSend`/`prepareSend`, plus a new `buildBody()` callback extracted from `handleSend`'s inline body construction (now shared by the send path and the answer path — mirrors the `GlobalAssistantView`/`SidebarChatTab` pattern). Both hooks now expose `askUserAnswering` on `UseAgentSessionChatReturn`.
- `SessionChat.tsx`: wraps `SessionChatView`'s render in `<AskUserAnswerProvider value={chat.askUserAnswering}>` — covers both the `'page'` (`ChatMessagesArea`) and `'console'` (`SidebarMessagesContent`) renderers, since both dispatch `AskUserQuestionCard` for `tool-ask_user` parts.

## Context
Found while investigating #2238 ("unblock ask_user selections in developer/machine chats"), which turned out to be fully superseded by #2112's `useAskUserAnswering` → `useAnswerAskUser` rewrite (closed, see #2238's closing comment). While verifying that rewrite covered #2238's original bug, this wiring gap in the pane/session surfaces turned up — it's the actual live "ask_user broken in panes" bug on master today.

## Verification
- ✅ New tests: `useAgentSessionChat.test.ts` and `useAssistantSessionChat.test.ts` each got a case seeding a pending `ask_user` tool part on the last assistant message, asserting `askUserAnswering.answerableToolCallIds` includes it, and that `submitAnswers` drives a real `addToolResult` call with the right `toolCallId`/`tool`.
- ✅ `bun run --filter web test -- src/components/agents/` — 307/307 passing (22 files), including the new cases.
- ✅ `bunx eslint` on all touched files — clean.
- ✅ `bun run --filter web typecheck` — clean.
