### PR TITLE
feat(agents): fully resource-addressed session orchestration — permission-gated, any surface, any workspace (#2335)

### DIFF
--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/claim/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/claim/__tests__/route.test.ts
@@ -187,12 +187,6 @@ describe('POST /api/agent-sessions/[sessionId]/conversations/[conversationId]/cl
     expect(response.status).toBe(400);
   });
 
-  it('409s an ended session', async () => {
-    mockClaimConversationInSession.mockResolvedValue('session_ended');
-    const response = await post();
-    expect(response.status).toBe(409);
-  });
-
   it("429s a session already at MAX_SESSION_CONVERSATIONS, as a quota refusal with the shared human message", async () => {
     mockClaimConversationInSession.mockResolvedValue('session_full');
     const response = await post();

--- a/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/claim/route.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/conversations/[conversationId]/claim/route.ts
@@ -96,10 +96,6 @@ export async function POST(request: Request, context: RouteContext) {
     );
   }
 
-  if (outcome === 'session_ended') {
-    return NextResponse.json({ error: 'This session has ended' }, { status: 409 });
-  }
-
   if (outcome === 'session_full') {
     return sessionConversationLimitExceeded(request, auth.userId, sessionId, ROUTE);
   }

--- a/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/__tests__/route.test.ts
@@ -549,7 +549,7 @@ describe("POST /api/agent-sessions — firstThing: 'claim'", () => {
   });
 
   it('given claim fails for a truly unexpected outcome, ENDS the session and responds 502', async () => {
-    mockClaimConversationInSession.mockResolvedValue('session_ended');
+    mockClaimConversationInSession.mockResolvedValue('session_full');
     const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
     expect(response.status).toBe(502);
     expect(mockEndSession).toHaveBeenCalledWith('ses-new');

--- a/apps/web/src/app/api/agent-sessions/route.ts
+++ b/apps/web/src/app/api/agent-sessions/route.ts
@@ -500,9 +500,8 @@ export async function POST(request: Request) {
     if (outcome !== 'claimed' && outcome !== 'already_in_session') {
       // The session row exists but its first (claimed) conversation failed:
       // end it rather than leave an empty workspace the model says cannot
-      // exist. `session_full`/`session_ended` are unreachable by
-      // construction (a session that was just spawned has zero
-      // conversations and cannot yet be ended) — folded into the generic
+      // exist. `session_full` is unreachable by construction (a session that
+      // was just spawned has zero conversations) — folded into the generic
       // refusal rather than special-cased.
       await endSession(spawned.session.id).catch(() => {});
       if (outcome === 'cross_drive_denied') {

--- a/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
@@ -104,6 +104,11 @@ export async function resolveOrCreateConversation(
       isActive: true,
       sessionId: null,
       title: opts?.title ?? null,
+      // Explicit, matching the page path (conversationRepository
+      // .createConversation): the column has no DB default, and leaving it to
+      // drizzle's fill-$onUpdate-columns-on-insert behavior is a subtlety no
+      // reader should have to know (issue #2335 initially suspected it).
+      updatedAt: new Date(),
     })
     .onConflictDoNothing()
     .returning();

--- a/apps/web/src/lib/agent-sessions/__tests__/claim-conversation-in-session.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/claim-conversation-in-session.test.ts
@@ -118,10 +118,10 @@ describe('claimConversationInSessionWith', () => {
       expect(deps.claimConversation).not.toHaveBeenCalled();
     });
 
-    it('refuses an ended session', async () => {
+    it('an ENDED session is a valid claim target — lifecycle state never gates a permitted claim (issue #2335); the runtime reopens its listing', async () => {
       deps.findSession.mockResolvedValue({ driveId: 'drive-1', endedAt: new Date('2026-01-01') });
-      await expect(run()).resolves.toBe('session_ended');
-      expect(deps.claimConversation).not.toHaveBeenCalled();
+      await expect(run()).resolves.toBe('claimed');
+      expect(deps.claimConversation).toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
@@ -193,6 +193,14 @@ describe('global arm', () => {
     ).rejects.toThrow(ConversationUnavailableError);
     expect(deps.claimConversation).not.toHaveBeenCalled();
   });
+
+  it('preserves the resolver\'s original error as `cause` for the boundary\'s log (issue #2335)', async () => {
+    const original = new Error('ConversationOwnershipError');
+    deps.createGlobalConversation.mockRejectedValue(original);
+    await expect(
+      createConversationInSessionWith(deps as CreateConversationInSessionDeps, input({ agentPageId: null })),
+    ).rejects.toMatchObject({ name: 'ConversationUnavailableError', cause: original });
+  });
 });
 
 describe('worker labels', () => {

--- a/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/create-conversation-in-session.test.ts
@@ -327,10 +327,10 @@ describe('the per-session conversation cap (issue #2262 finding 2, plus the P1 o
     expect(deps.createPageConversation).not.toHaveBeenCalled();
   });
 
-  it('refuses an ENDED session before weighing the cap or creating anything', async () => {
+  it('an ENDED session is a valid create target — lifecycle state never gates a permitted create; the claim reopens the listing (issue #2335)', async () => {
     deps.findSession.mockResolvedValue({ driveId: 'drive-1', endedAt: new Date('2026-01-01') });
-    await expect(run()).rejects.toThrow(ConversationUnavailableError);
-    expect(deps.countActiveConversations).not.toHaveBeenCalled();
-    expect(deps.createPageConversation).not.toHaveBeenCalled();
+    await expect(run()).resolves.toBeUndefined();
+    expect(deps.createPageConversation).toHaveBeenCalled();
+    expect(deps.claimConversation).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for issue #2335 — spawn_session from the global assistant.
+ *
+ * Two facts proven against a REAL migration-built Postgres:
+ *
+ *  1. The happy path works end-to-end: a global caller's session is
+ *     auto-minted and the worker conversation (agentPageId null) lands in it.
+ *     This is also the direct refutation of the issue's first hypothesis —
+ *     `conversations.updatedAt` has NO DB default here (exactly as migration
+ *     0000 created it), and the global insert still succeeds, because drizzle
+ *     fills a default-less `$onUpdate` column on INSERT.
+ *
+ *  2. The actual root cause: a conversation bound to an ENDED session. The
+ *     binding is write-once, so such a conversation can never join a live
+ *     session again — `resolveCallerSessionForWorker` must refuse truthfully
+ *     (`session_ended`), not hand the dead session to the create path, whose
+ *     generic `conversation_unavailable` blamed the conversation id.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable —
+ * mirrors the other integration tests in this directory.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { agentSessions } from '@pagespace/db/schema/agent-sessions';
+import { factories } from '@pagespace/db/test/factories';
+import { resolveOrCreateConversation } from '@/app/api/ai/global/[id]/messages/resolve-or-create-conversation';
+import { resolveCallerSessionForWorker } from '@/lib/ai/tools/session-tools-runtime';
+import {
+  createConversationInSession,
+  ensureGlobalSandboxSession,
+} from '../agent-sessions-runtime';
+
+let dbAvailable = false;
+
+describe('spawn_session from the global assistant (issue #2335)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('creates the worker conversation in the auto-minted global session', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+
+    // 1. The caller's global-assistant conversation (lazy first-message create).
+    const callerConversationId = createId();
+    const resolved = await resolveOrCreateConversation(owner.id, callerConversationId);
+    expect(resolved.isNew).toBe(true);
+
+    // 2. The session a worker would join — auto-minted for a global caller.
+    const ensured = await ensureGlobalSandboxSession(callerConversationId, owner.id);
+    if (!ensured.ok) throw new Error(`ensureGlobalSandboxSession failed: ${ensured.reason}`);
+
+    // 3. The worker conversation itself — createWorkerSession's inner call.
+    const workerConversationId = createId();
+    await createConversationInSession({
+      conversationId: workerConversationId,
+      userId: owner.id,
+      agentPageId: null,
+      sessionId: ensured.session.id,
+      title: 'repro worker',
+    });
+
+    const [worker] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, workerConversationId));
+    expect(worker).toBeDefined();
+    expect(worker.type).toBe('global');
+    expect(worker.sessionId).toBe(ensured.session.id);
+    expect(worker.title).toBe('repro worker');
+  });
+
+  it('a global conversation bound to an ENDED session refuses with session_ended, not conversation_unavailable', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const callerConversationId = createId();
+    await resolveOrCreateConversation(owner.id, callerConversationId);
+    const ensured = await ensureGlobalSandboxSession(callerConversationId, owner.id);
+    if (!ensured.ok) throw new Error(`ensureGlobalSandboxSession failed: ${ensured.reason}`);
+
+    // The session ends (user action, reconciler, teardown…).
+    await db
+      .update(agentSessions)
+      .set({ endedAt: new Date() })
+      .where(eq(agentSessions.id, ensured.session.id));
+
+    // The resolution refuses truthfully instead of handing back the dead
+    // session (pre-fix, this returned ok:true and the create path's generic
+    // refusal blamed the conversation id — the reported bug).
+    const resolved = await resolveCallerSessionForWorker(callerConversationId, owner.id);
+    expect(resolved).toEqual({ ok: false, reason: 'session_ended' });
+
+    // The create path's own ended-session gate still holds as the backstop,
+    // and now names its gate via `cause` for the boundary's log.
+    await expect(
+      createConversationInSession({
+        conversationId: createId(),
+        userId: owner.id,
+        agentPageId: null,
+        sessionId: ensured.session.id,
+        title: 'doomed worker',
+      }),
+    ).rejects.toMatchObject({
+      name: 'ConversationUnavailableError',
+      cause: expect.objectContaining({ message: 'session_ended' }),
+    });
+  });
+});

--- a/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
@@ -5,10 +5,16 @@
  *
  *  1. The happy path works end-to-end: a global caller's session is
  *     auto-minted and the worker conversation (agentPageId null) lands in it.
- *     This is also the direct refutation of the issue's first hypothesis —
  *     `conversations.updatedAt` has NO DB default here (exactly as migration
- *     0000 created it), and the global insert still succeeds, because drizzle
- *     fills a default-less `$onUpdate` column on INSERT.
+ *     0000 created it) — the insert succeeds because
+ *     `resolveOrCreateConversation` sets `updatedAt: new Date()` explicitly
+ *     (this PR's Fix 2, matching the page path). The issue's original
+ *     hypothesis — that the missing default was itself the bug — was
+ *     evaluated separately by inspecting drizzle-orm 0.45.2's insert
+ *     compiler (`pg-core/dialect.js`'s `buildInsertQuery`), which fills a
+ *     default-less `$onUpdate` column on INSERT too; this test does not
+ *     exercise that fallback (the explicit set makes it moot) and makes no
+ *     claim about it.
  *
  *  2. The actual root cause: a conversation bound to an ENDED session used to
  *     dead-end every spawn with a generic `conversation_unavailable` blaming

--- a/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
@@ -31,7 +31,10 @@ import { conversations } from '@pagespace/db/schema/conversations';
 import { agentSessions } from '@pagespace/db/schema/agent-sessions';
 import { factories } from '@pagespace/db/test/factories';
 import { resolveOrCreateConversation } from '@/app/api/ai/global/[id]/messages/resolve-or-create-conversation';
-import { resolveCallerSessionForWorker } from '@/lib/ai/tools/session-tools-runtime';
+import {
+  buildSessionToolsDeps,
+  resolveCallerSessionForWorker,
+} from '@/lib/ai/tools/session-tools-runtime';
 import {
   createConversationInSession,
   ensureGlobalSandboxSession,
@@ -128,5 +131,74 @@ describe('spawn_session from the global assistant (issue #2335)', () => {
       .from(agentSessions)
       .where(eq(agentSessions.id, ensured.session.id));
     expect(session.endedAt).toBeNull();
+  });
+
+  it('workspace placement: "new" mints an ISOLATED workspace, an explicit workspaceId targets it, a foreign workspaceId refuses, and the listing discovers it all', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const callerConversationId = createId();
+    await resolveOrCreateConversation(owner.id, callerConversationId);
+    const ensured = await ensureGlobalSandboxSession(callerConversationId, owner.id);
+    if (!ensured.ok) throw new Error(`ensureGlobalSandboxSession failed: ${ensured.reason}`);
+    const deps = buildSessionToolsDeps();
+
+    // 'new' → a fresh workspace, NOT the caller's.
+    const isolatedWorkerId = createId();
+    const isolated = await deps.createWorkerSession({
+      sessionId: isolatedWorkerId,
+      callerConversationId,
+      ownerId: owner.id,
+      agentPageId: null,
+      name: 'isolated worker',
+      workspace: 'new',
+    });
+    if (!isolated.ok) throw new Error(`isolated spawn failed: ${isolated.reason}`);
+    expect(isolated.workspaceSessionId).not.toBe(ensured.session.id);
+    const [isolatedWorker] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, isolatedWorkerId));
+    expect(isolatedWorker.sessionId).toBe(isolated.workspaceSessionId);
+
+    // Explicit target → lands exactly there (here: back in the caller's own).
+    const targetedWorkerId = createId();
+    const targeted = await deps.createWorkerSession({
+      sessionId: targetedWorkerId,
+      callerConversationId,
+      ownerId: owner.id,
+      agentPageId: null,
+      name: 'targeted worker',
+      workspace: ensured.session.id,
+    });
+    if (!targeted.ok) throw new Error(`targeted spawn failed: ${targeted.reason}`);
+    expect(targeted.workspaceSessionId).toBe(ensured.session.id);
+
+    // A workspace the caller cannot use reads as nonexistent.
+    const stranger = await factories.createUser();
+    const strangerConversationId = createId();
+    await resolveOrCreateConversation(stranger.id, strangerConversationId);
+    const strangerSession = await ensureGlobalSandboxSession(strangerConversationId, stranger.id);
+    if (!strangerSession.ok) throw new Error('stranger session failed');
+    const denied = await deps.createWorkerSession({
+      sessionId: createId(),
+      callerConversationId,
+      ownerId: owner.id,
+      agentPageId: null,
+      name: 'trespasser',
+      workspace: strangerSession.session.id,
+    });
+    expect(denied).toMatchObject({ ok: false, reason: 'workspace_not_found' });
+
+    // Discovery: the isolated workspace and its worker appear in the
+    // caller's cross-workspace listing, excluded-current respected.
+    const others = await deps.listOwnWorkspaces({
+      userId: owner.id,
+      excludeWorkspaceSessionId: ensured.session.id,
+    });
+    const isolatedListed = others.find((w) => w.workspaceId === isolated.workspaceSessionId);
+    expect(isolatedListed).toBeDefined();
+    expect(isolatedListed?.workers.map((w) => w.sessionId)).toContain(isolatedWorkerId);
+    expect(others.find((w) => w.workspaceId === ensured.session.id)).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/spawn-worker-global-session.integration.test.ts
@@ -10,11 +10,13 @@
  *     0000 created it), and the global insert still succeeds, because drizzle
  *     fills a default-less `$onUpdate` column on INSERT.
  *
- *  2. The actual root cause: a conversation bound to an ENDED session. The
- *     binding is write-once, so such a conversation can never join a live
- *     session again — `resolveCallerSessionForWorker` must refuse truthfully
- *     (`session_ended`), not hand the dead session to the create path, whose
- *     generic `conversation_unavailable` blamed the conversation id.
+ *  2. The actual root cause: a conversation bound to an ENDED session used to
+ *     dead-end every spawn with a generic `conversation_unavailable` blaming
+ *     the conversation id. Sessions are resumable by the lifecycle's own
+ *     model, so the fix is to USE the bound session regardless of lifecycle
+ *     state: the worker's claim reopens the listing (`planSessionReopen`) and
+ *     the next provision fresh-creates the sandbox through the ordinary
+ *     ensure path.
  *
  * Requires DATABASE_URL → a running Postgres with migrations applied
  * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable —
@@ -81,7 +83,7 @@ describe('spawn_session from the global assistant (issue #2335)', () => {
     expect(worker.title).toBe('repro worker');
   });
 
-  it('a global conversation bound to an ENDED session refuses with session_ended, not conversation_unavailable', async () => {
+  it('a global conversation bound to an ENDED session spawns anyway — the session is used as-is and its listing REOPENS when the worker claims in (issue #2335)', async () => {
     if (!dbAvailable) return;
 
     const owner = await factories.createUser();
@@ -96,25 +98,35 @@ describe('spawn_session from the global assistant (issue #2335)', () => {
       .set({ endedAt: new Date() })
       .where(eq(agentSessions.id, ensured.session.id));
 
-    // The resolution refuses truthfully instead of handing back the dead
-    // session (pre-fix, this returned ok:true and the create path's generic
-    // refusal blamed the conversation id — the reported bug).
+    // Resolution hands back the bound session — lifecycle state is not a
+    // refusal (pre-fix, the create path's generic conversation_unavailable
+    // blamed the conversation id here — the reported bug).
     const resolved = await resolveCallerSessionForWorker(callerConversationId, owner.id);
-    expect(resolved).toEqual({ ok: false, reason: 'session_ended' });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.session.id).toBe(ensured.session.id);
 
-    // The create path's own ended-session gate still holds as the backstop,
-    // and now names its gate via `cause` for the boundary's log.
-    await expect(
-      createConversationInSession({
-        conversationId: createId(),
-        userId: owner.id,
-        agentPageId: null,
-        sessionId: ensured.session.id,
-        title: 'doomed worker',
-      }),
-    ).rejects.toMatchObject({
-      name: 'ConversationUnavailableError',
-      cause: expect.objectContaining({ message: 'session_ended' }),
+    // The worker lands in that SAME workspace…
+    const workerConversationId = createId();
+    await createConversationInSession({
+      conversationId: workerConversationId,
+      userId: owner.id,
+      agentPageId: null,
+      sessionId: ensured.session.id,
+      title: 'recovered worker',
     });
+    const [worker] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, workerConversationId));
+    expect(worker.sessionId).toBe(ensured.session.id);
+
+    // …and the claim reopened the session's listing: the end-intent stamp is
+    // withdrawn, so the workspace is visible in the sidebar again.
+    const [session] = await db
+      .select()
+      .from(agentSessions)
+      .where(eq(agentSessions.id, ensured.session.id));
+    expect(session.endedAt).toBeNull();
   });
 });

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -319,9 +319,22 @@ function buildClaimDeps(): ClaimConversationInSessionDeps {
       // hook every claim path shares (worker spawns, the HTTP claim route,
       // the global auto-bind), so a session can never hold fresh work while
       // hidden from the sidebar (issue #2335). Best-effort by design: on a
-      // CAS miss the claim itself stands, and the next provision revives the
-      // row through the ordinary ensure path anyway.
-      if (outcome === 'claimed') await reopenEndedSessionListing(sessionId);
+      // CAS miss OR a thrown error, the claim itself still stands (the
+      // binding already committed above) — the next provision revives the
+      // row through the ordinary ensure path regardless. A reopen failure
+      // must therefore never surface as a creation failure: the caller would
+      // treat an ALREADY-BOUND conversation as unavailable and retry into a
+      // SessionFullError or a squat-guard refusal on its own successful bind
+      // (review finding — coderabbitai, PR #2336).
+      if (outcome === 'claimed') {
+        await reopenEndedSessionListing(sessionId).catch((error) => {
+          loggers.api.warn('Failed to reopen ended session listing after a successful claim', {
+            sessionId,
+            conversationId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
       return outcome;
     },
   };

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -71,6 +71,7 @@ import {
 import type { AgentSessionDTO } from '@pagespace/lib/agent-sessions/contract';
 import { decideAgentSessionAccess } from '@pagespace/lib/agent-sessions/decide-session-access';
 import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-sessions/plan-spawn-session';
+import { planSessionReopen } from '@pagespace/lib/agent-sessions/plan-session-lifecycle';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { resolveOrCreateConversation } from '@/app/api/ai/global/[id]/messages/resolve-or-create-conversation';
 import { createConversationInSessionWith } from '@/lib/agent-sessions/create-conversation-in-session';
@@ -312,9 +313,35 @@ function buildClaimDeps(): ClaimConversationInSessionDeps {
       const row = await findSessionRecord(sessionId);
       return row ? { driveId: row.driveId, endedAt: row.endedAt } : null;
     },
-    claimConversation: ({ conversationId, userId, sessionId }) =>
-      conversationRepository.claimConversation(conversationId, userId, sessionId),
+    claimConversation: async ({ conversationId, userId, sessionId }) => {
+      const outcome = await conversationRepository.claimConversation(conversationId, userId, sessionId);
+      // New work landing in an ENDED session reopens its listing — the ONE
+      // hook every claim path shares (worker spawns, the HTTP claim route,
+      // the global auto-bind), so a session can never hold fresh work while
+      // hidden from the sidebar (issue #2335). Best-effort by design: on a
+      // CAS miss the claim itself stands, and the next provision revives the
+      // row through the ordinary ensure path anyway.
+      if (outcome === 'claimed') await reopenEndedSessionListing(sessionId);
+      return outcome;
+    },
   };
+}
+
+/**
+ * Withdraw a session's end-intent (`planSessionReopen` — `endedAt` only, the
+ * confirmed-kill stamp stays; see its doc for why) when new work is claimed
+ * into it. CAS-guarded on the `endedAt` this read observed, so a concurrent
+ * re-end is never silently erased.
+ */
+async function reopenEndedSessionListing(sessionId: string): Promise<void> {
+  const store = await getAgentSessionStore();
+  const row = await store.findById(sessionId);
+  if (!row || row.endedAt === null) return;
+  await store.applyStamps({
+    sessionId,
+    stamps: planSessionReopen(),
+    cas: { endedAt: row.endedAt },
+  });
 }
 
 /**
@@ -540,16 +567,39 @@ export type EnsureGlobalSandboxSessionResult =
  * Auto-provision a workspace for a Global Assistant conversation that has
  * never had one — the exact same primitive a manual "New session → Global
  * Assistant" spawn uses (spawn, then claim), just triggered from the first
- * sandbox tool call instead of the command palette. The caller
- * (`sandbox-tools-runtime.ts`) is the one that decides this only applies to
- * `type === 'global'` conversations; this function only knows how to mint
- * and bind a session, not when that's appropriate.
+ * sandbox or session tool call instead of the command palette. The caller
+ * (`sandbox-tools-runtime.ts` / `session-tools-runtime.ts`) is the one that
+ * decides WHEN minting is appropriate and has checked the actor may spawn
+ * there; this function only knows how to mint and bind.
  */
 export async function ensureGlobalSandboxSession(
   conversationId: string,
   userId: string,
 ): Promise<EnsureGlobalSandboxSessionResult> {
-  const spawned = await spawnSession({ userId, driveId: null });
+  return ensureConversationSession(conversationId, userId, null);
+}
+
+/**
+ * The drive-scoped twin of `ensureGlobalSandboxSession` — same spawn+claim
+ * body, the session lives in `driveId` (a page agent's drive). Callers MUST
+ * have already authorized the mint (`checkAccessForSubject` on the drive plus
+ * the agent view check) — this is mechanism, not policy, exactly like the
+ * global variant.
+ */
+export async function ensureDriveSessionForConversation(
+  conversationId: string,
+  userId: string,
+  driveId: string,
+): Promise<EnsureGlobalSandboxSessionResult> {
+  return ensureConversationSession(conversationId, userId, driveId);
+}
+
+async function ensureConversationSession(
+  conversationId: string,
+  userId: string,
+  driveId: string | null,
+): Promise<EnsureGlobalSandboxSessionResult> {
+  const spawned = await spawnSession({ userId, driveId });
   if (!spawned.ok) {
     // `session_limit_reached` is a distinct, actionable denial ("end an
     // existing session first") the caller already knows how to surface —

--- a/apps/web/src/lib/agent-sessions/claim-conversation-in-session.ts
+++ b/apps/web/src/lib/agent-sessions/claim-conversation-in-session.ts
@@ -35,7 +35,6 @@ export type ClaimConversationOutcome =
   | 'already_in_session'
   | 'not_found'
   | 'cross_drive_denied'
-  | 'session_ended'
   | 'session_full';
 
 export interface ClaimConversationInSessionDeps {
@@ -88,7 +87,13 @@ export async function claimConversationInSessionWith(
 
   const sessionRow = await deps.findSession(sessionId);
   if (sessionRow === null) return 'not_found';
-  if (sessionRow.endedAt !== null) return 'session_ended';
+  // An ENDED session is a valid claim target, not a tombstone: the lifecycle
+  // treats ended rows as resumable ("a torn-down session re-provisions under
+  // the SAME key" — plan-session-lifecycle's ensure intent), and the claim
+  // wiring reopens the listing (`planSessionReopen`) when a claim lands in
+  // one. Refusing here contradicted that and permanently dead-ended every
+  // thread bound to an ended workspace (issue #2335). Session lifecycle
+  // state never gates a permitted claim; only ownership and drive rules do.
 
   if (row.type === 'page') {
     if (row.contextId === null) return 'not_found';

--- a/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
+++ b/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
@@ -132,7 +132,9 @@ export async function createConversationInSessionWith(
   // every retry (review finding — chatgpt-codex-connector: P1).
   const sessionRow = await deps.findSession(sessionId);
   if (sessionRow === null) throw new ConversationUnavailableError({ cause: new Error('session_not_found') });
-  if (sessionRow.endedAt !== null) throw new ConversationUnavailableError({ cause: new Error('session_ended') });
+  // No endedAt gate: an ended session is a valid target that REOPENS when a
+  // claim lands in it (see claim-conversation-in-session.ts) — lifecycle
+  // state never refuses a permitted create (issue #2335).
   if ((await deps.countActiveConversations(sessionId)) >= MAX_SESSION_CONVERSATIONS) {
     // Exempt an idempotent retry of a conversation ALREADY bound HERE — a
     // retry mints nothing new, so the cap must not stand between a caller
@@ -186,8 +188,8 @@ export async function createConversationInSessionWith(
   if (claimed === 'claimed' || claimed === 'already_in_session') return;
   if (claimed === 'session_full') throw new SessionFullError();
   if (claimed === 'cross_drive_denied') throw new AgentNotInSessionDriveError();
-  // 'not_found' (foreign/inactive/already-bound-elsewhere row) and
-  // 'session_ended' (a race after the pre-check above) both collapse to the
-  // same generic refusal — an id-guessing caller learns nothing either way.
+  // 'not_found' (foreign/inactive/already-bound-elsewhere row) collapses to
+  // the same generic refusal — an id-guessing caller learns nothing either
+  // way; the specific gate rides along as `cause` for the boundary's log.
   throw new ConversationUnavailableError({ cause: new Error(`claim_${claimed}`) });
 }

--- a/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
+++ b/apps/web/src/lib/agent-sessions/create-conversation-in-session.ts
@@ -31,8 +31,15 @@ import {
 } from './claim-conversation-in-session';
 
 export class ConversationUnavailableError extends Error {
-  constructor() {
-    super('conversation_unavailable');
+  /**
+   * `cause` carries the underlying failure (a creator throwing, a claim
+   * losing) for the server-side log at the tool boundary — the CALLER still
+   * sees only the one generic message, so an id-guessing caller learns
+   * nothing extra (issue #2335: the original error used to be dropped here,
+   * leaving the denial undiagnosable).
+   */
+  constructor(options?: ErrorOptions) {
+    super('conversation_unavailable', options);
     this.name = 'ConversationUnavailableError';
   }
 }
@@ -124,8 +131,8 @@ export async function createConversationInSessionWith(
   // not still leave a blank conversation cluttering the caller's history on
   // every retry (review finding — chatgpt-codex-connector: P1).
   const sessionRow = await deps.findSession(sessionId);
-  if (sessionRow === null) throw new ConversationUnavailableError();
-  if (sessionRow.endedAt !== null) throw new ConversationUnavailableError();
+  if (sessionRow === null) throw new ConversationUnavailableError({ cause: new Error('session_not_found') });
+  if (sessionRow.endedAt !== null) throw new ConversationUnavailableError({ cause: new Error('session_ended') });
   if ((await deps.countActiveConversations(sessionId)) >= MAX_SESSION_CONVERSATIONS) {
     // Exempt an idempotent retry of a conversation ALREADY bound HERE — a
     // retry mints nothing new, so the cap must not stand between a caller
@@ -140,10 +147,11 @@ export async function createConversationInSessionWith(
   if (agentPageId === null) {
     try {
       await deps.createGlobalConversation({ conversationId, userId, title });
-    } catch {
+    } catch (error) {
       // Foreign owner or a binding mismatch — one answer, because
       // distinguishing them would tell an id-guessing caller which it was.
-      throw new ConversationUnavailableError();
+      // The original error rides along as `cause` for the boundary's log.
+      throw new ConversationUnavailableError({ cause: error });
     }
   } else {
     // Cheap, early cross-drive exit before inserting a page conversation for
@@ -152,13 +160,13 @@ export async function createConversationInSessionWith(
     // common case where the mismatch is already knowable up front. Fail-
     // closed on unresolved facts.
     const agentDriveId = await deps.findAgentDriveId(agentPageId);
-    if (agentDriveId === null) throw new ConversationUnavailableError();
+    if (agentDriveId === null) throw new ConversationUnavailableError({ cause: new Error('agent_missing_or_trashed') });
     if (sessionRow.driveId !== null && sessionRow.driveId !== agentDriveId) {
       throw new AgentNotInSessionDriveError();
     }
 
     const outcome = await deps.createPageConversation({ conversationId, userId, agentPageId, title });
-    if (outcome === 'message_owner_conflict') throw new ConversationUnavailableError();
+    if (outcome === 'message_owner_conflict') throw new ConversationUnavailableError({ cause: new Error('message_owner_conflict') });
     if (outcome === 'exists') {
       // The repository's existence check is by id ALONE — no contextId
       // filter — so an id collision with a conversation anchored to a
@@ -169,7 +177,7 @@ export async function createConversationInSessionWith(
       // to "does this existing row even mean what the caller asked for".
       const row = await deps.findConversation(conversationId);
       if (row === null || row.type !== 'page' || row.contextId !== agentPageId) {
-        throw new ConversationUnavailableError();
+        throw new ConversationUnavailableError({ cause: new Error('id_collision_with_different_anchor') });
       }
     }
   }
@@ -181,5 +189,5 @@ export async function createConversationInSessionWith(
   // 'not_found' (foreign/inactive/already-bound-elsewhere row) and
   // 'session_ended' (a race after the pre-check above) both collapse to the
   // same generic refusal — an id-guessing caller learns nothing either way.
-  throw new ConversationUnavailableError();
+  throw new ConversationUnavailableError({ cause: new Error(`claim_${claimed}`) });
 }

--- a/apps/web/src/lib/ai/tools/__tests__/session-list-limit-invariant.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-list-limit-invariant.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { MAX_ACTIVE_SESSIONS_PER_OWNER } from '@/lib/agent-sessions/agent-sessions-runtime';
+import { SESSION_LIST_LIMIT } from '@pagespace/lib/services/agent-sessions/agent-sessions-store';
+
+/**
+ * `listOwnWorkspaces` (session-tools-runtime.ts) excludes the caller's
+ * current workspace AFTER `listSessions` already applied SESSION_LIST_LIMIT,
+ * not before — sound only because no owner can ever HAVE more sessions than
+ * this limit shows, so the cap never actually truncates and the exclusion
+ * never drops a workspace a pre-cap exclusion would have backfilled (review
+ * finding — CodeRabbit). That soundness rests entirely on this inequality;
+ * if it ever fails, `listOwnWorkspaces`' post-cap filter needs revisiting
+ * (push the exclusion into a new `AgentSessionListFilter` shape instead).
+ */
+describe('SESSION_LIST_LIMIT vs MAX_ACTIVE_SESSIONS_PER_OWNER — the invariant listOwnWorkspaces\' post-cap exclusion relies on', () => {
+  it('an owner can never accumulate more active sessions than one listing page shows', () => {
+    expect(MAX_ACTIVE_SESSIONS_PER_OWNER).toBeLessThanOrEqual(SESSION_LIST_LIMIT);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -17,6 +17,12 @@ const {
   mockEnsureGlobalSandboxSession,
   mockEnsureDriveSessionForConversation,
   mockCheckAccessForSubject,
+  mockCheckSessionAccess,
+  mockCreateConversationInSession,
+  mockSpawnSession,
+  mockEndSession,
+  mockListSessions,
+  mockListSessionConversationsBulk,
   mockCanUserViewPage,
   mockGetConversation,
   mockGetAiAgent,
@@ -25,6 +31,12 @@ const {
   mockEnsureGlobalSandboxSession: vi.fn(),
   mockEnsureDriveSessionForConversation: vi.fn(),
   mockCheckAccessForSubject: vi.fn(),
+  mockCheckSessionAccess: vi.fn(),
+  mockCreateConversationInSession: vi.fn(),
+  mockSpawnSession: vi.fn(),
+  mockEndSession: vi.fn(),
+  mockListSessions: vi.fn(),
+  mockListSessionConversationsBulk: vi.fn(),
   mockCanUserViewPage: vi.fn(),
   mockGetConversation: vi.fn(),
   mockGetAiAgent: vi.fn(),
@@ -35,7 +47,12 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   ensureGlobalSandboxSession: mockEnsureGlobalSandboxSession,
   ensureDriveSessionForConversation: mockEnsureDriveSessionForConversation,
   checkAccessForSubject: mockCheckAccessForSubject,
-  createConversationInSession: vi.fn(),
+  checkSessionAccess: mockCheckSessionAccess,
+  createConversationInSession: mockCreateConversationInSession,
+  spawnSession: mockSpawnSession,
+  endSession: mockEndSession,
+  listSessions: mockListSessions,
+  listSessionConversationsBulk: mockListSessionConversationsBulk,
   provisionSessionSandbox: vi.fn(),
   getAgentSessionStore: vi.fn(),
 }));
@@ -63,7 +80,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { ai: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
 }));
 
-import { resolveCallerSessionForWorker } from '../session-tools-runtime';
+import { resolveCallerSessionForWorker, buildSessionToolsDeps } from '../session-tools-runtime';
 
 const sessionRow = { id: 'ses-1', ownerId: 'user-1', endedAt: null };
 const globalConversation = { id: 'conv-g', type: 'global', userId: 'user-1', isActive: true, contextId: null };
@@ -187,5 +204,153 @@ describe('resolveCallerSessionForWorker', () => {
     const resolved = await resolveCallerSessionForWorker('conv-g', 'user-1');
 
     expect(resolved).toEqual({ ok: false, reason: 'no_session' });
+  });
+});
+
+// ============================================================================
+// Tests for session-tools-runtime.ts — createWorkerSession's placement logic
+//
+// The dep spawn_session calls. Placement is permission-gated, never
+// binding-state-gated: omitted = the caller's own workspace, 'new' = a
+// freshly minted ISOLATED workspace, anything else = an existing workspaceId
+// the caller may use.
+// ============================================================================
+
+describe('createWorkerSession — placement', () => {
+  const baseInput = {
+    sessionId: 'worker-conv-new',
+    callerConversationId: 'conv-caller',
+    ownerId: 'user-1',
+    agentPageId: null as string | null,
+    name: 'worker',
+  };
+
+  test('workspace omitted: resolves the caller\'s own session and creates the worker there', async () => {
+    mockFindSessionForConversation.mockResolvedValue({ id: 'ses-caller', ownerId: 'user-1', endedAt: null });
+    mockCreateConversationInSession.mockResolvedValue(undefined);
+
+    const deps = buildSessionToolsDeps();
+    const result = await deps.createWorkerSession(baseInput);
+
+    expect(result).toEqual({ ok: true, workspaceSessionId: 'ses-caller' });
+    expect(mockCreateConversationInSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'ses-caller', conversationId: 'worker-conv-new' }),
+    );
+    expect(mockSpawnSession).not.toHaveBeenCalled();
+    expect(mockCheckSessionAccess).not.toHaveBeenCalled();
+  });
+
+  describe('workspace: "new"', () => {
+    test('mints an isolated workspace and creates the worker in it', async () => {
+      mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+      mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-fresh' } });
+      mockCreateConversationInSession.mockResolvedValue(undefined);
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'new' });
+
+      expect(result).toEqual({ ok: true, workspaceSessionId: 'ses-fresh' });
+      expect(mockSpawnSession).toHaveBeenCalledWith({ userId: 'user-1', driveId: null });
+      expect(mockCreateConversationInSession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'ses-fresh' }),
+      );
+      expect(mockEndSession).not.toHaveBeenCalled();
+    });
+
+    test('derives the drive from the target agent when spawning for a page agent, and denies without checking spawnSession if the drive refuses', async () => {
+      mockGetAiAgent.mockResolvedValue({ id: 'agent-1', driveId: 'drive-1' });
+      mockCheckAccessForSubject.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, agentPageId: 'agent-1', workspace: 'new' });
+
+      expect(result).toEqual(expect.objectContaining({ ok: false, reason: 'not_permitted' }));
+      expect(mockCheckAccessForSubject).toHaveBeenCalledWith('user-1', expect.objectContaining({ driveId: 'drive-1' }));
+      expect(mockSpawnSession).not.toHaveBeenCalled();
+    });
+
+    test('a spawnSession cap refusal propagates as session_limit_reached', async () => {
+      mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+      mockSpawnSession.mockResolvedValue({ ok: false, reason: 'session_limit_reached' });
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'new' });
+
+      expect(result).toEqual(expect.objectContaining({ ok: false, reason: 'session_limit_reached' }));
+      expect(mockCreateConversationInSession).not.toHaveBeenCalled();
+    });
+
+    test('a create failure on a genuinely UNBOUND fresh worker unwinds the freshly minted workspace', async () => {
+      mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+      mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-fresh' } });
+      mockCreateConversationInSession.mockRejectedValue(new Error('conversation_unavailable'));
+      // Re-verification finds the worker genuinely never got bound.
+      mockFindSessionForConversation.mockResolvedValue(null);
+      mockEndSession.mockResolvedValue(undefined);
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'new' });
+
+      expect(result).toEqual(expect.objectContaining({ ok: false }));
+      expect(mockEndSession).toHaveBeenCalledWith('ses-fresh');
+    });
+
+    test('AMBIGUOUS THROW: the claim actually committed despite the thrown error — reports SUCCESS and never unwinds the workspace the worker is genuinely bound to', async () => {
+      // The exact hazard this regression-tests: createConversationInSession
+      // throws (e.g. a dropped connection after the guarded UPDATE already
+      // committed server-side), but the worker IS bound to the freshly
+      // minted workspace. Unwinding blind here would orphan a live worker
+      // on a session this call itself just killed, unreachable forever.
+      mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+      mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-fresh' } });
+      mockCreateConversationInSession.mockRejectedValue(new Error('connection reset'));
+      mockFindSessionForConversation.mockResolvedValue({ id: 'ses-fresh', ownerId: 'user-1', endedAt: null });
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'new' });
+
+      expect(result).toEqual({ ok: true, workspaceSessionId: 'ses-fresh' });
+      expect(mockEndSession).not.toHaveBeenCalled();
+    });
+
+    test('re-verification itself fails: the workspace is left alone rather than gambled on, and the original failure is still reported', async () => {
+      mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+      mockSpawnSession.mockResolvedValue({ ok: true, session: { id: 'ses-fresh' } });
+      mockCreateConversationInSession.mockRejectedValue(new Error('connection reset'));
+      mockFindSessionForConversation.mockRejectedValue(new Error('DB unreachable'));
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'new' });
+
+      expect(result).toEqual(expect.objectContaining({ ok: false }));
+      expect(mockEndSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('workspace: an explicit workspaceId', () => {
+    test('creates the worker directly in the named workspace when the caller may use it', async () => {
+      mockCheckSessionAccess.mockResolvedValue({ allowed: true });
+      mockCreateConversationInSession.mockResolvedValue(undefined);
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'ses-target' });
+
+      expect(result).toEqual({ ok: true, workspaceSessionId: 'ses-target' });
+      expect(mockCheckSessionAccess).toHaveBeenCalledWith('user-1', 'ses-target');
+      expect(mockCreateConversationInSession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'ses-target' }),
+      );
+      expect(mockSpawnSession).not.toHaveBeenCalled();
+    });
+
+    test('a workspace the caller may not use reads as nonexistent — never distinguished from a missing id', async () => {
+      mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'drive_access_denied' });
+
+      const deps = buildSessionToolsDeps();
+      const result = await deps.createWorkerSession({ ...baseInput, workspace: 'someone-elses-ses' });
+
+      expect(result).toEqual(expect.objectContaining({ ok: false, reason: 'workspace_not_found' }));
+      expect(mockCreateConversationInSession).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -51,7 +51,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 import { resolveCallerSessionForWorker } from '../session-tools-runtime';
 
-const sessionRow = { id: 'ses-1', ownerId: 'user-1' };
+const sessionRow = { id: 'ses-1', ownerId: 'user-1', endedAt: null };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -65,6 +65,16 @@ describe('resolveCallerSessionForWorker', () => {
 
     expect(resolved).toEqual({ ok: true, session: sessionRow });
     expect(mockGetConversation).not.toHaveBeenCalled();
+    expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
+  });
+
+  test('a conversation bound to an ENDED session refuses truthfully with session_ended — never the create path\'s generic conversation_unavailable (issue #2335)', async () => {
+    mockFindSessionForConversation.mockResolvedValue({ ...sessionRow, endedAt: new Date() });
+
+    const resolved = await resolveCallerSessionForWorker('conv-1', 'user-1');
+
+    expect(resolved).toEqual({ ok: false, reason: 'session_ended' });
+    // The binding is write-once — no re-mint is ever attempted for it.
     expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -3,33 +3,47 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 // ============================================================================
 // Tests for session-tools-runtime.ts — resolveCallerSessionForWorker
 //
-// A worker joins its SPAWNER's session. The one auto-bind exception is a
-// GLOBAL conversation (always minted session-less, nothing else ever claims
-// it): it gets the same spawn+claim its first sandbox tool call would
-// trigger, so spawn_session works on deployments where the compute
-// kill-switch is off and no sandbox tool exists to run the acquire path
-// (review #2326).
+// A worker works in its SPAWNER's workspace. PERMISSION gates minting;
+// workspace lifecycle state never does (issue #2335 product decision —
+// orchestration works from any surface):
+//  - a bound session is used AS IS, even if ended (the claim reopens it);
+//  - an unbound GLOBAL conversation mints with the user's own authority;
+//  - an unbound PAGE conversation mints in its agent's drive, gated by the
+//    same primitives the manual "New session" route enforces.
 // ============================================================================
 
 const {
   mockFindSessionForConversation,
   mockEnsureGlobalSandboxSession,
+  mockEnsureDriveSessionForConversation,
+  mockCheckAccessForSubject,
+  mockCanUserViewPage,
   mockGetConversation,
+  mockGetAiAgent,
 } = vi.hoisted(() => ({
   mockFindSessionForConversation: vi.fn(),
   mockEnsureGlobalSandboxSession: vi.fn(),
+  mockEnsureDriveSessionForConversation: vi.fn(),
+  mockCheckAccessForSubject: vi.fn(),
+  mockCanUserViewPage: vi.fn(),
   mockGetConversation: vi.fn(),
+  mockGetAiAgent: vi.fn(),
 }));
 
 vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
   findSessionForConversation: mockFindSessionForConversation,
   ensureGlobalSandboxSession: mockEnsureGlobalSandboxSession,
+  ensureDriveSessionForConversation: mockEnsureDriveSessionForConversation,
+  checkAccessForSubject: mockCheckAccessForSubject,
   createConversationInSession: vi.fn(),
   provisionSessionSandbox: vi.fn(),
   getAgentSessionStore: vi.fn(),
 }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: mockCanUserViewPage,
+}));
 vi.mock('@/lib/repositories/conversation-repository', () => ({
-  conversationRepository: { getConversation: mockGetConversation },
+  conversationRepository: { getConversation: mockGetConversation, getAiAgent: mockGetAiAgent },
 }));
 vi.mock('@pagespace/db/db', () => ({ db: {} }));
 vi.mock('@/lib/agent-sessions/session-shells-runtime', () => ({
@@ -52,6 +66,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 import { resolveCallerSessionForWorker } from '../session-tools-runtime';
 
 const sessionRow = { id: 'ses-1', ownerId: 'user-1', endedAt: null };
+const globalConversation = { id: 'conv-g', type: 'global', userId: 'user-1', isActive: true, contextId: null };
+const pageConversation = { id: 'conv-p', type: 'page', userId: 'user-1', isActive: true, contextId: 'agent-1' };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -68,19 +84,19 @@ describe('resolveCallerSessionForWorker', () => {
     expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
   });
 
-  test('a conversation bound to an ENDED session refuses truthfully with session_ended — never the create path\'s generic conversation_unavailable (issue #2335)', async () => {
-    mockFindSessionForConversation.mockResolvedValue({ ...sessionRow, endedAt: new Date() });
+  test('a conversation bound to an ENDED session still resolves it — lifecycle state never gates orchestration; the worker claim reopens the listing (issue #2335)', async () => {
+    const ended = { ...sessionRow, endedAt: new Date() };
+    mockFindSessionForConversation.mockResolvedValue(ended);
 
     const resolved = await resolveCallerSessionForWorker('conv-1', 'user-1');
 
-    expect(resolved).toEqual({ ok: false, reason: 'session_ended' });
-    // The binding is write-once — no re-mint is ever attempted for it.
+    expect(resolved).toEqual({ ok: true, session: ended });
     expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
   });
 
   test('an unbound GLOBAL conversation mints and binds a session via the shared spawn+claim primitive', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ id: 'conv-g', type: 'global' });
+    mockGetConversation.mockResolvedValue(globalConversation);
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: true, session: sessionRow });
 
     const resolved = await resolveCallerSessionForWorker('conv-g', 'user-1');
@@ -89,11 +105,65 @@ describe('resolveCallerSessionForWorker', () => {
     expect(mockEnsureGlobalSandboxSession).toHaveBeenCalledWith('conv-g', 'user-1');
   });
 
-  test('an unbound PAGE conversation keeps the truthful no_session refusal — never a lazily-minted per-thread environment', async () => {
+  test('an unbound PAGE conversation mints a session in ITS AGENT\'S drive when the caller passes the agent view check and the drive access check', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ id: 'conv-p', type: 'page' });
+    mockGetConversation.mockResolvedValue(pageConversation);
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', driveId: 'drive-1', title: 'Agent', type: 'AI_CHAT' });
+    mockCanUserViewPage.mockResolvedValue(true);
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: true });
+    mockEnsureDriveSessionForConversation.mockResolvedValue({ ok: true, session: sessionRow });
 
     const resolved = await resolveCallerSessionForWorker('conv-p', 'user-1');
+
+    expect(resolved).toEqual({ ok: true, session: sessionRow });
+    expect(mockCheckAccessForSubject).toHaveBeenCalledWith('user-1', {
+      sessionId: 'about-to-be-minted',
+      ownerId: 'user-1',
+      driveId: 'drive-1',
+    });
+    expect(mockEnsureDriveSessionForConversation).toHaveBeenCalledWith('conv-p', 'user-1', 'drive-1');
+  });
+
+  test('a PAGE conversation whose agent the caller cannot view refuses with not_permitted — RBAC is the gate, not binding state', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue(pageConversation);
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', driveId: 'drive-1', title: 'Agent', type: 'AI_CHAT' });
+    mockCanUserViewPage.mockResolvedValue(false);
+
+    const resolved = await resolveCallerSessionForWorker('conv-p', 'user-1');
+
+    expect(resolved).toEqual({ ok: false, reason: 'not_permitted' });
+    expect(mockEnsureDriveSessionForConversation).not.toHaveBeenCalled();
+  });
+
+  test('a PAGE conversation whose drive refuses the spawn (checkAccessForSubject) refuses with not_permitted', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue(pageConversation);
+    mockGetAiAgent.mockResolvedValue({ id: 'agent-1', driveId: 'drive-1', title: 'Agent', type: 'AI_CHAT' });
+    mockCanUserViewPage.mockResolvedValue(true);
+    mockCheckAccessForSubject.mockResolvedValue({ allowed: false, reason: 'not_a_member' });
+
+    const resolved = await resolveCallerSessionForWorker('conv-p', 'user-1');
+
+    expect(resolved).toEqual({ ok: false, reason: 'not_permitted' });
+    expect(mockEnsureDriveSessionForConversation).not.toHaveBeenCalled();
+  });
+
+  test('a foreign or history-deleted conversation refuses with no_session — the H1 ownership gate holds before any mint', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ ...globalConversation, userId: 'someone-else' });
+
+    const resolved = await resolveCallerSessionForWorker('conv-g', 'user-1');
+
+    expect(resolved).toEqual({ ok: false, reason: 'no_session' });
+    expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
+  });
+
+  test('a client (API-managed) conversation keeps the truthful no_session refusal', async () => {
+    mockFindSessionForConversation.mockResolvedValue(null);
+    mockGetConversation.mockResolvedValue({ id: 'conv-c', type: 'client', userId: 'user-1', isActive: true, contextId: null });
+
+    const resolved = await resolveCallerSessionForWorker('conv-c', 'user-1');
 
     expect(resolved).toEqual({ ok: false, reason: 'no_session' });
     expect(mockEnsureGlobalSandboxSession).not.toHaveBeenCalled();
@@ -101,7 +171,7 @@ describe('resolveCallerSessionForWorker', () => {
 
   test('a session-cap refusal surfaces as session_limit_reached, not a generic no_session', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ id: 'conv-g', type: 'global' });
+    mockGetConversation.mockResolvedValue(globalConversation);
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'session_limit_reached' });
 
     const resolved = await resolveCallerSessionForWorker('conv-g', 'user-1');
@@ -111,7 +181,7 @@ describe('resolveCallerSessionForWorker', () => {
 
   test('a transient spawn failure degrades to no_session — the caller retries a fresh spawn later', async () => {
     mockFindSessionForConversation.mockResolvedValue(null);
-    mockGetConversation.mockResolvedValue({ id: 'conv-g', type: 'global' });
+    mockGetConversation.mockResolvedValue(globalConversation);
     mockEnsureGlobalSandboxSession.mockResolvedValue({ ok: false, reason: 'spawn_failed' });
 
     const resolved = await resolveCallerSessionForWorker('conv-g', 'user-1');

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -31,6 +31,7 @@ function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
   return {
     findOwnWorkspace: vi.fn(async () => ({ sessionId: WORKSPACE_ID })),
     listSessionWorkers: vi.fn(async () => ({ sandbox: 'running' as const, workers: [], shells: [] })),
+    listOwnWorkspaces: vi.fn(async () => []),
     findSession: vi.fn(async (sessionId: string) => ({
       sessionId,
       ownerId: USER_ID,
@@ -42,7 +43,7 @@ function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
     })),
     countSessionConversations: vi.fn(async () => 0),
     canUseAgent: vi.fn(async () => true),
-    createWorkerSession: vi.fn(async () => ({ ok: true as const })),
+    createWorkerSession: vi.fn(async () => ({ ok: true as const, workspaceSessionId: WORKSPACE_ID })),
     dispatch: vi.fn(async () => ({ ok: true as const, waited: false as const })),
     readTranscript: vi.fn(async () => []),
     endSession: vi.fn(async () => ({ ok: true as const, spriteTornDown: true })),
@@ -111,7 +112,7 @@ describe('list_sessions', () => {
     const deps = makeDeps({ listSessionWorkers: vi.fn(async () => listing) });
     const tools = createSessionTools(deps);
     const result = await run(tools.list_sessions, {}, contextOptions());
-    expect(result).toEqual({ success: true, ...listing });
+    expect(result).toEqual({ success: true, workspaceId: WORKSPACE_ID, ...listing, otherWorkspaces: [] });
     // Review H2b's pin: the listing is resolved from the caller's workspace,
     // and every worker id it returns is a conversation id — the exact address
     // send_session/read_session/kill_session take.
@@ -119,14 +120,37 @@ describe('list_sessions', () => {
       workspaceSessionId: WORKSPACE_ID,
       callerConversationId: CALLER_CONVERSATION,
     });
+    // The caller's own workspace is excluded from the others list — it is
+    // already the top-level detail view.
+    expect(deps.listOwnWorkspaces).toHaveBeenCalledWith({
+      userId: USER_ID,
+      excludeWorkspaceSessionId: WORKSPACE_ID,
+    });
   });
 
-  it('a conversation with NO session says so instead of listing nothing', async () => {
-    const deps = makeDeps({ findOwnWorkspace: vi.fn(async () => null) });
+  it('a conversation with NO session says so — and still lists the caller\'s OTHER workspaces, whose workers are addressable from anywhere', async () => {
+    const elsewhere = {
+      workspaceId: 'ws-elsewhere',
+      name: 'research fleet',
+      driveId: null,
+      sandbox: 'running' as const,
+      workers: [{ sessionId: 'conv-far-worker', name: 'far worker', agent: null }],
+    };
+    const deps = makeDeps({
+      findOwnWorkspace: vi.fn(async () => null),
+      listOwnWorkspaces: vi.fn(async () => [elsewhere]),
+    });
     const tools = createSessionTools(deps);
     const result = await run(tools.list_sessions, {}, contextOptions());
-    expect(result).toMatchObject({ success: true, sandbox: 'none', workers: [], shells: [] });
-    expect(result.note).toContain('no session');
+    expect(result).toMatchObject({
+      success: true,
+      workspaceId: null,
+      sandbox: 'none',
+      workers: [],
+      shells: [],
+      otherWorkspaces: [elsewhere],
+    });
+    expect(result.note).toContain('no workspace');
     expect(deps.listSessionWorkers).not.toHaveBeenCalled();
   });
 
@@ -151,15 +175,50 @@ describe('spawn_session', () => {
     );
     expect(deps.createWorkerSession).toHaveBeenCalledWith({
       sessionId: 'new-session-id',
-      // The worker joins its SPAWNER's workspace — same session, same sandbox.
+      // Default placement: the worker joins its SPAWNER's workspace.
       callerConversationId: CALLER_CONVERSATION,
       ownerId: USER_ID,
       agentPageId: CALLER_AGENT,
       name: 'worker',
+      workspace: undefined,
     });
     expect(deps.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: 'new-session-id', depth: 1, wait: false, input: 'do the thing' }),
     );
+  });
+
+  it('workspace targeting passes through, reports where the worker landed, and skips the caller-workspace advisory count — fan-out aims wherever it likes', async () => {
+    const deps = makeDeps({
+      createWorkerSession: vi.fn(async () => ({ ok: true as const, workspaceSessionId: 'ws-target' })),
+      // The caller's own workspace being FULL must not refuse a spawn aimed
+      // elsewhere — the target's own enforced cap answers instead.
+      countSessionConversations: vi.fn(async () => 10_000),
+    });
+    const tools = createSessionTools(deps);
+    const result = await run(
+      tools.spawn_session,
+      { name: 'w', prompt: 'p', workspace: 'ws-target' },
+      contextOptions(),
+    );
+    expect(result).toEqual(expect.objectContaining({ success: true, workspaceId: 'ws-target' }));
+    expect(deps.createWorkerSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: 'ws-target' }),
+    );
+    expect(deps.countSessionConversations).not.toHaveBeenCalled();
+  });
+
+  it("workspace: 'new' passes through for an isolated worker", async () => {
+    const deps = makeDeps({
+      createWorkerSession: vi.fn(async () => ({ ok: true as const, workspaceSessionId: 'ws-fresh' })),
+    });
+    const tools = createSessionTools(deps);
+    const result = await run(
+      tools.spawn_session,
+      { name: 'w', prompt: 'p', workspace: 'new' },
+      contextOptions(),
+    );
+    expect(result).toEqual(expect.objectContaining({ success: true, workspaceId: 'ws-fresh' }));
+    expect(deps.createWorkerSession).toHaveBeenCalledWith(expect.objectContaining({ workspace: 'new' }));
   });
 
   it('given wait: true, should return the worker\'s reply directly', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -309,25 +309,46 @@ describe('send_session', () => {
   });
 });
 
-describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 parity with shells)', () => {
-  // The blast-radius case the shells fix (H2) never reached workers: a
-  // prompt-injected agent could aim send/read/kill_session at ANY conversation
-  // its user owns — another session's worker, another drive's thread, a plain
-  // session-less chat — and exfiltrate a private transcript or dispatch turns
-  // into a foreign sandbox. One address namespace per verb family means a
-  // worker verb resolves ONLY siblings in the caller's own session.
-  const CROSS_SESSION_ROW = {
+describe('worker verbs are RESOURCE-addressed — ownership is the gate, the calling surface is not (issue #2335 product decision, superseding #2262 finding 1\'s workspace confinement)', () => {
+  // The verbs work like read_page: the id is the address, permission decides.
+  // Deliberate tradeoff, decided by the product owner: the assistant
+  // orchestrates the user's workers from ANY surface, so "is this worker in
+  // MY workspace" is no longer a refusal. What still refuses: a row the
+  // caller does not OWN, a listing the human CLOSED, and a thread that is
+  // not a worker at all (no workspace binding). A page worker's dispatch
+  // additionally re-enforces the agent's RBAC inside the standard chat
+  // pipeline it runs through.
+  const OTHER_WORKSPACE_ROW = {
     sessionId: 'conv-other',
-    ownerId: USER_ID, // the caller's OWN conversation — ownership alone must not admit it
+    ownerId: USER_ID,
     agentPageId: CALLER_AGENT,
-    name: 'private thread',
+    name: 'worker elsewhere',
     endedAt: null,
-    workspaceSessionId: 'someone-elses-workspace',
+    workspaceSessionId: 'another-of-my-workspaces',
     isClosed: false,
   };
 
-  it('a conversation in ANOTHER session — even the caller\'s own — reads as nonexistent', async () => {
-    const deps = makeDeps({ findSession: vi.fn(async () => CROSS_SESSION_ROW) });
+  it('the caller\'s own worker in ANOTHER workspace is addressable — send/read/kill all reach it', async () => {
+    const deps = makeDeps({ findSession: vi.fn(async () => OTHER_WORKSPACE_ROW) });
+    const tools = createSessionTools(deps);
+
+    const sent = await run(tools.send_session, { sessionId: 'conv-other', input: 'x' }, contextOptions());
+    expect(sent.success).toBe(true);
+    expect(deps.dispatch).toHaveBeenCalled();
+
+    const readResult = await run(tools.read_session, { sessionId: 'conv-other' }, contextOptions());
+    expect(readResult.success).toBe(true);
+    expect(deps.readTranscript).toHaveBeenCalled();
+
+    const killed = await run(tools.kill_session, { sessionId: 'conv-other' }, contextOptions());
+    expect(killed.success).toBe(true);
+    expect(deps.endSession).toHaveBeenCalled();
+  });
+
+  it('a FOREIGN-owned worker reads as nonexistent — ownership is the gate that remains', async () => {
+    const deps = makeDeps({
+      findSession: vi.fn(async () => ({ ...OTHER_WORKSPACE_ROW, ownerId: 'someone-else' })),
+    });
     const tools = createSessionTools(deps);
 
     const sent = await run(tools.send_session, { sessionId: 'conv-other', input: 'x' }, contextOptions());
@@ -343,9 +364,9 @@ describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 p
     expect(deps.endSession).not.toHaveBeenCalled();
   });
 
-  it('a sibling the human already CLOSED reads as nonexistent — never dispatch/read/kill into a closed listing', async () => {
+  it('a worker the human already CLOSED reads as nonexistent — never dispatch/read/kill into a closed listing', async () => {
     const deps = makeDeps({
-      findSession: vi.fn(async () => ({ ...CROSS_SESSION_ROW, workspaceSessionId: WORKSPACE_ID, isClosed: true })),
+      findSession: vi.fn(async () => ({ ...OTHER_WORKSPACE_ROW, workspaceSessionId: WORKSPACE_ID, isClosed: true })),
     });
     const tools = createSessionTools(deps);
 
@@ -364,7 +385,7 @@ describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 p
 
   it('a SESSION-LESS conversation reads as nonexistent — it is not a worker anywhere', async () => {
     const deps = makeDeps({
-      findSession: vi.fn(async () => ({ ...CROSS_SESSION_ROW, workspaceSessionId: null })),
+      findSession: vi.fn(async () => ({ ...OTHER_WORKSPACE_ROW, workspaceSessionId: null })),
     });
     const tools = createSessionTools(deps);
     const result = await run(tools.read_session, { sessionId: 'conv-other' }, contextOptions());
@@ -372,15 +393,15 @@ describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 p
     expect(deps.readTranscript).not.toHaveBeenCalled();
   });
 
-  it('a caller whose conversation has NO workspace cannot address any worker', async () => {
+  it('a caller whose own conversation has NO workspace can still address workers by id — the source surface is irrelevant', async () => {
     const deps = makeDeps({ findOwnWorkspace: vi.fn(async () => null) });
     const tools = createSessionTools(deps);
     const result = await run(tools.send_session, { sessionId: 's1', input: 'x' }, contextOptions());
-    expect(result.success).toBe(false);
-    expect(deps.dispatch).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(deps.dispatch).toHaveBeenCalled();
   });
 
-  it('a caller with no conversation at all cannot address any worker', async () => {
+  it('a caller with no conversation in context can still read a worker — auth is the only context requirement', async () => {
     const deps = makeDeps();
     const tools = createSessionTools(deps);
     const result = await run(
@@ -388,14 +409,16 @@ describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 p
       { sessionId: 's1' },
       contextOptions({ conversationId: undefined }),
     );
-    expect(result.success).toBe(false);
-    expect(deps.readTranscript).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(deps.readTranscript).toHaveBeenCalled();
   });
 
   it('the refusal reads exactly like a nonexistent session — nothing to learn from the difference', async () => {
-    const deps = makeDeps({ findSession: vi.fn(async () => CROSS_SESSION_ROW) });
+    const deps = makeDeps({
+      findSession: vi.fn(async () => ({ ...OTHER_WORKSPACE_ROW, ownerId: 'someone-else' })),
+    });
     const noRowDeps = makeDeps({ findSession: vi.fn(async () => null) });
-    const crossSession = await run(
+    const foreign = await run(
       createSessionTools(deps).send_session,
       { sessionId: 'conv-other', input: 'x' },
       contextOptions(),
@@ -405,7 +428,7 @@ describe('worker verbs target only the CALLER\'s own workspace (issue #2262 H2 p
       { sessionId: 'conv-other', input: 'x' },
       contextOptions(),
     );
-    expect(crossSession).toEqual(noRow);
+    expect(foreign).toEqual(noRow);
   });
 });
 

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -508,6 +508,144 @@ function mapEnsured(
   };
 }
 
+type CreateWorkerSessionFailure = Extract<
+  Awaited<ReturnType<SessionToolsDeps['createWorkerSession']>>,
+  { ok: false }
+>;
+
+/**
+ * Resolve WHERE a spawned worker lands — permission-gated, never binding-
+ * state-gated (issue #2335). The three `workspace` shapes `createWorkerSession`
+ * accepts, isolated into one place so its own body reads as a straight-line
+ * pipeline: resolve placement, then create, then map errors.
+ */
+async function resolveWorkerPlacement(input: {
+  workspace: string | undefined;
+  callerConversationId: string;
+  ownerId: string;
+  agentPageId: string | null;
+}): Promise<
+  | { ok: true; workspaceSessionId: string; unwind: (() => Promise<void>) | null }
+  | CreateWorkerSessionFailure
+> {
+  const { workspace, callerConversationId, ownerId, agentPageId } = input;
+
+  if (workspace === undefined) {
+    // The caller's own workspace — minted if it has none.
+    const resolved = await resolveCallerSessionForWorker(callerConversationId, ownerId);
+    if (!resolved.ok) {
+      if (resolved.reason === 'session_limit_reached') {
+        return { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' };
+      }
+      if (resolved.reason === 'not_permitted') {
+        return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a session for this agent\'s drive.' };
+      }
+      return { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
+    }
+    return { ok: true, workspaceSessionId: resolved.session.id, unwind: null };
+  }
+
+  if (workspace === 'new') {
+    // A fresh ISOLATED workspace — its own sandbox and filesystem, for
+    // fan-out that must not share the caller's working context. It lives
+    // where its AGENT lives: a page agent's drive, or nowhere (global) — the
+    // same derivation the caller-thread minting path uses, gated by the same
+    // spawn-access primitive.
+    let driveId: string | null = null;
+    if (agentPageId !== null) {
+      const agent = await conversationRepository.getAiAgent(agentPageId);
+      if (!agent) {
+        return { ok: false, reason: 'conversation_unavailable', detail: 'That agent is not available.' };
+      }
+      driveId = agent.driveId;
+    }
+    const access = await checkAccessForSubject(ownerId, { sessionId: 'about-to-be-minted', ownerId, driveId });
+    if (!access.allowed) {
+      return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a workspace there.' };
+    }
+    const spawned = await spawnSession({ userId: ownerId, driveId });
+    if (!spawned.ok) {
+      return spawned.reason === 'session_limit_reached'
+        ? { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' }
+        : { ok: false, reason: 'spawn_failed', detail: 'Could not start a new workspace — try again.' };
+    }
+    // A fresh workspace minted FOR this spawn is unwound if the worker never
+    // lands in it — an empty session is the invariant violation the spawn
+    // route unwinds the same way.
+    const unwind = async () => {
+      await endSession(spawned.session.id).catch((cleanupError) => {
+        loggers.ai.warn('createWorkerSession: failed to unwind an empty minted workspace', {
+          workspaceSessionId: spawned.session.id,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        });
+      });
+    };
+    return { ok: true, workspaceSessionId: spawned.session.id, unwind };
+  }
+
+  // An existing workspaceId, gated by the ONE session access decision
+  // (`checkSessionAccess` — owner or drive member).
+  const access = await checkSessionAccess(ownerId, workspace);
+  if (!access.allowed) {
+    // Missing, foreign, and not-a-member all read identically — an
+    // id-guessing caller learns nothing.
+    return { ok: false, reason: 'workspace_not_found', detail: `There is no workspace "${workspace}" you can use. Call list_sessions to see yours.` };
+  }
+  return { ok: true, workspaceSessionId: workspace, unwind: null };
+}
+
+/**
+ * After `createConversationInSession` throws with a freshly-minted,
+ * unwindable workspace, determine whether the worker's claim actually
+ * COMMITTED despite the throw before tearing anything down.
+ *
+ * The claim's guarded UPDATE may have committed before this call saw the
+ * failure — the exact ambiguous-throw hazard `ensureGlobalSandboxSession`
+ * already documents and guards against elsewhere in this file (a connection
+ * dropping between a durable autocommit write and its acknowledgment).
+ * Unwinding blind on that false negative would end a session the worker is
+ * genuinely bound to: a bound-but-ended worker conversation is unreachable
+ * forever afterward (nothing will ever claim or list a freshly-minted-then-
+ * ended session again), which is worse than the failure this call would
+ * otherwise just report.
+ *
+ * `workerConversationId` was freshly minted by the caller of this dep, so it
+ * can only resolve to unbound or to exactly the workspace just minted —
+ * never a sibling's, unlike the caller-conversation case this pattern is
+ * mirrored from.
+ */
+async function recoverMintedWorkspaceAfterThrow(
+  workerConversationId: string,
+  workspaceSessionId: string,
+  unwind: () => Promise<void>,
+): Promise<'bound' | 'not_bound'> {
+  let boundAfterThrow: Awaited<ReturnType<typeof findSessionForConversation>> = null;
+  let verificationFailed = false;
+  try {
+    boundAfterThrow = await findSessionForConversation(workerConversationId);
+    if (!boundAfterThrow) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      boundAfterThrow = await findSessionForConversation(workerConversationId);
+    }
+  } catch (lookupError) {
+    verificationFailed = true;
+    loggers.ai.warn('createWorkerSession: failed to re-resolve a new worker\'s binding after a claim exception', {
+      workerConversationId,
+      workspaceSessionId,
+      error: lookupError instanceof Error ? lookupError.message : String(lookupError),
+    });
+  }
+  if (boundAfterThrow?.id === workspaceSessionId) return 'bound';
+  if (!verificationFailed) {
+    // Confirmed unbound — safe to unwind the empty workspace.
+    await unwind();
+  }
+  // Verification itself failed: leave the workspace alone rather than gamble
+  // — a stray, empty, endable-by-hand workspace is cheap and recoverable;
+  // wrongly killing one a worker is bound to is not.
+  return 'not_bound';
+}
+
 export function buildSessionToolsDeps(): SessionToolsDeps {
   return {
     findOwnWorkspace: async (conversationId) => {
@@ -577,70 +715,9 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
     },
 
     createWorkerSession: async ({ sessionId, callerConversationId, ownerId, agentPageId, name, workspace }) => {
-      // Placement — permission-gated, never binding-state-gated (issue #2335):
-      //  - omitted: the caller's own workspace (minted if needed);
-      //  - 'new': a fresh ISOLATED workspace — its own sandbox and filesystem,
-      //    for fan-out that must not share the caller's working context;
-      //  - anything else: an existing workspaceId, gated by the ONE session
-      //    access decision (`checkSessionAccess` — owner or drive member).
-      let workspaceSessionId: string;
-      // A fresh workspace minted FOR this spawn is unwound if the worker
-      // never lands in it — an empty session is the invariant violation the
-      // spawn route unwinds the same way.
-      let unwindMintedWorkspace: (() => Promise<void>) | null = null;
-
-      if (workspace === undefined) {
-        const resolved = await resolveCallerSessionForWorker(callerConversationId, ownerId);
-        if (!resolved.ok) {
-          if (resolved.reason === 'session_limit_reached') {
-            return { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' };
-          }
-          if (resolved.reason === 'not_permitted') {
-            return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a session for this agent\'s drive.' };
-          }
-          return { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
-        }
-        workspaceSessionId = resolved.session.id;
-      } else if (workspace === 'new') {
-        // The isolated workspace lives where its AGENT lives: a page agent's
-        // drive, or nowhere (global) — the same derivation the caller-thread
-        // minting path uses, gated by the same spawn-access primitive.
-        let driveId: string | null = null;
-        if (agentPageId !== null) {
-          const agent = await conversationRepository.getAiAgent(agentPageId);
-          if (!agent) {
-            return { ok: false, reason: 'conversation_unavailable', detail: 'That agent is not available.' };
-          }
-          driveId = agent.driveId;
-        }
-        const access = await checkAccessForSubject(ownerId, { sessionId: 'about-to-be-minted', ownerId, driveId });
-        if (!access.allowed) {
-          return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a workspace there.' };
-        }
-        const spawned = await spawnSession({ userId: ownerId, driveId });
-        if (!spawned.ok) {
-          return spawned.reason === 'session_limit_reached'
-            ? { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' }
-            : { ok: false, reason: 'spawn_failed', detail: 'Could not start a new workspace — try again.' };
-        }
-        workspaceSessionId = spawned.session.id;
-        unwindMintedWorkspace = async () => {
-          await endSession(spawned.session.id).catch((cleanupError) => {
-            loggers.ai.warn('createWorkerSession: failed to unwind an empty minted workspace', {
-              workspaceSessionId: spawned.session.id,
-              error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-            });
-          });
-        };
-      } else {
-        const access = await checkSessionAccess(ownerId, workspace);
-        if (!access.allowed) {
-          // Missing, foreign, and not-a-member all read identically — an
-          // id-guessing caller learns nothing.
-          return { ok: false, reason: 'workspace_not_found', detail: `There is no workspace "${workspace}" you can use. Call list_sessions to see yours.` };
-        }
-        workspaceSessionId = workspace;
-      }
+      const placement = await resolveWorkerPlacement({ workspace, callerConversationId, ownerId, agentPageId });
+      if (!placement.ok) return placement;
+      const { workspaceSessionId, unwind } = placement;
 
       try {
         await createConversationInSession({
@@ -655,50 +732,9 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           title: name,
         });
       } catch (error) {
-        if (unwindMintedWorkspace) {
-          // The claim's guarded UPDATE may have actually COMMITTED before
-          // this call saw the failure — the exact ambiguous-throw hazard
-          // `ensureGlobalSandboxSession` already documents and guards
-          // against elsewhere in this file (a connection dropping between a
-          // durable autocommit write and its acknowledgment). Unwinding
-          // blind on that false negative would end a session the worker is
-          // genuinely bound to: a bound-but-ended worker conversation is
-          // unreachable forever afterward (nothing will ever claim or list
-          // a freshly-minted-then-ended session again), which is worse than
-          // the failure this call would otherwise just report. `sessionId`
-          // was freshly minted by the caller of this dep, so it can only
-          // resolve to unbound or to exactly the workspace just minted —
-          // never a sibling's, unlike the caller-conversation case this
-          // pattern is mirrored from.
-          let boundAfterThrow: Awaited<ReturnType<typeof findSessionForConversation>> = null;
-          let verificationFailed = false;
-          try {
-            boundAfterThrow = await findSessionForConversation(sessionId);
-            if (!boundAfterThrow) {
-              await new Promise((resolve) => setTimeout(resolve, 250));
-              boundAfterThrow = await findSessionForConversation(sessionId);
-            }
-          } catch (lookupError) {
-            verificationFailed = true;
-            loggers.ai.warn('createWorkerSession: failed to re-resolve a new worker\'s binding after a claim exception', {
-              sessionId,
-              workspaceSessionId,
-              error: lookupError instanceof Error ? lookupError.message : String(lookupError),
-            });
-          }
-          if (boundAfterThrow?.id === workspaceSessionId) {
-            // The claim genuinely succeeded despite the thrown error.
-            return { ok: true, workspaceSessionId };
-          }
-          if (!verificationFailed) {
-            // Confirmed unbound — safe to unwind the empty workspace.
-            await unwindMintedWorkspace();
-          }
-          // Verification itself failed: leave the workspace alone rather
-          // than gamble (mirrors ensureGlobalSandboxSession) — a stray,
-          // empty, endable-by-hand workspace is cheap and recoverable;
-          // wrongly killing one a worker is bound to is not. Fall through
-          // to report the original error either way.
+        if (unwind) {
+          const recovered = await recoverMintedWorkspaceAfterThrow(sessionId, workspaceSessionId, unwind);
+          if (recovered === 'bound') return { ok: true, workspaceSessionId };
         }
         // A FIXED message per known cause, never the raw driver/error string
         // (issue #2262 finding 3): a database error's text is an internal

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -655,7 +655,51 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           title: name,
         });
       } catch (error) {
-        if (unwindMintedWorkspace) await unwindMintedWorkspace();
+        if (unwindMintedWorkspace) {
+          // The claim's guarded UPDATE may have actually COMMITTED before
+          // this call saw the failure — the exact ambiguous-throw hazard
+          // `ensureGlobalSandboxSession` already documents and guards
+          // against elsewhere in this file (a connection dropping between a
+          // durable autocommit write and its acknowledgment). Unwinding
+          // blind on that false negative would end a session the worker is
+          // genuinely bound to: a bound-but-ended worker conversation is
+          // unreachable forever afterward (nothing will ever claim or list
+          // a freshly-minted-then-ended session again), which is worse than
+          // the failure this call would otherwise just report. `sessionId`
+          // was freshly minted by the caller of this dep, so it can only
+          // resolve to unbound or to exactly the workspace just minted —
+          // never a sibling's, unlike the caller-conversation case this
+          // pattern is mirrored from.
+          let boundAfterThrow: Awaited<ReturnType<typeof findSessionForConversation>> = null;
+          let verificationFailed = false;
+          try {
+            boundAfterThrow = await findSessionForConversation(sessionId);
+            if (!boundAfterThrow) {
+              await new Promise((resolve) => setTimeout(resolve, 250));
+              boundAfterThrow = await findSessionForConversation(sessionId);
+            }
+          } catch (lookupError) {
+            verificationFailed = true;
+            loggers.ai.warn('createWorkerSession: failed to re-resolve a new worker\'s binding after a claim exception', {
+              sessionId,
+              workspaceSessionId,
+              error: lookupError instanceof Error ? lookupError.message : String(lookupError),
+            });
+          }
+          if (boundAfterThrow?.id === workspaceSessionId) {
+            // The claim genuinely succeeded despite the thrown error.
+            return { ok: true, workspaceSessionId };
+          }
+          if (!verificationFailed) {
+            // Confirmed unbound — safe to unwind the empty workspace.
+            await unwindMintedWorkspace();
+          }
+          // Verification itself failed: leave the workspace alone rather
+          // than gamble (mirrors ensureGlobalSandboxSession) — a stray,
+          // empty, endable-by-hand workspace is cheap and recoverable;
+          // wrongly killing one a worker is bound to is not. Fall through
+          // to report the original error either way.
+        }
         // A FIXED message per known cause, never the raw driver/error string
         // (issue #2262 finding 3): a database error's text is an internal
         // implementation detail, not something a model should read or repeat.

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -26,7 +26,9 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { deriveSandboxStatus } from '@pagespace/lib/services/agent-sessions/session-status';
 import {
+  checkAccessForSubject,
   createConversationInSession,
+  ensureDriveSessionForConversation,
   ensureGlobalSandboxSession,
   findSessionForConversation,
   provisionSessionSandbox,
@@ -381,21 +383,25 @@ async function readSessionTranscript(input: {
 
 type CallerSessionResolution =
   | { ok: true; session: NonNullable<Awaited<ReturnType<typeof findSessionForConversation>>> }
-  | { ok: false; reason: 'no_session' | 'session_limit_reached' | 'session_ended' };
+  | { ok: false; reason: 'no_session' | 'session_limit_reached' | 'not_permitted' };
 
 /**
  * Resolve the SESSION a worker would join for a caller conversation — a
  * worker works in its SPAWNER's workspace: same session, same sandbox, same
  * filesystem; that shared context is the point of spawning one.
  *
- * No caller session ⇒ refusal, never a lazily-minted per-thread environment
- * (the conflation the session model removed) — with the ONE exception the
- * sandbox acquire path already carved out (`resolveOrProvisionSession` in
- * sandbox-tools-runtime): a GLOBAL conversation is always minted session-less
- * and nothing else ever claims it, so it gets the same spawn+claim its first
- * sandbox tool call would trigger. Without this, a deployment where no
- * sandbox tool exists to run that acquire path (compute kill-switch off)
- * advertises spawn_session that can never succeed (review #2326).
+ * PERMISSION gates minting; workspace lifecycle state never does (issue
+ * #2335's product decision — orchestration must work from any surface):
+ *
+ *  - A bound session is used AS IS, even if ended: ended sessions are
+ *    resumable by the lifecycle's own model (ensure fresh-provisions them),
+ *    and the worker's claim reopens the listing (`planSessionReopen`).
+ *  - An unbound GLOBAL conversation mints a global session — the caller acts
+ *    with the user's own authority, which is the whole permission check.
+ *  - An unbound PAGE conversation mints a session in ITS AGENT'S drive,
+ *    gated by the exact primitives the manual "New session" route enforces:
+ *    the agent view check plus `checkAccessForSubject` on the drive. Same
+ *    rules, one source of truth — no tool-only policy.
  *
  * Exported for unit tests.
  */
@@ -404,21 +410,38 @@ export async function resolveCallerSessionForWorker(
   ownerId: string,
 ): Promise<CallerSessionResolution> {
   const existing = await findSessionForConversation(callerConversationId);
-  if (existing) {
-    // A bound-but-ENDED session is not a workspace a worker can join, and the
-    // binding is write-once — this conversation can never be re-claimed into a
-    // live one. Refuse truthfully rather than letting the create path's
-    // generic conversation_unavailable answer for it (issue #2335: every
-    // spawn_session in such a conversation failed with a message blaming the
-    // conversation id).
-    if (existing.endedAt !== null) return { ok: false, reason: 'session_ended' };
-    return { ok: true, session: existing };
-  }
+  if (existing) return { ok: true, session: existing };
 
   const conversation = await conversationRepository.getConversation(callerConversationId);
-  if (conversation?.type !== 'global') return { ok: false, reason: 'no_session' };
+  if (!conversation || conversation.userId !== ownerId || !conversation.isActive) {
+    return { ok: false, reason: 'no_session' };
+  }
 
-  const ensured = await ensureGlobalSandboxSession(callerConversationId, ownerId);
+  if (conversation.type === 'global') {
+    return mapEnsured(await ensureGlobalSandboxSession(callerConversationId, ownerId));
+  }
+
+  if (conversation.type === 'page' && conversation.contextId !== null) {
+    const agent = await conversationRepository.getAiAgent(conversation.contextId);
+    if (!agent) return { ok: false, reason: 'no_session' };
+    if (!(await canUserViewPage(ownerId, agent.id))) return { ok: false, reason: 'not_permitted' };
+    const access = await checkAccessForSubject(ownerId, {
+      sessionId: 'about-to-be-minted',
+      ownerId,
+      driveId: agent.driveId,
+    });
+    if (!access.allowed) return { ok: false, reason: 'not_permitted' };
+    return mapEnsured(await ensureDriveSessionForConversation(callerConversationId, ownerId, agent.driveId));
+  }
+
+  // 'client' (API-managed) rows have no in-app viewer — same policy the
+  // claim route applies.
+  return { ok: false, reason: 'no_session' };
+}
+
+function mapEnsured(
+  ensured: Awaited<ReturnType<typeof ensureGlobalSandboxSession>>,
+): CallerSessionResolution {
   if (ensured.ok) return { ok: true, session: ensured.session };
   return {
     ok: false,
@@ -439,6 +462,11 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       // spawn returned) — resolve the conversation, not a workspace row.
       const conversation = await conversationRepository.getConversation(sessionId);
       if (!conversation) return null;
+      // A history-deleted worker is not addressable. Load-bearing now that
+      // `openOwnSession` authorizes by the RESOURCE alone (ownership +
+      // bound + not closed) rather than by workspace membership — the old
+      // workspace comparison incidentally masked deleted rows.
+      if (!conversation.isActive) return null;
       return {
         sessionId,
         ownerId: conversation.userId,
@@ -449,15 +477,14 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
         endedAt: null,
         // The WORKSPACE this conversation is bound to (conversations.sessionId
         // — the agent_sessions.id FK), or null for a session-less thread.
-        // Compared against the CALLER's own workspace in openOwnSession
-        // (issue #2262 finding 1): ownership of the row alone is not enough,
-        // because a user's own conversation in a DIFFERENT session must still
-        // refuse — exactly what shells already enforce via findOwnWorkspace.
+        // `openOwnSession` requires it non-null (a plain thread is not a
+        // worker) but no longer compares it to the caller's own workspace —
+        // worker verbs are resource-addressed (issue #2335 product decision).
         workspaceSessionId: conversation.sessionId,
         // The human closed this conversation's LISTING (it no longer shows in
-        // their sidebar) — `openOwnSession` refuses on this the same way it
-        // refuses a foreign workspace, so a worker verb can never dispatch new
-        // work into, read, or kill a sibling the user has already closed.
+        // their sidebar) — `openOwnSession` refuses on this, so a worker verb
+        // can never dispatch new work into, read, or kill a worker the user
+        // has already closed.
         isClosed: conversation.closedInSessionAt !== null,
       };
     },
@@ -495,8 +522,8 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
         if (resolved.reason === 'session_limit_reached') {
           return { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' };
         }
-        if (resolved.reason === 'session_ended') {
-          return { ok: false, reason: 'session_ended', detail: 'This conversation\'s session has ended — a worker joins its caller\'s live session. Start a new conversation to spawn workers.' };
+        if (resolved.reason === 'not_permitted') {
+          return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a session for this agent\'s drive.' };
         }
         return { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
       }

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -352,6 +352,18 @@ async function listOwnWorkspaces({
   userId: string;
   excludeWorkspaceSessionId?: string;
 }): Promise<OwnWorkspaceSummary[]> {
+  // The exclusion runs AFTER `listSessions`' own SESSION_LIST_LIMIT cap, not
+  // as a query-level filter before it — deliberately, not an oversight: a
+  // pre-cap exclusion would need a new filter shape on the shared store
+  // (`AgentSessionListFilter`) for a scenario that cannot occur today.
+  // `SESSION_LIST_LIMIT` and `MAX_ACTIVE_SESSIONS_PER_OWNER` are both 100,
+  // and the latter is a STRUCTURAL cap (`createIfUnderLimit`'s atomic
+  // count-and-insert) — no owner can ever HAVE more than 100 active
+  // sessions, so `listSessions` never actually truncates here and this
+  // filter can never drop a workspace that a pre-cap exclusion would have
+  // backfilled (review finding — CodeRabbit). That soundness is CONTINGENT
+  // on the two constants staying equal and the cap staying structural; if
+  // either ever changes independently, revisit this filter's ordering.
   const sessions = (await listSessions({ ownerId: userId })).filter(
     (session) => session.sessionId !== excludeWorkspaceSessionId,
   );

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -19,7 +19,7 @@
 
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
-import { and, count, eq, isNull, ne, desc } from '@pagespace/db/operators';
+import { and, count, eq, inArray, isNull, ne, desc } from '@pagespace/db/operators';
 import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { conversations, messages as globalMessages } from '@pagespace/db/schema/conversations';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
@@ -27,11 +27,16 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { deriveSandboxStatus } from '@pagespace/lib/services/agent-sessions/session-status';
 import {
   checkAccessForSubject,
+  checkSessionAccess,
   createConversationInSession,
+  endSession,
   ensureDriveSessionForConversation,
   ensureGlobalSandboxSession,
   findSessionForConversation,
+  listSessions,
+  listSessionConversationsBulk,
   provisionSessionSandbox,
+  spawnSession,
   getAgentSessionStore,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
 import {
@@ -50,6 +55,7 @@ import { abortConversationStreams } from '@/lib/ai/core/abort-conversation-strea
 import {
   createSessionTools,
   type DispatchOutcome,
+  type OwnWorkspaceSummary,
   type SessionWorkspaceListing,
   type SessionToolsDeps,
   type TranscriptEntry,
@@ -330,6 +336,59 @@ async function listSessionWorkers({
   };
 }
 
+/**
+ * ALL the caller's active workspaces (their newest `SESSION_LIST_LIMIT`
+ * slice, same as the sidebar) with each one's workers — the discovery half of
+ * resource-addressed orchestration: every worker id here is addressable by
+ * the verbs from anywhere, and every workspaceId is a valid `spawn_session`
+ * `workspace` target. Composed from the SAME primitives the sidebar uses
+ * (`listSessions` + `listSessionConversationsBulk`), never a second query
+ * shape; agent labels resolved in one batched lookup.
+ */
+async function listOwnWorkspaces({
+  userId,
+  excludeWorkspaceSessionId,
+}: {
+  userId: string;
+  excludeWorkspaceSessionId?: string;
+}): Promise<OwnWorkspaceSummary[]> {
+  const sessions = (await listSessions({ ownerId: userId })).filter(
+    (session) => session.sessionId !== excludeWorkspaceSessionId,
+  );
+  if (sessions.length === 0) return [];
+
+  const workersBySession = await listSessionConversationsBulk(sessions.map((s) => s.sessionId));
+
+  const agentPageIds = [
+    ...new Set(
+      [...workersBySession.values()].flat().flatMap((w) => (w.agentPageId ? [w.agentPageId] : [])),
+    ),
+  ];
+  const agentTitles = new Map<string, string>();
+  if (agentPageIds.length > 0) {
+    const agentRows = await db
+      .select({ id: pages.id, title: pages.title })
+      .from(pages)
+      .where(inArray(pages.id, agentPageIds));
+    for (const row of agentRows) agentTitles.set(row.id, row.title);
+  }
+
+  return sessions.map((session) => ({
+    workspaceId: session.sessionId,
+    name: session.name,
+    driveId: session.driveId,
+    sandbox: session.sandboxStatus,
+    workers: (workersBySession.get(session.sessionId) ?? []).map((worker) => ({
+      sessionId: worker.conversationId,
+      name: worker.title ?? '',
+      agent:
+        worker.agentPageId !== null
+          ? { agentId: worker.agentPageId, title: agentTitles.get(worker.agentPageId) ?? '' }
+          : null,
+    })),
+  }));
+}
+
 async function readSessionTranscript(input: {
   sessionId: string;
   agentPageId: string | null;
@@ -456,6 +515,7 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       return row ? { sessionId: row.id } : null;
     },
     listSessionWorkers,
+    listOwnWorkspaces,
 
     findSession: async (sessionId) => {
       // The tool family's "sessionId" is the WORKER's conversation id (what
@@ -516,24 +576,78 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       return canUserViewPage(userId, agentPageId);
     },
 
-    createWorkerSession: async ({ sessionId, callerConversationId, ownerId, agentPageId, name }) => {
-      const resolved = await resolveCallerSessionForWorker(callerConversationId, ownerId);
-      if (!resolved.ok) {
-        if (resolved.reason === 'session_limit_reached') {
-          return { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' };
+    createWorkerSession: async ({ sessionId, callerConversationId, ownerId, agentPageId, name, workspace }) => {
+      // Placement — permission-gated, never binding-state-gated (issue #2335):
+      //  - omitted: the caller's own workspace (minted if needed);
+      //  - 'new': a fresh ISOLATED workspace — its own sandbox and filesystem,
+      //    for fan-out that must not share the caller's working context;
+      //  - anything else: an existing workspaceId, gated by the ONE session
+      //    access decision (`checkSessionAccess` — owner or drive member).
+      let workspaceSessionId: string;
+      // A fresh workspace minted FOR this spawn is unwound if the worker
+      // never lands in it — an empty session is the invariant violation the
+      // spawn route unwinds the same way.
+      let unwindMintedWorkspace: (() => Promise<void>) | null = null;
+
+      if (workspace === undefined) {
+        const resolved = await resolveCallerSessionForWorker(callerConversationId, ownerId);
+        if (!resolved.ok) {
+          if (resolved.reason === 'session_limit_reached') {
+            return { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' };
+          }
+          if (resolved.reason === 'not_permitted') {
+            return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a session for this agent\'s drive.' };
+          }
+          return { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
         }
-        if (resolved.reason === 'not_permitted') {
-          return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a session for this agent\'s drive.' };
+        workspaceSessionId = resolved.session.id;
+      } else if (workspace === 'new') {
+        // The isolated workspace lives where its AGENT lives: a page agent's
+        // drive, or nowhere (global) — the same derivation the caller-thread
+        // minting path uses, gated by the same spawn-access primitive.
+        let driveId: string | null = null;
+        if (agentPageId !== null) {
+          const agent = await conversationRepository.getAiAgent(agentPageId);
+          if (!agent) {
+            return { ok: false, reason: 'conversation_unavailable', detail: 'That agent is not available.' };
+          }
+          driveId = agent.driveId;
         }
-        return { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
+        const access = await checkAccessForSubject(ownerId, { sessionId: 'about-to-be-minted', ownerId, driveId });
+        if (!access.allowed) {
+          return { ok: false, reason: 'not_permitted', detail: 'You are not permitted to start a workspace there.' };
+        }
+        const spawned = await spawnSession({ userId: ownerId, driveId });
+        if (!spawned.ok) {
+          return spawned.reason === 'session_limit_reached'
+            ? { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' }
+            : { ok: false, reason: 'spawn_failed', detail: 'Could not start a new workspace — try again.' };
+        }
+        workspaceSessionId = spawned.session.id;
+        unwindMintedWorkspace = async () => {
+          await endSession(spawned.session.id).catch((cleanupError) => {
+            loggers.ai.warn('createWorkerSession: failed to unwind an empty minted workspace', {
+              workspaceSessionId: spawned.session.id,
+              error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            });
+          });
+        };
+      } else {
+        const access = await checkSessionAccess(ownerId, workspace);
+        if (!access.allowed) {
+          // Missing, foreign, and not-a-member all read identically — an
+          // id-guessing caller learns nothing.
+          return { ok: false, reason: 'workspace_not_found', detail: `There is no workspace "${workspace}" you can use. Call list_sessions to see yours.` };
+        }
+        workspaceSessionId = workspace;
       }
-      const callerSession = resolved.session;
+
       try {
         await createConversationInSession({
           conversationId: sessionId,
           userId: ownerId,
           agentPageId,
-          sessionId: callerSession.id,
+          sessionId: workspaceSessionId,
           // The worker's label, written AT BIRTH onto the conversation row —
           // it is what the sidebar and list_sessions display (codex review,
           // P2: the old path reported the name in the tool response and then
@@ -541,6 +655,7 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           title: name,
         });
       } catch (error) {
+        if (unwindMintedWorkspace) await unwindMintedWorkspace();
         // A FIXED message per known cause, never the raw driver/error string
         // (issue #2262 finding 3): a database error's text is an internal
         // implementation detail, not something a model should read or repeat.
@@ -566,7 +681,7 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
         });
         return { ok: false, reason: 'conversation_unavailable', detail: 'That conversation id is not available.' };
       }
-      return { ok: true };
+      return { ok: true, workspaceSessionId };
     },
 
     dispatch: dispatchThroughChatPipeline,

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -33,7 +33,6 @@ import {
   getAgentSessionStore,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
 import {
-  ConversationUnavailableError,
   AgentNotInSessionDriveError,
   SessionFullError,
 } from '@/lib/agent-sessions/create-conversation-in-session';
@@ -382,7 +381,7 @@ async function readSessionTranscript(input: {
 
 type CallerSessionResolution =
   | { ok: true; session: NonNullable<Awaited<ReturnType<typeof findSessionForConversation>>> }
-  | { ok: false; reason: 'no_session' | 'session_limit_reached' };
+  | { ok: false; reason: 'no_session' | 'session_limit_reached' | 'session_ended' };
 
 /**
  * Resolve the SESSION a worker would join for a caller conversation — a
@@ -405,7 +404,16 @@ export async function resolveCallerSessionForWorker(
   ownerId: string,
 ): Promise<CallerSessionResolution> {
   const existing = await findSessionForConversation(callerConversationId);
-  if (existing) return { ok: true, session: existing };
+  if (existing) {
+    // A bound-but-ENDED session is not a workspace a worker can join, and the
+    // binding is write-once — this conversation can never be re-claimed into a
+    // live one. Refuse truthfully rather than letting the create path's
+    // generic conversation_unavailable answer for it (issue #2335: every
+    // spawn_session in such a conversation failed with a message blaming the
+    // conversation id).
+    if (existing.endedAt !== null) return { ok: false, reason: 'session_ended' };
+    return { ok: true, session: existing };
+  }
 
   const conversation = await conversationRepository.getConversation(callerConversationId);
   if (conversation?.type !== 'global') return { ok: false, reason: 'no_session' };
@@ -484,9 +492,13 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
     createWorkerSession: async ({ sessionId, callerConversationId, ownerId, agentPageId, name }) => {
       const resolved = await resolveCallerSessionForWorker(callerConversationId, ownerId);
       if (!resolved.ok) {
-        return resolved.reason === 'session_limit_reached'
-          ? { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' }
-          : { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
+        if (resolved.reason === 'session_limit_reached') {
+          return { ok: false, reason: 'session_limit_reached', detail: 'You are at your active-session limit — end an existing session first.' };
+        }
+        if (resolved.reason === 'session_ended') {
+          return { ok: false, reason: 'session_ended', detail: 'This conversation\'s session has ended — a worker joins its caller\'s live session. Start a new conversation to spawn workers.' };
+        }
+        return { ok: false, reason: 'no_session', detail: 'This conversation has no session for a worker to join.' };
       }
       const callerSession = resolved.session;
       try {
@@ -512,9 +524,19 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
         if (error instanceof AgentNotInSessionDriveError) {
           return { ok: false, reason: 'conversation_unavailable', detail: 'That agent belongs to a different drive than this session.' };
         }
-        if (!(error instanceof ConversationUnavailableError)) {
-          loggers.ai.error('createWorkerSession: could not create the worker conversation', error instanceof Error ? error : undefined, { sessionId, callerConversationId, ownerId });
-        }
+        // ConversationUnavailableError is logged too — it is deliberately
+        // generic toward the CALLER, which is exactly why the server log must
+        // say which gate refused (issue #2335: excluding it here meant a
+        // deterministic denial left no trace anywhere). The logger serializes
+        // only name/message/stack, so the wrapped cause is surfaced in the
+        // metadata explicitly.
+        const cause = error instanceof Error && error.cause instanceof Error ? error.cause : undefined;
+        loggers.ai.error('createWorkerSession: could not create the worker conversation', error instanceof Error ? error : undefined, {
+          sessionId,
+          callerConversationId,
+          ownerId,
+          ...(cause ? { cause: `${cause.name}: ${cause.message}` } : {}),
+        });
         return { ok: false, reason: 'conversation_unavailable', detail: 'That conversation id is not available.' };
       }
       return { ok: true };

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -82,6 +82,13 @@ export const spawnSessionInputSchema = z
     prompt: z.string().min(1).max(MAX_SESSION_INPUT_BYTES),
     /** Spawn the worker under another agent — an agentId. Omitted = your own agent (or the global assistant). */
     agent: z.string().min(1).optional(),
+    /**
+     * WHERE the worker runs. Omitted = this conversation's own workspace
+     * (started automatically if it has none). `'new'` = a fresh ISOLATED
+     * workspace (its own sandbox and filesystem). Any other value = a
+     * workspaceId from `list_sessions` — one of the caller's workspaces.
+     */
+    workspace: z.string().min(1).optional(),
     /** Block until the worker's first reply and return it here. */
     wait: z.boolean().optional(),
   })
@@ -158,6 +165,23 @@ export interface SessionWorkspaceListing {
   shells: Array<Pick<ShellDTO, 'shellId' | 'name' | 'createdAt'>>;
 }
 
+/**
+ * One of the caller's OTHER workspaces, as `list_sessions` reports it —
+ * enough to address every worker anywhere (`sessionId`s for the verbs) and
+ * to target the workspace itself (`workspaceId` for `spawn_session`'s
+ * `workspace` input). No shells: those stay addressable only from inside
+ * their own workspace's conversations.
+ */
+export interface OwnWorkspaceSummary {
+  workspaceId: string;
+  /** Display label only — never an address. */
+  name: string;
+  /** The drive this workspace belongs to, or null for a global-assistant workspace. */
+  driveId: string | null;
+  sandbox: SandboxStatus;
+  workers: Array<Omit<WorkerListingEntry, 'isCaller'>>;
+}
+
 /** The identity slice of a session row the tools act on. */
 export interface SessionToolRow {
   sessionId: string;
@@ -167,11 +191,10 @@ export interface SessionToolRow {
   endedAt: string | null;
   /**
    * The WORKSPACE (agent_sessions.id) this conversation is bound to, or null
-   * for a session-less conversation. Compared against the CALLER's own
-   * workspace so a worker verb only ever reaches a sibling in the caller's own
-   * session — ownership of the row alone is not enough (issue #2262 finding
-   * 1): a user's OWN conversation in a DIFFERENT session must still refuse,
-   * exactly as shells already require via `findOwnWorkspace`.
+   * for a session-less conversation. `openOwnSession` requires it non-null (a
+   * plain thread is not a worker) but does NOT compare it to the caller's own
+   * workspace — worker verbs are resource-addressed (issue #2335 product
+   * decision, superseding #2262 finding 1's workspace confinement).
    */
   workspaceSessionId: string | null;
   /**
@@ -225,6 +248,16 @@ export interface SessionToolsDeps {
     workspaceSessionId: string;
     callerConversationId: string;
   }) => Promise<SessionWorkspaceListing>;
+  /**
+   * ALL the caller's active workspaces (minus `excludeWorkspaceSessionId`,
+   * their current one) with each workspace's workers — how a worker anywhere
+   * becomes addressable, and how `spawn_session`'s `workspace` targeting
+   * discovers its targets.
+   */
+  listOwnWorkspaces: (input: {
+    userId: string;
+    excludeWorkspaceSessionId?: string;
+  }) => Promise<OwnWorkspaceSummary[]>;
   /** One session row's identity slice, or null. */
   findSession: (sessionId: string) => Promise<SessionToolRow | null>;
   /**
@@ -244,12 +277,21 @@ export interface SessionToolsDeps {
   createWorkerSession: (input: {
     /** The WORKER's new conversation id (minted by the caller of this dep). */
     sessionId: string;
-    /** The conversation whose SESSION the worker joins — a worker works in its spawner's workspace. */
+    /** The caller's conversation — the workspace default when `workspace` is omitted. */
     callerConversationId: string;
     ownerId: string;
     agentPageId: string | null;
     name: string;
-  }) => Promise<{ ok: true } | { ok: false; reason: string; detail?: string }>;
+    /**
+     * Placement: omitted = the caller's own workspace (minted if needed);
+     * `'new'` = a fresh isolated workspace; anything else = an existing
+     * workspaceId the caller may use (`checkSessionAccess`).
+     */
+    workspace?: string;
+  }) => Promise<
+    | { ok: true; workspaceSessionId: string }
+    | { ok: false; reason: string; detail?: string }
+  >;
   /**
    * Dispatch one turn into a session's conversation THROUGH THE STANDARD CHAT
    * PIPELINE (the `ai_stream_sessions` background-run machinery normal
@@ -481,42 +523,49 @@ export function createSessionTools(deps: SessionToolsDeps): {
   return {
     list_sessions: tool({
       description:
-        'List YOUR SESSION\'s workers and shells: each worker\'s sessionId (the exact address send_session/read_session/kill_session take), its display name and agent; each shell\'s shellId (the address send_shell/read_shell/kill_shell take); and the one shared sandbox\'s status. Names are labels — always address by id.',
+        'List ALL your workspaces and their workers. Your current conversation\'s workspace comes with full detail (workers, shells, shared sandbox status); every other workspace lists its workspaceId (a spawn_session `workspace` target) and workers. Every worker\'s sessionId is the exact address send_session/read_session/kill_session take, from anywhere. Names are labels — always address by id.',
       inputSchema: listSessionsInputSchema,
       execute: async (_input, options) => {
         const context = readContext(options);
         const actor = readActor(context);
         if (!actor) return NEEDS_AUTH;
         const conversationId = context?.conversationId;
-        if (!conversationId) return NEEDS_CONVERSATION;
 
-        const workspace = await deps.findOwnWorkspace(conversationId);
+        const workspace = conversationId ? await deps.findOwnWorkspace(conversationId) : null;
+        const otherWorkspaces = await deps.listOwnWorkspaces({
+          userId: actor.userId,
+          excludeWorkspaceSessionId: workspace?.sessionId,
+        });
+
         if (!workspace) {
-          // A plain conversation: nothing to list, and saying so beats an
-          // empty array the model would read as "my workers disappeared".
+          // A plain conversation: nothing HERE, said explicitly — but the
+          // caller's other workspaces still list, because their workers are
+          // addressable from anywhere.
           return {
             success: true,
+            workspaceId: null,
             sandbox: 'none' as const,
             workers: [],
             shells: [],
-            note: 'This conversation has no session yet, so there are no workers or shells here. spawn_session will start one automatically (permission permitting); workers you spawned elsewhere remain addressable by their sessionId.',
+            otherWorkspaces,
+            note: 'This conversation has no workspace yet — spawn_session starts one automatically (permission permitting). Workers in your other workspaces are addressable by their sessionId.',
           };
         }
         const listing = await deps.listSessionWorkers({
           workspaceSessionId: workspace.sessionId,
-          callerConversationId: conversationId,
+          callerConversationId: conversationId as string,
         });
-        return { success: true, ...listing };
+        return { success: true, workspaceId: workspace.sessionId, ...listing, otherWorkspaces };
       },
     }),
 
     spawn_session: tool({
       description:
-        'Spawn a WORKER: a new labeled conversation in your session (same sandbox, same filesystem) that starts working on your prompt immediately, visible live in the sidebar like any conversation. If this conversation has no session yet, one is started automatically (permission permitting). Returns its sessionId — the address for send_session/read_session/kill_session (the name is only a label). ' +
+        'Spawn a WORKER: a new labeled conversation that starts working on your prompt immediately, visible live in the sidebar like any conversation. By default it runs in this conversation\'s workspace (same sandbox, same filesystem — started automatically if none exists yet, permission permitting). Pass workspace: "new" for a fresh ISOLATED workspace, or a workspaceId from list_sessions to place it in one of your other workspaces. Returns its sessionId — the address for send_session/read_session/kill_session (the name is only a label). ' +
         'Pass agent to run it under another agent (an agentId from list_agents); omit it to use this conversation\'s own agent. ' +
         'Default is fire-and-forget: the reply lands in the worker\'s own transcript (read_session), NOT here. Pass wait: true to block for the first reply and get it back directly.',
       inputSchema: spawnSessionInputSchema,
-      execute: async ({ name, prompt, agent, wait }, options) => {
+      execute: async ({ name, prompt, agent, workspace: targetWorkspace, wait }, options) => {
         const context = readContext(options);
         const actor = readActor(context);
         if (!actor) return NEEDS_AUTH;
@@ -524,13 +573,15 @@ export function createSessionTools(deps: SessionToolsDeps): {
         if (!callerConversationId) return NEEDS_CONVERSATION;
 
         // The session-level cap (issue #2262 finding 2) counts what a spawn
-        // actually mints — a conversation in THIS workspace — so it is read
-        // against the caller's own workspace, not any account-wide sandbox
-        // count (a worker spawn never creates a sandbox; codex round 11). A
-        // caller whose conversation has no session yet reads as zero here;
-        // createWorkerSession refuses that case with its own truthful reason
-        // once the plan clears.
-        const workspace = await deps.findOwnWorkspace(callerConversationId);
+        // actually mints — a conversation in the TARGET workspace. The
+        // advisory pre-count only applies when the target IS the caller's own
+        // workspace; for 'new' or an explicit target the ENFORCED cap at the
+        // claim answers (counting the caller's workspace there would refuse a
+        // spawn aimed somewhere with room — the fan-out case this parameter
+        // exists for). A worker spawn never creates a sandbox (codex round
+        // 11), so no compute quota applies here either way.
+        const workspace =
+          targetWorkspace === undefined ? await deps.findOwnWorkspace(callerConversationId) : null;
         const sessionConversationCount = workspace
           ? await deps.countSessionConversations(workspace.sessionId)
           : 0;
@@ -563,6 +614,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
           ownerId: actor.userId,
           agentPageId,
           name: plan.name,
+          workspace: targetWorkspace,
         });
         if (!created.ok) {
           return {
@@ -592,6 +644,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
           sessionId,
           name: plan.name,
           agent: agentPageId,
+          workspaceId: created.workspaceSessionId,
           ...(dispatched.waited
             ? { reply: dispatched.reply }
             : {

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -408,12 +408,22 @@ export function createSessionTools(deps: SessionToolsDeps): {
   kill_shell: Tool;
 } {
   /**
-   * A session verb's shared open: the row must exist, be the CALLER's own,
-   * AND be a sibling in the CALLER's own workspace session (issue #2262
-   * finding 1 — H2 parity: ownership alone let a worker verb reach any
-   * conversation the calling user owned, including other sessions, other
-   * drives, or session-less threads; mirrors `openOwnShell`'s workspace
-   * comparison).
+   * A session verb's shared open — RESOURCE-addressed, like `read_page`: the
+   * worker id is the address, permission is the only gate, and the calling
+   * conversation plays no authorization role (it supplies defaults and pane
+   * placement, nothing else). Product decision superseding issue #2262
+   * finding 1's workspace confinement: the assistant orchestrates the user's
+   * workers from ANY surface — dashboard, sidebar, panes, agents page — so
+   * "is this worker in MY workspace" is no longer a refusal.
+   *
+   * The gates that remain are about the RESOURCE:
+   *  - ownership — the worker conversation must be the caller's own (a page
+   *    worker's dispatch additionally re-enforces the agent's RBAC in the
+   *    standard chat pipeline it runs through);
+   *  - it must actually BE a worker (bound into some workspace) — a plain
+   *    session-less thread is not addressable as one;
+   *  - not closed — a listing the human closed stays closed to worker verbs.
+   * All three refuse identically: nothing to learn from the difference.
    */
   const openOwnSession = async (
     context: ToolExecutionContext | undefined,
@@ -424,20 +434,11 @@ export function createSessionTools(deps: SessionToolsDeps): {
   > => {
     const actor = readActor(context);
     if (!actor) return { ok: false, error: NEEDS_AUTH };
-    const conversationId = context?.conversationId;
-    if (!conversationId) return { ok: false, error: NEEDS_CONVERSATION };
-    const workspace = await deps.findOwnWorkspace(conversationId);
-    if (!workspace) return { ok: false, error: notYourSession(sessionId) };
     const row = await deps.findSession(sessionId);
-    // Someone else's session, a nonexistent one, a session outside the
-    // caller's own workspace, and one the human already closed all read
-    // identically — there is nothing to learn from the difference and
-    // nothing the caller could do with it.
     if (
       !row ||
       row.ownerId !== actor.userId ||
       row.workspaceSessionId === null ||
-      row.workspaceSessionId !== workspace.sessionId ||
       row.isClosed
     ) {
       return { ok: false, error: notYourSession(sessionId) };
@@ -498,7 +499,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
             sandbox: 'none' as const,
             workers: [],
             shells: [],
-            note: 'This conversation has no session, so there are no workers or shells, and spawn_session/spawn_shell will refuse here too — sessions are not started lazily from a plain conversation.',
+            note: 'This conversation has no session yet, so there are no workers or shells here. spawn_session will start one automatically (permission permitting); workers you spawned elsewhere remain addressable by their sessionId.',
           };
         }
         const listing = await deps.listSessionWorkers({
@@ -511,7 +512,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
 
     spawn_session: tool({
       description:
-        'Spawn a WORKER: a new labeled conversation IN YOUR OWN SESSION (same sandbox, same filesystem) that starts working on your prompt immediately, visible live in the sidebar like any conversation. Returns its sessionId — the address for send_session/read_session/kill_session (the name is only a label). ' +
+        'Spawn a WORKER: a new labeled conversation in your session (same sandbox, same filesystem) that starts working on your prompt immediately, visible live in the sidebar like any conversation. If this conversation has no session yet, one is started automatically (permission permitting). Returns its sessionId — the address for send_session/read_session/kill_session (the name is only a label). ' +
         'Pass agent to run it under another agent (an agentId from list_agents); omit it to use this conversation\'s own agent. ' +
         'Default is fire-and-forget: the reply lands in the worker\'s own transcript (read_session), NOT here. Pass wait: true to block for the first reply and get it back directly.',
       inputSchema: spawnSessionInputSchema,

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -537,10 +537,14 @@ export function createSessionTools(deps: SessionToolsDeps): {
           excludeWorkspaceSessionId: workspace?.sessionId,
         });
 
-        if (!workspace) {
-          // A plain conversation: nothing HERE, said explicitly — but the
-          // caller's other workspaces still list, because their workers are
-          // addressable from anywhere.
+        if (!conversationId || !workspace) {
+          // No conversation, or a plain one with no workspace: nothing HERE,
+          // said explicitly — but the caller's other workspaces still list,
+          // because their workers are addressable from anywhere. The `||`
+          // also lets TypeScript narrow `conversationId` below without a
+          // cast: `workspace` is only ever non-null when `conversationId`
+          // was truthy (see its assignment above), so this guard makes that
+          // fact one the compiler carries, not one a reader has to trust.
           return {
             success: true,
             workspaceId: null,
@@ -553,7 +557,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
         }
         const listing = await deps.listSessionWorkers({
           workspaceSessionId: workspace.sessionId,
-          callerConversationId: conversationId as string,
+          callerConversationId: conversationId,
         });
         return { success: true, workspaceId: workspace.sessionId, ...listing, otherWorkspaces };
       },

--- a/packages/lib/src/agent-sessions/__tests__/plan-session-lifecycle.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/plan-session-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   planAgentSessionLifecycle,
+  planSessionReopen,
   type AgentSessionLifecycleRow,
   type AgentSessionIntent,
 } from '../plan-session-lifecycle';
@@ -310,6 +311,19 @@ describe('planAgentSessionLifecycle — end (instance-guarded teardown, row reta
     if (plan.action !== 'noop') throw new Error('expected noop');
     expect(plan.reason).toBe('already_ended');
     expect(plan.stamps).toEqual({});
+  });
+
+  it('a REOPENED row (endedAt withdrawn by planSessionReopen, kill still confirmed) is re-endable: the fresh end-intent is stamped, nothing is re-killed', () => {
+    const reopened = row({ teardownRequestedAt: NOW, spriteTornDownAt: NOW, endedAt: null });
+    const plan = planAgentSessionLifecycle({ row: reopened, intent: 'end', canRun: true, now: NOW });
+    if (plan.action !== 'noop') throw new Error('expected noop');
+    expect(plan.stamps.endedAt).toEqual(NOW);
+  });
+});
+
+describe('planSessionReopen', () => {
+  it('withdraws ONLY the end-intent — the confirmed-kill stamp survives, so provisioning still fresh-creates and attach still refuses', () => {
+    expect(planSessionReopen()).toEqual({ endedAt: null });
   });
 });
 

--- a/packages/lib/src/agent-sessions/plan-session-lifecycle.ts
+++ b/packages/lib/src/agent-sessions/plan-session-lifecycle.ts
@@ -176,6 +176,25 @@ function reviveStamps(now: Date): AgentSessionRowStamps {
   };
 }
 
+/**
+ * REOPEN a session's listing without provisioning anything — the stamp for
+ * "a permitted actor put new work into this workspace" (a conversation
+ * claimed into it after it was ended; issue #2335). Withdraws only the
+ * user's end-INTENT (`endedAt`), so the session reappears in listings and
+ * its cap/verbs work again.
+ *
+ * Deliberately narrower than `reviveStamps` (private, provisioning-only):
+ * `spriteTornDownAt` — the CONFIRMED-kill record — is preserved, so
+ * `isEnded` stays true for the lifecycle until an actual provision runs:
+ * `ensure` still fresh-creates (never resumes onto the dead VM's stale
+ * `sandboxId`), `attach` still refuses, and the orphan reconciler's
+ * bookkeeping is untouched. Clearing it here, without a provision, would
+ * recreate exactly the stale-attach hazard `resolveLiveInstance` documents.
+ */
+export function planSessionReopen(): AgentSessionRowStamps {
+  return { endedAt: null };
+}
+
 /** Has the VM behind this session's name changed since the row last looked? */
 function instanceMoved(row: AgentSessionLifecycleRow, live: LiveSpriteInstance): boolean {
   return live.sandboxId !== row.sandboxId || (live.spriteInstanceId ?? null) !== (row.spriteInstanceId ?? null);
@@ -243,7 +262,13 @@ export function planAgentSessionLifecycle({
     // together on a CONFIRMED kill, so `endedAt` set with `spriteTornDownAt`
     // still null means the kill was never confirmed) — that row must still
     // retry teardown, not read as already-ended.
-    if (row.spriteTornDownAt !== null) return { action: 'noop', reason: 'already_ended', stamps: {} };
+    if (row.spriteTornDownAt !== null) {
+      // Sprite confirmed dead — never re-kill it. But a REOPENED row
+      // (`planSessionReopen` cleared `endedAt` when new work was claimed in)
+      // must still be endable: record the fresh end-intent, kill nothing.
+      if (row.endedAt !== null) return { action: 'noop', reason: 'already_ended', stamps: {} };
+      return { action: 'noop', reason: 'no_sandbox', stamps: { endedAt: now } };
+    }
     if (row.sandboxId !== null) {
       return {
         action: 'teardown',


### PR DESCRIPTION
Fixes #2335 — and builds out the full orchestration model decided while diagnosing it: **session tools are resource-addressed and permission-gated; binding state, lifecycle state, and calling surface never refuse a permitted operation.** Global assistant = the user's own authority, from any surface. Page AI = its drive's RBAC. Location's only job is defaults and pane placement.

## Commit 1 — diagnosis + stop swallowing errors

The issue's suspected root cause (`updatedAt` without a DB default) is **disproven**: drizzle-orm 0.45.2's insert compiler (`pg-core/dialect.js`'s `buildInsertQuery`) fills a default-less `$onUpdate` column on INSERT too, verified by direct source inspection. The reproduced cause: a conversation bound to an **ended** session dead-ended every spawn, invisibly.

- `ConversationUnavailableError` carries the refusing gate as `cause`; every throw site names its gate; `createWorkerSession` logs every failure (exclusion removed). Caller-facing messages stay generic.
- `resolveOrCreateConversation` sets `updatedAt` explicitly (consistency hardening, matching the page path) — which is also why the happy-path integration test below does NOT exercise drizzle's default-fill fallback: the explicit set makes it moot for this code path (CodeRabbit caught the test's doc comment overclaiming this — fixed).

## Commit 2 — the authorization re-model

1. **Verbs are resource-addressed, like `read_page`.** `send_session`/`read_session`/`kill_session` authorize against the resource: ownership, not human-closed, actually a worker, not history-deleted. The calling conversation plays no authorization role and isn't required. Supersedes #2262 finding 1's workspace confinement (product decision). Page-worker dispatch still re-enforces agent RBAC in the standard chat pipeline.
2. **Ended sessions are usable and REOPEN on use.** The lifecycle already treats ended rows as resumable; only the claim/create gates disagreed — the original bug. `session_ended` is gone everywhere. A claim landing in an ended session withdraws the end-intent via the pure `planSessionReopen()` stamp (`endedAt` only — the confirmed-kill stamp survives, so provisioning still fresh-creates and `attach` still refuses), applied CAS-guarded in the one claim dep all paths share. A reopened row is re-endable.
3. **Unbound threads mint permission-gated — both kinds.** Global with the user's authority; page conversations in their agent's drive behind the manual spawn route's exact primitives (`canUserViewPage` + `checkAccessForSubject`), through one generalized mint-and-claim body.

## Commit 3 — placement + discovery (the fan-out surface)

- **`spawn_session` gains `workspace`**: omitted = the caller's workspace (minted if needed); `'new'` = a fresh **isolated** workspace (own sandbox/filesystem — for subagent fleets that must not share the caller's working context; unwound if the worker never lands); an existing `workspaceId` = spawn straight into it (`checkSessionAccess`; foreign ids read as nonexistent). The advisory cap pre-count applies only to own-workspace spawns — a full caller workspace can't refuse a spawn aimed somewhere with room. Returns the `workspaceId` the worker landed in.
- **`list_sessions` lists ALL the caller's workspaces**: the current one in full detail (workers, shells, sandbox), every other with its `workspaceId` (a spawn target) and workers — every worker everywhere addressable by the verbs. Same primitives as the sidebar (`listSessions` + `listSessionConversationsBulk`). A session-less conversation still sees its other workspaces.

**Unchanged invariants:** the conversation→session binding stays write-once and owner-only (H1 hijack surface closed); shells stay workspace-scoped; the closed-listing gate holds.

## Commit 4 — review response

Two CodeRabbit findings, both fixed:
- **Major:** `claimConversation`'s post-claim `reopenEndedSessionListing` call was unguarded — a thrown error after the binding UPDATE already committed would propagate through `claimConversationInSessionWith` (no try/catch there) and surface as a false `conversation_unavailable` for a spawn that had, in fact, already succeeded. Now caught and logged; a reopen failure never misreports a successful claim.
- **Minor:** the integration test's doc comment overclaimed what it proves about drizzle's insert behavior (see Commit 1's note above) — corrected.

## Commit 5 — independent adversarial review (self-requested)

Dispatched a fresh review agent against the full diff to check for what an author reviewing their own work misses. It confirmed the two areas noted above were sound (resource-addressing keeps ownership as the sole-and-sufficient gate; the placement/CAS/lifecycle logic behaves as documented) and surfaced one real gap:

- **Correctness:** `spawn_session`'s `workspace: 'new'` path minted a fresh workspace, then on ANY thrown error from the worker's creation unconditionally ended that workspace — without the ambiguous-throw re-verification `ensureGlobalSandboxSession` already uses elsewhere in the same file for the identical hazard (a connection dropping between a durable UPDATE committing and its acknowledgment). If the claim had actually committed, this would end a session the worker is genuinely bound to, permanently orphaning it (nothing will ever claim or list a freshly-minted-then-ended session again). Fixed by reusing the same re-verify-before-cleanup pattern: bound to the just-minted workspace → report the success the throw obscured; confirmed unbound → unwind as before; verification itself fails → leave the workspace alone (cheap and recoverable) and still report the original failure.
- **Coverage gap it also found:** `createWorkerSession`'s placement logic had zero unit tests (only `resolveCallerSessionForWorker` was covered). Added a full suite, including a dedicated regression test for the ambiguous-throw fix.
- **Noted, deliberately out of scope:** `list_sessions`'s cross-workspace listing is scoped to workspaces the caller OWNS, while `spawn_session`'s explicit-`workspaceId` path (correctly) also permits drive members into a shared workspace — so a member can target a shared workspace by id but won't discover it via `list_sessions`. This is a pre-existing shared-workspace visibility question (not a security issue — the *spawn* gate's permission logic is unaffected), and expanding discovery to every drive a member belongs to is a separate, larger feature with its own privacy/scale tradeoffs. Flagging here rather than silently dropping it.

## Commit 6 — a fresh CodeRabbit pass, post-refactor

A later review submission (after the two earlier threads had already closed) surfaced two Trivial/Low-value nitpicks — both verified against current code and fixed:
- `list_sessions` carried an unnecessary `conversationId as string` cast; folded into the existing null-guard so TypeScript's own control-flow narrowing carries the fact instead.
- `listOwnWorkspaces` excludes the caller's current workspace *after* `listSessions`' own page-size cap, which could in principle drop a workspace a pre-cap exclusion would have backfilled — verified unreachable today (`SESSION_LIST_LIMIT` and `MAX_ACTIVE_SESSIONS_PER_OWNER` are both 100, and the latter is a structural cap enforced at every spawn path), documented the coupling explicitly, and added a standalone test that fails loudly if the two constants — defined in separate packages — ever drift apart.

## Tests

- Integration (migration-built Postgres): global spawn happy path; ended-session spawn recovering into the same workspace with listing reopen; isolated mint / explicit target / foreign-id refusal / cross-workspace discovery.
- Unit: resolver (ended used as-is; page RBAC minting allow/deny; foreign/client refusals), resource-addressed verb contract, ended-target claim/create acceptance, `planSessionReopen` + reopened-row re-end, spawn placement passthrough + advisory-count bypass, listing composition, full `createWorkerSession` placement coverage including the ambiguous-throw regression test, and the `SESSION_LIST_LIMIT`/`MAX_ACTIVE_SESSIONS_PER_OWNER` invariant guard.
- Affected suites: 1,743 passed. One pre-existing env-only failure in `activity-tools.test.ts` (untouched file; PR #1728's `users.email` dual-lookup vs a migrated local test DB) — not a regression from this branch. Full `@pagespace/lib` suite: 394 passed. `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJwgtR1MR6Dgo3hkjTV4Nw



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reopen ended sessions when creating or claiming conversations.
  * List sessions and workers across your accessible workspaces.
  * Spawn workers in the current workspace, a new isolated workspace, or another accessible workspace.
  * Support lazy workspace creation for conversations without an existing workspace.
  * Improve global and page session provisioning and worker discovery.

* **Bug Fixes**
  * Enforce clearer ownership, access, activity, and closed-session checks.
  * Preserve underlying errors when conversation creation fails.
  * Prevent unauthorized cross-workspace access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

