### PR TITLE
Refactor agent settings into focused subpages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Changed
 
+- **Agent settings are now a compact menu instead of one long scrolling form** — opening an
+  agent's settings (from the full agent page or from a pane) now shows a short list of categories
+  — Behavior, Access, Tools, and Integrations — instead of every option stacked on one
+  continuously scrolling page, and no longer shows an empty scrollable region when an agent has no
+  tools available. The full page and pane surfaces now share the same navigation, and
+  Integrations — previously only reachable from the full page — is available from panes too.
+  Unsaved edits are preserved when moving between the category menu and a configuration subpage,
+  and each pane tracks its own navigation state independently.
 - **Every Terminal agent session now runs in its own isolated sandbox** — previously only a
   *branch* session got a separate Sprite, while machine- and project-scoped sessions shared the
   owning Machine's single Sprite, so two agents spawned at the same location collapsed onto one

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -47,7 +47,6 @@ import {
   PageAgentHistoryTab,
   type PageAgentSettingsTabRef,
 } from '@/components/ai/page-agents';
-import { AgentIntegrationsPanel } from '@/components/ai/page-agents/AgentIntegrationsPanel';
 import { PageWebhooksDialog } from '@/components/shared/PageWebhooksDialog';
 import { useProviderSettings } from '@/lib/ai/shared/hooks/useProviderSettings';
 import { useConversations } from '@/lib/ai/shared/hooks/useConversations';
@@ -575,9 +574,6 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
             isProviderConfigured={isProviderConfigured}
             onSavingChange={setIsSettingsSaving}
           />
-          <div className="px-4 pb-4">
-            <AgentIntegrationsPanel pageId={page.id} driveId={page.driveId} />
-          </div>
         </TabsContent>
       </Tabs>
 

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -173,10 +173,6 @@ vi.mock('@/components/ai/page-agents', () => ({
   ),
 }));
 
-vi.mock('@/components/ai/page-agents/AgentIntegrationsPanel', () => ({
-  AgentIntegrationsPanel: () => <div data-testid="agent-integrations-panel" />,
-}));
-
 vi.mock('@/components/shared/PageWebhooksDialog', () => ({
   PageWebhooksDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="webhooks-dialog" /> : null),
 }));
@@ -355,7 +351,6 @@ describe('AgentPageView', () => {
 
     expect(await screen.findByText('Save Settings')).toBeInTheDocument();
     expect(screen.getByTestId('page-agent-settings-tab')).toBeInTheDocument();
-    expect(screen.getByTestId('agent-integrations-panel')).toBeInTheDocument();
   });
 
   it('loads the agent config so the Settings tab has data, not an eternal spinner', async () => {

--- a/apps/web/src/components/ai/page-agents/AgentIntegrationsPanel.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentIntegrationsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useId, useState, useMemo, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -92,6 +92,7 @@ const getEffectiveAllowed = (grant: SafeGrant, tools: ProviderTool[]): Set<strin
     : new Set(grant.allowedTools);
 
 export function AgentIntegrationsPanel({ pageId, driveId }: AgentIntegrationsPanelProps) {
+  const instanceId = useId();
   const { grants, isLoading: loadingGrants, error: grantsError, mutate: mutateGrants } = useAgentGrants(pageId);
   const { connections: userConnections, isLoading: loadingUser, error: userError } = useUserConnections();
   const { connections: driveConnections, isLoading: loadingDrive, error: driveError } = useDriveConnections(driveId);
@@ -271,11 +272,11 @@ export function AgentIntegrationsPanel({ pageId, driveId }: AgentIntegrationsPan
                   {grant && (
                     <div className="border-t px-3 py-3 space-y-3 bg-muted/30">
                       <div className="flex items-center justify-between">
-                        <Label htmlFor={`readonly-${grant.id}`} className="text-xs">
+                        <Label htmlFor={`readonly-${instanceId}-${grant.id}`} className="text-xs">
                           Read-only mode
                         </Label>
                         <Switch
-                          id={`readonly-${grant.id}`}
+                          id={`readonly-${instanceId}-${grant.id}`}
                           checked={grant.readOnly}
                           disabled={updatingGrant === grant.id}
                           onCheckedChange={(readOnly) => handleUpdateGrant(grant, { readOnly })}
@@ -360,7 +361,7 @@ export function AgentIntegrationsPanel({ pageId, driveId }: AgentIntegrationsPan
                                       {CATEGORY_LABELS[category]}
                                     </p>
                                     {toolsInCategory.map((tool) => {
-                                      const id = `tool-${grant.id}-${tool.id}`;
+                                      const id = `tool-${instanceId}-${grant.id}-${tool.id}`;
                                       return (
                                         <div
                                           key={tool.id}

--- a/apps/web/src/components/ai/page-agents/AgentIntegrationsPanel.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentIntegrationsPanel.tsx
@@ -200,7 +200,7 @@ export function AgentIntegrationsPanel({ pageId, driveId }: AgentIntegrationsPan
   };
 
   return (
-    <Card className="mt-4">
+    <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           <Plug2 className="h-4 w-4" />

--- a/apps/web/src/components/ai/page-agents/AgentSettingsMenu.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentSettingsMenu.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { forwardRef } from 'react';
 import { ChevronRight, type LucideIcon } from 'lucide-react';
 
 export type AgentSettingsCategory = 'behavior' | 'access' | 'tools' | 'integrations';
@@ -16,24 +17,28 @@ interface AgentSettingsMenuProps {
   selectCategory: (category: AgentSettingsCategory) => void;
 }
 
-export function AgentSettingsMenu({ items, selectCategory }: AgentSettingsMenuProps) {
-  return (
-    <div className="overflow-hidden rounded-lg border bg-card">
-      {items.map(({ key, title, description, icon: Icon }, index) => (
-        <button
-          key={key}
-          type="button"
-          onClick={() => selectCategory(key)}
-          className={`group flex w-full items-center gap-4 px-4 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground ${index > 0 ? 'border-t' : ''}`}
-        >
-          <Icon className="h-5 w-5 shrink-0 text-muted-foreground group-hover:text-accent-foreground" />
-          <span className="min-w-0 flex-1">
-            <span className="block font-medium">{title}</span>
-            <span className="block truncate text-sm text-muted-foreground group-hover:text-accent-foreground">{description}</span>
-          </span>
-          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground group-hover:text-accent-foreground" />
-        </button>
-      ))}
-    </div>
-  );
-}
+export const AgentSettingsMenu = forwardRef<HTMLDivElement, AgentSettingsMenuProps>(
+  ({ items, selectCategory }, ref) => {
+    return (
+      <div ref={ref} tabIndex={-1} className="overflow-hidden rounded-lg border bg-card outline-none">
+        {items.map(({ key, title, description, icon: Icon }, index) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => selectCategory(key)}
+            className={`group flex w-full items-center gap-4 px-4 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground ${index > 0 ? 'border-t' : ''}`}
+          >
+            <Icon className="h-5 w-5 shrink-0 text-muted-foreground group-hover:text-accent-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block font-medium">{title}</span>
+              <span className="block truncate text-sm text-muted-foreground group-hover:text-accent-foreground">{description}</span>
+            </span>
+            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground group-hover:text-accent-foreground" />
+          </button>
+        ))}
+      </div>
+    );
+  },
+);
+
+AgentSettingsMenu.displayName = 'AgentSettingsMenu';

--- a/apps/web/src/components/ai/page-agents/AgentSettingsMenu.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentSettingsMenu.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ChevronRight, type LucideIcon } from 'lucide-react';
+
+export type AgentSettingsCategory = 'behavior' | 'access' | 'tools' | 'integrations';
+
+export interface AgentSettingsMenuItem {
+  key: AgentSettingsCategory;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+interface AgentSettingsMenuProps {
+  items: AgentSettingsMenuItem[];
+  selectCategory: (category: AgentSettingsCategory) => void;
+}
+
+export function AgentSettingsMenu({ items, selectCategory }: AgentSettingsMenuProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      {items.map(({ key, title, description, icon: Icon }, index) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => selectCategory(key)}
+          className={`group flex w-full items-center gap-4 px-4 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground ${index > 0 ? 'border-t' : ''}`}
+        >
+          <Icon className="h-5 w-5 shrink-0 text-muted-foreground group-hover:text-accent-foreground" />
+          <span className="min-w-0 flex-1">
+            <span className="block font-medium">{title}</span>
+            <span className="block truncate text-sm text-muted-foreground group-hover:text-accent-foreground">{description}</span>
+          </span>
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground group-hover:text-accent-foreground" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/ai/page-agents/AgentSettingsMenu.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentSettingsMenu.tsx
@@ -20,7 +20,7 @@ interface AgentSettingsMenuProps {
 export const AgentSettingsMenu = forwardRef<HTMLDivElement, AgentSettingsMenuProps>(
   ({ items, selectCategory }, ref) => {
     return (
-      <div ref={ref} tabIndex={-1} className="overflow-hidden rounded-lg border bg-card outline-none">
+      <div ref={ref} className="overflow-hidden rounded-lg border bg-card">
         {items.map(({ key, title, description, icon: Icon }, index) => (
           <button
             key={key}

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -142,13 +142,6 @@ const SETTINGS_ITEMS: AgentSettingsMenuItem[] = [
   },
 ];
 
-const SETTINGS_TITLES: Record<AgentSettingsCategory, string> = {
-  behavior: 'Behavior',
-  access: 'Access',
-  tools: 'Tools',
-  integrations: 'Integrations',
-};
-
 const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettingsTabProps>(({
   pageId,
   driveId,
@@ -169,8 +162,14 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   const [isSaving, setIsSaving] = useState(false);
   const [category, setCategory] = useState<AgentSettingsCategory | null>(null);
   const settingsMenuRef = useRef<HTMLDivElement>(null);
-  const categoryHeadingRef = useRef<HTMLHeadingElement>(null);
   const isInitialCategoryRender = useRef(true);
+
+  // The category heading only ever mounts as the result of a deliberate
+  // navigation-in (category starts null, so it's never present on first
+  // render) — a mount-time callback ref is enough to focus it. Returning to
+  // the menu is the ambiguous case (AgentSettingsMenu also mounts on first
+  // render), so that transition still needs the guarded effect below.
+  const focusOnMount = useCallback((el: HTMLElement | null) => el?.focus(), []);
 
   useEffect(() => {
     if (isInitialCategoryRender.current) {
@@ -179,8 +178,6 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     }
     if (category === null) {
       settingsMenuRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
-    } else {
-      categoryHeadingRef.current?.focus();
     }
   }, [category]);
   // Shared across every mounted Settings surface for this agent (keyed by
@@ -582,8 +579,8 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
                 <ChevronLeft className="mr-1 h-4 w-4" />
                 Agent Settings
               </Button>
-              <h2 ref={categoryHeadingRef} tabIndex={-1} className="text-xl font-semibold outline-none">
-                {SETTINGS_TITLES[category]}
+              <h2 ref={focusOnMount} tabIndex={-1} className="text-xl font-semibold outline-none">
+                {SETTINGS_ITEMS.find((item) => item.key === category)?.title}
               </h2>
             </div>
 

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { Loader2, Bot, FolderTree, Shield, Copy, Check, Code2, Wrench, TerminalSquare } from 'lucide-react';
+import { Loader2, Bot, FolderTree, Shield, Copy, Check, Code2, Wrench, TerminalSquare, Cable, ChevronLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { useForm, useFormState, Controller } from 'react-hook-form';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -18,6 +18,12 @@ import { AgentDrivesCard } from './AgentDrivesCard';
 import { SANDBOX_TOOL_NAMES } from '@/lib/ai/core/tool-filtering';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useAgentMembership } from '@/lib/ai/shared/hooks/useAgentMembership';
+import { AgentIntegrationsPanel } from './AgentIntegrationsPanel';
+import {
+  AgentSettingsMenu,
+  type AgentSettingsCategory,
+  type AgentSettingsMenuItem,
+} from './AgentSettingsMenu';
 
 interface AgentConfig {
   systemPrompt: string;
@@ -109,6 +115,37 @@ interface FormData {
   sandboxEnabled: boolean;
 }
 
+const SETTINGS_ITEMS: AgentSettingsMenuItem[] = [
+  {
+    key: 'behavior',
+    title: 'Behavior',
+    description: 'Model, instructions, identity, and workspace context',
+    icon: Bot,
+  },
+  {
+    key: 'access',
+    title: 'Access',
+    description: 'Drive membership and workspace access',
+    icon: Shield,
+  },
+  {
+    key: 'tools',
+    title: 'Tools',
+    description: 'Sandbox, default tools, and tool exposure',
+    icon: Wrench,
+  },
+  {
+    key: 'integrations',
+    title: 'Integrations',
+    description: 'External services available to this agent',
+    icon: Cable,
+  },
+];
+
+const SETTINGS_TITLES: Record<AgentSettingsCategory, string> = Object.fromEntries(
+  SETTINGS_ITEMS.map(({ key, title }) => [key, title]),
+) as Record<AgentSettingsCategory, string>;
+
 const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettingsTabProps>(({
   pageId,
   driveId,
@@ -127,6 +164,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   // useEditingStore registration below, round 20).
   const mountId = useId();
   const [isSaving, setIsSaving] = useState(false);
+  const [category, setCategory] = useState<AgentSettingsCategory | null>(null);
   // Shared across every mounted Settings surface for this agent (keyed by
   // driveId in SWR's cache) — see useAgentMembership for why a per-instance
   // useState here previously let two Settings surfaces for the same agent
@@ -509,8 +547,28 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   }
 
   return (
-    <div className="p-4">
+    <div className="mx-auto w-full max-w-2xl p-4">
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col space-y-6">
+        {category === null ? (
+          <AgentSettingsMenu items={SETTINGS_ITEMS} selectCategory={setCategory} />
+        ) : (
+          <>
+            <div className="space-y-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="-ml-2"
+                onClick={() => setCategory(null)}
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                Agent Settings
+              </Button>
+              <h2 className="text-xl font-semibold">{SETTINGS_TITLES[category]}</h2>
+            </div>
+
+            {category === 'behavior' && (
+              <>
         {/* API Model ID */}
         <ApiModelIdCard pageId={pageId} />
 
@@ -610,8 +668,11 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
             <CardTitle className="text-lg">System Prompt</CardTitle>
           </CardHeader>
           <CardContent>
-            <label className="text-sm font-medium mb-2 block">Custom Instructions</label>
+            <label htmlFor={`${mountId}-system-prompt`} className="text-sm font-medium mb-2 block">
+              Custom Instructions
+            </label>
             <Textarea
+              id={`${mountId}-system-prompt`}
               {...register('systemPrompt')}
               placeholder="Define your AI agent's behavior, personality, and instructions here..."
               className="min-h-[200px] resize-none w-full"
@@ -729,7 +790,11 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
             </CardContent>
           )}
         </Card>
+              </>
+            )}
 
+            {category === 'access' && (
+              <>
         {/* Drive Membership */}
         <Card>
           <CardHeader>
@@ -808,7 +873,11 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
 
         {/* Drives this agent can access */}
         <AgentDrivesCard agentPageId={pageId} />
+              </>
+            )}
 
+            {category === 'tools' && (
+              <>
         {/* Sandbox — successor to the old Machine Access card, minus the
             machine topology: there is nothing to pick, because the sandbox
             belongs to the conversation's SESSION and is provisioned
@@ -871,45 +940,47 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
             <p className="text-sm text-muted-foreground mb-4">
               The agent&apos;s default toolset. The Tools menu in the chat composer is the live control at runtime — it can enable or disable any tool per session.
             </p>
-            <ScrollArea className="h-48">
-              <Controller
-                name="enabledTools"
-                control={control}
-                render={({ field: { value = [], onChange } }) => {
-                  const toolRow = (tool: { name: string; description: string }) => (
-                    <div key={tool.name} className="flex items-start space-x-3 p-2 rounded-lg hover:bg-muted/50">
-                      <Checkbox
-                        id={tool.name}
-                        checked={value.includes(tool.name)}
-                        onCheckedChange={(checked) => {
-                          const newValue = checked
-                            ? [...value, tool.name]
-                            : value.filter(t => t !== tool.name);
-                          onChange(newValue);
-                        }}
-                        className="mt-1"
-                      />
-                      <div className="flex-1">
-                        <label
-                          htmlFor={tool.name}
-                          className="text-sm font-medium cursor-pointer"
-                        >
-                          {tool.name}
-                        </label>
-                        <p className="text-xs text-muted-foreground">
-                          {tool.description}
-                        </p>
+            {visibleTools.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                No tools are available for this agent.
+              </p>
+            ) : (
+              <ScrollArea className="h-48">
+                <Controller
+                  name="enabledTools"
+                  control={control}
+                  render={({ field: { value = [], onChange } }) => {
+                    const toolRow = (tool: { name: string; description: string }) => (
+                      <div key={tool.name} className="flex items-start space-x-3 rounded-lg p-2 hover:bg-muted/50">
+                        <Checkbox
+                          id={`${mountId}-${tool.name}`}
+                          checked={value.includes(tool.name)}
+                          onCheckedChange={(checked) => {
+                            const newValue = checked
+                              ? [...value, tool.name]
+                              : value.filter(t => t !== tool.name);
+                            onChange(newValue);
+                          }}
+                          className="mt-1"
+                        />
+                        <div className="flex-1">
+                          <label
+                            htmlFor={`${mountId}-${tool.name}`}
+                            className="cursor-pointer text-sm font-medium"
+                          >
+                            {tool.name}
+                          </label>
+                          <p className="text-xs text-muted-foreground">
+                            {tool.description}
+                          </p>
+                        </div>
                       </div>
-                    </div>
-                  );
-                  return (
-                    <div className="space-y-3">
-                      {visibleTools.map(toolRow)}
-                    </div>
-                  );
-                }}
-              />
-            </ScrollArea>
+                    );
+                    return <div className="space-y-3">{visibleTools.map(toolRow)}</div>;
+                  }}
+                />
+              </ScrollArea>
+            )}
             <p className="text-xs text-muted-foreground mt-2">
               Selected {enabledTools.length} of {visibleTools.length} tools
             </p>
@@ -960,7 +1031,14 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
             </p>
           </CardContent>
         </Card>
+              </>
+            )}
 
+            {category === 'integrations' && (
+              <AgentIntegrationsPanel pageId={pageId} driveId={driveId} />
+            )}
+          </>
+        )}
       </form>
     </div>
   );

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -178,7 +178,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       return;
     }
     if (category === null) {
-      settingsMenuRef.current?.focus();
+      settingsMenuRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
     } else {
       categoryHeadingRef.current?.focus();
     }

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -142,9 +142,12 @@ const SETTINGS_ITEMS: AgentSettingsMenuItem[] = [
   },
 ];
 
-const SETTINGS_TITLES: Record<AgentSettingsCategory, string> = Object.fromEntries(
-  SETTINGS_ITEMS.map(({ key, title }) => [key, title]),
-) as Record<AgentSettingsCategory, string>;
+const SETTINGS_TITLES: Record<AgentSettingsCategory, string> = {
+  behavior: 'Behavior',
+  access: 'Access',
+  tools: 'Tools',
+  integrations: 'Integrations',
+};
 
 const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettingsTabProps>(({
   pageId,
@@ -165,6 +168,21 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   const mountId = useId();
   const [isSaving, setIsSaving] = useState(false);
   const [category, setCategory] = useState<AgentSettingsCategory | null>(null);
+  const settingsMenuRef = useRef<HTMLDivElement>(null);
+  const categoryHeadingRef = useRef<HTMLHeadingElement>(null);
+  const isInitialCategoryRender = useRef(true);
+
+  useEffect(() => {
+    if (isInitialCategoryRender.current) {
+      isInitialCategoryRender.current = false;
+      return;
+    }
+    if (category === null) {
+      settingsMenuRef.current?.focus();
+    } else {
+      categoryHeadingRef.current?.focus();
+    }
+  }, [category]);
   // Shared across every mounted Settings surface for this agent (keyed by
   // driveId in SWR's cache) — see useAgentMembership for why a per-instance
   // useState here previously let two Settings surfaces for the same agent
@@ -550,7 +568,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     <div className="mx-auto w-full max-w-2xl p-4">
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col space-y-6">
         {category === null ? (
-          <AgentSettingsMenu items={SETTINGS_ITEMS} selectCategory={setCategory} />
+          <AgentSettingsMenu ref={settingsMenuRef} items={SETTINGS_ITEMS} selectCategory={setCategory} />
         ) : (
           <>
             <div className="space-y-2">
@@ -564,7 +582,9 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
                 <ChevronLeft className="mr-1 h-4 w-4" />
                 Agent Settings
               </Button>
-              <h2 className="text-xl font-semibold">{SETTINGS_TITLES[category]}</h2>
+              <h2 ref={categoryHeadingRef} tabIndex={-1} className="text-xl font-semibold outline-none">
+                {SETTINGS_TITLES[category]}
+              </h2>
             </div>
 
             {category === 'behavior' && (

--- a/apps/web/src/components/ai/page-agents/__tests__/PageAgentSettingsTab.navigation.test.tsx
+++ b/apps/web/src/components/ai/page-agents/__tests__/PageAgentSettingsTab.navigation.test.tsx
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PageAgentSettingsTab from '../PageAgentSettingsTab';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/shared/hooks/useAgentMembership', () => ({
+  useAgentMembership: () => ({
+    membership: null,
+    membershipUserRole: 'MEMBER',
+    driveRoles: [],
+    updateRole: vi.fn(),
+    isSaving: false,
+  }),
+}));
+
+vi.mock('../AgentDrivesCard', () => ({
+  AgentDrivesCard: () => <div>Agent drives</div>,
+}));
+
+vi.mock('../AgentIntegrationsPanel', () => ({
+  AgentIntegrationsPanel: () => <div>Integration connections</div>,
+}));
+
+const config = {
+  systemPrompt: '',
+  enabledTools: [],
+  availableTools: [],
+  aiProvider: 'openai',
+  aiModel: 'gpt-4o',
+};
+
+const props = {
+  pageId: 'agent-1',
+  driveId: 'drive-1',
+  config,
+  onConfigUpdate: vi.fn(),
+  onConfigRevalidate: vi.fn(),
+  selectedProvider: 'openai',
+  selectedModel: 'gpt-4o',
+  onProviderChange: vi.fn(),
+  onModelChange: vi.fn(),
+  isProviderConfigured: () => true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PageAgentSettingsTab navigation', () => {
+  it('given the settings root, should open focused subpages and return to the menu', async () => {
+    const user = userEvent.setup();
+    render(<PageAgentSettingsTab {...props} />);
+
+    expect(screen.getByRole('button', { name: /behavior/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /access/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /tools/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /integrations/i })).toBeInTheDocument();
+    expect(screen.queryByText('System Prompt')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /behavior/i }));
+
+    expect(screen.getByRole('heading', { name: 'Behavior' })).toBeInTheDocument();
+    expect(screen.getByText('System Prompt')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /agent settings/i }));
+
+    expect(screen.getByRole('button', { name: /integrations/i })).toBeInTheDocument();
+    expect(screen.queryByText('System Prompt')).not.toBeInTheDocument();
+  });
+
+  it('given two pane settings surfaces, should keep their selected subpages independent', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <>
+        <section aria-label="First pane">
+          <PageAgentSettingsTab {...props} />
+        </section>
+        <section aria-label="Second pane">
+          <PageAgentSettingsTab {...props} />
+        </section>
+      </>
+    );
+    const firstPane = within(container.querySelector('[aria-label="First pane"]')!);
+    const secondPane = within(container.querySelector('[aria-label="Second pane"]')!);
+
+    await user.click(firstPane.getByRole('button', { name: /tools/i }));
+
+    expect(firstPane.getByRole('heading', { name: 'Tools' })).toBeInTheDocument();
+    expect(secondPane.getByRole('button', { name: /tools/i })).toBeInTheDocument();
+    expect(secondPane.queryByRole('heading', { name: 'Tools' })).not.toBeInTheDocument();
+  });
+
+  it('given unsaved edits, should preserve them while navigating through the menu', async () => {
+    const user = userEvent.setup();
+    render(<PageAgentSettingsTab {...props} />);
+
+    await user.click(screen.getByRole('button', { name: /behavior/i }));
+    await user.type(screen.getByLabelText('Custom Instructions'), 'Keep this draft');
+    await user.click(screen.getByRole('button', { name: /agent settings/i }));
+    await user.click(screen.getByRole('button', { name: /behavior/i }));
+
+    expect(screen.getByLabelText('Custom Instructions')).toHaveValue('Keep this draft');
+  });
+
+  it('given no available tools, should render an empty state without an empty scroll viewport', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<PageAgentSettingsTab {...props} />);
+
+    await user.click(screen.getByRole('button', { name: /tools/i }));
+
+    expect(screen.getByText('No tools are available for this agent.')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="scroll-area-viewport"]')).not.toBeInTheDocument();
+  });
+
+  it('given the integrations menu item, should expose integrations in the shared settings surface', async () => {
+    const user = userEvent.setup();
+    render(<PageAgentSettingsTab {...props} />);
+
+    await user.click(screen.getByRole('button', { name: /integrations/i }));
+
+    expect(screen.getByRole('heading', { name: 'Integrations' })).toBeInTheDocument();
+    expect(screen.getByText('Integration connections')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ai/page-agents/__tests__/PageAgentSettingsTab.navigation.test.tsx
+++ b/apps/web/src/components/ai/page-agents/__tests__/PageAgentSettingsTab.navigation.test.tsx
@@ -70,11 +70,13 @@ describe('PageAgentSettingsTab navigation', () => {
 
     expect(screen.getByRole('heading', { name: 'Behavior' })).toBeInTheDocument();
     expect(screen.getByText('System Prompt')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Behavior' })).toHaveFocus();
 
     await user.click(screen.getByRole('button', { name: /agent settings/i }));
 
     expect(screen.getByRole('button', { name: /integrations/i })).toBeInTheDocument();
     expect(screen.queryByText('System Prompt')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /behavior/i })).toHaveFocus();
   });
 
   it('given two pane settings surfaces, should keep their selected subpages independent', async () => {

--- a/tasks/agent-settings-navigation-epic.md
+++ b/tasks/agent-settings-navigation-epic.md
@@ -1,0 +1,9 @@
+# Agent settings navigation
+
+## Requirements
+
+- Given an agent settings surface on the agent page or in a pane, should show a category menu that opens focused Behavior, Access, Tools, and Integrations subpages.
+- Given multiple agent settings surfaces, should keep each surface's selected subpage independent.
+- Given a settings subpage, should provide a clear way back to the agent settings menu without losing unsaved configuration edits.
+- Given an agent with no available tools, should show an empty state without creating an empty scrollable tools region.
+- Given configuration edits made on any configuration subpage, should retain the existing pinned Save action and save behavior.


### PR DESCRIPTION
## Summary

- replace the long Page AI settings form with a focused menu for Behavior, Access, Tools, and Integrations
- use the same settings navigation in the full agent page and in agent panes, with independent navigation state per pane
- preserve unsaved form edits while moving between the menu and configuration subpages
- move Integrations into the shared settings surface so it is available in panes
- render a clear empty state instead of an empty fixed-height tools scroll area
- associate the Custom Instructions label with its textarea

## Why

Agent settings were presented as one continuously scrolling page, including an empty scrollable tools region when no tools were available. The page and pane settings surfaces also differed because Integrations was appended only by the full page. This refactor gives both surfaces the same compact, settings-style navigation and removes the empty scrolling behavior.

## Review-driven follow-ups (post-initial-commit)

- namespace `AgentIntegrationsPanel`'s DOM ids (`useId()`) so two panes rendering the same agent's Integrations panel don't collide on shared read-only-switch/tool-checkbox ids
- move keyboard focus to the category heading when entering a settings subpage, and to the first category button when returning to the menu — navigation previously left the focused element unmounted with nothing taking its place
- remove `AgentIntegrationsPanel`'s vestigial `mt-4` (left over from its old standalone layout in `AgentPageView.tsx`), which gave the Integrations subpage extra spacing the other three categories don't get
- add a CHANGELOG entry for the settings-navigation restructuring

## Simplification pass (post-review)

- dropped `SETTINGS_TITLES`, a hand-maintained duplicate of the titles already in `SETTINGS_ITEMS`; the heading now looks the title up from `SETTINGS_ITEMS` directly
- replaced the category-heading focus ref/effect-branch with a mount-time callback ref (the heading only ever mounts as a deliberate navigation-in, never on first render) — memoized with `useCallback` after an inline-arrow-function version caused the heading to reclaim focus after every keystroke elsewhere on the page (caught by the existing "preserve unsaved edits" test)

## Validation

- `bun run --filter 'web' test -- src/components/ai/page-agents/__tests__/PageAgentSettingsTab.navigation.test.tsx src/components/ai/page-agents/__tests__/AgentIntegrationsPanel.test.tsx src/components/agents/__tests__/AgentPageView.test.tsx src/components/agents/panes/__tests__/AgentPanes.test.tsx` — 143 tests passed (includes a new focus-management regression assertion)
- focused ESLint and `tsc --noEmit` on all changed TypeScript/TSX files — passed
- `git diff --check` — passed
- CI (`ci / Lint & TypeScript Check`, `ci / Unit Tests`) green on the final commit

## Known repository issue

The repository-wide web typecheck is currently blocked by unrelated workspace/schema resolution problems, including duplicate Drizzle 0.32/0.45 type instances and missing generated schema exports. No typecheck errors were isolated to this change.
