### PR TITLE
fix(ai): dispatch session tools with minted CSRF + forwarded Bearer credentials

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-dispatch.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-dispatch.test.ts
@@ -126,7 +126,12 @@ describe('dispatchThroughChatPipeline credentials (issue #2333)', () => {
     // The browser's own token expires after 1h — an agent turn can outlive it.
     // The hop must mint its own token from the server-validated session id
     // (the same binding validateCSRF checks), not replay the stale one.
-    incomingHeaders({ cookie: SESSION_COOKIE, 'x-csrf-token': STALE_BROWSER_CSRF });
+    incomingHeaders({
+      cookie: SESSION_COOKIE,
+      'x-csrf-token': STALE_BROWSER_CSRF,
+      origin: 'http://localhost:3000',
+      referer: 'http://localhost:3000/dashboard',
+    });
     const fetchMock = fetchAdmitted();
 
     const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
@@ -136,6 +141,36 @@ describe('dispatchThroughChatPipeline credentials (issue #2333)', () => {
     const sent = sentHeaders(fetchMock)['x-csrf-token'];
     expect(sent).not.toBe(STALE_BROWSER_CSRF);
     expect(validateCSRFToken(sent, AUTH_SESSION_ID)).toBe(true);
+    // The caller's own credentials ride along with the minted token — the
+    // route re-derives the CSRF binding from this cookie, and its origin
+    // validation for cookie sessions reads origin/referer.
+    expect(sentHeaders(fetchMock)['cookie']).toBe(SESSION_COOKIE);
+    expect(sentHeaders(fetchMock)['origin']).toBe('http://localhost:3000');
+    expect(sentHeaders(fetchMock)['referer']).toBe('http://localhost:3000/dashboard');
+  });
+
+  it('mints despite a non-Bearer Authorization header — only a Bearer credential exempts the hop from CSRF', async () => {
+    // A fronting proxy can inject e.g. `Authorization: Basic …`. The route's
+    // CSRF exemption checks the `Bearer ` prefix (getBearerToken), so a
+    // non-Bearer header must not suppress the mint or the hop 403s again.
+    incomingHeaders({ cookie: SESSION_COOKIE, authorization: 'Basic cHJveHk6aHVzaA==' });
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: true, waited: false });
+    expect(validateCSRFToken(sentHeaders(fetchMock)['x-csrf-token'], AUTH_SESSION_ID)).toBe(true);
+  });
+
+  it('degrades to the forwarded browser token when session validation throws — never a raw error out of the tool', async () => {
+    validateSessionMock.mockRejectedValue(new Error('db connection reset'));
+    incomingHeaders({ cookie: SESSION_COOKIE, 'x-csrf-token': STALE_BROWSER_CSRF });
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: true, waited: false });
+    expect(sentHeaders(fetchMock)['x-csrf-token']).toBe(STALE_BROWSER_CSRF);
   });
 
   it('mints even when the browser sent no CSRF token at all', async () => {
@@ -149,6 +184,7 @@ describe('dispatchThroughChatPipeline credentials (issue #2333)', () => {
 
     expect(outcome).toEqual({ ok: true, waited: false });
     expect(validateCSRFToken(sentHeaders(fetchMock)['x-csrf-token'], AUTH_SESSION_ID)).toBe(true);
+    expect(sentHeaders(fetchMock)['cookie']).toBe(SESSION_COOKIE);
   });
 
   it('falls back to the forwarded browser token when the cookie session does not validate', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-dispatch.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-dispatch.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { headers } from 'next/headers';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { dispatchThroughChatPipeline } from '../session-tools-runtime';
+
+// The dispatch replays/mints CREDENTIALS for an internal HTTP hop — everything
+// else the runtime module wires (db listings, sandbox provisioning, shells) is
+// out of scope here and mocked away so the credential seam is the only thing
+// under test (issue #2333). The sibling caller-session resolution seam is
+// covered in session-tools-runtime.test.ts.
+vi.mock('next/headers', () => ({ headers: vi.fn() }));
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({ canUserViewPage: vi.fn() }));
+vi.mock('@pagespace/lib/services/agent-sessions/session-status', () => ({ deriveSandboxStatus: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const silent = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return { loggers: { ai: silent, auth: silent } };
+});
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: { validateSession: vi.fn() },
+}));
+vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
+  createConversationInSession: vi.fn(),
+  ensureGlobalSandboxSession: vi.fn(),
+  findSessionForConversation: vi.fn(),
+  provisionSessionSandbox: vi.fn(),
+  getAgentSessionStore: vi.fn(),
+}));
+vi.mock('@/lib/agent-sessions/create-conversation-in-session', () => ({
+  ConversationUnavailableError: class ConversationUnavailableError extends Error {},
+  AgentNotInSessionDriveError: class AgentNotInSessionDriveError extends Error {},
+  SessionFullError: class SessionFullError extends Error {},
+}));
+vi.mock('@/lib/repositories/conversation-repository', () => ({ conversationRepository: {} }));
+vi.mock('@/lib/agent-sessions/session-shells-runtime', () => ({
+  getSessionShellStore: vi.fn(),
+  killShellById: vi.fn(),
+  listShells: vi.fn(),
+  spawnShell: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/abort-conversation-streams', () => ({ abortConversationStreams: vi.fn() }));
+vi.mock('../shell-io', () => ({ createShellIo: vi.fn(() => ({})), realtimeShellIoTransport: {} }));
+
+const headersMock = vi.mocked(headers);
+const validateSessionMock = vi.mocked(sessionService.validateSession);
+
+const AUTH_SESSION_ID = 'auth-session-row-1';
+const SESSION_COOKIE = 'session=opaque-session-token';
+const BEARER = 'Bearer ps_sess_desktop-token';
+/** A syntactically token-shaped browser CSRF header — NOT freshly minted. */
+const STALE_BROWSER_CSRF = 'deadbeef.1700000000.feedface';
+
+function incomingHeaders(entries: Record<string, string>): void {
+  headersMock.mockResolvedValue(new Headers(entries));
+}
+
+function fetchAdmitted(): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    body: null,
+    text: async () => '',
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function sentHeaders(fetchMock: ReturnType<typeof vi.fn>): Record<string, string> {
+  const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+  return init.headers;
+}
+
+const DISPATCH_INPUT = {
+  sessionId: 'worker-conversation-1',
+  agentPageId: 'agent-page-1',
+  input: 'hello',
+  userId: 'user-1',
+  depth: 1,
+  wait: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  vi.stubEnv('WEB_APP_URL', 'http://localhost:3000');
+  vi.stubEnv('CSRF_SECRET', 'test-csrf-secret');
+  // Default: the forwarded cookie resolves to a live browser session.
+  validateSessionMock.mockResolvedValue({
+    sessionId: AUTH_SESSION_ID,
+    userId: 'user-1',
+  } as never);
+});
+
+describe('dispatchThroughChatPipeline credentials (issue #2333)', () => {
+  it('forwards the caller\'s Bearer authorization on the internal POST', async () => {
+    // Desktop/mobile/MCP callers authenticate with Authorization, carry a
+    // cookie anyway (credentials: 'include'), and have NO CSRF token. Without
+    // the authorization header the hop degrades to cookie-only session auth
+    // and 403s "CSRF token required".
+    incomingHeaders({ cookie: SESSION_COOKIE, authorization: BEARER });
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: true, waited: false });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sentHeaders(fetchMock)['authorization']).toBe(BEARER);
+    // Bearer hops are CSRF-immune at the route — no minting, no session lookup.
+    expect(validateSessionMock).not.toHaveBeenCalled();
+    expect(sentHeaders(fetchMock)['x-csrf-token']).toBeUndefined();
+  });
+
+  it('dispatches with Bearer authorization alone — no cookie required', async () => {
+    incomingHeaders({ authorization: BEARER });
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: true, waited: false });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sentHeaders(fetchMock)['authorization']).toBe(BEARER);
+  });
+
+  it('mints a fresh CSRF token bound to the caller\'s cookie session instead of replaying the browser\'s', async () => {
+    // The browser's own token expires after 1h — an agent turn can outlive it.
+    // The hop must mint its own token from the server-validated session id
+    // (the same binding validateCSRF checks), not replay the stale one.
+    incomingHeaders({ cookie: SESSION_COOKIE, 'x-csrf-token': STALE_BROWSER_CSRF });
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: true, waited: false });
+    expect(validateSessionMock).toHaveBeenCalledWith('opaque-session-token', { expectedType: 'user' });
+    const sent = sentHeaders(fetchMock)['x-csrf-token'];
+    expect(sent).not.toBe(STALE_BROWSER_CSRF);
+    expect(validateCSRFToken(sent, AUTH_SESSION_ID)).toBe(true);
+  });
+
+  it('mints even when the browser sent no CSRF token at all', async () => {
+    // The exact issue-#2333 shape: a session-cookie caller whose own request
+    // never carried x-csrf-token (e.g. the route admitted it via Bearer or a
+    // CSRF-exempt path). Cookie-only replay is guaranteed to 403.
+    incomingHeaders({ cookie: SESSION_COOKIE });
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: true, waited: false });
+    expect(validateCSRFToken(sentHeaders(fetchMock)['x-csrf-token'], AUTH_SESSION_ID)).toBe(true);
+  });
+
+  it('falls back to the forwarded browser token when the cookie session does not validate', async () => {
+    // Revoked/expired cookie session: minting is impossible; forwarding what
+    // the caller sent lets the route answer with its own honest auth error.
+    validateSessionMock.mockResolvedValue(null as never);
+    incomingHeaders({ cookie: SESSION_COOKIE, 'x-csrf-token': STALE_BROWSER_CSRF });
+    const fetchMock = fetchAdmitted();
+
+    await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(sentHeaders(fetchMock)['x-csrf-token']).toBe(STALE_BROWSER_CSRF);
+  });
+
+  it('refuses with a fixed message when the request carries neither cookie nor authorization', async () => {
+    incomingHeaders({});
+    const fetchMock = fetchAdmitted();
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({
+      ok: false,
+      reason: 'failed',
+      detail: 'the calling request carries no session credentials to dispatch with',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the chat route\'s error body verbatim on a non-ok answer', async () => {
+    incomingHeaders({ cookie: SESSION_COOKIE });
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'CSRF token required' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outcome = await dispatchThroughChatPipeline(DISPATCH_INPUT);
+
+    expect(outcome).toEqual({ ok: false, reason: 'failed', detail: 'CSRF token required' });
+  });
+});

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -9,10 +9,12 @@
  * streaming pipeline a normal conversation uses and shows up live in the
  * sidebar. NEVER a second engine: this module contains no model call.
  *
- * The dispatch forwards the CALLER's own credentials (cookie/CSRF/origin from
- * the live request via `next/headers`) — the worker acts as the same user who
- * asked for it, through the same admission control (credit gate, takeover
- * discipline) the interactive path runs. The chain depth rides the
+ * The dispatch acts as the CALLER: it forwards the live request's own
+ * credentials (cookie/Bearer/origin via `next/headers`) and, for cookie
+ * sessions, MINTS a fresh CSRF token bound to that server-validated session —
+ * so the worker acts as the same user who asked for it, through the same
+ * admission control (credit gate, takeover discipline) the interactive path
+ * runs. The chain depth rides the
  * `X-Agent-Dispatch-Depth` header, which both chat routes fold back into
  * `agentCallDepth` so the pure depth cap keeps terminating across the hop.
  */
@@ -24,7 +26,10 @@ import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { conversations, messages as globalMessages } from '@pagespace/db/schema/conversations';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { deriveSandboxStatus } from '@pagespace/lib/services/agent-sessions/session-status';
+import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 import {
   createConversationInSession,
   ensureGlobalSandboxSession,
@@ -59,8 +64,46 @@ import { createShellIo, realtimeShellIoTransport } from './shell-io';
 // Worker dispatch through the standard chat pipeline
 // ---------------------------------------------------------------------------
 
-/** The headers the dispatch forwards verbatim — the caller's own credentials. */
-const FORWARDED_HEADERS = ['cookie', 'x-csrf-token', 'origin', 'referer'] as const;
+/**
+ * The headers the dispatch forwards verbatim — the caller's own credentials.
+ *
+ * `authorization` matters as much as `cookie`: desktop/mobile/MCP callers
+ * authenticate with a Bearer token, carry no CSRF token, and often send a
+ * cookie anyway (`credentials: 'include'`). Dropping their Bearer credential
+ * degraded the hop to cookie-only session auth, which the chat routes rightly
+ * refuse with "CSRF token required" (issue #2333).
+ */
+const FORWARDED_HEADERS = ['cookie', 'x-csrf-token', 'origin', 'referer', 'authorization'] as const;
+
+/**
+ * A fresh CSRF token for the internal hop, bound to the caller's
+ * server-validated cookie session — the exact binding `validateCSRF` checks on
+ * the receiving route. Minting (rather than replaying the browser's token)
+ * keeps cookie-session dispatches working when the caller's own token is
+ * absent (the route admitted them without one) or older than the 1-hour TTL
+ * (an agent turn can outlive it) — issue #2333. This is a credential FOR the
+ * caller's own session, not a bypass: no valid session cookie, no token, and
+ * nothing here consults any attacker-suppliable header.
+ *
+ * Bearer hops return null: Bearer auth is CSRF-immune at the route layer, and
+ * `authenticateSessionRequest` resolves Bearer before cookie, so the minted
+ * token would bind to a session the route never looks at.
+ */
+async function mintDispatchCSRFToken(incoming: Headers): Promise<string | null> {
+  if (incoming.get('authorization')) return null;
+  const sessionToken = getSessionFromCookies(incoming.get('cookie'));
+  if (!sessionToken) return null;
+  const claims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
+  if (!claims) return null;
+  try {
+    return generateCSRFToken(claims.sessionId);
+  } catch (error) {
+    // CSRF_SECRET missing/invalid — the forwarded browser token (if any) is
+    // still sent, so the route gives its own honest answer.
+    loggers.ai.error('session dispatch: could not mint a CSRF token for the internal hop', error instanceof Error ? error : undefined);
+    return null;
+  }
+}
 
 /**
  * The self base URL for the internal hop.
@@ -149,7 +192,7 @@ async function readLatestAssistantReply(sessionId: string, agentPageId: string |
  * `wait: true` drains the stream to completion, then reads the reply off the
  * transcript.
  */
-async function dispatchThroughChatPipeline(input: {
+export async function dispatchThroughChatPipeline(input: {
   sessionId: string;
   agentPageId: string | null;
   input: string;
@@ -177,7 +220,7 @@ async function dispatchThroughChatPipeline(input: {
       detail: 'the app\'s own URL is not configured (set WEB_APP_URL or NEXT_PUBLIC_APP_URL)',
     };
   }
-  if (!incoming.get('cookie')) {
+  if (!incoming.get('cookie') && !incoming.get('authorization')) {
     return { ok: false, reason: 'failed', detail: 'the calling request carries no session credentials to dispatch with' };
   }
 
@@ -197,6 +240,8 @@ async function dispatchThroughChatPipeline(input: {
     const value = incoming.get(name);
     if (value) requestHeaders[name] = value;
   }
+  const mintedCSRFToken = await mintDispatchCSRFToken(incoming);
+  if (mintedCSRFToken) requestHeaders['x-csrf-token'] = mintedCSRFToken;
 
   const body = JSON.stringify({
     ...(input.agentPageId !== null ? { chatId: input.agentPageId } : {}),

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -87,19 +87,24 @@ const FORWARDED_HEADERS = ['cookie', 'x-csrf-token', 'origin', 'referer', 'autho
  *
  * Bearer hops return null: Bearer auth is CSRF-immune at the route layer, and
  * `authenticateSessionRequest` resolves Bearer before cookie, so the minted
- * token would bind to a session the route never looks at.
+ * token would bind to a session the route never looks at. The check mirrors
+ * `getBearerToken`'s `Bearer ` prefix test exactly — a non-Bearer
+ * Authorization header (e.g. a fronting proxy's `Basic …`) does NOT exempt
+ * the hop from CSRF at the route, so it must not suppress the mint here.
  */
 async function mintDispatchCSRFToken(incoming: Headers): Promise<string | null> {
-  if (incoming.get('authorization')) return null;
+  if (incoming.get('authorization')?.startsWith('Bearer ')) return null;
   const sessionToken = getSessionFromCookies(incoming.get('cookie'));
   if (!sessionToken) return null;
-  const claims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
-  if (!claims) return null;
   try {
+    const claims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
+    if (!claims) return null;
     return generateCSRFToken(claims.sessionId);
   } catch (error) {
-    // CSRF_SECRET missing/invalid — the forwarded browser token (if any) is
-    // still sent, so the route gives its own honest answer.
+    // Transient session-store failure or missing CSRF_SECRET — degrade, never
+    // throw a raw internal error out of a tool (issue #2262 finding 3). The
+    // forwarded browser token (if any) is still sent, so the route gives its
+    // own honest answer.
     loggers.ai.error('session dispatch: could not mint a CSRF token for the internal hop', error instanceof Error ? error : undefined);
     return null;
   }


### PR DESCRIPTION
Fixes #2333

## Problem

`spawn_session` / `send_session` created worker sessions but every message dispatch failed with `"CSRF token required"` — blocking all programmatic agent-session orchestration (multi-agent workflows, eval harnesses, delegated work).

## Root cause

`dispatchThroughChatPipeline` re-POSTs through the standard chat routes and authenticated that internal hop by replaying only `cookie` / `x-csrf-token` / `origin` / `referer` from the caller's live request. That replay is incomplete in two real caller shapes:

- **Bearer callers** (desktop / mobile / MCP): they have no CSRF token, their `authorization` header was deliberately dropped, but their cookie rides along (`credentials: 'include'`) — so the hop degraded to cookie-only session auth and the route's CSRF check correctly refused it.
- **Cookie callers on long turns**: the browser's CSRF token has a 1-hour TTL; an agent turn that outlives it dispatched a stale token.

Session creation precedes dispatch, which is why sessionIds came back while every dispatch failed — matching all 12 failures in the issue.

## Fix

Two changes in `dispatchThroughChatPipeline`, per the repo's "mint a credential for the internal call" convention:

1. **Forward `authorization`** (and accept it as sufficient credentials without a cookie). Bearer auth is CSRF-immune at the route layer by design, and `authenticateSessionRequest` resolves Bearer before cookie, so mixed cookie+Bearer requests resolve correctly.
2. **Mint a fresh CSRF token for cookie sessions**: derive the caller's server-validated session id from the forwarded cookie (`sessionService.validateSession`, the exact derivation `validateCSRF` performs on the receiving route) and mint `generateCSRFToken(sessionId)` for the hop instead of replaying the browser's token. If the cookie session doesn't validate, the browser's own token is still forwarded so the route answers with its honest auth error.

## Security posture

- **No CSRF exemption is introduced.** Every route that can trigger a dispatch already enforces CSRF for cookie sessions on the outer request (`/api/ai/chat`, `/api/ai/global/[id]/messages`) or admits only Bearer/MCP auth (`/api/v1/chat/completions`); the workflow executor has no request context, so dispatch refuses before any minting. A cross-site attacker cannot reach the mint without already possessing a valid CSRF token.
- The mint consults **no attacker-suppliable header** (deliberately not `x-agent-dispatch-depth`); the presence of `authorization` only *disables* minting — fail-closed.
- The minted token is bound to the caller's own server-validated session — a credential *for* that session, not a bypass.

## Tests

New `session-tools-dispatch.test.ts` covering the credential seam (written red-first against the pre-fix behavior):
- Bearer + cookie → `authorization` forwarded, no mint, no session lookup
- Bearer alone (no cookie) → dispatch proceeds
- cookie + stale/absent browser CSRF token → fresh token minted, validates against the session id via the real `csrf-utils`
- invalid cookie session → falls back to forwarding the browser's token
- no credentials at all → fixed refusal, no fetch
- non-ok route answer → error body surfaced verbatim

## Verification

- `bun run --filter web test` on all three session-tools suites: 53/53 pass (including the `resolveCallerSessionForWorker` suite that landed on master mid-branch; rebased onto current master)
- `tsc --noEmit` clean; `eslint` clean on changed files; full web lint has only a pre-existing warning in `useVoiceMode.ts`
- One pre-existing env-only failure in `activity-tools.test.ts` (needs live test DB; untouched since #1591, unrelated)
- **Not verified end-to-end**: I did not run a live spawn_session → dispatch round-trip against a running deployment (needs sandbox provisioning + model calls). The unit tests pin the credential seam; the issue's exact reproduction should be re-run after deploy to close it out.

## Known limitation (pre-existing)

MCP-token callers still cannot dispatch to the **global-assistant** route (`allow: ['session']` rejects MCP Bearer) — they previously failed with the CSRF error, now they get the route's honest auth error. Page-agent dispatches from MCP callers work.

## Post-merge

`bun run changelog:generate` should pick this up once merged (it generates from merged PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHhEz7VwevVvVi4AYHMC4H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Bearer-authenticated requests alongside cookie-based sessions.
  * Improved session security by validating cookie sessions and issuing fresh CSRF tokens when needed.
  * Preserved compatibility with existing cookie, origin, and referrer authentication headers.

* **Bug Fixes**
  * Improved handling of missing or invalid credentials and chat-route error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->