### PR TITLE
fix(task-list): reflow task list/kanban by pane width, not viewport

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskKanbanView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskKanbanView.tsx
@@ -508,13 +508,13 @@ export function TaskKanbanView({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div className="flex gap-4 p-4 h-full overflow-x-auto">
+      <div className="flex gap-4 p-4 h-full overflow-x-auto @container">
         {statusOrder.map((status) => {
           const cfg = statusConfigMap[status];
           return (
           <div
             key={status}
-            className="flex-shrink-0 w-72 flex flex-col"
+            className="flex-shrink-0 w-72 @max-[500px]:w-60 flex flex-col"
           >
             <ColumnHeader
               status={status}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1,5 +1,13 @@
 'use client';
 
+/**
+ * Pane-safe by design: layout-mode decisions (card vs. table, toolbar wrap)
+ * use `@container` + `@[Npx]:` variants keyed to this view's own rendered
+ * width, not viewport (`sm:`/`md:`/`lg:`) breakpoints — a pane can be narrow
+ * at any viewport width. Follow this pattern for any other page-view
+ * component that needs to reflow inside a resizable pane.
+ */
+
 import { useState, useEffect, useId, useRef, useCallback, memo, useMemo } from 'react';
 import { type Editor } from '@tiptap/react';
 import { useRouter } from 'next/navigation';
@@ -1035,7 +1043,7 @@ function TaskListView({ page }: TaskListViewProps) {
   }
 
   return (
-    <div className="flex flex-col h-full min-w-0">
+    <div className="flex flex-col h-full min-w-0 @container">
       <TaskListHeader
         pageId={page.id}
         viewMode={viewMode}
@@ -1053,8 +1061,8 @@ function TaskListView({ page }: TaskListViewProps) {
         />
       )}
       {/* Toolbar */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b bg-background">
-        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+      <div className="flex flex-col @[420px]:flex-row @[420px]:items-center @[420px]:justify-between gap-3 px-4 py-3 border-b bg-background">
+        <div className="flex flex-col @[420px]:flex-row @[420px]:items-center gap-2">
           {/* Filter tabs */}
           <div className="flex items-center bg-muted rounded-md p-0.5">
             {(['all', 'active', 'completed'] as const).map((f) => (
@@ -1062,7 +1070,7 @@ function TaskListView({ page }: TaskListViewProps) {
                 key={f}
                 onClick={() => setFilter(f)}
                 className={cn(
-                  'px-3 py-1.5 text-sm font-medium rounded transition-colors flex-1 sm:flex-none',
+                  'px-3 py-1.5 text-sm font-medium rounded transition-colors flex-1 @[420px]:flex-none',
                   filter === f
                     ? 'bg-background text-foreground shadow-sm'
                     : 'text-muted-foreground hover:text-foreground'
@@ -1081,13 +1089,13 @@ function TaskListView({ page }: TaskListViewProps) {
               placeholder="Filter tasks..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-9 w-full sm:w-48"
+              className="pl-9 w-full @[420px]:w-48"
             />
           </div>
         </div>
 
-        <div className="flex flex-col sm:flex-row sm:items-center gap-2 w-full sm:w-auto">
-          <div className="flex items-center gap-2 sm:contents">
+        <div className="flex flex-col @[420px]:flex-row @[420px]:items-center gap-2 w-full @[420px]:w-auto">
+          <div className="flex items-center gap-2 @[420px]:contents">
             {canEdit && (
               <StatusConfigManager
                 pageId={page.id}
@@ -1104,7 +1112,7 @@ function TaskListView({ page }: TaskListViewProps) {
                 onClick={() => setWorkflowsDialogOpen(true)}
               >
                 <Zap className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">Workflows</span>
+                <span className="hidden @[420px]:inline">Workflows</span>
               </Button>
             )}
           </div>
@@ -1112,7 +1120,7 @@ function TaskListView({ page }: TaskListViewProps) {
           {canEdit && viewMode === 'table' && (
             <Button
               size="sm"
-              className="w-full sm:w-auto"
+              className="w-full @[420px]:w-auto"
               onClick={() => {
                 const mobileInput = document.getElementById('new-task-input-mobile');
                 const desktopInput = document.getElementById('new-task-input');
@@ -1129,8 +1137,8 @@ function TaskListView({ page }: TaskListViewProps) {
         </div>
       </div>
 
-      {/* Mobile Card View */}
-      <div className="flex-1 overflow-auto md:hidden p-4 space-y-3">
+      {/* Narrow Card View */}
+      <div className="flex-1 overflow-auto @[700px]:hidden p-4 space-y-3">
         {filteredTasks.map((task) => (
           <div key={task.id} data-task-id={task.id}>
           <MobileTaskCard
@@ -1187,8 +1195,8 @@ function TaskListView({ page }: TaskListViewProps) {
         )}
       </div>
 
-      {/* Desktop View (Table or Kanban) */}
-      <div className="flex-1 overflow-auto hidden md:block">
+      {/* Wide View (Table or Kanban) */}
+      <div className="flex-1 overflow-auto hidden @[700px]:block">
         {viewMode === 'kanban' ? (
           <TaskKanbanView
             tasks={filteredTasks}
@@ -1482,9 +1490,9 @@ function TaskListView({ page }: TaskListViewProps) {
       </div>
 
       {/* Footer stats */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] border-t bg-muted/50 text-sm text-muted-foreground">
+      <div className="flex flex-col @[420px]:flex-row @[420px]:items-center @[420px]:justify-between gap-2 px-4 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] border-t bg-muted/50 text-sm text-muted-foreground">
         <span><strong>{data?.tasks.length || 0}</strong> tasks</span>
-        <span className="text-xs sm:text-sm">
+        <span className="text-xs @[420px]:text-sm">
           Updated {data?.taskList.updatedAt
             ? formatDistanceToNow(new Date(data.taskList.updatedAt), { addSuffix: true })
             : 'never'}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1061,8 +1061,8 @@ function TaskListView({ page }: TaskListViewProps) {
         />
       )}
       {/* Toolbar */}
-      <div className="flex flex-col @[420px]:flex-row @[420px]:items-center @[420px]:justify-between gap-3 px-4 py-3 border-b bg-background">
-        <div className="flex flex-col @[420px]:flex-row @[420px]:items-center gap-2">
+      <div className="flex flex-col @[700px]:flex-row @[700px]:flex-wrap @[700px]:items-center @[700px]:justify-between gap-3 px-4 py-3 border-b bg-background">
+        <div className="flex flex-col @[700px]:flex-row @[700px]:items-center gap-2">
           {/* Filter tabs */}
           <div className="flex items-center bg-muted rounded-md p-0.5">
             {(['all', 'active', 'completed'] as const).map((f) => (
@@ -1070,7 +1070,7 @@ function TaskListView({ page }: TaskListViewProps) {
                 key={f}
                 onClick={() => setFilter(f)}
                 className={cn(
-                  'px-3 py-1.5 text-sm font-medium rounded transition-colors flex-1 @[420px]:flex-none',
+                  'px-3 py-1.5 text-sm font-medium rounded transition-colors flex-1 @[700px]:flex-none',
                   filter === f
                     ? 'bg-background text-foreground shadow-sm'
                     : 'text-muted-foreground hover:text-foreground'
@@ -1089,13 +1089,13 @@ function TaskListView({ page }: TaskListViewProps) {
               placeholder="Filter tasks..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-9 w-full @[420px]:w-48"
+              className="pl-9 w-full @[700px]:w-48"
             />
           </div>
         </div>
 
-        <div className="flex flex-col @[420px]:flex-row @[420px]:items-center gap-2 w-full @[420px]:w-auto">
-          <div className="flex items-center gap-2 @[420px]:contents">
+        <div className="flex flex-col @[700px]:flex-row @[700px]:items-center gap-2 w-full @[700px]:w-auto">
+          <div className="flex items-center gap-2 @[700px]:contents">
             {canEdit && (
               <StatusConfigManager
                 pageId={page.id}
@@ -1112,7 +1112,7 @@ function TaskListView({ page }: TaskListViewProps) {
                 onClick={() => setWorkflowsDialogOpen(true)}
               >
                 <Zap className="h-3.5 w-3.5" />
-                <span className="hidden @[420px]:inline">Workflows</span>
+                <span className="hidden @[700px]:inline">Workflows</span>
               </Button>
             )}
           </div>
@@ -1120,7 +1120,7 @@ function TaskListView({ page }: TaskListViewProps) {
           {canEdit && viewMode === 'table' && (
             <Button
               size="sm"
-              className="w-full @[420px]:w-auto"
+              className="w-full @[700px]:w-auto"
               onClick={() => {
                 const mobileInput = document.getElementById('new-task-input-mobile');
                 const desktopInput = document.getElementById('new-task-input');
@@ -1137,7 +1137,8 @@ function TaskListView({ page }: TaskListViewProps) {
         </div>
       </div>
 
-      {/* Narrow Card View */}
+      {/* Narrow Card View — table/card switch only; Kanban has its own always-visible view below */}
+      {viewMode !== 'kanban' && (
       <div className="flex-1 overflow-auto @[700px]:hidden p-4 space-y-3">
         {filteredTasks.map((task) => (
           <div key={task.id} data-task-id={task.id}>
@@ -1194,10 +1195,11 @@ function TaskListView({ page }: TaskListViewProps) {
           </div>
         )}
       </div>
+      )}
 
-      {/* Wide View (Table or Kanban) */}
-      <div className="flex-1 overflow-auto hidden @[700px]:block">
-        {viewMode === 'kanban' ? (
+      {/* Kanban View — horizontal-scrolling board; visible at any pane width via its own narrow-column step (@max-[500px]:w-60) */}
+      {viewMode === 'kanban' && (
+        <div className="flex-1 overflow-auto">
           <TaskKanbanView
             tasks={filteredTasks}
             driveId={page.driveId}
@@ -1211,7 +1213,13 @@ function TaskListView({ page }: TaskListViewProps) {
             onCreateTask={handleCreateTask}
             statusConfigs={statusConfigs}
           />
-        ) : (
+          {loadMoreControl}
+        </div>
+      )}
+
+      {/* Wide View (Table) — needs ~700px minimum; columns don't reflow */}
+      {viewMode !== 'kanban' && (
+      <div className="flex-1 overflow-auto hidden @[700px]:block">
           <>
             <DndContext
               sensors={sensors}
@@ -1484,10 +1492,9 @@ function TaskListView({ page }: TaskListViewProps) {
               </div>
             )}
           </>
-        )}
-
         {loadMoreControl}
       </div>
+      )}
 
       {/* Footer stats */}
       <div className="flex flex-col @[420px]:flex-row @[420px]:items-center @[420px]:justify-between gap-2 px-4 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] border-t bg-muted/50 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Task lists overflowed in narrow panes because the card/table switch was gated on Tailwind's `md:` viewport breakpoint instead of the pane's own width — a narrow pane in a wide browser window always rendered the ~700px-min table, clipped inside `overflow-x-auto`.
- Converts `TaskListView.tsx` and `TaskKanbanView.tsx` to Tailwind v4 `@container` queries keyed to each view's own rendered width, matching the pattern already established in `SessionChat.tsx`, `Breadcrumbs.tsx`, and `right-sidebar/index.tsx`.
- `TaskListView.tsx`: root gets `@container`; card↔table switch and all toolbar/footer `sm:`/`md:` variants converted to `@[420px]:`/`@[700px]:`; added a doc comment stating the pane-safe contract for future page-view work.
- `TaskKanbanView.tsx`: outer wrapper gets `@container`; columns step down from `w-72` to `w-60` under `@max-[500px]:` instead of showing a sliver of one column.
- Scope: task list only (table + kanban), per discussion — Sheet has separate narrow-pane issues that are a broader UX concern, out of scope here.

## Test plan
- [x] `tsc --noEmit` on `apps/web` — clean, 0 errors
- [x] `eslint` on both changed files — clean
- [ ] Manual: resize a pane in the main sidebar/center split with a wide viewport, confirm card↔table switches at ~700px pane width (not viewport width) and toolbar reflows below ~420px
- [ ] Manual: same check in a multi-pane agent session (`SessionPanes.tsx`)
- [ ] Manual: resize a pane showing kanban down to ~400-500px, confirm columns narrow instead of clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjLZZP7nB9mxH5r59VKZxG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved task list responsiveness based on the available pane width rather than the overall screen size.
  * Added adaptive layouts for toolbars, filters, search controls, view switching, and footer statistics.
  * Enabled Kanban boards to render independently across pane sizes.
  * Optimized Kanban columns for narrower containers while preserving desktop sizing.
  * Added responsive transitions between card and table views for improved usability in constrained layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->