### PR TITLE
test(e2e): dispatch + multiplayer harness with phase-gated blank-pane specs

### DIFF
--- a/apps/e2e/fixtures/chat.fixture.ts
+++ b/apps/e2e/fixtures/chat.fixture.ts
@@ -101,23 +101,31 @@ export function chatPageUrl(driveId: string, pageId: string): string {
   return `/dashboard/${driveId}/${pageId}`;
 }
 
-/** Navigate to a seeded AI_CHAT page and wait for the chat surface to mount. */
+/**
+ * Navigate to a seeded AI_CHAT page and wait for the chat surface to mount.
+ *
+ * `session-chat` is the page-chat surface root since the phase-6 unified AgentView
+ * (e479b0053 deleted AiChatView.tsx and its `ai-chat-view` testid — SessionChat now
+ * renders the one chat on AI_CHAT pages and in the agents console). The right-sidebar
+ * assistant is a separate surface (`sidebar-chat-tab`) and never renders `session-chat`,
+ * so this stays unique on a page-chat screen.
+ */
 export async function gotoChatPage(page: Page, driveId: string, pageId: string): Promise<void> {
   await page.goto(chatPageUrl(driveId, pageId));
-  await page.getByTestId('ai-chat-view').waitFor({ state: 'visible' });
+  await page.getByTestId('session-chat').waitFor({ state: 'visible' });
 }
 
 /**
  * Type into a surface's composer and send.
  *
- * `scope` is a surface root (`getByTestId('ai-chat-view')`, `'sidebar-chat-tab'`,
+ * `scope` is a surface root (`getByTestId('session-chat')`, `'sidebar-chat-tab'`,
  * `'global-assistant-view'`) — a Locator, never the bare Page, so the requirement is a compile
  * error rather than a comment nobody reads. The chat surfaces mount simultaneously and each
  * renders its own composer: with the right sidebar open, an unscoped `getByTestId('chat-send')`
  * matches TWO elements and fails Playwright's strict mode. (Verified live: sidebar open →
  * unscoped `chat-textarea`/`chat-send` resolve 2 each, `sidebar-chat-tab`-scoped resolve 1.)
  *
- * The retry is load-bearing, not defensive padding. `ai-chat-view` becomes visible from the
+ * The retry is load-bearing, not defensive padding. `session-chat` becomes visible from the
  * server-rendered markup, BEFORE React has hydrated the composer — and a `fill()` that lands
  * in that window is silently discarded when React mounts its controlled input. The value
  * vanishes, Send never leaves its disabled state, and `click()` then waits out the whole test

--- a/apps/e2e/fixtures/dispatch.fixture.ts
+++ b/apps/e2e/fixtures/dispatch.fixture.ts
@@ -1,0 +1,155 @@
+import { type APIRequestContext, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { createId } from '@paralleldrive/cuid2';
+import type { SeededUser } from '../support/db';
+import { sessionPost } from '../support/http';
+import { authedContext, gotoChatPage } from './chat.fixture';
+
+/**
+ * # Dispatch + multiplayer harness (Phase 0 of the Agent-Session Single Source of Truth epic)
+ *
+ * The epic's canonical bug: a server-side agent dispatch (`send_session`/`spawn_session` in
+ * `apps/web/src/lib/ai/tools/session-tools-runtime.ts` → `dispatchThroughChatPipeline`) POSTs
+ * an internal turn through the standard chat routes. The turn persists — the DB gets the user
+ * message and the assistant reply — but an OPEN pane showing that conversation stays blank:
+ * nothing broadcasts on message persistence, `chat:user_message` is gated on `isShared`
+ * (private by default, so your own dispatch is invisible to your own panes), and every client
+ * cache handler early-returns unless it already loaded the conversation. Phase 2 (PR 3 of the
+ * epic plan) fixes delivery; this harness is the executable spec Phase 2 must turn green.
+ *
+ * ## What lives here
+ *
+ * - {@link dispatchMessage} — the "second actor": a server-side message injection that mirrors
+ *   `dispatchThroughChatPipeline`'s POST exactly (same routes, same body shape, same synthetic
+ *   `X-Browser-Session-Id`), but authenticated through the FRONT DOOR: session cookie + the
+ *   session-bound CSRF token from `seedUser()`, rather than the forwarded-header + internally
+ *   minted CSRF hop the runtime does. The routes cannot tell the difference — which is the
+ *   point: the persistence/broadcast path under test is identical.
+ * - {@link openChatPane} / {@link renderedMessages} — open an AI_CHAT page's pane in its own
+ *   browser context and read back what the pane actually rendered.
+ * - {@link openTwoWindows} — two independent browser contexts (two "windows") for the same
+ *   user on the same pane; each context mints its own `X-Browser-Session-Id`, so the app
+ *   treats them as separate tabs.
+ *
+ * ## Which specs gate which phase (tests/16-dispatch-multiplayer.spec.ts)
+ *
+ * - PASSING today: the fixture smokes — dispatch → the turn is present after a manual reload
+ *   (page-chat surface) / present via the messages API (global surface). These pin the harness
+ *   itself; if they break, the fixme specs prove nothing.
+ * - `test.fixme` until epic Phase 2 / PR 3 lands (delete the `.fixme` then):
+ *   - blank-pane repro: a dispatch into an open pane renders live, NO reload;
+ *   - two windows on one conversation both see both sides of a dispatched turn live.
+ *   Phase 2's gate is exactly these two flipping green; PRs 7 and 12 re-verify them.
+ */
+
+const PAGE_CHAT_SURFACE = 'session-chat'; // page-chat surface root since phase-6 unified AgentView (see chat.fixture gotoChatPage)
+const CHAT_MESSAGE = 'chat-message';
+
+export interface DispatchOptions {
+  /**
+   * Target a page-anchored conversation on this AI_CHAT page via `POST /api/ai/chat`
+   * (what `dispatchThroughChatPipeline` does when `agentPageId !== null`). Omit to target a
+   * global-assistant conversation via `POST /api/ai/global/[id]/messages`.
+   */
+  agentPageId?: string;
+}
+
+/**
+ * Server-side message injection: POST one user turn into `conversationId` through the same
+ * chat route an agent dispatch uses, as `user`. Resolves once the whole assistant stream has
+ * been consumed (Playwright's request API buffers the full body), i.e. the model turn is over
+ * — though the terminal DB write happens in the route's `onFinish` and can commit a beat
+ * later, so specs asserting on persistence should poll.
+ *
+ * Auth surprises, documented so nobody re-derives them:
+ * - Both routes REQUIRE `X-Browser-Session-Id` (400 without it). The runtime sends a
+ *   synthetic `agent-dispatch-<id>`; we mirror that.
+ * - CSRF: the runtime mints a token internally from the forwarded session; the front-door
+ *   equivalent is `seedUser()`'s `csrf`, which `sessionPost` already sends. No Origin header
+ *   is needed — `validateOrigin` allows a missing Origin.
+ * - `x-agent-dispatch-depth` is deliberately NOT sent: depth only feeds the A→B→C chain cap,
+ *   and the routes persist/broadcast identically either way.
+ */
+export async function dispatchMessage(
+  request: APIRequestContext,
+  user: SeededUser,
+  conversationId: string,
+  text: string,
+  opts: DispatchOptions = {},
+): Promise<void> {
+  const url =
+    opts.agentPageId === undefined
+      ? `/api/ai/global/${encodeURIComponent(conversationId)}/messages`
+      : '/api/ai/chat';
+  const body = {
+    ...(opts.agentPageId !== undefined ? { chatId: opts.agentPageId } : {}),
+    conversationId,
+    messages: [{ id: createId(), role: 'user', parts: [{ type: 'text', text }] }],
+  };
+  const res = await sessionPost(request, url, user, body, {
+    'x-browser-session-id': `agent-dispatch-${createId()}`,
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `dispatchMessage: ${url} answered ${res.status()}: ${(await res.text()).slice(0, 500)}`,
+    );
+  }
+  // ok() implies the stream body was fully buffered — the assistant turn has completed.
+}
+
+/**
+ * Open an AI_CHAT page's pane in a fresh logged-in context. The pane opens on the page's
+ * NEWEST conversation, so seed exactly the conversation the spec wants open before calling.
+ * Caller owns closing `context` (push it onto the spec's cleanup list).
+ */
+export async function openChatPane(
+  browser: Browser,
+  user: SeededUser,
+  baseURL: string,
+  driveId: string,
+  pageId: string,
+): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await authedContext(browser, user.sessionToken, baseURL);
+  const page = await context.newPage();
+  await gotoChatPage(page, driveId, pageId);
+  return { context, page };
+}
+
+export interface RenderedMessage {
+  /** `data-role` of the bubble: 'user' | 'assistant' (null if the attribute is missing). */
+  role: string | null;
+  text: string;
+}
+
+/**
+ * What the pane has actually RENDERED, in order — scoped to the page's own chat surface
+ * (`session-chat`) so a sidebar chat can never leak into the reading. No auto-waiting: this
+ * is a snapshot, so wrap it in `expect(...).toPass()` / `expect.poll` when asserting on
+ * eventual state.
+ */
+export async function renderedMessages(page: Page): Promise<RenderedMessage[]> {
+  const bubbles = await page.getByTestId(PAGE_CHAT_SURFACE).getByTestId(CHAT_MESSAGE).all();
+  return Promise.all(
+    bubbles.map(async (bubble) => ({
+      role: await bubble.getAttribute('data-role'),
+      text: await bubble.innerText(),
+    })),
+  );
+}
+
+/**
+ * Two "windows": two independent logged-in contexts for the SAME user, both showing the same
+ * AI_CHAT pane. Independent contexts mean independent `X-Browser-Session-Id`s — the app's
+ * per-tab identity — so this is the real two-window topology, not two tabs sharing state.
+ * Caller owns closing both contexts.
+ */
+export async function openTwoWindows(
+  browser: Browser,
+  user: SeededUser,
+  baseURL: string,
+  driveId: string,
+  pageId: string,
+): Promise<{ contexts: [BrowserContext, BrowserContext]; pages: [Page, Page] }> {
+  const first = await openChatPane(browser, user, baseURL, driveId, pageId);
+  const second = await openChatPane(browser, user, baseURL, driveId, pageId);
+  return { contexts: [first.context, second.context], pages: [first.page, second.page] };
+}

--- a/apps/e2e/support/http.ts
+++ b/apps/e2e/support/http.ts
@@ -28,6 +28,20 @@ export function sessionPost(
 }
 
 /**
+ * GET as a session-authenticated user. GETs are outside the CSRF gate, so the session
+ * cookie alone is the whole contract.
+ */
+export function sessionGet(
+  request: APIRequestContext,
+  path: string,
+  user: SeededUser,
+): Promise<APIResponse> {
+  return request.get(path, {
+    headers: { cookie: `session=${user.sessionToken}` },
+  });
+}
+
+/**
  * POST with an MCP bearer token. Bearer auth is exempt from CSRF/origin checks, so this
  * is the clean way to drive routes that accept `allow: ['session', 'mcp']`.
  */

--- a/apps/e2e/tests/15-chat-fixture-smoke.spec.ts
+++ b/apps/e2e/tests/15-chat-fixture-smoke.spec.ts
@@ -55,7 +55,7 @@ test.describe('chat e2e harness smoke', () => {
     const page = await authedPage(browser, user.sessionToken, baseURL!);
     await gotoChatPage(page, user.driveId, pageId);
 
-    const bubbles = page.getByTestId('ai-chat-view').getByTestId('chat-message');
+    const bubbles = page.getByTestId('session-chat').getByTestId('chat-message');
     await expect(bubbles.filter({ hasText: 'conversation B: user asks' })).toBeVisible();
     await expect(bubbles.filter({ hasText: 'conversation B: assistant answers' })).toBeVisible();
     await expect(bubbles.filter({ hasText: 'conversation B: user asks' })).toHaveAttribute(
@@ -85,7 +85,7 @@ test.describe('chat e2e harness smoke', () => {
     const page = await authedPage(browser, user.sessionToken, baseURL!);
     await gotoChatPage(page, user.driveId, pageId);
 
-    await sendChatMessage(page.getByTestId('ai-chat-view'), 'hello');
+    await sendChatMessage(page.getByTestId('session-chat'), 'hello');
 
     // The request reached the model and is live — no sleep, no race. The ceiling exceeds
     // expect.poll's 5s default because a send does real work first (context resolution, DB
@@ -98,7 +98,7 @@ test.describe('chat e2e harness smoke', () => {
     // data-role is ON the chat-message element, not a descendant — so this must be an
     // attribute selector on the element itself, never a `has:` descendant filter.
     const assistant = page
-      .getByTestId('ai-chat-view')
+      .getByTestId('session-chat')
       .locator('[data-testid="chat-message"][data-role="assistant"]')
       .last();
     await expect(assistant).toBeVisible();
@@ -122,7 +122,7 @@ test.describe('chat e2e harness smoke', () => {
     const page = await authedPage(browser, user.sessionToken, baseURL!);
     await gotoChatPage(page, user.driveId, pageId);
 
-    await sendChatMessage(page.getByTestId('ai-chat-view'), 'hold please');
+    await sendChatMessage(page.getByTestId('session-chat'), 'hold please');
 
     await expect
       .poll(() => mockStreams(request).then((s) => s.held), { timeout: 30_000 })

--- a/apps/e2e/tests/16-dispatch-multiplayer.spec.ts
+++ b/apps/e2e/tests/16-dispatch-multiplayer.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect, type BrowserContext } from '@playwright/test';
+import { seedUser, createAgentPage, seedChatConversation, createGlobalConversation } from '../support/db';
+import { resetMock, sessionGet } from '../support/http';
+import {
+  dispatchMessage,
+  openChatPane,
+  openTwoWindows,
+  renderedMessages,
+} from '../fixtures/dispatch.fixture';
+
+/**
+ * Dispatch + multiplayer harness specs — Phase 0 of the Agent-Session Single Source of Truth
+ * epic. Full rationale and the phase → spec mapping live in the header of
+ * `fixtures/dispatch.fixture.ts`.
+ *
+ * Two tiers:
+ *  - the smokes PASS today and pin the harness (dispatch really writes through the pipeline);
+ *  - the `test.fixme` specs are the epic's canonical bug, written as the executable spec
+ *    Phase 2 (plan PR 3) must flip green: delete the `.fixme`s in that PR. PRs 7 and 12
+ *    re-verify them.
+ */
+
+// Seed our own openrouter-provider users (the shared storageState user is provider 'openai'
+// and would never reach the mock) — same opt-out the chat smoke uses.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// A dispatched turn does real work (context resolution, DB writes, a page-version write)
+// before and after the provider call; keep per-assertion ceilings the failure surface, not
+// the overall budget. Passing runs never approach this.
+test.setTimeout(150_000);
+
+const DISPATCH_TEXT = 'dispatched through the pipeline';
+
+// Closed in teardown, not inline, so a failing assertion never leaks a context.
+const openContexts: BrowserContext[] = [];
+
+test.beforeEach(async ({ request }) => {
+  await resetMock(request);
+});
+
+test.afterEach(async () => {
+  await Promise.all(openContexts.map((c) => c.close()));
+  openContexts.length = 0;
+});
+
+test.describe('dispatch harness smoke (passing — pins the fixtures)', () => {
+  test('a page-chat dispatch persists both sides of the turn (visible after reload)', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const user = await seedUser();
+    const pageId = await createAgentPage(user.driveId, user.userId);
+    const conversationId = await seedChatConversation(pageId, user.userId, {
+      contents: ['seeded question', 'seeded answer'],
+    });
+
+    const { context, page } = await openChatPane(browser, user, baseURL!, user.driveId, pageId);
+    openContexts.push(context);
+
+    // The pane really opened on the seeded conversation — otherwise the reload assertion
+    // below could pass against the wrong transcript.
+    await expect(
+      page.getByTestId('session-chat').getByTestId('chat-message').filter({ hasText: 'seeded question' }),
+    ).toBeVisible();
+
+    await dispatchMessage(request, user, conversationId, DISPATCH_TEXT, { agentPageId: pageId });
+
+    // TODAY the open pane stays blank (the Phase 2 gap — asserted as fixme below). What DOES
+    // hold today, and what this smoke pins: after a manual reload the dispatched user turn
+    // and the mock's assistant reply ('pong') are both there. The retry loop absorbs the gap
+    // between the buffered stream ending and the route's onFinish committing the terminal row.
+    await expect(async () => {
+      await page.reload();
+      await page.getByTestId('session-chat').waitFor({ state: 'visible' });
+      const rendered = await renderedMessages(page);
+      expect(rendered.some((m) => m.role === 'user' && m.text.includes(DISPATCH_TEXT))).toBe(true);
+      expect(rendered.some((m) => m.role === 'assistant' && m.text.includes('pong'))).toBe(true);
+    }).toPass({ timeout: 60_000 });
+  });
+
+  test('a global-assistant dispatch persists through the front door (messages API)', async ({
+    request,
+  }) => {
+    const user = await seedUser();
+    const conversationId = await createGlobalConversation(user.userId);
+
+    await dispatchMessage(request, user, conversationId, DISPATCH_TEXT);
+
+    // API-level readback (the global-assistant pane has no seeded-page helper yet): both
+    // sides of the turn are on the transcript. Poll: the terminal write lands in onFinish.
+    await expect
+      .poll(
+        async () => {
+          const res = await sessionGet(request, `/api/ai/global/${conversationId}/messages`, user);
+          if (!res.ok()) return `HTTP ${res.status()}`;
+          const { messages } = (await res.json()) as {
+            messages: Array<{ role: string; parts?: Array<{ type: string; text?: string }> }>;
+          };
+          const textOf = (m: { parts?: Array<{ text?: string }> }) =>
+            (m.parts ?? []).map((p) => p.text ?? '').join(' ');
+          const hasUser = messages.some((m) => m.role === 'user' && textOf(m).includes(DISPATCH_TEXT));
+          const hasAssistant = messages.some((m) => m.role === 'assistant' && textOf(m).trim().length > 0);
+          return hasUser && hasAssistant ? 'both sides present' : `only: ${messages.map((m) => m.role).join(',')}`;
+        },
+        { timeout: 60_000 },
+      )
+      .toBe('both sides present');
+  });
+});
+
+test.describe('blank-pane repro (fixme until epic Phase 2 / plan PR 3)', () => {
+  // KNOWN RED TODAY — this is the epic's canonical bug, kept as an executable spec: nothing
+  // broadcasts on message persistence, `chat:user_message` is gated on `isShared`, and cache
+  // handlers early-return for unloaded conversations. PR 3 deletes the `.fixme` and this
+  // becomes the gate.
+  test.fixme('a server dispatch into an open pane renders live without reload', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const user = await seedUser();
+    const pageId = await createAgentPage(user.driveId, user.userId);
+    const conversationId = await seedChatConversation(pageId, user.userId, {
+      contents: ['seeded question', 'seeded answer'],
+    });
+
+    const { context, page } = await openChatPane(browser, user, baseURL!, user.driveId, pageId);
+    openContexts.push(context);
+    const bubbles = page.getByTestId('session-chat').getByTestId('chat-message');
+    await expect(bubbles.filter({ hasText: 'seeded question' })).toBeVisible();
+
+    await dispatchMessage(request, user, conversationId, DISPATCH_TEXT, { agentPageId: pageId });
+
+    // NO reload between dispatch and these assertions — that is the entire point.
+    await expect(bubbles.filter({ hasText: DISPATCH_TEXT })).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByTestId('session-chat').locator('[data-testid="chat-message"][data-role="assistant"]').filter({ hasText: 'pong' }),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test.fixme('two windows on one conversation both see both sides of a dispatched turn live', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const user = await seedUser();
+    const pageId = await createAgentPage(user.driveId, user.userId);
+    const conversationId = await seedChatConversation(pageId, user.userId, {
+      contents: ['seeded question', 'seeded answer'],
+    });
+
+    const { contexts, pages } = await openTwoWindows(browser, user, baseURL!, user.driveId, pageId);
+    openContexts.push(...contexts);
+    for (const p of pages) {
+      await expect(
+        p.getByTestId('session-chat').getByTestId('chat-message').filter({ hasText: 'seeded question' }),
+      ).toBeVisible();
+    }
+
+    await dispatchMessage(request, user, conversationId, DISPATCH_TEXT, { agentPageId: pageId });
+
+    // Both windows, both sides, live — no reload in either window.
+    for (const p of pages) {
+      const bubbles = p.getByTestId('session-chat').getByTestId('chat-message');
+      await expect(bubbles.filter({ hasText: DISPATCH_TEXT })).toBeVisible({ timeout: 15_000 });
+      await expect(
+        p.getByTestId('session-chat').locator('[data-testid="chat-message"][data-role="assistant"]').filter({ hasText: 'pong' }),
+      ).toBeVisible({ timeout: 15_000 });
+    }
+  });
+});


### PR DESCRIPTION
Phase 0 of the Agent-Session Single Source of Truth epic: the executable spec for the epic's canonical bug, landed ahead of the fix.

## What this adds
- **`apps/e2e/fixtures/dispatch.fixture.ts`** — server-side dispatch through the real chat pipeline (page-chat via `POST /api/ai/chat`, global assistant via the messages API), plus `openChatPane`, `openTwoWindows`, and `renderedMessages` helpers.
- **`apps/e2e/tests/16-dispatch-multiplayer.spec.ts`** — 2 passing smoke specs that pin the harness (dispatch persists; message visible after reload), and 2 `test.fixme` specs that ARE the blank-pane bug: (a) a dispatch into an open pane renders live without refresh; (b) two windows both see a dispatched turn live. Phase 2 (plan PR 3) deletes the `.fixme`s — that flip is its merge gate.
- **Repair of a master regression**: the unified-AgentView commit (`e479b0053`) deleted `AiChatView.tsx` and its `ai-chat-view` testid, silently breaking every UI assertion in spec 15. Fixture now targets the current `session-chat` root.

## Verification
5 passed, 2 fixme-skipped, 0 failed (13s) against a production build + scratch Postgres 17. e2e typecheck clean.

Notable for local runs: `next dev` cannot serve this app under its own CSP (`buildCSPPolicy` emits `script-src` without `unsafe-eval`, no dev exemption) — e2e must run against `next build && next start`; production start needs a dummy `SENTRY_DSN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts