### PR TITLE
fix(ai): AI chat panes losing their own live stream + whole-screen flash on staleness

### DIFF
--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -37,14 +37,22 @@ const chat = vi.hoisted(() => ({
     clearError: vi.fn(),
     addToolResult: vi.fn(),
   },
+  // Mutable per-test override for useChat's own live return — distinct from
+  // the shared conversation cache, so a test can simulate a stream that is
+  // in-flight in useChat's local state but not yet (or never) mirrored into
+  // usePendingStreamsStore/the rendered cache.
+  state: {
+    messages: [] as UIMessage[],
+    status: 'ready' as 'ready' | 'submitted' | 'streaming' | 'error',
+  },
 }));
 
 vi.mock('@ai-sdk/react', () => ({
   useChat: vi.fn((config: Record<string, unknown> | undefined) => {
     if (config && typeof config.id === 'string') chat.capturedConfigs.push(config);
     return {
-      messages: [] as UIMessage[],
-      status: 'ready' as const,
+      messages: chat.state.messages,
+      status: chat.state.status,
       error: undefined,
       ...chat.instance,
     };
@@ -103,6 +111,7 @@ vi.mock('sonner', () => ({
 
 import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { useAgentSessionChat } from '../useAgentSessionChat';
 
 function agentFixture(id: string): AgentInfo {
@@ -129,9 +138,12 @@ function ids(slug: string) {
 beforeEach(() => {
   vi.clearAllMocks();
   chat.capturedConfigs.length = 0;
+  chat.state.messages = [];
+  chat.state.status = 'ready';
   multiplayer.calls.length = 0;
   activeStream.remoteStreams = [];
   useConversationMessagesStore.setState({ byConversationId: {} });
+  usePendingStreamsStore.setState({ streams: new Map() });
   mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({}) });
 });
 
@@ -320,5 +332,37 @@ describe('useAgentSessionChat', () => {
     const { result } = renderHook(() => useAgentSessionChat({ agent, conversationId }));
 
     expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(false);
+  });
+
+  // Regression: the sender's own pane went blank mid-stream while other viewers saw the reply
+  // stream in fine. useOwnStreamMirror's `ownMessages` must be useChat's OWN live-growing
+  // `messages` array (its doc comment: "This chat's ENTIRE message array (useChat's local
+  // state) — not a pre-picked message") so it can copy the in-flight assistant reply into
+  // usePendingStreamsStore — the store every pane actually renders from. Feeding it the
+  // rendered/cache-derived array instead (what shadowed a `messages` binding of the same name
+  // here) leaves that store empty for the sender, so their own pane shows nothing until a later
+  // reload. This test mounts the hook with useChat mid-stream (status: 'streaming', an assistant
+  // reply as the last message) and asserts the mirror actually wrote that message into the store.
+  it('mirrors an in-progress own-stream assistant reply into usePendingStreamsStore, from useChat\'s own live messages', async () => {
+    const { agent, conversationId } = ids('own-stream-mirror');
+    chat.state.status = 'streaming';
+    chat.state.messages = [
+      { id: 'm-user-1', role: 'user', parts: [{ type: 'text', text: 'hello agent' }] } as UIMessage,
+      {
+        id: 'm-assistant-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Partial reply in progress...' }],
+      } as UIMessage,
+    ];
+
+    renderHook(() => useAgentSessionChat({ agent, conversationId }));
+
+    await waitFor(() => {
+      const entry = usePendingStreamsStore.getState().streams.get('m-assistant-1');
+      expect(entry).toBeDefined();
+      expect(entry?.isOwn).toBe(true);
+      expect(entry?.pageId).toBe(agent.id);
+      expect(entry?.conversationId).toBe(conversationId);
+    });
   });
 });

--- a/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
@@ -35,14 +35,22 @@ const chat = vi.hoisted(() => ({
     clearError: vi.fn(),
     addToolResult: vi.fn(),
   },
+  // Mutable per-test override for useChat's own live return — distinct from
+  // the shared conversation cache, so a test can simulate a stream that is
+  // in-flight in useChat's local state but not yet (or never) mirrored into
+  // usePendingStreamsStore/the rendered cache.
+  state: {
+    messages: [] as UIMessage[],
+    status: 'ready' as 'ready' | 'submitted' | 'streaming' | 'error',
+  },
 }));
 
 vi.mock('@ai-sdk/react', () => ({
   useChat: vi.fn((config: Record<string, unknown> | undefined) => {
     if (config && typeof config.id === 'string') chat.capturedConfigs.push(config);
     return {
-      messages: [] as UIMessage[],
-      status: 'ready' as const,
+      messages: chat.state.messages,
+      status: chat.state.status,
       error: undefined,
       ...chat.instance,
     };
@@ -93,6 +101,8 @@ vi.mock('@/contexts/GlobalChatContext', () => ({
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
 import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { useAssistantSessionChat } from '../useAssistantSessionChat';
 
 function ids(slug: string) {
@@ -124,9 +134,12 @@ function sentBody() {
 beforeEach(() => {
   vi.clearAllMocks();
   chat.capturedConfigs.length = 0;
+  chat.state.messages = [];
+  chat.state.status = 'ready';
   route.pathname = '/dashboard/agents';
   activeStream.remoteStreams = [];
   useConversationMessagesStore.setState({ byConversationId: {} });
+  usePendingStreamsStore.setState({ streams: new Map() });
   useDriveStore.setState({ drives: [driveFixture('drive-1', 'Engineering')] });
   mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({}) });
 });
@@ -257,5 +270,35 @@ describe('useAssistantSessionChat — ask_user answering', () => {
     const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
 
     expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(false);
+  });
+});
+
+describe('useAssistantSessionChat — own-stream mirror', () => {
+  // Regression, sibling of useAgentSessionChat.test.ts's: the sender's own pane went blank
+  // mid-stream while other viewers saw the reply stream in fine. useOwnStreamMirror's
+  // `ownMessages` must be useChat's OWN live-growing `messages` array, not the
+  // rendered/cache-derived array this hook also happens to bind under the name `messages` —
+  // feeding it the latter leaves usePendingStreamsStore empty for the sender.
+  it("mirrors an in-progress own-stream assistant reply into usePendingStreamsStore, from useChat's own live messages", async () => {
+    const { conversationId } = ids('own-stream-mirror');
+    chat.state.status = 'streaming';
+    chat.state.messages = [
+      { id: 'm-user-1', role: 'user', parts: [{ type: 'text', text: 'hello' }] } as UIMessage,
+      {
+        id: 'm-assistant-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Partial reply in progress...' }],
+      } as UIMessage,
+    ];
+
+    renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
+
+    await waitFor(() => {
+      const entry = usePendingStreamsStore.getState().streams.get('m-assistant-1');
+      expect(entry).toBeDefined();
+      expect(entry?.isOwn).toBe(true);
+      expect(entry?.pageId).toBe(globalChannelId('user-1'));
+      expect(entry?.conversationId).toBe(conversationId);
+    });
   });
 });

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -117,9 +117,17 @@ export function useAgentSessionChat({
     });
   }, [transport, conversationId]);
 
-  const { sendMessage, status, error, clearError, regenerate, setMessages, stop, addToolResult } = useChat(
-    chatConfig ?? {},
-  );
+  const {
+    messages: agentChatMessages,
+    sendMessage,
+    status,
+    error,
+    clearError,
+    regenerate,
+    setMessages,
+    stop,
+    addToolResult,
+  } = useChat(chatConfig ?? {});
   const isStreaming = status === 'submitted' || status === 'streaming';
 
   const loadConversation = useCallback(
@@ -155,7 +163,7 @@ export function useAgentSessionChat({
   );
   const { getLatchedConversationId } = useOwnStreamMirror({
     status,
-    ownMessages: messages,
+    ownMessages: agentChatMessages,
     pageId: agent.id,
     conversationId,
     triggeredBy: mirrorTriggeredBy,

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -111,9 +111,17 @@ export function useAssistantSessionChat({
     });
   }, [transport, conversationId]);
 
-  const { sendMessage, status, error, clearError, regenerate, setMessages, stop, addToolResult } = useChat(
-    chatConfig ?? {},
-  );
+  const {
+    messages: assistantChatMessages,
+    sendMessage,
+    status,
+    error,
+    clearError,
+    regenerate,
+    setMessages,
+    stop,
+    addToolResult,
+  } = useChat(chatConfig ?? {});
   const isStreaming = status === 'submitted' || status === 'streaming';
 
   // No channel socket mounted here: GlobalChatProvider wraps the whole Layout
@@ -146,7 +154,7 @@ export function useAssistantSessionChat({
   );
   const { getLatchedConversationId } = useOwnStreamMirror({
     status,
-    ownMessages: messages,
+    ownMessages: assistantChatMessages,
     pageId: channelId ?? '',
     conversationId,
     triggeredBy: mirrorTriggeredBy,

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -26,7 +26,7 @@ import { useTabSync } from "@/hooks/useTabSync";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { useEditingStore } from "@/stores/useEditingStore";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Sheet,
   SheetContent,
@@ -56,6 +56,16 @@ interface LayoutProps {
 
 function Layout({ children }: LayoutProps) {
   const { isLoading, isAuthenticated } = useAuth();
+  // Has THIS mount observed a successful auth check yet? Starts false on every fresh
+  // mount regardless of what isAuthenticated was optimistically restored to from
+  // localStorage — see shouldShowAuthLoadingScreen's doc comment. Mutated inline
+  // during render (not an effect): the very render where isLoading first resolves to
+  // false while authenticated is exactly the render that no longer needs the ref, so
+  // there is no one-tick lag to matter for.
+  const hasConfirmedAuthRef = useRef(false);
+  if (isAuthenticated && !isLoading) {
+    hasConfirmedAuthRef.current = true;
+  }
   const router = useRouter();
   const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
 
@@ -294,7 +304,14 @@ function Layout({ children }: LayoutProps) {
   // Gated on shouldShowAuthLoadingScreen (not a raw isLoading check) so a routine
   // background loadSession() recheck of an ALREADY-authenticated session doesn't
   // unmount this entire subtree — GlobalChatProvider included — down to a spinner.
-  if (shouldShowAuthLoadingScreen({ isLoading, hasHydrated, isAuthenticated })) {
+  if (
+    shouldShowAuthLoadingScreen({
+      isLoading,
+      hasHydrated,
+      isAuthenticated,
+      hasConfirmedAuthThisMount: hasConfirmedAuthRef.current,
+    })
+  ) {
     return (
       <div className="flex items-center justify-center h-screen">
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -45,6 +45,7 @@ import {
   getRightSidebarSizeFromLayout,
   type ResizablePanelLayout,
 } from "@/components/layout/panel-layout";
+import { shouldShowAuthLoadingScreen } from "@/components/layout/shouldShowAuthLoadingScreen";
 
 const panelContainerClassName =
   "h-full w-full min-h-0 min-w-0 overflow-hidden @container";
@@ -289,8 +290,11 @@ function Layout({ children }: LayoutProps) {
     }
   }, []);
 
-  // Optimize loading checks - show UI earlier for better perceived performance
-  if (isLoading || !hasHydrated) {
+  // Optimize loading checks - show UI earlier for better perceived performance.
+  // Gated on shouldShowAuthLoadingScreen (not a raw isLoading check) so a routine
+  // background loadSession() recheck of an ALREADY-authenticated session doesn't
+  // unmount this entire subtree — GlobalChatProvider included — down to a spinner.
+  if (shouldShowAuthLoadingScreen({ isLoading, hasHydrated, isAuthenticated })) {
     return (
       <div className="flex items-center justify-center h-screen">
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/layout/LayoutErrorBoundary.tsx
+++ b/apps/web/src/components/layout/LayoutErrorBoundary.tsx
@@ -68,6 +68,8 @@ export class LayoutErrorBoundary extends Component<Props, State> {
     try {
       // Clear localStorage that might be corrupted
       localStorage.removeItem('layout-storage');
+      localStorage.removeItem('agent-workspace-storage');
+      localStorage.removeItem('drive-storage');
       sessionStorage.clear();
 
       console.log('Cleared potentially corrupted state');

--- a/apps/web/src/components/layout/LayoutErrorBoundary.tsx
+++ b/apps/web/src/components/layout/LayoutErrorBoundary.tsx
@@ -66,7 +66,17 @@ export class LayoutErrorBoundary extends Component<Props, State> {
 
   private clearCorruptedState = () => {
     try {
-      // Clear localStorage that might be corrupted
+      // Clear localStorage that might be corrupted. Deliberately NOT every
+      // persisted store this boundary wraps (there are more — see any
+      // `persist({ name: ... })` call under apps/web/src/stores and
+      // apps/web/src/hooks) — just the ones a prior crash-recovery
+      // investigation traced a bad reload to. USER_SPECIFIC_STORAGE_KEYS
+      // (clear-user-stores-core.ts) is a DIFFERENT list for a different
+      // trigger (sign-in identity switch) and isn't a drop-in replacement —
+      // it omits agent-workspace-storage/layout-storage entirely. A future
+      // corrupted store discovered here should be added explicitly; a
+      // shared "every persisted key" registry that both call sites draw
+      // from would be the deeper fix, not attempted in this pass.
       localStorage.removeItem('layout-storage');
       localStorage.removeItem('agent-workspace-storage');
       localStorage.removeItem('drive-storage');

--- a/apps/web/src/components/layout/__tests__/LayoutErrorBoundary.test.tsx
+++ b/apps/web/src/components/layout/__tests__/LayoutErrorBoundary.test.tsx
@@ -38,4 +38,24 @@ describe('LayoutErrorBoundary', () => {
     expect(screen.getByText('all good')).toBeInTheDocument();
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
+
+  // Regression: clearCorruptedState only ever removed 'layout-storage', so a corrupted
+  // 'agent-workspace-storage' or 'drive-storage' localStorage entry (the two other
+  // persisted Zustand stores backing the layout this boundary wraps) survived "Try
+  // Again"/"Reload Page" and re-threw the identical crash on every subsequent load.
+  it('clears the agent-workspace and drive persisted stores alongside layout-storage on catch', () => {
+    localStorage.setItem('layout-storage', 'x');
+    localStorage.setItem('agent-workspace-storage', 'x');
+    localStorage.setItem('drive-storage', 'x');
+
+    render(
+      <LayoutErrorBoundary>
+        <Bomb />
+      </LayoutErrorBoundary>
+    );
+
+    expect(localStorage.getItem('layout-storage')).toBeNull();
+    expect(localStorage.getItem('agent-workspace-storage')).toBeNull();
+    expect(localStorage.getItem('drive-storage')).toBeNull();
+  });
 });

--- a/apps/web/src/components/layout/__tests__/shouldShowAuthLoadingScreen.test.ts
+++ b/apps/web/src/components/layout/__tests__/shouldShowAuthLoadingScreen.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowAuthLoadingScreen } from '../shouldShowAuthLoadingScreen';
+
+describe('shouldShowAuthLoadingScreen', () => {
+  it('given hydration has not completed yet, should show the loading screen regardless of anything else', () => {
+    expect(
+      shouldShowAuthLoadingScreen({ hasHydrated: false, isLoading: false, isAuthenticated: true }),
+    ).toBe(true);
+  });
+
+  it('given a cold boot (hydrated, loading, never authenticated), should show the loading screen', () => {
+    expect(
+      shouldShowAuthLoadingScreen({ hasHydrated: true, isLoading: true, isAuthenticated: false }),
+    ).toBe(true);
+  });
+
+  // Regression: this is the case that used to unmount the ENTIRE app shell — including
+  // GlobalChatProvider, tearing down every socket room and wiping usePendingStreamsStore —
+  // for a routine 15-minute background loadSession() recheck of an already-good session.
+  it('given a background re-check of an ALREADY-authenticated session (isLoading transiently true), should NOT show the loading screen', () => {
+    expect(
+      shouldShowAuthLoadingScreen({ hasHydrated: true, isLoading: true, isAuthenticated: true }),
+    ).toBe(false);
+  });
+
+  it('given hydrated, not loading, and authenticated (the steady state), should not show the loading screen', () => {
+    expect(
+      shouldShowAuthLoadingScreen({ hasHydrated: true, isLoading: false, isAuthenticated: true }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/layout/__tests__/shouldShowAuthLoadingScreen.test.ts
+++ b/apps/web/src/components/layout/__tests__/shouldShowAuthLoadingScreen.test.ts
@@ -4,28 +4,68 @@ import { shouldShowAuthLoadingScreen } from '../shouldShowAuthLoadingScreen';
 describe('shouldShowAuthLoadingScreen', () => {
   it('given hydration has not completed yet, should show the loading screen regardless of anything else', () => {
     expect(
-      shouldShowAuthLoadingScreen({ hasHydrated: false, isLoading: false, isAuthenticated: true }),
+      shouldShowAuthLoadingScreen({
+        hasHydrated: false,
+        isLoading: false,
+        isAuthenticated: true,
+        hasConfirmedAuthThisMount: true,
+      }),
     ).toBe(true);
   });
 
   it('given a cold boot (hydrated, loading, never authenticated), should show the loading screen', () => {
     expect(
-      shouldShowAuthLoadingScreen({ hasHydrated: true, isLoading: true, isAuthenticated: false }),
+      shouldShowAuthLoadingScreen({
+        hasHydrated: true,
+        isLoading: true,
+        isAuthenticated: false,
+        hasConfirmedAuthThisMount: false,
+      }),
     ).toBe(true);
   });
 
   // Regression: this is the case that used to unmount the ENTIRE app shell — including
   // GlobalChatProvider, tearing down every socket room and wiping usePendingStreamsStore —
   // for a routine 15-minute background loadSession() recheck of an already-good session.
+  // hasConfirmedAuthThisMount: true because this mount already rendered authenticated once —
+  // that's what makes it a background recheck rather than a fresh boot.
   it('given a background re-check of an ALREADY-authenticated session (isLoading transiently true), should NOT show the loading screen', () => {
     expect(
-      shouldShowAuthLoadingScreen({ hasHydrated: true, isLoading: true, isAuthenticated: true }),
+      shouldShowAuthLoadingScreen({
+        hasHydrated: true,
+        isLoading: true,
+        isAuthenticated: true,
+        hasConfirmedAuthThisMount: true,
+      }),
     ).toBe(false);
   });
 
   it('given hydrated, not loading, and authenticated (the steady state), should not show the loading screen', () => {
     expect(
-      shouldShowAuthLoadingScreen({ hasHydrated: true, isLoading: false, isAuthenticated: true }),
+      shouldShowAuthLoadingScreen({
+        hasHydrated: true,
+        isLoading: false,
+        isAuthenticated: true,
+        hasConfirmedAuthThisMount: true,
+      }),
     ).toBe(false);
+  });
+
+  // Regression (review finding, PR #2312): a hard reload can restore a STALE persisted
+  // isAuthenticated: true (useAuthStore's partialize) for a session that was actually
+  // expired/revoked while the tab was closed. hasConfirmedAuthThisMount is false here
+  // because this mount has never itself observed a successful check — the persisted flag
+  // is unverified. Bypassing the loading screen in this exact case would render real
+  // cached drive/sidebar data before the first check's eventual 401 redirects away.
+  // Only a background recheck WITHIN an already-confirmed mount should bypass it.
+  it("given a fresh mount's FIRST auth check is in flight, with stale persisted isAuthenticated: true, should still show the loading screen", () => {
+    expect(
+      shouldShowAuthLoadingScreen({
+        hasHydrated: true,
+        isLoading: true,
+        isAuthenticated: true,
+        hasConfirmedAuthThisMount: false,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/components/layout/shouldShowAuthLoadingScreen.ts
+++ b/apps/web/src/components/layout/shouldShowAuthLoadingScreen.ts
@@ -10,11 +10,25 @@
  * the whole shell on that background case is what turned an ordinary auth refresh
  * into a whole-screen unmount/remount — tearing down every live socket room and
  * wiping `usePendingStreamsStore` in the process.
+ *
+ * `hasConfirmedAuthThisMount` (review finding, PR #2312) closes a gap the above
+ * alone leaves open: `isAuthenticated: true` is itself persisted, so a hard reload
+ * with a session that actually expired/was revoked while the tab was closed would
+ * otherwise bypass the screen on its very FIRST, still-unverified check — rendering
+ * real cached drive/sidebar data before the eventual 401 redirects away. The caller
+ * (`Layout.tsx`) tracks this per-mount, not per-store, deliberately: it's "has THIS
+ * tab observed a successful check yet," which starts false on every fresh mount
+ * regardless of what `isAuthenticated` was restored to, and only a LATER background
+ * recheck within an already-confirmed mount may skip the screen.
  */
 export function shouldShowAuthLoadingScreen(state: {
   isLoading: boolean;
   hasHydrated: boolean;
   isAuthenticated: boolean;
+  hasConfirmedAuthThisMount: boolean;
 }): boolean {
-  return !state.hasHydrated || (state.isLoading && !state.isAuthenticated);
+  return (
+    !state.hasHydrated ||
+    (state.isLoading && (!state.isAuthenticated || !state.hasConfirmedAuthThisMount))
+  );
 }

--- a/apps/web/src/components/layout/shouldShowAuthLoadingScreen.ts
+++ b/apps/web/src/components/layout/shouldShowAuthLoadingScreen.ts
@@ -1,0 +1,20 @@
+/**
+ * Should `Layout` blank its entire subtree (TopBar, sidebars, CenterPanel, RightPanel,
+ * and — critically — `GlobalChatProvider`, which owns every socket room subscription
+ * and the pending-streams store) down to a bare spinner?
+ *
+ * Only for a genuine cold boot — never for `loadSession`'s routine background
+ * revalidation of an already-authenticated session (`isAuthenticated: true` persists
+ * across reloads via `useAuthStore`'s `partialize`, but `isLoading` flips true on
+ * every `loadSession` call, cold boot or 15-minute background recheck alike). Gating
+ * the whole shell on that background case is what turned an ordinary auth refresh
+ * into a whole-screen unmount/remount — tearing down every live socket room and
+ * wiping `usePendingStreamsStore` in the process.
+ */
+export function shouldShowAuthLoadingScreen(state: {
+  isLoading: boolean;
+  hasHydrated: boolean;
+  isAuthenticated: boolean;
+}): boolean {
+  return !state.hasHydrated || (state.isLoading && !state.isAuthenticated);
+}

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -125,6 +125,7 @@ import {
   getChannelStreamSubscriberCount,
   resetChannelStreamSubscribers,
 } from '@/lib/ai/streams/channelStreamSubscribers';
+import { resetChannelRebootstrapSignal } from '@/lib/ai/streams/channelRebootstrapSignal';
 import type {
   AiStreamStartPayload,
   AiStreamCompletePayload,
@@ -208,6 +209,7 @@ describe('useChannelStreamSocket', () => {
     // Module state — a real reload clears it; a test file must too.
     resetConsumingChannels();
     resetChannelStreamSubscribers();
+    resetChannelRebootstrapSignal();
     mockConnectionStatus = 'disconnected';
     mockAuthUserId = LOCAL_USER_ID;
     mockConsumeStreamJoin.mockResolvedValue({ aborted: false });
@@ -1310,6 +1312,32 @@ describe('useChannelStreamSocket', () => {
       act(() => { mockSocket._trigger('access_revoked', { room: 'page-a', reason: 'permission_revoked' }); });
 
       expect(mockClearPageStreams).not.toHaveBeenCalled();
+    });
+
+    // Correctness-review finding (PR #2312): the abort loop released every controller's
+    // bootstrap claim but never removed the entries from `controllers` itself. A LATER
+    // real unmount (which can lag behind access_revoked by however long this component
+    // stays mounted showing a "you lost access" state) then read those stale entries as
+    // "was I actively consuming something," double-releasing an already-released claim
+    // and — worse — spuriously notifying a sibling to re-bootstrap a channel this user
+    // no longer has access to.
+    it('given access_revoked fires while a controller is active, a LATER real unmount should NOT double-release the claim or spuriously notify a sibling', async () => {
+      const first = renderHook(() => useChannelStreamSocket('page-a'));
+      const second = renderHook(() => useChannelStreamSocket('page-a'));
+
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+      act(() => { mockSocket._trigger('access_revoked', { room: 'page-a', reason: 'permission_revoked' }); });
+
+      vi.mocked(releaseBootstrapConsumer).mockClear();
+      const fetchCallsBeforeUnmount = mockFetchWithAuth.mock.calls.length;
+
+      first.unmount();
+      await act(async () => { await Promise.resolve(); });
+
+      expect(releaseBootstrapConsumer).not.toHaveBeenCalled();
+      expect(mockFetchWithAuth.mock.calls.length).toBe(fetchCallsBeforeUnmount);
+
+      second.unmount();
     });
   });
 

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -1372,6 +1372,64 @@ describe('useChannelStreamSocket', () => {
     });
   });
 
+  describe('sibling handoff on live-consumer unmount', () => {
+    // Review finding (chatgpt-codex-connector, PR #2312, P1): the refcount fix above
+    // stops the STORE from being wiped when a sibling remains, but does nothing about
+    // the actual live SSE connection — startConsume is claim-gated (bootstrapConsumerGuard),
+    // so only ONE co-mounted instance ever holds it per messageId. If THAT instance
+    // unmounts, its cleanup releases the claim but nothing tells a surviving sibling to
+    // reclaim consumption — the sibling's copy of the stream would silently stop
+    // receiving new tokens (frozen) until chat:stream_complete eventually arrives.
+    it('given the unmounting subscriber was actively consuming a live stream and a sibling remains, should trigger the sibling to re-bootstrap and reclaim consumption', async () => {
+      const first = renderHook(() => useChannelStreamSocket('page-a'));
+      const second = renderHook(() => useChannelStreamSocket('page-a'));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      const fetchCallsBeforeUnmount = mockFetchWithAuth.mock.calls.length;
+
+      // Both instances observe the same live start (mock socket broadcasts to every
+      // registered handler); at least one instance now holds an active controller for
+      // msg-1, which is what should be handed off on unmount.
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      first.unmount();
+      await act(async () => { await Promise.resolve(); });
+
+      expect(mockFetchWithAuth.mock.calls.length).toBeGreaterThan(fetchCallsBeforeUnmount);
+      expect(mockFetchWithAuth).toHaveBeenLastCalledWith(
+        '/api/ai/chat/active-streams?channelId=page-a',
+        expect.anything(),
+      );
+
+      second.unmount();
+    });
+
+    it('given the unmounting subscriber had NO active streams, should NOT trigger a sibling re-bootstrap (nothing to hand off)', async () => {
+      const first = renderHook(() => useChannelStreamSocket('page-a'));
+      const second = renderHook(() => useChannelStreamSocket('page-a'));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      const fetchCallsBeforeUnmount = mockFetchWithAuth.mock.calls.length;
+
+      first.unmount(); // never received chat:stream_start — controllers is empty
+      await act(async () => { await Promise.resolve(); });
+
+      expect(mockFetchWithAuth.mock.calls.length).toBe(fetchCallsBeforeUnmount);
+
+      second.unmount();
+    });
+
+    it('given the unmounting subscriber was the LAST subscriber (no sibling), should NOT attempt a handoff notify', () => {
+      const only = renderHook(() => useChannelStreamSocket('page-a'));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      // No sibling exists to notify — clearPageStreams fires (the existing
+      // last-subscriber path) and nothing should throw reaching for a nonexistent peer.
+      expect(() => only.unmount()).not.toThrow();
+      expect(mockClearPageStreams).toHaveBeenCalledWith('page-a');
+    });
+  });
+
   // AC5 — DB bootstrap on mount
   describe('DB bootstrap on mount', () => {
     it('given the hook mounts, should fetch active streams for the channelId', async () => {

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -121,6 +121,10 @@ import { useChannelStreamSocket } from '../useChannelStreamSocket';
 import { StreamJoinError } from '@/lib/ai/core/stream-join-client';
 import { releaseBootstrapConsumer } from '@/lib/ai/streams/bootstrapConsumerGuard';
 import { markChannelConsuming, resetConsumingChannels } from '@/lib/ai/streams/consumingChannels';
+import {
+  getChannelStreamSubscriberCount,
+  resetChannelStreamSubscribers,
+} from '@/lib/ai/streams/channelStreamSubscribers';
 import type {
   AiStreamStartPayload,
   AiStreamCompletePayload,
@@ -203,6 +207,7 @@ describe('useChannelStreamSocket', () => {
     mockSocket._reset();
     // Module state — a real reload clears it; a test file must too.
     resetConsumingChannels();
+    resetChannelStreamSubscribers();
     mockConnectionStatus = 'disconnected';
     mockAuthUserId = LOCAL_USER_ID;
     mockConsumeStreamJoin.mockResolvedValue({ aborted: false });
@@ -1324,6 +1329,46 @@ describe('useChannelStreamSocket', () => {
       expect(mockClearPageStreams).toHaveBeenCalledWith('page-a');
       expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_start', expect.any(Function));
       expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_complete', expect.any(Function));
+    });
+  });
+
+  describe('clearPageStreams — multi-subscriber refcounting', () => {
+    // Regression: two panes can be open on the same agent channel at once (by design —
+    // select-pane-agent.ts). Before refcounting, EITHER pane's unmount wiped the WHOLE
+    // channel's streams out of usePendingStreamsStore, including a sibling pane's own
+    // still-mid-generation stream.
+    it('given two subscribers on the same channel, unmounting one should NOT clearPageStreams (a sibling is still subscribed)', () => {
+      const first = renderHook(() => useChannelStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
+      expect(getChannelStreamSubscriberCount('page-a')).toBe(2);
+
+      first.unmount();
+
+      expect(mockClearPageStreams).not.toHaveBeenCalled();
+      expect(getChannelStreamSubscriberCount('page-a')).toBe(1);
+    });
+
+    it('given two subscribers on the same channel, unmounting the LAST one should clearPageStreams', () => {
+      const first = renderHook(() => useChannelStreamSocket('page-a'));
+      const second = renderHook(() => useChannelStreamSocket('page-a'));
+
+      first.unmount();
+      mockClearPageStreams.mockClear();
+      second.unmount();
+
+      expect(mockClearPageStreams).toHaveBeenCalledWith('page-a');
+      expect(getChannelStreamSubscriberCount('page-a')).toBe(0);
+    });
+
+    it('given subscribers on two DIFFERENT channels, unmounting one should not affect the other channel\'s count or clear it', () => {
+      const onA = renderHook(() => useChannelStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-b'));
+
+      onA.unmount();
+
+      expect(mockClearPageStreams).toHaveBeenCalledWith('page-a');
+      expect(mockClearPageStreams).not.toHaveBeenCalledWith('page-b');
+      expect(getChannelStreamSubscriberCount('page-b')).toBe(1);
     });
   });
 

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -686,6 +686,13 @@ export function useChannelStreamSocket(
         controller.abort();
         releaseBootstrapConsumer(msgId);
       }
+      // Correctness-review finding: without this, a stale entry survives here (the
+      // aborted consumeStreamJoin's .then()/.catch() returns early on `cancelled`
+      // before reaching its own controllers.delete) and a LATER real unmount reads it
+      // as "was I actively consuming something" — double-releasing an already-released
+      // claim and spuriously notifying a sibling to re-bootstrap a channel this user no
+      // longer has access to.
+      controllers.clear();
       abortAllPolls();
       // Release every own-stream claim we handed out. This is the ONLY chance: `cancelled`
       // is latched on this effect closure, so every future runBootstrap — including the

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -11,6 +11,10 @@ import { isOwnStream } from '@/lib/ai/streams/isOwnStream';
 import { shouldAttachStream } from '@/lib/ai/streams/shouldAttachStream';
 import { isChannelConsuming } from '@/lib/ai/streams/consumingChannels';
 import {
+  registerChannelStreamSubscriber,
+  unregisterChannelStreamSubscriber,
+} from '@/lib/ai/streams/channelStreamSubscribers';
+import {
   shouldRefreshOnReconnect,
   type ConnectionStatus,
 } from '@/lib/ai/streams/shouldRefreshOnReconnect';
@@ -205,6 +209,8 @@ export function useChannelStreamSocket(
 
   useEffect(() => {
     if (!socket || !channelId) return;
+
+    registerChannelStreamSubscriber(channelId);
 
     let cancelled = false;
     const localBrowserSessionId = getBrowserSessionId();
@@ -718,7 +724,14 @@ export function useChannelStreamSocket(
         releaseBootstrapConsumer(msgId);
       }
       abortAllPolls();
-      clearPageStreams(channelId);
+      // Scoped to the LAST subscriber for this channel — agent panes routinely
+      // co-mount multiple independent instances on the same channelId (the same
+      // agent open in more than one pane), and clearing unconditionally here wiped
+      // a sibling pane's still-mid-generation stream out of the store.
+      const wasLastSubscriber = unregisterChannelStreamSubscriber(channelId);
+      if (wasLastSubscriber) {
+        clearPageStreams(channelId);
+      }
     };
   }, [socket, channelId]);
 

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -15,6 +15,11 @@ import {
   unregisterChannelStreamSubscriber,
 } from '@/lib/ai/streams/channelStreamSubscribers';
 import {
+  registerChannelRebootstrap,
+  unregisterChannelRebootstrap,
+  notifyRemainingChannelSubscribers,
+} from '@/lib/ai/streams/channelRebootstrapSignal';
+import {
   shouldRefreshOnReconnect,
   type ConnectionStatus,
 } from '@/lib/ai/streams/shouldRefreshOnReconnect';
@@ -211,6 +216,12 @@ export function useChannelStreamSocket(
     if (!socket || !channelId) return;
 
     registerChannelStreamSubscriber(channelId);
+    // Lets a sibling reclaim this instance's live consumption if it unmounts while
+    // holding one — see channelRebootstrapSignal.ts. Reads bootstrapRef.current at
+    // CALL time (not closed over now), so it always invokes THIS effect run's own
+    // runBootstrap once that's assigned below.
+    const rebootstrapSelf = () => bootstrapRef.current?.();
+    registerChannelRebootstrap(channelId, rebootstrapSelf);
 
     let cancelled = false;
     const localBrowserSessionId = getBrowserSessionId();
@@ -719,6 +730,12 @@ export function useChannelStreamSocket(
       socket.off('chat:conversation_deleted', handleConversationDeleted);
       socket.off('chat:global_conversation_added', handleGlobalConversationAdded);
       socket.off('access_revoked', handleAccessRevoked);
+      unregisterChannelRebootstrap(channelId, rebootstrapSelf);
+      // Did THIS instance hold the live claim for anything (startConsume is
+      // claim-gated — only one co-mounted instance per channel ever does)? If so,
+      // a surviving sibling's copy of that stream is about to freeze the moment we
+      // release the claim below unless something reclaims it.
+      const wasConsumingLiveStreams = controllers.size > 0;
       for (const [msgId, controller] of controllers.entries()) {
         controller.abort();
         releaseBootstrapConsumer(msgId);
@@ -731,6 +748,11 @@ export function useChannelStreamSocket(
       const wasLastSubscriber = unregisterChannelStreamSubscriber(channelId);
       if (wasLastSubscriber) {
         clearPageStreams(channelId);
+      } else if (wasConsumingLiveStreams) {
+        // A sibling remains and our claim(s) just released — nudge every remaining
+        // subscriber's bootstrap to reclaim consumption. Idempotent and safe even
+        // with multiple siblings (same pattern as the reconnect re-bootstrap below).
+        notifyRemainingChannelSubscribers(channelId);
       }
     };
   }, [socket, channelId]);

--- a/apps/web/src/lib/ai/streams/__tests__/channelRebootstrapSignal.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/channelRebootstrapSignal.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  registerChannelRebootstrap,
+  unregisterChannelRebootstrap,
+  notifyRemainingChannelSubscribers,
+  resetChannelRebootstrapSignal,
+} from '../channelRebootstrapSignal';
+
+describe('channelRebootstrapSignal', () => {
+  beforeEach(() => {
+    resetChannelRebootstrapSignal();
+  });
+
+  it('given a registered callback, notifying its channel should call it', () => {
+    const callback = vi.fn();
+    registerChannelRebootstrap('page-a', callback);
+
+    notifyRemainingChannelSubscribers('page-a');
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('given two registered callbacks on one channel, notifying should call both', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    registerChannelRebootstrap('page-a', first);
+    registerChannelRebootstrap('page-a', second);
+
+    notifyRemainingChannelSubscribers('page-a');
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('given callbacks on two different channels, notifying one should not call the other\'s', () => {
+    const onA = vi.fn();
+    const onB = vi.fn();
+    registerChannelRebootstrap('page-a', onA);
+    registerChannelRebootstrap('page-b', onB);
+
+    notifyRemainingChannelSubscribers('page-a');
+
+    expect(onA).toHaveBeenCalledTimes(1);
+    expect(onB).not.toHaveBeenCalled();
+  });
+
+  it('given an unregistered callback, notifying should not call it', () => {
+    const callback = vi.fn();
+    registerChannelRebootstrap('page-a', callback);
+    unregisterChannelRebootstrap('page-a', callback);
+
+    notifyRemainingChannelSubscribers('page-a');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('given one of two callbacks unregisters, notifying should only call the remaining one', () => {
+    const leaving = vi.fn();
+    const staying = vi.fn();
+    registerChannelRebootstrap('page-a', leaving);
+    registerChannelRebootstrap('page-a', staying);
+
+    unregisterChannelRebootstrap('page-a', leaving);
+    notifyRemainingChannelSubscribers('page-a');
+
+    expect(leaving).not.toHaveBeenCalled();
+    expect(staying).toHaveBeenCalledTimes(1);
+  });
+
+  // Coverage gap this closes: unregister is called unconditionally by every unmounting
+  // useChannelStreamSocket instance, regardless of whether this exact channel/callback pair
+  // was ever registered (e.g. a channelId that changed before the effect's first run
+  // completed). Must be a safe no-op, not a throw.
+  it('given an unregister for a channel that was never registered, should not throw', () => {
+    expect(() => unregisterChannelRebootstrap('page-never', vi.fn())).not.toThrow();
+  });
+
+  // Coverage gap this closes: notifyRemainingChannelSubscribers is only reachable in
+  // production when a sibling remains registered (useChannelStreamSocket gates the call on
+  // wasLastSubscriber being false) — but as a standalone module function it must still
+  // safely no-op when called for a channel with no registered subscribers at all, rather
+  // than assuming the caller's invariant always holds.
+  it('given a notify for a channel with no registered subscribers, should not throw and should call nothing', () => {
+    expect(() => notifyRemainingChannelSubscribers('page-empty')).not.toThrow();
+  });
+
+  it('given a channel whose last subscriber already unregistered, a later notify should call nothing', () => {
+    const callback = vi.fn();
+    registerChannelRebootstrap('page-a', callback);
+    unregisterChannelRebootstrap('page-a', callback);
+
+    expect(() => notifyRemainingChannelSubscribers('page-a')).not.toThrow();
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/channelStreamSubscribers.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/channelStreamSubscribers.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerChannelStreamSubscriber,
+  unregisterChannelStreamSubscriber,
+  getChannelStreamSubscriberCount,
+  resetChannelStreamSubscribers,
+} from '../channelStreamSubscribers';
+
+describe('channelStreamSubscribers', () => {
+  beforeEach(() => {
+    resetChannelStreamSubscribers();
+  });
+
+  it('given an unregistered channel, should report a count of 0', () => {
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(0);
+  });
+
+  it('given one register, should report a count of 1', () => {
+    registerChannelStreamSubscriber('page-a');
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(1);
+  });
+
+  it('given a register then unregister, should return true (was the last) and count 0', () => {
+    registerChannelStreamSubscriber('page-a');
+    expect(unregisterChannelStreamSubscriber('page-a')).toBe(true);
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(0);
+  });
+
+  it('given two registers, unregistering the first should return false (not last), the second should return true', () => {
+    registerChannelStreamSubscriber('page-a');
+    registerChannelStreamSubscriber('page-a');
+
+    expect(unregisterChannelStreamSubscriber('page-a')).toBe(false);
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(1);
+
+    expect(unregisterChannelStreamSubscriber('page-a')).toBe(true);
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(0);
+  });
+
+  it('given registers on two different channels, should not leak into each other', () => {
+    registerChannelStreamSubscriber('page-a');
+    registerChannelStreamSubscriber('page-b');
+    registerChannelStreamSubscriber('page-b');
+
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(1);
+    expect(getChannelStreamSubscriberCount('page-b')).toBe(2);
+
+    unregisterChannelStreamSubscriber('page-a');
+    expect(getChannelStreamSubscriberCount('page-a')).toBe(0);
+    expect(getChannelStreamSubscriberCount('page-b')).toBe(2);
+  });
+
+  // Coverage gap this closes: unregister is only ever called by useChannelStreamSocket's
+  // own cleanup, always paired with an earlier register in the same effect instance — but
+  // the function itself has no way to enforce that. Called on a channel that was never
+  // registered (or already fully unregistered), it must not throw and should report "was
+  // the last" (true) rather than silently going negative — erring toward the caller's
+  // clearPageStreams path running rather than a phantom subscriber being assumed to remain.
+  it('given an unregister for a channel that was never registered, should not throw and should report true (nothing left)', () => {
+    expect(() => unregisterChannelStreamSubscriber('page-never')).not.toThrow();
+    expect(unregisterChannelStreamSubscriber('page-never')).toBe(true);
+    expect(getChannelStreamSubscriberCount('page-never')).toBe(0);
+  });
+});

--- a/apps/web/src/lib/ai/streams/channelRebootstrapSignal.ts
+++ b/apps/web/src/lib/ai/streams/channelRebootstrapSignal.ts
@@ -1,0 +1,48 @@
+/**
+ * Lets an unmounting `useChannelStreamSocket` instance hand off live consumption to a
+ * still-mounted sibling on the same channel (review finding, PR #2312, P1 —
+ * chatgpt-codex-connector).
+ *
+ * `startConsume` is claim-gated (`bootstrapConsumerGuard.ts`): only ONE co-mounted
+ * instance per channel ever holds the actual SSE join for a given messageId. The
+ * subscriber refcount in `channelStreamSubscribers.ts` stops the STORE from being
+ * wiped when that instance unmounts and a sibling remains — but does nothing about
+ * the live connection itself. Without this, the sibling's copy of the stream just
+ * stops receiving new tokens (frozen) the moment the claim-holder goes away, with no
+ * repair until the eventual `chat:stream_complete` broadcast.
+ *
+ * Each mounted instance registers its own re-bootstrap trigger here; an unmounting
+ * instance that WAS actively consuming something (non-empty `controllers`) notifies
+ * every remaining registered sibling to re-run bootstrap. `runBootstrap` is already
+ * idempotent (`claimBootstrapConsumer` + `shouldSkipBootstrappedStream`) and routinely
+ * re-run on every mounted instance on reconnect — notifying several siblings at once
+ * is the same pattern, not a new risk. Exactly one of them wins the now-released claim.
+ */
+
+const rebootstrapCallbacks = new Map<string, Set<() => void>>();
+
+/** Register `callback` (typically `() => bootstrapRef.current?.()`) to run when a sibling on `channelId` hands off consumption. */
+export function registerChannelRebootstrap(channelId: string, callback: () => void): void {
+  const callbacks = rebootstrapCallbacks.get(channelId) ?? new Set<() => void>();
+  callbacks.add(callback);
+  rebootstrapCallbacks.set(channelId, callbacks);
+}
+
+export function unregisterChannelRebootstrap(channelId: string, callback: () => void): void {
+  const callbacks = rebootstrapCallbacks.get(channelId);
+  if (!callbacks) return;
+  callbacks.delete(callback);
+  if (callbacks.size === 0) rebootstrapCallbacks.delete(channelId);
+}
+
+/** Notify every remaining registered subscriber on `channelId` to re-bootstrap. Call AFTER unregistering the caller's own callback. */
+export function notifyRemainingChannelSubscribers(channelId: string): void {
+  const callbacks = rebootstrapCallbacks.get(channelId);
+  if (!callbacks) return;
+  for (const callback of callbacks) callback();
+}
+
+/** Test-only reset; module state otherwise leaks across cases. */
+export function resetChannelRebootstrapSignal(): void {
+  rebootstrapCallbacks.clear();
+}

--- a/apps/web/src/lib/ai/streams/channelStreamSubscribers.ts
+++ b/apps/web/src/lib/ai/streams/channelStreamSubscribers.ts
@@ -1,0 +1,46 @@
+/**
+ * Tracks how many `useChannelStreamSocket` instances are currently subscribed to each
+ * channel, so its cleanup can call `usePendingStreamsStore.clearPageStreams(channelId)`
+ * only when the LAST subscriber for that channel goes away — not on every subscriber's
+ * own unmount/dep-change.
+ *
+ * Right sidebar / global-assistant surfaces are effectively singletons (one
+ * `GlobalChatProvider` mount for the whole session, at most one subscriber per
+ * channel), so this was invisible there. Agent panes are not: the same agent can be
+ * open in multiple panes at once by design (`select-pane-agent.ts`), each mounting its
+ * own `useChannelStreamSocket` instance on the same channelId. Without this, closing
+ * or reassigning ONE such pane wiped every stream on that channel — including a
+ * sibling pane's still-mid-generation own stream.
+ *
+ * Same refcounted-Map shape as `consumingChannels.ts`/`bootstrapConsumerGuard.ts`
+ * (sibling problems, same codebase, same pattern) — module-level state, no production
+ * reset on logout (logout is a soft `router.push`, not a hard reload). Harmless here:
+ * the count tracks "how many subscriber instances are mounted," not "which user," so
+ * it stays correct across a user switch in the same tab.
+ */
+
+const subscriberCounts = new Map<string, number>();
+
+export function registerChannelStreamSubscriber(channelId: string): void {
+  subscriberCounts.set(channelId, (subscriberCounts.get(channelId) ?? 0) + 1);
+}
+
+/** Returns true iff this was the last subscriber for `channelId` (count reached 0). */
+export function unregisterChannelStreamSubscriber(channelId: string): boolean {
+  const next = (subscriberCounts.get(channelId) ?? 0) - 1;
+  if (next > 0) {
+    subscriberCounts.set(channelId, next);
+    return false;
+  }
+  subscriberCounts.delete(channelId);
+  return true;
+}
+
+export function getChannelStreamSubscriberCount(channelId: string): number {
+  return subscriberCounts.get(channelId) ?? 0;
+}
+
+/** Test-only reset; module state otherwise leaks across cases. */
+export function resetChannelStreamSubscribers(): void {
+  subscriberCounts.clear();
+}

--- a/apps/web/src/lib/ai/streams/channelStreamSubscribers.ts
+++ b/apps/web/src/lib/ai/streams/channelStreamSubscribers.ts
@@ -21,6 +21,7 @@
 
 const subscriberCounts = new Map<string, number>();
 
+/** Mark one more `useChannelStreamSocket` instance as subscribed to `channelId`. */
 export function registerChannelStreamSubscriber(channelId: string): void {
   subscriberCounts.set(channelId, (subscriberCounts.get(channelId) ?? 0) + 1);
 }
@@ -36,6 +37,7 @@ export function unregisterChannelStreamSubscriber(channelId: string): boolean {
   return true;
 }
 
+/** Test-only introspection: how many subscribers `channelId` currently has. */
 export function getChannelStreamSubscriberCount(channelId: string): number {
   return subscriberCounts.get(channelId) ?? 0;
 }

--- a/apps/web/src/stores/__tests__/useAuthStore.test.ts
+++ b/apps/web/src/stores/__tests__/useAuthStore.test.ts
@@ -562,6 +562,54 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState()._authPromise).toBeNull();
     });
 
+    // Correctness-review finding (PR #2312): a 401 that successfully refreshes issues a
+    // NESTED loadSession(true) retry (line ~493) from inside the ORIGINAL call's own
+    // try block. Because `return get().loadSession(true)` is inside try/finally, the
+    // ORIGINAL call's `finally` runs immediately after — synchronously, in the same
+    // continuation, before the retry's own fetch has even been issued — and it used to
+    // unconditionally set `isLoading: false` (only `_authPromise` was guarded against a
+    // newer request having taken over). That let `isLoading` go false while
+    // `isAuthenticated` was still whatever it was before this call (e.g. a stale
+    // persisted `true`) and the retry — the actual check — was still in flight. Any
+    // consumer gating on `isLoading` (Layout's shouldShowAuthLoadingScreen) would treat
+    // the session as "settled" based on nothing.
+    it("given a 401 triggers a successful token-refresh retry, should NOT clear isLoading before the retry's own fetch resolves", async () => {
+      useAuthStore.setState({ user: createMockUser(), isAuthenticated: true });
+
+      let resolveRetryFetch!: (value: Response) => void;
+      const retryFetch = new Promise<Response>((resolve) => {
+        resolveRetryFetch = resolve;
+      });
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+        .mockImplementationOnce(() => retryFetch);
+
+      const { refreshAuthSession } = await import('@/lib/auth/auth-fetch');
+      vi.mocked(refreshAuthSession).mockResolvedValueOnce({ success: true, shouldLogout: false });
+
+      const loadPromise = useAuthStore.getState().loadSession();
+
+      // Wait until the retry's own fetch has actually been issued (the nested
+      // loadSession(true) call, and the original call's finally right after it, have
+      // both already run their synchronous continuation by this point) — without
+      // resolving that fetch yet.
+      await vi.waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      expect(useAuthStore.getState().isLoading).toBe(true);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+
+      resolveRetryFetch({
+        ok: true,
+        json: () => Promise.resolve(createMockUser()),
+      } as Response);
+      await loadPromise;
+
+      expect(useAuthStore.getState().isLoading).toBe(false);
+      expect(useAuthStore.getState()._authPromise).toBeNull();
+    });
+
     it('given network error, should record failed attempt', async () => {
       vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -546,10 +546,19 @@ export const useAuthStore = create<AuthState>()(
               lastFailedAuthCheck: Date.now(),
             });
           } finally {
-            // Clear loading state. Only clear _authPromise if this request is still current.
+            // Clear loading state — but ONLY if this call is still the current one.
+            // A 401 handler can issue a NESTED loadSession(true) retry (above) from
+            // inside this call's own try block; that retry's set({isLoading: true,
+            // _authPromise: newPromise}) already ran and is reflected in
+            // currentState._authPromise by the time this finally executes (return
+            // inside try/finally runs finally synchronously, before this async
+            // function's own promise settles — no await separates them). Touching
+            // isLoading here unconditionally clobbered that in-flight retry's state,
+            // making a stale isAuthenticated look "settled" before the retry's own
+            // fetch had even been issued (correctness-review finding, PR #2312).
             set((currentState) => {
               if (currentState._authPromise !== authPromise) {
-                return { isLoading: false };
+                return {};
               }
 
               return { isLoading: false, _authPromise: null };


### PR DESCRIPTION
## Summary

Fixes a reliability problem where users couldn't trust that sending a message,
navigating away, or coming back would keep an AI chat stream visible — plus the
underlying mechanism causing periodic whole-screen flashes app-wide, not just in
chat.

Four core fixes, each independently scoped and TDD-verified:

- **`fix(agents)` — mirror `useChat`'s own live messages, not the rendered cache.**
  `useAgentSessionChat.ts`/`useAssistantSessionChat.ts` fed `useOwnStreamMirror` a
  store-derived array instead of `useChat`'s own raw growing one, so the message
  *sender's* own pane showed nothing while streaming even though other viewers saw
  it fine.
- **`fix(layout)` — don't blank the app shell for a background auth recheck.**
  `Layout.tsx` unmounted its *entire* subtree — including `GlobalChatProvider`,
  which owns every socket room subscription — on every routine 15-minute
  `loadSession()` revalidation, not just a genuine cold boot. This was the root
  cause of the whole-screen flash on ordinary navigation/interaction, and it took
  every live AI stream down with it.
- **`fix(streams)` — refcount channel stream subscribers before
  `clearPageStreams`.** Closing or reassigning one agent pane wiped a *sibling*
  pane's still-mid-generation stream, because cleanup cleared the whole channel
  unconditionally with no reference counting. Agent panes routinely co-mount
  multiple subscribers on the same channel by design; the right sidebar doesn't,
  which is why it was comparatively reliable.
- **`fix(layout)` — clear `agent-workspace-storage`/`drive-storage` on error
  boundary catch.** `LayoutErrorBoundary`'s recovery only ever cleared
  `layout-storage`, so a corrupted entry in either of the other two persisted
  stores couldn't be healed by "Try Again"/"Reload Page".

### Follow-up fixes from review (chatgpt-codex-connector)

- **`fix(streams)` — hand off live consumption to a sibling on claim-holder
  unmount (P1).** The subscriber-refcount fix above stops the *store* from being
  wiped when a sibling pane remains, but `startConsume` is separately claim-gated
  (only one co-mounted instance per channel ever holds the live SSE join for a
  given message). If *that* instance unmounts, nothing told a surviving sibling to
  reclaim consumption — its copy of the stream would freeze until
  `chat:stream_complete`. Added `channelRebootstrapSignal.ts`: an unmounting
  instance that was actively consuming something now notifies remaining siblings
  to re-bootstrap and reclaim the released claim.
- **`fix(layout)` — don't optimistically bypass the loading screen on an
  unconfirmed mount (P2).** Since `isAuthenticated` is itself persisted across
  reloads, the original predicate could bypass the loading screen on a hard
  reload's very first (still-unverified) check for a session that had actually
  expired/been revoked — briefly rendering real cached drive/sidebar data before
  the eventual redirect. `Layout.tsx` now tracks `hasConfirmedAuthThisMount`
  locally (a ref, not persisted) so only a *later* background recheck within an
  already-confirmed mount may skip the screen — a fresh mount's first check always
  shows it, exactly as before this whole PR.

Also applied a proactive `/simplify` pass (reuse/simplification/efficiency/altitude)
against the full diff: documented `LayoutErrorBoundary`'s deliberately-scoped
storage-key list (it doesn't cover every persisted store — noted why, and why a
full registry is a separate, larger fix) and added missing per-function docstrings
to `channelStreamSubscribers.ts`.

## Test plan

- [x] TDD throughout: every fix's regression test written first and confirmed RED
      against the prior behavior, then GREEN after the fix — including the two
      review-driven follow-ups
- [x] `bun run --filter web typecheck` — clean
- [x] `bunx eslint` on all touched files — clean
- [x] Full targeted suite: `src/components/agents`, `src/components/layout`,
      `useChannelStreamSocket` — 987 tests passing, no regressions
- [ ] Manual: open the same agent in two panes, close one mid-stream on the other —
      confirm the surviving pane keeps streaming (including live token updates, not
      just a frozen snapshot)
- [ ] Manual: leave a session idle past 15 minutes, then navigate — confirm no
      whole-screen flash
- [ ] Manual: with a stale/revoked session and persisted `isAuthenticated: true`,
      hard-reload — confirm the loading screen still shows (no flash of cached
      private data before redirect)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Js2VgATvpEKETq6Dt39JRJ


### Additional fixes from a proactive adversarial correctness review

After the above, ran a self-directed adversarial correctness pass (2 independent
reviewers) against the new cross-instance signaling code and the auth-gating ref,
specifically hunting for race conditions and edge cases beyond what the automated
line-comment review had already caught. Found and fixed three more issues:

- **`fix(ci)` — wired `resetChannelRebootstrapSignal` into test isolation.** Knip's
  unused-export gate correctly caught this: the reset export existed for symmetry
  with its two sibling modules but was never actually called anywhere.
- **`fix(streams)` — clear `controllers` on `access_revoked`.** The abort loop
  released every claim but left stale entries in the `controllers` map (the normal
  cleanup path that would have removed them short-circuits on `cancelled`). A later
  real unmount then read those stale entries as "was I consuming something,"
  double-releasing an already-released claim and spuriously notifying a sibling to
  re-bootstrap a channel access was already revoked for. Not currently exploitable
  as data corruption, but a real, previously-untested logic bug.
- **`fix(auth)` (critical) — don't clobber `isLoading` when a nested token-refresh
  retry supersedes the current call.** `loadSession`'s 401 handler can issue a
  nested `loadSession(true)` retry when a refresh succeeds; because that happens
  inside a `try`/`finally`, the *original* call's `finally` ran immediately after —
  before the retry's own fetch was even issued — and unconditionally cleared
  `isLoading` (only `_authPromise` was guarded against a newer request having taken
  over). This directly undermined the `hasConfirmedAuthThisMount` fix above for
  exactly the case it targets: a 401 + successful refresh is the routine path on
  almost every reload past the access token's TTL, and this bug meant `isLoading`
  could read `false` (looking "settled") while the actual check hadn't run yet.
  Pre-existing bug in `useAuthStore.ts`, not introduced by this PR, but it directly
  undermines a fix this PR makes — fixed with a minimal, scoped change to the
  existing guard.

All three: TDD (RED confirmed against the prior behavior, then GREEN), full suite
green (1719 tests across the touched areas), typecheck/lint/knip clean.


### Coverage gate fix

The above correctness fixes were only indirectly exercised via `useChannelStreamSocket.test.ts`,
which never hit a couple of defensive branches in the two new modules — CI's per-directory
coverage gate (`src/lib/ai/streams/*.ts`, 99% branches) caught this. Added dedicated test
files for `channelStreamSubscribers.ts`/`channelRebootstrapSignal.ts`, matching this
directory's own convention of one test file per small utility module. Both now at 100%
branch coverage individually; directory aggregate back to 99.42%.
