### PR TITLE
fix(agents): restore sandbox access for the default Global Assistant chat

### DIFF
--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
@@ -30,6 +30,7 @@ import {
   claimConversationInSession,
   createConversationInSession,
   reopenConversationInSession,
+  ensureGlobalSandboxSession,
 } from '../agent-sessions-runtime';
 import { SessionFullError } from '../create-conversation-in-session';
 
@@ -326,4 +327,74 @@ describe('claim — real concurrency (the guarded UPDATE, not the advisory lock,
     expect(claimed.closedInSessionAt).toBeNull();
     expect(await openCountFor(newSession.id)).toBe(1);
   }, 20_000);
+});
+
+describe('ensureGlobalSandboxSession — auto-provisioning the default Global Assistant conversation', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('mints a real, ordinary session (driveId null) and binds it to a never-claimed global conversation', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const conversationId = createId();
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'global',
+      contextId: null,
+      sessionId: null,
+      isActive: true,
+    });
+
+    const session = await ensureGlobalSandboxSession(conversationId, owner.id);
+
+    expect(session).not.toBeNull();
+    expect(session?.ownerId).toBe(owner.id);
+    expect(session?.driveId).toBeNull();
+
+    const [bound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
+    expect(bound.sessionId).toBe(session?.id);
+  });
+
+  it('given a conversation already bound elsewhere, returns null and ends the freshly spawned session rather than leaving it empty', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const [existingSession] = await db
+      .insert(agentSessions)
+      .values({ id: createId(), driveId: null, ownerId: owner.id })
+      .returning();
+
+    const conversationId = createId();
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'global',
+      contextId: null,
+      sessionId: existingSession.id,
+      isActive: true,
+    });
+
+    const result = await ensureGlobalSandboxSession(conversationId, owner.id);
+    expect(result).toBeNull();
+
+    // The bound conversation's own session is untouched...
+    const [stillBound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
+    expect(stillBound.sessionId).toBe(existingSession.id);
+
+    // ...and the session this call spawned to try the claim did not end up
+    // sitting empty forever — it was torn down again rather than orphaned.
+    const [liveSessions] = await db
+      .select({ n: count() })
+      .from(agentSessions)
+      .where(and(eq(agentSessions.ownerId, owner.id), isNull(agentSessions.endedAt)));
+    expect(liveSessions.n).toBe(1); // only `existingSession` remains live
+  });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/agent-sessions-runtime.integration.test.ts
@@ -31,6 +31,7 @@ import {
   createConversationInSession,
   reopenConversationInSession,
   ensureGlobalSandboxSession,
+  MAX_ACTIVE_SESSIONS_PER_OWNER,
 } from '../agent-sessions-runtime';
 import { SessionFullError } from '../create-conversation-in-session';
 
@@ -353,17 +354,18 @@ describe('ensureGlobalSandboxSession — auto-provisioning the default Global As
       isActive: true,
     });
 
-    const session = await ensureGlobalSandboxSession(conversationId, owner.id);
+    const result = await ensureGlobalSandboxSession(conversationId, owner.id);
 
-    expect(session).not.toBeNull();
-    expect(session?.ownerId).toBe(owner.id);
-    expect(session?.driveId).toBeNull();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.session.ownerId).toBe(owner.id);
+    expect(result.session.driveId).toBeNull();
 
     const [bound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
-    expect(bound.sessionId).toBe(session?.id);
+    expect(bound.sessionId).toBe(result.session.id);
   });
 
-  it('given a conversation already bound elsewhere, returns null and ends the freshly spawned session rather than leaving it empty', async () => {
+  it('given a conversation already bound to an existing session, resolves to THAT session rather than failing — same code path a concurrent winner takes', async () => {
     if (!dbAvailable) return;
 
     const owner = await factories.createUser();
@@ -383,18 +385,88 @@ describe('ensureGlobalSandboxSession — auto-provisioning the default Global As
     });
 
     const result = await ensureGlobalSandboxSession(conversationId, owner.id);
-    expect(result).toBeNull();
 
-    // The bound conversation's own session is untouched...
-    const [stillBound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
-    expect(stillBound.sessionId).toBe(existingSession.id);
+    // The claim this call attempted lost (the conversation was already
+    // bound) — it re-resolves through the conversation instead of failing,
+    // so a caller sees the SAME outcome whether the binding happened just
+    // now (a concurrent winner) or long ago (a stale pre-check).
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.session.id).toBe(existingSession.id);
 
-    // ...and the session this call spawned to try the claim did not end up
-    // sitting empty forever — it was torn down again rather than orphaned.
+    // The scratch session this call spawned to attempt the claim did not
+    // end up sitting empty forever — it was torn down rather than orphaned.
     const [liveSessions] = await db
       .select({ n: count() })
       .from(agentSessions)
       .where(and(eq(agentSessions.ownerId, owner.id), isNull(agentSessions.endedAt)));
     expect(liveSessions.n).toBe(1); // only `existingSession` remains live
+  });
+
+  it('two concurrent calls for the SAME never-bound conversation converge on ONE session — the loser cleans up and adopts the winner\'s', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const conversationId = createId();
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'global',
+      contextId: null,
+      sessionId: null,
+      isActive: true,
+    });
+
+    const [a, b] = await Promise.all([
+      ensureGlobalSandboxSession(conversationId, owner.id),
+      ensureGlobalSandboxSession(conversationId, owner.id),
+    ]);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+    // Both concurrent callers end up pointed at the SAME sandbox — the
+    // shared-workspace invariant a per-conversation sandbox would violate.
+    expect(a.session.id).toBe(b.session.id);
+
+    const [bound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
+    expect(bound.sessionId).toBe(a.session.id);
+
+    // Exactly one session survives — the loser's scratch spawn was torn down,
+    // not left as an orphaned, empty, permanently-billed workspace.
+    const [liveSessions] = await db
+      .select({ n: count() })
+      .from(agentSessions)
+      .where(and(eq(agentSessions.ownerId, owner.id), isNull(agentSessions.endedAt)));
+    expect(liveSessions.n).toBe(1);
+  });
+
+  it('given the owner is already at the active-session cap, fails with session_limit_reached rather than the generic no_session', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    // Bulk-insert straight to the cap — bypasses spawnSession's own store
+    // logic (this test is about ensureGlobalSandboxSession's error mapping,
+    // not about the cap's own enforcement, which plan-spawn-session.test.ts
+    // already covers).
+    await db.insert(agentSessions).values(
+      Array.from({ length: MAX_ACTIVE_SESSIONS_PER_OWNER }, () => ({ id: createId(), driveId: null, ownerId: owner.id })),
+    );
+
+    const conversationId = createId();
+    await db.insert(conversations).values({
+      id: conversationId,
+      userId: owner.id,
+      type: 'global',
+      contextId: null,
+      sessionId: null,
+      isActive: true,
+    });
+
+    const result = await ensureGlobalSandboxSession(conversationId, owner.id);
+    expect(result).toEqual({ ok: false, reason: 'session_limit_reached' });
+
+    const [stillUnbound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
+    expect(stillUnbound.sessionId).toBeNull();
   });
 });

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -591,10 +591,28 @@ export async function ensureGlobalSandboxSession(
     // its retries, a DB connection fault) rather than resolving a normal
     // outcome — a path that skipped this cleanup entirely before, leaking
     // the scratch session on every such failure (review finding —
-    // chatgpt-codex-connector). Clean up, then propagate the original error
-    // — this is a genuine infra fault, not a normal "no session" business
-    // outcome this function's own result union is meant to describe.
+    // chatgpt-codex-connector).
+    //
+    // The thrown error is AMBIGUOUS in a way `claimed === 'not_found'` below
+    // never is: the guarded UPDATE may have actually COMMITTED server-side
+    // with the connection dropping before this call ever saw the
+    // acknowledgment. Ending our scratch session on that outcome would be
+    // catastrophic, not just wasteful — bindings are write-once, so a
+    // conversation left pointing at a session we just ENDED can never be
+    // re-claimed into a replacement, ever (review finding, second pass —
+    // chatgpt-codex-connector). Re-resolve BEFORE tearing anything down: if
+    // the conversation is now bound to the session we spawned, the claim
+    // genuinely succeeded despite the thrown error — treat it as one.
+    const boundAfterThrow = await findSessionForConversation(conversationId);
+    if (boundAfterThrow?.id === spawned.session.id) {
+      return { ok: true, session: spawned.session };
+    }
+    // Not bound to OUR session — either truly unclaimed, or a concurrent
+    // sibling's claim won in the meantime. Either way our scratch session
+    // is safe to tear down; adopt the sibling's session if one is there,
+    // otherwise this really is the infra fault it looked like — propagate it.
     await endScratchSession('a claim exception');
+    if (boundAfterThrow) return { ok: true, session: boundAfterThrow };
     throw error;
   }
   if (claimed === 'claimed' || claimed === 'already_in_session') return { ok: true, session: spawned.session };

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -603,7 +603,23 @@ export async function ensureGlobalSandboxSession(
     // chatgpt-codex-connector). Re-resolve BEFORE tearing anything down: if
     // the conversation is now bound to the session we spawned, the claim
     // genuinely succeeded despite the thrown error — treat it as one.
-    const boundAfterThrow = await findSessionForConversation(conversationId);
+    //
+    // A single autocommit UPDATE's commit is durable and immediately visible
+    // to any other connection the instant it completes server-side — there
+    // is no PostgreSQL window where a commit has finished but the write is
+    // not yet visible elsewhere, and a connection that drops before that
+    // point aborts the (never-committed) statement outright. So one re-read
+    // is already conclusive under normal Postgres semantics. The brief
+    // retry below is pure defense-in-depth against exactly that claim being
+    // wrong in some deployment-specific way (a pooler, a replica read) that
+    // isn't visible from this file alone — cheap insurance given how
+    // unrecoverable a wrong "unclaimed" verdict is here (review finding,
+    // third pass — chatgpt-codex-connector).
+    let boundAfterThrow = await findSessionForConversation(conversationId);
+    if (!boundAfterThrow) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      boundAfterThrow = await findSessionForConversation(conversationId);
+    }
     if (boundAfterThrow?.id === spawned.session.id) {
       return { ok: true, session: spawned.session };
     }

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -22,6 +22,7 @@ import { withAdvisoryLock } from '@pagespace/db/advisory-lock';
 import { and, count, eq, inArray, isNull, isNotNull, sql } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { users } from '@pagespace/db/schema/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkAgentSessionConcurrency } from '@pagespace/lib/services/sandbox/quota';
 import {
   refreshSessionStorageMeasurement,
@@ -561,11 +562,41 @@ export async function ensureGlobalSandboxSession(
     return { ok: false, reason: spawned.reason === 'session_limit_reached' ? 'session_limit_reached' : 'spawn_failed' };
   }
 
-  const claimed = await claimConversationInSession({
-    conversationId,
-    userId,
-    sessionId: spawned.session.id,
-  });
+  // Cleanup shared by both the "claim lost" and "claim threw" paths below —
+  // the freshly spawned session would otherwise sit empty forever, which the
+  // session model treats as an invariant violation (mirrors the same cleanup
+  // the spawn route itself does when its own first-conversation creation
+  // fails). Fail-open (never lets a cleanup fault surface as THIS call's own
+  // error) but logged — a silently swallowed failure here would leave the
+  // scratch session live, counting against MAX_ACTIVE_SESSIONS_PER_OWNER and
+  // accruing cost, with no signal anywhere (review finding — CodeRabbit).
+  const endScratchSession = (cause: string) =>
+    endSession(spawned.session.id).catch((error) => {
+      loggers.api.warn(`Failed to end scratch session after ${cause}`, {
+        sessionId: spawned.session.id,
+        conversationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+  let claimed: ClaimConversationOutcome;
+  try {
+    claimed = await claimConversationInSession({
+      conversationId,
+      userId,
+      sessionId: spawned.session.id,
+    });
+  } catch (error) {
+    // `claimConversationInSession` can THROW (the advisory lock exhausting
+    // its retries, a DB connection fault) rather than resolving a normal
+    // outcome — a path that skipped this cleanup entirely before, leaking
+    // the scratch session on every such failure (review finding —
+    // chatgpt-codex-connector). Clean up, then propagate the original error
+    // — this is a genuine infra fault, not a normal "no session" business
+    // outcome this function's own result union is meant to describe.
+    await endScratchSession('a claim exception');
+    throw error;
+  }
   if (claimed === 'claimed' || claimed === 'already_in_session') return { ok: true, session: spawned.session };
 
   // The claim lost a race — most likely a CONCURRENT call for the same
@@ -576,12 +607,7 @@ export async function ensureGlobalSandboxSession(
   // losing call would spuriously deny a conversation that, by the time this
   // line runs, genuinely has a session. Only a conversation deleted out
   // from under both calls resolves to nothing here.
-  //
-  // The freshly spawned session would otherwise sit empty forever, which
-  // the session model treats as an invariant violation (mirrors the same
-  // cleanup the spawn route itself does when its own first-conversation
-  // creation fails) — so it's torn down either way.
-  await endSession(spawned.session.id).catch(() => {});
+  await endScratchSession('a lost conversation claim');
   const winner = await findSessionForConversation(conversationId);
   return winner ? { ok: true, session: winner } : { ok: false, reason: 'no_session' };
 }

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -536,7 +536,22 @@ export async function findSessionForConversation(conversationId: string): Promis
 export type EnsureGlobalSandboxSessionFailureReason = 'session_limit_reached' | 'spawn_failed' | 'no_session';
 
 export type EnsureGlobalSandboxSessionResult =
-  | { ok: true; session: AgentSessionRecord }
+  | {
+      ok: true;
+      session: AgentSessionRecord;
+      /**
+       * True only when THIS call minted `session` AND successfully claimed
+       * it itself — false when the session is one a CONCURRENT sibling call
+       * spawned and claimed first, which this call merely adopted after
+       * losing its own claim race. That distinction matters to callers
+       * deciding whether it's safe to tear the session back down for a
+       * reason specific to THIS call (e.g. its own credit gate denying) —
+       * a sibling's session may have its own, unrelated, still-in-flight
+       * use; only a session this exact call both created and bound is
+       * unambiguously ours to destroy.
+       */
+      selfClaimed: boolean;
+    }
   | { ok: false; reason: EnsureGlobalSandboxSessionFailureReason };
 
 /**
@@ -648,7 +663,9 @@ export async function ensureGlobalSandboxSession(
       });
     }
     if (boundAfterThrow?.id === spawned.session.id) {
-      return { ok: true, session: spawned.session };
+      // Bound to the session WE spawned — the claim genuinely was ours,
+      // ambiguity and all.
+      return { ok: true, session: spawned.session, selfClaimed: true };
     }
     if (verificationFailed) {
       throw error;
@@ -659,10 +676,14 @@ export async function ensureGlobalSandboxSession(
     // sibling's session if one is there, otherwise this really is the infra
     // fault it looked like — propagate it.
     await endScratchSession('a claim exception');
-    if (boundAfterThrow) return { ok: true, session: boundAfterThrow };
+    // Not ours — a concurrent sibling's own session, not one this call
+    // created or claimed.
+    if (boundAfterThrow) return { ok: true, session: boundAfterThrow, selfClaimed: false };
     throw error;
   }
-  if (claimed === 'claimed' || claimed === 'already_in_session') return { ok: true, session: spawned.session };
+  if (claimed === 'claimed' || claimed === 'already_in_session') {
+    return { ok: true, session: spawned.session, selfClaimed: true };
+  }
 
   // The claim lost a race — most likely a CONCURRENT call for the same
   // conversation (two sandbox tool calls in one turn, two tabs) won first
@@ -674,7 +695,8 @@ export async function ensureGlobalSandboxSession(
   // from under both calls resolves to nothing here.
   await endScratchSession('a lost conversation claim');
   const winner = await findSessionForConversation(conversationId);
-  return winner ? { ok: true, session: winner } : { ok: false, reason: 'no_session' };
+  // Adopted a sibling's session, not one this call created or claimed.
+  return winner ? { ok: true, session: winner, selfClaimed: false } : { ok: false, reason: 'no_session' };
 }
 
 export interface SessionConversationEntry {

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -523,11 +523,20 @@ export async function findSessionForConversation(conversationId: string): Promis
   return (await getAgentSessionStore()).findByConversation(conversationId);
 }
 
+/**
+ * Every one of these is racy or retryable by nature (a session cap another
+ * concurrent call may have just filled, a transient spawn fault, a lost
+ * claim) — never a deterministic "this conversation can never have a
+ * session." Callers that gate on this (billing) must treat the whole set
+ * the same way, not narrow to whichever specific reason the last bug was
+ * about (two separate reviewer findings on PR #2314 were each a caller
+ * treating one of these as safely equivalent to "no session, ever").
+ */
+export type EnsureGlobalSandboxSessionFailureReason = 'session_limit_reached' | 'spawn_failed' | 'no_session';
+
 export type EnsureGlobalSandboxSessionResult =
   | { ok: true; session: AgentSessionRecord }
-  /** The owner is already at `MAX_ACTIVE_SESSIONS_PER_OWNER` — actionable and distinct from a generic "no session" denial. */
-  | { ok: false; reason: 'session_limit_reached' }
-  | { ok: false; reason: 'spawn_failed' | 'no_session' };
+  | { ok: false; reason: EnsureGlobalSandboxSessionFailureReason };
 
 /**
  * Auto-provision a workspace for a Global Assistant conversation that has

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -523,6 +523,42 @@ export async function findSessionForConversation(conversationId: string): Promis
   return (await getAgentSessionStore()).findByConversation(conversationId);
 }
 
+/**
+ * Auto-provision a workspace for a Global Assistant conversation that has
+ * never had one — the exact same primitive a manual "New session → Global
+ * Assistant" spawn uses (spawn, then claim), just triggered from the first
+ * sandbox tool call instead of the command palette. The caller
+ * (`sandbox-tools-runtime.ts`) is the one that decides this only applies to
+ * `type === 'global'` conversations; this function only knows how to mint
+ * and bind a session, not when that's appropriate.
+ *
+ * Returns null on any failure (session limit reached, spawn fault, or a race
+ * that bound/deleted the conversation before the claim landed) — the caller
+ * treats that identically to "no session".
+ */
+export async function ensureGlobalSandboxSession(
+  conversationId: string,
+  userId: string,
+): Promise<AgentSessionRecord | null> {
+  const spawned = await spawnSession({ userId, driveId: null });
+  if (!spawned.ok) return null;
+
+  const claimed = await claimConversationInSession({
+    conversationId,
+    userId,
+    sessionId: spawned.session.id,
+  });
+  if (claimed === 'claimed' || claimed === 'already_in_session') return spawned.session;
+
+  // The claim lost a race (the conversation got bound elsewhere or deleted
+  // between the read above and now) — the freshly spawned session would
+  // otherwise sit empty forever, which the session model treats as an
+  // invariant violation (mirrors the same cleanup the spawn route itself
+  // does when its own first-conversation creation fails).
+  await endSession(spawned.session.id).catch(() => {});
+  return null;
+}
+
 export interface SessionConversationEntry {
   conversationId: string;
   title: string | null;

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -536,22 +536,7 @@ export async function findSessionForConversation(conversationId: string): Promis
 export type EnsureGlobalSandboxSessionFailureReason = 'session_limit_reached' | 'spawn_failed' | 'no_session';
 
 export type EnsureGlobalSandboxSessionResult =
-  | {
-      ok: true;
-      session: AgentSessionRecord;
-      /**
-       * True only when THIS call minted `session` AND successfully claimed
-       * it itself — false when the session is one a CONCURRENT sibling call
-       * spawned and claimed first, which this call merely adopted after
-       * losing its own claim race. That distinction matters to callers
-       * deciding whether it's safe to tear the session back down for a
-       * reason specific to THIS call (e.g. its own credit gate denying) —
-       * a sibling's session may have its own, unrelated, still-in-flight
-       * use; only a session this exact call both created and bound is
-       * unambiguously ours to destroy.
-       */
-      selfClaimed: boolean;
-    }
+  | { ok: true; session: AgentSessionRecord }
   | { ok: false; reason: EnsureGlobalSandboxSessionFailureReason };
 
 /**
@@ -663,9 +648,7 @@ export async function ensureGlobalSandboxSession(
       });
     }
     if (boundAfterThrow?.id === spawned.session.id) {
-      // Bound to the session WE spawned — the claim genuinely was ours,
-      // ambiguity and all.
-      return { ok: true, session: spawned.session, selfClaimed: true };
+      return { ok: true, session: spawned.session };
     }
     if (verificationFailed) {
       throw error;
@@ -676,14 +659,10 @@ export async function ensureGlobalSandboxSession(
     // sibling's session if one is there, otherwise this really is the infra
     // fault it looked like — propagate it.
     await endScratchSession('a claim exception');
-    // Not ours — a concurrent sibling's own session, not one this call
-    // created or claimed.
-    if (boundAfterThrow) return { ok: true, session: boundAfterThrow, selfClaimed: false };
+    if (boundAfterThrow) return { ok: true, session: boundAfterThrow };
     throw error;
   }
-  if (claimed === 'claimed' || claimed === 'already_in_session') {
-    return { ok: true, session: spawned.session, selfClaimed: true };
-  }
+  if (claimed === 'claimed' || claimed === 'already_in_session') return { ok: true, session: spawned.session };
 
   // The claim lost a race — most likely a CONCURRENT call for the same
   // conversation (two sandbox tool calls in one turn, two tabs) won first
@@ -695,8 +674,7 @@ export async function ensureGlobalSandboxSession(
   // from under both calls resolves to nothing here.
   await endScratchSession('a lost conversation claim');
   const winner = await findSessionForConversation(conversationId);
-  // Adopted a sibling's session, not one this call created or claimed.
-  return winner ? { ok: true, session: winner, selfClaimed: false } : { ok: false, reason: 'no_session' };
+  return winner ? { ok: true, session: winner } : { ok: false, reason: 'no_session' };
 }
 
 export interface SessionConversationEntry {

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -615,10 +615,29 @@ export async function ensureGlobalSandboxSession(
     // isn't visible from this file alone — cheap insurance given how
     // unrecoverable a wrong "unclaimed" verdict is here (review finding,
     // third pass — chatgpt-codex-connector).
-    let boundAfterThrow = await findSessionForConversation(conversationId);
-    if (!boundAfterThrow) {
-      await new Promise((resolve) => setTimeout(resolve, 250));
+    //
+    // These re-reads are themselves NOT exception-safe by default: the same
+    // DB/connection fault that made the claim throw is plausibly still in
+    // effect, and an unguarded throw here would propagate straight out of
+    // this function, skipping `endScratchSession` entirely — the exact leak
+    // this whole catch block exists to close (review findings — CodeRabbit
+    // and chatgpt-codex-connector, both independently, same commit). A
+    // failed lookup is treated as "still unresolved" and falls through to
+    // the existing safe-to-end-and-rethrow path below, never as proof the
+    // conversation is claimed.
+    let boundAfterThrow: AgentSessionRecord | null = null;
+    try {
       boundAfterThrow = await findSessionForConversation(conversationId);
+      if (!boundAfterThrow) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        boundAfterThrow = await findSessionForConversation(conversationId);
+      }
+    } catch (lookupError) {
+      loggers.api.warn('Failed to re-resolve conversation binding after a claim exception', {
+        sessionId: spawned.session.id,
+        conversationId,
+        error: lookupError instanceof Error ? lookupError.message : String(lookupError),
+      });
     }
     if (boundAfterThrow?.id === spawned.session.id) {
       return { ok: true, session: spawned.session };

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -523,6 +523,12 @@ export async function findSessionForConversation(conversationId: string): Promis
   return (await getAgentSessionStore()).findByConversation(conversationId);
 }
 
+export type EnsureGlobalSandboxSessionResult =
+  | { ok: true; session: AgentSessionRecord }
+  /** The owner is already at `MAX_ACTIVE_SESSIONS_PER_OWNER` — actionable and distinct from a generic "no session" denial. */
+  | { ok: false; reason: 'session_limit_reached' }
+  | { ok: false; reason: 'spawn_failed' | 'no_session' };
+
 /**
  * Auto-provision a workspace for a Global Assistant conversation that has
  * never had one — the exact same primitive a manual "New session → Global
@@ -531,32 +537,44 @@ export async function findSessionForConversation(conversationId: string): Promis
  * (`sandbox-tools-runtime.ts`) is the one that decides this only applies to
  * `type === 'global'` conversations; this function only knows how to mint
  * and bind a session, not when that's appropriate.
- *
- * Returns null on any failure (session limit reached, spawn fault, or a race
- * that bound/deleted the conversation before the claim landed) — the caller
- * treats that identically to "no session".
  */
 export async function ensureGlobalSandboxSession(
   conversationId: string,
   userId: string,
-): Promise<AgentSessionRecord | null> {
+): Promise<EnsureGlobalSandboxSessionResult> {
   const spawned = await spawnSession({ userId, driveId: null });
-  if (!spawned.ok) return null;
+  if (!spawned.ok) {
+    // `session_limit_reached` is a distinct, actionable denial ("end an
+    // existing session first") the caller already knows how to surface —
+    // collapsing it into the generic no_session message would tell an agent
+    // sitting at its owner's session cap to do something that can't help
+    // ("start a new conversation").
+    return { ok: false, reason: spawned.reason === 'session_limit_reached' ? 'session_limit_reached' : 'spawn_failed' };
+  }
 
   const claimed = await claimConversationInSession({
     conversationId,
     userId,
     sessionId: spawned.session.id,
   });
-  if (claimed === 'claimed' || claimed === 'already_in_session') return spawned.session;
+  if (claimed === 'claimed' || claimed === 'already_in_session') return { ok: true, session: spawned.session };
 
-  // The claim lost a race (the conversation got bound elsewhere or deleted
-  // between the read above and now) — the freshly spawned session would
-  // otherwise sit empty forever, which the session model treats as an
-  // invariant violation (mirrors the same cleanup the spawn route itself
-  // does when its own first-conversation creation fails).
+  // The claim lost a race — most likely a CONCURRENT call for the same
+  // conversation (two sandbox tool calls in one turn, two tabs) won first
+  // and bound it to the session IT spawned. That winner's session is
+  // exactly as valid as the one this call would have minted, so re-resolve
+  // through the conversation rather than failing outright — otherwise the
+  // losing call would spuriously deny a conversation that, by the time this
+  // line runs, genuinely has a session. Only a conversation deleted out
+  // from under both calls resolves to nothing here.
+  //
+  // The freshly spawned session would otherwise sit empty forever, which
+  // the session model treats as an invariant violation (mirrors the same
+  // cleanup the spawn route itself does when its own first-conversation
+  // creation fails) — so it's torn down either way.
   await endSession(spawned.session.id).catch(() => {});
-  return null;
+  const winner = await findSessionForConversation(conversationId);
+  return winner ? { ok: true, session: winner } : { ok: false, reason: 'no_session' };
 }
 
 export interface SessionConversationEntry {

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -618,14 +618,21 @@ export async function ensureGlobalSandboxSession(
     //
     // These re-reads are themselves NOT exception-safe by default: the same
     // DB/connection fault that made the claim throw is plausibly still in
-    // effect, and an unguarded throw here would propagate straight out of
-    // this function, skipping `endScratchSession` entirely — the exact leak
-    // this whole catch block exists to close (review findings — CodeRabbit
-    // and chatgpt-codex-connector, both independently, same commit). A
-    // failed lookup is treated as "still unresolved" and falls through to
-    // the existing safe-to-end-and-rethrow path below, never as proof the
-    // conversation is claimed.
+    // effect. Distinguish "verification SUCCEEDED and found nothing" (safe
+    // to end — we have a real, current answer) from "verification itself
+    // FAILED" (unknown — treating that the same as "confirmed unclaimed"
+    // would let a compound failure (claim commits + verification ALSO
+    // fails) still end a session the conversation is genuinely bound to,
+    // reopening the exact stranding this whole catch block exists to
+    // prevent). On a failed verification, this leaves the scratch session
+    // alone rather than gambling on it — a stray, un-ended, sandbox-less
+    // session is a cheap, fully recoverable cost (visible in the sidebar,
+    // endable by hand); permanently stranding a conversation on a dead one
+    // is not (review findings — CodeRabbit and chatgpt-codex-connector,
+    // both independently, then a further round from chatgpt-codex-connector
+    // on the compound-failure case).
     let boundAfterThrow: AgentSessionRecord | null = null;
+    let verificationFailed = false;
     try {
       boundAfterThrow = await findSessionForConversation(conversationId);
       if (!boundAfterThrow) {
@@ -633,6 +640,7 @@ export async function ensureGlobalSandboxSession(
         boundAfterThrow = await findSessionForConversation(conversationId);
       }
     } catch (lookupError) {
+      verificationFailed = true;
       loggers.api.warn('Failed to re-resolve conversation binding after a claim exception', {
         sessionId: spawned.session.id,
         conversationId,
@@ -642,10 +650,14 @@ export async function ensureGlobalSandboxSession(
     if (boundAfterThrow?.id === spawned.session.id) {
       return { ok: true, session: spawned.session };
     }
-    // Not bound to OUR session — either truly unclaimed, or a concurrent
-    // sibling's claim won in the meantime. Either way our scratch session
-    // is safe to tear down; adopt the sibling's session if one is there,
-    // otherwise this really is the infra fault it looked like — propagate it.
+    if (verificationFailed) {
+      throw error;
+    }
+    // Verification SUCCEEDED and confirmed we are NOT bound to it — either
+    // truly unclaimed, or a concurrent sibling's claim won in the meantime.
+    // Either way our scratch session is safe to tear down; adopt the
+    // sibling's session if one is there, otherwise this really is the infra
+    // fault it looked like — propagate it.
     await endScratchSession('a claim exception');
     if (boundAfterThrow) return { ok: true, session: boundAfterThrow };
     throw error;

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -13,6 +13,7 @@ const {
   mockRecordSessionActivity,
   mockEnsureGlobalSandboxSession,
   mockGetConversation,
+  mockEndSession,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockRecordSessionActivity: vi.fn(),
   mockEnsureGlobalSandboxSession: vi.fn(),
   mockGetConversation: vi.fn(),
+  mockEndSession: vi.fn(async () => ({ ok: true }) as never),
 }));
 
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
@@ -33,6 +35,7 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   // or fail a tool call.
   measureWarmSessionStorage: mockMeasureWarmSessionStorage,
   ensureGlobalSandboxSession: mockEnsureGlobalSandboxSession,
+  endSession: mockEndSession,
 }));
 vi.mock('@/lib/repositories/conversation-repository', () => ({
   conversationRepository: { getConversation: mockGetConversation },
@@ -389,7 +392,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     // spawn uses.
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: sessionRecord });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: sessionRecord, selfClaimed: true });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-1', 'u1');
@@ -602,7 +605,7 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
     const provisioned = makeSessionRecord({ id: 'auto-ses-1', driveId: null, ownerId: 'u1' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
     const deps = buildRealSandboxRunDeps();
 
     const result = await deps.resolveBillingSession?.({
@@ -613,8 +616,51 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
       tier: 'pro',
     });
 
-    expect(result).toEqual({ sessionId: 'auto-ses-1', driveId: null, ownerId: 'u1' });
+    expect(result).toMatchObject({ sessionId: 'auto-ses-1', driveId: null, ownerId: 'u1' });
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-fresh-global', 'u1');
+  });
+
+  it('given a GLOBAL conversation this call itself just minted (selfClaimed), attaches a cleanupIfDenied that ends that session — a repeat credit-exhausted attempt must not leave a real, empty, permanently-bound session behind (review finding — P2, PR #2314, fourth pass)', async () => {
+    mockEndSession.mockClear();
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    const provisioned = makeSessionRecord({ id: 'auto-ses-2', driveId: null, ownerId: 'u1' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toHaveProperty('cleanupIfDenied');
+    const cleanupIfDenied = (result as { cleanupIfDenied?: () => Promise<void> })?.cleanupIfDenied;
+    expect(typeof cleanupIfDenied).toBe('function');
+    await cleanupIfDenied?.();
+    expect(mockEndSession).toHaveBeenCalledWith('auto-ses-2');
+  });
+
+  it('given a GLOBAL conversation whose session was ADOPTED from a concurrent sibling (not selfClaimed), does NOT attach cleanupIfDenied — that session is the sibling\'s to manage, not ours to tear down on our own credit denial', async () => {
+    mockEndSession.mockClear();
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    const siblingSession = makeSessionRecord({ id: 'sibling-ses-1', driveId: null, ownerId: 'u1' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: siblingSession, selfClaimed: false });
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toMatchObject({ sessionId: 'sibling-ses-1' });
+    expect((result as { cleanupIfDenied?: unknown })?.cleanupIfDenied).toBeUndefined();
   });
 
   it('given a GLOBAL conversation whose auto-provisioning hits the session cap, fails CLOSED with { deny } rather than resolving null — a concurrent sibling\'s claim could still let acquireSandbox succeed moments later, executing unmetered (review finding — P1, PR #2314, second pass)', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // with injected fakes and never touches the mocked defaults.
 const {
   mockFindSessionForConversation,
+  mockFindSessionRecord,
   mockProvisionSessionSandbox,
   mockMeasureWarmSessionStorage,
   mockCheckSessionRuntimeGuardrail,
@@ -16,6 +17,7 @@ const {
   mockEndSession,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
+  mockFindSessionRecord: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
   mockMeasureWarmSessionStorage: vi.fn(async () => {}),
   mockCheckSessionRuntimeGuardrail: vi.fn(),
@@ -28,6 +30,7 @@ const {
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
 vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   findSessionForConversation: mockFindSessionForConversation,
+  findSessionRecord: mockFindSessionRecord,
   provisionSessionSandbox: mockProvisionSessionSandbox,
   // Opportunistic storage measurement rides this path fire-and-forget. Stubbed
   // so the module loads; the assertions below deliberately do not await it,
@@ -620,12 +623,13 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-fresh-global', 'u1');
   });
 
-  it('given a GLOBAL conversation this call itself just minted (selfClaimed), attaches a cleanupIfDenied that ends that session — a repeat credit-exhausted attempt must not leave a real, empty, permanently-bound session behind (review finding — P2, PR #2314, fourth pass)', async () => {
+  it('given a GLOBAL conversation this call itself just minted (selfClaimed) and NOTHING has been provisioned in it since, attaches a cleanupIfDenied that ends that session — a repeat credit-exhausted attempt must not leave a real, empty, permanently-bound session behind (review finding — P2, PR #2314, fourth pass)', async () => {
     mockEndSession.mockClear();
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    const provisioned = makeSessionRecord({ id: 'auto-ses-2', driveId: null, ownerId: 'u1' });
+    const provisioned = makeSessionRecord({ id: 'auto-ses-2', driveId: null, ownerId: 'u1', sandboxId: null });
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
+    mockFindSessionRecord.mockResolvedValue(makeSessionRecord({ id: 'auto-ses-2', sandboxId: null }));
     const deps = buildRealSandboxRunDeps();
 
     const result = await deps.resolveBillingSession?.({
@@ -637,10 +641,38 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     });
 
     expect(result).toHaveProperty('cleanupIfDenied');
+    expect(mockEndSession).not.toHaveBeenCalled();
     const cleanupIfDenied = (result as { cleanupIfDenied?: () => Promise<void> })?.cleanupIfDenied;
     expect(typeof cleanupIfDenied).toBe('function');
     await cleanupIfDenied?.();
+    expect(mockFindSessionRecord).toHaveBeenCalledWith('auto-ses-2');
     expect(mockEndSession).toHaveBeenCalledWith('auto-ses-2');
+  });
+
+  it('given a GLOBAL conversation this call itself just minted, but a CONCURRENT sibling has since provisioned a sandbox in it, cleanupIfDenied does NOT end the session — that sibling may be actively, legitimately using it (review finding — P1, PR #2314, fifth pass)', async () => {
+    mockEndSession.mockClear();
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    const provisioned = makeSessionRecord({ id: 'auto-ses-3', driveId: null, ownerId: 'u1', sandboxId: null });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
+    // A fresh re-read shows a sandbox now exists — a sibling call won its
+    // own gate and started provisioning between our claim and our own
+    // gate's denial.
+    mockFindSessionRecord.mockResolvedValue(makeSessionRecord({ id: 'auto-ses-3', sandboxId: 'sbx-sibling-1' }));
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    const cleanupIfDenied = (result as { cleanupIfDenied?: () => Promise<void> })?.cleanupIfDenied;
+    await cleanupIfDenied?.();
+    expect(mockFindSessionRecord).toHaveBeenCalledWith('auto-ses-3');
+    expect(mockEndSession).not.toHaveBeenCalled();
   });
 
   it('given a GLOBAL conversation whose session was ADOPTED from a concurrent sibling (not selfClaimed), does NOT attach cleanupIfDenied — that session is the sibling\'s to manage, not ours to tear down on our own credit denial', async () => {
@@ -661,6 +693,7 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
 
     expect(result).toMatchObject({ sessionId: 'sibling-ses-1' });
     expect((result as { cleanupIfDenied?: unknown })?.cleanupIfDenied).toBeUndefined();
+    expect(mockEndSession).not.toHaveBeenCalled();
   });
 
   it('given a GLOBAL conversation whose auto-provisioning hits the session cap, fails CLOSED with { deny } rather than resolving null — a concurrent sibling\'s claim could still let acquireSandbox succeed moments later, executing unmetered (review finding — P1, PR #2314, second pass)', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // with injected fakes and never touches the mocked defaults.
 const {
   mockFindSessionForConversation,
-  mockFindSessionRecord,
   mockProvisionSessionSandbox,
   mockMeasureWarmSessionStorage,
   mockCheckSessionRuntimeGuardrail,
@@ -17,7 +16,6 @@ const {
   mockEndSession,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
-  mockFindSessionRecord: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
   mockMeasureWarmSessionStorage: vi.fn(async () => {}),
   mockCheckSessionRuntimeGuardrail: vi.fn(),
@@ -30,7 +28,6 @@ const {
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
 vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   findSessionForConversation: mockFindSessionForConversation,
-  findSessionRecord: mockFindSessionRecord,
   provisionSessionSandbox: mockProvisionSessionSandbox,
   // Opportunistic storage measurement rides this path fire-and-forget. Stubbed
   // so the module loads; the assertions below deliberately do not await it,
@@ -623,13 +620,12 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-fresh-global', 'u1');
   });
 
-  it('given a GLOBAL conversation this call itself just minted (selfClaimed) and NOTHING has been provisioned in it since, attaches a cleanupIfDenied that ends that session — a repeat credit-exhausted attempt must not leave a real, empty, permanently-bound session behind (review finding — P2, PR #2314, fourth pass)', async () => {
+  it('given a GLOBAL conversation this call itself just minted (selfClaimed), attaches a cleanupIfDenied that ends that session — a repeat credit-exhausted attempt must not leave a real, empty, permanently-bound session behind (review finding — P2, PR #2314, fourth pass)', async () => {
     mockEndSession.mockClear();
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    const provisioned = makeSessionRecord({ id: 'auto-ses-2', driveId: null, ownerId: 'u1', sandboxId: null });
+    const provisioned = makeSessionRecord({ id: 'auto-ses-2', driveId: null, ownerId: 'u1' });
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
-    mockFindSessionRecord.mockResolvedValue(makeSessionRecord({ id: 'auto-ses-2', sandboxId: null }));
     const deps = buildRealSandboxRunDeps();
 
     const result = await deps.resolveBillingSession?.({
@@ -641,38 +637,10 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     });
 
     expect(result).toHaveProperty('cleanupIfDenied');
-    expect(mockEndSession).not.toHaveBeenCalled();
     const cleanupIfDenied = (result as { cleanupIfDenied?: () => Promise<void> })?.cleanupIfDenied;
     expect(typeof cleanupIfDenied).toBe('function');
     await cleanupIfDenied?.();
-    expect(mockFindSessionRecord).toHaveBeenCalledWith('auto-ses-2');
     expect(mockEndSession).toHaveBeenCalledWith('auto-ses-2');
-  });
-
-  it('given a GLOBAL conversation this call itself just minted, but a CONCURRENT sibling has since provisioned a sandbox in it, cleanupIfDenied does NOT end the session — that sibling may be actively, legitimately using it (review finding — P1, PR #2314, fifth pass)', async () => {
-    mockEndSession.mockClear();
-    mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ type: 'global' });
-    const provisioned = makeSessionRecord({ id: 'auto-ses-3', driveId: null, ownerId: 'u1', sandboxId: null });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
-    // A fresh re-read shows a sandbox now exists — a sibling call won its
-    // own gate and started provisioning between our claim and our own
-    // gate's denial.
-    mockFindSessionRecord.mockResolvedValue(makeSessionRecord({ id: 'auto-ses-3', sandboxId: 'sbx-sibling-1' }));
-    const deps = buildRealSandboxRunDeps();
-
-    const result = await deps.resolveBillingSession?.({
-      userId: 'u1',
-      tenantId: 'u1',
-      conversationId: 'conv-fresh-global',
-      actorEmail: 'u1@example.com',
-      tier: 'pro',
-    });
-
-    const cleanupIfDenied = (result as { cleanupIfDenied?: () => Promise<void> })?.cleanupIfDenied;
-    await cleanupIfDenied?.();
-    expect(mockFindSessionRecord).toHaveBeenCalledWith('auto-ses-3');
-    expect(mockEndSession).not.toHaveBeenCalled();
   });
 
   it('given a GLOBAL conversation whose session was ADOPTED from a concurrent sibling (not selfClaimed), does NOT attach cleanupIfDenied — that session is the sibling\'s to manage, not ours to tear down on our own credit denial', async () => {
@@ -693,7 +661,6 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
 
     expect(result).toMatchObject({ sessionId: 'sibling-ses-1' });
     expect((result as { cleanupIfDenied?: unknown })?.cleanupIfDenied).toBeUndefined();
-    expect(mockEndSession).not.toHaveBeenCalled();
   });
 
   it('given a GLOBAL conversation whose auto-provisioning hits the session cap, fails CLOSED with { deny } rather than resolving null — a concurrent sibling\'s claim could still let acquireSandbox succeed moments later, executing unmetered (review finding — P1, PR #2314, second pass)', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -13,7 +13,6 @@ const {
   mockRecordSessionActivity,
   mockEnsureGlobalSandboxSession,
   mockGetConversation,
-  mockEndSession,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
@@ -22,7 +21,6 @@ const {
   mockRecordSessionActivity: vi.fn(),
   mockEnsureGlobalSandboxSession: vi.fn(),
   mockGetConversation: vi.fn(),
-  mockEndSession: vi.fn(async () => ({ ok: true }) as never),
 }));
 
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
@@ -35,7 +33,6 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   // or fail a tool call.
   measureWarmSessionStorage: mockMeasureWarmSessionStorage,
   ensureGlobalSandboxSession: mockEnsureGlobalSandboxSession,
-  endSession: mockEndSession,
 }));
 vi.mock('@/lib/repositories/conversation-repository', () => ({
   conversationRepository: { getConversation: mockGetConversation },
@@ -392,7 +389,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     // spawn uses.
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: sessionRecord, selfClaimed: true });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: sessionRecord });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-1', 'u1');
@@ -605,7 +602,7 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
     const provisioned = makeSessionRecord({ id: 'auto-ses-1', driveId: null, ownerId: 'u1' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned });
     const deps = buildRealSandboxRunDeps();
 
     const result = await deps.resolveBillingSession?.({
@@ -616,51 +613,8 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
       tier: 'pro',
     });
 
-    expect(result).toMatchObject({ sessionId: 'auto-ses-1', driveId: null, ownerId: 'u1' });
+    expect(result).toEqual({ sessionId: 'auto-ses-1', driveId: null, ownerId: 'u1' });
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-fresh-global', 'u1');
-  });
-
-  it('given a GLOBAL conversation this call itself just minted (selfClaimed), attaches a cleanupIfDenied that ends that session — a repeat credit-exhausted attempt must not leave a real, empty, permanently-bound session behind (review finding — P2, PR #2314, fourth pass)', async () => {
-    mockEndSession.mockClear();
-    mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ type: 'global' });
-    const provisioned = makeSessionRecord({ id: 'auto-ses-2', driveId: null, ownerId: 'u1' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned, selfClaimed: true });
-    const deps = buildRealSandboxRunDeps();
-
-    const result = await deps.resolveBillingSession?.({
-      userId: 'u1',
-      tenantId: 'u1',
-      conversationId: 'conv-fresh-global',
-      actorEmail: 'u1@example.com',
-      tier: 'pro',
-    });
-
-    expect(result).toHaveProperty('cleanupIfDenied');
-    const cleanupIfDenied = (result as { cleanupIfDenied?: () => Promise<void> })?.cleanupIfDenied;
-    expect(typeof cleanupIfDenied).toBe('function');
-    await cleanupIfDenied?.();
-    expect(mockEndSession).toHaveBeenCalledWith('auto-ses-2');
-  });
-
-  it('given a GLOBAL conversation whose session was ADOPTED from a concurrent sibling (not selfClaimed), does NOT attach cleanupIfDenied — that session is the sibling\'s to manage, not ours to tear down on our own credit denial', async () => {
-    mockEndSession.mockClear();
-    mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ type: 'global' });
-    const siblingSession = makeSessionRecord({ id: 'sibling-ses-1', driveId: null, ownerId: 'u1' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: siblingSession, selfClaimed: false });
-    const deps = buildRealSandboxRunDeps();
-
-    const result = await deps.resolveBillingSession?.({
-      userId: 'u1',
-      tenantId: 'u1',
-      conversationId: 'conv-fresh-global',
-      actorEmail: 'u1@example.com',
-      tier: 'pro',
-    });
-
-    expect(result).toMatchObject({ sessionId: 'sibling-ses-1' });
-    expect((result as { cleanupIfDenied?: unknown })?.cleanupIfDenied).toBeUndefined();
   });
 
   it('given a GLOBAL conversation whose auto-provisioning hits the session cap, fails CLOSED with { deny } rather than resolving null — a concurrent sibling\'s claim could still let acquireSandbox succeed moments later, executing unmetered (review finding — P1, PR #2314, second pass)', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -397,13 +397,16 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-1' });
   });
 
-  it('given a GLOBAL conversation with NO session, and auto-provisioning fails, should DENY with no_session', async () => {
+
+  it('given a GLOBAL conversation whose auto-provisioning was ATTEMPTED and failed (any reason), should DENY as provision_failed with that reason as the cause — never the plain no_session', async () => {
+    // Once an attempt was made, "no_session" alone would be misleading (it
+    // reads as "nothing was ever tried"); provision_failed/cause names WHY.
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'no_session' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'spawn_failed' });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
-    expect(result).toEqual({ ok: false, reason: 'no_session' });
+    expect(result).toEqual({ ok: false, reason: 'provision_failed', cause: 'spawn_failed' });
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
     expect(mockRecordSessionActivity).not.toHaveBeenCalled();
   });
@@ -631,7 +634,24 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     expect(result).toEqual({ deny: 'session_limit_reached' });
   });
 
-  it('given a GLOBAL conversation whose auto-provisioning fails for a reason that will NEVER resolve (no_session), resolves null — safe to let acquireSandbox deny the same way, since no concurrent call could make it succeed', async () => {
+  it('given a GLOBAL conversation whose auto-provisioning fails with a transient spawn fault, ALSO fails CLOSED with { deny } — same reasoning as session_limit_reached: a retry (this call\'s own acquireSandbox, or a concurrent sibling) could still succeed after the transient fault clears (review finding — P1, PR #2314, third round)', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'spawn_failed' });
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toEqual({ deny: 'provision_failed' });
+  });
+
+  it('given a GLOBAL conversation whose auto-provisioning attempt lost a claim with no winner found (attempted, reason no_session), STILL fails CLOSED — attempted-and-failed is never treated as safely null, regardless of which of the three reasons it is', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'no_session' });
@@ -645,7 +665,7 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
       tier: 'pro',
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ deny: 'provision_failed' });
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -614,10 +614,27 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-fresh-global', 'u1');
   });
 
-  it('given a GLOBAL conversation whose auto-provisioning fails (e.g. session limit reached), resolves null — acquireSandbox denies the same way moments later, never reaching a live sandbox unmetered', async () => {
+  it('given a GLOBAL conversation whose auto-provisioning hits the session cap, fails CLOSED with { deny } rather than resolving null — a concurrent sibling\'s claim could still let acquireSandbox succeed moments later, executing unmetered (review finding — P1, PR #2314, second pass)', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'session_limit_reached' });
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toEqual({ deny: 'session_limit_reached' });
+  });
+
+  it('given a GLOBAL conversation whose auto-provisioning fails for a reason that will NEVER resolve (no_session), resolves null — safe to let acquireSandbox deny the same way, since no concurrent call could make it succeed', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'no_session' });
     const deps = buildRealSandboxRunDeps();
 
     const result = await deps.resolveBillingSession?.({

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -301,7 +301,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     // `agentPageId`) — page conversations never auto-provision, so the default
     // here matches that and the global-only tests below override it.
     mockGetConversation.mockResolvedValue({ type: 'page' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue(null);
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'no_session' });
   });
 
   it('should WIRE the activity-feed seam — an unwired optional dep is a silently dead feature', async () => {
@@ -389,7 +389,7 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     // spawn uses.
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue(sessionRecord);
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: sessionRecord });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-1', 'u1');
@@ -400,10 +400,24 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
   it('given a GLOBAL conversation with NO session, and auto-provisioning fails, should DENY with no_session', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
     mockGetConversation.mockResolvedValue({ type: 'global' });
-    mockEnsureGlobalSandboxSession.mockResolvedValue(null);
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'no_session' });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
     expect(result).toEqual({ ok: false, reason: 'no_session' });
+    expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
+    expect(mockRecordSessionActivity).not.toHaveBeenCalled();
+  });
+
+  it('given a GLOBAL conversation with NO session, and the owner is at their session cap, should DENY with the specific session_limit_reached cause', async () => {
+    // A distinct, actionable denial ("end an existing session first") —
+    // collapsing it into the generic no_session message would tell an agent
+    // at its owner's session cap to do something that can't help.
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'session_limit_reached' });
+    const deps = buildRealSandboxRunDeps();
+    const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
+    expect(result).toEqual({ ok: false, reason: 'provision_failed', cause: 'session_limit_reached' });
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
     expect(mockRecordSessionActivity).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -11,12 +11,16 @@ const {
   mockMeasureWarmSessionStorage,
   mockCheckSessionRuntimeGuardrail,
   mockRecordSessionActivity,
+  mockEnsureGlobalSandboxSession,
+  mockGetConversation,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
   mockProvisionSessionSandbox: vi.fn(),
   mockMeasureWarmSessionStorage: vi.fn(async () => {}),
   mockCheckSessionRuntimeGuardrail: vi.fn(),
   mockRecordSessionActivity: vi.fn(),
+  mockEnsureGlobalSandboxSession: vi.fn(),
+  mockGetConversation: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
@@ -28,6 +32,10 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   // which is the property that matters — a billing observation must never delay
   // or fail a tool call.
   measureWarmSessionStorage: mockMeasureWarmSessionStorage,
+  ensureGlobalSandboxSession: mockEnsureGlobalSandboxSession,
+}));
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: { getConversation: mockGetConversation },
 }));
 vi.mock('@pagespace/lib/services/sandbox/quota', () => ({
   acquireCodeExecutionSlot: vi.fn(() => true),
@@ -289,6 +297,11 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     mockCheckSessionRuntimeGuardrail.mockReturnValue({ allowed: true });
     mockFindSessionForConversation.mockResolvedValue(sessionRecord);
     mockProvisionSessionSandbox.mockResolvedValue({ ok: true, sandboxId: 'sbx-1', resumed: false, sessionId: 'ws-1' });
+    // Most tests in this block exercise a PAGE conversation (`baseInput` sets
+    // `agentPageId`) — page conversations never auto-provision, so the default
+    // here matches that and the global-only tests below override it.
+    mockGetConversation.mockResolvedValue({ type: 'page' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue(null);
   });
 
   it('should WIRE the activity-feed seam — an unwired optional dep is a silently dead feature', async () => {
@@ -354,12 +367,42 @@ describe('buildRealSandboxRunDeps.acquireSandbox (session-anchored)', () => {
     expect(mockRecordSessionActivity).not.toHaveBeenCalled();
   });
 
-  it('given a conversation with NO session, should DENY — never lazily mint a per-thread environment', async () => {
+  it('given a PAGE conversation with NO session, should DENY — page agents still require an explicit "New session" spawn', async () => {
     // Per-conversation minting is exactly the conflation the session model
-    // removed; it is what made panes unable to share a sandbox.
+    // removed; it is what made panes unable to share a sandbox. Page agents
+    // never auto-provision — only the global-assistant case below does.
     mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'page' });
     const deps = buildRealSandboxRunDeps();
     const result = await deps.acquireSandbox(baseInput());
+    expect(result).toEqual({ ok: false, reason: 'no_session' });
+    expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
+    expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
+    expect(mockRecordSessionActivity).not.toHaveBeenCalled();
+  });
+
+  it('given a GLOBAL conversation with NO session, should auto-provision one and proceed to provision its sandbox', async () => {
+    // The default Global Assistant chat is always minted session-less and
+    // nothing else ever claims it — restore the pre-refactor "own machine"
+    // parity by auto-provisioning a REAL session the first time it's needed,
+    // through the exact same spawn+claim primitive a manual "New session"
+    // spawn uses.
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue(sessionRecord);
+    const deps = buildRealSandboxRunDeps();
+    const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
+    expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-1', 'u1');
+    expect(mockProvisionSessionSandbox).toHaveBeenCalledWith(sessionRecord, 'u1');
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-1' });
+  });
+
+  it('given a GLOBAL conversation with NO session, and auto-provisioning fails, should DENY with no_session', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue(null);
+    const deps = buildRealSandboxRunDeps();
+    const result = await deps.acquireSandbox(baseInput({ agentPageId: undefined }));
     expect(result).toEqual({ ok: false, reason: 'no_session' });
     expect(mockProvisionSessionSandbox).not.toHaveBeenCalled();
     expect(mockRecordSessionActivity).not.toHaveBeenCalled();

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -572,14 +572,58 @@ describe('buildRealSandboxRunDeps.resolveBillingSession', () => {
     expect(mockFindSessionForConversation).not.toHaveBeenCalled();
   });
 
-  it('given a conversation with no session yet, resolves null', async () => {
+  it('given a PAGE conversation with no session yet, resolves null (page agents never auto-provision)', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'page' });
     const deps = buildRealSandboxRunDeps();
 
     const result = await deps.resolveBillingSession?.({
       userId: 'u1',
       tenantId: 'u1',
       conversationId: 'conv-legacy',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toBeNull();
+    expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
+  });
+
+  it('given a GLOBAL conversation with no session yet, auto-provisions one and resolves ITS driveId/ownerId — closes the credit-gate bypass (review finding P1, PR #2314)', async () => {
+    // Before this fix, a session-less global conversation resolved null here
+    // (the old "nothing to bill, run() will just deny" assumption), but
+    // acquireSandbox's own auto-provisioning made run() actually SUCCEED —
+    // so a credit-exhausted user's first message executed completely
+    // unmetered. resolveBillingSession must see the SAME auto-provisioned
+    // session acquireSandbox is about to act on, not a stale "no session".
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    const provisioned = makeSessionRecord({ id: 'auto-ses-1', driveId: null, ownerId: 'u1' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: provisioned });
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
+      actorEmail: 'u1@example.com',
+      tier: 'pro',
+    });
+
+    expect(result).toEqual({ sessionId: 'auto-ses-1', driveId: null, ownerId: 'u1' });
+    expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-fresh-global', 'u1');
+  });
+
+  it('given a GLOBAL conversation whose auto-provisioning fails (e.g. session limit reached), resolves null — acquireSandbox denies the same way moments later, never reaching a live sandbox unmetered', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ type: 'global' });
+    mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'session_limit_reached' });
+    const deps = buildRealSandboxRunDeps();
+
+    const result = await deps.resolveBillingSession?.({
+      userId: 'u1',
+      tenantId: 'u1',
+      conversationId: 'conv-fresh-global',
       actorEmail: 'u1@example.com',
       tier: 'pro',
     });

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -138,7 +138,12 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         // exactly like any other), not a second sandbox-only mechanism.
         const conversation = await conversationRepository.getConversation(conversationId);
         if (conversation?.type === 'global') {
-          row = await ensureGlobalSandboxSession(conversationId, input.userId);
+          const ensured = await ensureGlobalSandboxSession(conversationId, input.userId);
+          if (ensured.ok) {
+            row = ensured.session;
+          } else if (ensured.reason === 'session_limit_reached') {
+            return { ok: false, reason: 'provision_failed', cause: 'session_limit_reached' };
+          }
         }
         if (!row) {
           return { ok: false, reason: 'no_session' };

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -55,7 +55,6 @@ import {
   provisionSessionSandbox,
   measureWarmSessionStorage,
   ensureGlobalSandboxSession,
-  endSession,
   type AgentSessionRecord,
   type EnsureGlobalSandboxSessionFailureReason,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
@@ -110,20 +109,7 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
 }
 
 type ResolveOrProvisionResult =
-  | {
-      ok: true;
-      session: AgentSessionRecord;
-      /**
-       * True only when THIS call minted the session (as opposed to finding
-       * one that already existed) — the signal `resolveBillingSession`
-       * needs to know whether it's safe to tear this session back down if
-       * the credit gate denies moments later. Ending a session that already
-       * existed before this call (has other history, other conversations)
-       * would be destructive; ending one THIS call just created and bound
-       * only to gate-deny cleanup is not.
-       */
-      justProvisioned: boolean;
-    }
+  | { ok: true; session: AgentSessionRecord }
   /**
    * Nothing was ever attempted here — not a global conversation (or the
    * conversation doesn't exist). This is the ONLY failure shape safe to
@@ -165,7 +151,7 @@ async function resolveOrProvisionSession(
   userId: string,
 ): Promise<ResolveOrProvisionResult> {
   const existing = await findSessionForConversation(conversationId);
-  if (existing) return { ok: true, session: existing, justProvisioned: false };
+  if (existing) return { ok: true, session: existing };
 
   // The default Global Assistant conversation is always minted session-less
   // (`resolveOrCreateConversation`) and nothing else ever claims it into
@@ -178,13 +164,7 @@ async function resolveOrProvisionSession(
   if (conversation?.type !== 'global') return { ok: false, attempted: false };
 
   const ensured = await ensureGlobalSandboxSession(conversationId, userId);
-  // `justProvisioned` mirrors `ensured.selfClaimed`, NOT a blanket `true`:
-  // when this call lost its own claim race and adopted a concurrent
-  // sibling's session instead, that session is the SIBLING'S to manage, not
-  // ours — a same-turn credit-deny cleanup must never tear down a session
-  // this call didn't itself create and claim, since the sibling may have
-  // its own unrelated, still-in-flight use for it.
-  if (ensured.ok) return { ok: true, session: ensured.session, justProvisioned: ensured.selfClaimed };
+  if (ensured.ok) return { ok: true, session: ensured.session };
   return { ok: false, attempted: true, reason: ensured.reason };
 }
 
@@ -346,22 +326,7 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       const resolved = await resolveOrProvisionSession(ctx.conversationId, ctx.userId);
       if (resolved.ok) {
         const row = resolved.session;
-        return {
-          sessionId: row.id,
-          driveId: row.driveId,
-          ownerId: row.ownerId,
-          // Only when THIS call itself minted+claimed the session (never
-          // for one that predates this call, or one adopted from a
-          // concurrent sibling's own claim — see `resolveOrProvisionSession`'s
-          // `justProvisioned` doc). A repeat credit-exhausted attempt from a
-          // fresh global conversation would otherwise leave a real, empty,
-          // permanently-bound session behind on every try — nothing ever
-          // ran in it, it was never going to be billed, and it just
-          // clutters the sidebar and eats into MAX_ACTIVE_SESSIONS_PER_OWNER
-          // (review finding — P2, PR #2314, fourth pass,
-          // chatgpt-codex-connector).
-          cleanupIfDenied: resolved.justProvisioned ? () => endSession(row.id).then(() => {}) : undefined,
-        };
+        return { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId };
       }
       if (!resolved.attempted) return null;
       return { deny: resolved.reason === 'session_limit_reached' ? 'session_limit_reached' : 'provision_failed' };

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -56,6 +56,7 @@ import {
   measureWarmSessionStorage,
   ensureGlobalSandboxSession,
   type AgentSessionRecord,
+  type EnsureGlobalSandboxSessionFailureReason,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import type { ToolExecutionContext } from '../core/types';
@@ -109,7 +110,27 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
 
 type ResolveOrProvisionResult =
   | { ok: true; session: AgentSessionRecord }
-  | { ok: false; reason: 'session_limit_reached' | 'no_session' };
+  /**
+   * Nothing was ever attempted here — not a global conversation (or the
+   * conversation doesn't exist). This is the ONLY failure shape safe to
+   * treat as a permanent "no session, ever" — a page-agent conversation
+   * denies the exact same way on every retry, forever.
+   */
+  | { ok: false; attempted: false }
+  /**
+   * A global conversation's auto-provision was ATTEMPTED and failed.
+   * Deliberately carries the FULL `EnsureGlobalSandboxSessionFailureReason`
+   * set, not a narrowed subset: every one of them (session cap, a transient
+   * spawn fault, a lost claim) is racy or retryable by nature — a
+   * concurrent sibling call, or a bare retry of THIS SAME call, can succeed
+   * where this attempt didn't. Any caller that would otherwise treat
+   * "attempted, failed" the same as "never attempted" reopens the exact
+   * billing bypass two separate reviewer findings caught (P1 round 1:
+   * session_limit_reached fell through unmetered; P1 round 2: spawn_failed
+   * did too) — so this is a closed set on purpose, not narrowed to
+   * whichever reason string the last bug happened to be about.
+   */
+  | { ok: false; attempted: true; reason: EnsureGlobalSandboxSessionFailureReason };
 
 /**
  * Resolve a conversation's session, auto-provisioning one for a Global
@@ -140,11 +161,11 @@ async function resolveOrProvisionSession(
   // shareable with sibling panes exactly like any other), not a second
   // sandbox-only mechanism.
   const conversation = await conversationRepository.getConversation(conversationId);
-  if (conversation?.type !== 'global') return { ok: false, reason: 'no_session' };
+  if (conversation?.type !== 'global') return { ok: false, attempted: false };
 
   const ensured = await ensureGlobalSandboxSession(conversationId, userId);
   if (ensured.ok) return { ok: true, session: ensured.session };
-  return { ok: false, reason: ensured.reason === 'session_limit_reached' ? 'session_limit_reached' : 'no_session' };
+  return { ok: false, attempted: true, reason: ensured.reason };
 }
 
 /** Wire the real lib deps for the runners (session-anchored acquire + real Sprites driver). */
@@ -170,10 +191,8 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       // whose own id folds the ONE Sprite key.
       const resolved = await resolveOrProvisionSession(conversationId, input.userId);
       if (!resolved.ok) {
-        if (resolved.reason === 'session_limit_reached') {
-          return { ok: false, reason: 'provision_failed', cause: 'session_limit_reached' };
-        }
-        return { ok: false, reason: 'no_session' };
+        if (!resolved.attempted) return { ok: false, reason: 'no_session' };
+        return { ok: false, reason: 'provision_failed', cause: resolved.reason };
       }
       const row = resolved.session;
 
@@ -281,17 +300,21 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
     // read, so a session-less global conversation is auto-provisioned HERE,
     // before the credit gate — not down in `run()`, unmetered.
     //
-    // `no_session` (never global, or global lookup found nothing) is safe to
-    // fall through as `null` — nothing could ever auto-provision here, so
-    // `acquireSandbox` will independently deny the exact same way.
-    // `session_limit_reached` is NOT safe to fall through: it's the outcome
-    // of THIS call's own spawn attempt racing a CONCURRENT sibling's, and by
-    // the time `acquireSandbox` runs moments later, that sibling's claim may
-    // have already landed — its own resolution would then find the
-    // sibling's session and succeed, executing unmetered against a session
-    // billing already gave up on. Fail the whole call closed instead of
-    // trusting the second, independent resolution to agree with the first
-    // (review finding — P1, PR #2314, second pass).
+    // `attempted: false` (never global, or the conversation doesn't exist) is
+    // safe to fall through as `null` — nothing could ever auto-provision
+    // here, so `acquireSandbox` will independently deny the exact same way,
+    // on every retry, forever. `attempted: true` (a global conversation's
+    // auto-provision was tried and failed) is NEVER safe to fall through,
+    // for ANY of its reasons: every one is racy or retryable by nature (a
+    // session-cap race, a transient spawn fault, a lost claim) — a
+    // concurrent sibling call, or a bare retry of THIS SAME call, can
+    // succeed where this attempt didn't. By the time `acquireSandbox` runs
+    // moments later, that could already have happened — its own resolution
+    // would then succeed and execute unmetered against a session billing
+    // already gave up on. Fail the whole call closed instead of trusting a
+    // second, independent resolution to agree with the first (review
+    // findings — P1, PR #2314, both rounds: session_limit_reached fell
+    // through unmetered first, then spawn_failed did too).
     resolveBillingSession: async (ctx) => {
       if (!ctx.conversationId) return null;
       const resolved = await resolveOrProvisionSession(ctx.conversationId, ctx.userId);
@@ -299,8 +322,8 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         const row = resolved.session;
         return { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId };
       }
-      if (resolved.reason === 'no_session') return null;
-      return { deny: 'session_limit_reached' };
+      if (!resolved.attempted) return null;
+      return { deny: resolved.reason === 'session_limit_reached' ? 'session_limit_reached' : 'provision_failed' };
     },
     // Sprites Platform Alignment 5-2: checkpoint the sandbox filesystem before
     // an agent bash batch runs (fail-open, at most once per turn — see

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -184,11 +184,17 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       }
 
       // The conversation's WORKING CONTEXT, through conversations.sessionId.
-      // A thread with no session gets a denial, never a lazily-minted
-      // environment — per-conversation minting is exactly the conflation the
-      // session model removed, and it is what made panes unable to share a
-      // sandbox. Every conversation in one session resolves this same row,
-      // whose own id folds the ONE Sprite key.
+      // A page conversation with no session gets a denial, never a
+      // lazily-minted environment — per-conversation minting is exactly the
+      // conflation the session model removed, and it is what made panes
+      // unable to share a sandbox. A GLOBAL conversation is the one
+      // exception: `resolveOrProvisionSession` auto-provisions it a real,
+      // ordinary, shareable session (see its own doc). Every conversation in
+      // one session resolves this same row, whose own id folds the ONE
+      // Sprite key (review finding — CodeRabbit: this comment used to read
+      // as a blanket invariant the auto-provisioning below it visibly
+      // contradicts, which is exactly the kind of drift that gets the new
+      // behavior "fixed" back out by a future reader trusting the comment).
       const resolved = await resolveOrProvisionSession(conversationId, input.userId);
       if (!resolved.ok) {
         if (!resolved.attempted) return { ok: false, reason: 'no_session' };

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -54,7 +54,9 @@ import {
   findSessionForConversation,
   provisionSessionSandbox,
   measureWarmSessionStorage,
+  ensureGlobalSandboxSession,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import type { ToolExecutionContext } from '../core/types';
 import { notifyShellAgentActivity } from '@/lib/websocket/socket-utils';
 
@@ -125,9 +127,22 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       // session model removed, and it is what made panes unable to share a
       // sandbox. Every conversation in one session resolves this same row,
       // whose own id folds the ONE Sprite key.
-      const row = await findSessionForConversation(conversationId);
+      let row = await findSessionForConversation(conversationId);
       if (!row) {
-        return { ok: false, reason: 'no_session' };
+        // The default Global Assistant conversation is always minted
+        // session-less (`resolveOrCreateConversation`) and nothing else ever
+        // claims it into one — unlike page agents, which still require an
+        // explicit "New session" spawn. Give it the same workspace that
+        // spawn would, automatically, the first time it actually needs a
+        // sandbox — a REAL session (visible, shareable with sibling panes
+        // exactly like any other), not a second sandbox-only mechanism.
+        const conversation = await conversationRepository.getConversation(conversationId);
+        if (conversation?.type === 'global') {
+          row = await ensureGlobalSandboxSession(conversationId, input.userId);
+        }
+        if (!row) {
+          return { ok: false, reason: 'no_session' };
+        }
       }
 
       // The per-sandbox continuous-runtime backstop, keyed by the SESSION id —

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -279,17 +279,28 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
     // hibernating sandbox): goes through the SAME `resolveOrProvisionSession`
     // `acquireSandbox` above uses, rather than a bare `findSessionForConversation`
     // read, so a session-less global conversation is auto-provisioned HERE,
-    // before the credit gate — not down in `run()`, unmetered. Returning null
-    // for an unresolvable session (a page-agent conversation, a spawn fault)
-    // is still safe: `acquireSandbox` resolves through the identical function
-    // moments later and denies for the exact same reason, so `run()` never
-    // reaches a live sandbox on the "nothing to bill" path either.
+    // before the credit gate — not down in `run()`, unmetered.
+    //
+    // `no_session` (never global, or global lookup found nothing) is safe to
+    // fall through as `null` — nothing could ever auto-provision here, so
+    // `acquireSandbox` will independently deny the exact same way.
+    // `session_limit_reached` is NOT safe to fall through: it's the outcome
+    // of THIS call's own spawn attempt racing a CONCURRENT sibling's, and by
+    // the time `acquireSandbox` runs moments later, that sibling's claim may
+    // have already landed — its own resolution would then find the
+    // sibling's session and succeed, executing unmetered against a session
+    // billing already gave up on. Fail the whole call closed instead of
+    // trusting the second, independent resolution to agree with the first
+    // (review finding — P1, PR #2314, second pass).
     resolveBillingSession: async (ctx) => {
       if (!ctx.conversationId) return null;
       const resolved = await resolveOrProvisionSession(ctx.conversationId, ctx.userId);
-      if (!resolved.ok) return null;
-      const row = resolved.session;
-      return { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId };
+      if (resolved.ok) {
+        const row = resolved.session;
+        return { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId };
+      }
+      if (resolved.reason === 'no_session') return null;
+      return { deny: 'session_limit_reached' };
     },
     // Sprites Platform Alignment 5-2: checkpoint the sandbox filesystem before
     // an agent bash batch runs (fail-open, at most once per turn — see

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -52,6 +52,7 @@ import { toSubscriptionTier } from '@pagespace/lib/billing/subscription-tiers';
 import { createSandboxTools, type ResolveSandboxContext, type SandboxGate } from './sandbox-tools';
 import {
   findSessionForConversation,
+  findSessionRecord,
   provisionSessionSandbox,
   measureWarmSessionStorage,
   ensureGlobalSandboxSession,
@@ -360,7 +361,29 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
           // clutters the sidebar and eats into MAX_ACTIVE_SESSIONS_PER_OWNER
           // (review finding — P2, PR #2314, fourth pass,
           // chatgpt-codex-connector).
-          cleanupIfDenied: resolved.justProvisioned ? () => endSession(row.id).then(() => {}) : undefined,
+          //
+          // `selfClaimed` only records who performed the ORIGINAL claim —
+          // once that claim commits, the binding is PUBLIC (any other tool
+          // call for this same conversation resolves the identical session
+          // via the ordinary `findSessionForConversation` path). A sibling
+          // call can legitimately start using it — win its OWN credit gate,
+          // provision a sandbox, run code — in the window between our claim
+          // landing and our OWN gate denying (e.g. a shared payer with just
+          // enough credit for one hold, not two racing ones). Blindly ending
+          // the session here would destroy that sibling's live, correctly-
+          // gated work. Re-check immediately before destroying: a session
+          // with a live `sandboxId` is doing real work for someone and must
+          // be left alone; only a still-empty one (nothing provisioned since
+          // we minted it) is unambiguously safe to end (review finding — P1,
+          // PR #2314, fifth pass, chatgpt-codex-connector).
+          cleanupIfDenied: resolved.justProvisioned
+            ? async () => {
+                const current = await findSessionRecord(row.id);
+                if (current && current.sandboxId === null) {
+                  await endSession(row.id);
+                }
+              }
+            : undefined,
         };
       }
       if (!resolved.attempted) return null;

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -55,6 +55,7 @@ import {
   provisionSessionSandbox,
   measureWarmSessionStorage,
   ensureGlobalSandboxSession,
+  endSession,
   type AgentSessionRecord,
   type EnsureGlobalSandboxSessionFailureReason,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
@@ -109,7 +110,20 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
 }
 
 type ResolveOrProvisionResult =
-  | { ok: true; session: AgentSessionRecord }
+  | {
+      ok: true;
+      session: AgentSessionRecord;
+      /**
+       * True only when THIS call minted the session (as opposed to finding
+       * one that already existed) — the signal `resolveBillingSession`
+       * needs to know whether it's safe to tear this session back down if
+       * the credit gate denies moments later. Ending a session that already
+       * existed before this call (has other history, other conversations)
+       * would be destructive; ending one THIS call just created and bound
+       * only to gate-deny cleanup is not.
+       */
+      justProvisioned: boolean;
+    }
   /**
    * Nothing was ever attempted here — not a global conversation (or the
    * conversation doesn't exist). This is the ONLY failure shape safe to
@@ -151,7 +165,7 @@ async function resolveOrProvisionSession(
   userId: string,
 ): Promise<ResolveOrProvisionResult> {
   const existing = await findSessionForConversation(conversationId);
-  if (existing) return { ok: true, session: existing };
+  if (existing) return { ok: true, session: existing, justProvisioned: false };
 
   // The default Global Assistant conversation is always minted session-less
   // (`resolveOrCreateConversation`) and nothing else ever claims it into
@@ -164,7 +178,13 @@ async function resolveOrProvisionSession(
   if (conversation?.type !== 'global') return { ok: false, attempted: false };
 
   const ensured = await ensureGlobalSandboxSession(conversationId, userId);
-  if (ensured.ok) return { ok: true, session: ensured.session };
+  // `justProvisioned` mirrors `ensured.selfClaimed`, NOT a blanket `true`:
+  // when this call lost its own claim race and adopted a concurrent
+  // sibling's session instead, that session is the SIBLING'S to manage, not
+  // ours — a same-turn credit-deny cleanup must never tear down a session
+  // this call didn't itself create and claim, since the sibling may have
+  // its own unrelated, still-in-flight use for it.
+  if (ensured.ok) return { ok: true, session: ensured.session, justProvisioned: ensured.selfClaimed };
   return { ok: false, attempted: true, reason: ensured.reason };
 }
 
@@ -326,7 +346,22 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       const resolved = await resolveOrProvisionSession(ctx.conversationId, ctx.userId);
       if (resolved.ok) {
         const row = resolved.session;
-        return { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId };
+        return {
+          sessionId: row.id,
+          driveId: row.driveId,
+          ownerId: row.ownerId,
+          // Only when THIS call itself minted+claimed the session (never
+          // for one that predates this call, or one adopted from a
+          // concurrent sibling's own claim — see `resolveOrProvisionSession`'s
+          // `justProvisioned` doc). A repeat credit-exhausted attempt from a
+          // fresh global conversation would otherwise leave a real, empty,
+          // permanently-bound session behind on every try — nothing ever
+          // ran in it, it was never going to be billed, and it just
+          // clutters the sidebar and eats into MAX_ACTIVE_SESSIONS_PER_OWNER
+          // (review finding — P2, PR #2314, fourth pass,
+          // chatgpt-codex-connector).
+          cleanupIfDenied: resolved.justProvisioned ? () => endSession(row.id).then(() => {}) : undefined,
+        };
       }
       if (!resolved.attempted) return null;
       return { deny: resolved.reason === 'session_limit_reached' ? 'session_limit_reached' : 'provision_failed' };

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -55,6 +55,7 @@ import {
   provisionSessionSandbox,
   measureWarmSessionStorage,
   ensureGlobalSandboxSession,
+  type AgentSessionRecord,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import type { ToolExecutionContext } from '../core/types';
@@ -106,6 +107,46 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
   return sandboxClientPromise;
 }
 
+type ResolveOrProvisionResult =
+  | { ok: true; session: AgentSessionRecord }
+  | { ok: false; reason: 'session_limit_reached' | 'no_session' };
+
+/**
+ * Resolve a conversation's session, auto-provisioning one for a Global
+ * Assistant conversation that has never had one — the ONE place this
+ * decision is made, shared by `acquireSandbox` AND `resolveBillingSession`
+ * below. Billing MUST see the same session (or the same absence of one)
+ * `acquireSandbox` is about to act on: `resolveBillingSession` runs BEFORE
+ * the credit gate, and its old "no session ⇒ nothing to bill, `run()` will
+ * just deny" assumption broke the moment `acquireSandbox` stopped always
+ * denying a session-less global conversation — a separate resolution there
+ * would let a credit-exhausted caller's FIRST message auto-provision a
+ * session and execute completely unmetered (review finding — P1, PR #2314).
+ * Calling this same function from both call sites keeps them from ever
+ * disagreeing about whether a session exists.
+ */
+async function resolveOrProvisionSession(
+  conversationId: string,
+  userId: string,
+): Promise<ResolveOrProvisionResult> {
+  const existing = await findSessionForConversation(conversationId);
+  if (existing) return { ok: true, session: existing };
+
+  // The default Global Assistant conversation is always minted session-less
+  // (`resolveOrCreateConversation`) and nothing else ever claims it into
+  // one — unlike page agents, which still require an explicit "New session"
+  // spawn. Give it the same workspace that spawn would, automatically, the
+  // first time it actually needs a sandbox — a REAL session (visible,
+  // shareable with sibling panes exactly like any other), not a second
+  // sandbox-only mechanism.
+  const conversation = await conversationRepository.getConversation(conversationId);
+  if (conversation?.type !== 'global') return { ok: false, reason: 'no_session' };
+
+  const ensured = await ensureGlobalSandboxSession(conversationId, userId);
+  if (ensured.ok) return { ok: true, session: ensured.session };
+  return { ok: false, reason: ensured.reason === 'session_limit_reached' ? 'session_limit_reached' : 'no_session' };
+}
+
 /** Wire the real lib deps for the runners (session-anchored acquire + real Sprites driver). */
 export function buildRealSandboxRunDeps(): SandboxRunDeps {
   return {
@@ -127,28 +168,14 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
       // session model removed, and it is what made panes unable to share a
       // sandbox. Every conversation in one session resolves this same row,
       // whose own id folds the ONE Sprite key.
-      let row = await findSessionForConversation(conversationId);
-      if (!row) {
-        // The default Global Assistant conversation is always minted
-        // session-less (`resolveOrCreateConversation`) and nothing else ever
-        // claims it into one — unlike page agents, which still require an
-        // explicit "New session" spawn. Give it the same workspace that
-        // spawn would, automatically, the first time it actually needs a
-        // sandbox — a REAL session (visible, shareable with sibling panes
-        // exactly like any other), not a second sandbox-only mechanism.
-        const conversation = await conversationRepository.getConversation(conversationId);
-        if (conversation?.type === 'global') {
-          const ensured = await ensureGlobalSandboxSession(conversationId, input.userId);
-          if (ensured.ok) {
-            row = ensured.session;
-          } else if (ensured.reason === 'session_limit_reached') {
-            return { ok: false, reason: 'provision_failed', cause: 'session_limit_reached' };
-          }
+      const resolved = await resolveOrProvisionSession(conversationId, input.userId);
+      if (!resolved.ok) {
+        if (resolved.reason === 'session_limit_reached') {
+          return { ok: false, reason: 'provision_failed', cause: 'session_limit_reached' };
         }
-        if (!row) {
-          return { ok: false, reason: 'no_session' };
-        }
+        return { ok: false, reason: 'no_session' };
       }
+      const row = resolved.session;
 
       // The per-sandbox continuous-runtime backstop, keyed by the SESSION id —
       // one budget per workspace, however many threads work in it.
@@ -249,14 +276,20 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
     billing: defaultSandboxBillingDeps,
     // Cheap billing-attribution resolve (`withMachineBilling` calls this
     // BEFORE gating, so a credit-exhausted payer is denied without waking a
-    // hibernating sandbox): the same session row `acquireSandbox` above
-    // resolves via `conversations.sessionId`, read again here rather than
-    // threaded through the acquire result — this runs BEFORE the sandbox is
-    // provisioned, so there is nothing from `acquireSandbox` to thread yet.
+    // hibernating sandbox): goes through the SAME `resolveOrProvisionSession`
+    // `acquireSandbox` above uses, rather than a bare `findSessionForConversation`
+    // read, so a session-less global conversation is auto-provisioned HERE,
+    // before the credit gate — not down in `run()`, unmetered. Returning null
+    // for an unresolvable session (a page-agent conversation, a spawn fault)
+    // is still safe: `acquireSandbox` resolves through the identical function
+    // moments later and denies for the exact same reason, so `run()` never
+    // reaches a live sandbox on the "nothing to bill" path either.
     resolveBillingSession: async (ctx) => {
       if (!ctx.conversationId) return null;
-      const row = await findSessionForConversation(ctx.conversationId);
-      return row ? { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId } : null;
+      const resolved = await resolveOrProvisionSession(ctx.conversationId, ctx.userId);
+      if (!resolved.ok) return null;
+      const row = resolved.session;
+      return { sessionId: row.id, driveId: row.driveId, ownerId: row.ownerId };
     },
     // Sprites Platform Alignment 5-2: checkpoint the sandbox filesystem before
     // an agent bash batch runs (fail-open, at most once per turn — see

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -52,7 +52,6 @@ import { toSubscriptionTier } from '@pagespace/lib/billing/subscription-tiers';
 import { createSandboxTools, type ResolveSandboxContext, type SandboxGate } from './sandbox-tools';
 import {
   findSessionForConversation,
-  findSessionRecord,
   provisionSessionSandbox,
   measureWarmSessionStorage,
   ensureGlobalSandboxSession,
@@ -361,29 +360,7 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
           // clutters the sidebar and eats into MAX_ACTIVE_SESSIONS_PER_OWNER
           // (review finding — P2, PR #2314, fourth pass,
           // chatgpt-codex-connector).
-          //
-          // `selfClaimed` only records who performed the ORIGINAL claim —
-          // once that claim commits, the binding is PUBLIC (any other tool
-          // call for this same conversation resolves the identical session
-          // via the ordinary `findSessionForConversation` path). A sibling
-          // call can legitimately start using it — win its OWN credit gate,
-          // provision a sandbox, run code — in the window between our claim
-          // landing and our OWN gate denying (e.g. a shared payer with just
-          // enough credit for one hold, not two racing ones). Blindly ending
-          // the session here would destroy that sibling's live, correctly-
-          // gated work. Re-check immediately before destroying: a session
-          // with a live `sandboxId` is doing real work for someone and must
-          // be left alone; only a still-empty one (nothing provisioned since
-          // we minted it) is unambiguously safe to end (review finding — P1,
-          // PR #2314, fifth pass, chatgpt-codex-connector).
-          cleanupIfDenied: resolved.justProvisioned
-            ? async () => {
-                const current = await findSessionRecord(row.id);
-                if (current && current.sandboxId === null) {
-                  await endSession(row.id);
-                }
-              }
-            : undefined,
+          cleanupIfDenied: resolved.justProvisioned ? () => endSession(row.id).then(() => {}) : undefined,
         };
       }
       if (!resolved.attempted) return null;

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -1256,64 +1256,6 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(acquireCalls).toBe(0);
   });
 
-  it('given the gate denies AND resolveBillingSession attached a cleanupIfDenied, awaits it before returning credit_exhausted — an auto-provisioned session this call itself just minted must not survive a same-turn credit denial (review finding — P2, PR #2314, fourth pass)', async () => {
-    const cleanupCalls: string[] = [];
-    const { billing } = makeBilling({
-      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
-    });
-    const { deps } = makeDeps({
-      billing,
-      resolveBillingSession: async () => ({
-        sessionId: 'auto-ses-1',
-        driveId: null,
-        ownerId: 'owner-42',
-        cleanupIfDenied: async () => {
-          cleanupCalls.push('auto-ses-1');
-        },
-      }),
-    });
-
-    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
-
-    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
-    expect(cleanupCalls).toEqual(['auto-ses-1']);
-  });
-
-  it('given the gate denies and cleanupIfDenied itself throws, still fails credit_exhausted — a cleanup fault must never turn a credit denial into a different (or delayed) failure', async () => {
-    const { billing } = makeBilling({
-      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
-    });
-    const { deps } = makeDeps({
-      billing,
-      resolveBillingSession: async () => ({
-        sessionId: 'auto-ses-1',
-        driveId: null,
-        ownerId: 'owner-42',
-        cleanupIfDenied: async () => {
-          throw new Error('cleanup exploded');
-        },
-      }),
-    });
-
-    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
-
-    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
-  });
-
-  it('given the gate denies and resolveBillingSession did NOT attach cleanupIfDenied (a pre-existing session, not one this call minted), fails credit_exhausted with no cleanup attempted', async () => {
-    const { billing } = makeBilling({
-      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
-    });
-    const { deps } = makeDeps({
-      billing,
-      resolveBillingSession: makeBillingSession(),
-    });
-
-    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
-
-    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
-  });
-
   it('given a forced execution error, releases the hold and records NO usage row (no ledger row)', async () => {
     const sandbox = makeSandbox({
       runCommand: async () => {

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -1180,6 +1180,32 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(trackUsageCalls).toEqual([]);
   });
 
+  it('given resolveBillingSession returns { deny }, fails closed with that reason and NEVER calls acquireSandbox — an implementation that auto-provisions must not fall through to an unmetered run() on an unsafe failure (review finding — P1, PR #2314, second pass)', async () => {
+    // The unsafe alternative this replaces: treating a `session_limit_reached`
+    // (or any auto-provisioning failure) the same as a legacy "no session,
+    // ever" conversation and returning null — which lets run()'s own,
+    // INDEPENDENT resolution race a concurrent sibling's claim and succeed
+    // unmetered. `{ deny }` must short-circuit before acquireSandbox is ever
+    // reached, exactly like the credit-exhausted gate does.
+    let acquireCalls = 0;
+    const { billing, gateCalls, trackUsageCalls } = makeBilling();
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: async () => ({ deny: 'session_limit_reached' }),
+      acquireSandbox: async () => {
+        acquireCalls += 1;
+        return { ok: true, sandboxId: 'sbx-1', resumed: false, sessionId: 'ws-1' };
+      },
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'session_limit_reached' });
+    expect(acquireCalls).toBe(0);
+    expect(gateCalls).toEqual([]);
+    expect(trackUsageCalls).toEqual([]);
+  });
+
   it('places a hold BEFORE the machine is acquired, keyed to the payer resolved from the SESSION', async () => {
     const { billing, gateCalls } = makeBilling();
     const { deps } = makeDeps({ billing, resolveBillingSession: makeBillingSession({ ownerId: 'owner-42' }) });

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -1256,6 +1256,64 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(acquireCalls).toBe(0);
   });
 
+  it('given the gate denies AND resolveBillingSession attached a cleanupIfDenied, awaits it before returning credit_exhausted — an auto-provisioned session this call itself just minted must not survive a same-turn credit denial (review finding — P2, PR #2314, fourth pass)', async () => {
+    const cleanupCalls: string[] = [];
+    const { billing } = makeBilling({
+      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
+    });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: async () => ({
+        sessionId: 'auto-ses-1',
+        driveId: null,
+        ownerId: 'owner-42',
+        cleanupIfDenied: async () => {
+          cleanupCalls.push('auto-ses-1');
+        },
+      }),
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
+    expect(cleanupCalls).toEqual(['auto-ses-1']);
+  });
+
+  it('given the gate denies and cleanupIfDenied itself throws, still fails credit_exhausted — a cleanup fault must never turn a credit denial into a different (or delayed) failure', async () => {
+    const { billing } = makeBilling({
+      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
+    });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: async () => ({
+        sessionId: 'auto-ses-1',
+        driveId: null,
+        ownerId: 'owner-42',
+        cleanupIfDenied: async () => {
+          throw new Error('cleanup exploded');
+        },
+      }),
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
+  });
+
+  it('given the gate denies and resolveBillingSession did NOT attach cleanupIfDenied (a pre-existing session, not one this call minted), fails credit_exhausted with no cleanup attempted', async () => {
+    const { billing } = makeBilling({
+      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
+    });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession(),
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
+  });
+
   it('given a forced execution error, releases the hold and records NO usage row (no ledger row)', async () => {
     const sandbox = makeSandbox({
       runCommand: async () => {

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -270,22 +270,9 @@ export interface SandboxRunDeps {
    *   whole call closed instead of gambling that the second, independent
    *   resolution will agree with the first (review finding — P1, PR #2314,
    *   second pass, chatgpt-codex-connector).
-   *
-   * The session-shaped outcome may carry an optional `cleanupIfDenied`: for
-   * an auto-provisioning implementation, THIS specific call may have just
-   * minted the session (as opposed to finding one that already existed).
-   * If the credit gate below denies the run, that freshly-minted session
-   * would otherwise sit permanently bound to the conversation with nothing
-   * ever having run in it — real resource/sidebar clutter for a call that
-   * was never going to be billed anyway, compounding across every repeat
-   * attempt from a credit-exhausted caller. `withMachineBilling` invokes
-   * this hook on a gate denial, never otherwise; omit it whenever the
-   * session predates this call (there is no such thing as "cleaning up"
-   * a session this call didn't create) (review finding — P2, PR #2314,
-   * fourth pass, chatgpt-codex-connector).
    */
   resolveBillingSession?: (ctx: SandboxActorContext) => Promise<
-    | { sessionId: string; driveId: string | null; ownerId: string; cleanupIfDenied?: () => Promise<void> }
+    | { sessionId: string; driveId: string | null; ownerId: string }
     | { deny: SandboxToolDenialReason }
     | null
   >;
@@ -550,17 +537,7 @@ async function withMachineBilling<S>(
     ownerId: billingSession.ownerId,
   });
   const gate = await billing.gate({ payerId });
-  if (!gate.allowed) {
-    // Awaited (not fire-and-forget): a request-scoped process can be
-    // suspended/torn down shortly after the response is sent, which would
-    // silently abandon an un-awaited cleanup. Best-effort regardless — a
-    // cleanup fault must never turn a credit denial into a different (or
-    // delayed) failure. Only present when THIS call's own
-    // `resolveBillingSession` just minted the session being gated — see
-    // the doc on `resolveBillingSession` above.
-    await billingSession.cleanupIfDenied?.().catch(() => {});
-    return fail('credit_exhausted');
-  }
+  if (!gate.allowed) return fail('credit_exhausted');
 
   const holdId = gate.holdId;
   const startedAt = deps.now().getTime();

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -270,9 +270,22 @@ export interface SandboxRunDeps {
    *   whole call closed instead of gambling that the second, independent
    *   resolution will agree with the first (review finding — P1, PR #2314,
    *   second pass, chatgpt-codex-connector).
+   *
+   * The session-shaped outcome may carry an optional `cleanupIfDenied`: for
+   * an auto-provisioning implementation, THIS specific call may have just
+   * minted the session (as opposed to finding one that already existed).
+   * If the credit gate below denies the run, that freshly-minted session
+   * would otherwise sit permanently bound to the conversation with nothing
+   * ever having run in it — real resource/sidebar clutter for a call that
+   * was never going to be billed anyway, compounding across every repeat
+   * attempt from a credit-exhausted caller. `withMachineBilling` invokes
+   * this hook on a gate denial, never otherwise; omit it whenever the
+   * session predates this call (there is no such thing as "cleaning up"
+   * a session this call didn't create) (review finding — P2, PR #2314,
+   * fourth pass, chatgpt-codex-connector).
    */
   resolveBillingSession?: (ctx: SandboxActorContext) => Promise<
-    | { sessionId: string; driveId: string | null; ownerId: string }
+    | { sessionId: string; driveId: string | null; ownerId: string; cleanupIfDenied?: () => Promise<void> }
     | { deny: SandboxToolDenialReason }
     | null
   >;
@@ -537,7 +550,17 @@ async function withMachineBilling<S>(
     ownerId: billingSession.ownerId,
   });
   const gate = await billing.gate({ payerId });
-  if (!gate.allowed) return fail('credit_exhausted');
+  if (!gate.allowed) {
+    // Awaited (not fire-and-forget): a request-scoped process can be
+    // suspended/torn down shortly after the response is sent, which would
+    // silently abandon an un-awaited cleanup. Best-effort regardless — a
+    // cleanup fault must never turn a credit denial into a different (or
+    // delayed) failure. Only present when THIS call's own
+    // `resolveBillingSession` just minted the session being gated — see
+    // the doc on `resolveBillingSession` above.
+    await billingSession.cleanupIfDenied?.().catch(() => {});
+    return fail('credit_exhausted');
+  }
 
   const holdId = gate.holdId;
   const startedAt = deps.now().getTime();

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -250,17 +250,32 @@ export interface SandboxRunDeps {
    * a credit-exhausted payer is denied without ever waking a hibernating
    * sandbox — the same fail-fast property the old (surface-derived, ctx-only)
    * payer resolution had, now backed by a real (if cheap) session read instead
-   * of trusting client-influenceable context. `null` = the conversation has no
-   * session yet (a legacy pre-session thread): `withMachineBilling` skips
-   * gating entirely and calls straight through to `run()`, which surfaces the
-   * ordinary `no_session` denial via `openSession`. Required whenever
-   * `billing` is set; never called otherwise.
+   * of trusting client-influenceable context. Required whenever `billing` is
+   * set; never called otherwise.
+   *
+   * Three outcomes:
+   * - A session: gate against its payer as usual.
+   * - `null` = the conversation will NEVER have a session on its own (a
+   *   legacy pre-session thread, or one whose type never auto-provisions):
+   *   nothing to gate against, so `withMachineBilling` falls through
+   *   unmetered and lets `run()` surface the ordinary `no_session` denial.
+   * - `{ deny }` = an implementation that auto-provisions a session (a
+   *   Global Assistant conversation) attempted to and failed for a reason
+   *   that is NOT safely "this will just deny again" — e.g. the owner's
+   *   session cap was hit by a CONCURRENT call's spawn. Returning `null`
+   *   here would be unsafe: `run()`'s own resolution moments later can
+   *   still succeed if a racing sibling's claim lands in the interim
+   *   (executing against the sibling's session), while this call already
+   *   gave up on billing it — an unmetered execution. `{ deny }` fails the
+   *   whole call closed instead of gambling that the second, independent
+   *   resolution will agree with the first (review finding — P1, PR #2314,
+   *   second pass, chatgpt-codex-connector).
    */
-  resolveBillingSession?: (ctx: SandboxActorContext) => Promise<{
-    sessionId: string;
-    driveId: string | null;
-    ownerId: string;
-  } | null>;
+  resolveBillingSession?: (ctx: SandboxActorContext) => Promise<
+    | { sessionId: string; driveId: string | null; ownerId: string }
+    | { deny: SandboxToolDenialReason }
+    | null
+  >;
   /**
    * Optional opportunistic storage-measurement seam (Sprites Platform Alignment
    * 6-1): while this sprite is ALREADY awake for this real op, capture its used
@@ -508,10 +523,13 @@ async function withMachineBilling<S>(
   // drive/agent page — a session hosts MANY conversations, and its drive can
   // differ from the one the caller happens to be chatting from.
   //
-  // `null` = no session yet for this conversation (a legacy pre-session
-  // thread): nothing to gate against, so fall through unmetered and let
-  // `run()` surface the ordinary `no_session` denial via `openSession`.
+  // See the three-outcome contract on `resolveBillingSession` above: `null`
+  // is only safe when nothing could ever auto-provision here; `{ deny }`
+  // fails the call closed rather than falling through to `run()`, whose own
+  // independent resolution might still succeed against a session a
+  // concurrent sibling call bound in the interim.
   const billingSession = deps.resolveBillingSession ? await deps.resolveBillingSession(ctx) : null;
+  if (billingSession && 'deny' in billingSession) return fail(billingSession.deny);
   if (!billingSession) return run();
 
   const payerId = await billing.resolvePayerId({


### PR DESCRIPTION
## Summary
- The default Global Assistant conversation was always minted session-less (`resolveOrCreateConversation`) and nothing ever claimed it into a workspace, so `acquireSandbox` denied every sandbox tool call with `no_session` — the old per-user "own machine" auto-provisioning was deleted in the machines-world teardown with no replacement.
- `acquireSandbox` now auto-provisions a real, ordinary session (the exact same spawn+claim primitive the manual "New session → Global Assistant" command-palette flow already uses) the first time a `type: 'global'` conversation needs a sandbox — no schema change, no hidden/implicit session, it behaves identically to a manually-spawned session everywhere (shows in the sidebar, shares its sandbox with sibling panes).
- Page-agent conversations are unaffected — they still require an explicit session spawn via `pages.sandboxEnabled` + "New session".

### Follow-up hardening (self-review + reviewer findings across two hazard classes)

**Billing-gate bypass** (`resolveBillingSession` runs BEFORE the credit gate; its pre-existing "no session ⇒ nothing to bill, `run()` will just deny" assumption quietly broke once `acquireSandbox` could actually succeed for a previously-always-denied conversation):
1. A session-less global conversation's first billing read saw nothing to gate, but `acquireSandbox` moments later actually created and used a session — unmetered execution. Fixed with one shared `resolveOrProvisionSession` helper used by both call sites.
2. That fix still collapsed `session_limit_reached` (a cap race between concurrent calls) to the same "safe null" as a never-gets-a-session conversation. Fixed by widening `resolveBillingSession` to a three-outcome contract (session / null / `{ deny }`) that fails closed instead of falling through.
3. The round-2 fix only special-cased `session_limit_reached`; `spawn_failed` was still an unnamed reason falling through. `resolveOrProvisionSession` now distinguishes `attempted: false` (never a global conversation) from `attempted: true` (carries the FULL failure-reason set, all fail closed) — any future new reason is fail-closed by default, not another whack-a-mole entry.

**Scratch-session leak / stranding on the auto-provision's own claim step** (`ensureGlobalSandboxSession` spawns a session then claims the conversation into it):
4. A thrown error from the claim call skipped cleanup entirely, leaking the scratch session. Wrapped in try/catch.
5. That cleanup could itself strand a conversation forever if the claim's write actually committed but the client only saw a dropped connection — ending the scratch session would permanently bind the (write-once) conversation to a dead workspace. Now re-resolves the binding before deciding what to tear down, with a defensive retry and the recovery reads themselves guarded against a secondary failure.

**A P2 resource-hygiene attempt that was reverted**: a `cleanupIfDenied` hook was added (and then hardened once) to avoid leaving behind a real, empty, permanently-bound session when a credit-exhausted caller's auto-provision succeeds but the credit gate denies moments later. A second review round showed the safety check is fundamentally insufficient — a sibling's sandboxId is legitimately null for the entire duration of its own provisioning, and the session-teardown path's own retry-on-conflict behavior means a sibling's freshly-provisioned sandbox can still get killed even racing an in-flight `endSession`. Closing that properly needs an atomic in-flight lease in the core session/sprite provisioning machinery — out of scope here. The whole feature was reverted rather than patched a third time: the stray-session cost it addressed is bounded (the 100-session cap), self-explanatory, and manually recoverable, while the risk it introduced (destroying a live, correctly-gated concurrent operation) is not.

**Also filed, not fixed here**: [#2315](https://github.com/2witstudios/PageSpace/issues/2315) — git/gh sandbox tools (`runGitInSandbox`) never wire billing at all (`resolveBillingSession`/`gate`/`trackUsage`), a pre-existing gap independent of this PR (a credit-exhausted user can already run `git_clone` unmetered today via any ordinary page-agent session). This PR's auto-provisioning adds one more way to reach a sandbox that then, like every existing way, runs into that gap — but fixing it properly means deciding gate/hold sizing semantics for potentially long-running git operations, a deliberate design decision that deserves its own PR.

Also: two concurrent sandbox tool calls on the same never-bound global conversation converge on the SAME session/sandbox, `session_limit_reached` surfaces as its own denial reason instead of a misleading generic message, and two CodeRabbit nitpicks (a silently-swallowed cleanup-failure log, a stale invariant comment) were fixed along the way.

## Test plan
- [x] `bun run --filter web typecheck` and `bun run --filter @pagespace/lib typecheck` — clean
- [x] `bun run --filter web lint` and `bun run --filter @pagespace/lib lint` — clean
- [x] `bun run knip:check` — no new issues (within baseline)
- [x] `sandbox-tools-runtime.test.ts` (35 tests) and `tool-runners.test.ts` (80 tests) — full coverage of the attempted/not-attempted split and the fail-closed billing path
- [x] `agent-sessions-runtime.integration.test.ts` — auto-provision success, already-bound resolves to existing session, concurrent-race convergence, session-cap denial, all against a real Postgres (9 tests)
- [x] Full apps/web AI test surface (~2000 tests) and full packages/lib suite (~8700 tests) passing
- [x] CI green: Unit Tests, Lint & TypeScript, Security Test Suite, CodeQL, Static Security Analysis, Dependency Audit, Secret Scanning — plus CodeRabbit's own independent review came back clean on the structural passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UW6N2FDWZU237B2DrkS7Pp