### PR TITLE
fix(auth): timeout unguarded refresh fetches, add signin recovering failsafe

### DIFF
--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -390,4 +390,88 @@ describe('useSigninRecovery', () => {
       vi.useRealTimers();
     }
   });
+
+  it('control: the failsafe does not misfire mid-chain on a legitimately slow (not hung) full recovery', async () => {
+    // The failsafe budget must cover the FULL bearer-platform chain, not just hasDeviceToken +
+    // checkMeAuthenticated: check-me failing routes to a device-token refresh, whose own
+    // AuthFetch-side timeout (Keychain read + refresh POST) adds up to another ~11s on top.
+    // Each step here resolves just under its own guard's deadline — genuinely slow, never
+    // hung — so the failsafe (25s) must not fire before the chain's own ~21.7s completes.
+    vi.useFakeTimers();
+    try {
+      const delayedResolve = <T,>(value: T, ms: number) =>
+        new Promise<T>((resolve) => setTimeout(() => resolve(value), ms));
+
+      getStoredSession.mockImplementation(() => delayedResolve({ deviceToken: 'dt_valid' }, 2900));
+      fetchWithAuth.mockImplementation(() => delayedResolve({ ok: false } as Response, 7900));
+      refreshAuthSession.mockImplementation(() =>
+        delayedResolve({ success: true, shouldLogout: false }, 10900),
+      );
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      // Just before the chain's own ~21.7s completion: still legitimately in progress.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2900 + 7900 + 10800);
+      });
+      expect(replace).not.toHaveBeenCalled();
+      expect(result.current.recovering).toBe(true);
+
+      // The chain completes on its own, well before the 25s failsafe deadline.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      expect(replace).toHaveBeenCalledWith('/dashboard');
+      expect(result.current.recovering).toBe(true); // stays true through the nav
+
+      // Advancing the rest of the way to the failsafe deadline must not disturb that outcome.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RECOVERY_FAILSAFE_TIMEOUT_MS);
+      });
+      expect(replace).toHaveBeenCalledTimes(1);
+      expect(result.current.recovering).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a refresh that resolves AFTER the failsafe already gave up must not redirect out from under the form', async () => {
+    // Defense-in-depth for the platforms whose device-token refresh has no timeout of its own
+    // yet (web's refreshWebSession, desktop's attemptDesktopDeviceRefresh — both deferred
+    // follow-ups). If one of those truly hangs past the failsafe, the user sees the form; if
+    // the hung call THEN eventually resolves successfully, it must not yank them into a
+    // surprise navigation after they've already started looking at (or filling in) the form.
+    vi.useFakeTimers();
+    try {
+      mockMe(false);
+      getStoredSession.mockResolvedValue({ deviceToken: 'dt_valid' });
+
+      let resolveRefresh: ((result: { success: boolean; shouldLogout: boolean }) => void) | undefined;
+      refreshAuthSession.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RECOVERY_FAILSAFE_TIMEOUT_MS);
+      });
+      expect(result.current.recovering).toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+
+      // The stuck refresh finally settles, long after the failsafe already showed the form.
+      await act(async () => {
+        resolveRefresh?.({ success: true, shouldLogout: false });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(replace).not.toHaveBeenCalled();
+      expect(result.current.recovering).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StrictMode } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { useSigninRecovery, DEVICE_TOKEN_TIMEOUT_MS } from '../useSigninRecovery';
+import {
+  useSigninRecovery,
+  DEVICE_TOKEN_TIMEOUT_MS,
+  CHECK_ME_TIMEOUT_MS,
+  RECOVERY_FAILSAFE_TIMEOUT_MS,
+} from '../useSigninRecovery';
 
 // Shell-level coverage for the recovery effect. The DECISION branches live in
 // signin-recovery.test.ts; here we assert the effects are wired to the right actions AND to the
@@ -316,5 +321,73 @@ describe('useSigninRecovery', () => {
     // Under StrictMode the effect is set up, torn down, then set up again on mount. The
     // second run must complete rather than being stranded by a latched guard.
     await waitFor(() => expect(result.current.recovering).toBe(false));
+  });
+
+  // ── Round 2: raw fetch() calls in this chain had NO timeout at all ───────────────────────
+  it('never hangs if the check-me fetch never resolves (network stall regression)', async () => {
+    // Reproduces a true network stall (no rejection, no resolution — e.g. iOS cold-launch
+    // before the network stack is up). Mimics real fetch()'s AbortController contract: the
+    // request promise only settles when the signal fires.
+    vi.useFakeTimers();
+    try {
+      fetchWithAuth.mockImplementation(
+        (_url: string, options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              const err = new Error('The operation was aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }),
+      );
+      getStoredSession.mockResolvedValue(null); // no device token → terminal show-form
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      expect(result.current.recovering).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(CHECK_ME_TIMEOUT_MS);
+      });
+
+      expect(result.current.recovering).toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('control: a fast check-me success is unaffected by the new timeout', async () => {
+    mockMe(true);
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
+    expect(result.current.recovering).toBe(true); // still recovering through the nav
+  });
+
+  it('the failsafe timer flips recovering to false even if a hang bypasses every individual guard', async () => {
+    // hasDeviceToken and checkMeAuthenticated each carry their own timeout, but this proves
+    // the failsafe is a true backstop: fetchWithAuth here never settles and never observes the
+    // abort signal, simulating a hang neither of the two dedicated guards catches. Only the
+    // unconditional failsafe timer can save the page in that case.
+    vi.useFakeTimers();
+    try {
+      getStoredSession.mockReturnValue(new Promise(() => {}));
+      fetchWithAuth.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      expect(result.current.recovering).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RECOVERY_FAILSAFE_TIMEOUT_MS);
+      });
+
+      expect(result.current.recovering).toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -19,11 +19,16 @@ export const DEVICE_TOKEN_TIMEOUT_MS = 3000;
 // screen against a true network stall (no rejection, no resolution).
 export const CHECK_ME_TIMEOUT_MS = 8000;
 
-// Backstop for the whole recovery driver — longer than the worst-case chain (up to
-// DEVICE_TOKEN_TIMEOUT_MS Keychain read + up to CHECK_ME_TIMEOUT_MS check-me + margin), so it
-// never fires on a normal run. Guards against a hang anywhere in the chain we haven't found
-// (or guarded) yet, including outside the two fetches above.
-export const RECOVERY_FAILSAFE_TIMEOUT_MS = 12000;
+// Backstop for the whole recovery driver — longer than the worst-case BOUNDED chain, so it
+// never fires while a legitimate (merely slow, not hung) recovery is still in flight. On the
+// bearer platforms (iOS/Android) this is sequential: DEVICE_TOKEN_TIMEOUT_MS (hasDeviceToken)
+// + CHECK_ME_TIMEOUT_MS (checkMeAuthenticated) + refreshBearerSession's own two-stage bound
+// (its Keychain read, capped at AuthFetch's TOKEN_RETRIEVAL_TIMEOUT_MS, then its refresh POST,
+// capped at AuthFetch's REFRESH_FETCH_TIMEOUT_MS) = 3000 + 8000 + (3000 + 8000) = 22000, plus
+// margin. Guards against a hang anywhere in the chain we haven't found or bounded yet —
+// notably the web and desktop device-token refresh paths, which remain unbounded (deferred
+// follow-up) — without misfiring mid-chain on the platform this recovery flow exists for.
+export const RECOVERY_FAILSAFE_TIMEOUT_MS = 25000;
 
 /**
  * Whether a device token exists to recover an expired session from — read from PLATFORM storage
@@ -124,8 +129,17 @@ export function useSigninRecovery(
     // Unconditional backstop: whatever hangs anywhere in the chain below, the loading screen
     // cannot outlive this timer. Cleared on every terminal path (show-form, redirect, the
     // fail-open catch, and unmount) so it never fires after a normal completion.
+    //
+    // Also marks the run cancelled, same as unmount: an unbounded step still pending when the
+    // failsafe fires (e.g. the web/desktop device-token refresh paths, which have no timeout
+    // of their own yet) must not be allowed to act on the page later — without this, a refresh
+    // that eventually resolves `redirect` after the form is already showing would yank the
+    // user away from it with no warning.
     const failsafeTimer = setTimeout(() => {
-      if (!cancelled) setRecovering(false);
+      if (!cancelled) {
+        cancelled = true;
+        setRecovering(false);
+      }
     }, RECOVERY_FAILSAFE_TIMEOUT_MS);
 
     const run = async () => {

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -21,13 +21,15 @@ export const CHECK_ME_TIMEOUT_MS = 8000;
 
 // Backstop for the whole recovery driver — longer than the worst-case BOUNDED chain, so it
 // never fires while a legitimate (merely slow, not hung) recovery is still in flight. On the
-// bearer platforms (iOS/Android) this is sequential: DEVICE_TOKEN_TIMEOUT_MS (hasDeviceToken)
-// + CHECK_ME_TIMEOUT_MS (checkMeAuthenticated) + refreshBearerSession's own two-stage bound
-// (its Keychain read, capped at AuthFetch's TOKEN_RETRIEVAL_TIMEOUT_MS, then its refresh POST,
-// capped at AuthFetch's REFRESH_FETCH_TIMEOUT_MS) = 3000 + 8000 + (3000 + 8000) = 22000, plus
-// margin. Guards against a hang anywhere in the chain we haven't found or bounded yet —
-// notably the web and desktop device-token refresh paths, which remain unbounded (deferred
-// follow-up) — without misfiring mid-chain on the platform this recovery flow exists for.
+// bearer platforms (iOS/Android) this is sequential: hasDeviceToken, then checkMeAuthenticated,
+// then (if needed) refreshBearerSession's own two-stage timeout in AuthFetch (its Keychain
+// read, then its refresh POST) — roughly 22s at today's per-step timeouts (DEVICE_TOKEN_TIMEOUT_MS,
+// CHECK_ME_TIMEOUT_MS, and AuthFetch's TOKEN_RETRIEVAL_TIMEOUT_MS + REFRESH_FETCH_TIMEOUT_MS,
+// summed by hand here since the AuthFetch constants are private and this value can't reference
+// them directly — re-check this sum if any of those change). Guards against a hang anywhere in
+// the chain we haven't found or bounded yet — notably the web and desktop device-token refresh
+// paths, which remain unbounded (deferred follow-up) — without misfiring mid-chain on the
+// platform this recovery flow exists for.
 export const RECOVERY_FAILSAFE_TIMEOUT_MS = 25000;
 
 /**

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -14,6 +14,17 @@ const DEFAULT_NEXT = '/dashboard';
 // can assert against it directly instead of a hardcoded duplicate that could silently drift.
 export const DEVICE_TOKEN_TIMEOUT_MS = 3000;
 
+// Bounds checkMeAuthenticated's fetchWithAuth call — long enough to cover a legitimate
+// refresh-and-retry cycle happening inside that same call, short enough to bound the loading
+// screen against a true network stall (no rejection, no resolution).
+export const CHECK_ME_TIMEOUT_MS = 8000;
+
+// Backstop for the whole recovery driver — longer than the worst-case chain (up to
+// DEVICE_TOKEN_TIMEOUT_MS Keychain read + up to CHECK_ME_TIMEOUT_MS check-me + margin), so it
+// never fires on a normal run. Guards against a hang anywhere in the chain we haven't found
+// (or guarded) yet, including outside the two fetches above.
+export const RECOVERY_FAILSAFE_TIMEOUT_MS = 12000;
+
 /**
  * Whether a device token exists to recover an expired session from — read from PLATFORM storage
  * (D1): desktop reads safeStorage over IPC (window.electron.auth) via DesktopStorage, web reads
@@ -52,12 +63,21 @@ async function hasDeviceToken(): Promise<boolean> {
  * the form. A raw `fetch` would have skipped both.
  */
 async function checkMeAuthenticated(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), CHECK_ME_TIMEOUT_MS);
+
   try {
-    const response = await fetchWithAuth('/api/auth/me', { credentials: 'include' });
+    const response = await fetchWithAuth('/api/auth/me', {
+      credentials: 'include',
+      signal: controller.signal,
+    });
     return response.ok;
   } catch {
-    // Network error — treat as unauthenticated and fall through to the device-token path.
+    // Network error (including an abort on timeout) — treat as unauthenticated and fall
+    // through to the device-token path.
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -101,6 +121,13 @@ export function useSigninRecovery(
 
     let cancelled = false;
 
+    // Unconditional backstop: whatever hangs anywhere in the chain below, the loading screen
+    // cannot outlive this timer. Cleared on every terminal path (show-form, redirect, the
+    // fail-open catch, and unmount) so it never fires after a normal completion.
+    const failsafeTimer = setTimeout(() => {
+      if (!cancelled) setRecovering(false);
+    }, RECOVERY_FAILSAFE_TIMEOUT_MS);
+
     const run = async () => {
       const observed: SigninRecoveryInput = {
         // Read fresh from the store rather than subscribing: this effect runs once and must
@@ -121,11 +148,13 @@ export function useSigninRecovery(
 
         switch (action.type) {
           case 'show-form':
+            clearTimeout(failsafeTimer);
             if (!cancelled) setRecovering(false);
             return;
 
           case 'redirect':
             // Keep `recovering` true through the navigation so the form never flashes.
+            clearTimeout(failsafeTimer);
             router.replace(nextPath ?? DEFAULT_NEXT);
             return;
 
@@ -148,11 +177,13 @@ export function useSigninRecovery(
     // result today, but their types make no never-throw guarantee, and neither does a dynamic
     // import inside them.
     void run().catch(() => {
+      clearTimeout(failsafeTimer);
       if (!cancelled) setRecovering(false);
     });
 
     return () => {
       cancelled = true;
+      clearTimeout(failsafeTimer);
     };
     // Starts once, when `ready` flips true; `nextPath` is fully resolved by then and stable
     // thereafter (browserPath is set a single time), so it is intentionally not a dependency.

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
@@ -89,3 +89,84 @@ describe('refreshBearerSession: getStoredSession timeout', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
+
+// Round 2: the getStoredSession read above is timeout-guarded, but the refresh POST itself
+// (the actual network call this whole chain exists to make) had no timeout at all — a true
+// network stall here left the AuthFetch singleton's isRefreshing/refreshPromise permanently
+// set, wedging auth for the whole app session, not just this page load.
+describe('refreshBearerSession: refresh fetch timeout', () => {
+  let originalFetch: typeof global.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    getStoredSession.mockReset();
+    getStoredSession.mockResolvedValue({ deviceToken: 'dt_valid' });
+    // vi.restoreAllMocks() in the sibling describe's afterEach wipes this mock's
+    // mockResolvedValue (set only once, at module scope) along with everything else — reapply
+    // it here so this describe doesn't depend on run order relative to the other one.
+    getDeviceInfo.mockReset();
+    getDeviceInfo.mockResolvedValue({ deviceId: 'device-1', userAgent: 'ua', appVersion: '1.0.0' });
+
+    delete (globalThis as typeof globalThis & { [key: symbol]: unknown })[
+      Symbol.for('pagespace.authfetch.singleton')
+    ];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('never hangs if the refresh fetch never resolves, and does NOT force a logout', async () => {
+    vi.useFakeTimers();
+    try {
+      // Mirrors real fetch()'s AbortController contract: the request promise only settles
+      // once the passed signal actually fires.
+      mockFetch.mockImplementation(
+        (_url: string, options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              const err = new Error('The operation was aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }),
+      );
+
+      const { AuthFetch } = await import('../auth-fetch');
+      const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+      const resultPromise = authFetch.refreshBearerSession();
+
+      await vi.advanceTimersByTimeAsync(8000);
+
+      const result = await resultPromise;
+
+      // Transient network stall is retryable, not proof the device token is dead — must not
+      // force a logout of what may still be a perfectly valid session.
+      expect(result).toEqual({ success: false, shouldLogout: false });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('control: a fast successful refresh is unaffected by the new timeout', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ sessionToken: 'st_new', csrfToken: 'csrf_new', deviceToken: 'dt_new' }),
+    });
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshBearerSession();
+
+    expect(result).toEqual({ success: true, shouldLogout: false });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
@@ -32,6 +32,18 @@ type RefreshInternals = {
   refreshBearerSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
 };
 
+// Mirrors real fetch()'s AbortController contract: the returned promise only settles once the
+// passed signal actually fires, never on its own.
+function rejectOnAbort<T>(signal: AbortSignal | undefined): Promise<T> {
+  return new Promise((_resolve, reject) => {
+    signal?.addEventListener('abort', () => {
+      const err = new Error('The operation was aborted');
+      err.name = 'AbortError';
+      reject(err);
+    });
+  });
+}
+
 describe('refreshBearerSession: getStoredSession timeout', () => {
   let originalFetch: typeof global.fetch;
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -123,17 +135,8 @@ describe('refreshBearerSession: refresh fetch timeout', () => {
   it('never hangs if the refresh fetch never resolves, and does NOT force a logout', async () => {
     vi.useFakeTimers();
     try {
-      // Mirrors real fetch()'s AbortController contract: the request promise only settles
-      // once the passed signal actually fires.
-      mockFetch.mockImplementation(
-        (_url: string, options?: { signal?: AbortSignal }) =>
-          new Promise((_resolve, reject) => {
-            options?.signal?.addEventListener('abort', () => {
-              const err = new Error('The operation was aborted');
-              err.name = 'AbortError';
-              reject(err);
-            });
-          }),
+      mockFetch.mockImplementation((_url: string, options?: { signal?: AbortSignal }) =>
+        rejectOnAbort(options?.signal),
       );
 
       const { AuthFetch } = await import('../auth-fetch');
@@ -165,14 +168,7 @@ describe('refreshBearerSession: refresh fetch timeout', () => {
         Promise.resolve({
           ok: true,
           status: 200,
-          json: () =>
-            new Promise((_resolve, reject) => {
-              options?.signal?.addEventListener('abort', () => {
-                const err = new Error('The operation was aborted');
-                err.name = 'AbortError';
-                reject(err);
-              });
-            }),
+          json: () => rejectOnAbort(options?.signal),
         }),
       );
 

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-refresh-bearer-session-timeout.test.ts
@@ -154,6 +154,44 @@ describe('refreshBearerSession: refresh fetch timeout', () => {
     }
   });
 
+  it('never hangs if the response body stalls after ok headers arrive (P1: timeout must stay armed through response.json())', async () => {
+    // fetch() resolves as soon as headers arrive, before the body is fully read — a server
+    // that flushes headers then stalls mid-body would otherwise hang here with no timeout
+    // protection if the abort controller were cleared right after the fetch() await, since
+    // response.json() runs afterward, outside that guard.
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockImplementation((_url: string, options?: { signal?: AbortSignal }) =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              options?.signal?.addEventListener('abort', () => {
+                const err = new Error('The operation was aborted');
+                err.name = 'AbortError';
+                reject(err);
+              });
+            }),
+        }),
+      );
+
+      const { AuthFetch } = await import('../auth-fetch');
+      const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+      const resultPromise = authFetch.refreshBearerSession();
+
+      await vi.advanceTimersByTimeAsync(8000);
+
+      const result = await resultPromise;
+
+      expect(result).toEqual({ success: false, shouldLogout: false });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('control: a fast successful refresh is unaffected by the new timeout', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -625,10 +625,9 @@ class AuthFetch {
 
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), this.REFRESH_FETCH_TIMEOUT_MS);
-      let response: Response;
 
       try {
-        response = await fetch(endpoint, {
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -640,45 +639,49 @@ class AuthFetch {
           }),
           signal: controller.signal,
         });
+
+        // response.json() below reads the body over the same signal — the controller must stay
+        // armed (clearTimeout deferred to the outer finally) through this whole block, not just
+        // the fetch() call: a server that flushes headers then stalls mid-body would otherwise
+        // hang here with no timeout protection, the exact bug this change exists to prevent.
+        if (response.ok) {
+          const data = await response.json();
+          await storage.storeSession({
+            sessionToken: data.sessionToken,
+            csrfToken: data.csrfToken || null,
+            deviceId: info.deviceId,
+            deviceToken: data.deviceToken || session.deviceToken,
+          });
+          this.clearSessionCache();
+          storage.dispatchAuthEvent?.('auth:refreshed');
+          this.logger.info(`${storage.platform}: Session refreshed successfully`);
+          return { success: true, shouldLogout: false };
+        }
+
+        if (response.status === 401) {
+          await storage.clearSession();
+          this.logger.warn(`${storage.platform}: Device token invalid - logging out`);
+          return { success: false, shouldLogout: true };
+        }
+
+        if (response.status === 429 || response.status >= 500) {
+          this.logger.warn(`${storage.platform}: Refresh returned retryable status`, { status: response.status });
+          return { success: false, shouldLogout: false };
+        }
+
+        this.logger.error(`${storage.platform}: Refresh failed`, { status: response.status });
+        return { success: false, shouldLogout: false };
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
-          this.logger.warn(`${storage.platform}: Refresh fetch timed out after ${this.REFRESH_FETCH_TIMEOUT_MS}ms`);
+          this.logger.warn(`${storage.platform}: Refresh timed out after ${this.REFRESH_FETCH_TIMEOUT_MS}ms`);
           // Transient network stall, not proof the device token is dead — retryable, same as
-          // the 429/5xx branch below.
+          // the 429/5xx branch above.
           return { success: false, shouldLogout: false };
         }
         throw error;
       } finally {
         clearTimeout(timeout);
       }
-
-      if (response.ok) {
-        const data = await response.json();
-        await storage.storeSession({
-          sessionToken: data.sessionToken,
-          csrfToken: data.csrfToken || null,
-          deviceId: info.deviceId,
-          deviceToken: data.deviceToken || session.deviceToken,
-        });
-        this.clearSessionCache();
-        storage.dispatchAuthEvent?.('auth:refreshed');
-        this.logger.info(`${storage.platform}: Session refreshed successfully`);
-        return { success: true, shouldLogout: false };
-      }
-
-      if (response.status === 401) {
-        await storage.clearSession();
-        this.logger.warn(`${storage.platform}: Device token invalid - logging out`);
-        return { success: false, shouldLogout: true };
-      }
-
-      if (response.status === 429 || response.status >= 500) {
-        this.logger.warn(`${storage.platform}: Refresh returned retryable status`, { status: response.status });
-        return { success: false, shouldLogout: false };
-      }
-
-      this.logger.error(`${storage.platform}: Refresh failed`, { status: response.status });
-      return { success: false, shouldLogout: false };
     } catch (error) {
       this.logger.error(`${storage.platform}: Refresh error`, {
         error: error instanceof Error ? error.message : String(error),

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -63,6 +63,10 @@ class AuthFetch {
 
   // Timeout for bearer token retrieval (IPC/Keychain) to prevent hung requests on cold start
   private readonly TOKEN_RETRIEVAL_TIMEOUT_MS = 3000;
+  // Bounds the bearer-refresh POST below (refreshBearerSession) — a true network stall (e.g.
+  // iOS cold-launch before the network stack is up) must not hang this indefinitely, same
+  // hazard the Keychain reads in this class are already guarded against.
+  private readonly REFRESH_FETCH_TIMEOUT_MS = 8000;
 
   // Platform storage abstraction for cross-platform auth
   private storage: PlatformStorage | null = null;
@@ -619,17 +623,34 @@ class AuthFetch {
         ? '/api/auth/mobile/refresh'
         : '/api/auth/device/refresh';
 
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          deviceToken: session.deviceToken,
-          deviceId: info.deviceId,
-          platform: storage.platform,
-          userAgent: info.userAgent,
-          appVersion: info.appVersion,
-        }),
-      });
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.REFRESH_FETCH_TIMEOUT_MS);
+      let response: Response;
+
+      try {
+        response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            deviceToken: session.deviceToken,
+            deviceId: info.deviceId,
+            platform: storage.platform,
+            userAgent: info.userAgent,
+            appVersion: info.appVersion,
+          }),
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          this.logger.warn(`${storage.platform}: Refresh fetch timed out after ${this.REFRESH_FETCH_TIMEOUT_MS}ms`);
+          // Transient network stall, not proof the device token is dead — retryable, same as
+          // the 429/5xx branch below.
+          return { success: false, shouldLogout: false };
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
 
       if (response.ok) {
         const data = await response.json();

--- a/tasks/reviews/pu-ios-signin-hang-fix-round2.md
+++ b/tasks/reviews/pu-ios-signin-hang-fix-round2.md
@@ -1,0 +1,30 @@
+# Review: pu/ios-signin-hang-fix-round2 — PR #2306
+
+fix(auth): timeout unguarded refresh fetches, add signin recovering failsafe
+
+## Context
+Round 2 of the iOS signin hang: a TestFlight user remained permanently stuck on "Welcome
+back / Loading..." after round 1 (#2291, merged) timeout-guarded two Keychain-read hangs.
+This round timeout-guards the two previously-unbounded `fetch()` calls in the same recovery
+chain (`refreshBearerSession()`'s refresh POST, `checkMeAuthenticated()`'s `/api/auth/me`
+call) and adds an unconditional failsafe timer on `recovering` as defense in depth. Full
+self-review (correctness, OWASP top 10, test coverage) plus two automated reviewers
+(CodeRabbit, chatgpt-codex-connector) on commit 9466d1c8, both fixed in 65fe782f2.
+
+## Findings
+
+- [x] MAJOR · `apps/web/src/lib/auth/auth-fetch.ts:652` (pre-fix) · `refreshBearerSession()`'s `AbortController` timeout was disarmed (`clearTimeout` in a `finally`) immediately after the `fetch()` await resolved — but `fetch()` resolves once response headers arrive, not once the body is fully read. A server that flushes headers then stalls mid-body would hang indefinitely in the subsequent `response.json()` call with no timeout protection, reintroducing the exact class of bug this PR exists to fix, one step later — and since this leaves `isRefreshing`/`refreshPromise` permanently set, it wedges auth for the whole app session, not just this page load. Correct is: keep the same controller armed through the full request+response cycle. — fixed in 65fe782f2 (chatgpt-codex-connector P1, coderabbitai major — same finding from both reviewers)
+- [x] MAJOR · `apps/web/src/app/auth/signin/useSigninRecovery.ts:129` (pre-fix) · The failsafe timer cleared `recovering` but did not mark the run cancelled. If a still-unbounded step (the web/desktop device-token refresh paths, which have no timeout of their own yet — deferred follow-ups) resolved after the failsafe already showed the form, `run()` could still reach the `redirect` action and call `router.replace()`, yanking the user away from a form they'd already started using (e.g. mid-passkey/magic-link/OAuth attempt). Correct is: set `cancelled = true` in the same branch, same as the unmount cleanup already does. — fixed in 65fe782f2 (chatgpt-codex-connector P2, coderabbitai major — same finding from both reviewers; coderabbitai's proposed diff applied verbatim)
+- [x] MAJOR · `apps/web/src/app/auth/signin/useSigninRecovery.ts:26` (pre-fix, found via proactive self-review, not an external comment) · `RECOVERY_FAILSAFE_TIMEOUT_MS` was 12000ms, sized only for `hasDeviceToken` (3s) + `checkMeAuthenticated` (8s). The actual worst-case *bounded* chain on the bearer platforms (iOS/Android) this bug targets also includes `refreshBearerSession`'s own two-stage timeout (Keychain read + refresh POST, ~11s), for a true worst case of ~22s — the original budget didn't account for the refresh step at all. A legitimately slow (not hung) full recovery could have hit the failsafe mid-chain, prematurely flashing the signin form. Correct is: size the failsafe to the actual full chain plus margin. — fixed in 65fe782f2 (raised to 25000ms, math documented inline)
+
+## Verified, no change needed
+- OWASP Top 10 pass over the diff: no injection surface (endpoint is a hardcoded string literal, not user-controlled — no SSRF), no access-control changes, no crypto/secrets touched. Auth-relevant check: every new timeout fails *closed* (transient/not-authenticated), never grants unauthorized access on abort — confirmed no fail-open regression.
+- `bun run knip:check` — 4 issues, all within the existing baseline; the two new exported constants (`CHECK_ME_TIMEOUT_MS`, `RECOVERY_FAILSAFE_TIMEOUT_MS`) are consumed by the new regression tests, not flagged as unused.
+- No overlap between this branch's changed files and the 9 commits `master` gained while this branch was open (`pu/pane-to-session` merge) — rebased cleanly, re-verified full suite green post-rebase.
+
+## Verdict
+0 blockers / 0 majors / 0 minors / 0 nits outstanding; 3 fixed (3 majors: 2 from paired
+external review + 1 from proactive self-review) in commit 65fe782f2. 37/37 tests passing
+(`useSigninRecovery.test.ts`, `signin-recovery.test.ts`,
+`auth-fetch-refresh-bearer-session-timeout.test.ts`); `bun run typecheck`, `bun run lint`
+(changed files), `bun run knip:check` all clean.


### PR DESCRIPTION
## Summary

Round 2 of the iOS signin hang. Round 1 (#2291) timeout-guarded two Keychain-read hangs in the signin recovery chain (`hasDeviceToken()` and the Keychain read inside `refreshBearerSession()`), but a TestFlight user remained permanently stuck on "Welcome back / Loading..." after that shipped. Re-investigation found the same class of bug one layer down: the raw `fetch()` calls in this exact recovery flow had **no timeout at all**, unlike the now-fixed Keychain reads.

- **`apps/web/src/lib/auth/auth-fetch.ts`** — `refreshBearerSession()`'s refresh POST (`/api/auth/mobile/refresh` / `/api/auth/device/refresh`) is now wrapped in an `AbortController` (8s), following the existing pattern in `google-avatar.ts`. On abort, returns `{ success: false, shouldLogout: false }` — retryable/transient, not proof the device token is dead, matching the semantics already used for the 429/5xx branch. Scoped narrowly to this one call site; the shared `AuthFetch.fetch()` method (~236 call sites app-wide) is untouched. The response-handling logic (including `response.json()`) lives inside the same guarded block as the `fetch()` call, so the timeout stays armed through the whole request+response cycle — a server that flushes headers then stalls mid-body is still bounded, not just a stalled `fetch()` itself.
- **`apps/web/src/app/auth/signin/useSigninRecovery.ts`** — `checkMeAuthenticated()` now passes an `AbortController` signal into `fetchWithAuth` (8s). No changes needed to `auth-fetch.ts` for this part — `FetchOptions` already extends `RequestInit`, so the signal flows straight through to the underlying `fetch()` calls.
- **`apps/web/src/app/auth/signin/useSigninRecovery.ts`** — an unconditional 25s failsafe timer flips `recovering` to `false` no matter what hangs anywhere in the chain, including a hang not yet found or guarded. Also marks the run cancelled (same as unmount), so a still-pending step that resolves *after* the failsafe already showed the form (e.g. the web/desktop device-token refresh paths, which have no timeout of their own yet) can't reach `router.replace` later and yank the user away from a form they've already started using. Cleared on every terminal path (show-form, redirect, the fail-open catch, unmount) so it never fires after a normal completion. Sized at 25s (not the original 12s) to actually cover the worst-case *bounded* chain on iOS/Android — `hasDeviceToken` + `checkMeAuthenticated` + `refreshBearerSession`'s own two-stage timeout ≈ 22s — so it never misfires mid-chain on a legitimately slow (not hung) recovery.

No changes to the pure decision core (`signin-recovery.ts`), no client-side telemetry added (deferred), and the other unrelated raw `fetch()` calls in `auth-fetch.ts` (`refreshWebSession`, `attemptDesktopDeviceRefresh`, `fetchCSRFToken`) are intentionally out of scope for this pass.

## Review history

CodeRabbit and chatgpt-codex-connector independently flagged the same two issues on the first commit (9466d1c8), both fixed in **65fe782f2**:
1. **P1/Major** — the refresh timeout was disarmed right after `fetch()` resolved (headers received), before `response.json()` ran, so a body stall could still hang indefinitely. Fixed by keeping the same `AbortController` armed through the full response-handling block.
2. **P2/Major** — the failsafe timer cleared `recovering` but didn't mark the run cancelled, so a very-late resolution could still fire `router.replace()` after the form was already showing. Fixed by setting `cancelled = true` in the same branch, matching CodeRabbit's proposed diff exactly.

A proactive self-review pass (while CI was running) additionally found the failsafe's original 12s budget didn't account for the refresh step's own ~11s bound, so it could misfire mid-chain on a real (not hung) slow recovery — raised to 25s with the math documented inline, also in 65fe782f2.

A follow-up `/simplify` pass (commit **1e9ccc3bb**) deduped a test fixture that had been copy-pasted 3x and softened a comment that read as an enforced invariant when it's actually a hand-maintained sum. It also considered and explicitly declined two tempting-but-wrong changes: extracting a shared `AbortController`+timeout helper for the two new call sites (premature for 2 sites with materially different requirements — one needs body-read coverage, the other must compose with `fetchWithAuth`'s bearer/refresh/CSRF plumbing), and adopting the existing-but-unused `packages/lib/src/utils/fetch-with-timeout.ts` (it has the identical body-stall gap the P1 fix above addresses, so using it here would have silently reintroduced that bug).

CodeRabbit auto-resolved both of its threads after verifying the fix. The two chatgpt-codex-connector threads remain open — both have been replied to with the exact fix commit, but Codex does not resolve its own threads (repo precedent).

Reviewed against the plan file this PR implements (`~/.claude/plans/users-jono-library-messages-attachments-harmonic-kahan.md`) — all three scoped changes, all explicitly-deferred follow-ups (Sentry telemetry, the other three unguarded `fetch()` calls, the unrelated iOS-cookie latent bug in the OAuth exchange route) correctly left out of scope.

## Test plan

- [x] `bun run typecheck` — clean across the monorepo
- [x] Existing suites still pass: `useSigninRecovery.test.ts`, `signin-recovery.test.ts`, `auth-fetch-refresh-bearer-session-timeout.test.ts`
- [x] New regression tests (fake timers, no real sleeps):
  - refresh POST hangs forever → resolves to `{ success: false, shouldLogout: false }` within timeout
  - refresh POST's response body stalls after `ok` headers arrive → still resolves within timeout (the P1 fix)
  - checkMeAuthenticated's fetch hangs forever → resolves within timeout instead of hanging
  - failsafe timer flips `recovering` false even when a hang bypasses both individual guards
  - failsafe budget doesn't misfire mid-chain on a legitimately slow (not hung) full recovery
  - a refresh that resolves after the failsafe already fired can no longer reach `router.replace` (the P2 fix)
  - happy-path controls for each new timeout confirming no regression
- [x] `bun run lint` on all four changed files — clean
- [x] `bun run knip:check` — within baseline, no new unused exports
- [x] Full suite: 37/37 tests passing, 0 skipped
- [x] All CI checks green (CodeQL, Security Test Suite, Static Security Analysis, Dependency Audit, Secret Scanning, Lint & TypeScript Check, Unit Tests) — verified across 3 consecutive scans, no flakes, no regressions
- [x] Branch rebased cleanly onto latest `master` (9 commits, no file overlap, no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FnsammHjS7MRcrPYDvkyf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in recovery now exits gracefully when authentication checks or recovery steps become unresponsive.
  * Stalled session refresh requests now time out instead of leaving the app waiting indefinitely.
  * Temporary refresh failures no longer immediately sign users out.
  * Normal sign-in redirects and successful session refreshes continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
