### PR TITLE
fix(agents): show session name in Agents tab title

### DIFF
--- a/apps/web/src/components/agents/useSessionRecord.ts
+++ b/apps/web/src/components/agents/useSessionRecord.ts
@@ -23,6 +23,7 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 export interface SessionRecordSummary {
   driveId: string | null;
+  name: string;
 }
 
 async function sessionFetcher(url: string): Promise<{ session: SessionRecordSummary | null }> {

--- a/apps/web/src/hooks/__tests__/useTabMeta.test.ts
+++ b/apps/web/src/hooks/__tests__/useTabMeta.test.ts
@@ -1,0 +1,129 @@
+/**
+ * useTabMeta — Agents tab branch. Covers the session-name title added on top
+ * of the existing static "Agents" fallback: a selected session's own name
+ * must win, switching sessions (a search-only change within the same tab)
+ * must update the title rather than sticking to whatever was fetched first,
+ * and no-session / not-yet-resolved / access-denied cases must all fall back
+ * to the static title rather than a "Loading..." flicker.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import React from 'react';
+
+const { mockFetchWithAuth } = vi.hoisted(() => ({ mockFetchWithAuth: vi.fn() }));
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: mockFetchWithAuth }));
+
+import { useTabMeta } from '../useTabMeta';
+import { createTab } from '@/lib/tabs/tab-navigation';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(SWRConfig, { value: { provider: () => new Map(), dedupingInterval: 0 } }, children);
+
+const jsonResponse = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+const sessionResponse = (name: string, driveId: string | null = 'drive-1') =>
+  jsonResponse({ session: { sessionId: 'sess-1', driveId, name } });
+
+beforeEach(() => {
+  mockFetchWithAuth.mockReset();
+});
+
+describe('useTabMeta - Agents tab', () => {
+  it('shows the static "Agents" title when no session is selected', async () => {
+    const tab = createTab({ path: '/dashboard/agents', search: '' });
+
+    const { result } = renderHook(() => useTabMeta(tab), { wrapper });
+
+    expect(result.current.title).toBe('Agents');
+    expect(result.current.iconName).toBe('Bot');
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('shows the selected session\'s own name once it resolves', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/api/agent-sessions/sess-1') return sessionResponse('Refactor auth flow');
+      throw new Error(`unexpected url ${url}`);
+    });
+    const tab = createTab({ path: '/dashboard/agents', search: 'session=sess-1' });
+
+    const { result } = renderHook(() => useTabMeta(tab), { wrapper });
+
+    await waitFor(() => expect(result.current.title).toBe('Refactor auth flow'));
+    expect(result.current.iconName).toBe('Bot');
+  });
+
+  it('falls back to the static "Agents" title while the session is still resolving', async () => {
+    mockFetchWithAuth.mockImplementation(
+      () => new Promise(() => {}), // never resolves within this test
+    );
+    const tab = createTab({ path: '/dashboard/agents', search: 'session=sess-1' });
+
+    const { result } = renderHook(() => useTabMeta(tab), { wrapper });
+
+    expect(result.current.title).toBe('Agents');
+  });
+
+  it('falls back to the static "Agents" title when the session doesn\'t resolve (e.g. access denied)', async () => {
+    mockFetchWithAuth.mockImplementation(async () => jsonResponse({ session: null }));
+    const tab = createTab({ path: '/dashboard/agents', search: 'session=sess-1' });
+
+    const { result } = renderHook(() => useTabMeta(tab), { wrapper });
+
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    expect(result.current.title).toBe('Agents');
+  });
+
+  it('updates the title when the same tab switches to a different session', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/api/agent-sessions/sess-1') return sessionResponse('First Session');
+      if (url === '/api/agent-sessions/sess-2') return jsonResponse({ session: { sessionId: 'sess-2', driveId: 'drive-1', name: 'Second Session' } });
+      throw new Error(`unexpected url ${url}`);
+    });
+    const firstTab = createTab({ path: '/dashboard/agents', search: 'session=sess-1' });
+
+    const { result, rerender } = renderHook((tab) => useTabMeta(tab), { wrapper, initialProps: firstTab });
+
+    await waitFor(() => expect(result.current.title).toBe('First Session'));
+
+    // Simulate useAgentSurfaceStore.commit() mirroring a new selection onto
+    // this tab's `search` via updateActiveTabSearch — same tab id/path, only
+    // the query string changes.
+    const secondTab = { ...firstTab, search: 'session=sess-2' };
+    rerender(secondTab);
+
+    await waitFor(() => expect(result.current.title).toBe('Second Session'));
+  });
+
+  it('reverts to the static "Agents" title when the session selection is cleared', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/api/agent-sessions/sess-1') return sessionResponse('First Session');
+      throw new Error(`unexpected url ${url}`);
+    });
+    const selectedTab = createTab({ path: '/dashboard/agents', search: 'session=sess-1' });
+
+    const { result, rerender } = renderHook((tab) => useTabMeta(tab), { wrapper, initialProps: selectedTab });
+
+    await waitFor(() => expect(result.current.title).toBe('First Session'));
+
+    rerender({ ...selectedTab, search: '' });
+
+    await waitFor(() => expect(result.current.title).toBe('Agents'));
+  });
+
+  it('applies the same session-name behavior to drive-scoped Agents tabs', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/api/agent-sessions/sess-1') return sessionResponse('Drive Session', 'drive-1');
+      throw new Error(`unexpected url ${url}`);
+    });
+    const tab = createTab({ path: '/dashboard/drive-1/agents', search: 'session=sess-1' });
+
+    const { result } = renderHook(() => useTabMeta(tab), { wrapper });
+
+    await waitFor(() => expect(result.current.title).toBe('Drive Session'));
+  });
+});

--- a/apps/web/src/hooks/__tests__/useTabMeta.test.ts
+++ b/apps/web/src/hooks/__tests__/useTabMeta.test.ts
@@ -66,6 +66,22 @@ describe('useTabMeta - Agents tab', () => {
     const { result } = renderHook(() => useTabMeta(tab), { wrapper });
 
     expect(result.current.title).toBe('Agents');
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('shows a generic "Session" fallback when the session resolves but has no name, instead of reading as unselected', async () => {
+    // An empty name is a supported, non-error wire value (AgentsSidebar falls
+    // back to 'Session' for the same case) - it must not collapse into the
+    // same "Agents" title as "no session selected".
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === '/api/agent-sessions/sess-1') return jsonResponse({ session: { sessionId: 'sess-1', driveId: 'drive-1', name: '' } });
+      throw new Error(`unexpected url ${url}`);
+    });
+    const tab = createTab({ path: '/dashboard/agents', search: 'session=sess-1' });
+
+    const { result } = renderHook(() => useTabMeta(tab), { wrapper });
+
+    await waitFor(() => expect(result.current.title).toBe('Session'));
   });
 
   it('falls back to the static "Agents" title when the session doesn\'t resolve (e.g. access denied)', async () => {

--- a/apps/web/src/hooks/useTabMeta.ts
+++ b/apps/web/src/hooks/useTabMeta.ts
@@ -75,7 +75,7 @@ export function useTabMeta(tab: Tab): UseTabMetaResult {
   // ever viewed in the tab).
   const isAgentsTab = parsed.type === 'dashboard-agents' || parsed.type === 'drive-agents';
   const agentsSessionId = isAgentsTab ? parseAgentSelection(tab.search).sessionId : null;
-  const { data: agentsSessionData } = useSessionRecord(agentsSessionId);
+  const { data: agentsSessionData, isLoading: isAgentsSessionLoading } = useSessionRecord(agentsSessionId);
 
   // Check if tab already has cached metadata for a page, channel, or public-page
   const isPageType = parsed.type === 'page' || parsed.type === 'channel' || parsed.type === 'public-page';
@@ -136,10 +136,23 @@ export function useTabMeta(tab: Tab): UseTabMetaResult {
   // of the generic "Agents" label. No session selected (list view) falls
   // through to the static meta below, unchanged.
   if (isAgentsTab && agentsSessionId) {
+    const agentsSession = agentsSessionData?.session;
+    if (agentsSession) {
+      // `name || 'Session'` matches AgentsSidebar's own fallback for a
+      // session with no label (a supported, non-error state) - an empty
+      // name must not read the same as "nothing resolved yet".
+      return {
+        title: agentsSession.name || 'Session',
+        iconName: 'Bot',
+        isLoading: false,
+      };
+    }
+    // Still resolving, or the session doesn't exist / access was denied -
+    // show the static list-view title rather than a "Loading..." flicker.
     return {
-      title: agentsSessionData?.session?.name || staticMeta?.title || 'Agents',
+      title: staticMeta?.title ?? 'Agents',
       iconName: 'Bot',
-      isLoading: false,
+      isLoading: isAgentsSessionLoading,
     };
   }
 

--- a/apps/web/src/hooks/useTabMeta.ts
+++ b/apps/web/src/hooks/useTabMeta.ts
@@ -7,6 +7,8 @@ import { useDriveStore } from '@/hooks/useDrive';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useTabsStore, type Tab } from '@/stores/useTabsStore';
 import { PageType } from '@pagespace/lib/utils/enums';
+import { parseAgentSelection } from '@/lib/agents/agent-selection';
+import { useSessionRecord } from '@/components/agents/useSessionRecord';
 
 interface PageMetaResponse {
   id: string;
@@ -66,6 +68,15 @@ export function useTabMeta(tab: Tab): UseTabMetaResult {
   const drives = useDriveStore((state) => state.drives);
   const updateTabMeta = useTabsStore((state) => state.updateTabMeta);
 
+  // Agents tab - the selected session lives in the query string, not the path,
+  // so it's read fresh from `tab.search` on every render rather than cached on
+  // the tab (search-only changes don't invalidate `tab.title` - see
+  // navigateInTab - which would otherwise freeze this on the first session
+  // ever viewed in the tab).
+  const isAgentsTab = parsed.type === 'dashboard-agents' || parsed.type === 'drive-agents';
+  const agentsSessionId = isAgentsTab ? parseAgentSelection(tab.search).sessionId : null;
+  const { data: agentsSessionData } = useSessionRecord(agentsSessionId);
+
   // Check if tab already has cached metadata for a page, channel, or public-page
   const isPageType = parsed.type === 'page' || parsed.type === 'channel' || parsed.type === 'public-page';
   const pageId = (parsed.type === 'page' || parsed.type === 'channel' || parsed.type === 'public-page') ? parsed.pageId : undefined;
@@ -120,6 +131,17 @@ export function useTabMeta(tab: Tab): UseTabMetaResult {
       });
     }
   }, [dmData, parsed.conversationId, tab.id, updateTabMeta]);
+
+  // Agents tab with a session selected - show the session's own name instead
+  // of the generic "Agents" label. No session selected (list view) falls
+  // through to the static meta below, unchanged.
+  if (isAgentsTab && agentsSessionId) {
+    return {
+      title: agentsSessionData?.session?.name || staticMeta?.title || 'Agents',
+      iconName: 'Bot',
+      isLoading: false,
+    };
+  }
 
   // Static routes - return immediately
   if (staticMeta) {


### PR DESCRIPTION
## Summary
- The app-level browser tab for the Agents surface always showed the static label "Agents", even with a specific session open — no way to tell tabs apart from the tab bar alone.
- `useTabMeta` now reads the selected session id out of the tab's `?session=` query string and, when present, shows that session's own `name` instead. No selection (list view) still shows "Agents".
- Session id is read fresh from `tab.search` on every render rather than cached on the tab object, since switching sessions is a search-only change within the same tab (wouldn't otherwise invalidate a cached title the way a path change does for page/DM tabs).
- A session that resolves with an empty `name` shows a generic "Session" fallback (matching `AgentsSidebar`'s existing convention) instead of collapsing into the same "Agents" title as "nothing selected" — an empty label is a valid, non-error state and must stay distinguishable from unselected.
- Added `apps/web/src/hooks/__tests__/useTabMeta.test.ts` (8 cases) covering: no session selected, session name shown once resolved, empty-name fallback, still-resolving fallback (with the real `isLoading` state), access-denied/not-found fallback, switching sessions within the same tab, clearing the selection, and the drive-scoped path variant. This hook had no prior test coverage at all.

## Test plan
- [x] `bun run --filter web typecheck` passes
- [x] `bun run --filter web test -- src/hooks/__tests__/useTabMeta.test.ts` — 8/8 passing
- [x] `bun run --filter web test -- src/hooks/__tests__ src/components/agents/__tests__ src/lib/agents/__tests__` — 733/733 passing (no regressions)
- [x] `bun run --filter web lint` — no issues in touched files
- [ ] Manually open a drive's Agents tab, select a session — tab title switches from "Agents" to the session name (truncated if long)
- [ ] Switch to a different session in the same tab — title updates again
- [ ] Clear the selection back to the list — title reverts to "Agents"
- [ ] Open a second Agents tab on a different session — each tab shows its own session name independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiV6odm1o3hJ7YELERCDuy
