### PR TITLE
fix(cli): pagespace mcp never dies or hangs before the MCP handshake + ChatGPT/Codex docs

### DIFF
--- a/apps/marketing/src/app/docs/integrations/mcp/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/mcp/page.tsx
@@ -98,6 +98,29 @@ claude mcp add pagespace -- pagespace mcp
 
 **Settings > MCP Servers** → add the \`mcpServers\` block above.
 
+### ChatGPT desktop / Codex
+
+ChatGPT desktop and the Codex CLI share one MCP config — \`~/.codex/config.toml\` — and it's **TOML, not the JSON \`mcpServers\` shape** the clients above use:
+
+\`\`\`toml
+[mcp_servers.pagespace]
+command = "npx"
+args = ["-y", "-p", "@pagespace/cli", "pagespace-mcp"]
+startup_timeout_sec = 120
+
+[mcp_servers.pagespace.env]
+PAGESPACE_API_URL = "https://pagespace.ai"
+PAGESPACE_TOKEN = "mcp_your_token_here"
+\`\`\`
+
+Three details matter:
+
+- **The \`-p\` flag is required.** Without it, npx can't pick between the package's two bins and dies with \`could not determine executable to run\` — Codex shows the server as **Tools: (none)**, ChatGPT as a connector that times out.
+- **\`startup_timeout_sec = 120\`** gives a cold \`npx\` install room to download the package before the client abandons the handshake.
+- **Name a credential in the \`env\` block.** \`pagespace mcp\` never falls back to your personal login; without a token (or \`PAGESPACE_KEY\`), tool calls return an error telling you to configure one.
+
+(\`command = "pagespace"\` works only when the CLI is on the PATH the app launches with — macOS GUI apps don't inherit your shell PATH, so prefer the \`npx\` form. "Auth: Unsupported" beside the server in Codex is normal for stdio servers, not an error.)
+
 ## Step 3: Capabilities
 
 \`pagespace mcp\` generates its tool list mechanically from the same operation registry that powers the \`pagespace\` CLI and [\`@pagespace/sdk\`](/docs/features/sdk), so the tool surface can't drift from what the CLI itself supports.

--- a/apps/marketing/src/app/docs/integrations/mcp/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/mcp/page.tsx
@@ -121,6 +121,17 @@ Three details matter:
 
 (\`command = "pagespace"\` works only when the CLI is on the PATH the app launches with — macOS GUI apps don't inherit your shell PATH, so prefer the \`npx\` form. "Auth: Unsupported" beside the server in Codex is normal for stdio servers, not an error.)
 
+### OpenAI Secure MCP Tunnel
+
+Using [OpenAI's Secure MCP Tunnel](https://developers.openai.com/api/docs/guides/secure-mcp-tunnels) to reach a private server from ChatGPT? \`tunnel-client\` spawns the stdio server itself:
+
+\`\`\`bash
+tunnel-client init --profile pagespace --tunnel-id <your-tunnel-id> \\
+  --mcp-command "npx -y -p @pagespace/cli pagespace-mcp"
+\`\`\`
+
+The same two rules apply — \`-p\` is required in the \`--mcp-command\`, and the credential env vars (\`PAGESPACE_TOKEN\`, plus \`PAGESPACE_API_URL\` for self-hosted) must be exported **in the environment where \`tunnel-client run\` executes**, since the spawned server inherits that process's env. Both mistakes surface in ChatGPT as tool calls that time out; \`tunnel-client doctor --profile pagespace --explain\` shows whether the server actually came up.
+
 ## Step 3: Capabilities
 
 \`pagespace mcp\` generates its tool list mechanically from the same operation registry that powers the \`pagespace\` CLI and [\`@pagespace/sdk\`](/docs/features/sdk), so the tool surface can't drift from what the CLI itself supports.

--- a/packages/cli/docs/migrating-from-pagespace-mcp.md
+++ b/packages/cli/docs/migrating-from-pagespace-mcp.md
@@ -131,6 +131,28 @@ works in your terminal. The `npx` form above sidesteps that.
 ("Auth: Unsupported" next to the server in Codex is normal for stdio servers — it means no OAuth
 flow on the transport, not a configuration problem.)
 
+### OpenAI Secure MCP Tunnel (`tunnel-client`)
+
+For ChatGPT reaching a *private* MCP server through [OpenAI's Secure MCP Tunnel](https://developers.openai.com/api/docs/guides/secure-mcp-tunnels),
+`tunnel-client` spawns the stdio server itself via `--mcp-command`:
+
+```bash
+tunnel-client init \
+  --profile pagespace \
+  --tunnel-id <your-tunnel-id> \
+  --mcp-command "npx -y -p @pagespace/cli pagespace-mcp"
+```
+
+The same two rules apply, and both failure modes surface as ChatGPT-side timeouts ("requests
+through the tunnel fail"):
+
+- **`-p` is required** in the `--mcp-command`, exactly as above.
+- **The credential env vars must exist in the environment where `tunnel-client run` executes** —
+  the spawned server inherits *that* process's env. Export `PAGESPACE_TOKEN` (or the legacy
+  `PAGESPACE_AUTH_TOKEN`) and any `PAGESPACE_API_URL` override in the shell, systemd unit, or
+  container that runs `tunnel-client`, then verify with
+  `tunnel-client doctor --profile pagespace --explain`.
+
 ## Explicit-token variant (agents, CI, headless boxes)
 
 `pagespace login` needs a browser and isn't appropriate for CI or a service account.

--- a/packages/cli/docs/migrating-from-pagespace-mcp.md
+++ b/packages/cli/docs/migrating-from-pagespace-mcp.md
@@ -92,6 +92,45 @@ New (the `env` block naming a credential is required here too):
 }
 ```
 
+## ChatGPT desktop / Codex
+
+ChatGPT desktop and the Codex CLI share one MCP config — `~/.codex/config.toml` — and it's
+**TOML, not the JSON `mcpServers` shape** every other client above uses. A working entry,
+verified end to end against a live Codex session:
+
+```toml
+[mcp_servers.pagespace]
+command = "npx"
+args = ["-y", "-p", "@pagespace/cli", "pagespace-mcp"]
+startup_timeout_sec = 120
+
+[mcp_servers.pagespace.env]
+PAGESPACE_API_URL = "https://pagespace.ai"
+PAGESPACE_TOKEN = "<TOKEN_FROM_SETTINGS_MCP>"
+```
+
+Three details are load-bearing:
+
+- **The `-p` is not optional.** `npx -y @pagespace/cli pagespace-mcp` (no `-p`) dies instantly
+  with `could not determine executable to run` — this package publishes two bins and neither is
+  named after the package, so npx can't pick one. Codex renders that dead child as
+  **Tools: (none)**; ChatGPT shows a connector that times out. If your server shows no tools,
+  check this flag first.
+- **`startup_timeout_sec = 120`** gives a cold `npx` install (first run, cleared cache) room to
+  download the package before the client gives up on the handshake. The default is much lower.
+- **Name a credential in the `env` block** (`PAGESPACE_TOKEN`, or `PAGESPACE_KEY` for a key
+  minted on this machine). `pagespace mcp` never falls back to your personal `pagespace login`
+  credential; without an explicit credential the server still starts, but every tool call
+  returns an error telling you to configure one.
+
+Prefer `command = "pagespace"` with `args = ["mcp"]` only if the CLI is installed globally *and*
+on the PATH the app actually launches with — GUI apps on macOS don't inherit your shell PATH, so
+an nvm- or Homebrew-installed global can be invisible to ChatGPT even though `which pagespace`
+works in your terminal. The `npx` form above sidesteps that.
+
+("Auth: Unsupported" next to the server in Codex is normal for stdio servers — it means no OAuth
+flow on the transport, not a configuration problem.)
+
 ## Explicit-token variant (agents, CI, headless boxes)
 
 `pagespace login` needs a browser and isn't appropriate for CI or a service account.

--- a/packages/cli/src/__tests__/pagespace-mcp-bin.test.ts
+++ b/packages/cli/src/__tests__/pagespace-mcp-bin.test.ts
@@ -1,17 +1,32 @@
 import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { run } from '../run.js';
 import { EXIT_USAGE_ERROR } from '../exit-codes.js';
 import { buildPagespaceMcpArgv, runPagespaceMcpBin } from '../pagespace-mcp-bin.js';
 import { createFakeCredentialStore, createRecordingSink } from './fake-context.js';
 
 function makeDeps(argv: string[], env: Record<string, string | undefined> = {}) {
+  // The mcp route now serves (degraded or not) instead of failing closed, so
+  // every dispatch that reaches it must go through the `createMcpTransport`
+  // seam — never the module-level handler's real StdioServerTransport, which
+  // would attach to the test runner's own stdin.
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
   return {
     argv,
     env,
     stdout: createRecordingSink(),
     stderr: createRecordingSink(),
     credentialStore: createFakeCredentialStore(),
+    createMcpTransport: () => serverTransport,
+    clientTransport,
   };
+}
+
+async function connectClient(clientTransport: InstanceType<typeof InMemoryTransport>) {
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  await client.connect(clientTransport);
+  return client;
 }
 
 describe('buildPagespaceMcpArgv — pure argv parity', () => {
@@ -25,11 +40,16 @@ describe('buildPagespaceMcpArgv — pure argv parity', () => {
 });
 
 describe('runPagespaceMcpBin — the first-class npx entry point, resolved as a plain function of injected deps', () => {
-  it('resolves identically to "pagespace mcp": same fail-closed exit code and the same auth-failure message with zero credentials', async () => {
+  it('resolves identically to "pagespace mcp": same degraded-serve exit code and the same auth warning with zero credentials', async () => {
     const aliasDeps = makeDeps([]);
     const directDeps = makeDeps(['mcp']);
 
-    const [aliasCode, directCode] = await Promise.all([runPagespaceMcpBin(aliasDeps), run(directDeps)]);
+    const [aliasCode, directCode] = await Promise.all([
+      runPagespaceMcpBin(aliasDeps),
+      run(directDeps),
+      connectClient(aliasDeps.clientTransport),
+      connectClient(directDeps.clientTransport),
+    ]);
 
     expect(aliasCode).toBe(directCode);
     expect(aliasDeps.stderr.lines.join('')).toMatch(/--key|--token/);
@@ -38,23 +58,24 @@ describe('runPagespaceMcpBin — the first-class npx entry point, resolved as a 
 
   it('keeps stdout pure MCP protocol and never frames itself as deprecated', async () => {
     const deps = makeDeps([]);
-    await runPagespaceMcpBin(deps);
+    await Promise.all([runPagespaceMcpBin(deps), connectClient(deps.clientTransport)]);
 
     expect(deps.stdout.lines.join('')).toBe('');
     const allOutput = `${deps.stdout.lines.join('')}${deps.stderr.lines.join('')}`.toLowerCase();
     expect(allOutput).not.toContain('deprecat');
   });
 
-  it('honors the legacy PAGESPACE_API_URL env var end to end (resolved host reaches the auth-failure message)', async () => {
-    // Zero credentials alone now fails closed on the host-agnostic, Phase 8
-    // task 4 "no explicit credential" gate before the host is ever
-    // consulted (see run.test.ts). `--key agent` makes the credential
-    // explicit (an unresolvable named key, not the ambient default) so
-    // the flow reaches past that gate into the same host-bearing
-    // `missingCredentialsMessage` path this test originally targeted.
+  it('honors the legacy PAGESPACE_API_URL env var end to end (resolved host reaches the tool-call auth failure)', async () => {
+    // `--key agent` names an explicit (but unresolvable) credential, so the
+    // server comes up and lazy resolution runs on the first tool call — the
+    // host-bearing `missingCredentialsMessage` this test targets now arrives
+    // as that call's error result, not as a startup stderr line (startup
+    // must stay failure-free for the spawning MCP client's sake).
     const deps = makeDeps(['--key', 'agent'], { PAGESPACE_API_URL: 'https://legacy.example.com' });
-    await runPagespaceMcpBin(deps);
-    expect(deps.stderr.lines.join('')).toContain('https://legacy.example.com');
+    const [, client] = await Promise.all([runPagespaceMcpBin(deps), connectClient(deps.clientTransport)]);
+    const result = await client.callTool({ name: 'drives.list', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain('https://legacy.example.com');
   });
 
   it('still enforces usage errors for unknown extra argv, just like "pagespace mcp <bogus-subcommand>" would', async () => {

--- a/packages/cli/src/__tests__/run.test.ts
+++ b/packages/cli/src/__tests__/run.test.ts
@@ -1,7 +1,25 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { CLI_VERSION, credentialSecret, EXIT_SUCCESS, EXIT_USAGE_ERROR, isLongRunningCommand, run } from '@pagespace/cli';
 import type { HostCredential, RunDependencies } from '@pagespace/cli';
 import { createFakeActiveKeyStore, createFakeCredentialStore, createRecordingSink } from './fake-context.js';
+
+/**
+ * Drives `run(['mcp', ...])` through the `createMcpTransport` seam with an
+ * in-memory transport pair — `run` must never attach a real stdio transport
+ * to the test process — and returns the connected MCP client alongside the
+ * exit code so callers can assert on the served protocol surface.
+ */
+async function runMcp(deps: RunDependencies) {
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [code] = await Promise.all([
+    run({ ...deps, createMcpTransport: () => serverTransport }),
+    client.connect(clientTransport),
+  ]);
+  return { code, client };
+}
 
 function makeDeps(argv: string[], env: Record<string, string | undefined> = {}): RunDependencies & {
   stdout: ReturnType<typeof createRecordingSink>;
@@ -91,13 +109,23 @@ describe('run', () => {
     expect(deleteCalls).toBe(0);
   });
 
-  it('"mcp" is not auth-exempt: fails closed with an actionable message and zero credentials', async () => {
+  it('"mcp" with zero credentials serves degraded: transport connects, every tool call fails with the actionable message', async () => {
+    // A pre-transport exit is indistinguishable from a hung server to the MCP
+    // client that spawned this process (hours-long "timeouts" in ChatGPT
+    // desktop), so the no-credential case must serve and fail per-call.
     const deps = makeDeps(['mcp']);
-    const code = await run(deps);
-    expect(code).not.toBe(EXIT_SUCCESS);
+    const { code, client } = await runMcp(deps);
+
+    expect(code).toBe(EXIT_SUCCESS);
     expect(deps.stderr.lines.join('')).toMatch(/--key|--token/);
     // The mcp-specific refusal: the active key must be called out as deliberately inapplicable.
     expect(deps.stderr.lines.join('')).toContain('deliberately does not apply to "pagespace mcp"');
+
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(60);
+    const result = await client.callTool({ name: 'drives.list', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain('keys create');
   });
 
   describe('"mcp" with a stored default profile but no explicit credential (Phase 8 task 4)', () => {
@@ -105,7 +133,7 @@ describe('run', () => {
       vi.unstubAllGlobals();
     });
 
-    it('never touches the personal credential at all: no discovery/refresh network call, no rotation', async () => {
+    it('never touches the personal credential at all: no store read, no discovery/refresh network call, no rotation', async () => {
       let networkCalls = 0;
       vi.stubGlobal(
         'fetch',
@@ -115,7 +143,7 @@ describe('run', () => {
         }) as unknown as typeof fetch,
       );
 
-      const store = createFakeCredentialStore();
+      const inner = createFakeCredentialStore();
       const personalCredential: HostCredential = {
         kind: 'oauth',
         refreshToken: 'ps_rt_personal_secret',
@@ -123,16 +151,34 @@ describe('run', () => {
         scopes: ['full'],
         createdAt: new Date(0).toISOString(),
       };
-      await store.set('https://pagespace.ai', personalCredential, 'default');
+      await inner.set('https://pagespace.ai', personalCredential, 'default');
+      // Degraded serve is STRONGER than the old fail-closed exit here: with
+      // nothing explicit named, `resolveCredentialSource` is never called, so
+      // the store isn't even read (a keychain call on macOS) — count reads to
+      // pin that.
+      let storeReads = 0;
+      const store = {
+        ...inner,
+        async get(host: string, name?: string) {
+          storeReads += 1;
+          return inner.get(host, name);
+        },
+      };
 
       const deps = { ...makeDeps(['mcp']), credentialStore: store };
-      const code = await run(deps);
+      const { code, client } = await runMcp(deps);
 
-      expect(code).not.toBe(EXIT_SUCCESS);
+      expect(code).toBe(EXIT_SUCCESS);
       expect(deps.stderr.lines.join('')).toContain('keys create');
-      expect(networkCalls).toBe(0);
 
-      const stillStored = await store.get('https://pagespace.ai', 'default');
+      const result = await client.callTool({ name: 'drives.list', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('keys create');
+
+      expect(networkCalls).toBe(0);
+      expect(storeReads).toBe(0);
+
+      const stillStored = await inner.get('https://pagespace.ai', 'default');
       expect(credentialSecret(stillStored!)).toBe('ps_rt_personal_secret');
     });
   });
@@ -502,7 +548,7 @@ describe('the active key (`pagespace keys use`) as the lowest-priority credentia
     expect(deps.stderr.lines.join('')).toContain('No explicit credential found');
   });
 
-  it('"mcp" still refuses with only an active key — zero network, active credential untouched', async () => {
+  it('"mcp" with only an active key serves degraded — zero network, active credential untouched, calls fail with the active-key refusal', async () => {
     let networkCalls = 0;
     vi.stubGlobal(
       'fetch',
@@ -516,10 +562,14 @@ describe('the active key (`pagespace keys use`) as the lowest-priority credentia
     await store.set(HOST, ACTIVE_CREDENTIAL, 'agent');
     const deps = { ...makeDeps(['mcp']), credentialStore: store, activeKeyStore: createFakeActiveKeyStore({ [HOST]: 'agent' }) };
 
-    const code = await run(deps);
+    const { code, client } = await runMcp(deps);
 
-    expect(code).not.toBe(EXIT_SUCCESS);
+    expect(code).toBe(EXIT_SUCCESS);
     expect(deps.stderr.lines.join('')).toContain('deliberately does not apply to "pagespace mcp"');
+
+    const result = await client.callTool({ name: 'drives.list', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain('deliberately does not apply');
     expect(networkCalls).toBe(0);
   });
 
@@ -556,5 +606,95 @@ describe('isLongRunningCommand', () => {
 
   it('is false when argv does not even parse — the usage-error path is one-shot', () => {
     expect(isLongRunningCommand(['mcp', '--token'])).toBe(false);
+  });
+});
+
+describe('"mcp" no-hang guarantees — initialize/tools-list always answer, auth failures are bounded per-call errors', () => {
+  const HOST = 'https://pagespace.ai';
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('a hung credential-store read (keychain prompt) never blocks the protocol: tools/list instant, tools/call errors after the bounded read timeout', async () => {
+    vi.useFakeTimers();
+    const store = {
+      ...createFakeCredentialStore(),
+      // A keychain read blocking on an unanswerable GUI access prompt.
+      get: () => new Promise<never>(() => {}),
+    };
+    const deps = { ...makeDeps(['mcp', '--key', 'agent']), credentialStore: store };
+
+    const { code, client } = await runMcp(deps);
+    expect(code).toBe(EXIT_SUCCESS);
+
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(60);
+
+    const pending = client.callTool({ name: 'drives.list', arguments: {} });
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await pending;
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain('timed out');
+    expect(JSON.stringify(result.content)).toContain('--token');
+  });
+
+  it('a stored oauth credential against a black-holed host errors after the bounded discovery timeout instead of hanging forever', async () => {
+    vi.useFakeTimers();
+    // fetch that never settles until aborted — a dead tunnel / unroutable host.
+    vi.stubGlobal(
+      'fetch',
+      ((_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        })) as unknown as typeof fetch,
+    );
+
+    const store = createFakeCredentialStore();
+    await store.set(
+      HOST,
+      { kind: 'oauth', refreshToken: 'ps_rt_x', clientId: 'cli', scopes: ['full'], createdAt: new Date(0).toISOString() },
+      'agent',
+    );
+    const deps = { ...makeDeps(['mcp', '--key', 'agent']), credentialStore: store };
+
+    const { code, client } = await runMcp(deps);
+    expect(code).toBe(EXIT_SUCCESS);
+
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(60);
+
+    const pending = client.callTool({ name: 'drives.list', arguments: {} });
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await pending;
+    expect(result.isError).toBe(true);
+
+    // The stored credential must survive the transient failure — no purge.
+    const stillStored = await store.get(HOST, 'agent');
+    expect(credentialSecret(stillStored!)).toBe('ps_rt_x');
+  });
+
+  it('--token happy path: lazy resolution is instant and the tool call reaches the API with the bearer token', async () => {
+    const authHeaders: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      (async (input: RequestInfo | URL, init?: RequestInit) => {
+        authHeaders.push(new Headers(init?.headers).get('authorization') ?? '');
+        void input;
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', 'X-PageSpace-API-Version': '1.0.0' },
+        });
+      }) as unknown as typeof fetch,
+    );
+
+    const deps = makeDeps(['mcp', '--token', 'mcp_explicit_token']);
+    const { code, client } = await runMcp(deps);
+    expect(code).toBe(EXIT_SUCCESS);
+
+    const result = await client.callTool({ name: 'drives.list', arguments: {} });
+    expect(result.isError ?? false).toBe(false);
+    expect(authHeaders).toContain('Bearer mcp_explicit_token');
   });
 });

--- a/packages/cli/src/auth/__tests__/discover.test.ts
+++ b/packages/cli/src/auth/__tests__/discover.test.ts
@@ -94,4 +94,31 @@ describe('createDiscoverMetadata', () => {
 
     await expect(createDiscoverMetadata(fetchImpl)('https://pagespace.ai')).rejects.toThrow(DiscoveryError);
   });
+
+  it('aborts a never-settling fetch after timeoutMs instead of hanging (the pre-initialize mcp hang)', async () => {
+    // A black-holed host (dead tunnel, unroutable address) makes fetch hang
+    // indefinitely; without the abort this promise would never settle and a
+    // `pagespace mcp` tool call would hang exactly like startup used to.
+    const fetchImpl = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      })) as unknown as typeof fetch;
+
+    const discover = createDiscoverMetadata(fetchImpl, { timeoutMs: 10 });
+    await expect(discover('https://pagespace.ai')).rejects.toThrow(/Timed out reaching .* after 10ms/);
+  });
+
+  it('passes its abort signal to fetch so the timeout can actually cancel the request', async () => {
+    let sawSignal = false;
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      sawSignal = init?.signal instanceof AbortSignal;
+      return { ok: true, json: async () => ({
+        authorization_endpoint: 'https://pagespace.ai/api/oauth/authorize',
+        token_endpoint: 'https://pagespace.ai/api/oauth/token',
+      }) };
+    }) as unknown as typeof fetch;
+
+    await createDiscoverMetadata(fetchImpl)('https://pagespace.ai');
+    expect(sawSignal).toBe(true);
+  });
 });

--- a/packages/cli/src/auth/__tests__/lazy-provider.test.ts
+++ b/packages/cli/src/auth/__tests__/lazy-provider.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthProvider } from '@pagespace/sdk';
+import { createLazyAuthProvider } from '../lazy-provider.js';
+
+function fakeProvider(token: string): AuthProvider & { invalidations: number } {
+  const provider = {
+    invalidations: 0,
+    async getAccessToken() {
+      return token;
+    },
+    invalidate() {
+      provider.invalidations += 1;
+    },
+  };
+  return provider;
+}
+
+describe('createLazyAuthProvider', () => {
+  it('defers resolution until the first getAccessToken call', async () => {
+    let resolved = 0;
+    const lazy = createLazyAuthProvider(async () => {
+      resolved += 1;
+      return fakeProvider('tok');
+    });
+
+    expect(resolved).toBe(0);
+    await expect(lazy.getAccessToken()).resolves.toBe('tok');
+    expect(resolved).toBe(1);
+  });
+
+  it('memoizes a successful resolution — later calls reuse the same inner provider', async () => {
+    let resolved = 0;
+    const lazy = createLazyAuthProvider(async () => {
+      resolved += 1;
+      return fakeProvider('tok');
+    });
+
+    await lazy.getAccessToken();
+    await lazy.getAccessToken();
+    await lazy.getAccessToken();
+    expect(resolved).toBe(1);
+  });
+
+  it('dedupes concurrent first calls into one in-flight resolution (mirrors OAuthTokenProvider #inFlightRefresh)', async () => {
+    let resolved = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const lazy = createLazyAuthProvider(async () => {
+      resolved += 1;
+      await gate;
+      return fakeProvider('tok');
+    });
+
+    const first = lazy.getAccessToken();
+    const second = lazy.getAccessToken();
+    release();
+    await expect(first).resolves.toBe('tok');
+    await expect(second).resolves.toBe('tok');
+    expect(resolved).toBe(1);
+  });
+
+  it('clears the memo on rejection so the next call retries (transient keychain/network outages recover in-process)', async () => {
+    let attempts = 0;
+    const lazy = createLazyAuthProvider(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('keychain locked');
+      return fakeProvider('tok');
+    });
+
+    await expect(lazy.getAccessToken()).rejects.toThrow('keychain locked');
+    await expect(lazy.getAccessToken()).resolves.toBe('tok');
+    expect(attempts).toBe(2);
+  });
+
+  it('invalidate() is a no-op before resolution and forwards after it', async () => {
+    const inner = fakeProvider('tok');
+    const lazy = createLazyAuthProvider(async () => inner);
+
+    lazy.invalidate();
+    expect(inner.invalidations).toBe(0);
+
+    await lazy.getAccessToken();
+    lazy.invalidate();
+    expect(inner.invalidations).toBe(1);
+  });
+});

--- a/packages/cli/src/auth/__tests__/silent-refresh.test.ts
+++ b/packages/cli/src/auth/__tests__/silent-refresh.test.ts
@@ -121,4 +121,24 @@ describe('createRefreshAccessToken', () => {
     expect(isRateLimitError(thrown)).toBe(false);
     expect(isServerError(thrown)).toBe(false);
   });
+
+  it('aborts a never-settling POST after timeoutMs with a retryable TimeoutError (never hangs, never purges)', async () => {
+    // An unreachable token endpoint (dead tunnel) must become the SDK's own
+    // TimeoutError: `classifyRefreshFailure` treats it as retryable, so the
+    // stored refresh token survives a transient outage instead of being
+    // purged — and the caller (a `pagespace mcp` tool call) gets an error
+    // instead of an indefinite hang.
+    const fetchImpl = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      })) as unknown as typeof fetch;
+
+    const refresh = createRefreshAccessToken(TOKEN_ENDPOINT, CLIENT_ID, fetchImpl, Date.now, { timeoutMs: 10 });
+
+    // isTimeoutError is exactly what the SDK's classifyRefreshFailure keys on
+    // for its 'retryable' verdict (packages/sdk/src/auth/decide.ts) — a
+    // bespoke error type here would classify terminal and purge the stored
+    // refresh token on a transient outage.
+    await expect(refresh('ps_rt_old')).rejects.toSatisfy((error: unknown) => isTimeoutError(error));
+  });
 });

--- a/packages/cli/src/auth/discover.ts
+++ b/packages/cli/src/auth/discover.ts
@@ -26,15 +26,47 @@ const metadataSchema = z.object({
 
 const WELL_KNOWN_PATH = '/.well-known/oauth-authorization-server';
 
-export function createDiscoverMetadata(fetchImpl: typeof fetch = fetch): DiscoverMetadata {
+/**
+ * Discovery can run before ANY transport is connected — `pagespace mcp`
+ * materializes auth on the first tool call of a server an MCP client already
+ * considers live — so an unreachable host must surface as an error, never an
+ * unbounded hang. Same abort shell as the SDK's transport/execute.ts.
+ */
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 10_000;
+
+export interface DiscoverMetadataOptions {
+  readonly timeoutMs?: number;
+  /** Injected so tests can control abort deterministically without real timers/network. */
+  readonly abortFactory?: () => AbortController;
+}
+
+export function createDiscoverMetadata(
+  fetchImpl: typeof fetch = fetch,
+  options: DiscoverMetadataOptions = {},
+): DiscoverMetadata {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+  const abortFactory = options.abortFactory ?? (() => new AbortController());
+
   return async (host: string): Promise<DiscoveredMetadata> => {
     const url = `${host.replace(/\/+$/, '')}${WELL_KNOWN_PATH}`;
 
+    const controller = abortFactory();
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+
     let response: Response;
     try {
-      response = await fetchImpl(url);
+      response = await fetchImpl(url, { signal: controller.signal });
     } catch (error) {
+      if (timedOut) {
+        throw new DiscoveryError(`Timed out reaching ${url} after ${timeoutMs}ms`);
+      }
       throw new DiscoveryError(`Could not reach ${url}: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      clearTimeout(timer);
     }
 
     if (!response.ok) {

--- a/packages/cli/src/auth/lazy-provider.ts
+++ b/packages/cli/src/auth/lazy-provider.ts
@@ -1,0 +1,52 @@
+/**
+ * Defers credential resolution until the first `getAccessToken()` call —
+ * built for `pagespace mcp`, whose stdio transport must connect and answer
+ * `initialize`/`tools/list` immediately even when the credential store or
+ * network is broken (run.ts's `lazyAuth` route wiring). Resolution effects
+ * (keychain read, OAuth discovery + refresh) move from process startup to
+ * the first tool call, where a failure surfaces as that call's `isError`
+ * result instead of a dead process the MCP client can only see as a hang.
+ *
+ * Concurrency contract mirrors `OAuthTokenProvider.#inFlightRefresh`
+ * (packages/sdk/src/auth/oauth.ts): concurrent callers join the in-flight
+ * resolution rather than racing duplicate keychain/network effects. A
+ * rejected resolution clears the memo so the next tool call retries — a
+ * transient keychain lock or network outage recovers without restarting
+ * the server.
+ */
+import type { AuthProvider } from '@pagespace/sdk';
+
+export function createLazyAuthProvider(resolve: () => Promise<AuthProvider>): AuthProvider {
+  let inner: AuthProvider | null = null;
+  let inFlight: Promise<AuthProvider> | null = null;
+
+  const materialize = async (): Promise<AuthProvider> => {
+    if (inner !== null) return inner;
+    if (inFlight === null) {
+      inFlight = resolve().then(
+        (provider) => {
+          inner = provider;
+          inFlight = null;
+          return provider;
+        },
+        (error: unknown) => {
+          inFlight = null;
+          throw error;
+        },
+      );
+    }
+    return inFlight;
+  };
+
+  return {
+    async getAccessToken(): Promise<string> {
+      const provider = await materialize();
+      return provider.getAccessToken();
+    },
+    invalidate(): void {
+      // Nothing to forward to until resolution has succeeded; a pending or
+      // failed resolution has issued no token that could need invalidating.
+      inner?.invalidate();
+    },
+  };
+}

--- a/packages/cli/src/auth/silent-refresh.ts
+++ b/packages/cli/src/auth/silent-refresh.ts
@@ -13,7 +13,7 @@
  * that would always classify as terminal regardless of cause.
  */
 import { z } from 'zod';
-import { classifyHttpError, NetworkError } from '@pagespace/sdk';
+import { classifyHttpError, NetworkError, TimeoutError } from '@pagespace/sdk';
 import type { OAuthTokens, RefreshAccessToken } from '@pagespace/sdk';
 
 const refreshResponseSchema = z.object({
@@ -32,12 +32,31 @@ const refreshResponseSchema = z.object({
  */
 const NOMINAL_REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
+/**
+ * This grant can run before ANY transport is connected (`pagespace mcp`
+ * resolves auth lazily on the first tool call), so an unreachable token
+ * endpoint must become a typed error, never an unbounded hang. The SDK's
+ * `TimeoutError` — not a bespoke type — so `classifyRefreshFailure` treats
+ * it as transient (retry next call), never as a purge-worthy rejection.
+ */
+const DEFAULT_REFRESH_TIMEOUT_MS = 10_000;
+
+export interface RefreshAccessTokenOptions {
+  readonly timeoutMs?: number;
+  /** Injected so tests can control abort deterministically without real timers/network. */
+  readonly abortFactory?: () => AbortController;
+}
+
 export function createRefreshAccessToken(
   tokenEndpoint: string,
   clientId: string,
   fetchImpl: typeof fetch = fetch,
   now: () => number = Date.now,
+  options: RefreshAccessTokenOptions = {},
 ): RefreshAccessToken {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS;
+  const abortFactory = options.abortFactory ?? (() => new AbortController());
+
   return async (refreshToken: string): Promise<OAuthTokens> => {
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
@@ -45,15 +64,31 @@ export function createRefreshAccessToken(
       client_id: clientId,
     });
 
+    const controller = abortFactory();
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+
     let response: Response;
     try {
       response = await fetchImpl(tokenEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: body.toString(),
+        signal: controller.signal,
       });
     } catch (error) {
+      if (timedOut) {
+        throw new TimeoutError(`Refresh token request timed out after ${timeoutMs}ms`, {
+          operation: 'auth.refresh',
+          timeoutMs,
+        });
+      }
       throw new NetworkError('Refresh token request failed', { cause: error, operation: 'auth.refresh' });
+    } finally {
+      clearTimeout(timer);
     }
 
     const bodyText = await response.text();

--- a/packages/cli/src/commands/__tests__/mcp.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp.test.ts
@@ -65,47 +65,76 @@ describe('createMcpHandler — thin stdio wiring over ctx.sdk', () => {
   });
 });
 
-describe('createMcpHandler — fails closed with no explicit credential (Phase 8 task 4)', () => {
-  it('no --token, no PAGESPACE_TOKEN, no --key, no PAGESPACE_KEY -> refuses to start, transport never touched', async () => {
-    let createTransportCalls = 0;
-    const handler = createMcpHandler({
-      createTransport: () => {
-        createTransportCalls += 1;
-        throw new Error('should never be reached');
-      },
-    });
+describe('createMcpHandler — serves degraded with no explicit credential (Phase 8 task 4 invariant, warn-and-serve failure mode)', () => {
+  it('no --token, no PAGESPACE_TOKEN, no --key, no PAGESPACE_KEY -> serves, but every tool call fails with the actionable message and ctx.sdk is never consulted', async () => {
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler({ createTransport: () => serverTransport });
 
     const stdout = createRecordingSink();
     const stderr = createRecordingSink();
-    const ctx = createFakeContext({ stdout, stderr, env: {} });
+    let sdkInvokeCalls = 0;
+    const ctx = createFakeContext({
+      stdout,
+      stderr,
+      env: {},
+      // A pre-transport exit is indistinguishable from a hung server to the
+      // MCP client on the far side of the pipe, so the credential-less case
+      // must connect and fail per-call — but strictly through the stub sdk:
+      // this recording ctx.sdk proves the ambient client is never touched.
+      sdk: {
+        invoke: async () => {
+          sdkInvokeCalls += 1;
+          throw new Error('ctx.sdk must never be consulted without an explicit credential');
+        },
+      } as never,
+    });
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
 
-    const code = await handler(ctx, commandIntent(['mcp']));
+    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
 
-    expect(code).toBe(EXIT_RUNTIME_ERROR);
-    expect(createTransportCalls).toBe(0);
+    expect(code).toBe(EXIT_SUCCESS);
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(60);
+
+    const result = await client.callTool({ name: 'drives.list', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/never falls back to your personal login/i);
+    expect(JSON.stringify(result.content)).toContain('keys create');
+
+    expect(sdkInvokeCalls).toBe(0);
     expect(stdout.lines).toEqual([]);
     expect(stderr.lines.join('')).toMatch(/never falls back to your personal login/i);
-    expect(stderr.lines.join('')).toContain('keys create');
-    expect(stderr.lines.join('')).not.toContain('serving');
+    expect(stderr.lines.join('')).toContain('serving');
   });
 
   it('does not silently fall back to a stored default login credential just because one exists', async () => {
-    let createTransportCalls = 0;
-    const handler = createMcpHandler({
-      createTransport: () => {
-        createTransportCalls += 1;
-        throw new Error('should never be reached');
-      },
-    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler({ createTransport: () => serverTransport });
 
     const stderr = createRecordingSink();
-    const ctx = createFakeContext({ stderr, env: {} });
+    let sdkInvokeCalls = 0;
     // A stored personal credential existing in ctx.sdk/credentialStore must not matter —
-    // the gate only looks at this invocation's own flags/env.
-    const code = await handler(ctx, commandIntent(['mcp']));
+    // the credential check only looks at this invocation's own flags/env, and
+    // the served-but-degraded server must fail calls through the stub, never
+    // reach for whatever run.ts happened to wire into ctx.sdk.
+    const ctx = createFakeContext({
+      stderr,
+      env: {},
+      sdk: {
+        invoke: async () => {
+          sdkInvokeCalls += 1;
+          return { drives: [] };
+        },
+      } as never,
+    });
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
 
-    expect(code).toBe(EXIT_RUNTIME_ERROR);
-    expect(createTransportCalls).toBe(0);
+    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    const result = await client.callTool({ name: 'drives.list', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(sdkInvokeCalls).toBe(0);
   });
 
   it('--key alone (no --token, no env) is sufficient to start', async () => {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -6,33 +6,39 @@
  * already proved who they are at a prompt. `mcp`'s entire purpose, by
  * contrast, is being invoked unattended by an automated MCP client — there
  * is no legitimate case where it should inherit the human's personal
- * credential behind that client's back (Phase 8 task 4). So before doing
- * anything else, this handler runs `hasExplicitCredential` — a pure
- * predicate over the parsed flags/env, deliberately independent of
- * `resolveAuth`/`resolveProfileName`, which both intentionally fall back to
- * the stored "default" profile — and refuses to start the stdio server at
- * all unless this invocation names a credential itself. `run.ts` runs this
- * same check even earlier, before dispatching here at all — needed because
- * by the time this handler runs, `run.ts` has already resolved and would
- * otherwise be about to enforce the ambient auth source (a real
- * discovery+refresh network call, and a credential rotation, for a stored
- * default profile) via `enforceAuth`. The check here is what makes this
- * handler safe to call directly (as the unit tests below do, bypassing
- * `run.ts` entirely) rather than a redundant no-op. Once past both gates,
- * it authenticates through `ctx.sdk` exactly like every other
- * command, ONLY through the resolver built once by `run.ts` (Phase 4 task 7
- * precedence, extended with the legacy credential env var support in
- * `auth/legacy-token-env.ts` — so existing `npx pagespace-mcp` configs keep
- * working). This file never constructs its own client and never reads a
- * credential env var itself — see `commands/__tests__/single-auth-path.test.ts`,
- * which enforces that structurally across every command module.
+ * credential behind that client's back (Phase 8 task 4). So before touching
+ * `ctx.sdk`, this handler runs `hasExplicitCredential` — a pure predicate
+ * over the parsed flags/env, deliberately independent of `resolveAuth`/
+ * `resolveProfileName`, which both intentionally fall back to the stored
+ * "default" profile. Without an explicit credential it still SERVES (an MCP
+ * client can only see a pre-transport exit as a hung server — the failure
+ * mode this command shipped with, indistinguishable from hours of downtime
+ * behind a spawning client like ChatGPT desktop), but through a stub sdk
+ * whose every call fails with the actionable message; `ctx.sdk` is never
+ * consulted. `run.ts` enforces the same invariant even earlier via the
+ * `lazyAuth` route property: with nothing explicit named it never calls
+ * `resolveCredentialSource` at all (the ambient stored credential is never
+ * even read), and with a credential named it defers resolution — the
+ * keychain read, discovery, refresh — to the first tool call via
+ * `createLazyAuthProvider`, so `initialize`/`tools/list` always answer
+ * immediately. The check here is what makes this handler safe to call
+ * directly (as the unit tests below do, bypassing `run.ts` entirely) rather
+ * than a redundant no-op. With a credential named, it authenticates through
+ * `ctx.sdk` exactly like every other command, ONLY through the resolver
+ * built once by `run.ts` (Phase 4 task 7 precedence, extended with the
+ * legacy credential env var support in `auth/legacy-token-env.ts` — so
+ * existing `npx pagespace-mcp` configs keep working). This file never
+ * constructs its own client and never reads a credential env var itself —
+ * see `commands/__tests__/single-auth-path.test.ts`, which enforces that
+ * structurally across every command module.
  */
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { AuthenticationError } from '@pagespace/sdk';
 import { hasExplicitCredential, mcpNoExplicitCredentialMessage } from '../auth/resolve.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS } from '../exit-codes.js';
 import type { CommandHandler } from '../router/router.js';
-import { buildOperationRegistry, createMcpServer } from '../mcp/serve.js';
+import { buildOperationRegistry, createMcpServer, type McpSdkClient } from '../mcp/serve.js';
 
 export interface McpHandlerDeps {
   readonly createTransport: () => Transport;
@@ -44,15 +50,35 @@ export function createMcpHandler(deps: McpHandlerDeps): CommandHandler {
     // keys use`) deliberately does NOT apply to `pagespace mcp` — an MCP
     // config must name its credential explicitly (--key/PAGESPACE_KEY or
     // --token), never ride the human's per-machine activation.
-    if (!hasExplicitCredential({ token: intent.flags.token, key: intent.flags.key }, ctx.env)) {
-      ctx.stderr.write(`${mcpNoExplicitCredentialMessage()}\n`);
-      return EXIT_RUNTIME_ERROR;
-    }
+    //
+    // Refusing here must NOT mean refusing to serve: an MCP client can only
+    // observe a child that exits before its transport connects as a hung
+    // server (the old `pagespace-mcp` npm package always served and failed
+    // per-call, which is what every migrated config's client is built
+    // against). So the credential-less case serves the registry anyway and
+    // fails every `tools/call` with the actionable message — through a stub
+    // sdk, NOT `ctx.sdk`, keeping the Phase 8 invariant structural: even if
+    // a run.ts regression someday wired an ambient credential into
+    // `ctx.sdk`, this handler still could not use it without a credential
+    // named in this invocation itself.
+    const explicit = hasExplicitCredential({ token: intent.flags.token, key: intent.flags.key }, ctx.env);
+    const sdk: McpSdkClient = explicit
+      ? ctx.sdk
+      : {
+          invoke: async () => {
+            throw new AuthenticationError(mcpNoExplicitCredentialMessage());
+          },
+        };
 
     const registry = buildOperationRegistry();
-    const server = createMcpServer({ registry, sdk: ctx.sdk });
+    const server = createMcpServer({ registry, sdk });
 
-    ctx.stderr.write(`pagespace mcp: serving ${registry.all.length} tools over stdio\n`);
+    if (!explicit) {
+      ctx.stderr.write(`${mcpNoExplicitCredentialMessage()}\n`);
+    }
+    ctx.stderr.write(
+      `pagespace mcp: serving ${registry.all.length} tools over stdio${explicit ? '' : ' (no credential — every tool call will fail until one is configured)'}\n`,
+    );
 
     try {
       await server.connect(deps.createTransport());

--- a/packages/cli/src/mcp/__tests__/serve.test.ts
+++ b/packages/cli/src/mcp/__tests__/serve.test.ts
@@ -145,14 +145,16 @@ describe('createMcpServer — call_tool round trips', () => {
     expect(JSON.stringify(result.content)).toContain('drive:admin');
   });
 
-  it('authentication failure surfaces as a distinct, actionable error result', async () => {
+  it('authentication failure surfaces as a distinct error result carrying the provider message', async () => {
     const client = await connectedClient(registryOf(echoOp), async () => {
-      throw new AuthenticationError('nope', 'test.echo');
+      throw new AuthenticationError('name a key with --key or PAGESPACE_KEY', 'test.echo');
     });
 
     const result = await client.callTool({ name: 'test.echo', arguments: { message: 'hi' } });
     expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.content)).toMatch(/login|token/i);
+    const text = (result.content as Array<{ text?: string }>)[0]?.text ?? '';
+    expect(text).toContain('Authentication failed for "test.echo"');
+    expect(text).toContain('name a key with --key or PAGESPACE_KEY');
   });
 
   it('not-found surfaces distinctly from permission-denied', async () => {

--- a/packages/cli/src/mcp/__tests__/tool-convert.test.ts
+++ b/packages/cli/src/mcp/__tests__/tool-convert.test.ts
@@ -210,9 +210,15 @@ describe('formatSdkErrorResult — distinct, secret-free messages per SDK error 
     expect(result.content[0]?.text).toContain('drive:admin');
   });
 
-  it('maps an authentication failure to an actionable message', () => {
-    const result = formatSdkErrorResult(globSearch, new FakeAuthenticationError('nope'));
-    expect(result.content[0]?.text).toMatch(/login|PAGESPACE_TOKEN/i);
+  it('maps an authentication failure to a message carrying the provider remediation text', () => {
+    // The CLI authors every AuthenticationError message reaching this server
+    // (FailingAuthProvider remediation copy, the lazy keychain-timeout
+    // message) — the fixed hint this branch used to append said `pagespace
+    // login`, the one remediation `pagespace mcp` deliberately refuses.
+    const result = formatSdkErrorResult(globSearch, new FakeAuthenticationError('mint a key with "pagespace keys create"'));
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Authentication failed for "search.glob"');
+    expect(result.content[0]?.text).toContain('mint a key with "pagespace keys create"');
   });
 
   it('maps a not-found error to a distinct message from permission-denied', () => {

--- a/packages/cli/src/mcp/tool-convert.ts
+++ b/packages/cli/src/mcp/tool-convert.ts
@@ -131,7 +131,14 @@ export function formatSdkErrorResult(op: Operation, error: unknown): McpCallResu
     return textResult(`Permission denied for "${op.name}".${scope}`, true);
   }
   if (isAuthenticationError(error)) {
-    return textResult(`Authentication failed for "${op.name}". Run "pagespace login" or set PAGESPACE_TOKEN.`, true);
+    // The message passes through: every `AuthenticationError` reaching this
+    // server is authored by this CLI (FailingAuthProvider's remediation
+    // copy, the lazy keychain-timeout message, `classifyHttpError`'s typed
+    // 401 text) and is secret-free by construction. The old fixed hint here
+    // said `Run "pagespace login"` — the one remediation `pagespace mcp`
+    // deliberately refuses (see commands/mcp.ts) — actively misdirecting
+    // the person debugging a credential-less MCP config.
+    return textResult(`Authentication failed for "${op.name}": ${error.message}`, true);
   }
   if (isNotFoundError(error)) {
     return textResult(`Not found: the target of "${op.name}" does not exist or is not accessible.`, true);

--- a/packages/cli/src/pagespace-mcp-bin.ts
+++ b/packages/cli/src/pagespace-mcp-bin.ts
@@ -1,7 +1,10 @@
 /**
  * `pagespace-mcp` bin — a first-class, zero-install entry point for running
- * the same `pagespace mcp` stdio server via `npx -y @pagespace/cli
- * pagespace-mcp`. `run.ts` already resolves `PAGESPACE_API_URL`/
+ * the same `pagespace mcp` stdio server via `npx -y -p @pagespace/cli
+ * pagespace-mcp`. (The `-p` is load-bearing: this package publishes two bins
+ * and neither is named after the package, so without it npx dies with
+ * "could not determine executable to run" — which an MCP client renders as
+ * a server that never came up.) `run.ts` already resolves `PAGESPACE_API_URL`/
  * `PAGESPACE_AUTH_TOKEN` (`auth/legacy-token-env.ts`) for every command, so
  * this alias needs no auth logic of its own — it just has to route to `mcp`.
  * Kept as a pure composition over injected `RunDependencies` (same shape

--- a/packages/cli/src/router/router.ts
+++ b/packages/cli/src/router/router.ts
@@ -21,6 +21,16 @@ export interface Route {
    * future long-running command can't forget to opt out of the force-exit.
    */
   readonly longRunning?: true;
+  /**
+   * The handler serves a protocol whose client can only observe a startup
+   * failure as a silent hang (e.g. `mcp`'s stdio server — a child that exits
+   * before the transport connects looks identical to a hung server from the
+   * far side of the pipe). `run.ts` must NOT materialize auth (keychain read,
+   * OAuth discovery/refresh) before dispatching such a route: it defers all
+   * credential resolution to the first actual use, where a failure surfaces
+   * through the protocol as an actionable error instead of a dead process.
+   */
+  readonly lazyAuth?: true;
 }
 
 export type RouteResolution =

--- a/packages/cli/src/router/routes.ts
+++ b/packages/cli/src/router/routes.ts
@@ -98,7 +98,7 @@ const OTHER_ROUTES: readonly RouteEntry[] = [
   { path: ['keys', 'list'], handler: tokensListHandler, summary: 'List access keys' },
   { path: ['keys', 'revoke'], handler: tokensRevokeHandler, summary: 'Revoke an access key' },
   { path: ['keys', 'use'], handler: keysUseHandler, summary: "Set this machine's active key (--device for a headless machine)" },
-  { path: ['mcp'], handler: mcpHandler, longRunning: true, summary: 'Serve the full operation registry as an MCP stdio server' },
+  { path: ['mcp'], handler: mcpHandler, longRunning: true, lazyAuth: true, summary: 'Serve the full operation registry as an MCP stdio server' },
   { path: ['drives', 'list'], handler: drivesListHandler, summary: 'List drives' },
   { path: ['drives', 'create'], handler: drivesCreateHandler, summary: 'Create a drive' },
   { path: ['drives', 'rename'], handler: drivesRenameHandler, summary: 'Rename a drive' },

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -4,18 +4,21 @@
  * and returns an exit code; `bin.ts` is the only caller that touches the
  * real process.
  */
-import { PageSpaceClient } from '@pagespace/sdk';
+import { AuthenticationError, PageSpaceClient } from '@pagespace/sdk';
+import type { AuthProvider } from '@pagespace/sdk';
 import { parseArgv } from './argv/parse.js';
-import { buildAuthProvider, enforceAuth } from './auth/auth-context.js';
+import { buildAuthProvider, enforceAuth, FailingAuthProvider } from './auth/auth-context.js';
 import { createDiscoverMetadata } from './auth/discover.js';
+import { createLazyAuthProvider } from './auth/lazy-provider.js';
 import { resolveEnvKeyName, resolveEnvToken } from './auth/legacy-token-env.js';
 import { createRefreshAccessToken } from './auth/silent-refresh.js';
-import { mcpNoExplicitCredentialMessage, noExplicitCredentialMessage } from './auth/resolve.js';
+import { hasExplicitCredential, mcpNoExplicitCredentialMessage, noExplicitCredentialMessage } from './auth/resolve.js';
 import { resolveCredentialSource } from './auth/resolve-credential-source.js';
 import { loginHandler } from './commands/login.js';
 import { loginDeviceHandler } from './commands/login-device.js';
 import { logoutHandler } from './commands/logout.js';
-import { mcpHandler } from './commands/mcp.js';
+import { createMcpHandler, mcpHandler } from './commands/mcp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { tokensCreateHandler } from './commands/keys/create.js';
 import { tokensListHandler } from './commands/keys/list.js';
 import { tokensRevokeHandler } from './commands/keys/revoke.js';
@@ -47,6 +50,14 @@ export interface RunDependencies {
   readonly isTTY?: boolean;
   /** Defaults to a function that never resolves truthily when omitted; only called when `isTTY` is true. */
   readonly prompt?: (message: string) => Promise<string>;
+  /**
+   * Test seam: when present and the mcp route is dispatched, the handler is
+   * built around this transport factory instead of the module-level
+   * `mcpHandler`'s real `StdioServerTransport` — `run(['mcp'])` in a test
+   * must never attach a live stdio transport to the test runner's process.
+   * `bin.ts` never sets it.
+   */
+  readonly createMcpTransport?: () => Transport;
 }
 
 /**
@@ -160,21 +171,69 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
   // per-machine activation (its config must name a credential itself).
   const activeKeyEligible = routedHandler !== null && !isAuthExempt && routedHandler !== mcpHandler;
 
-  const { source, activeKeyName, explicit } = await resolveCredentialSource({
-    flags: { token: parsed.flags.token, key: parsed.flags.key },
-    env: deps.env,
-    host,
-    credentialStore: deps.credentialStore,
-    activeKeyStore,
-    allowActiveKey: activeKeyEligible,
-  });
+  const isLazyAuthRoute = resolution.kind === 'match' && resolution.route.lazyAuth === true;
 
-  const auth = buildAuthProvider(source, {
+  const authProviderDeps = {
     discoverMetadata: createDiscoverMetadata(),
     createRefreshAccessToken,
     credentialStore: deps.credentialStore,
     now: Date.now,
-  });
+  };
+
+  let auth: AuthProvider;
+  let source: Awaited<ReturnType<typeof resolveCredentialSource>>['source'] | null;
+  let activeKeyName: string | null;
+  let explicit: boolean;
+
+  if (isLazyAuthRoute) {
+    // A lazy-auth route (today only `mcp`) serves a protocol whose client
+    // can only see a startup failure as a silent hang, so NOTHING about the
+    // credential may run before the handler connects its transport: no
+    // credential-store read (a native keychain call that can block on an
+    // access prompt when spawned headless by an MCP client), no OAuth
+    // discovery/refresh (unbounded-feeling network I/O against a possibly
+    // dead host), no store purge. The Phase 8 task 4 invariant — never ride
+    // the human's ambient login credential — is preserved *structurally*
+    // here: with nothing explicit given, `resolveCredentialSource` is never
+    // called at all, so the ambient stored credential cannot even be read,
+    // and the wired provider fails every call with the actionable mcp
+    // message. With an explicit credential named, resolution (including the
+    // keychain read, bounded below) and any discovery/refresh move to the
+    // first `getAccessToken()` — i.e. the first tool call — where a failure
+    // surfaces as that call's error result through the live server.
+    explicit = hasExplicitCredential({ token: parsed.flags.token, key: parsed.flags.key }, deps.env);
+    source = null;
+    activeKeyName = null;
+    auth = explicit
+      ? createLazyAuthProvider(async () => {
+          const resolved = await resolveWithTimeout(
+            resolveCredentialSource({
+              flags: { token: parsed.flags.token, key: parsed.flags.key },
+              env: deps.env,
+              host,
+              credentialStore: deps.credentialStore,
+              activeKeyStore,
+              allowActiveKey: false,
+            }),
+            CREDENTIAL_STORE_READ_TIMEOUT_MS,
+          );
+          return buildAuthProvider(resolved.source, authProviderDeps);
+        })
+      : new FailingAuthProvider(mcpNoExplicitCredentialMessage());
+  } else {
+    const resolved = await resolveCredentialSource({
+      flags: { token: parsed.flags.token, key: parsed.flags.key },
+      env: deps.env,
+      host,
+      credentialStore: deps.credentialStore,
+      activeKeyStore,
+      allowActiveKey: activeKeyEligible,
+    });
+    source = resolved.source;
+    activeKeyName = resolved.activeKeyName;
+    explicit = resolved.explicit;
+    auth = buildAuthProvider(resolved.source, authProviderDeps);
+  }
 
   const ctx: HandlerContext = {
     sdk: new PageSpaceClient({ baseUrl: host, auth }),
@@ -202,7 +261,7 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
     return EXIT_USAGE_ERROR;
   }
 
-  if (!isAuthExempt && !explicit && activeKeyName === null) {
+  if (!isAuthExempt && !isLazyAuthRoute && !explicit && activeKeyName === null) {
     // Must run before `enforceAuth` below: that call materializes `source` by
     // calling `auth.getAccessToken()`, which for a `kind: 'stored'` source
     // (the ambient "default"/personal credential falling through here with
@@ -214,18 +273,68 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
     // that the command never runs afterward. An active key (checked above,
     // never for `mcp`) satisfies this gate for content commands: a human
     // approved exactly that key for this machine in a browser.
+    //
+    // Lazy-auth routes (`mcp`) are exempted from this early *exit* but not
+    // from the invariant it protects: their no-explicit-credential case was
+    // handled above by wiring a `FailingAuthProvider` WITHOUT ever calling
+    // `resolveCredentialSource` — strictly stronger than this gate, which
+    // runs after that resolver has already read the store. Exiting here
+    // would recreate the exact failure this route shape exists to avoid: a
+    // child that dies before its transport connects is indistinguishable
+    // from a hung server to the MCP client on the other end of the pipe.
     deps.stderr.write(
       `${resolution.route.handler === mcpHandler ? mcpNoExplicitCredentialMessage() : noExplicitCredentialMessage()}\n`,
     );
     return EXIT_RUNTIME_ERROR;
   }
 
-  if (!isAuthExempt) {
+  if (!isAuthExempt && !isLazyAuthRoute && source !== null) {
+    // Deliberately skipped for lazy-auth routes: `enforceAuth` materializes
+    // a token (discovery + refresh network I/O) before the handler runs —
+    // pre-transport death on failure — and its stored-credential purge fires
+    // on ANY AuthenticationError, which a long outage can produce
+    // transiently; wiping the stored key over that turns a temporary outage
+    // into a permanent re-login. Lazy routes surface auth failures per call
+    // instead, and never purge.
     const failure = await enforceAuth({ auth, source, credentialStore: deps.credentialStore, stderr: deps.stderr });
     if (failure !== null) {
       return failure;
     }
   }
 
-  return resolution.route.handler(ctx, { ...parsed, args: resolution.rest });
+  const handler =
+    deps.createMcpTransport !== undefined && resolution.route.handler === mcpHandler
+      ? createMcpHandler({ createTransport: deps.createMcpTransport })
+      : resolution.route.handler;
+  return handler(ctx, { ...parsed, args: resolution.rest });
+}
+
+/**
+ * Bounds the lazy credential-store read for lazy-auth routes: on macOS a
+ * keychain read can surface a GUI access prompt, which never gets answered
+ * when the process was spawned headless by an MCP client — without a bound
+ * the first tool call would hang exactly the way startup used to.
+ */
+const CREDENTIAL_STORE_READ_TIMEOUT_MS = 5_000;
+
+async function resolveWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new AuthenticationError(
+              `Reading the stored credential timed out after ${timeoutMs}ms — the OS keychain may be locked or ` +
+                'waiting on an access prompt this process cannot show. Pass --token (or set PAGESPACE_TOKEN) in ' +
+                'the MCP config to avoid the credential store entirely.',
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }


### PR DESCRIPTION
## Problem

A user reported hours of ChatGPT MCP timeouts with the new CLI while the old \`pagespace-mcp\` npm package kept working. Live stdio probes against the published CLI confirmed three startup failure modes, all of which an MCP client (ChatGPT desktop, Codex, Claude Desktop, stdio bridges) can only render as a server that never came up:

1. **No explicit credential → exit 1 before the transport connects.** The old package warned and served; every migrated config's client is built against that tolerance.
2. **Stored oauth credential + unreachable host → infinite silent hang.** \`enforceAuth\` ran OAuth discovery + refresh before \`initialize\` with no fetch timeout — and then **purged the stored credential** on the transient failure, turning an outage into a forced re-login.
3. **Keychain read at startup** can block forever on a GUI access prompt in headless spawns.

Separately, the field failure that actually broke a live config: \`npx -y @pagespace/cli pagespace-mcp\` **without \`-p\`** dies with \`could not determine executable to run\` (two bins, neither named after the package) — Codex shows Tools: (none). No doc showed the ChatGPT/Codex TOML config shape.

## Fix

- \`lazyAuth\` route property: for \`mcp\`, run.ts never calls \`resolveCredentialSource\` when nothing explicit is named (zero store reads — strictly stronger than the old gate) and wires a \`FailingAuthProvider\`; with a credential named, resolution defers to the first tool call via \`createLazyAuthProvider\` (keychain read bounded 5s, retries on next call, never purges).
- OAuth discovery + silent-refresh fetches gain AbortSignal timeouts (10s); refresh timeout throws the SDK \`TimeoutError\` so it classifies retryable.
- \`commands/mcp.ts\` serves degraded through a stub sdk with no credential — \`initialize\`/\`tools/list\` always answer instantly, every \`tools/call\` returns the actionable \`isError\` message; \`ctx.sdk\` structurally unreachable without an explicit credential.
- \`tool-convert\` passes the auth error's remediation text through (old fixed hint said \`pagespace login\` — the one remediation mcp refuses).
- \`RunDependencies.createMcpTransport\` seam so run-level tests use \`InMemoryTransport\`.
- Docs: ChatGPT desktop / Codex section (TOML \`~/.codex/config.toml\`, load-bearing \`-p\`, \`startup_timeout_sec\`, GUI-PATH caveat) in the migration guide + marketing MCP page.

The Phase 8 task 4 invariant (never ride the ambient login credential) is preserved structurally — the no-credential path can no longer even read the store, and the zero-side-effect assertions in run.test.ts got stronger.

## Verification

- 1126 CLI tests green (incl. new no-hang tests: hung keychain, black-holed host, concurrency/memoization of the lazy provider); typecheck 16/16; lint green.
- Live stdio probes on the built CLI: no-env serves 71 tools in ~210ms with per-call auth errors; stored-oauth + black-holed host answers \`initialize\` in ~180ms and errors the call after the bounded timeout with the credential left intact.
- Real-client end-to-end: a live Codex session spawned the server and \`drives.list\` returned 56 drives.

Sibling change (separate repo, not in this PR): \`pagespace-mcp\` 5.2.8 corrects its deprecation notice, which pointed users at \`pagespace login\` (refused by mcp) and the renamed \`pagespace tokens create\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZ4Dp6SazFhnSpDHmk15cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP servers now remain available without credentials, showing tools while returning clear authentication guidance when actions are attempted.
  * Authentication is resolved only when needed, improving startup behavior and avoiding unnecessary credential access.
  * Added timeout handling for credential discovery and token refresh requests.
* **Documentation**
  * Added setup and migration guidance for ChatGPT Desktop, Codex CLI, and OpenAI Secure MCP Tunnel.
  * Clarified required `npx` configuration, environment variables, timeouts, PATH settings, and credential inheritance.
* **Bug Fixes**
  * Authentication errors now include provider-specific remediation details instead of generic guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->