### PR TITLE
fix(agents): make sidebar session/pane close optimistic

### DIFF
--- a/apps/web/src/components/agents/EndSessionDialog.tsx
+++ b/apps/web/src/components/agents/EndSessionDialog.tsx
@@ -23,12 +23,10 @@ export interface EndSessionDialogProps {
   onOpenChange(open: boolean): void;
   /** Display label, when the caller has one — "this session" otherwise (never an address). */
   sessionName?: string | null;
-  /** Disables both actions while the DELETE is in flight. */
-  isEnding: boolean;
   onConfirm(): void;
 }
 
-export default function EndSessionDialog({ open, onOpenChange, sessionName, isEnding, onConfirm }: EndSessionDialogProps) {
+export default function EndSessionDialog({ open, onOpenChange, sessionName, onConfirm }: EndSessionDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
@@ -39,10 +37,8 @@ export default function EndSessionDialog({ open, onOpenChange, sessionName, isEn
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isEnding}>Cancel</AlertDialogCancel>
-          <AlertDialogAction disabled={isEnding} onClick={onConfirm}>
-            End session
-          </AlertDialogAction>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>End session</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -70,6 +70,7 @@ import { decideClosePane } from './close-pane';
 import {
   agentSessionsKey,
   isAgentSessionsKey,
+  forgetSessionInCache,
   type SessionConversationSummary,
   type SessionListEntry,
 } from './session-conversations';
@@ -161,6 +162,7 @@ export default function AgentPanes({
   const assignPane = useAgentWorkspaceStore((state) => state.assignPane);
   const resetPane = useAgentWorkspaceStore((state) => state.resetPane);
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
+  const hydrateWorkspace = useAgentWorkspaceStore((state) => state.hydrateWorkspace);
   const replaceConversation = useAgentWorkspaceStore((state) => state.replaceConversation);
 
   // Layout AND tabs are server-persisted now — debounced, not per-transition
@@ -660,7 +662,20 @@ export default function AgentPanes({
 
   const confirmEndSession = useCallback(async () => {
     if (!pendingEndClose) return;
+    // Snapshot for rollback, then assume success immediately: the grid and
+    // sidebar row must not wait on the sandbox-kill round trip this DELETE
+    // triggers server-side — that's the whole point of this being optimistic.
+    // `forgetWorkspace` rather than `closePane` — this can fire with OTHER
+    // panes still in the grid (a terminal, say, when the closed listing was
+    // the session's last OPEN conversation rather than the grid's last pane),
+    // and ending the session tears down every one of them at once, not just
+    // the peeked pane's own.
+    const workspaceSnapshot = useAgentWorkspaceStore.getState().workspaces[sessionId] ?? null;
     setEndingSession(true);
+    forgetWorkspace(sessionId);
+    closeTerminalShell(pendingEndClose.scope);
+    setPendingEndClose(null);
+    forgetSessionInCache(mutate, sessionId);
     let hadOtherOpenConversations = false;
     try {
       const ended = await del<{ hadOtherOpenConversations?: boolean }>(
@@ -668,8 +683,11 @@ export default function AgentPanes({
       );
       hadOtherOpenConversations = ended?.hadOtherOpenConversations ?? false;
     } catch (error) {
-      // Nothing was mutated locally, so there is nothing to restore — the
-      // grid the user is looking at is still exactly the live session.
+      // The optimistic assumption was wrong — restore the grid, and let a
+      // real revalidate (not a stale local patch) put the session's row back,
+      // since the server is the authority on whether it's actually gone.
+      if (workspaceSnapshot) hydrateWorkspace(sessionId, workspaceSnapshot);
+      void mutate(isAgentSessionsKey);
       console.error('Failed to end session:', error);
       toast.error('Could not end the session', {
         description: error instanceof Error ? error.message : 'Please try again.',
@@ -677,17 +695,8 @@ export default function AgentPanes({
       setEndingSession(false);
       return;
     }
-    // Server-confirmed: NOW the grid comes down. `forgetWorkspace` rather
-    // than `closePane` — this can fire with OTHER panes still in the grid
-    // (a terminal, say, when the closed listing was the session's last OPEN
-    // conversation rather than the grid's last pane), and ending the session
-    // tears down every one of them at once, not just the peeked pane's own.
-    forgetWorkspace(sessionId);
-    closeTerminalShell(pendingEndClose.scope);
     setEndingSession(false);
-    setPendingEndClose(null);
-    // Same instant-freshness nudge as closeConversationListing — otherwise
-    // the now-dead session's row lingers in the sidebar until the next poll.
+    // Background reconcile only — the grid and sidebar are already right.
     void mutate(isAgentSessionsKey);
     if (hadOtherOpenConversations) {
       // Ending is unconditional by design — this can't be prevented client
@@ -699,7 +708,7 @@ export default function AgentPanes({
       toast.warning('This session had other open conversations, which were also ended.');
     }
     onSessionEnded?.();
-  }, [pendingEndClose, sessionId, forgetWorkspace, closeTerminalShell, onSessionEnded]);
+  }, [pendingEndClose, sessionId, forgetWorkspace, hydrateWorkspace, closeTerminalShell, onSessionEnded]);
 
   // Shared by cleanupOrphanedConversation's own post-DELETE recheck below and
   // handlePickHistoryConversation's rollback decision.

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -70,7 +70,9 @@ import { decideClosePane } from './close-pane';
 import {
   agentSessionsKey,
   isAgentSessionsKey,
+  isSessionListingKey,
   forgetSessionInCache,
+  restoreSessionInCache,
   type SessionConversationSummary,
   type SessionListEntry,
 } from './session-conversations';
@@ -669,10 +671,27 @@ export default function AgentPanes({
     // the session's last OPEN conversation rather than the grid's last pane),
     // and ending the session tears down every one of them at once, not just
     // the peeked pane's own.
+    const { scope } = pendingEndClose;
     const workspaceSnapshot = useAgentWorkspaceStore.getState().workspaces[sessionId] ?? null;
+    const sessionEntrySnapshot = sessionsData?.sessions.find((s) => s.sessionId === sessionId) ?? null;
     forgetWorkspace(sessionId);
-    closeTerminalShell(pendingEndClose.scope);
     setPendingEndClose(null);
+    // The bare top-level `mutate` import, matching every other call site in
+    // this file — NOT `useSWRConfig()`'s scoped one, unlike `AgentsSidebar.tsx`.
+    // Switching this specific spot to the scoped mutator (which does correctly
+    // match `sessionsData`'s own cache) was tried and reverted: it makes
+    // `sessionKnownToConversationsCache` (this component's own conversations-
+    // cache-readiness flag) flip correctly mid-teardown, which re-triggers the
+    // mount-time seed effect (`sessionKnownToConversationsCache` is one of its
+    // deps) — and THAT effect has no guard against re-seeding a session whose
+    // workspace was just deliberately forgotten, so it recreates a fresh
+    // single-pane grid right behind this function's own optimistic drop. That
+    // effect's missing guard is a real, pre-existing bug, but a different one
+    // than this PR is about; fixing it here would conflate two unrelated
+    // changes. No production `SWRConfig` provider exists anywhere in this app
+    // (confirmed repo-wide), so the bare import already targets the one real
+    // cache in practice — this is deferred as a known follow-up, not a
+    // regression (review finding — chatgpt-codex-connector on PR #2318).
     forgetSessionInCache(mutate, sessionId);
     let hadOtherOpenConversations = false;
     try {
@@ -681,19 +700,31 @@ export default function AgentPanes({
       );
       hadOtherOpenConversations = ended?.hadOtherOpenConversations ?? false;
     } catch (error) {
-      // The optimistic assumption was wrong — restore the grid, and let a
-      // real revalidate (not a stale local patch) put the session's row back,
-      // since the server is the authority on whether it's actually gone.
+      // The optimistic assumption was wrong. Restore the grid and the
+      // session's row LOCALLY from the snapshots above — a real revalidate
+      // alone isn't enough: it rides the same network whose failure is
+      // plausibly why the DELETE itself failed, so it could easily fail too
+      // and leave the row missing indefinitely (review finding —
+      // chatgpt-codex-connector on PR #2318). A revalidate still follows for
+      // eventual reconciliation, but the restore itself doesn't depend on it.
       if (workspaceSnapshot) hydrateWorkspace(sessionId, workspaceSnapshot);
-      void mutate(isAgentSessionsKey);
+      if (sessionEntrySnapshot) restoreSessionInCache(mutate, sessionEntrySnapshot);
+      void mutate(isSessionListingKey);
       console.error('Failed to end session:', error);
       toast.error('Could not end the session', {
         description: error instanceof Error ? error.message : 'Please try again.',
       });
       return;
     }
+    // Only NOW — server-confirmed — is it safe to tear down the shell this
+    // pane pointed at. Doing this earlier, alongside the optimistic grid
+    // drop, would irreversibly kill a live shell before knowing the session
+    // actually ended; a failed DELETE's rollback would then restore a
+    // terminal pane pointed at a shell that no longer exists (review
+    // finding — chatgpt-codex-connector on PR #2318).
+    closeTerminalShell(scope);
     // Background reconcile only — the grid and sidebar are already right.
-    void mutate(isAgentSessionsKey);
+    void mutate(isSessionListingKey);
     if (hadOtherOpenConversations) {
       // Ending is unconditional by design — this can't be prevented client
       // side — but the confirm the user just clicked may have been shown
@@ -704,7 +735,7 @@ export default function AgentPanes({
       toast.warning('This session had other open conversations, which were also ended.');
     }
     onSessionEnded?.();
-  }, [pendingEndClose, sessionId, forgetWorkspace, hydrateWorkspace, closeTerminalShell, onSessionEnded]);
+  }, [pendingEndClose, sessionId, sessionsData, forgetWorkspace, hydrateWorkspace, closeTerminalShell, onSessionEnded]);
 
   // Shared by cleanupOrphanedConversation's own post-DELETE recheck below and
   // handlePickHistoryConversation's rollback decision.

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -441,7 +441,6 @@ export default function AgentPanes({
   // taken before any IO or mutation — so cancelling, or the DELETE failing,
   // leaves nothing to roll back.
   const [pendingEndClose, setPendingEndClose] = useState<{ paneId: string; scope: PaneScope | null } | null>(null);
-  const [endingSession, setEndingSession] = useState(false);
 
   const closeShell = useCallback(
     (shellId: string) => {
@@ -671,7 +670,6 @@ export default function AgentPanes({
     // and ending the session tears down every one of them at once, not just
     // the peeked pane's own.
     const workspaceSnapshot = useAgentWorkspaceStore.getState().workspaces[sessionId] ?? null;
-    setEndingSession(true);
     forgetWorkspace(sessionId);
     closeTerminalShell(pendingEndClose.scope);
     setPendingEndClose(null);
@@ -692,10 +690,8 @@ export default function AgentPanes({
       toast.error('Could not end the session', {
         description: error instanceof Error ? error.message : 'Please try again.',
       });
-      setEndingSession(false);
       return;
     }
-    setEndingSession(false);
     // Background reconcile only — the grid and sidebar are already right.
     void mutate(isAgentSessionsKey);
     if (hadOtherOpenConversations) {
@@ -1533,7 +1529,6 @@ export default function AgentPanes({
         onOpenChange={(open) => {
           if (!open) setPendingEndClose(null);
         }}
-        isEnding={endingSession}
         onConfirm={() => void confirmEndSession()}
       />
     </>

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -339,6 +339,79 @@ describe('AgentPanes', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
+    it("does not kill the peeked pane's own shell until the session-end DELETE actually resolves", async () => {
+      // A lone TERMINAL pane (no conversation of its own) — closing it is a
+      // direct `end-session` decision, no conversation-listing DELETE first.
+      // The session's own (empty) listing must be CONFIRMED-known, not merely
+      // absent, or the close decision can't verify there's nothing to rebind.
+      mockSessionConversations([]);
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() =>
+        useAgentWorkspaceStore
+          .getState()
+          .assignPane('ses-1', paneId, { kind: 'terminal', name: 'shell-1', targetId: 'shell-9', agentPageId: null }),
+      );
+      await waitFor(() => expect(screen.getByTestId('pane-shell')).toBeInTheDocument());
+
+      let resolveSessionDel!: (value: unknown) => void;
+      mockDel.mockImplementation((url: string) =>
+        url === '/api/agent-sessions/ses-1'
+          ? new Promise((resolve) => {
+              resolveSessionDel = resolve;
+            })
+          : Promise.resolve(undefined),
+      );
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+      const dialog = await screen.findByRole('alertdialog');
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
+      // Still pending — the shell must not be touched before the session-end
+      // DELETE is known to have actually succeeded (review finding —
+      // chatgpt-codex-connector on PR #2318).
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/shells/shell-9');
+
+      resolveSessionDel({ hadOtherOpenConversations: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Only now, confirmed, is the shell actually torn down.
+      expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1/shells/shell-9');
+    });
+
+    it('never kills the shell at all if the session-end DELETE fails', async () => {
+      mockSessionConversations([]);
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const paneId = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes[0].id;
+      act(() =>
+        useAgentWorkspaceStore
+          .getState()
+          .assignPane('ses-1', paneId, { kind: 'terminal', name: 'shell-1', targetId: 'shell-9', agentPageId: null }),
+      );
+      await waitFor(() => expect(screen.getByTestId('pane-shell')).toBeInTheDocument());
+
+      mockDel.mockImplementation((url: string) =>
+        url === '/api/agent-sessions/ses-1'
+          ? Promise.reject(new Error('sandbox teardown failed'))
+          : Promise.resolve(undefined),
+      );
+      const errorSpy = vi.spyOn(toast, 'error').mockImplementation(() => '');
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+      const dialog = await screen.findByRole('alertdialog');
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+
+      await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+      // Never touched — a failed session-end must never have killed the
+      // shell a restored terminal pane still claims to hold.
+      expect(mockDel).not.toHaveBeenCalledWith('/api/agent-sessions/ses-1/shells/shell-9');
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+      expect(screen.getByTestId('pane-shell')).toBeInTheDocument();
+      errorSpy.mockRestore();
+    });
+
     it('warns (but still ends the session) when the server reports other open conversations existed', async () => {
       // Ending is unconditional by design and can't be prevented client
       // side — but THIS dialog's confirm was shown because the pane's own

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -290,7 +290,7 @@ describe('AgentPanes', () => {
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     });
 
-    it('confirming DELETEs the session, THEN drops the grid and reports it ended', async () => {
+    it('confirming drops the grid instantly, DELETEs the session, and reports it ended', async () => {
       mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
       mockDel.mockImplementation(async (url: string) => {
         if (url === '/api/agent-sessions/ses-1/conversations/conv-1') throw new ApiRequestError('conflict', 409);
@@ -308,6 +308,35 @@ describe('AgentPanes', () => {
       await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
       await waitFor(() => expect(onSessionEnded).toHaveBeenCalledTimes(1));
       expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeUndefined();
+    });
+
+    it('drops the grid instantly — before the sandbox-kill DELETE resolves, not after', async () => {
+      mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+      let resolveSessionDel!: (value: unknown) => void;
+      mockDel.mockImplementation((url: string) => {
+        if (url === '/api/agent-sessions/ses-1/conversations/conv-1') {
+          return Promise.reject(new ApiRequestError('conflict', 409));
+        }
+        return new Promise((resolve) => {
+          resolveSessionDel = resolve;
+        });
+      });
+      renderPanes();
+      await waitFor(() => expect(screen.getByTestId('pane-chat')).toBeInTheDocument());
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Close pane'));
+      const dialog = await screen.findByRole('alertdialog');
+
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
+      // Still pending — the sandbox-kill DELETE has not resolved yet, but the
+      // grid is already gone.
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeUndefined();
+      expect(screen.queryByTestId('pane-chat')).not.toBeInTheDocument();
+
+      resolveSessionDel({ hadOtherOpenConversations: false });
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
     it('warns (but still ends the session) when the server reports other open conversations existed', async () => {
@@ -336,7 +365,7 @@ describe('AgentPanes', () => {
       warnSpy.mockRestore();
     });
 
-    it('a failed DELETE leaves the grid exactly as it was — no rollback needed because nothing moved', async () => {
+    it('a failed DELETE rolls the grid back to exactly what it was', async () => {
       mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
       mockDel.mockImplementation(async (url: string) => {
         if (url === '/api/agent-sessions/ses-1/conversations/conv-1') throw new ApiRequestError('conflict', 409);
@@ -353,9 +382,11 @@ describe('AgentPanes', () => {
 
       await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
       expect(onSessionEnded).not.toHaveBeenCalled();
-      // The session is still live locally — no second session gets minted
-      // because nothing here ever creates one.
-      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+      // The grid dropped optimistically the instant "End session" was
+      // confirmed, then the DELETE failed — `hydrateWorkspace` restores it
+      // from the pre-close snapshot rather than leaving it gone. No second
+      // session gets minted because nothing here ever creates one.
+      await waitFor(() => expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined());
       expect(screen.getByTestId('pane-chat')).toBeInTheDocument();
     });
 

--- a/apps/web/src/components/agents/panes/session-conversations.ts
+++ b/apps/web/src/components/agents/panes/session-conversations.ts
@@ -76,10 +76,11 @@ export function isAgentSessionsKey(key: unknown): boolean {
 
 /**
  * Drop `sessionId`'s row from every open `/api/agent-sessions**` SWR entry,
- * locally, without waiting on revalidation — for a caller ending a session
- * that has no local SWR binding of its own to this cache (the sidebar).
- * `AgentPanes.tsx`'s equivalent (`recordSessionEnded`, keyed to its own
- * hook-bound `mutate`) is separate but does the identical filter.
+ * locally, without waiting on revalidation — used by both `AgentPanes.tsx`'s
+ * `confirmEndSession` and `AgentsSidebar.tsx`'s `endSession`, each passing
+ * its own scoped `mutate`, so ending a session drops its row everywhere the
+ * instant the client decides to end it, not after the sandbox-kill DELETE
+ * (or a follow-up revalidate) resolves.
  *
  * Takes `mutate` as a parameter rather than importing the bare top-level one
  * from `swr` — that top-level import only targets SWR's default cache, not a

--- a/apps/web/src/components/agents/panes/session-conversations.ts
+++ b/apps/web/src/components/agents/panes/session-conversations.ts
@@ -69,14 +69,37 @@ export function findOpenForAgent<T extends { agentPageId: string | null; lastMes
  * (mint, close, end-session) revalidates through this so every consumer of
  * the shared listing (the sidebar, other panes, `AgentPageView`'s own
  * replacement mint) sees it before its own poll interval, not after.
+ *
+ * Deliberately broad — this is safe for a bare revalidate (no data, no
+ * updater): each matched key just refetches through its OWN registered
+ * fetcher, so a per-session sub-resource cached under this same prefix (the
+ * shells listing, the singular session record) refreshes correctly too. It
+ * is NOT safe to pair with a `{sessions: [...]}`-shaped updater — see
+ * `isSessionListingKey` for that narrower, updater-safe predicate.
  */
 export function isAgentSessionsKey(key: unknown): boolean {
   return typeof key === 'string' && key.startsWith('/api/agent-sessions');
 }
 
 /**
- * Drop `sessionId`'s row from every open `/api/agent-sessions**` SWR entry,
- * locally, without waiting on revalidation — used by both `AgentPanes.tsx`'s
+ * The two BULK session-listing keys specifically — `agentSessionsKey(null)`
+ * ('/api/agent-sessions') and any drive-scoped `agentSessionsKey(driveId)`
+ * ('/api/agent-sessions?driveId=...') — never a per-session sub-resource path
+ * like `/api/agent-sessions/{id}/shells` or the singular session record,
+ * which `isAgentSessionsKey`'s broader prefix match also catches. Those
+ * cache entries hold no `sessions` array at all, so an updater written
+ * against `{sessions: [...]}` (`forgetSessionInCache`,
+ * `forgetConversationInCache`) must only ever run against keys THIS
+ * predicate matches, or it throws on the mismatched shape (review finding —
+ * chatgpt-codex-connector on PR #2318).
+ */
+export function isSessionListingKey(key: unknown): boolean {
+  return typeof key === 'string' && (key === '/api/agent-sessions' || key.startsWith('/api/agent-sessions?'));
+}
+
+/**
+ * Drop `sessionId`'s row from every open session-listing SWR entry, locally,
+ * without waiting on revalidation — used by both `AgentPanes.tsx`'s
  * `confirmEndSession` and `AgentsSidebar.tsx`'s `endSession`, each passing
  * its own scoped `mutate`, so ending a session drops its row everywhere the
  * instant the client decides to end it, not after the sandbox-kill DELETE
@@ -90,9 +113,33 @@ export function isAgentSessionsKey(key: unknown): boolean {
  */
 export function forgetSessionInCache(mutate: ScopedMutator, sessionId: string): void {
   void mutate(
-    isAgentSessionsKey,
+    isSessionListingKey,
     (current: { sessions: SessionListEntry[] } | undefined) =>
       current ? { ...current, sessions: current.sessions.filter((session) => session.sessionId !== sessionId) } : current,
+    { revalidate: false },
+  );
+}
+
+/**
+ * The mirror of `forgetSessionInCache`: put a previously-removed session row
+ * back into every open session-listing SWR entry, locally — the rollback
+ * half of the optimistic pair. A real revalidate (`mutate(isSessionListingKey)`
+ * with no data) is NOT a substitute for this: if the network is down (the
+ * same reason the DELETE that triggered this rollback failed), the
+ * revalidate fails too and the row stays missing until a later successful
+ * poll — this restores it unconditionally, from the caller's own
+ * already-in-hand snapshot, independent of the network (review finding —
+ * chatgpt-codex-connector on PR #2318). Generic over the caller's own row
+ * shape (`AgentPanes.tsx`'s minimal one vs. `AgentsSidebar.tsx`'s richer
+ * one) — this only ever needs `sessionId` to place it back correctly.
+ */
+export function restoreSessionInCache<T extends { sessionId: string }>(mutate: ScopedMutator, entry: T): void {
+  void mutate(
+    isSessionListingKey,
+    (current: { sessions: T[] } | undefined) =>
+      current && !current.sessions.some((session) => session.sessionId === entry.sessionId)
+        ? { ...current, sessions: [...current.sessions, entry] }
+        : current,
     { revalidate: false },
   );
 }
@@ -105,7 +152,7 @@ export function forgetSessionInCache(mutate: ScopedMutator, sessionId: string): 
  */
 export function forgetConversationInCache(mutate: ScopedMutator, sessionId: string, conversationId: string): void {
   void mutate(
-    isAgentSessionsKey,
+    isSessionListingKey,
     (current: { sessions: SessionListEntry[] } | undefined) =>
       current
         ? {

--- a/apps/web/src/components/agents/panes/session-conversations.ts
+++ b/apps/web/src/components/agents/panes/session-conversations.ts
@@ -1,3 +1,5 @@
+import type { ScopedMutator } from 'swr';
+
 /**
  * One of a session's OPEN (not-yet-closed) conversation listings — the shape
  * shared by the pane grid's pure decisions:
@@ -70,4 +72,50 @@ export function findOpenForAgent<T extends { agentPageId: string | null; lastMes
  */
 export function isAgentSessionsKey(key: unknown): boolean {
   return typeof key === 'string' && key.startsWith('/api/agent-sessions');
+}
+
+/**
+ * Drop `sessionId`'s row from every open `/api/agent-sessions**` SWR entry,
+ * locally, without waiting on revalidation — for a caller ending a session
+ * that has no local SWR binding of its own to this cache (the sidebar).
+ * `AgentPanes.tsx`'s equivalent (`recordSessionEnded`, keyed to its own
+ * hook-bound `mutate`) is separate but does the identical filter.
+ *
+ * Takes `mutate` as a parameter rather than importing the bare top-level one
+ * from `swr` — that top-level import only targets SWR's default cache, not a
+ * caller-specific `SWRConfig` provider (a custom-cache test harness, say).
+ * The caller supplies whatever `mutate` is actually bound to its own cache
+ * (`useSWRConfig()`'s, or a hook-bound one), so this keeps working regardless.
+ */
+export function forgetSessionInCache(mutate: ScopedMutator, sessionId: string): void {
+  void mutate(
+    isAgentSessionsKey,
+    (current: { sessions: SessionListEntry[] } | undefined) =>
+      current ? { ...current, sessions: current.sessions.filter((session) => session.sessionId !== sessionId) } : current,
+    { revalidate: false },
+  );
+}
+
+/**
+ * Drop one conversation listing from `sessionId`'s row, everywhere — the
+ * cross-file mirror of `AgentPanes.tsx`'s own `recordClosedConversation`,
+ * for a caller (the sidebar) with no local SWR binding of its own. See
+ * `forgetSessionInCache` for why `mutate` is a parameter, not an import.
+ */
+export function forgetConversationInCache(mutate: ScopedMutator, sessionId: string, conversationId: string): void {
+  void mutate(
+    isAgentSessionsKey,
+    (current: { sessions: SessionListEntry[] } | undefined) =>
+      current
+        ? {
+            ...current,
+            sessions: current.sessions.map((session) =>
+              session.sessionId === sessionId
+                ? { ...session, conversations: session.conversations.filter((c) => c.conversationId !== conversationId) }
+                : session,
+            ),
+          }
+        : current,
+    { revalidate: false },
+  );
 }

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -29,8 +29,10 @@ import { fetchWithAuth, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import type { PersistedWorkspaceState } from '@pagespace/lib/agent-sessions/contract';
 import {
   isAgentSessionsKey,
+  isSessionListingKey,
   forgetSessionInCache,
   forgetConversationInCache,
+  restoreSessionInCache,
 } from '@/components/agents/panes/session-conversations';
 import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
@@ -461,6 +463,7 @@ function SessionRow({
   const { mutate } = useSWRConfig();
   const selectedSessionId = useAgentSurfaceStore((state) => state.selectedSessionId);
   const selectedConversationId = useAgentSurfaceStore((state) => state.selectedConversationId);
+  const selectedAgentId = useAgentSurfaceStore((state) => state.selectedAgentId);
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const selectSession = useAgentSurfaceStore((state) => state.selectSession);
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
@@ -552,9 +555,13 @@ function SessionRow({
   const endSession = useCallback(async () => {
     // Snapshot for rollback, then assume success immediately — the row must
     // not linger in the sidebar for however long the sandbox-kill round trip
-    // this DELETE triggers server-side actually takes.
+    // this DELETE triggers server-side actually takes. `session` (the prop)
+    // IS this row's own current cache entry, so it doubles as the snapshot
+    // to restore on failure — no separate cache peek needed.
     const workspaceSnapshot = useAgentWorkspaceStore.getState().workspaces[session.sessionId] ?? null;
     const wasSelected = selectedSessionId === session.sessionId;
+    const previousConversationId = selectedConversationId;
+    const previousAgentId = selectedAgentId;
     // The session leaves the sidebar; its conversations remain as history in
     // each agent's list. Drop the local grid too — its panes pointed at a
     // sandbox that no longer exists.
@@ -565,17 +572,34 @@ function SessionRow({
     try {
       await del(`/api/agent-sessions/${encodeURIComponent(session.sessionId)}`);
     } catch (error) {
-      // The optimistic assumption was wrong — restore the grid and selection,
-      // and let a real revalidate (not a stale local patch) put the row back.
-      // Selection only, and only if NOTHING has claimed it since: `selectSession`
-      // also pushes a URL (`useAgentSurfaceStore`'s `commit`), so blindly
-      // restoring it here would yank the user back to this session even if
-      // they've since navigated elsewhere during this request's round trip.
+      // The optimistic assumption was wrong. Restore the grid and the
+      // session's row LOCALLY (from the snapshots above) — a real revalidate
+      // alone isn't enough: it rides the same network whose failure is
+      // plausibly why the DELETE itself failed, so it could easily fail too
+      // and leave the row missing indefinitely (review finding —
+      // chatgpt-codex-connector on PR #2318). A revalidate still follows for
+      // eventual reconciliation, but the restore itself doesn't depend on it.
+      //
+      // Selection restore, and only if NOTHING has claimed it since:
+      // `selectConversation`/`selectSession` also push a URL
+      // (`useAgentSurfaceStore`'s `commit`), so blindly restoring it here
+      // would yank the user back to this session even if they've since
+      // navigated elsewhere during this request's round trip. Restoring via
+      // `selectConversation` with the FULL previous trio, not `selectSession`
+      // alone — `selectSession` treats "was this the same session" against
+      // the NOW-cleared `null`, so it would drop the previously-selected
+      // conversation/agent even though nothing else claimed them (review
+      // finding — chatgpt-codex-connector on PR #2318).
       if (workspaceSnapshot) hydrateWorkspace(session.sessionId, workspaceSnapshot);
+      restoreSessionInCache(mutate, session);
       if (wasSelected && useAgentSurfaceStore.getState().selectedSessionId === null) {
-        selectSession(session.sessionId);
+        selectConversation({
+          sessionId: session.sessionId,
+          conversationId: previousConversationId,
+          agentId: previousAgentId,
+        });
       }
-      void mutate(isAgentSessionsKey);
+      void mutate(isSessionListingKey);
       console.error('Failed to end session:', error);
       toast.error('Could not end the session', {
         description: error instanceof Error ? error.message : 'Please try again.',
@@ -583,8 +607,18 @@ function SessionRow({
       return;
     }
     // Confirmed — background reconcile only; the grid and sidebar are already right.
-    void mutate(isAgentSessionsKey);
-  }, [forgetWorkspace, hydrateWorkspace, mutate, selectSession, selectedSessionId, session.sessionId]);
+    void mutate(isSessionListingKey);
+  }, [
+    forgetWorkspace,
+    hydrateWorkspace,
+    mutate,
+    selectConversation,
+    selectSession,
+    selectedAgentId,
+    selectedConversationId,
+    selectedSessionId,
+    session,
+  ]);
 
   const closeConversation = useCallback(
     async (conversationId: string) => {

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -469,7 +469,6 @@ function SessionRow({
   const assignPane = useAgentWorkspaceStore((state) => state.assignPane);
   const [expanded, setExpanded] = useState(false);
   const [confirmingEnd, setConfirmingEnd] = useState(false);
-  const [ending, setEnding] = useState(false);
   const isSelected = selectedSessionId === session.sessionId;
   const isRunning = session.sandboxStatus === 'running' || session.sandboxStatus === 'starting';
 
@@ -556,7 +555,6 @@ function SessionRow({
     // this DELETE triggers server-side actually takes.
     const workspaceSnapshot = useAgentWorkspaceStore.getState().workspaces[session.sessionId] ?? null;
     const wasSelected = selectedSessionId === session.sessionId;
-    setEnding(true);
     // The session leaves the sidebar; its conversations remain as history in
     // each agent's list. Drop the local grid too — its panes pointed at a
     // sandbox that no longer exists.
@@ -583,8 +581,6 @@ function SessionRow({
         description: error instanceof Error ? error.message : 'Please try again.',
       });
       return;
-    } finally {
-      setEnding(false);
     }
     // Confirmed — background reconcile only; the grid and sidebar are already right.
     void mutate(isAgentSessionsKey);
@@ -772,7 +768,6 @@ function SessionRow({
         open={confirmingEnd}
         onOpenChange={setConfirmingEnd}
         sessionName={session.name}
-        isEnding={ending}
         onConfirm={() => void endSession()}
       />
 

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -569,8 +569,14 @@ function SessionRow({
     } catch (error) {
       // The optimistic assumption was wrong — restore the grid and selection,
       // and let a real revalidate (not a stale local patch) put the row back.
+      // Selection only, and only if NOTHING has claimed it since: `selectSession`
+      // also pushes a URL (`useAgentSurfaceStore`'s `commit`), so blindly
+      // restoring it here would yank the user back to this session even if
+      // they've since navigated elsewhere during this request's round trip.
       if (workspaceSnapshot) hydrateWorkspace(session.sessionId, workspaceSnapshot);
-      if (wasSelected) selectSession(session.sessionId);
+      if (wasSelected && useAgentSurfaceStore.getState().selectedSessionId === null) {
+        selectSession(session.sessionId);
+      }
       void mutate(isAgentSessionsKey);
       console.error('Failed to end session:', error);
       toast.error('Could not end the session', {

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { ChevronDown, ChevronRight, Folder, Plus, Search, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 
 import EndSessionDialog from '@/components/agents/EndSessionDialog';
 import { useSpawnSession } from '@/components/agents/useSpawnSession';
@@ -27,6 +27,11 @@ import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspa
 import { panesOf, isLastPane, type PaneState } from '@/stores/agent-workspace/pane-reducer';
 import { fetchWithAuth, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import type { PersistedWorkspaceState } from '@pagespace/lib/agent-sessions/contract';
+import {
+  isAgentSessionsKey,
+  forgetSessionInCache,
+  forgetConversationInCache,
+} from '@/components/agents/panes/session-conversations';
 import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
 
@@ -364,12 +369,7 @@ function SessionList({
             />
           )}
           {group.sessions.map((session) => (
-            <SessionRow
-              key={session.sessionId}
-              session={session}
-              onChanged={onChanged}
-              agentNamesById={agentNamesById}
-            />
+            <SessionRow key={session.sessionId} session={session} agentNamesById={agentNamesById} />
           ))}
         </div>
       ))}
@@ -449,18 +449,22 @@ function SessionGroupHeader({
 /** One session: name + running dot, expanding to its conversations (never its panes). */
 function SessionRow({
   session,
-  onChanged,
   agentNamesById,
 }: {
   session: SessionListEntry;
-  onChanged: OnSessionsChanged;
   agentNamesById: Map<string, string>;
 }) {
+  // Bound to whatever `SWRConfig` provider wraps this tree (the app's default
+  // cache in production, an isolated one in tests) — NOT the bare top-level
+  // `mutate` import, which only ever targets SWR's default cache and would
+  // silently no-op under a custom provider.
+  const { mutate } = useSWRConfig();
   const selectedSessionId = useAgentSurfaceStore((state) => state.selectedSessionId);
   const selectedConversationId = useAgentSurfaceStore((state) => state.selectedConversationId);
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const selectSession = useAgentSurfaceStore((state) => state.selectSession);
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
+  const hydrateWorkspace = useAgentWorkspaceStore((state) => state.hydrateWorkspace);
   const resetPane = useAgentWorkspaceStore((state) => state.resetPane);
   const assignPane = useAgentWorkspaceStore((state) => state.assignPane);
   const [expanded, setExpanded] = useState(false);
@@ -547,25 +551,38 @@ function SessionRow({
   }, [openConversation, openShell, conversationEntryForTarget, session.workspace, session.conversations, session.shells]);
 
   const endSession = useCallback(async () => {
+    // Snapshot for rollback, then assume success immediately — the row must
+    // not linger in the sidebar for however long the sandbox-kill round trip
+    // this DELETE triggers server-side actually takes.
+    const workspaceSnapshot = useAgentWorkspaceStore.getState().workspaces[session.sessionId] ?? null;
+    const wasSelected = selectedSessionId === session.sessionId;
     setEnding(true);
+    // The session leaves the sidebar; its conversations remain as history in
+    // each agent's list. Drop the local grid too — its panes pointed at a
+    // sandbox that no longer exists.
+    forgetWorkspace(session.sessionId);
+    if (wasSelected) selectSession(null);
+    setConfirmingEnd(false);
+    forgetSessionInCache(mutate, session.sessionId);
     try {
       await del(`/api/agent-sessions/${encodeURIComponent(session.sessionId)}`);
-      // The session leaves the sidebar; its conversations remain as history in
-      // each agent's list. Drop the local grid too — its panes pointed at a
-      // sandbox that no longer exists.
-      forgetWorkspace(session.sessionId);
-      if (selectedSessionId === session.sessionId) selectSession(null);
-      setConfirmingEnd(false);
-      onChanged();
     } catch (error) {
+      // The optimistic assumption was wrong — restore the grid and selection,
+      // and let a real revalidate (not a stale local patch) put the row back.
+      if (workspaceSnapshot) hydrateWorkspace(session.sessionId, workspaceSnapshot);
+      if (wasSelected) selectSession(session.sessionId);
+      void mutate(isAgentSessionsKey);
       console.error('Failed to end session:', error);
       toast.error('Could not end the session', {
         description: error instanceof Error ? error.message : 'Please try again.',
       });
+      return;
     } finally {
       setEnding(false);
     }
-  }, [forgetWorkspace, onChanged, selectSession, selectedSessionId, session.sessionId]);
+    // Confirmed — background reconcile only; the grid and sidebar are already right.
+    void mutate(isAgentSessionsKey);
+  }, [forgetWorkspace, hydrateWorkspace, mutate, selectSession, selectedSessionId, session.sessionId]);
 
   const closeConversation = useCallback(
     async (conversationId: string) => {
@@ -573,7 +590,6 @@ function SessionRow({
         await del(
           `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/conversations/${encodeURIComponent(conversationId)}`,
         );
-        onChanged();
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 409) {
           // The session's LAST open listing — the server is the authority on
@@ -587,9 +603,17 @@ function SessionRow({
         toast.error('Could not close this conversation', {
           description: error instanceof Error ? error.message : 'Please try again.',
         });
+        return;
       }
+      // Instant sidebar freshness — a local cache patch instead of a full
+      // revalidate, so the row leaves the listing without a second, sequential
+      // network round trip on top of the DELETE that just resolved. A
+      // background reconcile still follows, same as every other mutating
+      // action here — it just no longer gates what the user sees.
+      forgetConversationInCache(mutate, session.sessionId, conversationId);
+      void mutate(isAgentSessionsKey);
     },
-    [onChanged, session.sessionId],
+    [mutate, session.sessionId],
   );
 
   // Closing a pane's own conversation from the sidebar — a real DELETE
@@ -600,10 +624,9 @@ function SessionRow({
   const closePaneConversation = useCallback(
     async (paneId: string, conversationId: string) => {
       // Read the LIVE grid, not the `session.workspace` prop — that's an SWR
-      // snapshot (polled every 20s, otherwise only as fresh as the last
-      // `onChanged()`), so a second pane opened on this same conversation
-      // moments ago could be invisible to it (review finding, carried over
-      // from this row's own tab-era close control).
+      // snapshot (polled every 20s), so a second pane opened on this same
+      // conversation moments ago could be invisible to it (review finding,
+      // carried over from this row's own tab-era close control).
       const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[session.sessionId];
       const shownElsewhere = liveWorkspace
         ? panesOf(liveWorkspace).some(
@@ -640,7 +663,14 @@ function SessionRow({
         } else {
           resetPane(session.sessionId, paneId);
         }
-        onChanged();
+        // Instant sidebar freshness — a local cache patch instead of a full
+        // revalidate, so the row leaves the listing without a second,
+        // sequential network round trip on top of the DELETE that just
+        // resolved. A background reconcile still follows, same as every
+        // other mutating action here — it just no longer gates what the
+        // user sees.
+        forgetConversationInCache(mutate, session.sessionId, conversationId);
+        void mutate(isAgentSessionsKey);
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 409) {
           setConfirmingEnd(true);
@@ -652,7 +682,7 @@ function SessionRow({
         });
       }
     },
-    [session.sessionId, session.conversations, resetPane, assignPane, onChanged],
+    [mutate, session.sessionId, session.conversations, resetPane, assignPane],
   );
 
   const conversationLabel = useCallback(

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -841,6 +841,76 @@ describe('AgentsSidebar', () => {
 
       expect(mockDel).not.toHaveBeenCalled();
     });
+
+    test('the grid, selection, and sidebar row drop instantly — before the sandbox-kill DELETE resolves, not after', async () => {
+      // The whole point: ending a session must not wait on the sandbox
+      // teardown this DELETE triggers server-side, which can take real
+      // seconds. Everything user-visible updates the moment the user
+      // confirms, not once the request comes back.
+      let resolveDel!: () => void;
+      mockDel.mockReturnValue(new Promise<void>((resolve) => (resolveDel = resolve)));
+      useAgentSurfaceStore.setState({
+        selectedSessionId: 'ses-1',
+        selectedConversationId: 'conv-1',
+        selectedAgentId: 'agent-1',
+      });
+      useAgentWorkspaceStore
+        .getState()
+        .ensureWorkspace('ses-1', { kind: 'chat', name: 'x', targetId: 'conv-1', agentPageId: 'agent-1' });
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      await user.click(screen.getByLabelText('End session'));
+      const dialog = await screen.findByRole('alertdialog');
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
+      // Still pending — nothing has resolved yet.
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeUndefined();
+      expect(useAgentSurfaceStore.getState().selectedSessionId).toBeNull();
+      expect(screen.queryByText('api refactor')).toBeNull();
+
+      resolveDel();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    test('a failed end-session restores the grid and selection, but does not yank the user back if they already navigated elsewhere', async () => {
+      // `selectSession` also pushes a URL — restoring a stale selection on a
+      // rare rollback must not silently override wherever the user has since
+      // navigated during this request's round trip.
+      let rejectDel!: (error: unknown) => void;
+      mockDel.mockReturnValue(new Promise((_resolve, reject) => (rejectDel = reject)));
+      useAgentSurfaceStore.setState({
+        selectedSessionId: 'ses-1',
+        selectedConversationId: 'conv-1',
+        selectedAgentId: 'agent-1',
+      });
+      useAgentWorkspaceStore
+        .getState()
+        .ensureWorkspace('ses-1', { kind: 'chat', name: 'x', targetId: 'conv-1', agentPageId: 'agent-1' });
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      await user.click(screen.getByLabelText('End session'));
+      const dialog = await screen.findByRole('alertdialog');
+      await user.click(within(dialog).getByRole('button', { name: 'End session' }));
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-sessions/ses-1'));
+
+      // While that DELETE is still pending, the user navigates to a
+      // different session entirely.
+      useAgentSurfaceStore.getState().selectSession('ses-2');
+
+      rejectDel(new Error('boom'));
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+
+      // The grid is restored (nothing else could have touched it)...
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+      // ...but the user's own, later navigation stands — not clobbered back
+      // to the session whose end just failed.
+      expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-2');
+    });
   });
 
   describe('session row menu', () => {


### PR DESCRIPTION
## Summary
- Closing a session's last pane awaited a DELETE that synchronously kills the sandbox server-side before the sidebar removed the row — `confirmEndSession`/`endSession` now drop the grid and sidebar row immediately, firing the DELETE in the background and rolling back on failure via a snapshot restore (workspace via `hydrateWorkspace`, the session's own listing row via a new `restoreSessionInCache` — both local, independent of the network, not a bare revalidate).
- Ordinary conversation/pane closes already hit a fast pure-DB endpoint, but the sidebar still lagged behind the already-instant middle pane due to a second, sequential revalidate after the DELETE resolved — `closeConversation`/`closePaneConversation` now patch the SWR cache locally instead, without reordering anything relative to the DELETE (preserving existing tested protection against a pane being reassigned mid-flight).
- Added `forgetSessionInCache`/`forgetConversationInCache`/`restoreSessionInCache` to `session-conversations.ts`, taking the caller's scoped `mutate` instead of SWR's bare global one where needed, and a narrower `isSessionListingKey` predicate (vs. the broader `isAgentSessionsKey`) so these shape-specific updaters never run against an unrelated cache entry (the shells listing, the singular session record).
- Deferred the peeked pane's shell teardown (`closeTerminalShell`) until *after* the session-ending DELETE actually succeeds — it was briefly part of the optimistic block, which could irreversibly kill a shell before knowing whether the end actually succeeded.
- `endSession`'s failure rollback restores the full previous selection (session + conversation + agent) via `selectConversation`, not just the session id, and only when nothing else has claimed the selection in the meantime (`selectSession`/`selectConversation` also push a URL, so a blind restore could yank the user back after they'd already navigated elsewhere).
- Removed the now-dead `isEnding`/`endingSession` disabled-state plumbing from both end-session confirm dialogs — since the dialog now closes in the same optimistic tick as the DELETE fires, that state stopped having any observable effect.

## Review
Reviewed by `chatgpt-codex-connector` (5 findings — 2×P1, 3×P2), all addressed or explicitly deferred with reasoning inline and in the corresponding review reply:
- Shell-teardown-before-confirmation (P1) — fixed, deferred to post-success.
- Rollback relying solely on a network revalidate (P1) — fixed, added local-snapshot restore.
- Overly-broad cache-key predicate crashing on mismatched shapes (P2) — fixed, added `isSessionListingKey`.
- Incomplete selection restore dropping the conversation/agent (P2) — fixed.
- `AgentPanes.tsx`'s `confirmEndSession` using the bare `mutate` import rather than `useSWRConfig()`'s scoped one (P2) — fixed the equivalent in `AgentsSidebar.tsx` (required there for its own tests); deferred in `AgentPanes.tsx` specifically, since switching it exposes a separate, pre-existing bug in the mount-time conversation-seed effect (no production `SWRConfig` provider exists anywhere in this app today, so no live impact) — documented in place.

## Test plan
- [x] `bun run --filter web typecheck` — clean
- [x] `eslint` on all touched source and test files — clean
- [x] `bun run --filter web test -- src/components/agents/panes/__tests__/AgentPanes.test.tsx src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx` — 139/139 passing, including new regression tests for the optimistic-before-resolve behavior, the shell-deferral fix, and the selection-restore race
- [ ] Manual: close a non-last pane/conversation in the agents console and confirm the sidebar updates immediately alongside the pane grid
- [ ] Manual: end a session (last pane) and confirm the sidebar row disappears instantly, without waiting for sandbox teardown; confirm the sandbox still tears down in the background
- [ ] Manual: force a network failure on each path and confirm the pane/session reappears with an error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW4yPYn9dyoiHLWRwVEFM2
