### PR TITLE
fix(agents): stop silently evicting a closed-in-session conversation's pane

### DIFF
--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -413,12 +413,6 @@ export default function AgentPanes({
     ? sessionConversations
     : null;
 
-  // Read fresh inside the seeding effect below without widening its
-  // deliberately narrow dep list (that would re-seed on every 20s poll) —
-  // same idiom as this file's other `useAgentWorkspaceStore.getState()` reads.
-  const sessionConversationsRef = useRef(sessionConversations);
-  sessionConversationsRef.current = sessionConversations;
-
   // Selection IS an instruction to show the conversation (review M1): on
   // mount this seeds the first pane; on a later selection within the same
   // session it focuses the pane already showing the thread, or opens it in a
@@ -454,13 +448,19 @@ export default function AgentPanes({
       },
       {
         liveConversationIds: sessionKnownToConversationsCache
-          ? new Set(sessionConversationsRef.current.map((c) => c.conversationId))
+          ? new Set(sessionConversations.map((c) => c.conversationId))
           : undefined,
       },
     );
     // name/agentPageId describe the same conversation — the id is the identity.
-    // sessionConversations itself deliberately excluded — read via ref above
-    // so a 20s poll refresh doesn't re-run the seed on every tick.
+    // sessionConversations itself deliberately excluded from the dep array —
+    // its ARRAY REFERENCE changes on every 20s poll and would re-run the seed
+    // on every tick — but reading it directly in the closure (rather than via
+    // a ref) is still exactly as fresh as it needs to be: it is recomputed
+    // from the same `sessionsData` in the same render that flips
+    // `sessionKnownToConversationsCache`, so whenever THIS effect actually
+    // re-runs (on that flip), the closure it runs with already has the
+    // matching, up-to-date value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, initialConversation.conversationId, openConversation, sessionKnownToConversationsCache]);
 

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -48,7 +48,7 @@ import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { fetchWithAuth, post, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { useWorkspaceServerSync } from '@/stores/agent-workspace/useWorkspaceServerSync';
-import { panesOf, tabsOf, isLastPane, type PaneState } from '@/stores/agent-workspace/pane-reducer';
+import { panesOf, tabsOf, isLastPane, paneShowing, type PaneState } from '@/stores/agent-workspace/pane-reducer';
 import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
 import { useAuth } from '@/hooks/useAuth';
 import { useConversationActiveStream } from '@/hooks/useActiveStream';
@@ -424,6 +424,26 @@ export default function AgentPanes({
   // session it focuses the pane already showing the thread, or opens it in a
   // non-terminal pane — the store owns that policy (`openConversation`).
   useEffect(() => {
+    const workspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
+    // A brand-new grid (`ensureWorkspace`'s fast path) or a target that's
+    // already showing (`openConversation`'s own focus path) never reaches
+    // `isReplaceable`'s eviction logic, so there is nothing to protect —
+    // safe to seed immediately regardless of cache readiness. Otherwise,
+    // WAIT for the live set before risking an eviction decision at all:
+    // calling this with an unprotected `undefined` set on a pre-existing
+    // grid would let a cold reload or a slow/failed listing fetch reproduce
+    // the exact eviction issue #2295 fixes — and since
+    // `sessionKnownToConversationsCache` is otherwise excluded from this
+    // effect's deps (to avoid re-seeding on every 20s poll), a later
+    // successful fetch could never repair a premature eviction after the
+    // fact (review finding, PR #2307). `sessionKnownToConversationsCache`
+    // is safe to depend on despite that: it only flips false→true once
+    // (unlike `sessionConversations`, whose array reference changes on
+    // every poll), so this adds at most one extra effect run, not a
+    // recurring one.
+    const alreadyShowing = workspace ? paneShowing(workspace, initialConversation.conversationId) !== undefined : false;
+    if (workspace && !alreadyShowing && !sessionKnownToConversationsCache) return;
+
     openConversation(
       sessionId,
       {
@@ -433,21 +453,16 @@ export default function AgentPanes({
         agentPageId: initialConversation.agentPageId,
       },
       {
-        // Gated on the cache actually knowing this session — before that,
-        // `sessionConversations` reads as `[]`, and an empty live set would
-        // make every existing chat pane non-replaceable, forcing an unwanted
-        // split on first load instead of today's correct reuse (issue #2295
-        // fix must not regress the common case it wasn't built for).
         liveConversationIds: sessionKnownToConversationsCache
           ? new Set(sessionConversationsRef.current.map((c) => c.conversationId))
           : undefined,
       },
     );
     // name/agentPageId describe the same conversation — the id is the identity.
-    // sessionConversations/sessionKnownToConversationsCache deliberately excluded —
-    // read via ref above so a 20s poll refresh doesn't re-run the seed.
+    // sessionConversations itself deliberately excluded — read via ref above
+    // so a 20s poll refresh doesn't re-run the seed on every tick.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, initialConversation.conversationId, openConversation]);
+  }, [sessionId, initialConversation.conversationId, openConversation, sessionKnownToConversationsCache]);
 
   // Ending the session: peeked, confirmed, and gated on the server (findings
   // 1 + 2). `pendingEndClose` carries the pane and its scope from the PEEK,

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -413,18 +413,39 @@ export default function AgentPanes({
     ? sessionConversations
     : null;
 
+  // Read fresh inside the seeding effect below without widening its
+  // deliberately narrow dep list (that would re-seed on every 20s poll) —
+  // same idiom as this file's other `useAgentWorkspaceStore.getState()` reads.
+  const sessionConversationsRef = useRef(sessionConversations);
+  sessionConversationsRef.current = sessionConversations;
+
   // Selection IS an instruction to show the conversation (review M1): on
   // mount this seeds the first pane; on a later selection within the same
   // session it focuses the pane already showing the thread, or opens it in a
   // non-terminal pane — the store owns that policy (`openConversation`).
   useEffect(() => {
-    openConversation(sessionId, {
-      kind: 'chat',
-      name: initialConversation.name,
-      targetId: initialConversation.conversationId,
-      agentPageId: initialConversation.agentPageId,
-    });
+    openConversation(
+      sessionId,
+      {
+        kind: 'chat',
+        name: initialConversation.name,
+        targetId: initialConversation.conversationId,
+        agentPageId: initialConversation.agentPageId,
+      },
+      {
+        // Gated on the cache actually knowing this session — before that,
+        // `sessionConversations` reads as `[]`, and an empty live set would
+        // make every existing chat pane non-replaceable, forcing an unwanted
+        // split on first load instead of today's correct reuse (issue #2295
+        // fix must not regress the common case it wasn't built for).
+        liveConversationIds: sessionKnownToConversationsCache
+          ? new Set(sessionConversationsRef.current.map((c) => c.conversationId))
+          : undefined,
+      },
+    );
     // name/agentPageId describe the same conversation — the id is the identity.
+    // sessionConversations/sessionKnownToConversationsCache deliberately excluded —
+    // read via ref above so a 20s poll refresh doesn't re-run the seed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, initialConversation.conversationId, openConversation]);
 

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1357,6 +1357,60 @@ describe('AgentPanes', () => {
       expect(shown).toContain('conv-2');
     });
 
+    // review finding — chatgpt-codex-connector on PR #2307: before THIS
+    // session's own entry has appeared in the switch-decision cache (a cold
+    // reload, a slow fetch, or one that never resolves), `sessionKnownToConversationsCache`
+    // reads false. The seeding effect must not fall back to the OLD
+    // unprotected eviction behavior in that window — that would reopen the
+    // exact race issue #2295 fixes on every cold load — and once the fetch
+    // DOES resolve, the deferred decision must still run (protected) rather
+    // than leaving the pane stuck on stale data forever.
+    it('defers the eviction decision (rather than evicting unprotected) while the live listing has not resolved, then finishes it once it does', async () => {
+      let resolveSessions!: () => void;
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        // The sessions-LISTING endpoint specifically (`?driveId=`) — not the
+        // per-session `/workspace` sub-route `useWorkspaceServerSync` also
+        // fetches (same prefix, see the readiness test above this block).
+        if (url.includes('/api/agent-sessions?')) {
+          return new Promise((resolve) => {
+            resolveSessions = () =>
+              resolve(
+                jsonOk({
+                  sessions: [
+                    { sessionId: 'ses-1', conversations: [{ conversationId: 'conv-2', agentPageId: 'agent-1', lastMessageAt: null }] },
+                  ],
+                }),
+              );
+          });
+        }
+        return jsonOk(defaultFetchRoute(url));
+      });
+      // A pre-existing grid — e.g. restored from persisted storage — already
+      // showing conv-1, before this mount's seeding effect (targeting
+      // conv-2) ever runs.
+      useAgentWorkspaceStore
+        .getState()
+        .ensureWorkspace('ses-1', { kind: 'chat', name: 'Existing', targetId: 'conv-1', agentPageId: 'agent-1' });
+
+      renderPanes({ initialConversation: { conversationId: 'conv-2', agentPageId: 'agent-1', name: 'Conversation 2' } });
+
+      // The listing fetch hasn't resolved yet — the effect must have
+      // deferred rather than evicting conv-1's pane unprotected.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(screen.getAllByTestId('pane-chat')).toHaveLength(1);
+      expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1');
+
+      resolveSessions();
+
+      // conv-1 is absent from the resolved live listing (closed-in-session):
+      // the deferred decision runs protected — conv-1's pane survives, conv-2
+      // opens in a split rather than evicting it.
+      await waitFor(() => expect(screen.getAllByTestId('pane-chat')).toHaveLength(2));
+      const shownAfter = screen.getAllByTestId('pane-chat').map((el) => el.textContent);
+      expect(shownAfter).toContain('conv-1');
+      expect(shownAfter).toContain('conv-2');
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: switching to Chat
     // immediately (fire-and-forget) after starting an async reopen showed the
     // OLD pane content as if a failed pick had succeeded.

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1324,6 +1324,39 @@ describe('AgentPanes', () => {
       expect(firstPaneAfter?.scope?.targetId).toBe('conv-1');
     });
 
+    // issue #2295: a pane the user closed out of this session
+    // (`closedInSessionAt`) must never be silently overwritten by an
+    // unrelated LATER conversation selection — e.g. clicking a different
+    // row in the past-conversations list, or the sidebar's session
+    // re-entry, both of which funnel into the seeding effect that fires
+    // `openConversation` on an `initialConversation` prop change. `conv-1`
+    // is deliberately absent from the live listing below to simulate it.
+    it('does not evict a pane showing a conversation absent from the live listing when a different conversation is selected', async () => {
+      mockSessionConversations([{ conversationId: 'conv-2', agentPageId: 'agent-1' }]);
+      const { rerender } = renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toHaveTextContent('conv-1'));
+      // Wait for the session's own entry to have actually appeared in the
+      // switch-decision cache — the same readiness signal `findEnabledSelector`
+      // above waits on — so the seeding effect's `liveConversationIds` is
+      // populated from real data rather than racing an unresolved fetch.
+      await waitFor(() => expect(screen.getByRole('button', { name: /Researcher/ })).not.toBeDisabled());
+
+      rerender(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <AgentPanes
+            sessionId="ses-1"
+            driveId="drive-1"
+            initialConversation={{ conversationId: 'conv-2', agentPageId: 'agent-1', name: 'Conversation 2' }}
+          />
+        </SWRConfig>,
+      );
+
+      await waitFor(() => expect(screen.getAllByTestId('pane-chat')).toHaveLength(2));
+      const shown = screen.getAllByTestId('pane-chat').map((el) => el.textContent);
+      expect(shown).toContain('conv-1');
+      expect(shown).toContain('conv-2');
+    });
+
     // review finding — chatgpt-codex-connector on PR #2299: switching to Chat
     // immediately (fire-and-forget) after starting an async reopen showed the
     // OLD pane content as if a failed pick had succeeded.

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -504,14 +504,22 @@ function SessionRow({
   const openShell = useCallback(
     (shell: { shellId: string; name: string }) => {
       selectSession(session.sessionId);
-      useAgentWorkspaceStore.getState().openConversation(session.sessionId, {
-        kind: 'terminal',
-        name: shell.name,
-        targetId: shell.shellId,
-        agentPageId: null,
-      });
+      // `session.conversations` is this row's own already-resolved live
+      // listing (the row couldn't exist here otherwise) — protects a chat
+      // pane showing a conversation closed out of the session from being
+      // silently evicted by an unrelated shell reattach (issue #2295).
+      useAgentWorkspaceStore.getState().openConversation(
+        session.sessionId,
+        {
+          kind: 'terminal',
+          name: shell.name,
+          targetId: shell.shellId,
+          agentPageId: null,
+        },
+        { liveConversationIds: new Set(session.conversations.map((c) => c.conversationId)) },
+      );
     },
-    [selectSession, session.sessionId],
+    [selectSession, session.sessionId, session.conversations],
   );
 
   const openSession = useCallback(() => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -685,6 +685,59 @@ describe('AgentsSidebar', () => {
         agentPageId: null,
       });
     });
+
+    // issue #2295 (adversarial review, PR #2307): `openShell` calls the
+    // store's `openConversation` directly — a second, independent path into
+    // the same eviction-prone `isReplaceable` heuristic the main fix
+    // protects, reachable without ever touching AgentPanes.tsx's seeding
+    // effect. A pane already showing a conversation absent from THIS
+    // session's own live listing (closed-in-session) must not be silently
+    // overwritten just because the user reattached an unrelated shell.
+    test('reattaching a shell does not evict a pane showing a conversation closed out of the session', async () => {
+      const existingGrid = {
+        id: 'ses-1',
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              {
+                id: 'pane-1',
+                scope: { kind: 'chat', name: 'Conversation', targetId: 'conv-closed', agentPageId: 'agent-1' },
+                tabs: [{ kind: 'chat', name: 'Conversation', targetId: 'conv-closed', agentPageId: 'agent-1' }],
+              },
+            ],
+          },
+        ],
+        activePaneId: 'pane-1',
+        pendingPickerPaneId: null,
+      };
+      act(() => {
+        useAgentWorkspaceStore.getState().hydrateWorkspace('ses-1', existingGrid as WorkspaceState);
+      });
+      // `conv-closed` is deliberately absent from `conversations` — this
+      // session's own live listing — simulating it having been closed out
+      // of the session while its pane is still bound to it.
+      respondWithSessions([
+        { ...SESSION, conversations: [], shells: [{ shellId: 'shell-a', name: 'shell-1' }], workspace: existingGrid },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('shell-1'));
+
+      const panes = useAgentWorkspaceStore.getState().workspaces['ses-1']!.columns.flatMap((c) => c.panes);
+      // Protected: the original pane still shows conv-closed, untouched.
+      expect(panes.find((p) => p.id === 'pane-1')?.scope?.targetId).toBe('conv-closed');
+      // The shell opened in a NEW pane instead of evicting it.
+      expect(panes.find((p) => p.scope?.kind === 'terminal')?.scope).toEqual({
+        kind: 'terminal',
+        name: 'shell-1',
+        targetId: 'shell-a',
+        agentPageId: null,
+      });
+      expect(panes).toHaveLength(2);
+    });
   });
 
   describe('new session', () => {

--- a/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
@@ -276,6 +276,40 @@ describe('openConversation — selection means SHOW it (review M1)', () => {
     expect(panes.find((p) => p.id === inFlightPane.id)?.scope?.targetId).toBeNull();
     expect(panes.find((p) => p.scope?.targetId === 'conv-2')).toBeDefined();
   });
+
+  it('never evicts a pane showing a conversation closed-in-session — absent from liveConversationIds', () => {
+    store().openConversation('ses-1', conv('conv-1'));
+    const closedPane = panesOf(grid())[0];
+
+    store().openConversation('ses-1', conv('conv-2'), { liveConversationIds: new Set(['conv-2']) });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === closedPane.id)?.scope?.targetId).toBe('conv-1');
+    expect(panes.find((p) => p.scope?.targetId === 'conv-2')).toBeDefined();
+  });
+
+  it('still evicts a pane whose conversation IS in liveConversationIds', () => {
+    store().openConversation('ses-1', conv('conv-1'));
+    const paneId = panesOf(grid())[0].id;
+
+    store().openConversation('ses-1', conv('conv-2'), { liveConversationIds: new Set(['conv-1', 'conv-2']) });
+
+    expect(panesOf(grid())).toHaveLength(1);
+    expect(panesOf(grid())[0].id).toBe(paneId);
+    expect(panesOf(grid())[0].scope?.targetId).toBe('conv-2');
+  });
+
+  it('omitting liveConversationIds preserves today\'s eviction behavior — strictly additive/opt-in', () => {
+    store().openConversation('ses-1', conv('conv-1'));
+    const paneId = panesOf(grid())[0].id;
+
+    store().openConversation('ses-1', conv('conv-2'));
+
+    expect(panesOf(grid())).toHaveLength(1);
+    expect(panesOf(grid())[0].id).toBe(paneId);
+    expect(panesOf(grid())[0].scope?.targetId).toBe('conv-2');
+  });
 });
 
 describe('openPage — the page-pane sibling of openConversation', () => {

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -62,8 +62,20 @@ interface AgentWorkspaceState {
    * in the first chat pane — never over a TERMINAL (a running PTY loses its
    * only surface; there is no reattach UI). With every pane a terminal, split
    * the active pane right.
+   *
+   * `options.liveConversationIds`, when supplied, additionally protects a
+   * chat pane whose target is NOT in that set — e.g. a conversation the user
+   * closed out of this session (`closedInSessionAt`) — from being silently
+   * evicted by an unrelated later selection (issue #2295); it falls through
+   * to the split fallback instead, exactly like a terminal/dirty pane does.
+   * Omitted (any caller that hasn't learned the live set yet), behavior is
+   * unchanged — this guard is strictly additive.
    */
-  openConversation(sessionId: string, scope: PaneScope): void;
+  openConversation(
+    sessionId: string,
+    scope: PaneScope,
+    options?: { liveConversationIds?: ReadonlySet<string> },
+  ): void;
   /**
    * Make a PAGE visible in the session's grid — the page-pane sibling of
    * `openConversation`, sharing its focus-or-replace-or-split policy (with
@@ -183,7 +195,7 @@ function focusOrAssignScope(
   set: (fn: (state: AgentWorkspaceState) => Partial<AgentWorkspaceState>) => void,
   sessionId: string,
   scope: PaneScope,
-  options?: { excludeTargetId?: string },
+  options?: { excludeTargetId?: string; liveConversationIds?: ReadonlySet<string> },
 ) {
   const state = useAgentWorkspaceStore.getState();
   const workspace = state.workspaces[sessionId];
@@ -208,11 +220,22 @@ function focusOrAssignScope(
   // a pane with unsaved edits (`isPaneDirty`), and — when the caller passed
   // `excludeTargetId` — the pane already showing THAT target (the
   // `open_page_pane` tool's own invoking conversation must never be evicted
-  // by its own tool call; it should get a split beside it instead).
+  // by its own tool call; it should get a split beside it instead). Also
+  // excluded when the caller passed `liveConversationIds` (only
+  // `openConversation` ever does): a CHAT pane whose target is not in that
+  // live set — a conversation closed out of this session — must never be
+  // silently overwritten by an unrelated later selection (issue #2295).
+  // Scoped to `kind === 'chat'` deliberately: a page pane is a different
+  // domain concept already governed by `isPaneDirty`/`excludeTargetId`, and
+  // `openPage` never supplies this option, so its call sites are unaffected.
   const isReplaceable = (pane: PaneState) =>
     (pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null)) &&
     !isPaneDirty(pane) &&
-    (options?.excludeTargetId === undefined || pane.scope?.targetId !== options.excludeTargetId);
+    (options?.excludeTargetId === undefined || pane.scope?.targetId !== options.excludeTargetId) &&
+    (options?.liveConversationIds === undefined ||
+      pane.scope?.kind !== 'chat' ||
+      pane.scope.targetId === null ||
+      options.liveConversationIds.has(pane.scope.targetId));
   const replaceable = active && isReplaceable(active) ? active : panes.find(isReplaceable);
   if (replaceable) {
     state.assignPane(sessionId, replaceable.id, scope);
@@ -250,7 +273,7 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
           };
         }),
 
-      openConversation: (sessionId, scope) => focusOrAssignScope(set, sessionId, scope),
+      openConversation: (sessionId, scope, options) => focusOrAssignScope(set, sessionId, scope, options),
 
       openPage: (sessionId, scope, options) => focusOrAssignScope(set, sessionId, scope, options),
 


### PR DESCRIPTION
## Summary

`useAgentWorkspaceStore`'s pane-reuse heuristic (`isReplaceable`, inside `focusOrAssignScope`) treated ANY non-terminal, non-dirty chat pane as fair game to silently overwrite — including a pane still showing a conversation the user closed out of the session (`closedInSessionAt`, set server-side). An unrelated LATER `openConversation` call for a different conversation in the same session (via the past-conversations list, the sidebar's session re-entry, or reattaching a shell) could evict that pane with zero warning, swapping the user's view mid-read. No data loss, but a silent UX regression.

- `openConversation` now accepts an optional third argument, `{ liveConversationIds }`. A chat pane whose target is absent from that set is excluded from `isReplaceable`'s eviction, falling through to the split-right fallback instead — the same treatment terminal/dirty/excluded-target panes already get. Omitted entirely, behavior is byte-for-byte unchanged (strictly additive/opt-in).
- `AgentPanes.tsx`'s seeding effect (mount + the past-conversations list + the sidebar's session re-entry) supplies the live conversation set. It also **defers** the `openConversation` call itself — rather than calling it with an unprotected `undefined` set — whenever a pre-existing grid's eviction risk can't yet be evaluated safely (workspace already exists, target isn't already showing, live listing hasn't resolved yet). This closes a race a reviewer caught: without deferring, a cold reload or a slow/failed listing fetch could reproduce the exact unprotected eviction on every cold load, since cache readiness is deliberately excluded from the effect's dependency list and a later successful fetch could never repair a premature eviction after the fact. `sessionKnownToConversationsCache` is safe to add back as a dependency for this purpose — it only flips false→true once, unlike `sessionConversations` itself, whose array reference changes on every 20s poll.
- `AgentsSidebar.tsx`'s `openShell` (reattaching a terminal from the sidebar) is a second, independent path into the same `openConversation`/`isReplaceable` heuristic that a self-review pass found was still unprotected — found by exhaustively grepping every call site of `openConversation` in the codebase. Now threads through the same live listing (already available on the session row as `session.conversations`, no readiness gating needed there).
- `useSpawnSession.tsx`'s own direct `openConversation` call was checked and ruled out: it only ever targets a session id just returned from its own `POST`, which can't have an existing grid yet, so `ensureWorkspace`'s fast path always applies and `isReplaceable` is never reached.
- `handleSwitchAgent`'s own focus path is untouched — this branch was rebased on top of #2304 (the tabbable-panes rewrite), which moved that handler off `openConversation` onto `switchTab`/`replaceTab`. Those only ever act within the target pane's own tab list and never evict another pane's scope, so the bug this PR fixes cannot occur on that path anymore.

Closes #2295

## Test plan
- [x] `bun run --filter web test -- useAgentWorkspaceStore.test.ts` — RED-then-GREEN store tests (44/44 passing)
- [x] `bun run --filter web test -- AgentPanes.test.tsx` — new integration test + a race-condition regression test for the deferred decision + all pre-existing pane tests passing (72/72)
- [x] `bun run --filter web test -- AgentsSidebar.test.tsx` — new regression test for the shell-reattach path, RED-then-GREEN (58/58 passing)
- [x] Broader collateral sweep: 18 related test files across `agent-workspace`/`agents`/`left-sidebar` (403/403 passing)
- [x] `bun run typecheck`
- [x] `bun run lint` on touched files
- [x] CI: Lint & TypeScript Check, Unit Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvKpxwLYoTBKcruuQM9P4F