### PR TITLE
fix(sandbox): route git/gh tools through the same credit gate bash uses

### DIFF
--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -5,7 +5,7 @@ import {
   GH_CONFIG_DIR,
   type GitSandboxRunDeps,
 } from '../git-tool-runners';
-import type { SandboxActorContext } from '../tool-runners';
+import type { SandboxActorContext, SandboxRunDeps } from '../tool-runners';
 import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
 import { SANDBOX_ROOT } from '../sandbox-paths';
 import { assert } from './riteway';
@@ -449,5 +449,129 @@ describe('opportunistic storage measurement', () => {
     await Promise.resolve();
 
     expect(measured).toMatchObject([{ sessionId: 'ws-1' }]);
+  });
+});
+
+/**
+ * Mirrors `tool-runners.test.ts`'s `makeBilling` — the same fake `billing`
+ * deps every other sandbox-op runner's billing tests use.
+ */
+function makeBilling(over: Partial<NonNullable<SandboxRunDeps['billing']>> = {}): {
+  billing: NonNullable<SandboxRunDeps['billing']>;
+  resolvePayerIdCalls: Array<{ driveId: string | null; ownerId: string }>;
+  gateCalls: Array<{ payerId: string }>;
+  trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string; driveId?: string; sessionId?: string }>;
+  releaseHoldCalls: string[];
+} {
+  const resolvePayerIdCalls: Array<{ driveId: string | null; ownerId: string }> = [];
+  const gateCalls: Array<{ payerId: string }> = [];
+  const trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string; driveId?: string; sessionId?: string }> = [];
+  const releaseHoldCalls: string[] = [];
+  const billing: NonNullable<SandboxRunDeps['billing']> = {
+    resolvePayerId: async (input) => {
+      resolvePayerIdCalls.push(input);
+      return input.ownerId;
+    },
+    gate: async (input) => {
+      gateCalls.push(input);
+      return { allowed: true, holdId: 'hold-1' };
+    },
+    trackUsage: async (input) => {
+      trackUsageCalls.push(input);
+    },
+    releaseHold: async (holdId) => {
+      releaseHoldCalls.push(holdId);
+    },
+    ...over,
+  };
+  return { billing, resolvePayerIdCalls, gateCalls, trackUsageCalls, releaseHoldCalls };
+}
+
+/** Mirrors `tool-runners.test.ts`'s `makeBillingSession` fake. */
+function makeBillingSession(
+  over: Partial<{ sessionId: string; driveId: string | null; ownerId: string }> = {},
+): NonNullable<SandboxRunDeps['resolveBillingSession']> {
+  return async (ctx) => ({
+    sessionId: over.sessionId ?? 'ws-1',
+    driveId: over.driveId !== undefined ? over.driveId : (ctx.driveId ?? null),
+    ownerId: over.ownerId ?? ctx.tenantId,
+  });
+}
+
+describe('runGitInSandbox — machine billing (issue #2315: git/gh tools were never gated)', () => {
+  it('places a hold BEFORE the sandbox is acquired, keyed to the payer resolved from the SESSION', async () => {
+    const { deps, slots } = makeDepsWithSpy();
+    const { billing, gateCalls } = makeBilling();
+    deps.billing = billing;
+    deps.resolveBillingSession = makeBillingSession({ ownerId: 'owner-42' });
+
+    await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+
+    expect(gateCalls).toEqual([{ payerId: 'owner-42' }]);
+    // The gate ran before acquisition — proven by acquisition having happened
+    // at all (a denied gate, tested below, never reaches it).
+    expect(slots.acquired).toBe(1);
+  });
+
+  it('on a successful git run, settles EXACTLY one usage row via trackUsage with the real active-window seconds', async () => {
+    let now = NOW.getTime();
+    const { sandbox } = makeSandbox({
+      runCommand: async () => {
+        now += 3000; // the sandbox was "active" for 3s running this git command
+        return { exitCode: 0, stdout: 'ok', stderr: '' };
+      },
+    });
+    const { deps } = makeDeps({ reconnect: async () => sandbox, now: () => new Date(now) });
+    const { billing, trackUsageCalls, releaseHoldCalls } = makeBilling();
+    deps.billing = billing;
+    deps.resolveBillingSession = makeBillingSession({ ownerId: 'owner-42', driveId: 'd1', sessionId: 'ws-1' });
+
+    const result = await runGitInSandbox({ cmd: 'git', args: ['clone', 'https://github.com/a/b'], ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: true });
+    expect(trackUsageCalls).toEqual([
+      { payerId: 'owner-42', holdId: 'hold-1', activeSeconds: 3, pageId: undefined, driveId: 'd1', sessionId: 'ws-1' },
+    ]);
+    expect(releaseHoldCalls).toEqual([]);
+  });
+
+  it('given the gate denies (insufficient credits), fails credit_exhausted, NEVER acquires a sandbox slot, and NEVER runs the git command — this is the exact gap issue #2315 closes', async () => {
+    const { deps, slots, runCommandCalls } = makeDepsWithSpy();
+    const { billing } = makeBilling({
+      gate: async () => ({ allowed: false, reason: 'insufficient_balance' }),
+    });
+    deps.billing = billing;
+    deps.resolveBillingSession = makeBillingSession();
+
+    const result = await runGitInSandbox({ cmd: 'git', args: ['clone', 'https://github.com/a/b'], ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'credit_exhausted' });
+    expect(slots.acquired).toBe(0);
+    expect(runCommandCalls).toHaveLength(0);
+  });
+
+  it('given a forced execution error, releases the hold and records NO usage row', async () => {
+    const { sandbox } = makeSandbox({
+      runCommand: async () => {
+        throw new Error('sandbox crashed');
+      },
+    });
+    const { deps } = makeDeps({ reconnect: async () => sandbox });
+    const { billing, trackUsageCalls, releaseHoldCalls } = makeBilling();
+    deps.billing = billing;
+    deps.resolveBillingSession = makeBillingSession();
+
+    const result = await runGitInSandbox({ cmd: 'git', args: ['fetch'], ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: false, reason: 'execution_failed' });
+    expect(trackUsageCalls).toEqual([]);
+    expect(releaseHoldCalls).toEqual(['hold-1']);
+  });
+
+  it('given NO billing deps at all, runs unmetered exactly as before — an unmetered deployment is unaffected by this wiring', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    const result = await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: true });
+    expect(runCommandCalls).toHaveLength(1);
   });
 });

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -2,8 +2,7 @@ import { SANDBOX_TIMEOUT_MS, SANDBOX_MAX_OUTPUT_BYTES } from './execution-policy
 import { truncateToBytes } from './output-limit';
 import { SANDBOX_ROOT, resolveSandboxPath } from './sandbox-paths';
 import type { SandboxActorContext, SandboxRunDeps, BashToolResult } from './tool-runners';
-import type { ExecutableSandbox } from './sandbox-client/types';
-import { DENIAL_MESSAGES, reasonFromAcquire, safeLogWarn } from './tool-runners';
+import { DENIAL_MESSAGES, openSession, withMachineBilling } from './tool-runners';
 
 export interface GitSandboxRunDeps extends SandboxRunDeps {
   /** Fetches the user's GitHub OAuth access token from their integration connection. */
@@ -124,122 +123,84 @@ export async function runGitInSandbox({
     resolvedCwd = candidate;
   }
 
-  // Pre-fetch token BEFORE acquiring a sandbox slot — a missing token on a
-  // network-requiring command must not consume quota.
+  // Pre-fetch token BEFORE acquiring a sandbox slot or placing a billing
+  // hold — a missing token on a network-requiring command must not consume
+  // quota or money.
   const token =
     preResolvedToken !== undefined
       ? preResolvedToken
       : await deps.resolveGitHubToken(ctx.userId);
 
-  if (!deps.quota.acquireSlot({ userId: ctx.userId, tier: ctx.tier })) {
-    return {
-      success: false,
-      error: 'Too many concurrent runs. Wait for a run to finish and retry.',
-      reason: 'concurrency_limit',
-    };
-  }
-
-  // Held across the try/finally so the post-op storage measurement can reach the
-  // sandbox handle; null whenever the run never got one.
-  let measurable: ExecutableSandbox | null = null;
-  let measurableSessionId: string | null = null;
-  // Slot held — every exit path below must release it.
-  try {
-    const acquired = await deps.acquireSandbox({
-      tenantId: ctx.tenantId,
-      driveId: ctx.driveId,
-      userId: ctx.userId,
-      requestOrigin: ctx.requestOrigin,
-      agentPageId: ctx.agentPageId,
-      // The session address (the caller's session, resolved from its conversation) — what the session-anchored
-      // acquire implementation folds the Sprite key off.
-      conversationId: ctx.conversationId,
-    });
-    if (!acquired.ok) {
-      // Same narrowing the bash path does: a plan-ceiling refusal must not
-      // reach a git tool as a generic provisioning fault, or the agent retries
-      // a limit that only ending a session clears.
-      const reason = reasonFromAcquire(acquired);
-      return { success: false, error: DENIAL_MESSAGES[reason], reason };
+  // Routes through the SAME acquire (`openSession`) and metering
+  // (`withMachineBilling`) paths `runBashInSandbox`/`writeSandboxFile`/etc.
+  // use, rather than a hand-rolled copy — git/gh tools going years without a
+  // credit gate wired in was exactly a duplicated acquire path silently
+  // drifting from the canonical one (review finding, PR #2314 follow-up,
+  // issue #2315). `openSession` also gives acquisition failures the same
+  // AUTHZ-vs-infra-fault logging split the bash path already had, which this
+  // runner never had before.
+  return withMachineBilling<{
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+    truncated: boolean;
+  }>(ctx, deps, async () => {
+    const session = await openSession(ctx, deps);
+    if (!session.ok) {
+      return { success: false, error: DENIAL_MESSAGES[session.reason], reason: session.reason };
     }
 
-    const sandbox = await deps.reconnect(acquired.sandboxId);
-    if (!sandbox) {
-      return { success: false, error: 'Could not provision a sandbox.', reason: 'provision_failed' };
-    }
-    // Held for the `finally`'s post-op measurement, which cannot see this
-    // block's scope.
-    measurable = sandbox;
-    measurableSessionId = acquired.sessionId;
-
-    const startedAt = deps.now();
-
-    let run: { exitCode: number; stdout: string; stderr: string };
     try {
-      run = await sandbox.runCommand({
-        cmd,
-        args,
-        cwd: resolvedCwd,
-        env: buildGitToolEnv({ baseEnv: deps.buildEnv(), token }),
-        timeoutMs: SANDBOX_TIMEOUT_MS,
-        maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
-      });
-    } catch {
-      const durationMs = deps.now().getTime() - startedAt.getTime();
-      await safeAudit(deps, ctx, { cmd: `${cmd} ${args.join(' ')}`, exitCode: null, durationMs });
-      return { success: false, error: 'Command execution failed or timed out.', reason: 'execution_failed' };
-    }
+      const startedAt = deps.now();
 
-    const durationMs = deps.now().getTime() - startedAt.getTime();
-    // Injection seam (fail-open): screen untrusted git/gh stdout+stderr (fetched
-    // commit messages, file contents, PR bodies, etc.) BEFORE truncation, same as
-    // the bash runner. The screen owns its own fail-open behavior; never blocks.
-    const screenedStdout = deps.screenOutput ? await deps.screenOutput(run.stdout) : run.stdout;
-    const screenedStderr = deps.screenOutput ? await deps.screenOutput(run.stderr) : run.stderr;
-    const stdout = truncateToBytes({ text: screenedStdout, maxBytes: SANDBOX_MAX_OUTPUT_BYTES });
-    const stderr = truncateToBytes({ text: screenedStderr, maxBytes: SANDBOX_MAX_OUTPUT_BYTES });
-
-    await safeAudit(deps, ctx, {
-      cmd: `${cmd} ${args.join(' ')}`,
-      exitCode: run.exitCode,
-      durationMs,
-    });
-
-    return {
-      success: true,
-      stdout: stdout.text,
-      stderr: stderr.text,
-      exitCode: run.exitCode,
-      truncated: stdout.truncated || stderr.truncated,
-    };
-  } finally {
-    deps.quota.releaseSlot({ userId: ctx.userId });
-    // Same opportunistic measurement the bash path does, in the same `finally`
-    // and for the same reason: the bytes worth billing are the ones the command
-    // just wrote. It matters MORE here — `git_clone` is the largest writer in
-    // the system, and a session that only ever runs git tools would otherwise
-    // never be measured at all, billing its empty-disk baseline while the
-    // reconcile advanced its watermark over gigabytes of checkout.
-    //
-    // Throttled per session inside the supplier, never awaited, and its own
-    // failures are swallowed — a billing observation must not affect the tool
-    // result that already succeeded.
-    if (measurable && measurableSessionId !== null && deps.measureStorage) {
-      const sessionId = measurableSessionId;
-      void deps.measureStorage({ sandbox: measurable, sessionId }).catch((error) => {
-        // Logged, not swallowed. Best-effort must not mean invisible: if the
-        // measurement throws on EVERY git call — a bad exec adapter, a missing
-        // `du` — the largest writer in the system silently stops being measured,
-        // which is the bug this seam was just wired to fix, reappearing with no
-        // symptom at all. Same wrapper and same message as the bash path, which
-        // logs the identical failure.
-        safeLogWarn(deps.logger, 'Opportunistic storage measurement failed', {
-          sessionId,
-          error: error instanceof Error ? error.message : String(error),
+      let run: { exitCode: number; stdout: string; stderr: string };
+      try {
+        run = await session.sandbox.runCommand({
+          cmd,
+          args,
+          cwd: resolvedCwd,
+          env: buildGitToolEnv({ baseEnv: deps.buildEnv(), token }),
+          timeoutMs: SANDBOX_TIMEOUT_MS,
+          maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
         });
+      } catch {
+        const durationMs = deps.now().getTime() - startedAt.getTime();
+        await safeAudit(deps, ctx, { cmd: `${cmd} ${args.join(' ')}`, exitCode: null, durationMs });
+        return { success: false, error: 'Command execution failed or timed out.', reason: 'execution_failed' };
+      }
+
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      // Injection seam (fail-open): screen untrusted git/gh stdout+stderr (fetched
+      // commit messages, file contents, PR bodies, etc.) BEFORE truncation, same as
+      // the bash runner. The screen owns its own fail-open behavior; never blocks.
+      const screenedStdout = deps.screenOutput ? await deps.screenOutput(run.stdout) : run.stdout;
+      const screenedStderr = deps.screenOutput ? await deps.screenOutput(run.stderr) : run.stderr;
+      const stdout = truncateToBytes({ text: screenedStdout, maxBytes: SANDBOX_MAX_OUTPUT_BYTES });
+      const stderr = truncateToBytes({ text: screenedStderr, maxBytes: SANDBOX_MAX_OUTPUT_BYTES });
+
+      await safeAudit(deps, ctx, {
+        cmd: `${cmd} ${args.join(' ')}`,
+        exitCode: run.exitCode,
+        durationMs,
       });
+
+      return {
+        success: true,
+        stdout: stdout.text,
+        stderr: stderr.text,
+        exitCode: run.exitCode,
+        truncated: stdout.truncated || stderr.truncated,
+      };
+    } finally {
+      // Releases the quota slot AND fires the same opportunistic, throttled
+      // storage measurement the bash path's `release()` does — the bytes
+      // worth billing are the ones the command just wrote, which matters
+      // MORE here: `git_clone` is the largest writer in the system, and a
+      // session that only ever runs git tools would otherwise never be
+      // measured at all.
+      session.release();
     }
-  }
+  });
 }
 
 async function safeAudit(

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -492,7 +492,7 @@ const anomalyForExit = (exitCode: number): CodeExecutionAnomaly | undefined => {
   return exitCode === 137 ? 'timeout' : 'nonzero_exit';
 };
 
-type MeteredResult<S> =
+export type MeteredResult<S> =
   | ({ success: true } & S)
   | { success: false; error: string; reason: SandboxToolDenialReason };
 
@@ -506,8 +506,14 @@ type MeteredResult<S> =
  * there is nothing to charge (mirrors the voice STT recipe's `holdHandedOff`
  * safety net). Skipped entirely (no hold, no charge) when `deps.billing` is
  * unset — an unmetered deployment behaves exactly as before this seam existed.
+ *
+ * Exported so every sandbox tool-op runner (bash, write, read, edit, git/gh)
+ * shares this ONE metering path rather than a per-runner copy — git/gh's own
+ * runner going years without billing wired in was exactly a duplicated-acquire
+ * path silently drifting from this one (review finding, PR #2314 follow-up,
+ * issue #2315).
  */
-async function withMachineBilling<S>(
+export async function withMachineBilling<S>(
   ctx: SandboxActorContext,
   deps: SandboxRunDeps,
   run: () => Promise<MeteredResult<S>>,
@@ -570,8 +576,11 @@ async function withMachineBilling<S>(
  * `finally`, or a denial (with the slot already released). The kill-switch and
  * any op-specific policy (command / path) are checked by the caller BEFORE this,
  * so a policy-blocked op never reaches quota or provisioning.
+ *
+ * Exported for the same reason as `withMachineBilling`: every sandbox-op
+ * runner acquires through this ONE path, never a local copy.
  */
-async function openSession(
+export async function openSession(
   ctx: SandboxActorContext,
   deps: SandboxRunDeps,
 ): Promise<


### PR DESCRIPTION
## Summary
Closes #2315.

- `runGitInSandbox` called `deps.acquireSandbox` directly and never invoked `resolveBillingSession`/`billing.gate`/`trackUsage`, unlike `runBashInSandbox`/`writeSandboxFile`/`readSandboxFile`/`editSandboxFile`, which all go through the `withMachineBilling` wrapper before acquiring a sandbox. `buildGitSandboxRunDeps` already supplied the billing deps (spread in from `buildRealSandboxRunDeps()`) — `runGitInSandbox` simply never read them. A credit-exhausted user could run `git_clone`/`git_*`/`gh_*` completely unmetered, on any conversation — pre-existing and independent of any particular session-provisioning mechanism (found during review of #2314).
- Exported `openSession` and `withMachineBilling` from `tool-runners.ts` and refactored `runGitInSandbox` to route through them instead of a hand-rolled copy of the quota/acquire/reconnect/storage-measure sequence — the duplicated acquire path was exactly how billing silently never got wired in the first place. This also gives git/gh acquisition failures the same AUTHZ-vs-infra-fault logging split the bash path already had (which the old inline logic didn't have at all).
- **No special hold-sizing decision was needed**, contrary to what #2315 originally speculated: `billing.gate` places a flat, duration-agnostic hold (`MACHINE_HOLD_ESTIMATE_CENTS`) regardless of tool type, settled to the real active-window duration after the op completes — the same model already applied uniformly to bash/write/read/edit now applies to git/gh too, with zero new design decisions.
- **No apps/web changes**: `buildGitSandboxRunDeps` already spreads `billing`/`resolveBillingSession` in from `buildRealSandboxRunDeps()`; the gap was purely that the runner in `packages/lib` never consumed them.
- Storage billing (disk bytes, via `measureStorage`) was already correctly wired for git tools before this change and is unaffected — this PR closes the missing *compute/wall-clock* billing specifically.

## Test plan
- [x] `bun run --filter @pagespace/lib typecheck` and `bun run --filter web typecheck` — clean
- [x] `bun run --filter @pagespace/lib lint` — clean
- [x] `bun run knip:check` — no new issues (within baseline)
- [x] All 25 pre-existing `git-tool-runners.test.ts` tests pass unchanged (external behavior preserved)
- [x] 5 new tests added: hold placed before acquisition with the session's own payer, successful run settles the real active-window duration, credit-exhausted denies before acquiring a slot or running the command, a forced execution error releases the hold with no usage row, and an unmetered deployment (no billing deps) is unaffected
- [x] Full `packages/lib` suite (8698 tests) and `apps/web` typecheck passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UW6N2FDWZU237B2DrkS7Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox command billing and credit handling.
  * Prevented usage charges when sandbox execution fails.
  * Ensured active session time is measured accurately.
  * Standardized session denial messages and cleanup behavior.
  * Preserved support for unmetered sandbox operations.
* **Tests**
  * Added coverage for payer resolution, credit limits, usage tracking, successful holds, failed executions, and session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->