### PR TITLE
feat(agents): animate the Save button instead of using a success toast

### DIFF
--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -51,6 +51,7 @@ import {
 } from '@/components/ai/page-agents';
 import { PageWebhooksDialog } from '@/components/shared/PageWebhooksDialog';
 import { useProviderSettings } from '@/lib/ai/shared/hooks/useProviderSettings';
+import { useAgentSettingsSaveState } from '@/lib/ai/shared/hooks/useAgentSettingsSaveState';
 import { useConversations } from '@/lib/ai/shared/hooks/useConversations';
 import { useAgentConfig } from '@/lib/ai/shared/hooks/useAgentConfig';
 import { buildAgentSelectionUrl } from '@/lib/agents/agent-selection';
@@ -167,29 +168,13 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // agent's Settings tab (see `useAgentConfig`'s own doc), not a private
   // per-instance fetch.
   const { config: agentConfig, setConfig: setAgentConfig, revalidate: revalidateAgentConfig } = useAgentConfig(page.id);
-  const [isSettingsSaving, setIsSettingsSaving] = useState(false);
-  const [isSettingsDirty, setIsSettingsDirty] = useState(false);
-  const [settingsJustSaved, setSettingsJustSaved] = useState(false);
-  const settingsSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const {
+    saveState: settingsSaveState,
+    setIsSaving: setIsSettingsSaving,
+    setIsDirty: setIsSettingsDirty,
+    handleSaved: handleSettingsSaved,
+  } = useAgentSettingsSaveState();
   const agentSettingsRef = useRef<PageAgentSettingsTabRef>(null);
-  // clean/dirty/saving/saved — drives the Save button's color, animation, and
-  // inline "Saved" confirmation, replacing the success toast that used to
-  // cover the Chat/History/Settings tabs and Webhooks button beside it.
-  const settingsSaveState = isSettingsSaving
-    ? 'saving'
-    : isSettingsDirty
-    ? 'dirty'
-    : settingsJustSaved
-    ? 'saved'
-    : 'clean';
-  const handleSettingsSaved = useCallback(() => {
-    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
-    setSettingsJustSaved(true);
-    settingsSavedTimeoutRef.current = setTimeout(() => setSettingsJustSaved(false), 1800);
-  }, []);
-  useEffect(() => () => {
-    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
-  }, []);
 
   const isReadOnly = usePermissionsCheck(page.id, user?.id);
 
@@ -481,6 +466,11 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
                   variant={settingsSaveState === 'clean' ? 'outline' : 'default'}
                   onClick={() => agentSettingsRef.current?.submitForm()}
                   disabled={settingsSaveState !== 'dirty'}
+                  // The state change (Saving.../Saved) is now the ONLY save
+                  // confirmation — there's no toast to announce it anymore,
+                  // so screen readers need this to catch it.
+                  aria-live="polite"
+                  aria-atomic="true"
                   className={cn(
                     'min-w-[100px] transition-colors sm:min-w-[120px]',
                     settingsSaveState === 'dirty' &&

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -485,18 +485,25 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
                 >
                   {settingsSaveState === 'saving' ? (
                     <>
-                      <Loader2 className="h-4 w-4 animate-spin sm:mr-2" />
-                      <span className="hidden sm:inline">Saving...</span>
+                      <Loader2 className="h-4 w-4 animate-spin sm:mr-2" aria-hidden="true" />
+                      {/* sr-only below `sm` instead of `hidden` — a `hidden`
+                          span drops out of the a11y tree too, leaving this
+                          icon-only button with no accessible name at all on
+                          mobile (the icons above carry none of their own),
+                          which would make aria-live's announcement above
+                          silent exactly where the removed toast used to
+                          still work. */}
+                      <span className="sr-only sm:not-sr-only sm:inline">Saving...</span>
                     </>
                   ) : settingsSaveState === 'saved' ? (
                     <>
-                      <Check className="h-4 w-4 animate-in zoom-in-50 fade-in-0 duration-200 sm:mr-2" />
-                      <span className="hidden sm:inline">Saved</span>
+                      <Check className="h-4 w-4 animate-in zoom-in-50 fade-in-0 duration-200 sm:mr-2" aria-hidden="true" />
+                      <span className="sr-only sm:not-sr-only sm:inline">Saved</span>
                     </>
                   ) : (
                     <>
                       <span className="relative inline-flex sm:mr-2">
-                        <Save className="h-4 w-4" />
+                        <Save className="h-4 w-4" aria-hidden="true" />
                         {settingsSaveState === 'dirty' && (
                           <span
                             aria-hidden="true"
@@ -504,7 +511,7 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
                           />
                         )}
                       </span>
-                      <span className="hidden sm:inline">Save Settings</span>
+                      <span className="sr-only sm:not-sr-only sm:inline">Save Settings</span>
                     </>
                   )}
                 </Button>

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -168,12 +168,16 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // agent's Settings tab (see `useAgentConfig`'s own doc), not a private
   // per-instance fetch.
   const { config: agentConfig, setConfig: setAgentConfig, revalidate: revalidateAgentConfig } = useAgentConfig(page.id);
+  // `activeTab` can seed straight to 'settings' from a `?tab=settings` URL
+  // (see the effect above), so the Settings tab — and this Save button —
+  // can be visible before `agentConfig` has resolved. Same guard AgentPanes
+  // passes for the same reason (review finding — coderabbitai on this PR).
   const {
     saveState: settingsSaveState,
     setIsSaving: setIsSettingsSaving,
     setIsDirty: setIsSettingsDirty,
     handleSaved: handleSettingsSaved,
-  } = useAgentSettingsSaveState();
+  } = useAgentSettingsSaveState({ isConfigLoaded: agentConfig !== null });
   const agentSettingsRef = useRef<PageAgentSettingsTabRef>(null);
 
   const isReadOnly = usePermissionsCheck(page.id, user?.id);

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -30,6 +30,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
   AlertCircle,
+  Check,
   ExternalLink,
   History,
   Loader2,
@@ -40,6 +41,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { mutate } from 'swr';
+import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -166,7 +168,28 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
   // per-instance fetch.
   const { config: agentConfig, setConfig: setAgentConfig, revalidate: revalidateAgentConfig } = useAgentConfig(page.id);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
+  const [isSettingsDirty, setIsSettingsDirty] = useState(false);
+  const [settingsJustSaved, setSettingsJustSaved] = useState(false);
+  const settingsSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const agentSettingsRef = useRef<PageAgentSettingsTabRef>(null);
+  // clean/dirty/saving/saved — drives the Save button's color, animation, and
+  // inline "Saved" confirmation, replacing the success toast that used to
+  // cover the Chat/History/Settings tabs and Webhooks button beside it.
+  const settingsSaveState = isSettingsSaving
+    ? 'saving'
+    : isSettingsDirty
+    ? 'dirty'
+    : settingsJustSaved
+    ? 'saved'
+    : 'clean';
+  const handleSettingsSaved = useCallback(() => {
+    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
+    setSettingsJustSaved(true);
+    settingsSavedTimeoutRef.current = setTimeout(() => setSettingsJustSaved(false), 1800);
+  }, []);
+  useEffect(() => () => {
+    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
+  }, []);
 
   const isReadOnly = usePermissionsCheck(page.id, user?.id);
 
@@ -454,18 +477,39 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
 
               {activeTab === 'settings' && (
                 <Button
+                  type="button"
+                  variant={settingsSaveState === 'clean' ? 'outline' : 'default'}
                   onClick={() => agentSettingsRef.current?.submitForm()}
-                  disabled={isSettingsSaving}
-                  className="min-w-[100px] sm:min-w-[120px]"
+                  disabled={settingsSaveState !== 'dirty'}
+                  className={cn(
+                    'min-w-[100px] transition-colors sm:min-w-[120px]',
+                    settingsSaveState === 'dirty' &&
+                      'border-warning/40 bg-warning/10 text-warning hover:bg-warning/15',
+                    settingsSaveState === 'saving' && 'border-warning/40 bg-warning/10 text-warning',
+                    settingsSaveState === 'saved' && 'border-success/40 bg-success/10 text-success hover:bg-success/10',
+                  )}
                 >
-                  {isSettingsSaving ? (
+                  {settingsSaveState === 'saving' ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin sm:mr-2" />
                       <span className="hidden sm:inline">Saving...</span>
+                    </>
+                  ) : settingsSaveState === 'saved' ? (
+                    <>
+                      <Check className="h-4 w-4 animate-in zoom-in-50 fade-in-0 duration-200 sm:mr-2" />
+                      <span className="hidden sm:inline">Saved</span>
                     </>
                   ) : (
                     <>
-                      <Save className="h-4 w-4 sm:mr-2" />
+                      <span className="relative inline-flex sm:mr-2">
+                        <Save className="h-4 w-4" />
+                        {settingsSaveState === 'dirty' && (
+                          <span
+                            aria-hidden="true"
+                            className="absolute -right-0.5 -top-0.5 size-1.5 animate-pulse rounded-full bg-warning"
+                          />
+                        )}
+                      </span>
                       <span className="hidden sm:inline">Save Settings</span>
                     </>
                   )}
@@ -573,6 +617,8 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
             onModelChange={setSelectedModel}
             isProviderConfigured={isProviderConfigured}
             onSavingChange={setIsSettingsSaving}
+            onDirtyChange={setIsSettingsDirty}
+            onSaved={handleSettingsSaved}
           />
         </TabsContent>
       </Tabs>

--- a/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentPageView.test.tsx
@@ -152,8 +152,30 @@ vi.mock('@/lib/ai/shared/hooks/useAgentConfig', () => ({
 }));
 
 vi.mock('@/components/ai/page-agents', () => ({
-  PageAgentSettingsTab: ({ config }: { config: unknown }) => (
-    <div data-testid="page-agent-settings-tab" data-has-config={String(config !== null)} />
+  PageAgentSettingsTab: ({
+    config,
+    onDirtyChange,
+    onSaved,
+  }: {
+    config: unknown;
+    onDirtyChange?: (isDirty: boolean) => void;
+    onSaved?: () => void;
+  }) => (
+    <div data-testid="page-agent-settings-tab" data-has-config={String(config !== null)}>
+      <button onClick={() => onDirtyChange?.(true)}>mark-dirty</button>
+      {/* Named to avoid the substring "save" — it would otherwise collide
+          with `getByRole('button', { name: /save/i })` queries for the
+          host's real Save button. Mirrors the real component: a successful
+          save resets dirty around the same time onSaved fires. */}
+      <button
+        onClick={() => {
+          onDirtyChange?.(false);
+          onSaved?.();
+        }}
+      >
+        finish-config-update
+      </button>
+    </div>
   ),
   PageAgentHistoryTab: ({
     onSelectConversation,
@@ -351,6 +373,44 @@ describe('AgentPageView', () => {
 
     expect(await screen.findByText('Save Settings')).toBeInTheDocument();
     expect(screen.getByTestId('page-agent-settings-tab')).toBeInTheDocument();
+  });
+
+  it('disables Save Settings until PageAgentSettingsTab reports a dirty change', async () => {
+    mockUseAgentConfig.mockReturnValue({
+      config: { systemPrompt: '', enabledTools: [], availableTools: [] },
+      setConfig: vi.fn(),
+    });
+    resolveTo({ conversationId: 'conv-1', sessionId: null });
+    render(<AgentPageView page={pageFixture()} />);
+
+    await userEvent.click(screen.getByRole('tab', { name: /settings/i }));
+    const saveButton = await screen.findByRole('button', { name: /save settings/i });
+    expect(saveButton).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'mark-dirty' }));
+
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('shows an inline "Saved" confirmation after a save, then reverts to disabled', async () => {
+    mockUseAgentConfig.mockReturnValue({
+      config: { systemPrompt: '', enabledTools: [], availableTools: [] },
+      setConfig: vi.fn(),
+    });
+    resolveTo({ conversationId: 'conv-1', sessionId: null });
+    render(<AgentPageView page={pageFixture()} />);
+
+    await userEvent.click(screen.getByRole('tab', { name: /settings/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'mark-dirty' }));
+    const saveButton = screen.getByRole('button', { name: /save settings/i });
+    expect(saveButton).not.toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'finish-config-update' }));
+
+    expect(await screen.findByRole('button', { name: /saved/i })).toBeDisabled();
+    await waitFor(() => expect(screen.getByRole('button', { name: /^save settings$/i })).toBeDisabled(), {
+      timeout: 3000,
+    });
   });
 
   it('loads the agent config so the Settings tab has data, not an eternal spinner', async () => {

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -40,7 +40,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createId } from '@paralleldrive/cuid2';
-import { History, Loader2, MessageSquare, Plus, Save, Settings } from 'lucide-react';
+import { Check, History, Loader2, MessageSquare, Plus, Save, Settings } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
@@ -1681,7 +1681,33 @@ function ChatPane({
     isProviderConfigured,
   } = useProviderSettings(scope.agentPageId ? { pageId: scope.agentPageId } : {});
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
+  const [isSettingsDirty, setIsSettingsDirty] = useState(false);
+  const [settingsJustSaved, setSettingsJustSaved] = useState(false);
+  const settingsSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settingsRef = useRef<PageAgentSettingsTabRef>(null);
+  // clean/dirty/saving/saved — same state machine as AgentPageView's Save
+  // Settings button, scaled down for this 30px pane bar. `agentConfig ===
+  // null` folds into "clean": PageAgentSettingsTab registers `submitForm`
+  // before its own config-loaded check returns, and its form defaults
+  // contain an EMPTY prompt/tool list, so this button must stay inert (not
+  // just "clean"-styled) until real config has loaded and been edited.
+  const settingsSaveState = agentConfig === null
+    ? 'clean'
+    : isSettingsSaving
+    ? 'saving'
+    : isSettingsDirty
+    ? 'dirty'
+    : settingsJustSaved
+    ? 'saved'
+    : 'clean';
+  const handleSettingsSaved = useCallback(() => {
+    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
+    setSettingsJustSaved(true);
+    settingsSavedTimeoutRef.current = setTimeout(() => setSettingsJustSaved(false), 1800);
+  }, []);
+  useEffect(() => () => {
+    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
+  }, []);
 
   const toggleConversationShare = useCallback(
     async (targetConversationId: string, isShared: boolean) => {
@@ -1804,17 +1830,32 @@ function ChatPane({
                   e.stopPropagation();
                   settingsRef.current?.submitForm();
                 }}
-                // `PageAgentSettingsTab` registers `submitForm` before its own
-                // config-loaded check returns, and its form defaults contain
-                // an EMPTY prompt/tool list — clicking Save before agentConfig
-                // arrives would PATCH those defaults over the agent's real
-                // config (review finding — chatgpt-codex-connector on PR
-                // #2299).
-                disabled={isSettingsSaving || agentConfig === null}
-                className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+                // Only clickable once there's something to save — also the
+                // guard against clicking before agentConfig arrives (see
+                // settingsSaveState above; review finding — chatgpt-codex-
+                // connector on PR #2299).
+                disabled={settingsSaveState !== 'dirty'}
+                className={cn(
+                  'flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium transition-colors disabled:pointer-events-none',
+                  settingsSaveState === 'clean' && 'text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50',
+                  settingsSaveState === 'dirty' && 'text-warning hover:bg-warning/10',
+                  settingsSaveState === 'saving' && 'text-warning',
+                  settingsSaveState === 'saved' && 'text-success',
+                )}
               >
-                {isSettingsSaving ? <Loader2 className="size-3 animate-spin" aria-hidden="true" /> : <Save className="size-3" aria-hidden="true" />}
-                Save
+                {settingsSaveState === 'saving' ? (
+                  <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+                ) : settingsSaveState === 'saved' ? (
+                  <Check className="size-3 animate-in zoom-in-50 fade-in-0 duration-200" aria-hidden="true" />
+                ) : (
+                  <span className="relative inline-flex">
+                    <Save className="size-3" aria-hidden="true" />
+                    {settingsSaveState === 'dirty' && (
+                      <span aria-hidden="true" className="absolute -right-0.5 -top-0.5 size-1 animate-pulse rounded-full bg-warning" />
+                    )}
+                  </span>
+                )}
+                {settingsSaveState === 'saved' ? 'Saved' : 'Save'}
               </button>
             )}
             <button
@@ -1892,6 +1933,8 @@ function ChatPane({
               onModelChange={setSelectedModel}
               isProviderConfigured={isProviderConfigured}
               onSavingChange={setIsSettingsSaving}
+              onDirtyChange={setIsSettingsDirty}
+              onSaved={handleSettingsSaved}
             />
           </div>
         ) : (

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -55,6 +55,7 @@ import { useConversationActiveStream } from '@/hooks/useActiveStream';
 import { AISelector } from '@/components/ai/shared';
 import { useConversations } from '@/lib/ai/shared/hooks/useConversations';
 import { useAgentConfig } from '@/lib/ai/shared/hooks/useAgentConfig';
+import { useAgentSettingsSaveState } from '@/lib/ai/shared/hooks/useAgentSettingsSaveState';
 import { useProviderSettings } from '@/lib/ai/shared/hooks/useProviderSettings';
 import { PageAgentHistoryTab, PageAgentSettingsTab, type PageAgentSettingsTabRef } from '@/components/ai/page-agents';
 import { cn } from '@/lib/utils';
@@ -1680,34 +1681,19 @@ function ChatPane({
     setSelectedModel,
     isProviderConfigured,
   } = useProviderSettings(scope.agentPageId ? { pageId: scope.agentPageId } : {});
-  const [isSettingsSaving, setIsSettingsSaving] = useState(false);
-  const [isSettingsDirty, setIsSettingsDirty] = useState(false);
-  const [settingsJustSaved, setSettingsJustSaved] = useState(false);
-  const settingsSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const settingsRef = useRef<PageAgentSettingsTabRef>(null);
   // clean/dirty/saving/saved — same state machine as AgentPageView's Save
   // Settings button, scaled down for this 30px pane bar. `agentConfig ===
   // null` folds into "clean": PageAgentSettingsTab registers `submitForm`
   // before its own config-loaded check returns, and its form defaults
   // contain an EMPTY prompt/tool list, so this button must stay inert (not
   // just "clean"-styled) until real config has loaded and been edited.
-  const settingsSaveState = agentConfig === null
-    ? 'clean'
-    : isSettingsSaving
-    ? 'saving'
-    : isSettingsDirty
-    ? 'dirty'
-    : settingsJustSaved
-    ? 'saved'
-    : 'clean';
-  const handleSettingsSaved = useCallback(() => {
-    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
-    setSettingsJustSaved(true);
-    settingsSavedTimeoutRef.current = setTimeout(() => setSettingsJustSaved(false), 1800);
-  }, []);
-  useEffect(() => () => {
-    if (settingsSavedTimeoutRef.current) clearTimeout(settingsSavedTimeoutRef.current);
-  }, []);
+  const {
+    saveState: settingsSaveState,
+    setIsSaving: setIsSettingsSaving,
+    setIsDirty: setIsSettingsDirty,
+    handleSaved: handleSettingsSaved,
+  } = useAgentSettingsSaveState({ isConfigLoaded: agentConfig !== null });
+  const settingsRef = useRef<PageAgentSettingsTabRef>(null);
 
   const toggleConversationShare = useCallback(
     async (targetConversationId: string, isShared: boolean) => {
@@ -1835,6 +1821,11 @@ function ChatPane({
                 // settingsSaveState above; review finding — chatgpt-codex-
                 // connector on PR #2299).
                 disabled={settingsSaveState !== 'dirty'}
+                // The state change (Saving.../Saved) is now the ONLY save
+                // confirmation — there's no toast to announce it anymore,
+                // so screen readers need this to catch it.
+                aria-live="polite"
+                aria-atomic="true"
                 className={cn(
                   'flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium transition-colors disabled:pointer-events-none',
                   settingsSaveState === 'clean' && 'text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50',

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -97,8 +97,33 @@ vi.mock('@/components/ai/page-agents', () => ({
       ))}
     </div>
   ),
-  PageAgentSettingsTab: ({ pageId, config }: { pageId: string; config: unknown }) => (
-    <div data-testid="pane-settings-tab" data-page-id={pageId} data-has-config={String(config !== null)} />
+  PageAgentSettingsTab: ({
+    pageId,
+    config,
+    onDirtyChange,
+    onSaved,
+  }: {
+    pageId: string;
+    config: unknown;
+    onDirtyChange?: (isDirty: boolean) => void;
+    onSaved?: () => void;
+  }) => (
+    <div data-testid="pane-settings-tab" data-page-id={pageId} data-has-config={String(config !== null)}>
+      <button onClick={() => onDirtyChange?.(true)}>mark-dirty</button>
+      {/* Named to avoid the substring "save" — it would otherwise collide
+          with `getByRole('button', { name: /save/i })` queries for the
+          host's real Save button. */}
+      <button
+        onClick={() => {
+          // Mirrors the real component: a successful save resets the form
+          // (dirty -> false) around the same time onSaved fires.
+          onDirtyChange?.(false);
+          onSaved?.();
+        }}
+      >
+        finish-config-update
+      </button>
+    </div>
   ),
 }));
 
@@ -2361,8 +2386,11 @@ describe('AgentPanes', () => {
     // registers submitForm before its own config-loaded check returns, and its
     // form defaults contain an empty prompt/tool list — clicking Save before
     // agentConfig arrives would PATCH those defaults over the agent's real
-    // config.
-    it('disables the Save button until the agent config has finished loading', async () => {
+    // config. The Save button now stays disabled until there's actually
+    // something to save, which subsumes that original guard: it can't turn
+    // dirty before config has loaded, since the form has nothing of the
+    // user's to differ from yet.
+    it('disables the Save button until the agent config has loaded and the user has made an edit', async () => {
       let resolveConfig!: () => void;
       mockFetchWithAuth.mockImplementation(async (url: string) => {
         if (url === '/api/pages/agent-1/agent-config') {
@@ -2383,7 +2411,35 @@ describe('AgentPanes', () => {
       expect(saveButton).toBeDisabled();
 
       resolveConfig();
+      // Config has loaded, but nothing has been edited yet — the Save
+      // button only lights up once there's something to save.
+      await waitFor(() => expect(screen.getByTestId('pane-settings-tab')).toHaveAttribute('data-has-config', 'true'));
+      expect(saveButton).toBeDisabled();
+
+      await userEvent.click(screen.getByRole('button', { name: 'mark-dirty' }));
+
       await waitFor(() => expect(saveButton).not.toBeDisabled());
+    });
+
+    // A success toast used to cover the very tab strip/buttons a user needs
+    // to leave Settings with — the confirmation now shows on the Save
+    // button itself instead (no toast is asserted here; there's simply
+    // nothing left that would fire one).
+    it('shows an inline "Saved" confirmation on the Save button, then reverts to disabled', async () => {
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+
+      await userEvent.click(await screen.findByRole('tab', { name: /researcher settings/i }));
+      await screen.findByTestId('pane-settings-tab');
+
+      const saveButton = screen.getByRole('button', { name: /save/i });
+      await userEvent.click(screen.getByRole('button', { name: 'mark-dirty' }));
+      expect(saveButton).not.toBeDisabled();
+
+      await userEvent.click(screen.getByRole('button', { name: 'finish-config-update' }));
+
+      expect(await screen.findByRole('button', { name: /saved/i })).toBeDisabled();
+      await waitFor(() => expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled(), { timeout: 3000 });
     });
 
     it("is disabled until THIS session's entry appears in the switch decision's own data", async () => {

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -58,6 +58,14 @@ interface PageAgentSettingsTabProps {
   onModelChange: (model: string) => void;
   isProviderConfigured: (provider: string) => boolean;
   onSavingChange?: (isSaving: boolean) => void;
+  /** Mirrors react-hook-form's `formState.isDirty` out to the host so its
+   * own Save button can show an unsaved-changes state — see AgentPageView
+   * and AgentPanes, which render the button outside this component. */
+  onDirtyChange?: (isDirty: boolean) => void;
+  /** Fires after a successful save instead of a toast — a toast can cover
+   * the very tabs/buttons the user needs to leave Settings with, so the
+   * host's Save button shows the confirmation inline instead. */
+  onSaved?: () => void;
 }
 
 function ApiModelIdCard({ pageId }: { pageId: string }) {
@@ -153,7 +161,9 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   onProviderChange,
   onModelChange,
   isProviderConfigured,
-  onSavingChange
+  onSavingChange,
+  onDirtyChange,
+  onSaved
 }, ref) => {
   // Stable per-MOUNT identifier — distinguishes this instance from another
   // Settings surface for the SAME agent mounted elsewhere (see the
@@ -450,7 +460,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       // overlapping sibling save has also had a chance to land (review
       // finding — chatgpt-codex-connector on PR #2299, round 23).
       onConfigRevalidate();
-      toast.success('Agent configuration saved successfully');
+      onSaved?.();
     } catch (error) {
       console.error('Error saving agent configuration:', error);
       toast.error('Failed to save configuration');
@@ -458,7 +468,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       setIsSaving(false);
       onSavingChange?.(false);
     }
-  }, [pageId, config, onConfigUpdate, onConfigRevalidate, selectedProvider, selectedModel, onSavingChange, dirtyFields]);
+  }, [pageId, config, onConfigUpdate, onConfigRevalidate, selectedProvider, selectedModel, onSavingChange, onSaved, dirtyFields]);
 
   const handleProviderSelectChange = useCallback(
     (provider: string) => {
@@ -482,6 +492,13 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     },
     isSaving
   }), [handleSubmit, onSubmit, isSaving]);
+
+  // Mirror dirty state out to the host's own Save button (rendered outside
+  // this component — see AgentPageView/AgentPanes) so it can show an
+  // unsaved-changes state without polling the ref every render.
+  useEffect(() => {
+    onDirtyChange?.(formIsDirty);
+  }, [formIsDirty, onDirtyChange]);
 
   // Eagerly fetch models for the DISPLAYED provider (see displayedProvider
   // above) when it's Ollama or LM Studio — must match what's actually

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -567,15 +567,22 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   // isAnyEditing(), letting SWR revalidation and other editing-paused
   // background work resume while it still has unsaved edits (review
   // finding — chatgpt-codex-connector on PR #2299, round 20).
+  //
+  // `formIsDirty` alone misses a provider/model-only change (same gap as
+  // the `onDirtyChange` mirror above) — without `providerOrModelTouched`
+  // here too, an SWR revalidation or auth-refresh cycle is free to
+  // interrupt/clobber a pending provider/model selection this component
+  // never told useEditingStore about (review finding — coderabbitai on
+  // this PR).
   useEffect(() => {
     const componentId = `page-agent-settings-${pageId}-${mountId}`;
-    if (formIsDirty) {
+    if (formIsDirty || providerOrModelTouched) {
       useEditingStore.getState().startEditing(componentId, 'form', { pageId });
     } else {
       useEditingStore.getState().endEditing(componentId);
     }
     return () => { useEditingStore.getState().endEditing(componentId); };
-  }, [formIsDirty, pageId, mountId]);
+  }, [formIsDirty, providerOrModelTouched, pageId, mountId]);
 
   if (!config) {
     return (

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -496,9 +496,19 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   // Mirror dirty state out to the host's own Save button (rendered outside
   // this component — see AgentPageView/AgentPanes) so it can show an
   // unsaved-changes state without polling the ref every render.
+  //
+  // `formIsDirty` alone misses a provider/model-only change: the AI
+  // Provider/Model Selects above aren't wired through react-hook-form
+  // (`handleProviderSelectChange`/`handleModelSelectChange` update parent-
+  // owned state and `providerTouchedRef`/`modelTouchedRef` instead — see
+  // those refs' own comment), so `dirtyFields`/`formIsDirty` never reflects
+  // them. Without `providerOrModelTouched` here too, a Save button gated on
+  // this callback would stay disabled for a provider/model-only change —
+  // making it unsavable unless the user also touched an unrelated field
+  // (review finding — chatgpt-codex-connector on this PR).
   useEffect(() => {
-    onDirtyChange?.(formIsDirty);
-  }, [formIsDirty, onDirtyChange]);
+    onDirtyChange?.(formIsDirty || providerOrModelTouched);
+  }, [formIsDirty, providerOrModelTouched, onDirtyChange]);
 
   // Eagerly fetch models for the DISPLAYED provider (see displayedProvider
   // above) when it's Ollama or LM Studio — must match what's actually

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -460,6 +460,17 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       // overlapping sibling save has also had a chance to land (review
       // finding — chatgpt-codex-connector on PR #2299, round 23).
       onConfigRevalidate();
+      // Called directly here rather than relying solely on the
+      // onDirtyChange mirror effect below: that effect only re-fires once
+      // formIsDirty/providerOrModelTouched actually change value across a
+      // render, but formIsDirty only flips to false once the separate
+      // config-reset effect's reset() call takes effect — a LATER effect
+      // than this synchronous success path. Without this, a save with a
+      // real (non-provider/model) dirty field could render one frame with
+      // isSaving:false, justSaved:true, but the mirror effect's stale
+      // formIsDirty still true — flashing back to "dirty" before settling
+      // on "saved" (review finding — general-purpose adversarial review).
+      onDirtyChange?.(false);
       onSaved?.();
     } catch (error) {
       console.error('Error saving agent configuration:', error);
@@ -468,7 +479,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       setIsSaving(false);
       onSavingChange?.(false);
     }
-  }, [pageId, config, onConfigUpdate, onConfigRevalidate, selectedProvider, selectedModel, onSavingChange, onSaved, dirtyFields]);
+  }, [pageId, config, onConfigUpdate, onConfigRevalidate, selectedProvider, selectedModel, onSavingChange, onDirtyChange, onSaved, dirtyFields]);
 
   const handleProviderSelectChange = useCallback(
     (provider: string) => {

--- a/apps/web/src/components/ai/page-agents/__tests__/PageAgentSettingsTab.dirty.test.tsx
+++ b/apps/web/src/components/ai/page-agents/__tests__/PageAgentSettingsTab.dirty.test.tsx
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { forwardRef, useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PageAgentSettingsTab, { type PageAgentSettingsTabRef } from '../PageAgentSettingsTab';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/shared/hooks/useAgentMembership', () => ({
+  useAgentMembership: () => ({
+    membership: null,
+    membershipUserRole: 'MEMBER',
+    driveRoles: [],
+    updateRole: vi.fn(),
+    isSaving: false,
+  }),
+}));
+
+vi.mock('../AgentDrivesCard', () => ({
+  AgentDrivesCard: () => <div>Agent drives</div>,
+}));
+
+vi.mock('../AgentIntegrationsPanel', () => ({
+  AgentIntegrationsPanel: () => <div>Integration connections</div>,
+}));
+
+interface HarnessAgentConfig {
+  systemPrompt: string;
+  enabledTools: string[];
+  availableTools: Array<{ name: string; description: string }>;
+  // Optional — matches PageAgentSettingsTab's own AgentConfig shape, where
+  // these (and everything past them) are optional.
+  aiProvider?: string;
+  aiModel?: string;
+}
+
+const initialConfig: HarnessAgentConfig = {
+  systemPrompt: '',
+  enabledTools: [],
+  availableTools: [],
+  aiProvider: 'openai',
+  aiModel: 'gpt-4o',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * Mirrors how a real host (AgentPageView/AgentPanes) actually wires this
+ * component — `selectedProvider`/`config` are host-owned state, not inert
+ * mocks: `onProviderChange` is `setSelectedProvider`, and `onConfigUpdate`
+ * is `setConfig` (accepts the same updater-function form `onSubmit` calls
+ * it with, exactly like `useAgentConfig`'s real `setConfig`). Passing bare
+ * `vi.fn()`s here would skip every re-render a real save actually causes in
+ * production, making this an unfaithful re-creation of the bug.
+ */
+const Harness = forwardRef<PageAgentSettingsTabRef, { onDirtyChange: (isDirty: boolean) => void }>(
+  ({ onDirtyChange }, ref) => {
+    const [config, setConfig] = useState(initialConfig);
+    const [selectedProvider, setSelectedProvider] = useState('openai');
+    return (
+      <PageAgentSettingsTab
+        ref={ref}
+        pageId="agent-1"
+        driveId="drive-1"
+        config={config}
+        onConfigUpdate={(next) => setConfig((current) => (typeof next === 'function' ? next(current) : next))}
+        onConfigRevalidate={vi.fn()}
+        selectedProvider={selectedProvider}
+        selectedModel="gpt-4o"
+        onProviderChange={setSelectedProvider}
+        onModelChange={vi.fn()}
+        isProviderConfigured={() => true}
+        onDirtyChange={onDirtyChange}
+      />
+    );
+  },
+);
+Harness.displayName = 'Harness';
+
+// review finding — chatgpt-codex-connector on this PR: `handleProviderSelectChange`/
+// `handleModelSelectChange` update parent-owned `selectedProvider`/`selectedModel`
+// state and `providerTouchedRef`/`modelTouchedRef`, never react-hook-form state, so
+// `formIsDirty` alone misses a provider/model-only change. A Save button gated on
+// `onDirtyChange` must still see this as dirty, or it becomes unsavable through the
+// button unless the user also edits an unrelated field.
+describe('PageAgentSettingsTab dirty tracking', () => {
+  it('reports dirty when only the AI Provider is changed — no other field touched', async () => {
+    const user = userEvent.setup();
+    const onDirtyChange = vi.fn();
+
+    render(<Harness onDirtyChange={onDirtyChange} />);
+    await user.click(screen.getByRole('button', { name: /behavior/i }));
+
+    expect(onDirtyChange).not.toHaveBeenCalledWith(true);
+
+    // The Provider Select renders before the Model Select in the grid —
+    // index 0 is always Provider.
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(await screen.findByRole('option', { name: /anthropic/i }));
+
+    expect(onDirtyChange).toHaveBeenCalledWith(true);
+  });
+
+  it('drops back to not-dirty once the provider-only change is actually saved', async () => {
+    const user = userEvent.setup();
+    const onDirtyChange = vi.fn();
+
+    const { patch } = await import('@/lib/auth/auth-fetch');
+    (patch as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const { container } = render(<Harness onDirtyChange={onDirtyChange} />);
+    await user.click(screen.getByRole('button', { name: /behavior/i }));
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(await screen.findByRole('option', { name: /anthropic/i }));
+    expect(onDirtyChange).toHaveBeenCalledWith(true);
+
+    onDirtyChange.mockClear();
+    // Submit the real <form> (same handleSubmit(onSubmit) the ref's
+    // submitForm() also calls) via a real DOM event.
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() =>
+      expect(patch).toHaveBeenCalledWith(
+        '/api/pages/agent-1/agent-config',
+        expect.objectContaining({ aiProvider: 'anthropic' }),
+      ),
+    );
+    await waitFor(() => expect(onDirtyChange).toHaveBeenCalledWith(false));
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentSettingsSaveState.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useAgentSettingsSaveState.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAgentSettingsSaveState } from '../useAgentSettingsSaveState';
+
+describe('useAgentSettingsSaveState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts clean, and only reaches dirty once setIsDirty(true) is called', () => {
+    const { result } = renderHook(() => useAgentSettingsSaveState());
+
+    expect(result.current.saveState).toBe('clean');
+
+    act(() => result.current.setIsDirty(true));
+
+    expect(result.current.saveState).toBe('dirty');
+  });
+
+  it('reports saving whenever setIsSaving(true) is set, regardless of dirty state', () => {
+    const { result } = renderHook(() => useAgentSettingsSaveState());
+
+    act(() => result.current.setIsDirty(true));
+    act(() => result.current.setIsSaving(true));
+
+    expect(result.current.saveState).toBe('saving');
+  });
+
+  it('shows saved after handleSaved(), then reverts to clean once the confirmation window elapses', () => {
+    const { result } = renderHook(() => useAgentSettingsSaveState());
+
+    act(() => result.current.setIsDirty(true));
+    // Mirrors the real flow: a successful save resets dirty around the same
+    // time onSaved fires (see AgentPageView/AgentPanes wiring).
+    act(() => {
+      result.current.setIsDirty(false);
+      result.current.handleSaved();
+    });
+
+    expect(result.current.saveState).toBe('saved');
+
+    act(() => vi.advanceTimersByTime(1799));
+    expect(result.current.saveState).toBe('saved');
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.saveState).toBe('clean');
+  });
+
+  it('lets a new edit during the saved window immediately override it back to dirty', () => {
+    const { result } = renderHook(() => useAgentSettingsSaveState());
+
+    act(() => {
+      result.current.setIsDirty(true);
+      result.current.setIsDirty(false);
+      result.current.handleSaved();
+    });
+    expect(result.current.saveState).toBe('saved');
+
+    act(() => result.current.setIsDirty(true));
+    expect(result.current.saveState).toBe('dirty');
+
+    // The still-pending "revert to clean" timeout from the earlier save must
+    // not clobber this fresh edit once it fires.
+    act(() => vi.advanceTimersByTime(1800));
+    expect(result.current.saveState).toBe('dirty');
+  });
+
+  it('debounces back-to-back saves — a second handleSaved() call resets the confirmation window instead of stacking timers', () => {
+    const { result } = renderHook(() => useAgentSettingsSaveState());
+
+    act(() => result.current.handleSaved());
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.saveState).toBe('saved');
+
+    // A second save arrives before the first confirmation window closed.
+    act(() => result.current.handleSaved());
+    act(() => vi.advanceTimersByTime(1000));
+    // Only 1000ms since the SECOND call — the window should not have closed
+    // yet if the timer was correctly restarted rather than left stacked.
+    expect(result.current.saveState).toBe('saved');
+
+    act(() => vi.advanceTimersByTime(800));
+    expect(result.current.saveState).toBe('clean');
+  });
+
+  it('forces clean whenever isConfigLoaded is false, even while dirty', () => {
+    const { result, rerender } = renderHook(
+      ({ isConfigLoaded }: { isConfigLoaded: boolean }) => useAgentSettingsSaveState({ isConfigLoaded }),
+      { initialProps: { isConfigLoaded: false } },
+    );
+
+    act(() => result.current.setIsDirty(true));
+    expect(result.current.saveState).toBe('clean');
+
+    rerender({ isConfigLoaded: true });
+    expect(result.current.saveState).toBe('dirty');
+  });
+
+  it('clears the pending revert-to-clean timeout on unmount, without throwing', () => {
+    const { result, unmount } = renderHook(() => useAgentSettingsSaveState());
+
+    act(() => result.current.handleSaved());
+    unmount();
+
+    expect(() => act(() => vi.advanceTimersByTime(5000))).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/useAgentSettingsSaveState.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAgentSettingsSaveState.ts
@@ -1,0 +1,59 @@
+/**
+ * useAgentSettingsSaveState - the Agent Settings Save button's
+ * clean/dirty/saving/saved state machine.
+ *
+ * Shared by the two hosts that render their OWN Save button around a
+ * `PageAgentSettingsTab` instance — `AgentPageView`'s full page header and
+ * `AgentPanes`' compact per-pane bar. Both wire the returned setters into
+ * `PageAgentSettingsTab`'s `onSavingChange`/`onDirtyChange`/`onSaved` props.
+ *
+ * - clean: nothing to save (also forced whenever `isConfigLoaded` is
+ *   false — `PageAgentSettingsTab` registers `submitForm` before its own
+ *   config-loaded check returns, with EMPTY prompt/tool list defaults, so
+ *   the button must stay inert until real config has loaded AND been
+ *   edited; review finding — chatgpt-codex-connector on PR #2299).
+ * - dirty: unsaved edits, the only state the button is clickable in.
+ * - saving: a submit is in flight.
+ * - saved: a brief (`SAVED_CONFIRMATION_MS`) confirmation window after a
+ *   successful save, replacing the success toast that used to cover the
+ *   Chat/History/Settings tabs and other header buttons.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type AgentSettingsSaveState = 'clean' | 'dirty' | 'saving' | 'saved';
+
+const SAVED_CONFIRMATION_MS = 1800;
+
+interface UseAgentSettingsSaveStateOptions {
+  /** Defaults to true — pass false while the agent config is still loading. */
+  isConfigLoaded?: boolean;
+}
+
+export function useAgentSettingsSaveState({ isConfigLoaded = true }: UseAgentSettingsSaveStateOptions = {}) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [justSaved, setJustSaved] = useState(false);
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSaved = useCallback(() => {
+    if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current);
+    setJustSaved(true);
+    savedTimeoutRef.current = setTimeout(() => setJustSaved(false), SAVED_CONFIRMATION_MS);
+  }, []);
+
+  useEffect(() => () => {
+    if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current);
+  }, []);
+
+  const saveState: AgentSettingsSaveState = !isConfigLoaded
+    ? 'clean'
+    : isSaving
+    ? 'saving'
+    : isDirty
+    ? 'dirty'
+    : justSaved
+    ? 'saved'
+    : 'clean';
+
+  return { saveState, isSaving, setIsSaving, setIsDirty, handleSaved };
+}


### PR DESCRIPTION
## Summary
- The Agent Settings Save button (full "Page AI" page header and the compact split-pane Settings tab) now carries its own unsaved/saving/saved state instead of a plain always-clickable button plus a success toast: clean (quiet/outline, disabled), dirty (amber, pulsing dot), saving (spinner, unchanged), saved (green checkmark, ~1.8s, fades back to clean).
- Removes `toast.success('Agent configuration saved successfully')` — it used to float over the Chat/History/Settings tabs and Webhooks button needed to leave Settings, blocking navigation. `toast.error` on failure is unchanged.
- `PageAgentSettingsTab` exposes new `onDirtyChange`/`onSaved` callback props instead; both host components (`AgentPageView`, `AgentPanes`) wire these into their own Save button's state machine via a shared `useAgentSettingsSaveState` hook (`apps/web/src/lib/ai/shared/hooks/useAgentSettingsSaveState.ts`) — avoids the two hosts' state machines drifting apart.
- Both Save buttons announce state changes via `aria-live="polite"`/`aria-atomic="true"` — the removed toast was the only save-confirmation signal for screen readers, so the button itself announces now. `AgentPageView`'s button icons are `aria-hidden` and its state label uses `sr-only sm:not-sr-only sm:inline` so it stays screen-reader-visible at every width (a plain `hidden sm:inline` would drop it from the a11y tree — and the button's accessible name entirely — below the `sm` breakpoint).

## Review fixes (from Codex, CodeRabbit, and an adversarial re-review)
- A provider/model-only change (the AI Provider/Model Selects bypass react-hook-form) wasn't counted as dirty by the Save button OR the `useEditingStore` SWR/auth-refresh guard — both fixed, with regression tests.
- `AgentPageView`'s Save button now correctly stays clean while `agentConfig` hasn't resolved yet (matches `AgentPanes`' existing guard), covering the `?tab=settings` deep-link case.
- Closed a theoretical race where a save with a real dirty field could flash the button back to "dirty" for one frame before settling on "saved" — `onSubmit` now clears dirty state directly in the same synchronous block as the saved callback, instead of relying solely on a mirror effect that updates on a later render.
- `AgentPageView.test.tsx` now covers the dirty-gating and "Saved" confirmation lifecycle (previously only `AgentPanes` had this).

## Test plan
- [x] `bun run --filter web test` — `AgentPageView.test.tsx`, `AgentPanes.test.tsx`, `PageAgentSettingsTab.navigation.test.tsx`, `PageAgentSettingsTab.dirty.test.tsx`, `useAgentSettingsSaveState.test.ts` — 131 passing
- [x] `bun run --filter web typecheck` — clean
- [x] `bun run --filter web lint` — clean
- [x] `bun run knip:check` — within baseline
- [ ] Manual: edit a field in Page AI settings, confirm button turns amber/pulsing, save, confirm inline green "Saved" appears with no toast, confirm it fades to clean. Repeat inside a split pane's compact Settings tab. Verify changing only the AI Provider/Model enables Save. Verify at a narrow (mobile) viewport with a screen reader that Save button state is announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013a1LCWSoyMvcWc9nEZRnd9