### PR TITLE
fix(agents): keep session/conversation selection alive across sidebar nav

### DIFF
--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -47,6 +47,7 @@ import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { fetchWithAuth, post, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useWorkspaceServerSync } from '@/stores/agent-workspace/useWorkspaceServerSync';
 import { panesOf, isLastPane, paneShowing, type PaneState } from '@/stores/agent-workspace/pane-reducer';
 import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
@@ -937,6 +938,15 @@ export default function AgentPanes({
         // id captured BEFORE this mint sequence began still names the
         // conversation actually being replaced.
         assignPane(sessionId, paneId, newScope);
+        // Tell the surface's own selection about this swap — mirroring what
+        // `useSpawnSession` already does after spawning a session. Without
+        // this, `selectedConversationId` keeps naming the REPLACED
+        // conversation, and a later remount's seeding effect (this file,
+        // below) tries to re-open that stale id against a pane that no
+        // longer shows it — reverting the swap or, once the eviction guard
+        // treats this pane as protected, splitting a second pane open for it
+        // instead of recognizing the swap as already done (caught in review).
+        useAgentSurfaceStore.getState().selectConversation({ sessionId, conversationId, agentId: agentPageId });
         if (priorScopeConversationId !== null) {
           void closeReplacedConversation(paneId, priorScopeConversationId, conversationId, agentPageId);
         }

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -939,15 +939,24 @@ export default function AgentPanes({
         // id captured BEFORE this mint sequence began still names the
         // conversation actually being replaced.
         assignPane(sessionId, paneId, newScope);
-        // Tell the surface's own selection about this swap — mirroring what
-        // `useSpawnSession` already does after spawning a session. Without
-        // this, `selectedConversationId` keeps naming the REPLACED
-        // conversation, and a later remount's seeding effect (this file,
-        // below) tries to re-open that stale id against a pane that no
+        // Tell the Agents CONSOLE's own selection about this swap —
+        // mirroring what `useSpawnSession` already does after spawning a
+        // session. Without this, `selectedConversationId` keeps naming the
+        // REPLACED conversation, and a later remount's seeding effect (this
+        // file, below) tries to re-open that stale id against a pane that no
         // longer shows it — reverting the swap or, once the eviction guard
         // treats this pane as protected, splitting a second pane open for it
         // instead of recognizing the swap as already done (caught in review).
-        selectConversation({ sessionId, conversationId, agentId: agentPageId });
+        // Scoped to `chatContext === 'console'`: this component is also
+        // embedded in a regular page's chat tab (`AgentPageView`, chatContext
+        // "page"), whose `initialConversation` is driven by its own local
+        // state, not this store — writing here unconditionally would both
+        // do nothing useful there AND push a `/dashboard/agents` URL via
+        // `history.pushState`, silently navigating a page-embedded chat's
+        // user away to the Agents console (caught in review).
+        if (chatContext === 'console') {
+          selectConversation({ sessionId, conversationId, agentId: agentPageId });
+        }
         if (priorScopeConversationId !== null) {
           void closeReplacedConversation(paneId, priorScopeConversationId, conversationId, agentPageId);
         }
@@ -1005,6 +1014,7 @@ export default function AgentPanes({
       recordMintedConversation,
       beginPaneAssign,
       selectConversation,
+      chatContext,
     ],
   );
 

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -167,6 +167,7 @@ export default function AgentPanes({
   const forgetWorkspace = useAgentWorkspaceStore((state) => state.forgetWorkspace);
   const hydrateWorkspace = useAgentWorkspaceStore((state) => state.hydrateWorkspace);
   const replaceConversation = useAgentWorkspaceStore((state) => state.replaceConversation);
+  const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
 
   // Layout AND tabs are server-persisted now — debounced, not per-transition
   // (see the hook's own file header for why that distinction matters).
@@ -946,7 +947,7 @@ export default function AgentPanes({
         // longer shows it — reverting the swap or, once the eviction guard
         // treats this pane as protected, splitting a second pane open for it
         // instead of recognizing the swap as already done (caught in review).
-        useAgentSurfaceStore.getState().selectConversation({ sessionId, conversationId, agentId: agentPageId });
+        selectConversation({ sessionId, conversationId, agentId: agentPageId });
         if (priorScopeConversationId !== null) {
           void closeReplacedConversation(paneId, priorScopeConversationId, conversationId, agentPageId);
         }
@@ -1003,6 +1004,7 @@ export default function AgentPanes({
       closeReplacedConversation,
       recordMintedConversation,
       beginPaneAssign,
+      selectConversation,
     ],
   );
 

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -840,6 +840,34 @@ export default function AgentPanes({
     [sessionId, isConversationShownSomewhere, closeDecisionListing, onConversationClosed, recordClosedConversation],
   );
 
+  // Keep the Agents CONSOLE's own selection in sync whenever a pane's
+  // conversation changes to something the console didn't already know about
+  // — mirroring what `useSpawnSession` already does after spawning a
+  // session. Every call site that reassigns a pane's `targetId` to a
+  // DIFFERENT conversation (a mint, or focusing one already open elsewhere)
+  // needs this: without it, `selectedConversationId` keeps naming whatever
+  // this pane USED to show, and a later remount's seeding effect tries to
+  // re-open that stale id against a pane that no longer shows it —
+  // reverting the swap or, once the eviction guard treats this pane as
+  // protected, splitting a second pane open for it instead of recognizing
+  // the swap as already done (caught in review). Centralized here, rather
+  // than inlined at each call site, so the `chatContext` gate below lives in
+  // exactly one place.
+  //
+  // Scoped to `chatContext === 'console'`: this component is also embedded
+  // in a regular page's chat tab (`AgentPageView`, chatContext "page"),
+  // whose `initialConversation` is driven by its own local state, not this
+  // store — syncing there would both do nothing useful AND push a
+  // `/dashboard/agents` URL via `history.pushState`, silently navigating a
+  // page-embedded chat's user away to the Agents console (caught in review).
+  const syncConsoleSelection = useCallback(
+    (conversationId: string, agentPageId: string | null) => {
+      if (chatContext !== 'console') return;
+      selectConversation({ sessionId, conversationId, agentId: agentPageId });
+    },
+    [chatContext, selectConversation, sessionId],
+  );
+
   const handlePickAgent = useCallback(
     async (paneId: string, agentPageId: string | null): Promise<boolean> => {
       // Also supersedes any pending `handlePickHistoryConversation` call for
@@ -939,24 +967,7 @@ export default function AgentPanes({
         // id captured BEFORE this mint sequence began still names the
         // conversation actually being replaced.
         assignPane(sessionId, paneId, newScope);
-        // Tell the Agents CONSOLE's own selection about this swap —
-        // mirroring what `useSpawnSession` already does after spawning a
-        // session. Without this, `selectedConversationId` keeps naming the
-        // REPLACED conversation, and a later remount's seeding effect (this
-        // file, below) tries to re-open that stale id against a pane that no
-        // longer shows it — reverting the swap or, once the eviction guard
-        // treats this pane as protected, splitting a second pane open for it
-        // instead of recognizing the swap as already done (caught in review).
-        // Scoped to `chatContext === 'console'`: this component is also
-        // embedded in a regular page's chat tab (`AgentPageView`, chatContext
-        // "page"), whose `initialConversation` is driven by its own local
-        // state, not this store — writing here unconditionally would both
-        // do nothing useful there AND push a `/dashboard/agents` URL via
-        // `history.pushState`, silently navigating a page-embedded chat's
-        // user away to the Agents console (caught in review).
-        if (chatContext === 'console') {
-          selectConversation({ sessionId, conversationId, agentId: agentPageId });
-        }
+        syncConsoleSelection(conversationId, agentPageId);
         if (priorScopeConversationId !== null) {
           void closeReplacedConversation(paneId, priorScopeConversationId, conversationId, agentPageId);
         }
@@ -1013,8 +1024,7 @@ export default function AgentPanes({
       closeReplacedConversation,
       recordMintedConversation,
       beginPaneAssign,
-      selectConversation,
-      chatContext,
+      syncConsoleSelection,
     ],
   );
 
@@ -1396,6 +1406,7 @@ export default function AgentPanes({
           targetId: decision.conversationId,
           agentPageId: nextAgentPageId,
         });
+        syncConsoleSelection(decision.conversationId, nextAgentPageId);
         if (oldTargetId !== null) {
           void closeReplacedConversation(paneId, oldTargetId, decision.conversationId, nextAgentPageId);
         }
@@ -1403,7 +1414,15 @@ export default function AgentPanes({
       }
       void handlePickAgent(paneId, nextAgentPageId);
     },
-    [workspace, sessionConversations, sessionId, assignPane, closeReplacedConversation, handlePickAgent],
+    [
+      workspace,
+      sessionConversations,
+      sessionId,
+      assignPane,
+      closeReplacedConversation,
+      handlePickAgent,
+      syncConsoleSelection,
+    ],
   );
 
   const handlePickShell = useCallback(

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -9,6 +9,9 @@ import { useAuth } from "@/hooks/useAuth";
 import { useLayoutStore } from "@/stores/useLayoutStore";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { useSidebarBadges } from "@/hooks/useSidebarBadges";
+import { useShallow } from "zustand/react/shallow";
+import { useAgentSurfaceStore } from "@/stores/agents/useAgentSurfaceStore";
+import { agentsBasePath, buildAgentSelectionUrl } from "@/lib/agents/agent-selection";
 
 interface PrimaryNavigationProps {
     driveId?: string;
@@ -24,6 +27,31 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     // refuse a non-admin, and the surface mounts no session view for one), so a
     // non-admin gets no nav entry rather than a destination that refuses them.
     const isAdmin = user?.role === "admin";
+
+    // The Agents surface keeps its whole selection in the URL query string
+    // (see useAgentSurfaceStore's "the URL is the state" design) and never
+    // clears it on route unmount, so the store still has the right values in
+    // memory even after navigating away. A bare href here would silently drop
+    // them on the way back in — derive the link's href from the live
+    // selection instead, scoped to this nav's own drive so a different
+    // drive's (or global vs. drive-scoped) session is never carried over.
+    const agentSelection = useAgentSurfaceStore(
+        useShallow((state) => ({
+            driveId: state.driveId,
+            sessionId: state.selectedSessionId,
+            conversationId: state.selectedConversationId,
+            agentId: state.selectedAgentId,
+        }))
+    );
+    const agentsTargetDriveId = driveId ?? null;
+    const agentsMatchesDrive = agentSelection.driveId === agentsTargetDriveId;
+    const agentsBasePathForDrive = agentsBasePath(driveId);
+    const agentsHref = buildAgentSelectionUrl({
+        driveId: agentsTargetDriveId,
+        sessionId: agentsMatchesDrive ? agentSelection.sessionId : null,
+        conversationId: agentsMatchesDrive ? agentSelection.conversationId : null,
+        agentId: agentsMatchesDrive ? agentSelection.agentId : null,
+    });
 
     const navigation = [
         {
@@ -75,7 +103,11 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
         ...(isAdmin
             ? [{
                 name: "Agents",
-                href: driveId ? `/dashboard/${driveId}/agents` : "/dashboard/agents",
+                href: agentsHref,
+                // The href above can carry a query string (the live selection);
+                // isActive must compare against the bare path, since
+                // usePathname() never includes the query string.
+                matchPath: agentsBasePathForDrive,
                 icon: Bot,
                 exact: false,
                 badge: 0,
@@ -92,9 +124,10 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     return (
         <nav className="flex flex-col gap-0.5 mb-2">
             {navigation.map((item) => {
+                const matchPath = ("matchPath" in item ? item.matchPath : undefined) ?? item.href;
                 const isActive = item.exact
-                    ? pathname === item.href
-                    : pathname?.startsWith(item.href);
+                    ? pathname === matchPath
+                    : pathname?.startsWith(matchPath);
 
                 return (
                     <Link

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -11,7 +11,7 @@ import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { useSidebarBadges } from "@/hooks/useSidebarBadges";
 import { useShallow } from "zustand/react/shallow";
 import { useAgentSurfaceStore } from "@/stores/agents/useAgentSurfaceStore";
-import { agentsBasePath, buildAgentSelectionUrl } from "@/lib/agents/agent-selection";
+import { EMPTY_AGENT_SELECTION, buildAgentSelectionUrl } from "@/lib/agents/agent-selection";
 
 interface PrimaryNavigationProps {
     driveId?: string;
@@ -35,22 +35,19 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     // them on the way back in — derive the link's href from the live
     // selection instead, scoped to this nav's own drive so a different
     // drive's (or global vs. drive-scoped) session is never carried over.
+    const agentsSelectionDriveId = useAgentSurfaceStore((state) => state.driveId);
     const agentSelection = useAgentSurfaceStore(
         useShallow((state) => ({
-            driveId: state.driveId,
             sessionId: state.selectedSessionId,
             conversationId: state.selectedConversationId,
             agentId: state.selectedAgentId,
         }))
     );
     const agentsTargetDriveId = driveId ?? null;
-    const agentsMatchesDrive = agentSelection.driveId === agentsTargetDriveId;
-    const agentsBasePathForDrive = agentsBasePath(agentsTargetDriveId);
+    const agentsMatchesDrive = agentsSelectionDriveId === agentsTargetDriveId;
     const agentsHref = buildAgentSelectionUrl({
         driveId: agentsTargetDriveId,
-        sessionId: agentsMatchesDrive ? agentSelection.sessionId : null,
-        conversationId: agentsMatchesDrive ? agentSelection.conversationId : null,
-        agentId: agentsMatchesDrive ? agentSelection.agentId : null,
+        ...(agentsMatchesDrive ? agentSelection : EMPTY_AGENT_SELECTION),
     });
 
     const navigation = [
@@ -104,10 +101,6 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
             ? [{
                 name: "Agents",
                 href: agentsHref,
-                // The href above can carry a query string (the live selection);
-                // isActive must compare against the bare path, since
-                // usePathname() never includes the query string.
-                matchPath: agentsBasePathForDrive,
                 icon: Bot,
                 exact: false,
                 badge: 0,
@@ -124,7 +117,12 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     return (
         <nav className="flex flex-col gap-0.5 mb-2">
             {navigation.map((item) => {
-                const matchPath = ("matchPath" in item ? item.matchPath : undefined) ?? item.href;
+                // The Agents entry's href can carry a query string (the live
+                // agent-session selection); isActive must compare against the
+                // bare path, since usePathname() never includes the query
+                // string. Every other item's href never has a "?", so this
+                // is a no-op for them.
+                const matchPath = item.href.split("?")[0];
                 const isActive = item.exact
                     ? pathname === matchPath
                     : pathname?.startsWith(matchPath);

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -45,7 +45,7 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     );
     const agentsTargetDriveId = driveId ?? null;
     const agentsMatchesDrive = agentSelection.driveId === agentsTargetDriveId;
-    const agentsBasePathForDrive = agentsBasePath(driveId);
+    const agentsBasePathForDrive = agentsBasePath(agentsTargetDriveId);
     const agentsHref = buildAgentSelectionUrl({
         driveId: agentsTargetDriveId,
         sessionId: agentsMatchesDrive ? agentSelection.sessionId : null,


### PR DESCRIPTION
## Summary
- Sidebar's "Agents" link was a static href with no query string, while the Agents surface's whole selection lives in the URL query (`useAgentSurfaceStore`). Navigating away and back via that link reset the selection to nothing, even though the in-memory store still had it — fixed by deriving the link's href from the live store selection, scoped to the correct drive.
- The in-pane "+" (start a new conversation in the current session) swapped the pane's content but never told `useAgentSurfaceStore` about it, unlike `useSpawnSession`'s equivalent update when spawning a new session. On a later remount, the seeding effect tried to reopen the stale old conversation against a pane that no longer showed it, tripping the eviction guard's split fallback instead of recognizing the swap as done — producing a phantom second pane. Fixed by calling `selectConversation` right after the swap, **scoped to `chatContext === 'console'`** (review finding: `AgentPanes` is also embedded in a regular page's chat tab via `AgentPageView`, `chatContext="page"`, whose selection isn't sourced from this store — an unconditional call there would silently navigate that user to `/dashboard/agents`).
- Same fix extended to `handleSwitchAgent`'s "focus-existing" branch (switching an agent already open elsewhere into the current pane) — it has the identical shape (treats the pane's outgoing conversation as replaced, just like the mint path) and was equally vulnerable to the same staleness bug, just reachable via a different everyday action. Consolidated both call sites behind one `syncConsoleSelection` helper instead of duplicating the `chatContext` guard.

## Test plan
- [x] `bun run typecheck`, `eslint`, and `knip:check` pass on all changed files
- [x] Stood up a local instance (isolated Postgres container, seeded admin session, production build) and drove it with Playwright:
  - [x] Spawn a new session, navigate away (Dashboard) and back via the sidebar "Agents" link — selection now persists (previously reset)
  - [x] Use the in-pane "+" to start a new conversation, navigate away and back — exactly one pane shows, with the new conversation (previously showed a phantom second pane with the old conversation)
  - [x] Confirmed the "Agents" nav row still highlights correctly when browsing other sections (regression check on the active-link logic)
- [x] Verified `AgentPanes`'s only other rendering context (`AgentPageView`, page-embedded chat) is unaffected by the console-selection sync (gated on `chatContext`)
- [x] Ran a proactive self-review pass (reuse / simplification / efficiency / altitude) on the diff; applied the simplifications and the `handleSwitchAgent` coverage extension above. Deliberately did not extend to `handleClosePane`'s rebind-pane branch — that branch only ever repoints a pane that held no conversation of its own, so there's nothing stale to sync there, and forcing it would risk hijacking the console's selection based on an unrelated pane close elsewhere in the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxRVM6D5xXQz6urBaeSdjs