### PR TITLE
feat(agents): offer Global Assistant in the New Session drive picker

### DIFF
--- a/apps/web/src/components/agents/AgentsListHeader.tsx
+++ b/apps/web/src/components/agents/AgentsListHeader.tsx
@@ -47,7 +47,7 @@ export default function AgentsListHeader({ driveId }: { driveId?: string }) {
   const [createDriveOpen, setCreateDriveOpen] = useState(false);
   const { agentsByDrive } = usePageAgents(undefined, { enabled: canSpawn });
   const { mutate } = useSWRConfig();
-  const { openSpawn, paletteElement } = useSpawnSession(agentsByDrive, () => {
+  const { openSpawn, openAssistantSpawn, paletteElement } = useSpawnSession(agentsByDrive, () => {
     // Broad match: the sidebar's sessions key is drive-scoped or global
     // depending on ITS OWN route, and this header doesn't know which is
     // mounted alongside it — without this, a session spawned from here only
@@ -87,6 +87,11 @@ export default function AgentsListHeader({ driveId }: { driveId?: string }) {
       return;
     }
     setPickerFor('agent');
+  };
+
+  const handleGlobalAssistantPicked = () => {
+    setPickerFor(null);
+    openAssistantSpawn();
   };
 
   const handleDrivePicked = (pickedDriveId: string, pickedDriveName: string) => {
@@ -153,6 +158,7 @@ export default function AgentsListHeader({ driveId }: { driveId?: string }) {
         open={pickerFor !== null}
         onOpenChange={(open) => !open && setPickerFor(null)}
         onPick={handleDrivePicked}
+        onPickGlobalAssistant={pickerFor === 'session' ? handleGlobalAssistantPicked : undefined}
       />
     </div>
   );

--- a/apps/web/src/components/agents/DrivePickerDialog.tsx
+++ b/apps/web/src/components/agents/DrivePickerDialog.tsx
@@ -38,14 +38,16 @@ export default function DrivePickerDialog({
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Choose a drive"
-      description="Pick which drive to create this in"
+      title={onPickGlobalAssistant ? 'Choose a destination' : 'Choose a drive'}
+      description={
+        onPickGlobalAssistant ? 'Pick a drive or the Global Assistant' : 'Pick which drive to create this in'
+      }
       showCloseButton={false}
       className="max-w-[420px]"
     >
-      <CommandInput placeholder="Search drives…" autoFocus />
+      <CommandInput placeholder={onPickGlobalAssistant ? 'Search…' : 'Search drives…'} autoFocus />
       <CommandList>
-        <CommandEmpty>No drives found.</CommandEmpty>
+        <CommandEmpty>{onPickGlobalAssistant ? 'Nothing found.' : 'No drives found.'}</CommandEmpty>
         {onPickGlobalAssistant && (
           <CommandGroup>
             <CommandItem value="assistant-Global Assistant" onSelect={onPickGlobalAssistant}>

--- a/apps/web/src/components/agents/DrivePickerDialog.tsx
+++ b/apps/web/src/components/agents/DrivePickerDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Folder } from 'lucide-react';
+import { Bot, Folder } from 'lucide-react';
 
 import {
   CommandDialog,
@@ -16,15 +16,21 @@ import { useDriveStore } from '@/hooks/useDrive';
  * Picks a drive to create something in — the step "New session" and "New
  * agent" need on the global Agents page, which has no drive of its own.
  * Trashed drives are excluded, same as `AgentsSidebar`'s own drive roster.
+ * When `onPickGlobalAssistant` is provided (the session flow — a drive-less
+ * assistant session is a valid target there, unlike "New agent", which needs
+ * a drive to navigate into), a "Global Assistant" entry is listed above the
+ * drives.
  */
 export default function DrivePickerDialog({
   open,
   onOpenChange,
   onPick,
+  onPickGlobalAssistant,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onPick: (driveId: string, driveName: string) => void;
+  onPickGlobalAssistant?: () => void;
 }) {
   const drives = useDriveStore((state) => state.drives).filter((drive) => !drive.isTrashed);
 
@@ -40,6 +46,14 @@ export default function DrivePickerDialog({
       <CommandInput placeholder="Search drives…" autoFocus />
       <CommandList>
         <CommandEmpty>No drives found.</CommandEmpty>
+        {onPickGlobalAssistant && (
+          <CommandGroup>
+            <CommandItem value="assistant-Global Assistant" onSelect={onPickGlobalAssistant}>
+              <Bot className="size-3.5" aria-hidden="true" />
+              <span className="truncate">Global Assistant</span>
+            </CommandItem>
+          </CommandGroup>
+        )}
         <CommandGroup>
           {drives.map((drive) => (
             <CommandItem

--- a/apps/web/src/components/agents/__tests__/AgentsListHeader.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsListHeader.test.tsx
@@ -113,8 +113,10 @@ describe('AgentsListHeader', () => {
     // The global-only drive picker must never appear for a drive-scoped spawn.
     // `CommandDialog`'s title/description render outside its Radix `DialogContent`
     // (so it's queryable even while closed) — assert on the picker's actual
-    // content instead, which IS gated on `open`.
+    // content instead, which IS gated on `open`. Both placeholder variants:
+    // the picker's copy depends on whether it offers the Global Assistant.
     expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
+    expect(screen.queryByPlaceholderText('Search…')).toBeNull();
   });
 
   test('drive-scoped: "New Agent" opens Quick Create scoped to the drive root', async () => {
@@ -141,12 +143,15 @@ describe('AgentsListHeader', () => {
     render(<AgentsListHeader />);
 
     await user.click(screen.getByRole('button', { name: /New Session/ }));
-    expect(await screen.findByText('Choose a drive')).toBeDefined();
+    // The session picker's neutral copy (it offers more than drives) — and,
+    // since a closed `CommandDialog` still renders its title, seeing the
+    // conditional variant proves the session picker is the one that opened.
+    expect(await screen.findByText('Choose a destination')).toBeDefined();
 
     await user.click(screen.getByText('Alpha'));
 
     expect(await screen.findByText('Choose an agent to start a session with in Alpha')).toBeDefined();
-    expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
+    expect(screen.queryByPlaceholderText('Search…')).toBeNull();
   });
 
   test('global (no driveId): the session picker offers "Global Assistant", which skips straight to naming a drive-less session', async () => {
@@ -161,7 +166,7 @@ describe('AgentsListHeader', () => {
     // Straight to the naming step — no drive was picked, so no target step.
     expect(await screen.findByPlaceholderText('Global Assistant')).toBeDefined();
     expect(screen.getByText('Leave blank to use "Global Assistant"')).toBeDefined();
-    expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
+    expect(screen.queryByPlaceholderText('Search…')).toBeNull();
   });
 
   test('global (no driveId): "New Agent" opens a drive picker, then navigates into the picked drive without opening Quick Create until that drive is live', async () => {

--- a/apps/web/src/components/agents/__tests__/AgentsListHeader.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsListHeader.test.tsx
@@ -149,12 +149,30 @@ describe('AgentsListHeader', () => {
     expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
   });
 
+  test('global (no driveId): the session picker offers "Global Assistant", which skips straight to naming a drive-less session', async () => {
+    const user = userEvent.setup();
+    render(<AgentsListHeader />);
+
+    await user.click(screen.getByRole('button', { name: /New Session/ }));
+    expect(await screen.findByText('Global Assistant')).toBeDefined();
+
+    await user.click(screen.getByText('Global Assistant'));
+
+    // Straight to the naming step — no drive was picked, so no target step.
+    expect(await screen.findByPlaceholderText('Global Assistant')).toBeDefined();
+    expect(screen.getByText('Leave blank to use "Global Assistant"')).toBeDefined();
+    expect(screen.queryByPlaceholderText('Search drives…')).toBeNull();
+  });
+
   test('global (no driveId): "New Agent" opens a drive picker, then navigates into the picked drive without opening Quick Create until that drive is live', async () => {
     const user = userEvent.setup();
     const { rerender } = render(<AgentsListHeader />);
 
     await user.click(screen.getByRole('button', { name: /New Agent/ }));
     expect(await screen.findByText('Choose a drive')).toBeDefined();
+    // A drive-less assistant session is only a valid target for "New
+    // Session" — the agent flow needs a real drive to navigate into.
+    expect(screen.queryByText('Global Assistant')).toBeNull();
 
     await user.click(screen.getByText('Beta'));
 


### PR DESCRIPTION
## Summary

The global Agents console's **New Session** button opened a raycast-style drive picker that only listed drives, so a drive-less global-assistant session could only be spawned from the sidebar's Assistant group "+". The picker now lists a **Global Assistant** entry that jumps straight to the existing naming step.

- `DrivePickerDialog`: new optional `onPickGlobalAssistant` prop — when set, renders a "Global Assistant" item (same `Bot` icon as the spawn palette) in its own group above the drives.
- `AgentsListHeader`: wires the entry via the existing `openAssistantSpawn()` from `useSpawnSession`, **session flow only** — the "New Agent" picker still lists drives only, since agent creation needs a real drive to navigate into.
- No backend/store changes: `POST /api/agent-sessions` with null `driveId`/`agentPageId` already creates the global session, and sidebar grouping/panes already handle `driveId === null`.

## Testing

- `AgentsListHeader.test.tsx`: new test for picker → naming-step flow for Global Assistant, plus an assertion the New Agent picker never shows the entry — 8/8 passing.
- `bun run --filter web typecheck` and `lint` clean (only pre-existing warnings in unrelated hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLXPJie89VLSvARqGfTMZu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Global Assistant” option to the session drive picker.
  - Selecting it starts a new assistant session directly, without requiring drive selection.
  - Global Assistant is available for new sessions but not when creating a new agent.

- **Bug Fixes**
  - Improved the new session flow to correctly support global assistant sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->