### PR TITLE
fix(agents): invalidate sessions cache after claiming a history row

### DIFF
--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { formatDistanceToNow } from 'date-fns';
 import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 
 import { fetchWithAuth, post, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils';
 import EmptyState from './EmptyState';
 import { resolveNavigationTarget, type ConversationKind, type ClaimableFallback } from './resolveNavigationTarget';
 import { classifySpawnRefusal } from './spawn-refusal';
+import { isAgentSessionsKey } from './panes/session-conversations';
 
 const PAGE_SIZE = 20;
 
@@ -147,6 +148,10 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
             '/api/agent-sessions',
             { firstThing: 'claim', conversationId: target.conversationId, driveId: target.driveId ?? undefined },
           );
+          // The sidebar (and any other pane) reads this same shared listing —
+          // without this, the freshly claimed session is invisible there until
+          // its own 20s poll happens to fire.
+          void mutate(isAgentSessionsKey);
           selectConversation({
             sessionId: created.session.sessionId,
             conversationId: created.conversationId,

--- a/apps/web/src/components/agents/__tests__/AgentsPastConversationsList.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsPastConversationsList.test.tsx
@@ -28,6 +28,15 @@ vi.mock('@/lib/auth/auth-fetch', async (importOriginal) => {
   };
 });
 
+// Spies on the shared `/api/agent-sessions**` invalidation only — `useSWR`
+// and `SWRConfig` stay real so this component's own data fetching (via the
+// isolated per-test Map provider below) is unaffected.
+const mockMutate = vi.hoisted(() => vi.fn());
+vi.mock('swr', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('swr')>();
+  return { ...actual, mutate: (...args: unknown[]) => mockMutate(...args) };
+});
+
 const mockLoadConversation = vi.hoisted(() => vi.fn());
 vi.mock('@/contexts/GlobalChatContext', () => ({
   useGlobalChatConversation: () => ({ loadConversation: mockLoadConversation }),
@@ -40,6 +49,7 @@ vi.mock('sonner', () => ({ toast: { error: mockToastError, info: mockToastInfo }
 import AgentsPastConversationsList from '../AgentsPastConversationsList';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { ApiRequestError } from '@/lib/auth/auth-fetch';
+import { isAgentSessionsKey } from '../panes/session-conversations';
 
 interface Row {
   conversationId: string;
@@ -155,6 +165,29 @@ describe('AgentsPastConversationsList', () => {
     expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-page');
     expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('a successful claim invalidates the shared sessions cache so the sidebar picks it up', async () => {
+    mockFetchWithAuth.mockResolvedValue(conversationsResponse([PAGE_ROW]));
+    mockPost.mockResolvedValue({ session: { sessionId: 'ses-new' }, conversationId: 'conv-page' });
+    renderList();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('Page chat'));
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalledWith(isAgentSessionsKey));
+  });
+
+  test('a failed claim does NOT invalidate the shared sessions cache', async () => {
+    mockFetchWithAuth.mockResolvedValue(conversationsResponse([PAGE_ROW]));
+    mockPost.mockRejectedValue(new ApiRequestError('Forbidden', 403));
+    renderList();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('Page chat'));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalled());
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
   test('a session-less global row claims with the surface\'s own (absent) drive scope', async () => {


### PR DESCRIPTION
## Summary
- Clicking a session-less conversation in the Agents console's default history view (`AgentsPastConversationsList`) already claims it into a freshly spawned session and switches the console over to it — but the left sidebar's session list never picked up the new session until its own 20s poll fired.
- Root cause: every other action that mutates session-listing membership (mint, close, end-session) revalidates the shared `/api/agent-sessions**` SWR cache via `mutate(isAgentSessionsKey)` afterward (see the doc comment on `isAgentSessionsKey`, which explicitly names the sidebar as a dependent consumer) — the claim path was the one spot that skipped this.
- Fix: call `void mutate(isAgentSessionsKey)` right after a successful claim, matching the pattern already used in `AgentPageView.tsx` and `AgentPanes.tsx`.

## Test plan
- [x] `bun run --filter web typecheck`
- [x] `bun run --filter web test -- src/components/agents/__tests__/AgentsPastConversationsList.test.tsx` (8/8 passing, including two new regression tests: a successful claim invalidates `isAgentSessionsKey`, a failed claim does not)
- [x] `bunx eslint` on both changed files — clean
- [ ] Manual: from `/dashboard/[driveId]/agents`, click a session-less past conversation and confirm the new session appears in the left sidebar immediately, not just after ~20s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R48Q3k7VQWRSm3gtjHX9q4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation claiming so newly created agent sessions appear immediately in shared session lists.
  * Preserved fallback navigation behavior when claiming a conversation fails.

* **Tests**
  * Added coverage for session-list updates after successful claims and ensured failed claims do not trigger unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->