### PR TITLE
fix(agents): pane UI — sidebar page rows, xterm css, agent split-not-replace, reload persistence

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -16,6 +16,17 @@ svg.lucide {
   stroke-width: 1.5;
 }
 
+/* Backstop for xterm's containing blocks (the real sheet is imported by
+   XtermTerminal.tsx). xterm's selection/viewport/helper layers are
+   `position: absolute` against these two elements; if the vendor import is
+   ever lost again (it happened once, when its previous host component was
+   deleted), a text selection in one terminal pane paints its highlight into
+   whichever ancestor happens to be positioned — visually, a different pane. */
+.xterm,
+.xterm .xterm-screen {
+  position: relative;
+}
+
 /* ---------------------------------------------------------------------------
    Hover-revealed controls on touch devices.
 

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -10,7 +10,6 @@ import { panesOf } from '@/stores/agent-workspace/pane-reducer';
 import { useLatestRef } from '@/hooks/useLatestRef';
 import { useSessionRecord } from './useSessionRecord';
 import AgentPanes from './panes/AgentPanes';
-import EmptyState from './EmptyState';
 import AgentsPastConversationsList from './AgentsPastConversationsList';
 import AgentsListHeader from './AgentsListHeader';
 
@@ -155,17 +154,27 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
 
   return (
     <div className="flex h-full flex-col">
-      {selectedSessionId && selectedConversationId ? (
+      {selectedSessionId ? (
         sessionDriveResolved ? (
+          // A session selection alone mounts the grid — the conversation is
+          // the SEED, not a precondition. A session can be page- or
+          // terminal-only now (the sidebar's page rows select a session and
+          // focus a pane, with no conversation to name), and `AgentPanes`
+          // accepts a null `initialConversation` for exactly that: it
+          // renders the stored/hydrated grid and seeds nothing.
           <AgentPanes
             key={selectedSessionId}
             sessionId={selectedSessionId}
             driveId={sessionDriveId}
-            initialConversation={{
-              conversationId: selectedConversationId,
-              agentPageId: selectedAgentId,
-              name: 'Conversation',
-            }}
+            initialConversation={
+              selectedConversationId
+                ? {
+                    conversationId: selectedConversationId,
+                    agentPageId: selectedAgentId,
+                    name: 'Conversation',
+                  }
+                : null
+            }
             onSessionEnded={() => selectSession(null)}
             onConversationClosed={handleConversationClosed}
           />
@@ -174,15 +183,6 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
             <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden="true" />
           </div>
         )
-      ) : selectedSessionId ? (
-        // A session is selected but its opening conversation has not resolved
-        // from the URL (a hand-trimmed link). The sidebar's session rows always
-        // write both, so this is the degenerate-deep-link case, not a step in
-        // the normal flow.
-        <EmptyState
-          title="Pick a conversation"
-          description="This session's conversations are listed under it in the sidebar."
-        />
       ) : (
         // Keyed by drive: this surface's own `driveId` prop CAN change on an
         // already-mounted instance (switching drives while staying on the

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../panes/AgentPanes', () => ({
   }: {
     sessionId: string;
     driveId: string | null;
-    initialConversation: { conversationId: string; agentPageId: string | null };
+    initialConversation: { conversationId: string; agentPageId: string | null } | null;
     onConversationClosed?: (event: { conversationId: string; next: string | null; nextAgentPageId: string | null }) => void;
   }) {
     // Captured ONCE, on this component's first render — models the closure a
@@ -48,13 +48,16 @@ vi.mock('../panes/AgentPanes', () => ({
     const staleOnConversationClosed = useRef(onConversationClosed).current;
     return (
       <div data-testid="agent-panes" data-drive-id={driveId ?? 'none'}>
-        {sessionId}/{initialConversation.conversationId}/{initialConversation.agentPageId ?? 'no-agent'}
+        {sessionId}/
+        {initialConversation
+          ? `${initialConversation.conversationId}/${initialConversation.agentPageId ?? 'no-agent'}`
+          : 'no-conversation'}
         <button
           type="button"
           data-testid="fire-conversation-closed-rebind"
           onClick={() =>
             onConversationClosed?.({
-              conversationId: initialConversation.conversationId,
+              conversationId: initialConversation?.conversationId ?? 'conv-none',
               next: 'conv-next',
               nextAgentPageId: 'agent-next',
             })
@@ -64,7 +67,7 @@ vi.mock('../panes/AgentPanes', () => ({
           type="button"
           data-testid="fire-conversation-closed-no-rebind"
           onClick={() =>
-            onConversationClosed?.({ conversationId: initialConversation.conversationId, next: null, nextAgentPageId: null })
+            onConversationClosed?.({ conversationId: initialConversation?.conversationId ?? 'conv-none', next: null, nextAgentPageId: null })
           }
         />
         <button
@@ -199,14 +202,15 @@ describe('AgentsSurface', () => {
     expect(screen.getByText('Select a session')).toBeDefined();
   });
 
-  test('a session with no conversation is the degenerate deep link, not the grid', () => {
-    // The sidebar always writes session AND conversation together; only a
-    // hand-trimmed URL lands here. It must render a prompt, never a
-    // speculative pane grid for a conversation that isn't named.
+  test('a session with no conversation still mounts the grid, with nothing to seed', () => {
+    // A session can be page- or terminal-only now: the sidebar's page rows
+    // select a session WITHOUT naming a conversation (there is none to
+    // name), and a hand-trimmed deep link does the same. The grid mounts
+    // and renders whatever the store/hydration holds; a null
+    // `initialConversation` seeds nothing.
     window.history.replaceState({}, '', '/dashboard/agents?session=ses-1');
     render(<AgentsSurface />);
-    expect(screen.getByText('Pick a conversation')).toBeDefined();
-    expect(screen.queryByTestId('agent-panes')).toBeNull();
+    expect(screen.getByTestId('agent-panes')).toHaveTextContent('ses-1/no-conversation');
   });
 
   test('renders the pane grid, keyed by the session, once a conversation is selected', () => {

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -88,9 +88,12 @@ export interface AgentPanesProps {
   driveId: string | null;
   /**
    * The session's FIRST conversation, used once to seed the opening pane (a
-   * session is born with one — the grid never starts on a picker).
+   * session is born with one — the grid never starts on a picker). Null for
+   * a session-only selection (a page/terminal row in the sidebar, a
+   * conversation-less deep link): there is nothing to seed or assert, the
+   * grid renders whatever the store/hydration holds.
    */
-  initialConversation: { conversationId: string; agentPageId: string | null; name: string };
+  initialConversation: { conversationId: string; agentPageId: string | null; name: string } | null;
   /** Fired after the last pane closed and the session was ended — the host owns what renders next. */
   onSessionEnded?: () => void;
   /**
@@ -394,6 +397,10 @@ export default function AgentPanes({
   // session it focuses the pane already showing the thread, or opens it in a
   // non-terminal pane — the store owns that policy (`openConversation`).
   useEffect(() => {
+    // Session-only selection (no conversation named): nothing to seed or
+    // assert — the grid is whatever the store already holds or server
+    // hydration seats.
+    if (!initialConversation) return;
     const workspace = useAgentWorkspaceStore.getState().workspaces[sessionId];
     // A brand-new grid (`ensureWorkspace`'s fast path) or a target that's
     // already showing (`openConversation`'s own focus path) never reaches
@@ -438,7 +445,7 @@ export default function AgentPanes({
     // re-runs (on that flip), the closure it runs with already has the
     // matching, up-to-date value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, initialConversation.conversationId, openConversation, sessionKnownToConversationsCache]);
+  }, [sessionId, initialConversation?.conversationId, openConversation, sessionKnownToConversationsCache]);
 
   // Ending the session: peeked, confirmed, and gated on the server (findings
   // 1 + 2). `pendingEndClose` carries the pane and its scope from the PEEK,
@@ -1478,10 +1485,20 @@ export default function AgentPanes({
   );
 
   if (!workspace) {
-    // The openConversation effect seeds the grid on the next tick.
+    // With a conversation to seed, the openConversation effect creates the
+    // grid on the next tick — the spinner is a single-frame state. A
+    // session-only selection has nothing to seed locally; until
+    // `useWorkspaceServerSync`'s hydration seats a saved grid (if one
+    // exists), point at the sidebar rather than spin forever.
     return (
       <div className="flex h-full items-center justify-center">
-        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        {initialConversation ? (
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            This session&apos;s conversations are listed under it in the sidebar.
+          </p>
+        )}
       </div>
     );
   }

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1586,7 +1586,7 @@ export default function AgentPanes({
           ) : surface.surface === 'page' ? (
             <PagePaneView pageId={surface.pageId} />
           ) : surface.surface === 'terminal' ? (
-            <Shell shellId={surface.shellId} name={pane.scope?.name} />
+            <Shell key={surface.shellId} shellId={surface.shellId} name={pane.scope?.name} />
           ) : null}
         </div>
       </div>

--- a/apps/web/src/components/agents/shell/XtermTerminal.tsx
+++ b/apps/web/src/components/agents/shell/XtermTerminal.tsx
@@ -22,6 +22,15 @@
 import { useEffect, useRef } from 'react';
 import type { Socket } from 'socket.io-client';
 import type { Terminal as XtermTerminalInstance } from '@xterm/xterm';
+// Not cosmetic: xterm's overlay layers (selection, viewport, helper textarea,
+// char-measure) are positioned absolute and rely on this sheet making
+// `.xterm`/`.xterm-screen` their containing block. Without it the selection
+// highlight paints relative to the nearest positioned ANCESTOR — i.e. into a
+// different pane — and cell measurement/scrolling break. This import was lost
+// once already when its previous host (`MachineView`) was deleted; it lives
+// here now, beside the only `Terminal` construction site (a `position:
+// relative` backstop also exists in `globals.css`).
+import '@xterm/xterm/css/xterm.css';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useXtermTheme } from '@/hooks/useXtermTheme';
 import { getCssVar } from '@/lib/theme/css-color-resolution';
@@ -356,9 +365,10 @@ export default function XtermTerminal({ socket, shellId, initialInput, onInitial
           return !!el && el.offsetParent !== null && el.clientWidth > 0 && el.clientHeight > 0;
         };
 
-        const resize: { observer?: ResizeObserver } = {};
+        const resize: { observer?: ResizeObserver; raf?: number } = {};
         teardown = () => {
           resize.observer?.disconnect();
+          if (resize.raf !== undefined) cancelAnimationFrame(resize.raf);
           // The pending write is cancelled, but the prompt is NOT spent: this shell
           // may be going away only for a moment (StrictMode remounts it in
           // development; a tab switch remounts it later), and the agent it
@@ -397,11 +407,20 @@ export default function XtermTerminal({ socket, shellId, initialInput, onInitial
         if (socket.connected) handleSocketConnect();
 
         resize.observer = new ResizeObserver(() => {
-          // Skip while hidden (0×0) — avoids garbage fits and 0-wide resizes.
-          // Fires again with correct dims when the shell is re-shown.
-          if (!isVisible()) return;
-          fitAddon.fit();
-          socket.emit('shell:resize', { cols: terminal.cols, rows: terminal.rows, connectionId });
+          // Coalesce to one fit per frame: dragging a pane's ResizableHandle
+          // streams observations, and each fit() + shell:resize is real work
+          // for the renderer AND a PTY round-trip. The trailing frame always
+          // runs, so the final geometry is never skipped.
+          if (resize.raf !== undefined) return;
+          resize.raf = requestAnimationFrame(() => {
+            resize.raf = undefined;
+            // Skip while hidden (0×0) — avoids garbage fits and 0-wide
+            // resizes. Fires again with correct dims when the shell is
+            // re-shown.
+            if (!isVisible()) return;
+            fitAddon.fit();
+            socket.emit('shell:resize', { cols: terminal.cols, rows: terminal.rows, connectionId });
+          });
         });
         resize.observer.observe(containerRef.current!);
 

--- a/apps/web/src/components/agents/shell/__tests__/XtermTerminal.test.tsx
+++ b/apps/web/src/components/agents/shell/__tests__/XtermTerminal.test.tsx
@@ -45,6 +45,9 @@ vi.mock('@xterm/addon-fit', () => ({
     dispose() {}
   },
 }));
+// The component statically imports xterm's stylesheet; there is nothing to
+// test in it and vitest shouldn't spend a PostCSS pass on it.
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
 vi.mock('@/hooks/useXtermTheme', () => ({ useXtermTheme: () => ({}) }));
 /** Stable across calls (unlike a fresh `vi.fn()` per `getState()`) so tests can
  * assert on endEditing — the dead-shell leak fix needs it to see across events. */

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { ChevronDown, ChevronRight, Folder, Plus, Search, SquareTerminal, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, FileText, Folder, Plus, Search, SquareTerminal, X } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { useSWRConfig } from 'swr';
 
@@ -470,6 +470,8 @@ function SessionRow({
   const hydrateWorkspace = useAgentWorkspaceStore((state) => state.hydrateWorkspace);
   const resetPane = useAgentWorkspaceStore((state) => state.resetPane);
   const assignPane = useAgentWorkspaceStore((state) => state.assignPane);
+  const selectPane = useAgentWorkspaceStore((state) => state.selectPane);
+  const closePane = useAgentWorkspaceStore((state) => state.closePane);
   const [expanded, setExpanded] = useState(false);
   const [confirmingEnd, setConfirmingEnd] = useState(false);
   const isSelected = selectedSessionId === session.sessionId;
@@ -542,6 +544,17 @@ function SessionRow({
         openConversation(conversationEntryForTarget(chatPane.scope.targetId, chatPane.scope.agentPageId));
         return;
       }
+      // No chat pane at all — a page-only grid still opens on its work:
+      // focus the active page pane (or the first one) rather than falling
+      // through and re-seeding a conversation over it.
+      const pagePane =
+        (activePane?.scope?.kind === 'page' && activePane.scope.targetId ? activePane : undefined) ??
+        panes.find((p) => p.scope?.kind === 'page' && p.scope.targetId !== null);
+      if (pagePane) {
+        selectSession(session.sessionId);
+        selectPane(session.sessionId, pagePane.id);
+        return;
+      }
     }
     const first = session.conversations[0];
     if (first) {
@@ -550,7 +563,7 @@ function SessionRow({
     }
     const firstShell = session.shells[0];
     if (firstShell) openShell(firstShell);
-  }, [openConversation, openShell, conversationEntryForTarget, session.workspace, session.conversations, session.shells]);
+  }, [openConversation, openShell, conversationEntryForTarget, selectSession, selectPane, session.sessionId, session.workspace, session.conversations, session.shells]);
 
   const endSession = useCallback(async () => {
     // Snapshot for rollback, then assume success immediately — the row must
@@ -744,10 +757,11 @@ function SessionRow({
     [],
   );
 
-  // Only chat panes address a conversation — a terminal/page/still-unbound
-  // pane has nothing to show here (shells get their own section below,
-  // unchanged). `null` when this session has no saved grid yet, so the
-  // render falls back to the flat `session.conversations` list.
+  // Only chat panes address a conversation — a terminal/still-unbound pane
+  // has nothing to show here (shells get their own section below,
+  // unchanged; page panes get their own rows via `pagePanes`). `null` when
+  // this session has no saved grid yet, so the render falls back to the
+  // flat `session.conversations` list.
   const chatPanes = useMemo(
     () =>
       session.workspace
@@ -757,6 +771,49 @@ function SessionRow({
           )
         : null,
     [session.workspace],
+  );
+
+  // Page panes are server-persisted workspace artifacts exactly like chat
+  // panes, so a session's expansion lists them too — a document or task
+  // page opened into the grid (by the picker or by an agent's
+  // `open_page_pane`) was invisible here before, unlike every other pane.
+  // Terminal panes are deliberately NOT listed from the grid: the
+  // `session.shells` section below already covers them, and a second row
+  // per shell would double-list.
+  const pagePanes = useMemo(
+    () =>
+      session.workspace
+        ? panesOf(session.workspace).filter(
+            (pane): pane is PaneState & { scope: { kind: 'page'; targetId: string; name: string } } =>
+              pane.scope?.kind === 'page' && pane.scope.targetId !== null,
+          )
+        : [],
+    [session.workspace],
+  );
+
+  const openPagePane = useCallback(
+    (paneId: string) => {
+      // A page pane has no conversation to select — focus the session and
+      // the existing pane in its grid directly.
+      selectSession(session.sessionId);
+      selectPane(session.sessionId, paneId);
+    },
+    [selectSession, selectPane, session.sessionId],
+  );
+
+  const closePagePane = useCallback(
+    (paneId: string) => {
+      const workspace = useAgentWorkspaceStore.getState().workspaces[session.sessionId];
+      // Closing the LAST pane empties the session, which ends it — route
+      // through the same confirm dialog the chat path's 409 raises rather
+      // than tearing the sandbox down from an innocuous-looking row action.
+      if (workspace && isLastPane(workspace, paneId)) {
+        setConfirmingEnd(true);
+        return;
+      }
+      closePane(session.sessionId, paneId);
+    },
+    [closePane, session.sessionId],
   );
 
   return (
@@ -845,6 +902,30 @@ function SessionRow({
                   </button>
                 </RowMenu>
               ))}
+          {pagePanes.map((pane) => (
+            <RowMenu
+              key={pane.id}
+              items={[
+                {
+                  label: 'Close',
+                  icon: X,
+                  onSelect: () => closePagePane(pane.id),
+                  destructive: true,
+                },
+              ]}
+              menuLabel="Page pane actions"
+              className="gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                onClick={() => openPagePane(pane.id)}
+              >
+                <FileText className="size-3 shrink-0" aria-hidden="true" />
+                <span className="truncate">{pane.scope.name}</span>
+              </button>
+            </RowMenu>
+          ))}
           {session.shells.map((shell) => (
             <button
               key={shell.shellId}
@@ -856,7 +937,7 @@ function SessionRow({
               <span className="truncate">{shell.name}</span>
             </button>
           ))}
-          {(chatPanes ?? session.conversations).length === 0 && (
+          {(chatPanes ?? session.conversations).length === 0 && pagePanes.length === 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">No conversations</div>
           )}
         </div>

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -24,7 +24,9 @@ import { canManageDrive } from '@/hooks/usePermissions';
 import { usePageAgents, type DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
 import { useAgentSurfaceStore, SHEET_BREAKPOINT_QUERY } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+import { adoptServerWorkspaceAsHydrated } from '@/stores/agent-workspace/useWorkspaceServerSync';
 import { panesOf, isLastPane, type PaneState } from '@/stores/agent-workspace/pane-reducer';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { fetchWithAuth, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import type { PersistedWorkspaceState } from '@pagespace/lib/agent-sessions/contract';
 import {
@@ -508,12 +510,21 @@ function SessionRow({
   // A row action can target a session that is NOT currently displayed — for
   // it, `AgentPanes` (and the `useWorkspaceServerSync` it mounts) is not
   // rendered, so the local store may have never seen its grid. Seat this
-  // row's own server-listing snapshot first, never overwriting a grid the
-  // store already holds (which is always at least as fresh). Returns
-  // whatever the store holds afterwards.
+  // row's own server-listing snapshot first. Never overwrite a grid the
+  // store already holds: it isn't necessarily fresher (zustand `persist`
+  // rehydrates every session's grid from localStorage at page load, which
+  // another tab or device may have since moved past — see `closePagePane`'s
+  // stale-row guard), but clobbering it here could just as easily destroy a
+  // NEWER local grid. Returns whatever the store holds afterwards.
   const ensureLocalWorkspace = useCallback(() => {
     if (!useAgentWorkspaceStore.getState().workspaces[session.sessionId] && session.workspace) {
       hydrateWorkspace(session.sessionId, session.workspace);
+      // The snapshot IS server state (this row was rendered from the
+      // listing), so it counts as this page load's hydration — without
+      // this, the sync hook's own mount-time GET lands server-wins one
+      // round-trip after the click and silently drops the very mutation
+      // the click makes (the pane focus, a freshly opened shell pane).
+      adoptServerWorkspaceAsHydrated(session.sessionId);
     }
     return useAgentWorkspaceStore.getState().workspaces[session.sessionId];
   }, [hydrateWorkspace, session.sessionId, session.workspace]);
@@ -834,7 +845,16 @@ function SessionRow({
         setConfirmingEnd(true);
         return;
       }
-      closePane(session.sessionId, paneId);
+      // Anything but 'closed' means the LOCAL grid didn't know this pane —
+      // the row (rendered from the server listing) and the store (possibly
+      // a stale localStorage rehydrate another tab has moved past) diverge.
+      // PUTting the local grid wholesale from here would clobber the
+      // server's newer layout with an unrelated one AND leave the clicked
+      // pane alive; refresh the listing instead and let it reconcile.
+      if (closePane(session.sessionId, paneId) !== 'closed') {
+        void mutate(isAgentSessionsKey);
+        return;
+      }
       const updated = useAgentWorkspaceStore.getState().workspaces[session.sessionId];
       if (!updated) return;
       // Persist the close directly: `useWorkspaceServerSync` only observes
@@ -842,7 +862,11 @@ function SessionRow({
       // would otherwise reach Zustand/localStorage only and be resurrected
       // by server-wins hydration the next time that session opens. When the
       // session IS the displayed one, the sync hook debounce-PUTs the same
-      // grid — an idempotent duplicate, not a conflict.
+      // grid — an idempotent duplicate, not a conflict. Registered with
+      // `useEditingStore` for the PUT's duration, same as the sync hook's
+      // own `performSave` — the repo's refresh-protection rule.
+      const editingId = `sidebar-pane-close:${session.sessionId}:${paneId}`;
+      useEditingStore.getState().startEditing(editingId, 'other', { componentName: 'sidebar-pane-close' });
       try {
         const response = await fetchWithAuth(
           `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/workspace`,
@@ -857,13 +881,20 @@ function SessionRow({
         // without waiting for the next poll.
         void mutate(isAgentSessionsKey);
       } catch (error) {
+        // The close already landed locally; a failed PUT leaves the pane
+        // alive on the server (and every other device), silently diverging
+        // until hydration resurrects it. Restore the row's own snapshot so
+        // what the user sees matches what is actually durable, then say so.
+        if (session.workspace) hydrateWorkspace(session.sessionId, session.workspace);
         console.error('Failed to close this pane:', error);
         toast.error('Could not close this pane', {
           description: error instanceof Error ? error.message : 'Please try again.',
         });
+      } finally {
+        useEditingStore.getState().endEditing(editingId);
       }
     },
-    [ensureLocalWorkspace, closePane, mutate, session.sessionId],
+    [ensureLocalWorkspace, closePane, hydrateWorkspace, mutate, session.sessionId, session.workspace],
   );
 
   return (

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -505,8 +505,25 @@ function SessionRow({
     [session.conversations],
   );
 
+  // A row action can target a session that is NOT currently displayed — for
+  // it, `AgentPanes` (and the `useWorkspaceServerSync` it mounts) is not
+  // rendered, so the local store may have never seen its grid. Seat this
+  // row's own server-listing snapshot first, never overwriting a grid the
+  // store already holds (which is always at least as fresh). Returns
+  // whatever the store holds afterwards.
+  const ensureLocalWorkspace = useCallback(() => {
+    if (!useAgentWorkspaceStore.getState().workspaces[session.sessionId] && session.workspace) {
+      hydrateWorkspace(session.sessionId, session.workspace);
+    }
+    return useAgentWorkspaceStore.getState().workspaces[session.sessionId];
+  }, [hydrateWorkspace, session.sessionId, session.workspace]);
+
   const openShell = useCallback(
     (shell: { shellId: string; name: string }) => {
+      // Seat the saved grid first, so the shell opens INTO it — without
+      // this, a click on a non-displayed session's shell row would mint a
+      // fresh one-pane grid that server-wins hydration then overwrites.
+      ensureLocalWorkspace();
       selectSession(session.sessionId);
       // `session.conversations` is this row's own already-resolved live
       // listing (the row couldn't exist here otherwise) — protects a chat
@@ -523,7 +540,7 @@ function SessionRow({
         { liveConversationIds: new Set(session.conversations.map((c) => c.conversationId)) },
       );
     },
-    [selectSession, session.sessionId, session.conversations],
+    [ensureLocalWorkspace, selectSession, session.sessionId, session.conversations],
   );
 
   const openSession = useCallback(() => {
@@ -551,6 +568,7 @@ function SessionRow({
         (activePane?.scope?.kind === 'page' && activePane.scope.targetId ? activePane : undefined) ??
         panes.find((p) => p.scope?.kind === 'page' && p.scope.targetId !== null);
       if (pagePane) {
+        ensureLocalWorkspace();
         selectSession(session.sessionId);
         selectPane(session.sessionId, pagePane.id);
         return;
@@ -563,7 +581,7 @@ function SessionRow({
     }
     const firstShell = session.shells[0];
     if (firstShell) openShell(firstShell);
-  }, [openConversation, openShell, conversationEntryForTarget, selectSession, selectPane, session.sessionId, session.workspace, session.conversations, session.shells]);
+  }, [openConversation, openShell, conversationEntryForTarget, ensureLocalWorkspace, selectSession, selectPane, session.sessionId, session.workspace, session.conversations, session.shells]);
 
   const endSession = useCallback(async () => {
     // Snapshot for rollback, then assume success immediately — the row must
@@ -794,26 +812,58 @@ function SessionRow({
   const openPagePane = useCallback(
     (paneId: string) => {
       // A page pane has no conversation to select — focus the session and
-      // the existing pane in its grid directly.
+      // the existing pane in its grid. The grid must be seated locally
+      // BEFORE `selectPane`, which no-ops on a session the store has never
+      // seen (hydration normally runs inside the very `AgentPanes` this
+      // click is mounting).
+      ensureLocalWorkspace();
       selectSession(session.sessionId);
       selectPane(session.sessionId, paneId);
     },
-    [selectSession, selectPane, session.sessionId],
+    [ensureLocalWorkspace, selectSession, selectPane, session.sessionId],
   );
 
   const closePagePane = useCallback(
-    (paneId: string) => {
-      const workspace = useAgentWorkspaceStore.getState().workspaces[session.sessionId];
+    async (paneId: string) => {
+      const workspace = ensureLocalWorkspace();
+      if (!workspace) return;
       // Closing the LAST pane empties the session, which ends it — route
       // through the same confirm dialog the chat path's 409 raises rather
       // than tearing the sandbox down from an innocuous-looking row action.
-      if (workspace && isLastPane(workspace, paneId)) {
+      if (isLastPane(workspace, paneId)) {
         setConfirmingEnd(true);
         return;
       }
       closePane(session.sessionId, paneId);
+      const updated = useAgentWorkspaceStore.getState().workspaces[session.sessionId];
+      if (!updated) return;
+      // Persist the close directly: `useWorkspaceServerSync` only observes
+      // the session AgentPanes is displaying, so a close on any OTHER row
+      // would otherwise reach Zustand/localStorage only and be resurrected
+      // by server-wins hydration the next time that session opens. When the
+      // session IS the displayed one, the sync hook debounce-PUTs the same
+      // grid — an idempotent duplicate, not a conflict.
+      try {
+        const response = await fetchWithAuth(
+          `/api/agent-sessions/${encodeURIComponent(session.sessionId)}/workspace`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspace: updated }),
+          },
+        );
+        if (!response.ok) throw new Error(`Failed to save the session layout (${response.status})`);
+        // Refresh the listing so this row's pane list reflects the close
+        // without waiting for the next poll.
+        void mutate(isAgentSessionsKey);
+      } catch (error) {
+        console.error('Failed to close this pane:', error);
+        toast.error('Could not close this pane', {
+          description: error instanceof Error ? error.message : 'Please try again.',
+        });
+      }
     },
-    [closePane, session.sessionId],
+    [ensureLocalWorkspace, closePane, mutate, session.sessionId],
   );
 
   return (
@@ -909,7 +959,7 @@ function SessionRow({
                 {
                   label: 'Close',
                   icon: X,
-                  onSelect: () => closePagePane(pane.id),
+                  onSelect: () => void closePagePane(pane.id),
                   destructive: true,
                 },
               ]}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -335,7 +335,12 @@ describe('AgentsSidebar', () => {
       expect(screen.getByText('Spec doc')).toBeDefined();
     });
 
-    test('clicking a page pane row focuses the session and that pane in the grid', async () => {
+    test('clicking a page pane row focuses the session and that pane, seating the grid from the row\'s own listing', async () => {
+      // Deliberately NO local grid: the session isn't the displayed one, so
+      // `AgentPanes`/`useWorkspaceServerSync` never hydrated it. The click
+      // must seat the row's own server-listing snapshot before focusing —
+      // `selectPane` no-ops on a session the store has never seen (review
+      // P1, chatgpt-codex-connector).
       const withPagePane = {
         ...workspaceFixture,
         columns: [
@@ -348,9 +353,6 @@ describe('AgentsSidebar', () => {
           },
         ],
       };
-      act(() => {
-        useAgentWorkspaceStore.getState().hydrateWorkspace('ses-1', withPagePane as WorkspaceState);
-      });
       respondWithSessions([{ ...SESSION, workspace: withPagePane }]);
       const user = userEvent.setup();
       renderSidebar();
@@ -360,6 +362,82 @@ describe('AgentsSidebar', () => {
 
       expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
       expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId).toBe('pane-3');
+    });
+
+    test('closing a page pane row persists the close to the server — the sync hook only covers the displayed session (review P1)', async () => {
+      const withPagePane = {
+        ...workspaceFixture,
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              ...workspaceFixture.columns[0].panes,
+              { id: 'pane-3', scope: { kind: 'page', name: 'Spec doc', targetId: 'page-1', agentPageId: null } },
+            ],
+          },
+        ],
+      };
+      respondWithSessions([{ ...SESSION, workspace: withPagePane }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Spec doc'));
+      await user.click(await screen.findByText('Close'));
+
+      // The local grid dropped the pane…
+      await waitFor(() => {
+        const panes = useAgentWorkspaceStore
+          .getState()
+          .workspaces['ses-1'].columns.flatMap((c) => c.panes);
+        expect(panes.find((p) => p.scope?.targetId === 'page-1')).toBeUndefined();
+      });
+      // …and the close was PUT to the server, not left to a sync hook that
+      // isn't mounted for a non-displayed session.
+      await waitFor(() => {
+        const putCall = mockFetchWithAuth.mock.calls.find(
+          ([url, init]) =>
+            url === '/api/agent-sessions/ses-1/workspace' &&
+            (init as RequestInit | undefined)?.method === 'PUT',
+        );
+        expect(putCall).toBeDefined();
+        const body = JSON.parse((putCall![1] as RequestInit).body as string) as {
+          workspace: WorkspaceState;
+        };
+        const putPanes = body.workspace.columns.flatMap((c) => c.panes);
+        expect(putPanes.find((p) => p.scope?.targetId === 'page-1')).toBeUndefined();
+        expect(putPanes).toHaveLength(2);
+      });
+    });
+
+    test('closing the LAST pane via a page row asks to end the session instead of silently tearing it down', async () => {
+      const pageOnlyWorkspace = {
+        id: 'ses-1',
+        columns: [
+          {
+            id: 'col-1',
+            panes: [{ id: 'pane-1', scope: { kind: 'page', name: 'Spec doc', targetId: 'page-1', agentPageId: null } }],
+          },
+        ],
+        activePaneId: 'pane-1',
+        pendingPickerPaneId: null,
+      };
+      respondWithSessions([{ ...SESSION, conversations: [], workspace: pageOnlyWorkspace }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Spec doc'));
+      await user.click(await screen.findByText('Close'));
+
+      // The end-session confirm opened; nothing was closed or PUT yet.
+      expect(await screen.findByText(/end session/i)).toBeDefined();
+      const putCall = mockFetchWithAuth.mock.calls.find(
+        ([url, init]) =>
+          url === '/api/agent-sessions/ses-1/workspace' &&
+          (init as RequestInit | undefined)?.method === 'PUT',
+      );
+      expect(putCall).toBeUndefined();
     });
 
     test('selecting a session with a saved grid opens the ACTIVE pane\'s own conversation', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -410,6 +410,92 @@ describe('AgentsSidebar', () => {
       });
     });
 
+    test('closing a row the local store no longer knows refreshes the listing instead of clobbering the server', async () => {
+      // The store holds a DIFFERENT grid for ses-1 with no page pane —
+      // zustand persist rehydrates every session's grid from localStorage
+      // at page load, and another tab/device may have moved past this
+      // row's snapshot. A wholesale PUT of that grid would overwrite the
+      // server's newer layout AND leave the clicked pane alive (review P2).
+      act(() => {
+        useAgentWorkspaceStore.getState().hydrateWorkspace('ses-1', {
+          id: 'ses-1',
+          columns: [
+            {
+              id: 'col-9',
+              panes: [{ id: 'pane-9', scope: { kind: 'chat', name: 'Conversation', targetId: 'conv-9', agentPageId: null } }],
+            },
+          ],
+          activePaneId: 'pane-9',
+          pendingPickerPaneId: null,
+        } as WorkspaceState);
+      });
+      const withPagePane = {
+        ...workspaceFixture,
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              ...workspaceFixture.columns[0].panes,
+              { id: 'pane-3', scope: { kind: 'page', name: 'Spec doc', targetId: 'page-1', agentPageId: null } },
+            ],
+          },
+        ],
+      };
+      respondWithSessions([{ ...SESSION, workspace: withPagePane }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Spec doc'));
+      await user.click(await screen.findByText('Close'));
+
+      await waitFor(() => {
+        // The listing was asked to refresh… (the GET listing call count grows)
+        expect(mockFetchWithAuth.mock.calls.length).toBeGreaterThan(1);
+      });
+      // …but nothing was PUT, and the local grid is untouched.
+      const putCall = mockFetchWithAuth.mock.calls.find(
+        ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
+      );
+      expect(putCall).toBeUndefined();
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId).toBe('pane-9');
+    });
+
+    test('a failed close-PUT restores the row snapshot locally and surfaces an error', async () => {
+      const withPagePane = {
+        ...workspaceFixture,
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              ...workspaceFixture.columns[0].panes,
+              { id: 'pane-3', scope: { kind: 'page', name: 'Spec doc', targetId: 'page-1', agentPageId: null } },
+            ],
+          },
+        ],
+      };
+      mockFetchWithAuth.mockImplementation(async (...args: unknown[]) => {
+        const init = args[1] as RequestInit | undefined;
+        if (init?.method === 'PUT') return { ok: false, status: 500, json: async () => ({}) };
+        return { ok: true, json: async () => ({ sessions: [{ ...SESSION, workspace: withPagePane }] }) };
+      });
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Spec doc'));
+      await user.click(await screen.findByText('Close'));
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+      // The close landed locally, the PUT failed — the local grid must be
+      // restored to the durable (server) state rather than silently
+      // diverging until hydration resurrects the pane (review P3).
+      const panes = useAgentWorkspaceStore
+        .getState()
+        .workspaces['ses-1'].columns.flatMap((c) => c.panes);
+      expect(panes.find((p) => p.scope?.targetId === 'page-1')).toBeDefined();
+    });
+
     test('closing the LAST pane via a page row asks to end the session instead of silently tearing it down', async () => {
       const pageOnlyWorkspace = {
         id: 'ses-1',

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -310,6 +310,58 @@ describe('AgentsSidebar', () => {
       expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-2');
     });
 
+    test('lists a PAGE pane as its own row, labeled by the page title', async () => {
+      // A document/task page opened into the grid (picker or an agent's
+      // `open_page_pane`) is a persisted pane like any other — it must not
+      // be invisible in the sidebar while chat panes and shells are listed.
+      const withPagePane = {
+        ...workspaceFixture,
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              ...workspaceFixture.columns[0].panes,
+              { id: 'pane-3', scope: { kind: 'page', name: 'Spec doc', targetId: 'page-1', agentPageId: null } },
+            ],
+          },
+        ],
+      };
+      respondWithSessions([{ ...SESSION, workspace: withPagePane }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('Spec doc')).toBeDefined();
+    });
+
+    test('clicking a page pane row focuses the session and that pane in the grid', async () => {
+      const withPagePane = {
+        ...workspaceFixture,
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              ...workspaceFixture.columns[0].panes,
+              { id: 'pane-3', scope: { kind: 'page', name: 'Spec doc', targetId: 'page-1', agentPageId: null } },
+            ],
+          },
+        ],
+      };
+      act(() => {
+        useAgentWorkspaceStore.getState().hydrateWorkspace('ses-1', withPagePane as WorkspaceState);
+      });
+      respondWithSessions([{ ...SESSION, workspace: withPagePane }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      await user.click(await screen.findByText('Spec doc'));
+
+      expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1'].activePaneId).toBe('pane-3');
+    });
+
     test('selecting a session with a saved grid opens the ACTIVE pane\'s own conversation', async () => {
       respondWithSessions([{ ...SESSION, workspace: workspaceFixture }]);
       const user = userEvent.setup();

--- a/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useOpenPagePane.ts
@@ -28,8 +28,11 @@ interface OpenPagePaneToolPart {
  * conversation's OWN pane must never be the one the tool call replaces — a
  * pane grid with only this one chat pane open would otherwise satisfy
  * `focusOrAssignScope`'s "replaceable" check and evict the very conversation
- * that just asked to show its work, which is backwards. The store instead
- * splits a new pane beside it.
+ * that just asked to show its work, which is backwards. `preferSplit` goes
+ * further, for every OTHER pane: an agent opening a page is adding a
+ * surface beside what the user is doing, never navigating the user's panes,
+ * so nothing bound is ever evicted — the store fills an unbound picker pane
+ * if one exists, and otherwise splits a new pane.
  */
 export function useOpenPagePane({
   sessionId,
@@ -93,7 +96,7 @@ export function useOpenPagePane({
           targetId: toolPart.output.pageId,
           agentPageId: null,
         },
-        { excludeTargetId: conversationId },
+        { excludeTargetId: conversationId, preferSplit: true },
       );
     }
   }, [sessionId, conversationId, messages]);

--- a/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/useAgentWorkspaceStore.test.ts
@@ -400,19 +400,106 @@ describe('openPage — the page-pane sibling of openConversation', () => {
     expect(panes.find((p) => p.scope?.targetId === 'page-1')).toBeDefined();
   });
 
-  it('still replaces a DIFFERENT replaceable pane when excludeTargetId only protects the invoker', () => {
+  it('with preferSplit, never evicts ANY bound pane — the agent path splits beside the user\'s panes', () => {
+    // The shape from the bug report: agent in conv-1 opens a page while the
+    // user is looking at a different page pane. The old policy replaced that
+    // active pane; the agent path must add a surface, not navigate one.
     store().ensureWorkspace('ses-1', conv('conv-1'));
     const chatPane = panesOf(grid())[0];
     store().splitRight('ses-1', chatPane.id);
     const otherPane = panesOf(grid()).find((p) => p.id !== chatPane.id)!;
     store().assignPane('ses-1', otherPane.id, page('page-1'));
 
-    store().openPage('ses-1', page('page-2'), { excludeTargetId: 'conv-1' });
+    store().openPage('ses-1', page('page-2'), { excludeTargetId: 'conv-1', preferSplit: true });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(3);
+    expect(panes.find((p) => p.id === chatPane.id)?.scope?.targetId).toBe('conv-1');
+    expect(panes.find((p) => p.id === otherPane.id)?.scope?.targetId).toBe('page-1');
+    expect(panes.find((p) => p.scope?.targetId === 'page-2')).toBeDefined();
+  });
+
+  it('with preferSplit, fills an unbound picker pane rather than splitting a fourth one', () => {
+    store().ensureWorkspace('ses-1', conv('conv-1'));
+    const chatPane = panesOf(grid())[0];
+    store().splitRight('ses-1', chatPane.id);
+    const pickerPane = panesOf(grid()).find((p) => p.id !== chatPane.id)!;
+    expect(pickerPane.scope).toBeNull();
+
+    store().openPage('ses-1', page('page-1'), { excludeTargetId: 'conv-1', preferSplit: true });
 
     const panes = panesOf(grid());
     expect(panes).toHaveLength(2);
-    expect(panes.find((p) => p.id === chatPane.id)?.scope?.targetId).toBe('conv-1');
-    expect(panes.find((p) => p.id === otherPane.id)?.scope?.targetId).toBe('page-2');
+    expect(panes.find((p) => p.id === pickerPane.id)?.scope?.targetId).toBe('page-1');
+  });
+
+  it('with preferSplit, still focuses the pane already showing the page instead of duplicating it', () => {
+    store().ensureWorkspace('ses-1', conv('conv-1'));
+    const chatPane = panesOf(grid())[0];
+    store().splitRight('ses-1', chatPane.id);
+    const pagePane = panesOf(grid()).find((p) => p.id !== chatPane.id)!;
+    store().assignPane('ses-1', pagePane.id, page('page-1'));
+    store().selectPane('ses-1', chatPane.id);
+
+    store().openPage('ses-1', page('page-1'), { excludeTargetId: 'conv-1', preferSplit: true });
+
+    expect(panesOf(grid())).toHaveLength(2);
+    expect(grid().activePaneId).toBe(pagePane.id);
+  });
+});
+
+describe('openConversation must not evict a page pane — the reload-seed shape', () => {
+  const page = (targetId: string, name = 'Doc'): PaneScope => ({
+    kind: 'page',
+    name,
+    targetId,
+    agentPageId: null,
+  });
+  const conv = (targetId: string, name = 'Thread'): PaneScope => ({
+    kind: 'chat',
+    name,
+    targetId,
+    agentPageId: 'agent-1',
+  });
+
+  it('with liveConversationIds supplied, a page pane splits rather than being replaced', () => {
+    // The refresh path: the persisted grid holds only an agent-opened page
+    // pane (its chat pane was replaced pre-fix, or closed); the mount-time
+    // seed re-asserts the URL-selected conversation. The page pane is a
+    // deliberate, persisted artifact — the seed must open BESIDE it, or an
+    // agent-opened page silently vanishes on every reload.
+    store().openPage('ses-1', page('page-1'));
+    const pagePane = panesOf(grid())[0];
+
+    store().openConversation('ses-1', conv('conv-1'), { liveConversationIds: new Set(['conv-1']) });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === pagePane.id)?.scope?.targetId).toBe('page-1');
+    expect(panes.find((p) => p.scope?.targetId === 'conv-1')).toBeDefined();
+  });
+
+  it('with liveConversationIds supplied, an unbound picker pane is still fillable', () => {
+    store().openConversation('ses-1', conv('conv-1'));
+    store().splitRight('ses-1', panesOf(grid())[0].id);
+    const pickerPane = panesOf(grid()).find((p) => p.scope === null)!;
+
+    store().openConversation('ses-1', conv('conv-2'), { liveConversationIds: new Set(['conv-1', 'conv-2']) });
+
+    const panes = panesOf(grid());
+    expect(panes).toHaveLength(2);
+    expect(panes.find((p) => p.id === pickerPane.id)?.scope?.targetId).toBe('conv-2');
+  });
+
+  it('without liveConversationIds, a page pane remains replaceable — user selection behavior unchanged', () => {
+    store().openPage('ses-1', page('page-1'));
+    const paneId = panesOf(grid())[0].id;
+
+    store().openConversation('ses-1', conv('conv-1'));
+
+    expect(panesOf(grid())).toHaveLength(1);
+    expect(panesOf(grid())[0].id).toBe(paneId);
+    expect(panesOf(grid())[0].scope?.targetId).toBe('conv-1');
   });
 });
 

--- a/apps/web/src/stores/agent-workspace/__tests__/useWorkspaceServerSync.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/useWorkspaceServerSync.test.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
-import { useWorkspaceServerSync, __resetHydratedSessionsForTests } from '../useWorkspaceServerSync';
+import {
+  useWorkspaceServerSync,
+  adoptServerWorkspaceAsHydrated,
+  __resetHydratedSessionsForTests,
+} from '../useWorkspaceServerSync';
 import { useAgentWorkspaceStore } from '../useAgentWorkspaceStore';
 
 vi.mock('@/lib/auth/auth-fetch', () => ({
@@ -146,6 +150,20 @@ describe('hydration', () => {
     await waitFor(() => expect(getCalls()).toHaveLength(2));
   });
 
+  it('a session adopted from a server listing snapshot is not re-fetched on mount', async () => {
+    // The sidebar seats a row's own listing snapshot (server state) before
+    // acting on it and marks it adopted — the hook's own GET would land
+    // server-wins one round-trip after the click and silently drop the
+    // click's mutation (review P2). Adopted = hydrated for this page load.
+    store().ensureWorkspace('ses-1', scope());
+    adoptServerWorkspaceAsHydrated('ses-1');
+
+    renderHook(() => useWorkspaceServerSync('ses-1'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getCalls()).toHaveLength(0);
+  });
+
   it('a hydration cancelled by unmount before it resolves is retried on the next mount', async () => {
     store().ensureWorkspace('ses-1', scope());
     let resolveFetch!: (value: unknown) => void;
@@ -249,6 +267,100 @@ describe('debounced save', () => {
 
     const putCalls = mockFetch.mock.calls.filter((c) => c[1]?.method === 'PUT');
     expect(putCalls).toHaveLength(0);
+  });
+});
+
+describe('the hydration latch is by reference, not a boolean', () => {
+  it('hydration clears a pending pre-hydration save — the unmount flush must not resurrect the overwritten grid', async () => {
+    // The stale-flush race: a mutation goes pending, THEN hydration lands
+    // and server-wins over it. A boolean latch left `pendingRef` holding the
+    // pre-hydration grid, so the unmount flush PUT stale local state back
+    // over what the server (and now the store) actually holds.
+    store().ensureWorkspace('ses-1', scope());
+    let resolveFetch!: (value: unknown) => void;
+    mockFetch.mockReturnValueOnce(new Promise((resolve) => { resolveFetch = resolve; }));
+
+    const { unmount } = renderHook(() => useWorkspaceServerSync('ses-1', { debounceMs: 60_000 }));
+
+    act(() => {
+      store().splitRight('ses-1', grid().activePaneId);
+    });
+
+    const saved = {
+      id: 'ses-1',
+      columns: [{ id: 'col-x', panes: [{ id: 'pane-x', scope: scope('conv-saved') }] }],
+      activePaneId: 'pane-x',
+      pendingPickerPaneId: null,
+    };
+    await act(async () => {
+      resolveFetch({ ok: true, json: () => Promise.resolve({ workspace: saved }) });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(grid()).toEqual(saved);
+
+    unmount();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The pre-hydration split was discarded by design (server wins on first
+    // load); nothing may PUT it back.
+    expect(mockFetch.mock.calls.filter((c) => c[1]?.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('does not redundantly PUT when hydration had to normalize a dangling activePaneId', async () => {
+    // `hydrateWorkspace` normalizes a saved grid whose activePaneId names
+    // no real pane into a NEW object — the latch must track what the store
+    // actually holds, or the very next debounce tick PUTs the server's own
+    // grid straight back (review P3).
+    vi.useFakeTimers();
+    store().ensureWorkspace('ses-1', scope());
+    const saved = {
+      id: 'ses-1',
+      columns: [{ id: 'col-x', panes: [{ id: 'pane-x', scope: scope('conv-saved') }] }],
+      activePaneId: 'ghost',
+      pendingPickerPaneId: null,
+    };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ workspace: saved }) });
+
+    renderHook(() => useWorkspaceServerSync('ses-1', { debounceMs: 1000 }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(grid().activePaneId).toBe('pane-x');
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(mockFetch.mock.calls.filter((c) => c[1]?.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('a mutation AFTER hydration still saves — the skip is one-shot for exactly the hydrated grid', async () => {
+    store().ensureWorkspace('ses-1', scope());
+    const saved = {
+      id: 'ses-1',
+      columns: [{ id: 'col-x', panes: [{ id: 'pane-x', scope: scope('conv-saved') }] }],
+      activePaneId: 'pane-x',
+      pendingPickerPaneId: null,
+    };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ workspace: saved }) });
+
+    const { unmount } = renderHook(() => useWorkspaceServerSync('ses-1', { debounceMs: 60_000 }));
+    await waitFor(() => expect(grid()).toEqual(saved));
+
+    act(() => {
+      store().splitRight('ses-1', 'pane-x');
+    });
+    const latest = grid();
+
+    unmount();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const putCalls = mockFetch.mock.calls.filter((c) => c[1]?.method === 'PUT');
+    expect(putCalls).toHaveLength(1);
+    expect(JSON.parse(putCalls[0][1].body as string).workspace).toEqual(latest);
   });
 });
 

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -61,11 +61,13 @@ interface AgentWorkspaceState {
    *
    * `options.liveConversationIds`, when supplied, additionally protects a
    * chat pane whose target is NOT in that set — e.g. a conversation the user
-   * closed out of this session (`closedInSessionAt`) — from being silently
-   * evicted by an unrelated later selection (issue #2295); it falls through
-   * to the split fallback instead, exactly like a terminal/dirty pane does.
-   * Omitted (any caller that hasn't learned the live set yet), behavior is
-   * unchanged — this guard is strictly additive.
+   * closed out of this session (`closedInSessionAt`) — AND any page pane (a
+   * deliberate, persisted artifact; a reload's seed effect used to silently
+   * evict agent-opened pages this way) from an unrelated later selection
+   * (issue #2295); both fall through to the split fallback instead, exactly
+   * like a terminal/dirty pane does. Omitted (any caller that hasn't
+   * learned the live set yet), behavior is unchanged — this guard is
+   * strictly additive.
    */
   openConversation(
     sessionId: string,
@@ -82,8 +84,18 @@ interface AgentWorkspaceState {
    * conversation's own id, for the agent-driven `open_page_pane` path) is
    * never replaced either — both fall through to a split instead. Used by
    * the picker's "Pages" section and by `useOpenPagePane`'s resolution.
+   *
+   * `options.preferSplit` (the agent-driven path): an agent opening a page
+   * is ADDING a surface beside what the user is doing, not navigating —
+   * with it set, no bound pane is ever evicted; only an unbound picker pane
+   * may be filled, and otherwise the grid splits. Without it (a user pick),
+   * the replace policy is unchanged: the user asked to see the page HERE.
    */
-  openPage(sessionId: string, scope: PaneScope, options?: { excludeTargetId?: string }): void;
+  openPage(
+    sessionId: string,
+    scope: PaneScope,
+    options?: { excludeTargetId?: string; preferSplit?: boolean },
+  ): void;
   splitRight(sessionId: string, fromPaneId: string): void;
   splitDown(sessionId: string, fromPaneId: string): void;
   /**
@@ -183,7 +195,11 @@ function focusOrAssignScope(
   set: (fn: (state: AgentWorkspaceState) => Partial<AgentWorkspaceState>) => void,
   sessionId: string,
   scope: PaneScope,
-  options?: { excludeTargetId?: string; liveConversationIds?: ReadonlySet<string> },
+  options?: {
+    excludeTargetId?: string;
+    liveConversationIds?: ReadonlySet<string>;
+    preferSplit?: boolean;
+  },
 ) {
   const state = useAgentWorkspaceStore.getState();
   const workspace = state.workspaces[sessionId];
@@ -210,20 +226,25 @@ function focusOrAssignScope(
   // `open_page_pane` tool's own invoking conversation must never be evicted
   // by its own tool call; it should get a split beside it instead). Also
   // excluded when the caller passed `liveConversationIds` (only
-  // `openConversation` ever does): a CHAT pane whose target is not in that
-  // live set — a conversation closed out of this session — must never be
-  // silently overwritten by an unrelated later selection (issue #2295).
-  // Scoped to `kind === 'chat'` deliberately: a page pane is a different
-  // domain concept already governed by `isPaneDirty`/`excludeTargetId`, and
-  // `openPage` never supplies this option, so its call sites are unaffected.
+  // `openConversation` ever does, from the selection/mount-seed paths): a
+  // BOUND pane whose scope is not a live chat — a conversation closed out
+  // of this session (issue #2295), or a PAGE pane, a deliberate persisted
+  // artifact a conversation selection has no business evicting (a reload's
+  // seed effect used to eat agent-opened page panes this way) — must never
+  // be silently overwritten by an unrelated later selection; both fall
+  // through to the split fallback instead, exactly like a terminal. And
+  // excluded wholesale under `preferSplit` (the agent-driven `openPage`
+  // path): an agent adds a surface, it never navigates the user's panes,
+  // so only an unbound picker pane may be filled.
   const isReplaceable = (pane: PaneState) =>
     (pane.scope === null || (pane.scope.kind !== 'terminal' && pane.scope.targetId !== null)) &&
     !isPaneDirty(pane) &&
     (options?.excludeTargetId === undefined || pane.scope?.targetId !== options.excludeTargetId) &&
+    (options?.preferSplit !== true || pane.scope === null) &&
     (options?.liveConversationIds === undefined ||
-      pane.scope?.kind !== 'chat' ||
-      pane.scope.targetId === null ||
-      options.liveConversationIds.has(pane.scope.targetId));
+      pane.scope === null ||
+      (pane.scope.kind === 'chat' &&
+        (pane.scope.targetId === null || options.liveConversationIds.has(pane.scope.targetId))));
   const replaceable = active && isReplaceable(active) ? active : panes.find(isReplaceable);
   if (replaceable) {
     state.assignPane(sessionId, replaceable.id, scope);

--- a/apps/web/src/stores/agent-workspace/useWorkspaceServerSync.ts
+++ b/apps/web/src/stores/agent-workspace/useWorkspaceServerSync.ts
@@ -44,6 +44,20 @@ export function __resetHydratedSessionsForTests(): void {
   hydratedSessionsThisPageLoad.clear();
 }
 
+/**
+ * The sidebar seats a session's grid from the server LISTING snapshot before
+ * acting on a row (`ensureLocalWorkspace`). That snapshot IS server state —
+ * so it counts as this page load's hydration. Without this, the hook's own
+ * mount-time GET lands server-wins one round-trip AFTER the row click's
+ * mutation (a pane focus, a freshly opened shell pane) and silently drops
+ * it — the reference latch rightly treats the hydrated grid as "nothing new
+ * to save", but the mutation it replaced is gone with it. Only call with a
+ * grid that genuinely came from the server, never a locally built one.
+ */
+export function adoptServerWorkspaceAsHydrated(sessionId: string): void {
+  hydratedSessionsThisPageLoad.add(sessionId);
+}
+
 export function useWorkspaceServerSync(
   sessionId: string,
   options?: { enabled?: boolean; debounceMs?: number },
@@ -145,8 +159,17 @@ export function useWorkspaceServerSync(
         if (!json?.workspace) return;
         const parsed = persistedWorkspaceStateSchema.safeParse(json.workspace);
         if (!parsed.success) return;
-        justHydratedRef.current = parsed.data;
+        const before = useAgentWorkspaceStore.getState().workspaces[sessionId];
         hydrateWorkspace(sessionId, parsed.data);
+        const stored = useAgentWorkspaceStore.getState().workspaces[sessionId];
+        // Latch what the store ACTUALLY holds, not `parsed.data`:
+        // `hydrateWorkspace` normalizes a dangling `activePaneId` into a
+        // NEW object, and latching the pre-normalization value would miss
+        // and debounce-PUT the server's own grid straight back — harmless
+        // but exactly the duplicate save this latch exists to prevent. A
+        // no-op hydration (id mismatch) stores nothing new: latch nothing,
+        // or a later unrelated effect run could wrongly skip a real save.
+        if (stored !== before) justHydratedRef.current = stored;
       })
       .catch(() => {});
 

--- a/apps/web/src/stores/agent-workspace/useWorkspaceServerSync.ts
+++ b/apps/web/src/stores/agent-workspace/useWorkspaceServerSync.ts
@@ -56,10 +56,15 @@ export function useWorkspaceServerSync(
 
   const pendingRef = useRef<WorkspaceState | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Set right before a hydration write, so the debounce effect's next run
-  // (triggered by that very write) knows there is nothing NEW to persist —
-  // the server is already holding exactly what was just written.
-  const justHydratedRef = useRef(false);
+  // Set to the exact grid object right before a hydration write, so the
+  // debounce effect's next run (triggered by that very write) knows there is
+  // nothing NEW to persist — the server is already holding exactly what was
+  // just written. Compared by REFERENCE, not a boolean latch: a genuine
+  // mutation that lands between the hydration write and the effect run
+  // produces a different object and must still be saved, where a boolean
+  // would swallow it (and leave a stale pre-hydration grid in `pendingRef`
+  // for the unmount flush to resurrect).
+  const justHydratedRef = useRef<WorkspaceState | null>(null);
   // A purely local identifier for `useEditingStore` bookkeeping — `useId()`,
   // not the domain `createId()` (`@paralleldrive/cuid2`): this is never a
   // conversation/session id, and sharing that generator would (and in
@@ -93,8 +98,11 @@ export function useWorkspaceServerSync(
   // Debounced save on every observed change.
   useEffect(() => {
     if (!enabled || !workspace) return;
-    if (justHydratedRef.current) {
-      justHydratedRef.current = false;
+    if (justHydratedRef.current === workspace) {
+      justHydratedRef.current = null;
+      // Server-wins: hydration replaced whatever was pending, so the unmount
+      // flush must not PUT the pre-hydration grid back over it.
+      pendingRef.current = null;
       return;
     }
     pendingRef.current = workspace;
@@ -137,7 +145,7 @@ export function useWorkspaceServerSync(
         if (!json?.workspace) return;
         const parsed = persistedWorkspaceStateSchema.safeParse(json.workspace);
         if (!parsed.success) return;
-        justHydratedRef.current = true;
+        justHydratedRef.current = parsed.data;
         hydrateWorkspace(sessionId, parsed.data);
       })
       .catch(() => {});


### PR DESCRIPTION
## Summary

Fixes four pane-UI bugs reported from live use of the agents console:

1. **Page/task panes were invisible in the left sidebar.** `AgentsSidebar` filtered the pane list to `kind === 'chat'` only (terminals appeared via the separate `session.shells` listing, so page panes rendered nowhere). Page panes now get their own rows — labeled by the page title already carried in `scope.name`, click focuses the session + pane, Close in the row menu (routed through the end-session confirm when it's the last pane). The "No conversations" empty state accounts for them, and `openSession` gained a page-pane fallback so a page-only grid opens on its work.

2. **Selecting text in a terminal highlighted a different pane.** `@xterm/xterm/css/xterm.css` was never imported — its only import lived in the deleted `MachineView.tsx` (`623e632e7`), and `XtermTerminal` was ported out without it. Without the sheet, `.xterm-screen` is `position: static`, so xterm's absolutely-positioned selection layer resolved its containing block up to `<main>` and painted at the top-left of the content area, unclipped by the pane. The same gap broke scrolling, cell measurement (wrong cols/rows to the PTY), and leaked the helper textarea into layout — much of "terminals break easily". Restored the import beside the only `Terminal` construction site, added a `position: relative` backstop in `globals.css` so the regression can't recur silently, keyed `<Shell>` by `shellId` per its documented contract, and coalesced ResizeObserver fits to one per frame.

3. **An agent-opened pane replaced the pane the user was viewing.** `focusOrAssignScope` prefers replacing the ACTIVE pane — right for a user selection, wrong for an agent adding a surface. `openPage` now takes `preferSplit` (passed by `useOpenPagePane`): no bound pane is ever evicted — an empty picker pane is filled, otherwise the grid splits. The test that codified the old behavior is rewritten to the new policy.

4. **The agent-opened pane vanished on refresh.** Downstream of (3): the pane WAS persisted, but the mount-time seed that re-asserts the URL-selected conversation treated page panes as freely replaceable, overwrote it on reload, and the debounced sync made the loss permanent. With `liveConversationIds` supplied (the seed/selection path), page panes are now protected exactly like terminals — the seed splits beside them. Also fixed the `useWorkspaceServerSync` hydration latch (boolean → reference comparison) so a mutation racing hydration is neither silently dropped nor clobbered by a stale unmount flush.

## Test plan

- [x] `useAgentWorkspaceStore` tests: 6 new cases (preferSplit split/picker-fill/focus, seed-path page protection, opt-in unchanged behavior) — 44 pass
- [x] `AgentsSidebar` tests: 2 new cases (page row listed by title, click focuses session + pane) — 61 pass
- [x] Shell/XtermTerminal (31), panes + AI hooks suites (258) pass
- [x] `tsc --noEmit` clean, `next lint` clean

Known follow-ups deliberately not in this PR (terminal fragility with more invasive fixes): History/Settings tab switch unmounts the grid and disconnects shells; crossing the 768px breakpoint remounts every pane; auth-refresh socket swap tears terminals down; dead shells have no reconnect affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013R2tVxF1EnfhnzDyFEBFH1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying, selecting, and closing persisted page panes in the Agents sidebar.
  * Agent-requested pages now open in available panes or new splits without replacing active panes.
* **Bug Fixes**
  * Improved terminal selection, resizing, and switching between shells.
  * Prevented workspace hydration from overwriting changes made during loading.
* **Usability**
  * Closing the final page pane now prompts before ending the session.
  * Existing page and chat panes are better preserved during workspace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up (d6e5211a4)

Both codex P1 findings addressed — the sidebar's page-row actions assumed the row's session was the one being displayed:

- **Cross-session open**: `AgentsSurface` now mounts the pane grid on a session selection alone (`initialConversation` is nullable in `AgentPanes`; a null seed asserts nothing). Sidebar row actions (`openPagePane`, `openSession`'s page branch, `openShell`) seat the row's own `session.workspace` listing snapshot into the store first, so `selectPane` focuses a real, visible grid.
- **Cross-session close**: `closePagePane` PUTs the updated grid to the workspace endpoint directly and revalidates the listing — the debounced sync hook only observes the *displayed* session, so a local-only close was resurrected by server-wins hydration. Last-pane closes route through the end-session confirm.

New/updated tests: sidebar page-row click with an empty local store, close-persists-PUT, last-pane-asks-to-end; AgentsSurface's "session with no conversation" test inverted to the new mount-the-grid contract.


## Hardening pass (92e764916)

An adversarial self-review over the branch surfaced five issues in the cross-session close/open paths, all fixed with regression tests:

- **Stale-grid PUT guard**: `closePagePane` bails (and refreshes the listing) when the local grid didn't know the pane — a stale localStorage rehydrate could otherwise be PUT wholesale over the server's newer layout.
- **Hydration race on first click**: seating a row's listing snapshot now counts as the page load's hydration (`adoptServerWorkspaceAsHydrated`), so the sync hook's mount GET no longer lands server-wins one round-trip after the click and drops its mutation.
- **Latch normalization miss**: the hydration latch captures the object the store actually stored (activePaneId normalization mints a new one), preventing a redundant PUT of the server's own grid.
- **Refresh-protection**: the direct close-PUT registers with `useEditingStore` like the sync hook's `performSave`.
- **Failure convergence**: a failed close-PUT restores the row's snapshot locally so visible state matches durable state.
