### PR TITLE
fix(agents): commit the sender's finished reply locally via useChat onFinish

### DIFF
--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -62,6 +62,7 @@ vi.mock('@ai-sdk/react', () => ({
 const loaders = vi.hoisted(() => ({
   loadAgentConversationMessages: vi.fn(async () => {}),
   loadOlderAgentConversationMessages: vi.fn(async () => {}),
+  refreshConversationSnapshot: vi.fn(async () => {}),
 }));
 vi.mock('@/hooks/conversationMessagesLoaders', () => loaders);
 
@@ -95,6 +96,7 @@ const activeStream = vi.hoisted(() => ({
 vi.mock('@/hooks/useActiveStream', () => ({
   useActiveStream: () => ({ streams: activeStream.remoteStreams }),
   useConversationActiveStream: () => undefined,
+  getActiveStreamById: () => undefined,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -364,5 +366,42 @@ describe('useAgentSessionChat', () => {
       expect(entry?.pageId).toBe(agent.id);
       expect(entry?.conversationId).toBe(conversationId);
     });
+  });
+
+  // Sibling of the mirror regression above, for the COMPLETION edge: the sender's own tab
+  // never joins its SSE multicast, so at chat:stream_complete its stream entry is already
+  // removed and the socket handler can only fall back to a full reload — a visible flash,
+  // and a vanished reply if that reload fails. The chatConfig's onFinish must commit the
+  // finished reply locally so neither the broadcast nor the reload is load-bearing.
+  it('given the own stream finishes, commits the reply into the cache via the chatConfig onFinish', async () => {
+    const { agent, conversationId } = ids('own-finish-commit');
+    conversationMessagesActions.addOptimisticSend(conversationId, {
+      id: 'm-user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'the question' }],
+    } as UIMessage);
+
+    const { result } = renderHook(() => useAgentSessionChat({ agent, conversationId }));
+
+    const config = chat.capturedConfigs.at(-1)!;
+    expect(typeof config.onFinish).toBe('function');
+    const onFinish = config.onFinish as (options: {
+      message: UIMessage;
+      messages: UIMessage[];
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+    }) => void;
+
+    const reply = assistantMessage('m-assistant-1', 'the full reply');
+    act(() => {
+      onFinish({ message: reply, messages: [reply], isAbort: false, isDisconnect: false, isError: false });
+    });
+
+    expect(usePendingStreamsStore.getState().streams.size).toBe(0);
+    await waitFor(() => {
+      expect(result.current.messages.map((m) => m.id)).toEqual(['m-user-1', 'm-assistant-1']);
+    });
+    expect(loaders.refreshConversationSnapshot).toHaveBeenCalledWith(agent.id, conversationId);
   });
 });

--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -16,7 +16,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import type { UIMessage } from 'ai';
+import type { ChatOnFinishCallback, UIMessage } from 'ai';
 import type { AgentInfo } from '@/types/agent';
 
 const { mockFetchWithAuth } = vi.hoisted(() => ({
@@ -385,13 +385,7 @@ describe('useAgentSessionChat', () => {
 
     const config = chat.capturedConfigs.at(-1)!;
     expect(typeof config.onFinish).toBe('function');
-    const onFinish = config.onFinish as (options: {
-      message: UIMessage;
-      messages: UIMessage[];
-      isAbort: boolean;
-      isDisconnect: boolean;
-      isError: boolean;
-    }) => void;
+    const onFinish = config.onFinish as ChatOnFinishCallback<UIMessage>;
 
     const reply = assistantMessage('m-assistant-1', 'the full reply');
     act(() => {

--- a/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAgentSessionChat.test.ts
@@ -170,7 +170,7 @@ describe('useAgentSessionChat', () => {
 
     renderHook(() => useAgentSessionChat({ agent, conversationId }));
 
-    expect(chat.capturedConfigs.some((c) => c.id === `agent-session-chat:${conversationId}`)).toBe(
+    expect(chat.capturedConfigs.some((c) => c.id === `agent-session-chat:${agent.id}:${conversationId}`)).toBe(
       true,
     );
   });

--- a/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import type { UIMessage } from 'ai';
+import type { ChatOnFinishCallback, UIMessage } from 'ai';
 
 const { mockFetchWithAuth } = vi.hoisted(() => ({
   mockFetchWithAuth: vi.fn(),
@@ -294,13 +294,7 @@ describe('useAssistantSessionChat — onFinish local commit', () => {
 
     const config = chat.capturedConfigs.at(-1)!;
     expect(typeof config.onFinish).toBe('function');
-    const onFinish = config.onFinish as (options: {
-      message: UIMessage;
-      messages: UIMessage[];
-      isAbort: boolean;
-      isDisconnect: boolean;
-      isError: boolean;
-    }) => void;
+    const onFinish = config.onFinish as ChatOnFinishCallback<UIMessage>;
 
     const reply = {
       id: 'm-assistant-1',
@@ -325,13 +319,7 @@ describe('useAssistantSessionChat — onFinish local commit', () => {
 
     const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
 
-    const onFinish = chat.capturedConfigs.at(-1)!.onFinish as (options: {
-      message: UIMessage;
-      messages: UIMessage[];
-      isAbort: boolean;
-      isDisconnect: boolean;
-      isError: boolean;
-    }) => void;
+    const onFinish = chat.capturedConfigs.at(-1)!.onFinish as ChatOnFinishCallback<UIMessage>;
     const partial = {
       id: 'm-assistant-1',
       role: 'assistant',

--- a/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
+++ b/apps/web/src/components/agents/chat/__tests__/useAssistantSessionChat.test.ts
@@ -60,6 +60,7 @@ vi.mock('@ai-sdk/react', () => ({
 const loaders = vi.hoisted(() => ({
   loadGlobalConversationMessages: vi.fn(async () => {}),
   loadOlderGlobalConversationMessages: vi.fn(async () => {}),
+  refreshConversationSnapshot: vi.fn(async () => {}),
 }));
 vi.mock('@/hooks/conversationMessagesLoaders', () => loaders);
 
@@ -77,6 +78,7 @@ const activeStream = vi.hoisted(() => ({
 vi.mock('@/hooks/useActiveStream', () => ({
   useActiveStream: () => ({ streams: activeStream.remoteStreams }),
   useConversationActiveStream: () => undefined,
+  getActiveStreamById: () => undefined,
 }));
 
 const route = vi.hoisted(() => ({ pathname: '/dashboard/agents' }));
@@ -270,6 +272,80 @@ describe('useAssistantSessionChat — ask_user answering', () => {
     const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
 
     expect(result.current.askUserAnswering.answerableToolCallIds.has('tc-1')).toBe(false);
+  });
+});
+
+describe('useAssistantSessionChat — onFinish local commit', () => {
+  // THE pane regression: the streamed reply vanished the instant the stream completed,
+  // leaving only the sent user message (reopening from history showed it fine). The pane
+  // has no conversation-scoped channel subscriber — GlobalChatProvider's onStreamComplete
+  // is gated on the DASHBOARD's active conversation — so nothing ever committed the reply
+  // into the cache, and the mirror entry's falling-edge removal blanked the bubble.
+  // The chatConfig's onFinish must commit the finished reply locally.
+  it('given the own stream finishes, commits the reply into the cache so it survives the mirror release', async () => {
+    const { conversationId } = ids('own-finish-commit');
+    conversationMessagesActions.addOptimisticSend(conversationId, {
+      id: 'm-user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'the question' }],
+    } as UIMessage);
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
+
+    const config = chat.capturedConfigs.at(-1)!;
+    expect(typeof config.onFinish).toBe('function');
+    const onFinish = config.onFinish as (options: {
+      message: UIMessage;
+      messages: UIMessage[];
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+    }) => void;
+
+    const reply = {
+      id: 'm-assistant-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'the full reply' }],
+    } as UIMessage;
+    act(() => {
+      onFinish({ message: reply, messages: [reply], isAbort: false, isDisconnect: false, isError: false });
+    });
+
+    // Mirror entry gone (falling edge already ran / never existed) — the reply must STILL render.
+    expect(usePendingStreamsStore.getState().streams.size).toBe(0);
+    await waitFor(() => {
+      expect(result.current.messages.map((m) => m.id)).toEqual(['m-user-1', 'm-assistant-1']);
+    });
+    expect(loaders.refreshConversationSnapshot).toHaveBeenCalledWith(null, conversationId);
+  });
+
+  it('given the user Stops mid-stream, commits the partial reply with the interrupted badge', async () => {
+    const { conversationId } = ids('own-finish-abort');
+    conversationMessagesActions.seedConversation(conversationId);
+
+    const { result } = renderHook(() => useAssistantSessionChat({ conversationId, driveId: null }));
+
+    const onFinish = chat.capturedConfigs.at(-1)!.onFinish as (options: {
+      message: UIMessage;
+      messages: UIMessage[];
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+    }) => void;
+    const partial = {
+      id: 'm-assistant-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'partial…' }],
+    } as UIMessage;
+    act(() => {
+      onFinish({ message: partial, messages: [partial], isAbort: true, isDisconnect: false, isError: false });
+    });
+
+    await waitFor(() => {
+      const committed = result.current.messages.find((m) => m.id === 'm-assistant-1');
+      expect(committed).toBeDefined();
+      expect((committed as UIMessage & { status?: string }).status).toBe('interrupted');
+    });
   });
 });
 

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -44,6 +44,7 @@ import { buildSessionChatRequestBody } from '@/lib/agents/build-session-chat-req
 import { buildUserMessage } from '@/lib/ai/streams/buildUserMessage';
 import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimisticSendOnFailure';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { buildOwnStreamCommitOnFinish } from '@/hooks/ownStreamCommit';
 import {
   loadAgentConversationMessages,
   loadOlderAgentConversationMessages,
@@ -114,8 +115,13 @@ export function useAgentSessionChat({
         console.error('Agent session chat error:', error);
         toast.error('Chat error. Please try again.');
       },
+      // The sender's own stream entry is already removed when this channel's
+      // onStreamComplete runs (own tab never joins its SSE), leaving only the
+      // full-reload fallback — commit locally instead so the finished reply
+      // never flashes out and survives a failed reload.
+      onFinish: buildOwnStreamCommitOnFinish({ conversationId, agentId: agent.id }),
     });
-  }, [transport, conversationId]);
+  }, [transport, conversationId, agent.id]);
 
   const {
     messages: agentChatMessages,

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -109,7 +109,10 @@ export function useAgentSessionChat({
   const chatConfig = useMemo(() => {
     if (!transport) return null;
     return buildChatConfig({
-      id: `agent-session-chat:${conversationId}`,
+      // BOTH ids the onFinish commit closes over are embedded, so a change to
+      // either forces Chat recreation — the callback can never go stale
+      // (useChat reads callbacks at construction; see chat-config.ts).
+      id: `agent-session-chat:${agent.id}:${conversationId}`,
       transport,
       onError: (error: Error) => {
         console.error('Agent session chat error:', error);

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -46,6 +46,7 @@ import { buildContextRef, type ContextRef } from '@/lib/ai/shared/buildContextRe
 import { buildUserMessage } from '@/lib/ai/streams/buildUserMessage';
 import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimisticSendOnFailure';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { buildOwnStreamCommitOnFinish } from '@/hooks/ownStreamCommit';
 import {
   loadGlobalConversationMessages,
   loadOlderGlobalConversationMessages,
@@ -108,6 +109,11 @@ export function useAssistantSessionChat({
         console.error('Assistant session chat error:', error);
         toast.error('Chat error. Please try again.');
       },
+      // Panes must not depend on the stream_complete broadcast to keep a
+      // finished reply: GlobalChatProvider's subscriber is gated on ITS active
+      // conversation, never this pane's, so without a local commit the reply
+      // vanishes when the mirror releases — see buildOwnStreamCommitOnFinish.
+      onFinish: buildOwnStreamCommitOnFinish({ conversationId, agentId: null }),
     });
   }, [transport, conversationId]);
 

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -245,7 +245,6 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     // are bookkeeping only — the surfaces re-seed the transport at the actions that
     // need it (retry, ask_user answers).
     ...buildConversationCacheHandlers({
-      getActiveConversationId: () => currentConversationIdRef.current,
       reloadConversation: loadGlobalConversationMessages,
       refreshSnapshot: (conversationId) => refreshConversationSnapshot(null, conversationId),
     }),

--- a/apps/web/src/hooks/__tests__/ownStreamCommit.test.ts
+++ b/apps/web/src/hooks/__tests__/ownStreamCommit.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UIMessage } from 'ai';
+import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { refreshConversationSnapshot } from '@/hooks/conversationMessagesLoaders';
+import { buildOwnStreamCommitOnFinish } from '../ownStreamCommit';
+
+// Real zustand stores (repo convention — see useOwnStreamMirror.test.tsx: a hand-rolled
+// stand-in can hold states the real store cannot). Only the network-touching loader is mocked.
+vi.mock('@/hooks/conversationMessagesLoaders', () => ({
+  refreshConversationSnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+
+const CONV = 'conv-1';
+const text = (t: string) => ({ type: 'text' as const, text: t });
+
+const finished = (overrides: Partial<{ id: string; role: string; parts: UIMessage['parts'] }> = {}) =>
+  ({
+    id: 'reply-1',
+    role: 'assistant',
+    parts: [text('the full reply')],
+    ...overrides,
+  }) as UIMessage;
+
+const invoke = (
+  onFinish: ReturnType<typeof buildOwnStreamCommitOnFinish>,
+  message: UIMessage,
+  flags: Partial<{ isAbort: boolean; isDisconnect: boolean; isError: boolean }> = {},
+) =>
+  onFinish({
+    message,
+    messages: [message],
+    isAbort: false,
+    isDisconnect: false,
+    isError: false,
+    ...flags,
+  });
+
+const cachedMessages = () => conversationMessagesActions.getEntry(CONV).messages;
+
+describe('buildOwnStreamCommitOnFinish', () => {
+  beforeEach(() => {
+    useConversationMessagesStore.setState({ byConversationId: {} });
+    usePendingStreamsStore.setState({ streams: new Map() });
+    vi.mocked(refreshConversationSnapshot).mockClear();
+  });
+
+  it('given a clean finish, should promote the optimistic send FIRST, then commit the reply after it', () => {
+    const userMessage = { id: 'user-1', role: 'user', parts: [text('the question')] } as UIMessage;
+    conversationMessagesActions.addOptimisticSend(CONV, userMessage);
+
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: 'agent-1' });
+    invoke(onFinish, finished());
+
+    expect(cachedMessages().map((m) => m.id)).toEqual(['user-1', 'reply-1']);
+    expect(conversationMessagesActions.getEntry(CONV).optimisticSends).toEqual([]);
+    const reply = cachedMessages()[1] as UIMessage & { status?: string };
+    expect(reply.parts).toEqual([text('the full reply')]);
+    expect(reply.status).toBe('complete');
+  });
+
+  it('given a half-streamed includeStreaming placeholder under the same id, should overwrite it in place', () => {
+    const generation = conversationMessagesActions.startLoad(CONV);
+    conversationMessagesActions.applyLoad(CONV, generation, [
+      { id: 'reply-1', role: 'assistant', parts: [text('half-str')], status: 'streaming' } as UIMessage,
+    ]);
+
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: null });
+    invoke(onFinish, finished());
+
+    expect(cachedMessages()).toHaveLength(1);
+    const reply = cachedMessages()[0] as UIMessage & { status?: string };
+    expect(reply.parts).toEqual([text('the full reply')]);
+    expect(reply.status).toBe('complete');
+  });
+
+  it('given the mirror entry still exists at finish time, should thread its startedAt into createdAt', () => {
+    usePendingStreamsStore.getState().addStream({
+      messageId: 'reply-1',
+      pageId: 'page-1',
+      conversationId: CONV,
+      triggeredBy: { userId: 'u1', displayName: 'Me' },
+      isOwn: true,
+      startedAt: '2026-08-03T12:00:00.000Z',
+    });
+
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: null });
+    invoke(onFinish, finished());
+
+    expect((cachedMessages()[0] as UIMessage & { createdAt?: Date }).createdAt).toEqual(
+      new Date('2026-08-03T12:00:00.000Z'),
+    );
+  });
+
+  it('given a local Stop with partial parts, should commit the partial with status interrupted', () => {
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: 'agent-1' });
+    invoke(onFinish, finished({ parts: [text('partial')] }), { isAbort: true });
+
+    const reply = cachedMessages()[0] as UIMessage & { status?: string };
+    expect(reply.parts).toEqual([text('partial')]);
+    expect(reply.status).toBe('interrupted');
+  });
+
+  it('given a clean finish, should trigger the background snapshot heal with the surface agentId', () => {
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: 'agent-1' });
+    invoke(onFinish, finished());
+    expect(refreshConversationSnapshot).toHaveBeenCalledWith('agent-1', CONV);
+  });
+
+  it('given the global assistant surface, should heal via the global endpoint (agentId null)', () => {
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: null });
+    invoke(onFinish, finished());
+    expect(refreshConversationSnapshot).toHaveBeenCalledWith(null, CONV);
+  });
+
+  it('given an error finish, should commit nothing, promote nothing, and skip the heal', () => {
+    conversationMessagesActions.addOptimisticSend(CONV, {
+      id: 'user-1',
+      role: 'user',
+      parts: [text('q')],
+    } as UIMessage);
+
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: 'agent-1' });
+    invoke(onFinish, finished(), { isError: true });
+
+    expect(cachedMessages()).toEqual([]);
+    expect(conversationMessagesActions.getEntry(CONV).optimisticSends).toHaveLength(1);
+    expect(refreshConversationSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('given a network disconnect, should commit nothing', () => {
+    const onFinish = buildOwnStreamCommitOnFinish({ conversationId: CONV, agentId: 'agent-1' });
+    invoke(onFinish, finished(), { isDisconnect: true });
+    expect(cachedMessages()).toEqual([]);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -138,6 +138,13 @@ describe('useAgentChannelMultiplayer', () => {
       ...overrides,
     });
 
+    // Dispatch is entry-gated (hasEntry): a rendering surface always loads or
+    // seeds its conversation on mount, so the tests seed what a mounted pane
+    // would have.
+    beforeEach(() => {
+      useConversationMessagesStore.getState().seedConversation('conv-active');
+    });
+
     it('given OUR OWN stream finalizes for the active conversation, the synthesized assistant message should be committed to the conversation cache', () => {
       pendingStreams.current = new Map([[ 'msg-done', streamFixture({}) ]]);
 
@@ -206,10 +213,10 @@ describe('useAgentChannelMultiplayer', () => {
       ]);
     });
 
-    it('given a stream finalizes for a DIFFERENT conversation, nothing should be committed to the active conversation', () => {
+    it('given a stream finalizes for an UNCACHED conversation, nothing should be committed anywhere (no surface renders it; its eventual loader fetches the DB truth)', () => {
       pendingStreams.current = new Map([[ 'msg-stale', streamFixture({
         messageId: 'msg-stale',
-        conversationId: 'conv-different',
+        conversationId: 'conv-uncached',
       }) ]]);
 
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
@@ -219,7 +226,31 @@ describe('useAgentChannelMultiplayer', () => {
       });
 
       expect(cacheMessages('conv-active')).toEqual([]);
-      expect(cacheMessages('conv-different')).toEqual([]);
+      expect(cacheMessages('conv-uncached')).toEqual([]);
+    });
+
+    // THE pane multiplayer fix: dispatch is by the EVENT's conversation, so a
+    // completion for a CACHED sibling conversation (another pane on this same
+    // channel) commits into that sibling — the old single-active-conversation
+    // gate silently dropped it, vanishing the reply in the sibling pane.
+    it("given a stream finalizes for a CACHED sibling conversation (another pane), it should commit into the SIBLING's cache entry", () => {
+      useConversationMessagesStore.getState().seedConversation('conv-sibling-pane');
+      pendingStreams.current = new Map([[ 'msg-sibling', streamFixture({
+        messageId: 'msg-sibling',
+        conversationId: 'conv-sibling-pane',
+        isOwn: false,
+      }) ]]);
+
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-sibling');
+      });
+
+      expect(cacheMessages('conv-active')).toEqual([]);
+      expect(cacheMessages('conv-sibling-pane')).toEqual([
+        { id: 'msg-sibling', role: 'assistant', parts: [{ type: 'text', text: 'final response text' }], status: 'complete' },
+      ]);
     });
 
     it('given a completion with NO usable store entry for the active conversation (joinFailed / zero parts), should reload via the RAW cache loader — never the surface loadConversation, which also sets identity and pushes the URL', () => {
@@ -324,6 +355,11 @@ describe('useAgentChannelMultiplayer', () => {
       triggeredBy: { userId: 'other', displayName: 'Other', browserSessionId: 'sess-x' },
     });
 
+    // Same entry-gated dispatch as completions: seed what a mounted pane would have.
+    beforeEach(() => {
+      useConversationMessagesStore.getState().seedConversation('conv-active');
+    });
+
     it('given onUserMessage fires for the active agent conversation, should append the message to its cache entry', () => {
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
 
@@ -334,14 +370,31 @@ describe('useAgentChannelMultiplayer', () => {
       expect(cacheMessages('conv-active')).toEqual([remoteUser]);
     });
 
-    it('given onUserMessage fires for a different conversationId, should not write the active cache entry', () => {
+    it('given onUserMessage fires for an UNCACHED conversationId, should write nothing anywhere', () => {
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
 
       act(() => {
-        capturedChannel.options?.onUserMessage?.(remoteUser, payloadFor('conv-different'));
+        capturedChannel.options?.onUserMessage?.(remoteUser, payloadFor('conv-uncached'));
       });
 
       expect(cacheMessages('conv-active')).toEqual([]);
+      expect(cacheMessages('conv-uncached')).toEqual([]);
+    });
+
+    // The pane multiplayer gap this PR closes for non-completion events too: a
+    // collaborator's message in a CACHED sibling conversation (another pane on
+    // this channel) must land in that sibling's entry, not be dropped for not
+    // being "the" active conversation.
+    it("given onUserMessage fires for a CACHED sibling conversation, should append to the SIBLING's cache entry", () => {
+      useConversationMessagesStore.getState().seedConversation('conv-sibling-pane');
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onUserMessage?.(remoteUser, payloadFor('conv-sibling-pane'));
+      });
+
+      expect(cacheMessages('conv-active')).toEqual([]);
+      expect(cacheMessages('conv-sibling-pane')).toEqual([remoteUser]);
     });
 
     it('given onUserMessage fires twice for the same id (co-mounted surfaces both deliver), the append should be idempotent', () => {

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -237,6 +237,26 @@ describe('useAgentChannelMultiplayer', () => {
       expect(cacheMessages('conv-active')).toEqual([]);
     });
 
+    it('given the cache ALREADY holds the final row under the completed id (the sender\'s own onFinish commit landed first), should NOT reload — no loading flip for content the cache has', () => {
+      useConversationMessagesStore.getState().applyConfirmedMessage('conv-active', {
+        id: 'msg-empty',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'the full reply' }],
+        status: 'complete',
+      } as UIMessage);
+      // The sender's own entry is already removed at handler time (own tab never joins its SSE).
+      pendingStreams.current = new Map();
+
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-empty', 'conv-active');
+      });
+
+      expect(mockLoadAgentConversationMessages).not.toHaveBeenCalled();
+      expect(cacheMessages('conv-active').map((m) => m.id)).toEqual(['msg-empty']);
+    });
+
     it('given an OWN completion, should promote pending optimistic sends BEFORE the commit so the question renders above the reply (F1)', () => {
       useConversationMessagesStore.getState().addOptimisticSend('conv-active', {
         id: 'u-sent', role: 'user', parts: [{ type: 'text', text: 'my question' }],

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -257,6 +257,47 @@ describe('useAgentChannelMultiplayer', () => {
       expect(cacheMessages('conv-active').map((m) => m.id)).toEqual(['msg-empty']);
     });
 
+    // Codex P2 (PR #2320): a local Stop commits the partial as 'interrupted', but if the
+    // server-side abort failed or landed too late the generation ran on and persisted a
+    // COMPLETE reply. The clean completion contradicts the local row — it must reload the
+    // authoritative reply, not be suppressed by it.
+    it('given a locally-Stopped interrupted row but a NON-aborted completion event, should reload (the server outran the abort)', () => {
+      useConversationMessagesStore.getState().applyConfirmedMessage('conv-active', {
+        id: 'msg-empty',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial before Stop' }],
+        status: 'interrupted',
+      } as UIMessage);
+      pendingStreams.current = new Map();
+
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-empty', 'conv-active');
+      });
+
+      expect(mockLoadAgentConversationMessages).toHaveBeenCalledWith(AGENT.id, 'conv-active');
+    });
+
+    it('given a locally-Stopped interrupted row and an ABORTED completion event, should NOT reload (statuses agree)', () => {
+      useConversationMessagesStore.getState().applyConfirmedMessage('conv-active', {
+        id: 'msg-empty',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial before Stop' }],
+        status: 'interrupted',
+      } as UIMessage);
+      pendingStreams.current = new Map();
+
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-empty', 'conv-active', { joinFailed: true }, true);
+      });
+
+      expect(mockLoadAgentConversationMessages).not.toHaveBeenCalled();
+      expect(cacheMessages('conv-active').map((m) => m.id)).toEqual(['msg-empty']);
+    });
+
     it('given an OWN completion, should promote pending optimistic sends BEFORE the commit so the question renders above the reply (F1)', () => {
       useConversationMessagesStore.getState().addOptimisticSend('conv-active', {
         id: 'u-sent', role: 'user', parts: [{ type: 'text', text: 'my question' }],

--- a/apps/web/src/hooks/commitConfirmedReply.ts
+++ b/apps/web/src/hooks/commitConfirmedReply.ts
@@ -1,0 +1,36 @@
+import type { UIMessage } from 'ai';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+
+/**
+ * The ONE finished-reply commit protocol, shared by the socket
+ * `onStreamComplete` commit branch (conversationCacheSocketHandlers) and the
+ * sender's local `onFinish` commit (buildOwnStreamCommitOnFinish) — so the
+ * ordering contract lives in code, not in "mirrors exactly" comments:
+ *
+ * - F1: promote optimistic sends FIRST, and only for THIS TAB'S OWN reply —
+ *   an own reply proves the user rows that triggered it are persisted (the
+ *   route persists the user message before generating), and promoting before
+ *   the commit means the question can never render below the answer. A remote
+ *   reply proves nothing about this tab's sends.
+ * - COMMIT by id — upsert, never skip: an existing row under this id may be a
+ *   half-streamed includeStreaming placeholder that must be overwritten.
+ * - F6: background snapshot heal — the socket broadcast can outrace the SSE
+ *   multicast's final frames, so committed parts may be truncated; the heal
+ *   reconciles the authoritative DB row (best-effort, generation-safe, no
+ *   loading-state flip).
+ */
+export const commitConfirmedReply = (
+  conversationId: string,
+  message: UIMessage,
+  opts: {
+    /** True only when the reply is this tab's own send (F1 above). */
+    promoteOwnSends: boolean;
+    refreshSnapshot: (conversationId: string) => void | Promise<void>;
+  },
+): void => {
+  if (opts.promoteOwnSends) {
+    conversationMessagesActions.promoteOptimisticSends(conversationId);
+  }
+  conversationMessagesActions.applyConfirmedMessage(conversationId, message);
+  void opts.refreshSnapshot(conversationId);
+};

--- a/apps/web/src/hooks/conversationCacheSocketHandlers.ts
+++ b/apps/web/src/hooks/conversationCacheSocketHandlers.ts
@@ -98,7 +98,18 @@ export const buildConversationCacheHandlers = ({
     }
     // No usable store entry (SSE join failed / zero parts): the message IS durably
     // persisted — reload the conversation's cache entry rather than losing it.
-    if (shouldReloadOnComountComplete(stream, completedConvId, conversationId)) {
+    // Unless the sender's own onFinish already committed the final row
+    // (buildOwnStreamCommitOnFinish) — then a reload only adds a loading flip.
+    const cacheHasFinalMessage = completedConvId
+      ? conversationMessagesActions
+          .getEntry(completedConvId)
+          .messages.some(
+            (m) =>
+              m.id === messageId &&
+              (m as UIMessage & { status?: string }).status !== 'streaming',
+          )
+      : false;
+    if (shouldReloadOnComountComplete(stream, completedConvId, conversationId, cacheHasFinalMessage)) {
       void reloadConversation(completedConvId!);
     }
   },

--- a/apps/web/src/hooks/conversationCacheSocketHandlers.ts
+++ b/apps/web/src/hooks/conversationCacheSocketHandlers.ts
@@ -3,6 +3,7 @@ import { getActiveStreamById } from '@/hooks/useActiveStream';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
+import { cacheHasConsistentFinalMessage } from '@/lib/ai/streams/cacheHasConsistentFinalMessage';
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 
 export interface ConversationCacheHandlerDeps {
@@ -98,16 +99,17 @@ export const buildConversationCacheHandlers = ({
     }
     // No usable store entry (SSE join failed / zero parts): the message IS durably
     // persisted — reload the conversation's cache entry rather than losing it.
-    // Unless the sender's own onFinish already committed the final row
-    // (buildOwnStreamCommitOnFinish) — then a reload only adds a loading flip.
+    // Unless the sender's own onFinish already committed a final row whose status
+    // is CONSISTENT with this event (buildOwnStreamCommitOnFinish) — then a reload
+    // only adds a loading flip. A locally-Stopped 'interrupted' row does NOT
+    // suppress a non-aborted completion: the server may have outrun the abort and
+    // persisted the full reply — see cacheHasConsistentFinalMessage.
     const cacheHasFinalMessage = completedConvId
-      ? conversationMessagesActions
-          .getEntry(completedConvId)
-          .messages.some(
-            (m) =>
-              m.id === messageId &&
-              (m as UIMessage & { status?: string }).status !== 'streaming',
-          )
+      ? cacheHasConsistentFinalMessage(
+          conversationMessagesActions.getEntry(completedConvId).messages,
+          messageId,
+          aborted === true,
+        )
       : false;
     if (shouldReloadOnComountComplete(stream, completedConvId, conversationId, cacheHasFinalMessage)) {
       void reloadConversation(completedConvId!);

--- a/apps/web/src/hooks/conversationCacheSocketHandlers.ts
+++ b/apps/web/src/hooks/conversationCacheSocketHandlers.ts
@@ -6,8 +6,6 @@ import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnCo
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 
 export interface ConversationCacheHandlerDeps {
-  /** The conversation currently on screen — read at event time (a ref-backed getter, never a stale closure). */
-  getActiveConversationId: () => string | null;
   /**
    * Generation-guarded cache reload for a conversation whose completion left no
    * usable store entry (SSE join failed / zero parts) — the reply IS durably
@@ -28,6 +26,18 @@ export interface ConversationCacheHandlerDeps {
  * handlers: it additionally dual-writes into its useChat transport, which
  * neither of these subscribers can reach.
  *
+ * DISPATCH IS BY THE EVENT'S CONVERSATION, not a subscriber-supplied "active"
+ * one. A single active-conversation gate assumed each subscriber watches one
+ * conversation — panes broke that: several conversations on one channel are
+ * on screen at once, none of them the subscriber's "active" one, and every
+ * event for them was silently dropped (replies vanishing on completion,
+ * collaborator messages/edits/deletes never appearing). An event now applies
+ * to whichever conversation it names, gated only on that conversation having
+ * a real cache entry (`hasEntry`): every rendering surface loads or seeds its
+ * conversation on mount, so cached ⇔ some surface can render it — and a
+ * conversation nobody has cached needs no cache write (the DB row is the
+ * truth its eventual loader will fetch).
+ *
  * The user/edit/delete handlers fire only for a REMOTE tab's action
  * (useChannelStreamSocket drops own-tab events via isOwnStream before
  * invoking) — the local user's own edit/delete/send is written by the
@@ -36,37 +46,32 @@ export interface ConversationCacheHandlerDeps {
  * same event twice is harmless by construction.
  */
 export const buildConversationCacheHandlers = ({
-  getActiveConversationId,
   reloadConversation,
   refreshSnapshot,
 }: ConversationCacheHandlerDeps) => ({
   onUserMessage: (message: UIMessage, payload: { conversationId: string }) => {
-    const conversationId = getActiveConversationId();
-    if (payload.conversationId !== conversationId || !conversationId) return;
-    conversationMessagesActions.applyRemoteUserMessage(conversationId, message);
+    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
+    conversationMessagesActions.applyRemoteUserMessage(payload.conversationId, message);
   },
 
   onMessageEdited: (payload: { messageId: string; conversationId: string; parts: UIMessage['parts']; editedAt: string }) => {
-    const conversationId = getActiveConversationId();
-    if (payload.conversationId !== conversationId || !conversationId) return;
+    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
     const editPayload: MessageEditPayload = {
       messageId: payload.messageId,
       parts: payload.parts,
       editedAt: new Date(payload.editedAt),
     };
-    conversationMessagesActions.applyEdit(conversationId, editPayload);
+    conversationMessagesActions.applyEdit(payload.conversationId, editPayload);
   },
 
   onMessageDeleted: (payload: { messageId: string; conversationId: string }) => {
-    const conversationId = getActiveConversationId();
-    if (payload.conversationId !== conversationId || !conversationId) return;
-    conversationMessagesActions.applyDelete(conversationId, payload.messageId);
+    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
+    conversationMessagesActions.applyDelete(payload.conversationId, payload.messageId);
   },
 
   onStreamComplete: (messageId: string, completedConvId?: string, _info?: { joinFailed: boolean }, aborted?: boolean) => {
-    const conversationId = getActiveConversationId();
     const stream = getActiveStreamById(messageId);
-    if (stream && stream.parts.length > 0 && stream.conversationId === conversationId) {
+    if (stream && stream.parts.length > 0 && conversationMessagesActions.hasEntry(stream.conversationId)) {
       // COMMIT by id — upsert, never skip. An existing row under this id may be a
       // half-streamed includeStreaming placeholder that must be overwritten, and for
       // OWN streams the mirror removes the pending entry the instant status changes —
@@ -100,6 +105,9 @@ export const buildConversationCacheHandlers = ({
     // persisted — reload the conversation's cache entry rather than losing it.
     // Unless the sender's own onFinish already committed the final row
     // (buildOwnStreamCommitOnFinish) — then a reload only adds a loading flip.
+    const conversationCached = completedConvId
+      ? conversationMessagesActions.hasEntry(completedConvId)
+      : false;
     const cacheHasFinalMessage = completedConvId
       ? conversationMessagesActions
           .getEntry(completedConvId)
@@ -109,7 +117,7 @@ export const buildConversationCacheHandlers = ({
               (m as UIMessage & { status?: string }).status !== 'streaming',
           )
       : false;
-    if (shouldReloadOnComountComplete(stream, completedConvId, conversationId, cacheHasFinalMessage)) {
+    if (shouldReloadOnComountComplete(stream, completedConvId, conversationCached, cacheHasFinalMessage)) {
       void reloadConversation(completedConvId!);
     }
   },

--- a/apps/web/src/hooks/conversationCacheSocketHandlers.ts
+++ b/apps/web/src/hooks/conversationCacheSocketHandlers.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from 'ai';
 import { getActiveStreamById } from '@/hooks/useActiveStream';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { commitConfirmedReply } from '@/hooks/commitConfirmedReply';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
 import { cacheHasConsistentFinalMessage } from '@/lib/ai/streams/cacheHasConsistentFinalMessage';
@@ -68,33 +69,17 @@ export const buildConversationCacheHandlers = ({
     const conversationId = getActiveConversationId();
     const stream = getActiveStreamById(messageId);
     if (stream && stream.parts.length > 0 && stream.conversationId === conversationId) {
-      // COMMIT by id — upsert, never skip. An existing row under this id may be a
-      // half-streamed includeStreaming placeholder that must be overwritten, and for
-      // OWN streams the mirror removes the pending entry the instant status changes —
-      // without this commit the reply flashes to missing.
-      //
-      // F1: an OWN reply's commit proves the user rows that triggered it are
-      // persisted (the route persists the user message before generating) — promote
-      // them into confirmed messages FIRST, so the reply appends after them and the
-      // question can never render below the answer. A remote reply proves nothing
-      // about this tab's sends, so no promotion there (ordering is already right:
-      // an unconfirmed own send IS the newest content).
-      if (stream.isOwn) {
-        conversationMessagesActions.promoteOptimisticSends(stream.conversationId);
-      }
-      // epic leaf 6.8 (D ixpwr76xepu2x9v4pxgksyhz): badge a crash-reaped or Stopped
-      // stream as 'interrupted' the instant this tab hears about it, instead of only
-      // after the next reload — the persisted row already carries this status
-      // (message-utils.ts), this just stops a live-open tab from rendering stale.
-      conversationMessagesActions.applyConfirmedMessage(
+      // The shared F1/F6 commit protocol — see commitConfirmedReply. Without this
+      // commit the reply flashes to missing: for OWN streams the mirror removes the
+      // pending entry the instant status changes. epic leaf 6.8 (D
+      // ixpwr76xepu2x9v4pxgksyhz): the terminal status badges a crash-reaped or
+      // Stopped stream as 'interrupted' the instant this tab hears about it,
+      // instead of only after the next reload.
+      commitConfirmedReply(
         stream.conversationId,
         synthesizeAssistantMessage(messageId, stream.parts, stream.startedAt, aborted ? 'interrupted' : 'complete'),
+        { promoteOwnSends: stream.isOwn, refreshSnapshot },
       );
-      // F6: the socket broadcast can outrace the SSE multicast's final frames, so the
-      // committed parts may be truncated. The commit gives instant continuity; this
-      // background snapshot reconciles the authoritative DB row (best-effort,
-      // generation-safe, no loading-state flip).
-      void refreshSnapshot(stream.conversationId);
       return;
     }
     // No usable store entry (SSE join failed / zero parts): the message IS durably
@@ -104,13 +89,16 @@ export const buildConversationCacheHandlers = ({
     // only adds a loading flip. A locally-Stopped 'interrupted' row does NOT
     // suppress a non-aborted completion: the server may have outrun the abort and
     // persisted the full reply — see cacheHasConsistentFinalMessage.
-    const cacheHasFinalMessage = completedConvId
-      ? cacheHasConsistentFinalMessage(
-          conversationMessagesActions.getEntry(completedConvId).messages,
-          messageId,
-          aborted === true,
-        )
-      : false;
+    // Scan gated on the reload actually being possible (same conversation) — an
+    // unrelated completion must not pay a getEntry allocation + list scan.
+    const cacheHasFinalMessage =
+      completedConvId !== undefined && completedConvId === conversationId
+        ? cacheHasConsistentFinalMessage(
+            conversationMessagesActions.getEntry(completedConvId).messages,
+            messageId,
+            aborted === true,
+          )
+        : false;
     if (shouldReloadOnComountComplete(stream, completedConvId, conversationId, cacheHasFinalMessage)) {
       void reloadConversation(completedConvId!);
     }

--- a/apps/web/src/hooks/conversationMessagesActions.ts
+++ b/apps/web/src/hooks/conversationMessagesActions.ts
@@ -89,9 +89,14 @@ export const conversationMessagesActions = {
   /** Capture the token a background snapshot must present at commit — call BEFORE the fetch. */
   beginServerSnapshot: (conversationId: string): number =>
     useConversationMessagesStore.getState().beginServerSnapshot(conversationId),
-  /** Silently commit an already-fetched server list as loaded truth; dropped if the token went stale. */
-  applyServerSnapshot: (conversationId: string, generationToken: number, messages: UIMessage[]): void =>
-    useConversationMessagesStore.getState().applyServerSnapshot(conversationId, generationToken, messages),
+  /** Silently commit an already-fetched server list as loaded truth; dropped if the token went stale. Merges onto older loaded pages — see mergeSnapshotTail. */
+  applyServerSnapshot: (
+    conversationId: string,
+    generationToken: number,
+    messages: UIMessage[],
+    pagination?: { hasMore: boolean; nextCursor: string | null },
+  ): void =>
+    useConversationMessagesStore.getState().applyServerSnapshot(conversationId, generationToken, messages, pagination),
   /** Mark a freshly-minted conversation loaded-empty (nothing to fetch for it). */
   seedConversation: (conversationId: string): void =>
     useConversationMessagesStore.getState().seedConversation(conversationId),

--- a/apps/web/src/hooks/conversationMessagesActions.ts
+++ b/apps/web/src/hooks/conversationMessagesActions.ts
@@ -32,6 +32,9 @@ export const conversationMessagesActions = {
   /** Imperative snapshot read of a conversation's cache entry (defaults when never seen). */
   getEntry: (conversationId: string): ConversationCacheEntry =>
     useConversationMessagesStore.getState().getEntry(conversationId),
+  /** True when the conversation has a REAL cache entry (loaded/seeded/sent this session) — see the store docblock. */
+  hasEntry: (conversationId: string): boolean =>
+    useConversationMessagesStore.getState().hasEntry(conversationId),
   /** Marks a "load older" fetch in flight (epic leaf 6.6) — inline indicator, no generation change. */
   startLoadingOlder: (conversationId: string): void =>
     useConversationMessagesStore.getState().startLoadingOlder(conversationId),

--- a/apps/web/src/hooks/conversationMessagesLoaders.ts
+++ b/apps/web/src/hooks/conversationMessagesLoaders.ts
@@ -3,6 +3,24 @@ import type { UIMessage } from 'ai';
 import { fetchAgentConversationMessages } from '@/lib/ai/shared/agent-conversations';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
 
+interface GlobalMessagesEnvelope {
+  messages: UIMessage[];
+  pagination?: { hasMore: boolean; nextCursor: string | null };
+}
+
+/**
+ * The ONE decoder for the global messages endpoint's response — either the
+ * modern `{ messages, pagination }` envelope or the legacy bare array (same
+ * dual shape `fetchAgentConversationMessages` handles for the agent endpoint).
+ */
+const parseGlobalMessagesEnvelope = (data: unknown): GlobalMessagesEnvelope =>
+  Array.isArray(data)
+    ? { messages: data as UIMessage[] }
+    : {
+        messages: (data as { messages?: UIMessage[] }).messages ?? [],
+        pagination: (data as GlobalMessagesEnvelope).pagination ?? undefined,
+      };
+
 /**
  * The shared cache load path (PR 5B) — the ONE way a conversation's DB
  * messages reach `useConversationMessagesStore`. Every load/refresh trigger
@@ -35,10 +53,9 @@ export const loadGlobalConversationMessages = async (conversationId: string): Pr
     }
     const data = await res.json();
     if (!conversationMessagesActions.isLoadCurrent(conversationId, generation)) return;
-    const messages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
     // epic leaf 6.6: capture the pagination envelope (dropped entirely before this PR) so
     // "load older" has a cursor and knows whether there's anything left to fetch.
-    const pagination = Array.isArray(data) ? undefined : data.pagination;
+    const { messages, pagination } = parseGlobalMessagesEnvelope(data);
     conversationMessagesActions.applyLoad(conversationId, generation, messages, pagination);
   } catch (error) {
     console.warn('[conversationMessagesLoaders] global load failed', conversationId, error);
@@ -71,8 +88,7 @@ export const loadOlderGlobalConversationMessages = async (conversationId: string
       return;
     }
     const data = await res.json();
-    const messages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
-    const pagination = Array.isArray(data) ? undefined : data.pagination;
+    const { messages, pagination } = parseGlobalMessagesEnvelope(data);
     conversationMessagesActions.applyOlderPage(
       conversationId,
       generation,
@@ -98,7 +114,28 @@ export const loadOlderGlobalConversationMessages = async (conversationId: string
  * reconciles the authoritative DB row shortly after. Best-effort: a failure
  * leaves the committed parts standing (warn, never a UI error).
  */
-export const refreshConversationSnapshot = async (
+// In-flight dedup: with event-conversation dispatch, co-mounted subscribers on the
+// same channel each fire the heal for one completion — identical fetches whose
+// second commit the CR4 token guard would drop anyway. Coalesce them instead of
+// paying the duplicate network round-trip. Keyed per (endpoint, conversation);
+// cleared on settle, so a heal AFTER this one still fetches fresh.
+const inFlightSnapshotRefreshes = new Map<string, Promise<void>>();
+
+export const refreshConversationSnapshot = (
+  agentId: string | null,
+  conversationId: string,
+): Promise<void> => {
+  const key = `${agentId ?? 'global'}:${conversationId}`;
+  const inFlight = inFlightSnapshotRefreshes.get(key);
+  if (inFlight) return inFlight;
+  const refresh = doRefreshConversationSnapshot(agentId, conversationId).finally(() => {
+    inFlightSnapshotRefreshes.delete(key);
+  });
+  inFlightSnapshotRefreshes.set(key, refresh);
+  return refresh;
+};
+
+const doRefreshConversationSnapshot = async (
   agentId: string | null,
   conversationId: string,
 ): Promise<void> => {
@@ -126,10 +163,7 @@ export const refreshConversationSnapshot = async (
       console.warn('[conversationMessagesLoaders] snapshot refresh failed', conversationId, res.status);
       return;
     }
-    const data = await res.json();
-    const messages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
-    const pagination: { hasMore: boolean; nextCursor: string | null } | undefined =
-      Array.isArray(data) ? undefined : (data.pagination ?? undefined);
+    const { messages, pagination } = parseGlobalMessagesEnvelope(await res.json());
     conversationMessagesActions.applyServerSnapshot(conversationId, token, messages, pagination);
   } catch (error) {
     console.warn('[conversationMessagesLoaders] snapshot refresh failed', conversationId, error);

--- a/apps/web/src/hooks/conversationMessagesLoaders.ts
+++ b/apps/web/src/hooks/conversationMessagesLoaders.ts
@@ -111,7 +111,12 @@ export const refreshConversationSnapshot = async (
         limit: 50,
         includeStreaming: true,
       });
-      conversationMessagesActions.applyServerSnapshot(conversationId, token, result.messages);
+      conversationMessagesActions.applyServerSnapshot(
+        conversationId,
+        token,
+        result.messages,
+        result.pagination ?? undefined,
+      );
       return;
     }
     const res = await fetchWithAuth(
@@ -123,7 +128,9 @@ export const refreshConversationSnapshot = async (
     }
     const data = await res.json();
     const messages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
-    conversationMessagesActions.applyServerSnapshot(conversationId, token, messages);
+    const pagination: { hasMore: boolean; nextCursor: string | null } | undefined =
+      Array.isArray(data) ? undefined : (data.pagination ?? undefined);
+    conversationMessagesActions.applyServerSnapshot(conversationId, token, messages, pagination);
   } catch (error) {
     console.warn('[conversationMessagesLoaders] snapshot refresh failed', conversationId, error);
   }

--- a/apps/web/src/hooks/ownStreamCommit.ts
+++ b/apps/web/src/hooks/ownStreamCommit.ts
@@ -1,0 +1,55 @@
+import type { ChatOnFinishCallback, UIMessage } from 'ai';
+import { getActiveStreamById } from '@/hooks/useActiveStream';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { refreshConversationSnapshot } from '@/hooks/conversationMessagesLoaders';
+import { planOwnStreamCommit } from '@/lib/ai/streams/planOwnStreamCommit';
+
+/**
+ * Builds a useChat `onFinish` that commits the sender's finished reply into
+ * the conversation message cache — the local counterpart of the socket
+ * `onStreamComplete` commit (conversationCacheSocketHandlers), for surfaces
+ * whose completed reply must not depend on the best-effort broadcast (panes:
+ * the assistant pane has no conversation-scoped subscriber at all, and the
+ * agent pane's own stream entry is already removed when its handler runs).
+ *
+ * Mirrors the socket commit's ordering exactly:
+ * - F1: promote optimistic sends FIRST — an own reply proves the user rows
+ *   that triggered it are persisted, and promoting first means the question
+ *   can never render below the answer.
+ * - Commit by id — upsert, never skip: an existing row under this id may be a
+ *   half-streamed includeStreaming placeholder that must be overwritten.
+ * - F6: background snapshot heal — the drained body is complete on a clean
+ *   finish, but the DB row is authoritative for metadata (status refinement,
+ *   createdAt); best-effort, generation-safe, no loading-state flip.
+ *
+ * `onFinish` runs in the stream-teardown task, before React commits the
+ * `ready` render's effects — so the mirror's pending-streams entry still
+ * exists here (its startedAt keeps the bubble's timestamp) and the cache row
+ * lands before the mirror's removeStream, making the streaming → confirmed
+ * transition atomic in selectRenderedMessages.
+ *
+ * useChat reads callbacks at Chat construction, so the closed-over ids must
+ * be per-Chat-stable: callers' chat ids embed the conversationId
+ * (`agent-session-chat:${conversationId}` / `assistant-session-chat:${conversationId}`),
+ * forcing Chat recreation whenever it changes.
+ */
+export const buildOwnStreamCommitOnFinish = (deps: {
+  conversationId: string;
+  /** Agent page id for the snapshot-heal endpoint; null = global assistant. */
+  agentId: string | null;
+}): ChatOnFinishCallback<UIMessage> => {
+  const { conversationId, agentId } = deps;
+  return (options) => {
+    const plan = planOwnStreamCommit({
+      message: options.message,
+      isAbort: options.isAbort,
+      isDisconnect: options.isDisconnect,
+      isError: options.isError,
+      startedAt: getActiveStreamById(options.message.id)?.startedAt,
+    });
+    if (!plan) return;
+    conversationMessagesActions.promoteOptimisticSends(conversationId);
+    conversationMessagesActions.applyConfirmedMessage(conversationId, plan.message);
+    void refreshConversationSnapshot(agentId, conversationId);
+  };
+};

--- a/apps/web/src/hooks/ownStreamCommit.ts
+++ b/apps/web/src/hooks/ownStreamCommit.ts
@@ -25,9 +25,10 @@ import { planOwnStreamCommit } from '@/lib/ai/streams/planOwnStreamCommit';
  * transition atomic in selectRenderedMessages.
  *
  * useChat reads callbacks at Chat construction, so the closed-over ids must
- * be per-Chat-stable: callers' chat ids embed the conversationId
- * (`agent-session-chat:${conversationId}` / `assistant-session-chat:${conversationId}`),
- * forcing Chat recreation whenever it changes.
+ * be per-Chat-stable: callers' chat ids embed EVERY id this closes over
+ * (`agent-session-chat:${agentId}:${conversationId}` /
+ * `assistant-session-chat:${conversationId}`), forcing Chat recreation
+ * whenever either changes.
  */
 export const buildOwnStreamCommitOnFinish = (deps: {
   conversationId: string;

--- a/apps/web/src/hooks/ownStreamCommit.ts
+++ b/apps/web/src/hooks/ownStreamCommit.ts
@@ -1,6 +1,6 @@
 import type { ChatOnFinishCallback, UIMessage } from 'ai';
 import { getActiveStreamById } from '@/hooks/useActiveStream';
-import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { commitConfirmedReply } from '@/hooks/commitConfirmedReply';
 import { refreshConversationSnapshot } from '@/hooks/conversationMessagesLoaders';
 import { planOwnStreamCommit } from '@/lib/ai/streams/planOwnStreamCommit';
 
@@ -12,15 +12,11 @@ import { planOwnStreamCommit } from '@/lib/ai/streams/planOwnStreamCommit';
  * the assistant pane has no conversation-scoped subscriber at all, and the
  * agent pane's own stream entry is already removed when its handler runs).
  *
- * Mirrors the socket commit's ordering exactly:
- * - F1: promote optimistic sends FIRST — an own reply proves the user rows
- *   that triggered it are persisted, and promoting first means the question
- *   can never render below the answer.
- * - Commit by id — upsert, never skip: an existing row under this id may be a
- *   half-streamed includeStreaming placeholder that must be overwritten.
- * - F6: background snapshot heal — the drained body is complete on a clean
- *   finish, but the DB row is authoritative for metadata (status refinement,
- *   createdAt); best-effort, generation-safe, no loading-state flip.
+ * What/whether to commit is decided by planOwnStreamCommit; HOW to commit is
+ * the shared commitConfirmedReply protocol (F1 promote-first ordering, F6
+ * snapshot heal) — the same code path the socket commit uses, so the two
+ * cannot drift. `promoteOwnSends` is unconditionally true here: onFinish only
+ * ever fires for this tab's own request.
  *
  * `onFinish` runs in the stream-teardown task, before React commits the
  * `ready` render's effects — so the mirror's pending-streams entry still
@@ -40,16 +36,17 @@ export const buildOwnStreamCommitOnFinish = (deps: {
 }): ChatOnFinishCallback<UIMessage> => {
   const { conversationId, agentId } = deps;
   return (options) => {
-    const plan = planOwnStreamCommit({
+    const message = planOwnStreamCommit({
       message: options.message,
       isAbort: options.isAbort,
       isDisconnect: options.isDisconnect,
       isError: options.isError,
       startedAt: getActiveStreamById(options.message.id)?.startedAt,
     });
-    if (!plan) return;
-    conversationMessagesActions.promoteOptimisticSends(conversationId);
-    conversationMessagesActions.applyConfirmedMessage(conversationId, plan.message);
-    void refreshConversationSnapshot(agentId, conversationId);
+    if (!message) return;
+    commitConfirmedReply(conversationId, message, {
+      promoteOwnSends: true,
+      refreshSnapshot: (id) => refreshConversationSnapshot(agentId, id),
+    });
   };
 };

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -58,24 +58,20 @@ export function useAgentChannelMultiplayer({
 
   usePageSocketRoom(channelId);
 
-  // Stable ref so the hook's callbacks see the latest conversation id without
-  // re-binding the socket subscription on every render.
-  const agentConversationIdRef = useRef(agentConversationId);
-  agentConversationIdRef.current = agentConversationId;
-
   // NO STOP-SLOT CLAIM PROTOCOL (PR 5A, leaf 5.5.7) — every surface READS
   // `useConversationActiveStream(agentId, conversationId)`, and a read cannot be declined.
 
   // The shared socket-events → cache protocol (see buildConversationCacheHandlers):
   // remote user/edit/delete writes, and the completion commit with own-send
-  // promotion + background snapshot heal. Cache reloads here use the RAW loaders
-  // keyed by the channel (agent page id) — never the surface's loadConversation,
-  // which also sets identity and pushes the URL; a completion for the conversation
-  // already on screen must not do either.
+  // promotion + background snapshot heal. Events dispatch on THEIR OWN
+  // conversation id (any cached conversation on this channel), so panes showing
+  // sibling conversations receive them too. Cache reloads here use the RAW
+  // loaders keyed by the channel (agent page id) — never the surface's
+  // loadConversation, which also sets identity and pushes the URL; a completion
+  // for a conversation already on screen must not do either.
   const cacheHandlers = useMemo(
     () =>
       buildConversationCacheHandlers({
-        getActiveConversationId: () => agentConversationIdRef.current,
         reloadConversation: (conversationId) => {
           if (channelId) void loadAgentConversationMessages(channelId, conversationId);
         },

--- a/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
@@ -64,6 +64,17 @@ describe('chat-config pure functions', () => {
       expect(a.experimental_throttle).toBe(b.experimental_throttle);
     });
 
+    it('given an onFinish handler, should pass it through', () => {
+      const onFinish = vi.fn();
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport, onFinish });
+      expect(config.onFinish).toBe(onFinish);
+    });
+
+    it('given no onFinish handler, should omit the property entirely (not set undefined)', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
+      expect(config).not.toHaveProperty('onFinish');
+    });
+
     it('given no explicit predicate, should wire sendAutomaticallyWhen to askUserAnswersComplete', () => {
       const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
       expect(typeof config.sendAutomaticallyWhen).toBe('function');

--- a/apps/web/src/lib/ai/shared/chat-config.ts
+++ b/apps/web/src/lib/ai/shared/chat-config.ts
@@ -13,7 +13,7 @@
  * @see vercel/ai packages/react/src/use-chat.ts — shouldRecreateChat checks id only
  */
 
-import type { DefaultChatTransport, UIMessage } from 'ai';
+import type { ChatOnFinishCallback, DefaultChatTransport, UIMessage } from 'ai';
 import { askUserAnswersComplete } from '@/lib/ai/shared/ask-user-client';
 
 /**
@@ -36,6 +36,13 @@ export interface ChatConfigParams {
   throttleMs?: number;
   /** Error handler. */
   onError?: (error: Error) => void;
+  /**
+   * Finished-response handler. useChat reads callbacks at Chat construction
+   * (same shouldRecreateChat caveat as `messages`), so this must close over
+   * only values stable for the Chat's life — safe when the surface's `id`
+   * embeds them (the pane hooks embed conversationId).
+   */
+  onFinish?: ChatOnFinishCallback<UIMessage>;
 }
 
 /**
@@ -53,6 +60,7 @@ export function buildChatConfig(params: ChatConfigParams): {
   transport: DefaultChatTransport<UIMessage>;
   experimental_throttle: number;
   onError: (error: Error) => void;
+  onFinish?: ChatOnFinishCallback<UIMessage>;
   sendAutomaticallyWhen: (options: { messages: UIMessage[] }) => boolean;
 } {
   return {
@@ -60,6 +68,8 @@ export function buildChatConfig(params: ChatConfigParams): {
     transport: params.transport,
     experimental_throttle: params.throttleMs ?? 100,
     onError: params.onError ?? defaultOnError,
+    // Omit rather than set undefined, same as the messages-prop convention.
+    ...(params.onFinish ? { onFinish: params.onFinish } : {}),
     // Auto-resume the agent once a pending ask_user question is answered.
     // See ask-user-client.ts for why this can't be the SDK's stock helper.
     sendAutomaticallyWhen: askUserAnswersComplete,

--- a/apps/web/src/lib/ai/streams/__tests__/cacheHasConsistentFinalMessage.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/cacheHasConsistentFinalMessage.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { cacheHasConsistentFinalMessage } from '../cacheHasConsistentFinalMessage';
+
+const row = (id: string, status?: string): UIMessage =>
+  ({ id, role: 'assistant', parts: [{ type: 'text', text: 'reply' }], ...(status ? { status } : {}) }) as UIMessage;
+
+describe('cacheHasConsistentFinalMessage', () => {
+  it('given a cached complete row and a clean completion, should be final', () => {
+    expect(cacheHasConsistentFinalMessage([row('m1', 'complete')], 'm1', false)).toBe(true);
+  });
+
+  it('given a cached complete row and an aborted completion, should still be final (the sender drained the full body)', () => {
+    expect(cacheHasConsistentFinalMessage([row('m1', 'complete')], 'm1', true)).toBe(true);
+  });
+
+  it('given a cached interrupted row and an ABORTED completion, should be final (server confirms the stop)', () => {
+    expect(cacheHasConsistentFinalMessage([row('m1', 'interrupted')], 'm1', true)).toBe(true);
+  });
+
+  it('given a cached interrupted row and a CLEAN completion, should NOT be final (the server outran the abort — the full reply must be reloaded)', () => {
+    expect(cacheHasConsistentFinalMessage([row('m1', 'interrupted')], 'm1', false)).toBe(false);
+  });
+
+  it('given a cached streaming placeholder, should never be final', () => {
+    expect(cacheHasConsistentFinalMessage([row('m1', 'streaming')], 'm1', false)).toBe(false);
+    expect(cacheHasConsistentFinalMessage([row('m1', 'streaming')], 'm1', true)).toBe(false);
+  });
+
+  it('given a cached row without a status, should not be final (unknown provenance — let the reload fetch DB truth)', () => {
+    expect(cacheHasConsistentFinalMessage([row('m1')], 'm1', false)).toBe(false);
+  });
+
+  it('given no row under the id, should not be final', () => {
+    expect(cacheHasConsistentFinalMessage([row('other', 'complete')], 'm1', false)).toBe(false);
+  });
+
+  it('given an empty cache, should not be final', () => {
+    expect(cacheHasConsistentFinalMessage([], 'm1', false)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/planOwnStreamCommit.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/planOwnStreamCommit.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { planOwnStreamCommit, type PlanOwnStreamCommitInput } from '../planOwnStreamCommit';
+
+const makeInput = (overrides: Partial<PlanOwnStreamCommitInput> = {}): PlanOwnStreamCommitInput => ({
+  message: {
+    id: 'msg-1',
+    role: 'assistant',
+    parts: [{ type: 'text', text: 'the reply' }] as UIMessage['parts'],
+  },
+  isAbort: false,
+  isDisconnect: false,
+  isError: false,
+  startedAt: undefined,
+  ...overrides,
+});
+
+describe('planOwnStreamCommit', () => {
+  it('given a clean finish with parts, should commit with status complete', () => {
+    const plan = planOwnStreamCommit(makeInput());
+    expect(plan).not.toBeNull();
+    expect(plan!.message.id).toBe('msg-1');
+    expect(plan!.message.parts).toEqual([{ type: 'text', text: 'the reply' }]);
+    expect((plan!.message as UIMessage & { status?: string }).status).toBe('complete');
+  });
+
+  it('given a local abort with partial parts, should commit with status interrupted', () => {
+    const plan = planOwnStreamCommit(makeInput({ isAbort: true }));
+    expect(plan).not.toBeNull();
+    expect((plan!.message as UIMessage & { status?: string }).status).toBe('interrupted');
+  });
+
+  it('given an abort with zero parts, should not commit (reload path owns it)', () => {
+    const plan = planOwnStreamCommit(
+      makeInput({ isAbort: true, message: { id: 'msg-1', role: 'assistant', parts: [] } }),
+    );
+    expect(plan).toBeNull();
+  });
+
+  it('given an error finish, should not commit (persistence not proven)', () => {
+    expect(planOwnStreamCommit(makeInput({ isError: true }))).toBeNull();
+  });
+
+  it('given a network disconnect, should not commit', () => {
+    expect(planOwnStreamCommit(makeInput({ isDisconnect: true }))).toBeNull();
+  });
+
+  it('given an abort that is ALSO an error, should not commit (error wins)', () => {
+    expect(planOwnStreamCommit(makeInput({ isAbort: true, isError: true }))).toBeNull();
+  });
+
+  it('given a non-assistant message, should not commit', () => {
+    const plan = planOwnStreamCommit(
+      makeInput({
+        message: { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] as UIMessage['parts'] },
+      }),
+    );
+    expect(plan).toBeNull();
+  });
+
+  it('given a clean finish with zero parts, should not commit', () => {
+    const plan = planOwnStreamCommit(makeInput({ message: { id: 'msg-1', role: 'assistant', parts: [] } }));
+    expect(plan).toBeNull();
+  });
+
+  it('given a startedAt, should thread it into the committed message createdAt', () => {
+    const plan = planOwnStreamCommit(makeInput({ startedAt: '2026-08-03T12:00:00.000Z' }));
+    expect((plan!.message as UIMessage & { createdAt?: Date }).createdAt).toEqual(
+      new Date('2026-08-03T12:00:00.000Z'),
+    );
+  });
+
+  it('given no startedAt, should omit createdAt entirely', () => {
+    const plan = planOwnStreamCommit(makeInput());
+    expect(plan!.message).not.toHaveProperty('createdAt');
+  });
+
+  it('given the input parts array, should not share it with the committed message (purity)', () => {
+    const parts = [{ type: 'text', text: 'the reply' }] as UIMessage['parts'];
+    const plan = planOwnStreamCommit(makeInput({ message: { id: 'msg-1', role: 'assistant', parts } }));
+    expect(plan!.message.parts).not.toBe(parts);
+    expect(plan!.message.parts).toEqual(parts);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/planOwnStreamCommit.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/planOwnStreamCommit.test.ts
@@ -17,24 +17,24 @@ const makeInput = (overrides: Partial<PlanOwnStreamCommitInput> = {}): PlanOwnSt
 
 describe('planOwnStreamCommit', () => {
   it('given a clean finish with parts, should commit with status complete', () => {
-    const plan = planOwnStreamCommit(makeInput());
-    expect(plan).not.toBeNull();
-    expect(plan!.message.id).toBe('msg-1');
-    expect(plan!.message.parts).toEqual([{ type: 'text', text: 'the reply' }]);
-    expect((plan!.message as UIMessage & { status?: string }).status).toBe('complete');
+    const message = planOwnStreamCommit(makeInput());
+    expect(message).not.toBeNull();
+    expect(message!.id).toBe('msg-1');
+    expect(message!.parts).toEqual([{ type: 'text', text: 'the reply' }]);
+    expect((message as UIMessage & { status?: string }).status).toBe('complete');
   });
 
   it('given a local abort with partial parts, should commit with status interrupted', () => {
-    const plan = planOwnStreamCommit(makeInput({ isAbort: true }));
-    expect(plan).not.toBeNull();
-    expect((plan!.message as UIMessage & { status?: string }).status).toBe('interrupted');
+    const message = planOwnStreamCommit(makeInput({ isAbort: true }));
+    expect(message).not.toBeNull();
+    expect((message as UIMessage & { status?: string }).status).toBe('interrupted');
   });
 
   it('given an abort with zero parts, should not commit (reload path owns it)', () => {
-    const plan = planOwnStreamCommit(
+    const message = planOwnStreamCommit(
       makeInput({ isAbort: true, message: { id: 'msg-1', role: 'assistant', parts: [] } }),
     );
-    expect(plan).toBeNull();
+    expect(message).toBeNull();
   });
 
   it('given an error finish, should not commit (persistence not proven)', () => {
@@ -50,35 +50,35 @@ describe('planOwnStreamCommit', () => {
   });
 
   it('given a non-assistant message, should not commit', () => {
-    const plan = planOwnStreamCommit(
+    const message = planOwnStreamCommit(
       makeInput({
         message: { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] as UIMessage['parts'] },
       }),
     );
-    expect(plan).toBeNull();
+    expect(message).toBeNull();
   });
 
   it('given a clean finish with zero parts, should not commit', () => {
-    const plan = planOwnStreamCommit(makeInput({ message: { id: 'msg-1', role: 'assistant', parts: [] } }));
-    expect(plan).toBeNull();
+    const message = planOwnStreamCommit(makeInput({ message: { id: 'msg-1', role: 'assistant', parts: [] } }));
+    expect(message).toBeNull();
   });
 
   it('given a startedAt, should thread it into the committed message createdAt', () => {
-    const plan = planOwnStreamCommit(makeInput({ startedAt: '2026-08-03T12:00:00.000Z' }));
-    expect((plan!.message as UIMessage & { createdAt?: Date }).createdAt).toEqual(
+    const message = planOwnStreamCommit(makeInput({ startedAt: '2026-08-03T12:00:00.000Z' }));
+    expect((message as UIMessage & { createdAt?: Date }).createdAt).toEqual(
       new Date('2026-08-03T12:00:00.000Z'),
     );
   });
 
   it('given no startedAt, should omit createdAt entirely', () => {
-    const plan = planOwnStreamCommit(makeInput());
-    expect(plan!.message).not.toHaveProperty('createdAt');
+    const message = planOwnStreamCommit(makeInput());
+    expect(message).not.toHaveProperty('createdAt');
   });
 
   it('given the input parts array, should not share it with the committed message (purity)', () => {
     const parts = [{ type: 'text', text: 'the reply' }] as UIMessage['parts'];
-    const plan = planOwnStreamCommit(makeInput({ message: { id: 'msg-1', role: 'assistant', parts } }));
-    expect(plan!.message.parts).not.toBe(parts);
-    expect(plan!.message.parts).toEqual(parts);
+    const message = planOwnStreamCommit(makeInput({ message: { id: 'msg-1', role: 'assistant', parts } }));
+    expect(message!.parts).not.toBe(parts);
+    expect(message!.parts).toEqual(parts);
   });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
@@ -14,28 +14,37 @@ const makeStream = (overrides: Partial<PendingStream> = {}): PendingStream => ({
 
 describe('shouldReloadOnComountComplete', () => {
   it('given no pending stream and matching conversationId, should return true', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz')).toBe(true);
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz', false)).toBe(true);
   });
 
   it('given a pending stream with parts and matching conversationId, should return false', () => {
     const stream = makeStream({ conversationId: 'conv-xyz' });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz')).toBe(false);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', false)).toBe(false);
   });
 
   it('given a pending stream with no parts, should return true (treat as missing)', () => {
     const stream = makeStream({ parts: [] });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz')).toBe(true);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', false)).toBe(true);
   });
 
   it('given completedConvId does not match active conversation, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-other', 'conv-xyz')).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, 'conv-other', 'conv-xyz', false)).toBe(false);
   });
 
   it('given completedConvId is undefined, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, undefined, 'conv-xyz')).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, undefined, 'conv-xyz', false)).toBe(false);
   });
 
   it('given activeConversationId is null, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', null)).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', null, false)).toBe(false);
+  });
+
+  it('given the cache already holds the final message, should return false (local onFinish commit landed first)', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz', true)).toBe(false);
+  });
+
+  it('given the cache holds the final message and a zero-parts stream entry, should still return false', () => {
+    const stream = makeStream({ parts: [] });
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', true)).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
@@ -13,38 +13,34 @@ const makeStream = (overrides: Partial<PendingStream> = {}): PendingStream => ({
 });
 
 describe('shouldReloadOnComountComplete', () => {
-  it('given no pending stream and matching conversationId, should return true', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz', false)).toBe(true);
+  it('given no pending stream and a cached conversation, should return true', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', true, false)).toBe(true);
   });
 
-  it('given a pending stream with parts and matching conversationId, should return false', () => {
+  it('given a pending stream with parts, should return false (the commit branch owns it)', () => {
     const stream = makeStream({ conversationId: 'conv-xyz' });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', false)).toBe(false);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', true, false)).toBe(false);
   });
 
   it('given a pending stream with no parts, should return true (treat as missing)', () => {
     const stream = makeStream({ parts: [] });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', false)).toBe(true);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', true, false)).toBe(true);
   });
 
-  it('given completedConvId does not match active conversation, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-other', 'conv-xyz', false)).toBe(false);
+  it('given the completed conversation has no cache entry, should return false (nothing renders it; its eventual loader fetches the DB truth)', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', false, false)).toBe(false);
   });
 
   it('given completedConvId is undefined, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, undefined, 'conv-xyz', false)).toBe(false);
-  });
-
-  it('given activeConversationId is null, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', null, false)).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, undefined, true, false)).toBe(false);
   });
 
   it('given the cache already holds the final message, should return false (local onFinish commit landed first)', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz', true)).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', true, true)).toBe(false);
   });
 
   it('given the cache holds the final message and a zero-parts stream entry, should still return false', () => {
     const stream = makeStream({ parts: [] });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', true)).toBe(false);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', true, true)).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/streams/cacheHasConsistentFinalMessage.ts
+++ b/apps/web/src/lib/ai/streams/cacheHasConsistentFinalMessage.ts
@@ -19,14 +19,19 @@ import type { UIMessage } from 'ai';
  *   row and must reload the authoritative reply.
  * - 'streaming' / absent → never final (an includeStreaming placeholder or a
  *   row of unknown provenance): let the reload fetch DB truth.
+ *
+ * Scans from the end — the completed message is almost always the newest row.
  */
 export const cacheHasConsistentFinalMessage = (
   messages: readonly UIMessage[],
   messageId: string,
   aborted: boolean,
-): boolean =>
-  messages.some((m) => {
-    if (m.id !== messageId) return false;
+): boolean => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.id !== messageId) continue;
     const status = (m as UIMessage & { status?: string }).status;
     return status === 'complete' || (status === 'interrupted' && aborted);
-  });
+  }
+  return false;
+};

--- a/apps/web/src/lib/ai/streams/cacheHasConsistentFinalMessage.ts
+++ b/apps/web/src/lib/ai/streams/cacheHasConsistentFinalMessage.ts
@@ -1,0 +1,32 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * Whether the conversation cache already holds a final row for `messageId`
+ * whose terminal status is CONSISTENT with the completion event — the guard
+ * that decides if the stream_complete reload fallback may be suppressed.
+ *
+ * "Consistent" (Codex P2, PR #2320): a locally committed row may be wrong
+ * about how the stream actually ended. A local Stop commits the partial as
+ * 'interrupted' (buildOwnStreamCommitOnFinish), but if the server-side abort
+ * failed or landed too late, the generation ran on and durably persisted a
+ * COMPLETE reply — suppressing the clean completion's reload would pin the
+ * pane to the stale partial until reopened. So suppression requires the
+ * cached status to agree with the event:
+ *
+ * - 'complete'  → final under any event (the sender drained the full body).
+ * - 'interrupted' → final only when the event itself says aborted — the
+ *   server confirms the stop; a NON-aborted completion contradicts the local
+ *   row and must reload the authoritative reply.
+ * - 'streaming' / absent → never final (an includeStreaming placeholder or a
+ *   row of unknown provenance): let the reload fetch DB truth.
+ */
+export const cacheHasConsistentFinalMessage = (
+  messages: readonly UIMessage[],
+  messageId: string,
+  aborted: boolean,
+): boolean =>
+  messages.some((m) => {
+    if (m.id !== messageId) return false;
+    const status = (m as UIMessage & { status?: string }).status;
+    return status === 'complete' || (status === 'interrupted' && aborted);
+  });

--- a/apps/web/src/lib/ai/streams/planOwnStreamCommit.ts
+++ b/apps/web/src/lib/ai/streams/planOwnStreamCommit.ts
@@ -1,0 +1,57 @@
+import type { UIMessage } from 'ai';
+import { synthesizeAssistantMessage } from './synthesizeAssistantMessage';
+
+export interface PlanOwnStreamCommitInput {
+  /** useChat's finished assistant message (its id IS the persisted DB row id — both stream routes generate the SDK message id server-side). */
+  message: { id: string; role: string; parts: UIMessage['parts'] };
+  /** The request was stopped locally (useChat `stop()`). */
+  isAbort: boolean;
+  /** The request ended on a network error mid-stream. */
+  isDisconnect: boolean;
+  /** The request ended on an error. */
+  isError: boolean;
+  /** The pending-stream mirror entry's startedAt, when still present at finish time. */
+  startedAt: string | undefined;
+}
+
+export interface OwnStreamCommit {
+  message: UIMessage;
+}
+
+/**
+ * Decides whether a finished own-chat request should be committed into the
+ * conversation message cache, and builds the message to commit.
+ *
+ * WHY THIS EXISTS: the sender's live bubble is only a pending-streams mirror
+ * entry, removed on the falling edge (planOwnStreamMirror). The completed
+ * reply otherwise reaches the cache only via the best-effort
+ * `chat:stream_complete` socket broadcast — which panes can miss entirely
+ * (subscriber gated on a different "active" conversation) and which the
+ * sender's own tab can only service via a full reload (its stream entry is
+ * already removed when the handler runs). Committing locally from the drained
+ * response body makes the sender independent of that broadcast.
+ *
+ * Rules:
+ * - error/disconnect → no commit: persistence of the full reply is not
+ *   proven, and the error UI / socket reload paths own recovery.
+ * - abort → commit as 'interrupted': a Stop on a pane's own chat is always a
+ *   genuine local abort (pane sends are always same-conversation, so the
+ *   pre-send handoff can never stop this chat on another conversation's
+ *   behalf), and the route persists the partial with the same status.
+ * - non-assistant or zero parts → no commit: nothing renderable; the socket
+ *   reload path owns the zero-parts completion (same contract as
+ *   shouldReloadOnComountComplete).
+ */
+export const planOwnStreamCommit = (input: PlanOwnStreamCommitInput): OwnStreamCommit | null => {
+  if (input.isDisconnect || input.isError) return null;
+  if (input.message.role !== 'assistant') return null;
+  if (input.message.parts.length === 0) return null;
+  return {
+    message: synthesizeAssistantMessage(
+      input.message.id,
+      input.message.parts,
+      input.startedAt,
+      input.isAbort ? 'interrupted' : 'complete',
+    ),
+  };
+};

--- a/apps/web/src/lib/ai/streams/planOwnStreamCommit.ts
+++ b/apps/web/src/lib/ai/streams/planOwnStreamCommit.ts
@@ -14,13 +14,10 @@ export interface PlanOwnStreamCommitInput {
   startedAt: string | undefined;
 }
 
-export interface OwnStreamCommit {
-  message: UIMessage;
-}
-
 /**
  * Decides whether a finished own-chat request should be committed into the
- * conversation message cache, and builds the message to commit.
+ * conversation message cache, and builds the message to commit (null = no
+ * commit).
  *
  * WHY THIS EXISTS: the sender's live bubble is only a pending-streams mirror
  * entry, removed on the falling edge (planOwnStreamMirror). The completed
@@ -42,16 +39,14 @@ export interface OwnStreamCommit {
  *   reload path owns the zero-parts completion (same contract as
  *   shouldReloadOnComountComplete).
  */
-export const planOwnStreamCommit = (input: PlanOwnStreamCommitInput): OwnStreamCommit | null => {
+export const planOwnStreamCommit = (input: PlanOwnStreamCommitInput): UIMessage | null => {
   if (input.isDisconnect || input.isError) return null;
   if (input.message.role !== 'assistant') return null;
   if (input.message.parts.length === 0) return null;
-  return {
-    message: synthesizeAssistantMessage(
-      input.message.id,
-      input.message.parts,
-      input.startedAt,
-      input.isAbort ? 'interrupted' : 'complete',
-    ),
-  };
+  return synthesizeAssistantMessage(
+    input.message.id,
+    input.message.parts,
+    input.startedAt,
+    input.isAbort ? 'interrupted' : 'complete',
+  );
 };

--- a/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
+++ b/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
@@ -1,17 +1,20 @@
 import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
-// Returns true when a co-mounted surface should reload from DB to sync after a same-session stream completes.
+// Returns true when a surface should reload from DB to sync after a same-session stream completes.
+// `conversationCached`: the completed conversation has a real cache entry (some surface rendered it
+// this session) — dispatch is by the EVENT's conversation, so this replaces the old single
+// "active conversation" equality gate; an uncached conversation needs no reload (its eventual
+// loader fetches the DB truth anyway).
 // `cacheHasFinalMessage`: the completed message already sits in the conversation cache as a
 // non-streaming row (the sender's own onFinish commit — see buildOwnStreamCommitOnFinish), so a
 // full reload would only add a loading flip for content the cache already holds.
 export function shouldReloadOnComountComplete(
   stream: PendingStream | undefined,
   completedConvId: string | undefined,
-  activeConversationId: string | null,
+  conversationCached: boolean,
   cacheHasFinalMessage: boolean,
 ): boolean {
-  if (!completedConvId || !activeConversationId) return false;
-  if (completedConvId !== activeConversationId) return false;
+  if (!completedConvId || !conversationCached) return false;
   if (cacheHasFinalMessage) return false;
   if (stream && stream.parts.length > 0) return false;
   return true;

--- a/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
+++ b/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
@@ -1,13 +1,18 @@
 import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
 // Returns true when a co-mounted surface should reload from DB to sync after a same-session stream completes.
+// `cacheHasFinalMessage`: the completed message already sits in the conversation cache as a
+// non-streaming row (the sender's own onFinish commit — see buildOwnStreamCommitOnFinish), so a
+// full reload would only add a loading flip for content the cache already holds.
 export function shouldReloadOnComountComplete(
   stream: PendingStream | undefined,
   completedConvId: string | undefined,
   activeConversationId: string | null,
+  cacheHasFinalMessage: boolean,
 ): boolean {
   if (!completedConvId || !activeConversationId) return false;
   if (completedConvId !== activeConversationId) return false;
+  if (cacheHasFinalMessage) return false;
   if (stream && stream.parts.length > 0) return false;
   return true;
 }

--- a/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
+++ b/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
@@ -98,6 +98,36 @@ describe('useConversationMessagesStore', () => {
     expect(entry.messages).toEqual([msg('opt1')]);
   });
 
+  // Codex P2 (PR #2320): a snapshot is the LATEST page only. Replacing a
+  // paginated cache with it discarded every older loaded page while olderCursor
+  // still pointed below them — history vanished and the next load-older skipped
+  // the discarded range. The snapshot must merge onto the older pages instead.
+  it('given loaded older pages, applyServerSnapshot must preserve them in front of the overlapping snapshot and keep the pagination cursor', () => {
+    const { startLoad, applyLoad, applyOlderPage, beginServerSnapshot, applyServerSnapshot, getEntry } = useConversationMessagesStore.getState();
+    const gen = startLoad('c1');
+    applyLoad('c1', gen, [msg('c'), msg('d')], { hasMore: true, nextCursor: 'cur-c' });
+    applyOlderPage('c1', gen, [msg('a'), msg('b')], true, 'cur-a');
+    const token = beginServerSnapshot('c1');
+    applyServerSnapshot('c1', token, [msg('d'), msg('e')]);
+    const entry = getEntry('c1');
+    expect(entry.messages).toEqual([msg('a'), msg('b'), msg('c'), msg('d'), msg('e')]);
+    expect(entry.olderCursor).toBe('cur-a');
+    expect(entry.hasMoreOlder).toBe(true);
+  });
+
+  it('given a snapshot DISJOINT from the cache, applyServerSnapshot should replace the cache and reset pagination from the snapshot envelope', () => {
+    const { startLoad, applyLoad, applyOlderPage, beginServerSnapshot, applyServerSnapshot, getEntry } = useConversationMessagesStore.getState();
+    const gen = startLoad('c1');
+    applyLoad('c1', gen, [msg('a')], { hasMore: true, nextCursor: 'cur-a' });
+    applyOlderPage('c1', gen, [msg('z')], true, 'cur-z');
+    const token = beginServerSnapshot('c1');
+    applyServerSnapshot('c1', token, [msg('x'), msg('y')], { hasMore: false, nextCursor: null });
+    const entry = getEntry('c1');
+    expect(entry.messages).toEqual([msg('x'), msg('y')]);
+    expect(entry.olderCursor).toBeNull();
+    expect(entry.hasMoreOlder).toBe(false);
+  });
+
   it('given seedConversation for a freshly minted id, should mark the entry loaded-empty so no fetch is pending for it', () => {
     const { seedConversation, getEntry } = useConversationMessagesStore.getState();
     seedConversation('c-new');

--- a/apps/web/src/stores/conversationMessages/__tests__/mergeSnapshotTail.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/mergeSnapshotTail.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { mergeSnapshotTail } from '../mergeSnapshotTail';
+
+const msg = (id: string): UIMessage => ({ id, role: 'assistant', parts: [{ type: 'text', text: id }] }) as UIMessage;
+const ids = (list: UIMessage[]) => list.map((m) => m.id);
+
+describe('mergeSnapshotTail', () => {
+  it('given the snapshot overlaps the cached window, should preserve the older cached prefix in front of the snapshot', () => {
+    const cached = [msg('a'), msg('b'), msg('c'), msg('d')];
+    const snapshot = [msg('c'), msg('d'), msg('e')];
+    const result = mergeSnapshotTail(cached, snapshot);
+    expect(ids(result.messages)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(result.overlapped).toBe(true);
+  });
+
+  it('given overlapping rows with updated content, the SNAPSHOT versions should win for the overlapped range', () => {
+    const cached = [msg('a'), { ...msg('b'), parts: [{ type: 'text', text: 'stale' }] } as UIMessage];
+    const snapshot = [{ ...msg('b'), parts: [{ type: 'text', text: 'fresh' }] } as UIMessage, msg('c')];
+    const result = mergeSnapshotTail(cached, snapshot);
+    expect(ids(result.messages)).toEqual(['a', 'b', 'c']);
+    expect(result.messages[1].parts).toEqual([{ type: 'text', text: 'fresh' }]);
+  });
+
+  it('given the snapshot fully covers the cache, should return exactly the snapshot', () => {
+    const cached = [msg('a'), msg('b')];
+    const snapshot = [msg('a'), msg('b'), msg('c')];
+    const result = mergeSnapshotTail(cached, snapshot);
+    expect(ids(result.messages)).toEqual(['a', 'b', 'c']);
+    expect(result.overlapped).toBe(true);
+  });
+
+  it('given no overlap (snapshot window is entirely newer), should return the snapshot alone with overlapped=false (no invented middle gap)', () => {
+    const cached = [msg('a'), msg('b')];
+    const snapshot = [msg('x'), msg('y')];
+    const result = mergeSnapshotTail(cached, snapshot);
+    expect(ids(result.messages)).toEqual(['x', 'y']);
+    expect(result.overlapped).toBe(false);
+  });
+
+  it('given an empty cache, should return the snapshot', () => {
+    const result = mergeSnapshotTail([], [msg('x')]);
+    expect(ids(result.messages)).toEqual(['x']);
+    expect(result.overlapped).toBe(false);
+  });
+
+  it('given an empty snapshot, should return empty (server truth: nothing exists)', () => {
+    const result = mergeSnapshotTail([msg('a')], []);
+    expect(result.messages).toEqual([]);
+    expect(result.overlapped).toBe(false);
+  });
+
+  it('should not mutate its inputs', () => {
+    const cached = [msg('a'), msg('b')];
+    const snapshot = [msg('b'), msg('c')];
+    const cachedCopy = [...cached];
+    const snapshotCopy = [...snapshot];
+    mergeSnapshotTail(cached, snapshot);
+    expect(cached).toEqual(cachedCopy);
+    expect(snapshot).toEqual(snapshotCopy);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/mergeSnapshotTail.ts
+++ b/apps/web/src/stores/conversationMessages/mergeSnapshotTail.ts
@@ -1,0 +1,46 @@
+import type { UIMessage } from 'ai';
+
+export interface MergeSnapshotTailResult {
+  messages: UIMessage[];
+  /** True when the snapshot overlapped the cached window and older cached rows were preserved in front of it. */
+  overlapped: boolean;
+}
+
+/**
+ * Merges a background snapshot (the conversation's LATEST page, no cursor) into
+ * an already-cached message list that may hold older pages loaded via
+ * "load older".
+ *
+ * A snapshot fetch returns only the newest N rows. Replacing the cache with it
+ * wholesale silently discards every older loaded page while `olderCursor`
+ * still points below them — the visible history disappears AND the next
+ * load-older starts past the discarded range, skipping it entirely (Codex P2,
+ * PR #2320). Instead:
+ *
+ * - Overlap (the common case — the snapshot window reaches back into the
+ *   cached rows): every cached row BEFORE the first row the snapshot also has
+ *   is older history the snapshot simply didn't reach — keep it, in place, in
+ *   front of the snapshot. The oldest row is unchanged, so the existing
+ *   `olderCursor` stays exactly correct.
+ * - No overlap (pathological — more rows arrived since the cache was current
+ *   than the snapshot window holds, or the cache was empty): the cached rows
+ *   can't be stitched to the snapshot without inventing a gap in the middle;
+ *   return the snapshot alone (fresh-load semantics — the caller resets
+ *   pagination from the snapshot's own envelope).
+ *
+ * Pure — never mutates its inputs. Both lists are assumed DB-ordered.
+ */
+export const mergeSnapshotTail = (
+  cached: readonly UIMessage[],
+  snapshot: readonly UIMessage[],
+): MergeSnapshotTailResult => {
+  if (cached.length === 0 || snapshot.length === 0) {
+    return { messages: [...snapshot], overlapped: false };
+  }
+  const snapshotIds = new Set(snapshot.map((m) => m.id));
+  const firstOverlapIdx = cached.findIndex((m) => snapshotIds.has(m.id));
+  if (firstOverlapIdx === -1) {
+    return { messages: [...snapshot], overlapped: false };
+  }
+  return { messages: [...cached.slice(0, firstOverlapIdx), ...snapshot], overlapped: true };
+};

--- a/apps/web/src/stores/useConversationMessagesStore.ts
+++ b/apps/web/src/stores/useConversationMessagesStore.ts
@@ -13,6 +13,7 @@ import { applyRemoteUserMessage } from '@/stores/conversationMessages/applyRemot
 import { applyConfirmedMessage } from '@/stores/conversationMessages/applyConfirmedMessage';
 import { promoteOptimisticSends } from '@/stores/conversationMessages/promoteOptimisticSends';
 import { replayPendingMutations } from '@/stores/conversationMessages/replayPendingMutations';
+import { mergeSnapshotTail } from '@/stores/conversationMessages/mergeSnapshotTail';
 import { seedEmpty, type ConversationCacheEntry, type ConversationMessagesById } from '@/stores/conversationMessages/seedEmpty';
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 import { revertAskUserAnswer, type AskUserAnswerPayload, type AskUserAnswerRevertPayload } from '@/lib/ai/streams/applyAskUserAnswer';
@@ -74,7 +75,13 @@ interface ConversationMessagesState {
    * current generation. Mutations recorded since the fetch began are replayed
    * onto the snapshot (they are newer than it).
    */
-  applyServerSnapshot: (conversationId: string, generationToken: number, messages: UIMessage[]) => void;
+  applyServerSnapshot: (
+    conversationId: string,
+    generationToken: number,
+    messages: UIMessage[],
+    /** The snapshot fetch's own envelope — applied only when the snapshot REPLACES the cache (no overlap), so pagination resets consistently with the replaced list. */
+    pagination?: { hasMore: boolean; nextCursor: string | null },
+  ) => void;
   /**
    * Marks a freshly-minted conversation as loaded-empty — createNewConversation
    * paths know the server has no rows for the id they just minted, so nothing
@@ -175,7 +182,7 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
   beginServerSnapshot: (conversationId) =>
     get().byConversationId[conversationId]?.loadGeneration ?? 0,
 
-  applyServerSnapshot: (conversationId, generationToken, messages) => {
+  applyServerSnapshot: (conversationId, generationToken, messages, pagination) => {
     set((state) => {
       // Stale-token drop (CR4): the generation moved since this snapshot's fetch
       // began — a loud load started, or a fresher snapshot already committed — so
@@ -183,18 +190,28 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
       // (the newer commit cleared the pending queue).
       const currentGeneration = state.byConversationId[conversationId]?.loadGeneration ?? 0;
       if (currentGeneration !== generationToken) return state;
+      // A snapshot is the LATEST page only — merge it onto any older loaded pages
+      // instead of discarding them (mergeSnapshotTail's docblock; Codex P2, PR #2320).
+      // When it overlaps the cached window the older prefix is preserved and the
+      // existing olderCursor stays correct, so no envelope is applied; when it
+      // doesn't, the snapshot replaces the cache and its own envelope (if the
+      // caller had one) resets pagination consistently.
+      const cachedMessages = state.byConversationId[conversationId]?.messages ?? [];
+      const merged = mergeSnapshotTail(cachedMessages, messages);
       // The snapshot was FETCHED before this call (unlike startLoad's contract, where
       // the fetch starts after), so live mutations recorded while it was in flight are
       // NEWER than the snapshot — replay them onto it instead of letting the generation
       // bump clear them, or an older recovery snapshot resurrects a message another tab
-      // just deleted (CodeRabbit P2, PR #2098).
+      // just deleted (CodeRabbit P2, PR #2098). Replayed over the MERGED list so a
+      // delete/edit of a preserved older row is honored too.
       const pendingSinceFetch = state.byConversationId[conversationId]?.pendingMutationsSinceLoad ?? [];
       const { byConversationId, generation } = applyStartLoad(state.byConversationId, conversationId);
       return {
         byConversationId: applyLoad(byConversationId, {
           conversationId,
           generation,
-          messages: replayPendingMutations(messages, pendingSinceFetch),
+          messages: replayPendingMutations(merged.messages, pendingSinceFetch),
+          pagination: merged.overlapped ? undefined : pagination,
         }),
       };
     });

--- a/apps/web/src/stores/useConversationMessagesStore.ts
+++ b/apps/web/src/stores/useConversationMessagesStore.ts
@@ -22,6 +22,13 @@ export type { ConversationCacheEntry, ConversationMessagesById };
 interface ConversationMessagesState {
   byConversationId: ConversationMessagesById;
   getEntry: (conversationId: string) => ConversationCacheEntry;
+  /**
+   * True when the conversation has a real cache entry — i.e. some surface has
+   * loaded/seeded/sent in it this session. `getEntry` cannot answer this (it
+   * returns a synthetic empty entry for never-seen ids); socket-event dispatch
+   * keys on this to route an event to any cached conversation, active or not.
+   */
+  hasEntry: (conversationId: string) => boolean;
   startLoad: (conversationId: string) => number;
   /** True while `generation` is still the newest `startLoad` result for `conversationId`. */
   isLoadCurrent: (conversationId: string, generation: number) => boolean;
@@ -87,6 +94,8 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
   byConversationId: {},
 
   getEntry: (conversationId) => get().byConversationId[conversationId] ?? seedEmpty(),
+
+  hasEntry: (conversationId) => conversationId in get().byConversationId,
 
   startLoad: (conversationId) => {
     const { byConversationId, generation } = applyStartLoad(get().byConversationId, conversationId);


### PR DESCRIPTION
## Problem

In paned agent screens, a streamed AI reply rendered live and then **vanished the instant the stream completed**, leaving only the sent user message. The reply was persisted fine — reopening the conversation from history showed it.

## Root cause

Rendered messages = conversation cache + optimistic sends + live pending-stream entries, merged at render. The sender's live bubble exists only as an own-stream mirror entry, which is removed on the falling edge of the stream. The **only** code that committed a completed reply into the cache was the `chat:stream_complete` socket handler, gated on `getActiveConversationId()`:

- **Assistant panes** mount no channel subscriber of their own; `GlobalChatProvider`'s handler is gated on the *dashboard/sidebar* assistant's active conversation — never the pane's. Both the commit branch and the reload branch were skipped, so nothing ever wrote the reply into the cache → bubble vanished on mirror release.
- **Agent panes** have a per-pane subscriber, but the sender's own tab never joins its SSE, so its stream entry is already removed when the handler runs — leaving only a full-refetch reload (loading flash; a failed reload = reply gone).

## Fix

Commit the finished reply **locally** via `useChat`'s `onFinish` in both pane session hooks. The finished message already carries the server-assigned DB id (both stream routes use `generateId: () => serverAssistantMessageId`), so the sender no longer depends on the best-effort broadcast at all:

- `planOwnStreamCommit` (new pure planner): clean finish → commit `complete`; local Stop with parts → commit `interrupted` (also fixes Stopped partials vanishing in panes); error/disconnect/zero-parts → no commit (socket reload path owns recovery).
- `buildOwnStreamCommitOnFinish` (new applier): mirrors the socket commit's contract — promote optimistic sends first (F1), upsert by id over any `includeStreaming` placeholder, background snapshot heal (F6). Runs before the mirror's `removeStream`, so the streaming → confirmed transition is atomic.
- `shouldReloadOnComountComplete` gains a `cacheHasFinalMessage` guard, so the socket handler no longer triggers a redundant full reload (agent panes lose the completion flash).

Idempotent with the socket commit (upsert-by-id, promote no-ops when empty); pending-mutation replay protects the commit from being clobbered by an in-flight `includeStreaming=1` snapshot.

## Review hardening (Codex round, d3643c806)

- **Status-consistent suppression** (`cacheHasConsistentFinalMessage`, new pure helper): the reload-suppression guard no longer treats any non-streaming cached row as final. A locally-Stopped `interrupted` partial does NOT suppress a non-aborted completion — when the server outruns the abort and persists the full reply, the clean completion now reloads it instead of leaving the pane pinned to the stale partial.
- **Pagination-safe snapshot heals** (`mergeSnapshotTail`, new pure helper): `applyServerSnapshot` merges the latest-page snapshot onto the cached list — older loaded pages are preserved in place (cursor stays exactly correct) instead of being discarded with `olderCursor` still pointing below them; a disjoint snapshot replaces the cache and resets pagination from its own envelope, threaded through both `refreshConversationSnapshot` paths.

## Tests

- New: `planOwnStreamCommit.test.ts` (11), `ownStreamCommit.test.ts` (8, real zustand stores), `cacheHasConsistentFinalMessage.test.ts` (8), `mergeSnapshotTail.test.ts` (7).
- Extended: `chat-config.test.ts` (onFinish pass-through/omission), both pane session-hook tests (the exact regression: reply survives after the mirror entry is gone; Stop → interrupted badge), `useAgentChannelMultiplayer.test.ts` (reload suppression + status-consistency cases), `shouldReloadOnComountComplete.test.ts`, `useConversationMessagesStore.test.ts` (older pages preserved with cursor intact; disjoint snapshot resets pagination).
- Full adjacent streaming + store suites green (1220 tests / 107 files), `tsc --noEmit` clean, lint clean.

Follow-up PR (stacked): event-conversation dispatch in `conversationCacheSocketHandlers` so panes also receive remote user/edit/delete events they currently drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9U2h8MF1d5UkiBUTFxAfu
