### PR TITLE
fix: prevent Google Calendar sync from duplicating attendee events

### DIFF
--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -353,6 +353,72 @@ describe('syncGoogleCalendar', () => {
       expected: 1,
     });
   });
+
+  it('should not create a duplicate on second sync of the same attendee-linked event', async () => {
+    // After the first sync links the Google event to Noah's event,
+    // a second sync must find it via the attendee-based lookup, not create a copy.
+    mockGetValidAccessToken.mockResolvedValue({
+      success: true,
+      accessToken: 'valid-token',
+    });
+    mockFindFirst.mockResolvedValue({
+      status: 'active',
+      selectedCalendars: ['primary'],
+      syncCursor: null,
+      targetDriveId: null,
+      markAsReadOnly: false,
+      webhookChannels: null,
+      googleEmail: 'user@gmail.com',
+    });
+    mockListEvents.mockResolvedValue({
+      success: true,
+      data: {
+        events: [
+          {
+            id: 'google-evt-2',
+            status: 'confirmed',
+            summary: 'Standup',
+            start: { dateTime: '2025-01-01T09:00:00Z' },
+            end: { dateTime: '2025-01-01T09:30:00Z' },
+          },
+        ],
+        nextSyncToken: 'token-2',
+      },
+    });
+
+    const { db } = await import('@pagespace/db/db');
+    // createdById lookups return null (event was created by Noah)
+    (db.query.calendarEvents.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    // Attendee-based lookup (select) returns the already-linked event
+    mockSelectResolveValue = [{
+      id: 'noahs-event-2',
+      lastGoogleSync: new Date(),
+      title: 'Standup',
+      startAt: new Date('2025-01-01T09:00:00Z'),
+      endAt: new Date('2025-01-01T09:30:00Z'),
+      googleCalendarId: 'user@gmail.com',
+    }];
+
+    mockWatchCalendar.mockResolvedValue({ success: false, error: 'skip' });
+
+    const { syncGoogleCalendar } = await import('../sync-service');
+    const result = await syncGoogleCalendar('user-1');
+
+    assert({
+      given: 'second sync of attendee-linked event',
+      should: 'report success',
+      actual: result.success,
+      expected: true,
+    });
+
+    assert({
+      given: 'second sync of attendee-linked event',
+      should: 'count 0 created events',
+      actual: result.eventsCreated,
+      expected: 0,
+    });
+  });
 });
 
 describe('parseSyncCursors (tested via syncGoogleCalendar)', () => {

--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -13,8 +13,19 @@ const mockInsert = vi.fn().mockReturnValue({
     onConflictDoUpdate: vi.fn(),
   }),
 });
-const mockSelect = vi.fn().mockReturnValue({
-  from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+// Chain builder for select queries — supports from/innerJoin/where/limit
+const buildSelectChain = (resolveValue: unknown[] = []) => {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.limit = vi.fn().mockResolvedValue(resolveValue);
+  chain.where = vi.fn().mockReturnValue({ limit: chain.limit });
+  chain.innerJoin = vi.fn().mockReturnValue({ where: chain.where });
+  const from = vi.fn().mockReturnValue({ where: chain.where, innerJoin: chain.innerJoin });
+  return { from, _chain: chain };
+};
+let mockSelectResolveValue: unknown[] = [];
+const mockSelect = vi.fn().mockImplementation(() => {
+  const { from } = buildSelectChain(mockSelectResolveValue);
+  return { from };
 });
 const mockTransaction = vi.fn(async (cb: (tx: unknown) => Promise<void>) => {
   await cb({
@@ -75,6 +86,13 @@ vi.mock('@pagespace/db/schema/calendar', () => ({
   },
 }));
 
+vi.mock('@pagespace/lib/auth/user-repository', () => ({
+  userEmailInListMatch: vi.fn(),
+  decryptUserRows: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/lib/logging/mask', () => ({
+  maskIdentifier: vi.fn((id: string) => id),
+}));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
     api: {
@@ -127,6 +145,7 @@ vi.mock('../webhook-token', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSelectResolveValue = [];
 });
 
 describe('syncGoogleCalendar', () => {
@@ -265,6 +284,72 @@ describe('syncGoogleCalendar', () => {
       given: 'successful sync with one new event',
       should: 'count 1 created event',
       actual: result.eventsCreated,
+      expected: 1,
+    });
+  });
+
+  it('should link to existing attendee event instead of creating a duplicate', async () => {
+    // Scenario: Noah created 'Meeting' and invited user-1.
+    // Google propagates it to user-1's calendar. Sync should link, not create.
+    mockGetValidAccessToken.mockResolvedValue({
+      success: true,
+      accessToken: 'valid-token',
+    });
+    mockFindFirst.mockResolvedValue({
+      status: 'active',
+      selectedCalendars: ['primary'],
+      syncCursor: null,
+      targetDriveId: null,
+      markAsReadOnly: false,
+      webhookChannels: null,
+      googleEmail: 'user@gmail.com',
+    });
+    mockListEvents.mockResolvedValue({
+      success: true,
+      data: {
+        events: [
+          {
+            id: 'google-evt-1',
+            status: 'confirmed',
+            summary: 'Meeting',
+            start: { dateTime: '2025-01-01T10:00:00Z' },
+            end: { dateTime: '2025-01-01T11:00:00Z' },
+          },
+        ],
+        nextSyncToken: 'new-token',
+      },
+    });
+
+    // No existing event found by googleEventId (first lookup + fallback)
+    const { db } = await import('@pagespace/db/db');
+    (db.query.calendarEvents.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    // Simulate: attendee check finds existing event created by another user
+    mockSelectResolveValue = [{ eventId: 'noahs-event-1' }];
+
+    mockWatchCalendar.mockResolvedValue({ success: false, error: 'skip' });
+
+    const { syncGoogleCalendar } = await import('../sync-service');
+    const result = await syncGoogleCalendar('user-1');
+
+    assert({
+      given: 'event exists as attendee-created event',
+      should: 'report success',
+      actual: result.success,
+      expected: true,
+    });
+
+    assert({
+      given: 'attendee event found matching Google event',
+      should: 'count 0 created events',
+      actual: result.eventsCreated,
+      expected: 0,
+    });
+
+    assert({
+      given: 'attendee event found matching Google event',
+      should: 'count 1 updated event (linked)',
+      actual: result.eventsUpdated,
       expected: 1,
     });
   });

--- a/apps/web/src/lib/integrations/google-calendar/sync-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/sync-service.ts
@@ -624,6 +624,56 @@ const upsertEvent = async (
     }
   }
 
+  // Attendee duplicate check: catch events created by OTHER PageSpace users
+  // (e.g., Noah creates a meeting and invites Jono). The event propagates through
+  // Google Calendar's attendee system back to the invitee's calendar, so the sync
+  // would otherwise create a second copy owned by the syncing user.
+  if (pageSpaceEvent.title && pageSpaceEvent.startAt) {
+    const attendeeStartWindow = new Date(pageSpaceEvent.startAt.getTime() - 60_000);
+    const attendeeEndWindow = new Date(pageSpaceEvent.startAt.getTime() + 60_000);
+
+    const attendeeEvent = await db
+      .select({ eventId: eventAttendees.eventId })
+      .from(eventAttendees)
+      .innerJoin(calendarEvents, eq(calendarEvents.id, eventAttendees.eventId))
+      .where(
+        and(
+          eq(eventAttendees.userId, userId),
+          eq(calendarEvents.title, pageSpaceEvent.title),
+          eq(calendarEvents.isTrashed, false),
+          isNull(calendarEvents.googleEventId),
+          sql`${calendarEvents.startAt} >= ${attendeeStartWindow}`,
+          sql`${calendarEvents.startAt} <= ${attendeeEndWindow}`
+        )
+      )
+      .limit(1);
+
+    if (attendeeEvent.length > 0) {
+      // Link the Google event to the existing event (created by another user).
+      // Don't set syncedFromGoogle — the original creator should still be able
+      // to push edits. We're just attaching the Google ID for two-way sync.
+      try {
+        await db
+          .update(calendarEvents)
+          .set({
+            googleEventId: googleEvent.id,
+            googleCalendarId: calendarId,
+            lastGoogleSync: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(calendarEvents.id, attendeeEvent[0].eventId));
+
+        await mapAttendeesToUsers(attendeeEvent[0].eventId, googleEvent.attendees);
+        return { action: 'updated' };
+      } catch (err) {
+        if (isUniqueConstraintError(err)) {
+          return { action: 'skipped' };
+        }
+        throw err;
+      }
+    }
+  }
+
   // Create new event
   const inserted = await db
     .insert(calendarEvents)

--- a/apps/web/src/lib/integrations/google-calendar/sync-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/sync-service.ts
@@ -519,6 +519,36 @@ const upsertEvent = async (
     }
   }
 
+  // Third fallback: attendee-based lookup. After the attendee dedup below links
+  // a Google event ID onto an event created by ANOTHER user, subsequent syncs
+  // won't find it via createdById. Check if the syncing user is an attendee on
+  // an event with this googleEventId.
+  if (!existingEvent) {
+    const attendeeLinked = await db
+      .select({
+        id: calendarEvents.id,
+        lastGoogleSync: calendarEvents.lastGoogleSync,
+        title: calendarEvents.title,
+        startAt: calendarEvents.startAt,
+        endAt: calendarEvents.endAt,
+        googleCalendarId: calendarEvents.googleCalendarId,
+      })
+      .from(eventAttendees)
+      .innerJoin(calendarEvents, eq(calendarEvents.id, eventAttendees.eventId))
+      .where(
+        and(
+          eq(eventAttendees.userId, userId),
+          eq(calendarEvents.googleEventId, googleEvent.id),
+          eq(calendarEvents.isTrashed, false)
+        )
+      )
+      .limit(1);
+
+    if (attendeeLinked.length > 0) {
+      existingEvent = attendeeLinked[0];
+    }
+  }
+
   // Handle cancelled/deleted events
   if (googleEvent.status === 'cancelled') {
     if (existingEvent) {


### PR DESCRIPTION
## Problem

When user A creates a meeting and invites user B, the event propagates through Google Calendar's attendee system to user B's calendar. User B's sync then imports it as a **new** event instead of recognizing the existing one — because the near-duplicate check in `upsertEvent()` only queries `createdById = syncingUser`.

This caused meetings to double (and sometimes triple) on the calendar:
1. Original event (created by A, B is attendee)
2. Sync duplicate (created by B, synced from Google)
3. Sometimes a third copy from race conditions between webhook and cron sync

## Fix

Added an **attendee-based duplicate check** before event creation in `sync-service.ts`. After the existing near-duplicate check (which covers self-created events), the new check:

1. Queries `eventAttendees` joined with `calendarEvents`
2. Matches events where the syncing user is an **attendee** (not creator)
3. Matches title and start time (±1 min window)
4. Only links events with no `googleEventId` yet
5. When found, attaches the Google event ID to the existing event instead of creating a duplicate

## Test

New test: `should link to existing attendee event instead of creating a duplicate`
- Simulates Noah creating "Meeting" and inviting the syncing user
- Verifies `eventsCreated: 0` and `eventsUpdated: 1` (linked, not duplicated)

Also fixed pre-existing missing mocks (`@pagespace/lib/auth/user-repository`, `@/lib/logging/mask`) that prevented the test suite from importing.

## Files Changed

- `apps/web/src/lib/integrations/google-calendar/sync-service.ts` — attendee dedup check
- `apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts` — new test + mock fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Calendar synchronization to recognize and update existing events attended by the syncing user instead of creating duplicates.
  * Preserved event details, synchronization metadata, and attendee information when linking matching events.
  * Improved handling of duplicate-creation conflicts during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->