### PR TITLE
fix(agents): show global-assistant sessions in every drive's sidebar

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -36,7 +36,7 @@ import {
   forgetConversationInCache,
   restoreSessionInCache,
 } from '@/components/agents/panes/session-conversations';
-import { buildSessionGroups, ASSISTANT_GROUP_KEY, type DriveGroup } from './session-groups';
+import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
 
 /**
@@ -332,17 +332,15 @@ function SessionList({
   // as the same thing when it is not.
   const groups = useMemo(() => {
     if (driveId) {
-      const ownSessions = filteredSessions.filter((session) => session.driveId === driveId);
-      const assistantSessions = filteredSessions.filter((session) => session.driveId === null);
-      const result: DriveGroup<SessionListEntry>[] = [];
-      if (assistantSessions.length > 0) {
-        result.push({ driveId: ASSISTANT_GROUP_KEY, driveName: 'Global Assistant', sessions: assistantSessions });
-      }
-      result.push({ driveId, driveName: null, sessions: ownSessions });
-      return result;
+      // Same bucketing/ordering `buildSessionGroups` already does for global
+      // mode, just handed a single-drive roster — `assistant: false` is what
+      // encodes "no canSpawn escape hatch" above (`hasAssistantSessions`
+      // still shows the group once one exists).
+      const driveName = drives.find((d) => d.id === driveId)?.name ?? driveId;
+      return buildSessionGroups(filteredSessions, { assistant: false, drives: [{ driveId, driveName }] });
     }
     return buildSessionGroups(filteredSessions, { assistant: canSpawn, drives: roster });
-  }, [driveId, filteredSessions, canSpawn, roster]);
+  }, [driveId, filteredSessions, drives, canSpawn, roster]);
 
   // While actively searching, a group with no matches is noise — hide it
   // rather than showing an empty group with a spawn "+". Outside search the
@@ -384,7 +382,10 @@ function SessionList({
       )}
       {visibleGroups.map((group) => (
         <div key={group.driveId}>
-          {(!driveId || group.driveId !== driveId) && (
+          {/* `group.driveId` is always a real string (never undefined), so
+              this alone already covers global mode (every group differs from
+              an undefined `driveId`) — no separate `!driveId ||` needed. */}
+          {group.driveId !== driveId && (
             <SessionGroupHeader
               label={group.driveName ?? group.driveId}
               newSessionLabel={`New session in ${group.driveName ?? 'this drive'}`}

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -315,19 +315,30 @@ function SessionList({
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
   // first — see session-groups.ts for the ordering rule). In drive mode, the
   // drive's own sessions get an always-present implicit group (even with zero
-  // sessions, so its header's spawn affordance never disappears mid-load),
-  // plus a second "Global Assistant" group for the caller's global sessions
-  // (driveId null) — those aren't this drive's data, they're the user's, and
-  // the API now includes them in every drive-scoped listing (see
-  // agent-sessions-store.ts's `list()`).
+  // sessions, so its header's spawn affordance never disappears mid-load).
+  // A second "Global Assistant" group, ahead of it (same "Assistant first"
+  // rule as global mode), surfaces the caller's global sessions (driveId
+  // null) — those aren't this drive's data, they're the user's, and the API
+  // now includes them in every drive-scoped listing (see
+  // agent-sessions-store.ts's `list()`) — but ONLY when there's at least one:
+  // unlike global mode's Assistant group, this one has no `canSpawn`
+  // always-show escape hatch, because "Global Assistant" already names a
+  // different, unrelated affordance in drive mode: the new-session drive
+  // palette's own "Global Assistant" agent-picker entry
+  // (`useSpawnSession.tsx`'s `onPickTarget({ kind: 'assistant', ... label:
+  // 'Global Assistant' })`), which spawns a DRIVE-scoped session whose first
+  // conversation happens to be with the assistant agent — an
+  // always-rendered empty group here would sit right next to that and read
+  // as the same thing when it is not.
   const groups = useMemo(() => {
     if (driveId) {
       const ownSessions = filteredSessions.filter((session) => session.driveId === driveId);
       const assistantSessions = filteredSessions.filter((session) => session.driveId === null);
-      const result: DriveGroup<SessionListEntry>[] = [{ driveId, driveName: null, sessions: ownSessions }];
-      if (canSpawn || assistantSessions.length > 0) {
+      const result: DriveGroup<SessionListEntry>[] = [];
+      if (assistantSessions.length > 0) {
         result.push({ driveId: ASSISTANT_GROUP_KEY, driveName: 'Global Assistant', sessions: assistantSessions });
       }
+      result.push({ driveId, driveName: null, sessions: ownSessions });
       return result;
     }
     return buildSessionGroups(filteredSessions, { assistant: canSpawn, drives: roster });

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -36,7 +36,7 @@ import {
   forgetConversationInCache,
   restoreSessionInCache,
 } from '@/components/agents/panes/session-conversations';
-import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
+import { buildSessionGroups, ASSISTANT_GROUP_KEY, type DriveGroup } from './session-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
 
 /**
@@ -313,11 +313,23 @@ function SessionList({
   });
 
   // Group by drive in global mode (roster ∪ session-implied drives, Assistant
-  // first — see session-groups.ts for the ordering rule); a single implicit
-  // group in drive mode, always present (even with zero sessions) so its
-  // header — and the header's spawn affordance — never disappears mid-load.
+  // first — see session-groups.ts for the ordering rule). In drive mode, the
+  // drive's own sessions get an always-present implicit group (even with zero
+  // sessions, so its header's spawn affordance never disappears mid-load),
+  // plus a second "Global Assistant" group for the caller's global sessions
+  // (driveId null) — those aren't this drive's data, they're the user's, and
+  // the API now includes them in every drive-scoped listing (see
+  // agent-sessions-store.ts's `list()`).
   const groups = useMemo(() => {
-    if (driveId) return [{ driveId, driveName: null, sessions: filteredSessions }];
+    if (driveId) {
+      const ownSessions = filteredSessions.filter((session) => session.driveId === driveId);
+      const assistantSessions = filteredSessions.filter((session) => session.driveId === null);
+      const result: DriveGroup<SessionListEntry>[] = [{ driveId, driveName: null, sessions: ownSessions }];
+      if (canSpawn || assistantSessions.length > 0) {
+        result.push({ driveId: ASSISTANT_GROUP_KEY, driveName: 'Global Assistant', sessions: assistantSessions });
+      }
+      return result;
+    }
     return buildSessionGroups(filteredSessions, { assistant: canSpawn, drives: roster });
   }, [driveId, filteredSessions, canSpawn, roster]);
 
@@ -361,7 +373,7 @@ function SessionList({
       )}
       {visibleGroups.map((group) => (
         <div key={group.driveId}>
-          {!driveId && (
+          {(!driveId || group.driveId !== driveId) && (
             <SessionGroupHeader
               label={group.driveName ?? group.driveId}
               newSessionLabel={`New session in ${group.driveName ?? 'this drive'}`}

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -107,8 +107,17 @@ export default function AgentsSidebar({ className }: SidebarProps) {
     refreshInterval: 20_000,
   });
 
-  // The spawn chooser's agent list rides the same fetch both modes already use.
-  const { agentsByDrive } = usePageAgents(driveId, { enabled: isAdmin });
+  // Unfiltered (no driveId arg) in BOTH modes now, not just global mode: a
+  // drive's sidebar can show a global-assistant session whose conversations
+  // are with agents from ANY accessible drive (agent-sessions-store.ts's
+  // `list()` now surfaces those), so `agentNamesById` below needs every
+  // accessible agent's name, not just this drive's, to label them correctly
+  // instead of falling back to the generic "Agent" (review: Codex P2 on
+  // #2325). The spawn palette stays correctly drive-scoped regardless —
+  // `useSpawnSession` already does its own `agentsByDrive.find(entry =>
+  // entry.driveId === spawnTarget.driveId)` lookup, so handing it the full
+  // list changes nothing about which agents a drive's "+" offers.
+  const { agentsByDrive } = usePageAgents(undefined, { enabled: isAdmin });
 
   useEffect(() => {
     setIsElectronMac(isElectron() && /Mac/.test(navigator.platform));

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1241,6 +1241,84 @@ describe('AgentsSidebar', () => {
     });
   });
 
+  describe('drive mode + the caller\'s global-assistant sessions (review #2325)', () => {
+    /**
+     * Three parents up, not the `global mode` describe's two: label span →
+     * header-row span → header-row div (`SessionGroupHeader`'s own root, which
+     * is enough to scope a click on its "+") → the actual GROUP div
+     * (`<div key={group.driveId}>`), which is what's needed here to also
+     * assert on sibling `SessionRow`s inside the same group.
+     */
+    const groupContainer = (headerText: string) =>
+      screen.getByText(headerText).parentElement?.parentElement?.parentElement as HTMLElement;
+
+    test('a null-driveId session renders under its own "Global Assistant" header, separate from the drive\'s own (headerless) sessions', async () => {
+      respondWithSessions([
+        SESSION,
+        {
+          ...SESSION,
+          sessionId: 'ses-g',
+          driveId: null,
+          name: 'assistant session',
+          conversations: [{ conversationId: 'conv-g', title: 'Thread', agentPageId: null }],
+        },
+      ]);
+      renderSidebar();
+
+      expect(await screen.findByText('api refactor')).toBeDefined();
+      expect(await screen.findByText('assistant session')).toBeDefined();
+      // The drive's own group stays headerless (unchanged from before this
+      // session type existed) — only the Assistant group gets a header.
+      expect(screen.queryAllByText('Global Assistant')).toHaveLength(1);
+      expect(within(groupContainer('Global Assistant')).getByText('assistant session')).toBeDefined();
+      expect(within(groupContainer('Global Assistant')).queryByText('api refactor')).toBeNull();
+    });
+
+    test('given only drive-scoped sessions, does NOT render an empty "Global Assistant" group — it would collide with the palette\'s unrelated "Global Assistant" agent-picker entry', async () => {
+      // Regression pin for the review round where this group rendered
+      // unconditionally (mirroring global mode's `canSpawn` escape hatch) and
+      // broke two unrelated pre-existing tests via a duplicate-text collision:
+      // the new-session palette's "Global Assistant" agent choice, and the
+      // "falls back to Global Assistant for a null agentPageId" conversation
+      // label. Both name the SAME agent-picker concept, not this session-scope
+      // group, so the group must earn its place on screen only when relevant.
+      renderSidebar();
+
+      await screen.findByText('api refactor');
+      expect(screen.queryByText('Global Assistant')).toBeNull();
+    });
+
+    test('spawning from the Assistant group posts driveId: null, distinct from the drive palette\'s own "Global Assistant" agent pick', async () => {
+      mockPost.mockResolvedValue({ session: { sessionId: 'ses-a' }, conversationId: 'conv-a' });
+      respondWithSessions([
+        SESSION,
+        {
+          ...SESSION,
+          sessionId: 'ses-g',
+          driveId: null,
+          name: 'assistant session',
+          conversations: [],
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('assistant session');
+      await user.click(within(groupContainer('Global Assistant')).getByRole('button', { name: /^New session/i }));
+
+      const nameInput = await screen.findByPlaceholderText('Global Assistant');
+      await user.type(nameInput, '{Enter}');
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {
+          driveId: null,
+          agentPageId: null,
+          name: '',
+        }),
+      );
+    });
+  });
+
   describe('global mode', () => {
     beforeEach(() => {
       mockUseParams.mockReturnValue({});

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -208,7 +208,10 @@ describe('AgentsSidebar', () => {
     // The load-bearing half: neither fetch is ever made, rather than made and
     // discarded.
     expect(mockFetchWithAuth).not.toHaveBeenCalled();
-    expect(mockUsePageAgents).toHaveBeenCalledWith('drive-1', { enabled: false });
+    // Unfiltered (no driveId arg) now in both modes — see AgentsSidebar.tsx's
+    // comment on the `usePageAgents` call — but the load-bearing half of
+    // this assertion is `enabled: false`, unchanged.
+    expect(mockUsePageAgents).toHaveBeenCalledWith(undefined, { enabled: false });
   });
 
   test('shows the cold-load state rather than the empty notice', () => {
@@ -1286,6 +1289,41 @@ describe('AgentsSidebar', () => {
 
       await screen.findByText('api refactor');
       expect(screen.queryByText('Global Assistant')).toBeNull();
+    });
+
+    test('labels a global session\'s conversation with an OUT-OF-DRIVE agent\'s real name, not the generic fallback (review: Codex P2 on #2325)', async () => {
+      // Before this fix, `usePageAgents(driveId)` filtered agent names down to
+      // the CURRENT drive only, so a global session's conversation with an
+      // agent from a different drive (a legitimate shape — a global session
+      // may host any accessible agent) fell back to the generic "Agent" label
+      // even though its real name was fetchable.
+      mockUsePageAgents.mockImplementation((driveId?: string) => ({
+        agentsByDrive: [
+          { driveId: 'drive-1', driveName: 'Alpha', agentCount: 1, agents: [{ id: 'agent-1', title: 'Researcher', driveId: 'drive-1' }] },
+          { driveId: 'drive-2', driveName: 'Beta', agentCount: 1, agents: [{ id: 'agent-2', title: 'Beta Agent', driveId: 'drive-2' }] },
+        ].filter((entry) => driveId === undefined || entry.driveId === driveId),
+        isLoading: false,
+        isError: false,
+        mutate: vi.fn(),
+      }));
+      respondWithSessions([
+        SESSION,
+        {
+          ...SESSION,
+          sessionId: 'ses-g',
+          driveId: null,
+          name: 'assistant session',
+          conversations: [{ conversationId: 'conv-g', title: null, agentPageId: 'agent-2' }],
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await screen.findByText('assistant session');
+      await user.click(await screen.findByLabelText(/expand assistant session/i));
+
+      expect(await screen.findByText('Beta Agent')).toBeDefined();
+      expect(screen.queryByText('Agent')).toBeNull();
     });
 
     test('spawning from the Assistant group posts driveId: null, distinct from the drive palette\'s own "Global Assistant" agent pick', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1307,13 +1307,13 @@ describe('AgentsSidebar', () => {
       await user.click(within(groupContainer('Global Assistant')).getByRole('button', { name: /^New session/i }));
 
       const nameInput = await screen.findByPlaceholderText('Global Assistant');
-      await user.type(nameInput, '{Enter}');
+      await user.type(nameInput, 'my assistant session{Enter}');
 
       await waitFor(() =>
         expect(mockPost).toHaveBeenCalledWith('/api/agent-sessions', {
           driveId: null,
           agentPageId: null,
-          name: '',
+          name: 'my assistant session',
         }),
       );
     });

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
@@ -597,6 +597,38 @@ describe('list — driveId filter also includes the caller\'s own global session
       await db.delete(users).where(eq(users.id, otherOwnerId));
     }
   });
+
+  it('given an OWNERLESS driveId filter, excludes every global session — no owner to scope the union to (review: Codex P1 on #2325)', async () => {
+    // `{ driveId }` alone is the admin "every session in this drive, any
+    // owner" shape (`agent-sessions.test.ts`'s `listAgentSessions` "given a
+    // drive filter" case). Without an owner in the filter, unioning in
+    // `driveId IS NULL` would return every user's global-assistant sessions
+    // across the whole deployment, not just sessions relevant to this drive.
+    const otherOwnerId = createId();
+    await db.insert(users).values({
+      id: otherOwnerId,
+      email: `agent-sessions-store-ownerless-${otherOwnerId}@example.test`,
+      name: 'Ownerless Probe Owner',
+    });
+    const otherGlobalSessionId = createId();
+    await db.insert(agentSessions).values({
+      id: otherGlobalSessionId,
+      ownerId: otherOwnerId,
+      driveId: null,
+      updatedAt: new Date(),
+    });
+    const driveScoped = await seedSession();
+
+    try {
+      const listed = await store.list({ driveId });
+      const ids = listed.map((row) => row.id);
+      expect(ids).toContain(driveScoped);
+      expect(ids).not.toContain(otherGlobalSessionId);
+    } finally {
+      await db.delete(agentSessions).where(eq(agentSessions.id, otherGlobalSessionId));
+      await db.delete(users).where(eq(users.id, otherOwnerId));
+    }
+  });
 });
 
 describe('createIfUnderLimit — the spawn ceiling made atomic (review #2261/2)', () => {

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
@@ -23,7 +23,7 @@ import { drives, pages } from '@pagespace/db/schema/core';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { agentSessions } from '@pagespace/db/schema/agent-sessions';
 import { machineSpriteReclaims } from '@pagespace/db/schema/machine-sprite-reclaims';
-import { createDbAgentSessionStore } from '../agent-sessions-store';
+import { createDbAgentSessionStore, type AgentSessionListFilter } from '../agent-sessions-store';
 
 const ownerId = createId();
 const driveId = createId();
@@ -621,6 +621,39 @@ describe('list — driveId filter also includes the caller\'s own global session
 
     try {
       const listed = await store.list({ driveId });
+      const ids = listed.map((row) => row.id);
+      expect(ids).toContain(driveScoped);
+      expect(ids).not.toContain(otherGlobalSessionId);
+    } finally {
+      await db.delete(agentSessions).where(eq(agentSessions.id, otherGlobalSessionId));
+      await db.delete(users).where(eq(users.id, otherOwnerId));
+    }
+  });
+
+  it('given driveId with an explicitly-undefined ownerId, behaves as ownerless against real Postgres (review: CodeRabbit)', async () => {
+    // `AgentSessionListFilter` no longer has a variant shaped like this — the
+    // cast pins the runtime guard against a value that reaches here some
+    // other way (a bypassed cast, a loosely-typed caller upstream), proving
+    // the SQL itself (not just the type system) refuses to treat a
+    // present-but-unset ownerId as "owned".
+    const otherOwnerId = createId();
+    await db.insert(users).values({
+      id: otherOwnerId,
+      email: `agent-sessions-store-undef-owner-${otherOwnerId}@example.test`,
+      name: 'Undefined-Owner Probe Owner',
+    });
+    const otherGlobalSessionId = createId();
+    await db.insert(agentSessions).values({
+      id: otherGlobalSessionId,
+      ownerId: otherOwnerId,
+      driveId: null,
+      updatedAt: new Date(),
+    });
+    const driveScoped = await seedSession();
+    const filter = { driveId, ownerId: undefined } as unknown as AgentSessionListFilter;
+
+    try {
+      const listed = await store.list(filter);
       const ids = listed.map((row) => row.id);
       expect(ids).toContain(driveScoped);
       expect(ids).not.toContain(otherGlobalSessionId);

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts
@@ -559,6 +559,46 @@ describe('list bounds and ordering (review M3/M4)', () => {
   });
 });
 
+describe('list — driveId filter also includes the caller\'s own global sessions', () => {
+  it('includes a null-driveId (global-assistant) session for the same owner', async () => {
+    const globalSessionId = createId();
+    sessionIds.push(globalSessionId);
+    await db.insert(agentSessions).values({
+      id: globalSessionId,
+      ownerId,
+      driveId: null,
+      updatedAt: new Date(),
+    });
+
+    const listed = await store.list({ driveId, ownerId });
+    expect(listed.map((row) => row.id)).toContain(globalSessionId);
+  });
+
+  it('still excludes a null-driveId session belonging to a DIFFERENT owner', async () => {
+    const otherOwnerId = createId();
+    await db.insert(users).values({
+      id: otherOwnerId,
+      email: `agent-sessions-store-other-${otherOwnerId}@example.test`,
+      name: 'Other Owner',
+    });
+    const otherGlobalSessionId = createId();
+    await db.insert(agentSessions).values({
+      id: otherGlobalSessionId,
+      ownerId: otherOwnerId,
+      driveId: null,
+      updatedAt: new Date(),
+    });
+
+    try {
+      const listed = await store.list({ driveId, ownerId });
+      expect(listed.map((row) => row.id)).not.toContain(otherGlobalSessionId);
+    } finally {
+      await db.delete(agentSessions).where(eq(agentSessions.id, otherGlobalSessionId));
+      await db.delete(users).where(eq(users.id, otherOwnerId));
+    }
+  });
+});
+
 describe('createIfUnderLimit — the spawn ceiling made atomic (review #2261/2)', () => {
   it('given the owner is under the ceiling, should mint a session', async () => {
     const result = await store.createIfUnderLimit({

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions.test.ts
@@ -6,6 +6,7 @@ import {
   toAgentSessionDTO,
   type SpawnAgentSessionDeps,
 } from '../agent-sessions';
+import type { AgentSessionListFilter } from '../agent-sessions-store';
 import { ensureAgentSessionSandbox, type AgentSessionSpriteRow } from '../agent-session-sprite';
 import { agentSessionDtoSchema } from '../../../agent-sessions/contract';
 import { deriveAgentSessionSpriteKey } from '../../../agent-sessions/session-sprite-key';
@@ -477,6 +478,18 @@ describe('listAgentSessions', () => {
         filter: { driveId: DRIVE_ID },
         deps: { store: store.store },
       });
+      expect(sessions.map((session) => session.sessionId)).toEqual(['ses-drive']);
+    });
+
+    it('given driveId with an explicitly-undefined ownerId, should behave as ownerless — presence of the key is not enough (review: CodeRabbit)', async () => {
+      // `AgentSessionListFilter` no longer HAS a variant shaped like this
+      // (`ownerId` is either a real string or the key is absent entirely) —
+      // the cast exists to pin the runtime guard against a value that
+      // reaches here some other way (a bypassed cast, a loosely-typed
+      // caller upstream), not to describe a shape callers should construct.
+      const store = makeAgentSessionStore(withGlobal);
+      const filter = { driveId: DRIVE_ID, ownerId: undefined } as unknown as AgentSessionListFilter;
+      const sessions = await listAgentSessions({ filter, deps: { store: store.store } });
       expect(sessions.map((session) => session.sessionId)).toEqual(['ses-drive']);
     });
   });

--- a/packages/lib/src/services/agent-sessions/__tests__/agent-sessions.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/agent-sessions.test.ts
@@ -454,4 +454,30 @@ describe('listAgentSessions', () => {
     const store = makeAgentSessionStore();
     expect(await listAgentSessions({ filter: { ownerId: OWNER_ID }, deps: { store: store.store } })).toEqual([]);
   });
+
+  describe('drive filter + global-assistant sessions (review: Codex P1 on #2325)', () => {
+    const withGlobal = [
+      makeSessionRecord({ id: 'ses-drive', sandboxId: SESSION_KEY }),
+      makeSessionRecord({ id: 'ses-owner-global', driveId: null }),
+      makeSessionRecord({ id: 'ses-other-owner-global', driveId: null, ownerId: 'user-2' }),
+    ];
+
+    it('given driveId + ownerId, should also include that owner\'s global sessions, not other owners\'', async () => {
+      const store = makeAgentSessionStore(withGlobal);
+      const sessions = await listAgentSessions({
+        filter: { driveId: DRIVE_ID, ownerId: OWNER_ID },
+        deps: { store: store.store },
+      });
+      expect(sessions.map((session) => session.sessionId).sort()).toEqual(['ses-drive', 'ses-owner-global']);
+    });
+
+    it('given driveId with NO owner, should exclude every global session — no owner to scope the union to', async () => {
+      const store = makeAgentSessionStore(withGlobal);
+      const sessions = await listAgentSessions({
+        filter: { driveId: DRIVE_ID },
+        deps: { store: store.store },
+      });
+      expect(sessions.map((session) => session.sessionId)).toEqual(['ses-drive']);
+    });
+  });
 });

--- a/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
@@ -137,10 +137,10 @@ export function makeAgentSessionStore(
         .filter((row) => {
           if ('driveId' in filter) {
             const matchesDrive = row.driveId === filter.driveId;
-            const matchesOwnerGlobal = filter.ownerId !== undefined && row.driveId === null;
+            const matchesOwnerGlobal = 'ownerId' in filter && row.driveId === null;
             if (!matchesDrive && !matchesOwnerGlobal) return false;
           }
-          if (filter.ownerId !== undefined && row.ownerId !== filter.ownerId) return false;
+          if ('ownerId' in filter && row.ownerId !== filter.ownerId) return false;
           return row.endedAt === null;
         })
         .sort((a, b) => {

--- a/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
@@ -127,10 +127,19 @@ export function makeAgentSessionStore(
       // Mirrors the real store: active rows only, newest activity first,
       // capped at SESSION_LIST_LIMIT (the sidebar polls this every few
       // seconds — an unbounded fake would let a test pass against a query
-      // shape the real store never allows).
+      // shape the real store never allows). Also mirrors the real store's
+      // driveId+ownerId union: an OWNED drive-scoped filter additionally
+      // matches that owner's own global sessions (driveId null); an
+      // OWNERLESS drive-scoped filter does not, since without an owner to
+      // scope it that would leak every user's global sessions (review: Codex
+      // P1 on #2325).
       return [...rows.values()]
         .filter((row) => {
-          if ('driveId' in filter && row.driveId !== filter.driveId) return false;
+          if ('driveId' in filter) {
+            const matchesDrive = row.driveId === filter.driveId;
+            const matchesOwnerGlobal = filter.ownerId !== undefined && row.driveId === null;
+            if (!matchesDrive && !matchesOwnerGlobal) return false;
+          }
           if (filter.ownerId !== undefined && row.ownerId !== filter.ownerId) return false;
           return row.endedAt === null;
         })

--- a/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/fakes.ts
@@ -132,15 +132,18 @@ export function makeAgentSessionStore(
       // matches that owner's own global sessions (driveId null); an
       // OWNERLESS drive-scoped filter does not, since without an owner to
       // scope it that would leak every user's global sessions (review: Codex
-      // P1 on #2325).
+      // P1 on #2325). Normalized to a VALUE check (not `'ownerId' in filter`),
+      // matching the real store's guard against `{ driveId, ownerId:
+      // undefined }` being treated as owned (review: CodeRabbit on #2325).
+      const ownerId = 'ownerId' in filter ? filter.ownerId : undefined;
       return [...rows.values()]
         .filter((row) => {
           if ('driveId' in filter) {
             const matchesDrive = row.driveId === filter.driveId;
-            const matchesOwnerGlobal = 'ownerId' in filter && row.driveId === null;
+            const matchesOwnerGlobal = ownerId !== undefined && row.driveId === null;
             if (!matchesDrive && !matchesOwnerGlobal) return false;
           }
-          if ('ownerId' in filter && row.ownerId !== filter.ownerId) return false;
+          if (ownerId !== undefined && row.ownerId !== ownerId) return false;
           return row.endedAt === null;
         })
         .sort((a, b) => {

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -65,9 +65,20 @@ export interface NewAgentSessionInput {
  * runtime guard: an unfiltered enumeration of every session in the deployment is
  * not a query any caller has a use for, and making it unrepresentable is
  * cheaper than remembering to reject it.
+ *
+ * THREE variants, not two-with-an-optional-field — `ownerId` being present vs.
+ * absent on the drive-scoped shape is a real behavioral fork in `list()` (the
+ * owned shape additionally unions in the caller's own global sessions; the
+ * ownerless one is a plain drive-wide listing), so it earns its own variant
+ * rather than an optional property a caller could accidentally pass as
+ * `undefined` and silently land in either behavior (review: Codex P1 on
+ * #2325, where that exact ambiguity — a runtime presence-check standing in
+ * for a type-level distinction — let an ownerless drive listing return every
+ * user's global sessions).
  */
 export type AgentSessionListFilter =
-  | { driveId: string; ownerId?: string }
+  | { driveId: string; ownerId: string }
+  | { driveId: string }
   | { ownerId: string };
 
 /** The most sessions one listing returns — the sidebar shows the newest slice, not an archive. */
@@ -401,8 +412,8 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
 
     async list(filter) {
       const conditions = [];
-      if (filter.ownerId !== undefined) conditions.push(eq(agentSessions.ownerId, filter.ownerId));
-      if ('driveId' in filter) {
+      if ('ownerId' in filter) conditions.push(eq(agentSessions.ownerId, filter.ownerId));
+      if ('driveId' in filter && 'ownerId' in filter) {
         // A drive-scoped listing ALSO named to an owner (the sidebar's shape,
         // `{ driveId, ownerId }`) additionally includes that owner's own
         // global-assistant sessions (driveId IS NULL) — those aren't drive
@@ -410,18 +421,16 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
         // the dashboard sidebar does (see session-groups.ts's
         // ASSISTANT_GROUP_KEY). The ownerId condition above ANDs this whole
         // clause down to that one caller.
-        //
+        conditions.push(or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!);
+      } else if ('driveId' in filter) {
         // An OWNERLESS `{ driveId }` listing — the admin "every session in
         // this drive, any owner" shape `agent-sessions.test.ts`'s
         // `listAgentSessions` "given a drive filter" case exercises — must
-        // NOT gain the OR: with no owner to scope it, `driveId IS NULL` would
-        // return every user's global sessions across the whole deployment
-        // (review: Codex P1, github.com/2witstudios/PageSpace/pull/2325).
-        conditions.push(
-          filter.ownerId !== undefined
-            ? or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!
-            : eq(agentSessions.driveId, filter.driveId),
-        );
+        // NOT gain the OR above: with no owner to scope it, `driveId IS NULL`
+        // would return every user's global sessions across the whole
+        // deployment (review: Codex P1,
+        // github.com/2witstudios/PageSpace/pull/2325).
+        conditions.push(eq(agentSessions.driveId, filter.driveId));
       }
       if (conditions.length === 0) {
         // Unreachable through `AgentSessionListFilter`, which requires a

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -403,14 +403,25 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
       const conditions = [];
       if (filter.ownerId !== undefined) conditions.push(eq(agentSessions.ownerId, filter.ownerId));
       if ('driveId' in filter) {
-        // A drive-scoped listing also includes the caller's own
+        // A drive-scoped listing ALSO named to an owner (the sidebar's shape,
+        // `{ driveId, ownerId }`) additionally includes that owner's own
         // global-assistant sessions (driveId IS NULL) — those aren't drive
         // data, they're the user's, and every drive shows them the same way
         // the dashboard sidebar does (see session-groups.ts's
-        // ASSISTANT_GROUP_KEY). The ownerId condition above already scopes
-        // this to the caller when supplied, so this can't surface another
-        // user's global sessions.
-        conditions.push(or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!);
+        // ASSISTANT_GROUP_KEY). The ownerId condition above ANDs this whole
+        // clause down to that one caller.
+        //
+        // An OWNERLESS `{ driveId }` listing — the admin "every session in
+        // this drive, any owner" shape `agent-sessions.test.ts`'s
+        // `listAgentSessions` "given a drive filter" case exercises — must
+        // NOT gain the OR: with no owner to scope it, `driveId IS NULL` would
+        // return every user's global sessions across the whole deployment
+        // (review: Codex P1, github.com/2witstudios/PageSpace/pull/2325).
+        conditions.push(
+          filter.ownerId !== undefined
+            ? or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!
+            : eq(agentSessions.driveId, filter.driveId),
+        );
       }
       if (conditions.length === 0) {
         // Unreachable through `AgentSessionListFilter`, which requires a

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -412,25 +412,34 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
 
     async list(filter) {
       const conditions = [];
-      if ('ownerId' in filter) conditions.push(eq(agentSessions.ownerId, filter.ownerId));
-      if ('driveId' in filter && 'ownerId' in filter) {
-        // A drive-scoped listing ALSO named to an owner (the sidebar's shape,
-        // `{ driveId, ownerId }`) additionally includes that owner's own
-        // global-assistant sessions (driveId IS NULL) — those aren't drive
-        // data, they're the user's, and every drive shows them the same way
-        // the dashboard sidebar does (see session-groups.ts's
-        // ASSISTANT_GROUP_KEY). The ownerId condition above ANDs this whole
-        // clause down to that one caller.
-        conditions.push(or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!);
-      } else if ('driveId' in filter) {
-        // An OWNERLESS `{ driveId }` listing — the admin "every session in
-        // this drive, any owner" shape `agent-sessions.test.ts`'s
-        // `listAgentSessions` "given a drive filter" case exercises — must
-        // NOT gain the OR above: with no owner to scope it, `driveId IS NULL`
-        // would return every user's global sessions across the whole
-        // deployment (review: Codex P1,
-        // github.com/2witstudios/PageSpace/pull/2325).
-        conditions.push(eq(agentSessions.driveId, filter.driveId));
+      // Normalized to a VALUE check, not just `'ownerId' in filter`: the `in`
+      // operator is true for `{ driveId, ownerId: undefined }` too (the key is
+      // present, just unset), which would otherwise both push a
+      // never-matching `ownerId = NULL` condition AND wrongly take the
+      // owner-scoped union branch below for what is, in effect, an ownerless
+      // filter (review: CodeRabbit, github.com/2witstudios/PageSpace/pull/2325).
+      const ownerId = 'ownerId' in filter ? filter.ownerId : undefined;
+      if (ownerId !== undefined) conditions.push(eq(agentSessions.ownerId, ownerId));
+      if ('driveId' in filter) {
+        conditions.push(
+          ownerId !== undefined
+            ? // A drive-scoped listing ALSO named to an owner (the sidebar's
+              // shape, `{ driveId, ownerId }`) additionally includes that
+              // owner's own global-assistant sessions (driveId IS NULL) —
+              // those aren't drive data, they're the user's, and every drive
+              // shows them the same way the dashboard sidebar does (see
+              // session-groups.ts's ASSISTANT_GROUP_KEY). The ownerId
+              // condition above ANDs this whole clause down to that one caller.
+              or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!
+            : // An OWNERLESS `{ driveId }` listing — the admin "every session
+              // in this drive, any owner" shape `agent-sessions.test.ts`'s
+              // `listAgentSessions` "given a drive filter" case exercises —
+              // must NOT gain the OR above: with no owner to scope it,
+              // `driveId IS NULL` would return every user's global sessions
+              // across the whole deployment (review: Codex P1,
+              // github.com/2witstudios/PageSpace/pull/2325).
+              eq(agentSessions.driveId, filter.driveId),
+        );
       }
       if (conditions.length === 0) {
         // Unreachable through `AgentSessionListFilter`, which requires a

--- a/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
+++ b/packages/lib/src/services/agent-sessions/agent-sessions-store.ts
@@ -331,7 +331,7 @@ export function revivedAgentSessionColumns(input: {
  * pin it rather than asserting "some recent timestamp".
  */
 export async function createDbAgentSessionStore(now: () => Date = () => new Date()): Promise<AgentSessionStore> {
-  const [{ db }, { eq, and, eqOrIsNull, isNotNull, isNull, sql, count, desc }, { agentSessions }, { machineSpriteReclaims }, { conversations }] =
+  const [{ db }, { eq, and, or, eqOrIsNull, isNotNull, isNull, sql, count, desc }, { agentSessions }, { machineSpriteReclaims }, { conversations }] =
     await Promise.all([
       import('@pagespace/db/db'),
       import('@pagespace/db/operators'),
@@ -403,10 +403,14 @@ export async function createDbAgentSessionStore(now: () => Date = () => new Date
       const conditions = [];
       if (filter.ownerId !== undefined) conditions.push(eq(agentSessions.ownerId, filter.ownerId));
       if ('driveId' in filter) {
-        // driveId is a real column now — a session IS drive-scoped, and a
-        // global-assistant session (null driveId) never appears in a
-        // drive-scoped listing because NULL never equals the filter.
-        conditions.push(eq(agentSessions.driveId, filter.driveId));
+        // A drive-scoped listing also includes the caller's own
+        // global-assistant sessions (driveId IS NULL) — those aren't drive
+        // data, they're the user's, and every drive shows them the same way
+        // the dashboard sidebar does (see session-groups.ts's
+        // ASSISTANT_GROUP_KEY). The ownerId condition above already scopes
+        // this to the caller when supplied, so this can't surface another
+        // user's global sessions.
+        conditions.push(or(eq(agentSessions.driveId, filter.driveId), isNull(agentSessions.driveId))!);
       }
       if (conditions.length === 0) {
         // Unreachable through `AgentSessionListFilter`, which requires a


### PR DESCRIPTION
## Summary
- Clicking a past conversation from a drive's Agents page opened the pane correctly, but never populated that drive's left sidebar — because the conversation lived in a global-assistant session (`agent_sessions.driveId IS NULL`), and the sidebar's `list()` query filtered with a plain `driveId = X` equality, which never matches `NULL` in Postgres.
- Global-assistant sessions belong to the user, not to any drive, so every drive's sidebar now unconditionally shows them in their own **"Global Assistant"** section (mirroring the dashboard sidebar's existing Assistant group), rather than inferring drive membership from a global session's conversation activity — which would create cross-drive ambiguity about what "belongs" to a drive.
- `agent-sessions-store.ts`: `list()`'s `driveId` filter now ORs in `driveId IS NULL`, still gated by the `ownerId` condition so it can't leak another user's global sessions across drives.
- `AgentsSidebar.tsx`: drive-mode now splits into the drive's own session group (unchanged, headerless) plus a distinct Global Assistant group, reusing the existing `ASSISTANT_GROUP_KEY`/spawn affordance.
- Adds integration test coverage (inclusion for the same owner + exclusion for a different owner's global session).

## Test plan
- [x] `bun run typecheck` passes for `@pagespace/lib` and `web`
- [ ] `bun run --filter '@pagespace/lib' test:db -- src/services/agent-sessions/__tests__/agent-sessions-store.integration.test.ts` against a real Postgres instance (couldn't run in this worktree — no local DB role configured)
- [ ] Manual: open/create a global-assistant session, chat with an agent from Drive D, navigate to Drive D's Agents page, click that past conversation — confirm it now appears under "Global Assistant" in Drive D's sidebar, and also in Drive E's sidebar (not just D's), while drive-scoped sessions still don't leak across drives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WjrwseJCNQTQPNrQ6nZ2S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drive views now separate drive-specific sessions from Global Assistant sessions.
  * Existing Global Assistant sessions appear in a dedicated group when viewing a drive.
  * New assistant sessions started from a drive are correctly associated with the Global Assistant.

* **Bug Fixes**
  * Improved session filtering so relevant global sessions appear for the selected owner while unrelated sessions remain hidden.

* **Tests**
  * Added coverage for session grouping, filtering, empty states, and assistant session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->