### PR TITLE
fix(agents): dispatch socket cache events by the event's conversation, not one active id

### DIFF
--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -245,7 +245,6 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     // are bookkeeping only — the surfaces re-seed the transport at the actions that
     // need it (retry, ask_user answers).
     ...buildConversationCacheHandlers({
-      getActiveConversationId: () => currentConversationIdRef.current,
       reloadConversation: loadGlobalConversationMessages,
       refreshSnapshot: (conversationId) => refreshConversationSnapshot(null, conversationId),
     }),

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -138,6 +138,13 @@ describe('useAgentChannelMultiplayer', () => {
       ...overrides,
     });
 
+    // Dispatch is entry-gated (hasEntry): a rendering surface always loads or
+    // seeds its conversation on mount, so the tests seed what a mounted pane
+    // would have.
+    beforeEach(() => {
+      useConversationMessagesStore.getState().seedConversation('conv-active');
+    });
+
     it('given OUR OWN stream finalizes for the active conversation, the synthesized assistant message should be committed to the conversation cache', () => {
       pendingStreams.current = new Map([[ 'msg-done', streamFixture({}) ]]);
 
@@ -206,10 +213,10 @@ describe('useAgentChannelMultiplayer', () => {
       ]);
     });
 
-    it('given a stream finalizes for a DIFFERENT conversation, nothing should be committed to the active conversation', () => {
+    it('given a stream finalizes for an UNCACHED conversation, nothing should be committed anywhere (no surface renders it; its eventual loader fetches the DB truth)', () => {
       pendingStreams.current = new Map([[ 'msg-stale', streamFixture({
         messageId: 'msg-stale',
-        conversationId: 'conv-different',
+        conversationId: 'conv-uncached',
       }) ]]);
 
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
@@ -219,7 +226,31 @@ describe('useAgentChannelMultiplayer', () => {
       });
 
       expect(cacheMessages('conv-active')).toEqual([]);
-      expect(cacheMessages('conv-different')).toEqual([]);
+      expect(cacheMessages('conv-uncached')).toEqual([]);
+    });
+
+    // THE pane multiplayer fix: dispatch is by the EVENT's conversation, so a
+    // completion for a CACHED sibling conversation (another pane on this same
+    // channel) commits into that sibling — the old single-active-conversation
+    // gate silently dropped it, vanishing the reply in the sibling pane.
+    it("given a stream finalizes for a CACHED sibling conversation (another pane), it should commit into the SIBLING's cache entry", () => {
+      useConversationMessagesStore.getState().seedConversation('conv-sibling-pane');
+      pendingStreams.current = new Map([[ 'msg-sibling', streamFixture({
+        messageId: 'msg-sibling',
+        conversationId: 'conv-sibling-pane',
+        isOwn: false,
+      }) ]]);
+
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-sibling');
+      });
+
+      expect(cacheMessages('conv-active')).toEqual([]);
+      expect(cacheMessages('conv-sibling-pane')).toEqual([
+        { id: 'msg-sibling', role: 'assistant', parts: [{ type: 'text', text: 'final response text' }], status: 'complete' },
+      ]);
     });
 
     it('given a completion with NO usable store entry for the active conversation (joinFailed / zero parts), should reload via the RAW cache loader — never the surface loadConversation, which also sets identity and pushes the URL', () => {
@@ -324,6 +355,11 @@ describe('useAgentChannelMultiplayer', () => {
       triggeredBy: { userId: 'other', displayName: 'Other', browserSessionId: 'sess-x' },
     });
 
+    // Same entry-gated dispatch as completions: seed what a mounted pane would have.
+    beforeEach(() => {
+      useConversationMessagesStore.getState().seedConversation('conv-active');
+    });
+
     it('given onUserMessage fires for the active agent conversation, should append the message to its cache entry', () => {
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
 
@@ -334,14 +370,31 @@ describe('useAgentChannelMultiplayer', () => {
       expect(cacheMessages('conv-active')).toEqual([remoteUser]);
     });
 
-    it('given onUserMessage fires for a different conversationId, should not write the active cache entry', () => {
+    it('given onUserMessage fires for an UNCACHED conversationId, should write nothing anywhere', () => {
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
 
       act(() => {
-        capturedChannel.options?.onUserMessage?.(remoteUser, payloadFor('conv-different'));
+        capturedChannel.options?.onUserMessage?.(remoteUser, payloadFor('conv-uncached'));
       });
 
       expect(cacheMessages('conv-active')).toEqual([]);
+      expect(cacheMessages('conv-uncached')).toEqual([]);
+    });
+
+    // The pane multiplayer gap this PR closes for non-completion events too: a
+    // collaborator's message in a CACHED sibling conversation (another pane on
+    // this channel) must land in that sibling's entry, not be dropped for not
+    // being "the" active conversation.
+    it("given onUserMessage fires for a CACHED sibling conversation, should append to the SIBLING's cache entry", () => {
+      useConversationMessagesStore.getState().seedConversation('conv-sibling-pane');
+      renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
+
+      act(() => {
+        capturedChannel.options?.onUserMessage?.(remoteUser, payloadFor('conv-sibling-pane'));
+      });
+
+      expect(cacheMessages('conv-active')).toEqual([]);
+      expect(cacheMessages('conv-sibling-pane')).toEqual([remoteUser]);
     });
 
     it('given onUserMessage fires twice for the same id (co-mounted surfaces both deliver), the append should be idempotent', () => {

--- a/apps/web/src/hooks/conversationCacheSocketHandlers.ts
+++ b/apps/web/src/hooks/conversationCacheSocketHandlers.ts
@@ -6,8 +6,6 @@ import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnCo
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 
 export interface ConversationCacheHandlerDeps {
-  /** The conversation currently on screen — read at event time (a ref-backed getter, never a stale closure). */
-  getActiveConversationId: () => string | null;
   /**
    * Generation-guarded cache reload for a conversation whose completion left no
    * usable store entry (SSE join failed / zero parts) — the reply IS durably
@@ -28,6 +26,18 @@ export interface ConversationCacheHandlerDeps {
  * handlers: it additionally dual-writes into its useChat transport, which
  * neither of these subscribers can reach.
  *
+ * DISPATCH IS BY THE EVENT'S CONVERSATION, not a subscriber-supplied "active"
+ * one. A single active-conversation gate assumed each subscriber watches one
+ * conversation — panes broke that: several conversations on one channel are
+ * on screen at once, none of them the subscriber's "active" one, and every
+ * event for them was silently dropped (replies vanishing on completion,
+ * collaborator messages/edits/deletes never appearing). An event now applies
+ * to whichever conversation it names, gated only on that conversation having
+ * a real cache entry (`hasEntry`): every rendering surface loads or seeds its
+ * conversation on mount, so cached ⇔ some surface can render it — and a
+ * conversation nobody has cached needs no cache write (the DB row is the
+ * truth its eventual loader will fetch).
+ *
  * The user/edit/delete handlers fire only for a REMOTE tab's action
  * (useChannelStreamSocket drops own-tab events via isOwnStream before
  * invoking) — the local user's own edit/delete/send is written by the
@@ -36,37 +46,32 @@ export interface ConversationCacheHandlerDeps {
  * same event twice is harmless by construction.
  */
 export const buildConversationCacheHandlers = ({
-  getActiveConversationId,
   reloadConversation,
   refreshSnapshot,
 }: ConversationCacheHandlerDeps) => ({
   onUserMessage: (message: UIMessage, payload: { conversationId: string }) => {
-    const conversationId = getActiveConversationId();
-    if (payload.conversationId !== conversationId || !conversationId) return;
-    conversationMessagesActions.applyRemoteUserMessage(conversationId, message);
+    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
+    conversationMessagesActions.applyRemoteUserMessage(payload.conversationId, message);
   },
 
   onMessageEdited: (payload: { messageId: string; conversationId: string; parts: UIMessage['parts']; editedAt: string }) => {
-    const conversationId = getActiveConversationId();
-    if (payload.conversationId !== conversationId || !conversationId) return;
+    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
     const editPayload: MessageEditPayload = {
       messageId: payload.messageId,
       parts: payload.parts,
       editedAt: new Date(payload.editedAt),
     };
-    conversationMessagesActions.applyEdit(conversationId, editPayload);
+    conversationMessagesActions.applyEdit(payload.conversationId, editPayload);
   },
 
   onMessageDeleted: (payload: { messageId: string; conversationId: string }) => {
-    const conversationId = getActiveConversationId();
-    if (payload.conversationId !== conversationId || !conversationId) return;
-    conversationMessagesActions.applyDelete(conversationId, payload.messageId);
+    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
+    conversationMessagesActions.applyDelete(payload.conversationId, payload.messageId);
   },
 
   onStreamComplete: (messageId: string, completedConvId?: string, _info?: { joinFailed: boolean }, aborted?: boolean) => {
-    const conversationId = getActiveConversationId();
     const stream = getActiveStreamById(messageId);
-    if (stream && stream.parts.length > 0 && stream.conversationId === conversationId) {
+    if (stream && stream.parts.length > 0 && conversationMessagesActions.hasEntry(stream.conversationId)) {
       // COMMIT by id — upsert, never skip. An existing row under this id may be a
       // half-streamed includeStreaming placeholder that must be overwritten, and for
       // OWN streams the mirror removes the pending entry the instant status changes —
@@ -100,6 +105,9 @@ export const buildConversationCacheHandlers = ({
     // persisted — reload the conversation's cache entry rather than losing it.
     // Unless the sender's own onFinish already committed the final row
     // (buildOwnStreamCommitOnFinish) — then a reload only adds a loading flip.
+    const conversationCached = completedConvId
+      ? conversationMessagesActions.hasEntry(completedConvId)
+      : false;
     const cacheHasFinalMessage = completedConvId
       ? conversationMessagesActions
           .getEntry(completedConvId)
@@ -109,7 +117,7 @@ export const buildConversationCacheHandlers = ({
               (m as UIMessage & { status?: string }).status !== 'streaming',
           )
       : false;
-    if (shouldReloadOnComountComplete(stream, completedConvId, conversationId, cacheHasFinalMessage)) {
+    if (shouldReloadOnComountComplete(stream, completedConvId, conversationCached, cacheHasFinalMessage)) {
       void reloadConversation(completedConvId!);
     }
   },

--- a/apps/web/src/hooks/conversationMessagesActions.ts
+++ b/apps/web/src/hooks/conversationMessagesActions.ts
@@ -32,6 +32,9 @@ export const conversationMessagesActions = {
   /** Imperative snapshot read of a conversation's cache entry (defaults when never seen). */
   getEntry: (conversationId: string): ConversationCacheEntry =>
     useConversationMessagesStore.getState().getEntry(conversationId),
+  /** True when the conversation has a REAL cache entry (loaded/seeded/sent this session) — see the store docblock. */
+  hasEntry: (conversationId: string): boolean =>
+    useConversationMessagesStore.getState().hasEntry(conversationId),
   /** Marks a "load older" fetch in flight (epic leaf 6.6) — inline indicator, no generation change. */
   startLoadingOlder: (conversationId: string): void =>
     useConversationMessagesStore.getState().startLoadingOlder(conversationId),

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -58,24 +58,20 @@ export function useAgentChannelMultiplayer({
 
   usePageSocketRoom(channelId);
 
-  // Stable ref so the hook's callbacks see the latest conversation id without
-  // re-binding the socket subscription on every render.
-  const agentConversationIdRef = useRef(agentConversationId);
-  agentConversationIdRef.current = agentConversationId;
-
   // NO STOP-SLOT CLAIM PROTOCOL (PR 5A, leaf 5.5.7) — every surface READS
   // `useConversationActiveStream(agentId, conversationId)`, and a read cannot be declined.
 
   // The shared socket-events → cache protocol (see buildConversationCacheHandlers):
   // remote user/edit/delete writes, and the completion commit with own-send
-  // promotion + background snapshot heal. Cache reloads here use the RAW loaders
-  // keyed by the channel (agent page id) — never the surface's loadConversation,
-  // which also sets identity and pushes the URL; a completion for the conversation
-  // already on screen must not do either.
+  // promotion + background snapshot heal. Events dispatch on THEIR OWN
+  // conversation id (any cached conversation on this channel), so panes showing
+  // sibling conversations receive them too. Cache reloads here use the RAW
+  // loaders keyed by the channel (agent page id) — never the surface's
+  // loadConversation, which also sets identity and pushes the URL; a completion
+  // for a conversation already on screen must not do either.
   const cacheHandlers = useMemo(
     () =>
       buildConversationCacheHandlers({
-        getActiveConversationId: () => agentConversationIdRef.current,
         reloadConversation: (conversationId) => {
           if (channelId) void loadAgentConversationMessages(channelId, conversationId);
         },

--- a/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
@@ -13,38 +13,34 @@ const makeStream = (overrides: Partial<PendingStream> = {}): PendingStream => ({
 });
 
 describe('shouldReloadOnComountComplete', () => {
-  it('given no pending stream and matching conversationId, should return true', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz', false)).toBe(true);
+  it('given no pending stream and a cached conversation, should return true', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', true, false)).toBe(true);
   });
 
-  it('given a pending stream with parts and matching conversationId, should return false', () => {
+  it('given a pending stream with parts, should return false (the commit branch owns it)', () => {
     const stream = makeStream({ conversationId: 'conv-xyz' });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', false)).toBe(false);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', true, false)).toBe(false);
   });
 
   it('given a pending stream with no parts, should return true (treat as missing)', () => {
     const stream = makeStream({ parts: [] });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', false)).toBe(true);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', true, false)).toBe(true);
   });
 
-  it('given completedConvId does not match active conversation, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-other', 'conv-xyz', false)).toBe(false);
+  it('given the completed conversation has no cache entry, should return false (nothing renders it; its eventual loader fetches the DB truth)', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', false, false)).toBe(false);
   });
 
   it('given completedConvId is undefined, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, undefined, 'conv-xyz', false)).toBe(false);
-  });
-
-  it('given activeConversationId is null, should return false', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', null, false)).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, undefined, true, false)).toBe(false);
   });
 
   it('given the cache already holds the final message, should return false (local onFinish commit landed first)', () => {
-    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz', true)).toBe(false);
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', true, true)).toBe(false);
   });
 
   it('given the cache holds the final message and a zero-parts stream entry, should still return false', () => {
     const stream = makeStream({ parts: [] });
-    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz', true)).toBe(false);
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', true, true)).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
+++ b/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
@@ -1,17 +1,20 @@
 import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
-// Returns true when a co-mounted surface should reload from DB to sync after a same-session stream completes.
+// Returns true when a surface should reload from DB to sync after a same-session stream completes.
+// `conversationCached`: the completed conversation has a real cache entry (some surface rendered it
+// this session) — dispatch is by the EVENT's conversation, so this replaces the old single
+// "active conversation" equality gate; an uncached conversation needs no reload (its eventual
+// loader fetches the DB truth anyway).
 // `cacheHasFinalMessage`: the completed message already sits in the conversation cache as a
 // non-streaming row (the sender's own onFinish commit — see buildOwnStreamCommitOnFinish), so a
 // full reload would only add a loading flip for content the cache already holds.
 export function shouldReloadOnComountComplete(
   stream: PendingStream | undefined,
   completedConvId: string | undefined,
-  activeConversationId: string | null,
+  conversationCached: boolean,
   cacheHasFinalMessage: boolean,
 ): boolean {
-  if (!completedConvId || !activeConversationId) return false;
-  if (completedConvId !== activeConversationId) return false;
+  if (!completedConvId || !conversationCached) return false;
   if (cacheHasFinalMessage) return false;
   if (stream && stream.parts.length > 0) return false;
   return true;

--- a/apps/web/src/stores/useConversationMessagesStore.ts
+++ b/apps/web/src/stores/useConversationMessagesStore.ts
@@ -22,6 +22,13 @@ export type { ConversationCacheEntry, ConversationMessagesById };
 interface ConversationMessagesState {
   byConversationId: ConversationMessagesById;
   getEntry: (conversationId: string) => ConversationCacheEntry;
+  /**
+   * True when the conversation has a real cache entry — i.e. some surface has
+   * loaded/seeded/sent in it this session. `getEntry` cannot answer this (it
+   * returns a synthetic empty entry for never-seen ids); socket-event dispatch
+   * keys on this to route an event to any cached conversation, active or not.
+   */
+  hasEntry: (conversationId: string) => boolean;
   startLoad: (conversationId: string) => number;
   /** True while `generation` is still the newest `startLoad` result for `conversationId`. */
   isLoadCurrent: (conversationId: string, generation: number) => boolean;
@@ -87,6 +94,8 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
   byConversationId: {},
 
   getEntry: (conversationId) => get().byConversationId[conversationId] ?? seedEmpty(),
+
+  hasEntry: (conversationId) => conversationId in get().byConversationId,
 
   startLoad: (conversationId) => {
     const { byConversationId, generation } = applyStartLoad(get().byConversationId, conversationId);


### PR DESCRIPTION
Stacked on #2320 (Part 2 of the pane streaming fixes — merge that first; this PR's base is its branch).

## Problem

`buildConversationCacheHandlers` gated every socket event — completions, remote user messages, edits, deletes — on a subscriber-supplied single "active" conversation (`getActiveConversationId`). That assumption predates panes: with several conversations from one channel on screen at once, none of them is the subscriber's "active" one, so every event for them was silently dropped. Concretely:

- Assistant panes never received collaborator messages, edits, or deletes (GlobalChatProvider's active id is the dashboard/sidebar's).
- Completions for a pane's conversation were dropped unless it happened to be "the" conversation — including when switching panes mid-stream.

## Fix

Dispatch on the **event's** `conversationId`, gated only on that conversation having a real cache entry:

- New `hasEntry(conversationId)` on `useConversationMessagesStore` (+ facade): true when some surface loaded/seeded/sent in the conversation this session. `getEntry` can't answer this — it returns a synthetic empty entry for never-seen ids.
- All four handlers apply to the event's conversation when cached; an uncached conversation gets no write (nothing renders it, and its eventual loader fetches the DB truth).
- `shouldReloadOnComountComplete`: the active-id equality param becomes a `conversationCached` gate (keeps the Part 1 `cacheHasFinalMessage` suppression).
- Both subscribers (`GlobalChatContext`, `useAgentChannelMultiplayer`) drop the `getActiveConversationId` dep; their reconnect-refresh and undo logic (genuinely scoped to the visible conversation) is untouched.

Safety: every cache action was already an idempotent append-if-absent/upsert-by-id (the documented co-mounted-subscriber contract), so event-based dispatch adds no double-apply hazard. Writes to cached-but-closed conversations are bounded by session-opened conversations and keep their caches fresh for reopening.

## Tests

- `useAgentChannelMultiplayer.test.ts`: handler tests now seed the entry a mounted pane would have; new cases prove the new capability (completion and remote user message land in a CACHED sibling conversation's entry) and the guard (uncached conversation → no write anywhere).
- `shouldReloadOnComountComplete.test.ts` updated for the new signature.
- Full adjacent sweep green: 883 tests / 57 files (stores, channel socket, session chat hooks, GlobalChatContext, dual-stream handoff), `tsc --noEmit` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9U2h8MF1d5UkiBUTFxAfu