### PR TITLE
fix(agents): list_sessions discovers shared workspaces; redact foreign private threads

### DIFF
--- a/apps/web/src/lib/agent-sessions/__tests__/session-discovery-symmetry.integration.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/session-discovery-symmetry.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Discovery symmetry + shared-metadata redaction (epic Phase 2), against a
+ * REAL migration-built Postgres.
+ *
+ * PR #2336 flagged (deliberately out of scope there): `list_sessions`' cross-
+ * workspace listing was scoped to workspaces the caller OWNS, while
+ * `spawn_session`'s explicit-`workspaceId` path (correctly) also admits drive
+ * MEMBERS into a shared workspace — so a member could target a shared
+ * workspace by id but never learn the id from `list_sessions`. Restored here:
+ * discovery (`listSharedWorkspaces`) and the spawn gate (`checkSessionAccess`
+ * → `decideAgentSessionAccess`) are the same one decision, proven by
+ * exercising BOTH against the same real rows:
+ *
+ *  1. a drive MEMBER discovers another member's shared-drive workspace AND
+ *     can spawn into it;
+ *  2. a NON-member gets neither — the workspace is absent from their listing
+ *     and its id reads as nonexistent to the spawn;
+ *  3. the shared listing redacts other members' private-thread titles to
+ *     `(private thread)` while keeping the rows (honest count, agent +
+ *     activity preserved), the member's own and deliberately-shared titles
+ *     intact — and the workspace's OWNER keeps seeing everything in their
+ *     own workspace, unredacted.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable —
+ * mirrors the other integration tests in this directory.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { factories } from '@pagespace/db/test/factories';
+import { PRIVATE_THREAD_REDACTION } from '@pagespace/lib/agent-sessions/redact-conversation-listing';
+import { resolveOrCreateConversation } from '@/app/api/ai/global/[id]/messages/resolve-or-create-conversation';
+import { buildSessionToolsDeps } from '@/lib/ai/tools/session-tools-runtime';
+import { createConversationInSession, spawnSession } from '../agent-sessions-runtime';
+
+let dbAvailable = false;
+
+describe('discovery symmetry + shared-metadata redaction (issue #2262 finding 6, PR #2336 follow-up)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('a drive member DISCOVERS another member\'s shared workspace, sees redacted titles honestly, and can SPAWN into it; a non-member gets neither', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const member = await factories.createUser();
+    const stranger = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    await factories.createDriveMember(drive.id, member.id);
+
+    // The OWNER's drive-scoped workspace, hosting three threads: the owner's
+    // private one, the owner's deliberately shared one, and the member's own.
+    const spawned = await spawnSession({ userId: owner.id, driveId: drive.id, name: 'team workspace' });
+    if (!spawned.ok) throw new Error(`spawnSession failed: ${spawned.reason}`);
+    const workspaceId = spawned.session.id;
+
+    const ownerPrivateId = createId();
+    await createConversationInSession({
+      conversationId: ownerPrivateId,
+      userId: owner.id,
+      agentPageId: null,
+      sessionId: workspaceId,
+      title: 'owner secret plans',
+    });
+    const ownerSharedId = createId();
+    await createConversationInSession({
+      conversationId: ownerSharedId,
+      userId: owner.id,
+      agentPageId: null,
+      sessionId: workspaceId,
+      title: 'team notes',
+    });
+    await db.update(conversations).set({ isShared: true }).where(eq(conversations.id, ownerSharedId));
+    const memberThreadId = createId();
+    await createConversationInSession({
+      conversationId: memberThreadId,
+      userId: member.id,
+      agentPageId: null,
+      sessionId: workspaceId,
+      title: 'member research',
+    });
+
+    const deps = buildSessionToolsDeps();
+
+    // 1. DISCOVERY — the member's shared listing carries the workspace…
+    const memberShared = await deps.listSharedWorkspaces({ userId: member.id });
+    const listed = memberShared.find((w) => w.workspaceId === workspaceId);
+    expect(listed).toBeDefined();
+    if (!listed) return;
+    expect(listed.driveId).toBe(drive.id);
+
+    // …with an HONEST worker count and the one redaction rule applied.
+    expect(listed.workers).toHaveLength(3);
+    const titleById = new Map(listed.workers.map((w) => [w.sessionId, w.name]));
+    expect(titleById.get(memberThreadId)).toBe('member research');
+    expect(titleById.get(ownerSharedId)).toBe('team notes');
+    expect(titleById.get(ownerPrivateId)).toBe(PRIVATE_THREAD_REDACTION);
+    expect(JSON.stringify(listed)).not.toContain('owner secret plans');
+
+    // 2. SYMMETRY — the id the listing surfaced is spawnable-into, through
+    // the same gate the explicit-workspaceId path always enforced.
+    const memberCallerId = createId();
+    await resolveOrCreateConversation(member.id, memberCallerId);
+    const memberWorkerId = createId();
+    const spawnedInto = await deps.createWorkerSession({
+      conversationId: memberWorkerId,
+      callerConversationId: memberCallerId,
+      ownerId: member.id,
+      agentPageId: null,
+      name: 'member worker',
+      workspace: workspaceId,
+    });
+    expect(spawnedInto).toEqual({ ok: true, workspaceId });
+    const [memberWorker] = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, memberWorkerId));
+    expect(memberWorker.sessionId).toBe(workspaceId);
+
+    // 3. The workspace's OWNER sees everything in their own workspace,
+    // unchanged — including the member's thread title. (Their shared listing
+    // does NOT re-list their own workspace: that is the own set's job.)
+    const ownerDetail = await deps.listWorkspaceWorkers({
+      workspaceId,
+      callerConversationId: ownerPrivateId,
+      callerUserId: owner.id,
+    });
+    const ownerTitles = new Map(ownerDetail.workers.map((w) => [w.sessionId, w.name]));
+    expect(ownerTitles.get(ownerPrivateId)).toBe('owner secret plans');
+    expect(ownerTitles.get(memberThreadId)).toBe('member research');
+    const ownerSharedListing = await deps.listSharedWorkspaces({ userId: owner.id });
+    expect(ownerSharedListing.find((w) => w.workspaceId === workspaceId)).toBeUndefined();
+
+    // 4. A NON-member's workspace appears in NEITHER: absent from discovery,
+    // and its id reads as nonexistent to the spawn — the same one decision
+    // refusing both.
+    const strangerShared = await deps.listSharedWorkspaces({ userId: stranger.id });
+    expect(strangerShared.find((w) => w.workspaceId === workspaceId)).toBeUndefined();
+    const strangerCallerId = createId();
+    await resolveOrCreateConversation(stranger.id, strangerCallerId);
+    const refused = await deps.createWorkerSession({
+      conversationId: createId(),
+      callerConversationId: strangerCallerId,
+      ownerId: stranger.id,
+      agentPageId: null,
+      name: 'trespasser',
+      workspace: workspaceId,
+    });
+    expect(refused).toMatchObject({ ok: false, reason: 'workspace_not_found' });
+  });
+});

--- a/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/agent-sessions-runtime.ts
@@ -735,6 +735,15 @@ export interface SessionConversationEntry {
   /** The thread's agent page (`contextId` for a page chat), or null for a global-assistant thread. */
   agentPageId: string | null;
   lastMessageAt: Date | null;
+  /**
+   * The thread's own owner (`conversations.userId`) and deliberate-share flag
+   * (`conversations.isShared`) — the two facts the shared-workspace title
+   * redaction rule weighs (`redact-conversation-listing.ts` in
+   * `@pagespace/lib`; see this function's doc below). Derived at read from
+   * the same row, never a second copy.
+   */
+  ownerId: string;
+  isShared: boolean;
 }
 
 /**
@@ -754,14 +763,23 @@ export interface SessionConversationEntry {
  * — one hot session's rows cannot crowd another session's out of a shared cap
  * ordered across all of them together.
  *
- * DELIBERATE metadata exposure (issue #2262 finding 6): every caller with
- * access to a session (its owner, or any member whose own conversation lives
- * there) sees every OTHER conversation's title and agent in that session,
- * this way — including threads it did not create. Shared-workspace semantics,
- * not a leak: a session is one shared sandbox by design. TRANSCRIPT content
- * is a separate, still owner-gated read (`checkSessionAccess` /
- * `openOwnSession` in the tool layer) — this listing carries no message
- * bodies.
+ * Metadata exposure (issue #2262 finding 6) — the rule, decided where the
+ * queries live: the SESSION'S OWNER sees every conversation's title in their
+ * own session (shared-workspace semantics — one shared sandbox by design).
+ * A viewer who does NOT own the session sees a title only for threads that
+ * are their own or deliberately shared (`conversations.isShared`); every
+ * other row survives with its agent and activity time but its title replaced
+ * by the fixed `(private thread)` marker. The mechanism is ONE pure function
+ * — `redactConversationTitleForViewer`
+ * (`@pagespace/lib/agent-sessions/redact-conversation-listing`) — which every
+ * viewer-facing mapping of these rows must route titles through (today: the
+ * session-tool listings in `session-tools-runtime.ts`; the sidebar/API
+ * surfaces only ever enumerate the caller's OWN sessions, where the owner
+ * rule makes redaction a no-op). This entry therefore carries `ownerId` and
+ * `isShared` so mapping layers can apply the rule without a second query.
+ * TRANSCRIPT content is a separate, still owner-gated read
+ * (`checkSessionAccess` / `openOwnSession` in the tool layer) — this listing
+ * carries no message bodies.
  */
 export async function listSessionConversationsBulk(
   sessionIds: string[],
@@ -777,6 +795,8 @@ export async function listSessionConversationsBulk(
       type: conversations.type,
       contextId: conversations.contextId,
       lastMessageAt: conversations.lastMessageAt,
+      ownerId: conversations.userId,
+      isShared: conversations.isShared,
       rowNumber: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${conversations.sessionId} ORDER BY ${conversations.lastMessageAt} DESC)`.as(
         'row_number',
       ),
@@ -802,6 +822,8 @@ export async function listSessionConversationsBulk(
       type: rankedConversations.type,
       contextId: rankedConversations.contextId,
       lastMessageAt: rankedConversations.lastMessageAt,
+      ownerId: rankedConversations.ownerId,
+      isShared: rankedConversations.isShared,
     })
     .from(rankedConversations)
     .where(sql`${rankedConversations.rowNumber} <= ${MAX_SESSION_CONVERSATIONS}`);
@@ -814,6 +836,8 @@ export async function listSessionConversationsBulk(
       title: row.title,
       agentPageId: row.type === 'page' ? row.contextId : null,
       lastMessageAt: row.lastMessageAt,
+      ownerId: row.ownerId,
+      isShared: row.isShared,
     });
     grouped.set(row.sessionId, bucket);
   }

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-contract.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-contract.test.ts
@@ -46,6 +46,7 @@ function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
     findOwnWorkspace: vi.fn(async () => ({ workspaceId: WORKSPACE_ID })),
     listWorkspaceWorkers: vi.fn(async () => ({ sandbox: 'running' as const, workers: [], shells: [] })),
     listOwnWorkspaces: vi.fn(async () => []),
+    listSharedWorkspaces: vi.fn(async () => []),
     findWorker: vi.fn(async (conversationId: string) => ({ ...OWN_WORKER, conversationId })),
     countOpenConversations: vi.fn(async () => 0),
     canUseAgent: vi.fn(async () => true),
@@ -88,8 +89,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('list_sessions description: "List ALL your workspaces and their workers ... from anywhere"', () => {
-  it('returns the current workspace in full detail (workers, shells, sandbox) PLUS every other workspace with its workspaceId and workers', async () => {
+describe('list_sessions description: "List the workspaces you can reach, and their workers ... from anywhere"', () => {
+  it('returns the current workspace in full detail (workers, shells, sandbox) PLUS every other owned workspace and every shared one, in distinctly labeled sections', async () => {
     const here = {
       sandbox: 'running' as const,
       workers: [{ sessionId: 'conv-worker', name: 'w', agent: null, isCaller: false }],
@@ -102,16 +103,55 @@ describe('list_sessions description: "List ALL your workspaces and their workers
       sandbox: 'none' as const,
       workers: [{ sessionId: 'conv-far-worker', name: 'far', agent: null }],
     };
+    const shared = {
+      workspaceId: 'ws-shared',
+      name: 'team workspace',
+      driveId: 'drive-1',
+      sandbox: 'running' as const,
+      workers: [{ sessionId: 'conv-their-worker', name: '(private thread)', agent: null, lastActiveAt: null }],
+    };
     const deps = makeDeps({
       listWorkspaceWorkers: vi.fn(async () => here),
       listOwnWorkspaces: vi.fn(async () => [elsewhere]),
+      listSharedWorkspaces: vi.fn(async () => [shared]),
     });
     const tools = createSessionTools(deps);
     const result = await run(tools.list_sessions, {}, contextOptions());
-    expect(result).toEqual({ success: true, workspaceId: WORKSPACE_ID, ...here, otherWorkspaces: [elsewhere] });
+    expect(result).toEqual({
+      success: true,
+      workspaceId: WORKSPACE_ID,
+      ...here,
+      otherWorkspaces: [elsewhere],
+      sharedWorkspaces: [shared],
+    });
   });
 
-  it('"Every worker\'s sessionId is the exact address send_session/read_session/kill_session take, from anywhere": a listed worker in ANOTHER workspace is reachable by all three verbs', async () => {
+  it('"sharedWorkspaces lists OTHER members\' workspaces ... equally valid spawn_session `workspace` targets": a workspaceId discovered in sharedWorkspaces is spawnable-into (discovery symmetry with the spawn gate)', async () => {
+    const shared = {
+      workspaceId: 'ws-shared',
+      name: 'team workspace',
+      driveId: 'drive-1',
+      sandbox: 'running' as const,
+      workers: [],
+    };
+    const deps = makeDeps({
+      listSharedWorkspaces: vi.fn(async () => [shared]),
+      createWorkerSession: vi.fn(async () => ({ ok: true as const, workspaceId: 'ws-shared' })),
+    });
+    const tools = createSessionTools(deps);
+
+    const listed = (await run(tools.list_sessions, {}, contextOptions())) as {
+      sharedWorkspaces: Array<{ workspaceId: string }>;
+    };
+    const target = listed.sharedWorkspaces[0]?.workspaceId;
+    expect(target).toBe('ws-shared');
+
+    const spawned = await run(tools.spawn_session, { name: 'w', prompt: 'p', workspace: target }, contextOptions());
+    expect(spawned).toEqual(expect.objectContaining({ success: true, workspaceId: 'ws-shared' }));
+    expect(deps.createWorkerSession).toHaveBeenCalledWith(expect.objectContaining({ workspace: 'ws-shared' }));
+  });
+
+  it('"Your own workers\' sessionIds are the exact addresses send_session/read_session/kill_session take, from anywhere": a listed worker in ANOTHER workspace is reachable by all three verbs', async () => {
     // The cross-workspace claim: the listing's ids are conversation ids, and
     // the verbs are resource-addressed — a worker outside the caller's own
     // workspace is exactly as addressable as a sibling.

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -24,6 +24,8 @@ const {
   mockListSessions,
   mockListSessionConversationsBulk,
   mockCanUserViewPage,
+  mockGetDriveIdsForUser,
+  mockResolveDriveMembership,
   mockGetConversation,
   mockGetAiAgent,
 } = vi.hoisted(() => ({
@@ -38,6 +40,8 @@ const {
   mockListSessions: vi.fn(),
   mockListSessionConversationsBulk: vi.fn(),
   mockCanUserViewPage: vi.fn(),
+  mockGetDriveIdsForUser: vi.fn(),
+  mockResolveDriveMembership: vi.fn(),
   mockGetConversation: vi.fn(),
   mockGetAiAgent: vi.fn(),
 }));
@@ -58,6 +62,13 @@ vi.mock('@/lib/agent-sessions/agent-sessions-runtime', () => ({
 }));
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserViewPage: mockCanUserViewPage,
+  getDriveIdsForUser: mockGetDriveIdsForUser,
+}));
+// The tenant gather is mocked (it reads the DB); the pure access decision and
+// the pure redaction rule are deliberately REAL — the whole point of the
+// shared-workspace listing is that it reuses those exact functions.
+vi.mock('@pagespace/lib/services/agent-sessions/agent-session-tenant', () => ({
+  resolveDriveMembership: mockResolveDriveMembership,
 }));
 vi.mock('@/lib/repositories/conversation-repository', () => ({
   conversationRepository: { getConversation: mockGetConversation, getAiAgent: mockGetAiAgent },
@@ -387,5 +398,120 @@ describe('killWorker — kill_session never tears the sandbox down', () => {
 
     expect(result).toEqual({ ok: true, spriteTornDown: false });
     expect(mockEndSession).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Tests for session-tools-runtime.ts — listSharedWorkspaces (discovery
+// symmetry, PR #2336's flagged asymmetry)
+//
+// The spawn gate's explicit-workspaceId path admits any caller
+// `checkSessionAccess` allows (owner OR drive member); discovery must
+// enumerate by the SAME decision. These tests run the REAL pure gate
+// (`decideAgentSessionAccess`) and the REAL redaction rule
+// (`redactConversationTitleForViewer`) — only the IO gathers are mocked.
+// ============================================================================
+
+describe('listSharedWorkspaces — member-visible discovery, gated by the one session-access decision', () => {
+  const VIEWER = 'user-1';
+  const OTHER_OWNER = 'user-2';
+
+  const sharedSession = {
+    sessionId: 'ses-shared',
+    driveId: 'drive-member',
+    ownerId: OTHER_OWNER,
+    name: 'team workspace',
+    sandboxStatus: 'running' as const,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    lastActiveAt: '2026-08-02T00:00:00.000Z',
+    endedAt: null,
+  };
+
+  test('a drive the caller belongs to lists other members\' sessions; the caller\'s own rows and the current workspace are excluded; a page-permission-only drive (membership none) is never even queried', async () => {
+    mockGetDriveIdsForUser.mockResolvedValue(['drive-member', 'drive-page-only']);
+    mockResolveDriveMembership.mockImplementation(async ({ driveId }: { driveId: string }) =>
+      driveId === 'drive-member' ? 'member' : 'none',
+    );
+    mockListSessions.mockResolvedValue([
+      sharedSession,
+      // The caller's OWN session in the shared drive — the own listing's job.
+      { ...sharedSession, sessionId: 'ses-mine', ownerId: VIEWER },
+      // The caller's CURRENT workspace — the top-level detail view.
+      { ...sharedSession, sessionId: 'ses-current' },
+    ]);
+    mockListSessionConversationsBulk.mockResolvedValue(new Map());
+
+    const deps = buildSessionToolsDeps();
+    const shared = await deps.listSharedWorkspaces({ userId: VIEWER, excludeWorkspaceId: 'ses-current' });
+
+    expect(shared.map((w) => w.workspaceId)).toEqual(['ses-shared']);
+    expect(shared[0]).toEqual(
+      expect.objectContaining({ driveId: 'drive-member', name: 'team workspace', sandbox: 'running' }),
+    );
+    expect(mockListSessions).toHaveBeenCalledTimes(1);
+    expect(mockListSessions).toHaveBeenCalledWith({ driveId: 'drive-member' });
+    expect(mockListSessionConversationsBulk).toHaveBeenCalledWith(['ses-shared']);
+  });
+
+  test('a NON-member sees nothing: the same pure decision that refuses the spawn refuses the discovery', async () => {
+    mockGetDriveIdsForUser.mockResolvedValue(['drive-page-only']);
+    mockResolveDriveMembership.mockResolvedValue('none');
+
+    const deps = buildSessionToolsDeps();
+    const shared = await deps.listSharedWorkspaces({ userId: VIEWER });
+
+    expect(shared).toEqual([]);
+    expect(mockListSessions).not.toHaveBeenCalled();
+  });
+
+  test('worker titles route through the ONE redaction rule: the member sees their own and deliberately-shared titles, and "(private thread)" for another member\'s private one — the row (agent slot + activity) survives', async () => {
+    mockGetDriveIdsForUser.mockResolvedValue(['drive-member']);
+    mockResolveDriveMembership.mockResolvedValue('member');
+    mockListSessions.mockResolvedValue([sharedSession]);
+    mockListSessionConversationsBulk.mockResolvedValue(
+      new Map([
+        [
+          'ses-shared',
+          [
+            { conversationId: 'conv-mine', title: 'my research', agentPageId: null, lastMessageAt: new Date('2026-08-02T00:00:00.000Z'), ownerId: VIEWER, isShared: false },
+            { conversationId: 'conv-shared', title: 'team notes', agentPageId: null, lastMessageAt: null, ownerId: OTHER_OWNER, isShared: true },
+            { conversationId: 'conv-private', title: 'their secret', agentPageId: null, lastMessageAt: new Date('2026-08-01T12:00:00.000Z'), ownerId: OTHER_OWNER, isShared: false },
+          ],
+        ],
+      ]),
+    );
+
+    const deps = buildSessionToolsDeps();
+    const shared = await deps.listSharedWorkspaces({ userId: VIEWER });
+
+    expect(shared).toHaveLength(1);
+    // The COUNT is honest — every row survives redaction.
+    expect(shared[0].workers).toHaveLength(3);
+    expect(shared[0].workers.map((w) => w.name)).toEqual(['my research', 'team notes', '(private thread)']);
+    // The real title never leaks anywhere in the redacted entry.
+    expect(JSON.stringify(shared[0])).not.toContain('their secret');
+    // Activity time survives redaction — the orchestration signal.
+    expect(shared[0].workers[2].lastActiveAt).toBe('2026-08-01T12:00:00.000Z');
+  });
+
+  test('the member-visible set carries its own explicit bound (100, newest activity first) — unlike the own set, nothing structural caps it', async () => {
+    mockGetDriveIdsForUser.mockResolvedValue(['drive-member']);
+    mockResolveDriveMembership.mockResolvedValue('member');
+    const many = Array.from({ length: 150 }, (_, i) => ({
+      ...sharedSession,
+      sessionId: `ses-${String(i).padStart(3, '0')}`,
+      lastActiveAt: new Date(Date.UTC(2026, 0, 1) + i * 60_000).toISOString(),
+    }));
+    mockListSessions.mockResolvedValue(many);
+    mockListSessionConversationsBulk.mockResolvedValue(new Map());
+
+    const deps = buildSessionToolsDeps();
+    const shared = await deps.listSharedWorkspaces({ userId: VIEWER });
+
+    // MAX_MEMBER_VISIBLE_WORKSPACES — the documented member-visible bound.
+    expect(shared).toHaveLength(100);
+    // Newest activity first: the most recent 100 survive the cut.
+    expect(shared[0].workspaceId).toBe('ses-149');
+    expect(shared[99].workspaceId).toBe('ses-050');
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-schema.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-schema.test.ts
@@ -55,8 +55,13 @@ describe('session + shell tools — frozen wire contract', () => {
   it('every tool description and JSON input schema is byte-identical to the pinned contract', () => {
     expect(wireSurface()).toEqual({
       list_sessions: {
+        // DELIBERATE description change (discovery-symmetry PR): the listing
+        // gained the member-visible `sharedWorkspaces` section with redacted
+        // foreign private-thread titles, and the addressability claim narrowed
+        // to the workers the caller actually owns. Re-pinned in the same
+        // commit as the tool change — this is a contract edit, not drift.
         description:
-          'List ALL your workspaces and their workers. Your current conversation\'s workspace comes with full detail (workers, shells, shared sandbox status); every other workspace lists its workspaceId (a spawn_session `workspace` target) and workers. Every worker\'s sessionId is the exact address send_session/read_session/kill_session take, from anywhere. Names are labels — always address by id.',
+          'List the workspaces you can reach, and their workers. Your current conversation\'s workspace comes with full detail (workers, shells, shared sandbox status); every other workspace you OWN lists its workspaceId (a spawn_session `workspace` target) and workers; sharedWorkspaces lists OTHER members\' workspaces in drives you belong to — equally valid spawn_session `workspace` targets, shown for awareness with other members\' private thread titles redacted to "(private thread)". Your own workers\' sessionIds are the exact addresses send_session/read_session/kill_session take, from anywhere; another member\'s worker is not yours to address. Names are labels — always address by id.',
         inputSchema: {
           $schema: 'http://json-schema.org/draft-07/schema#',
           type: 'object',

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -32,6 +32,7 @@ function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
     findOwnWorkspace: vi.fn(async () => ({ workspaceId: WORKSPACE_ID })),
     listWorkspaceWorkers: vi.fn(async () => ({ sandbox: 'running' as const, workers: [], shells: [] })),
     listOwnWorkspaces: vi.fn(async () => []),
+    listSharedWorkspaces: vi.fn(async () => []),
     findWorker: vi.fn(async (conversationId: string) => ({
       conversationId,
       ownerId: USER_ID,
@@ -111,17 +112,30 @@ describe('list_sessions', () => {
     const deps = makeDeps({ listWorkspaceWorkers: vi.fn(async () => listing) });
     const tools = createSessionTools(deps);
     const result = await run(tools.list_sessions, {}, contextOptions());
-    expect(result).toEqual({ success: true, workspaceId: WORKSPACE_ID, ...listing, otherWorkspaces: [] });
+    expect(result).toEqual({
+      success: true,
+      workspaceId: WORKSPACE_ID,
+      ...listing,
+      otherWorkspaces: [],
+      sharedWorkspaces: [],
+    });
     // Review H2b's pin: the listing is resolved from the caller's workspace,
     // and every worker id it returns is a conversation id — the exact address
-    // send_session/read_session/kill_session take.
+    // send_session/read_session/kill_session take. The caller's user id rides
+    // along as the VIEWER for the shared-workspace title redaction rule.
     expect(deps.listWorkspaceWorkers).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
       callerConversationId: CALLER_CONVERSATION,
+      callerUserId: USER_ID,
     });
-    // The caller's own workspace is excluded from the others list — it is
-    // already the top-level detail view.
+    // The caller's own workspace is excluded from BOTH cross-workspace lists
+    // — it is already the top-level detail view (and a caller spawned into a
+    // shared workspace has a current workspace they do not own).
     expect(deps.listOwnWorkspaces).toHaveBeenCalledWith({
+      userId: USER_ID,
+      excludeWorkspaceId: WORKSPACE_ID,
+    });
+    expect(deps.listSharedWorkspaces).toHaveBeenCalledWith({
       userId: USER_ID,
       excludeWorkspaceId: WORKSPACE_ID,
     });

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -24,7 +24,10 @@ import { db } from '@pagespace/db/db';
 import { and, eq, inArray, isNull, ne, desc } from '@pagespace/db/operators';
 import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { conversations, messages as globalMessages } from '@pagespace/db/schema/conversations';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { canUserViewPage, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
+import { resolveDriveMembership } from '@pagespace/lib/services/agent-sessions/agent-session-tenant';
+import { decideAgentSessionAccess } from '@pagespace/lib/agent-sessions/decide-session-access';
+import { redactConversationTitleForViewer } from '@pagespace/lib/agent-sessions/redact-conversation-listing';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
@@ -62,6 +65,7 @@ import {
   createSessionTools,
   type DispatchOutcome,
   type OwnWorkspaceSummary,
+  type SharedWorkspaceSummary,
   type SessionWorkspaceListing,
   type SessionToolsDeps,
   type TranscriptEntry,
@@ -323,22 +327,28 @@ export async function dispatchThroughChatPipeline(input: {
  * to exist (issue #2262 finding 4 — no unbounded `db.select()` feeding model
  * context).
  *
- * DELIBERATE metadata exposure (issue #2262 finding 6): this lists EVERY
- * active conversation in the session — including siblings the CALLER did not
- * spawn and does not own — by title and agent, to whichever member's agent
- * asks. That is shared-workspace semantics, not a leak: a session is one
- * shared sandbox and filesystem by design, so knowing what else is running
- * there is the same visibility a human teammate has glancing at the sidebar.
- * What stays owner-gated is TRANSCRIPT content — `read_session` still requires
- * `openOwnSession`'s ownership check, so seeing a sibling listed here grants
- * no access to what it said.
+ * Metadata exposure (issue #2262 finding 6): every active conversation in the
+ * session lists — including siblings the CALLER did not spawn — by agent and
+ * row, to whichever member's agent asks. Shared-workspace semantics: a
+ * session is one shared sandbox and filesystem by design, so knowing what
+ * else is running there is the same visibility a human teammate has glancing
+ * at the sidebar. TITLES, though, follow the one listing redaction rule
+ * (`redactConversationTitleForViewer` — full rule documented on
+ * `listSessionConversationsBulk`): the workspace's owner sees them all; a
+ * caller listing a workspace they do NOT own (their conversation was spawned
+ * into a shared one) sees `(private thread)` for siblings that are neither
+ * theirs nor deliberately shared. TRANSCRIPT content stays owner-gated
+ * either way — `read_session` still requires `openOwnSession`'s ownership
+ * check, so seeing a sibling listed here grants no access to what it said.
  */
 async function listWorkspaceWorkers({
   workspaceId,
   callerConversationId,
+  callerUserId,
 }: {
   workspaceId: string;
   callerConversationId: string;
+  callerUserId: string;
 }): Promise<SessionWorkspaceListing> {
   const store = await getAgentSessionStore();
   const [row, workerRows, shells] = await Promise.all([
@@ -350,6 +360,8 @@ async function listWorkspaceWorkers({
         agentPageId: conversations.contextId,
         type: conversations.type,
         agentTitle: pages.title,
+        ownerId: conversations.userId,
+        isShared: conversations.isShared,
       })
       .from(conversations)
       .leftJoin(pages, eq(pages.id, conversations.contextId))
@@ -372,7 +384,14 @@ async function listWorkspaceWorkers({
     sandbox: row ? deriveSandboxStatus(row) : 'none',
     workers: workerRows.map((worker) => ({
       sessionId: worker.conversationId,
-      name: worker.title ?? '',
+      name:
+        redactConversationTitleForViewer({
+          viewerId: callerUserId,
+          // A vanished workspace row (FK-nulled edge) has no owner to grant
+          // through — the empty id matches nobody, so the rule fails CLOSED.
+          workspaceOwnerId: row?.ownerId ?? '',
+          conversation: { ownerId: worker.ownerId, isShared: worker.isShared, title: worker.title },
+        }) ?? '',
       agent:
         worker.type === 'page' && worker.agentPageId !== null
           ? { agentId: worker.agentPageId, title: worker.agentTitle ?? '' }
@@ -423,20 +442,7 @@ async function listOwnWorkspaces({
   if (sessions.length === 0) return [];
 
   const workersBySession = await listSessionConversationsBulk(sessions.map((s) => s.sessionId));
-
-  const agentPageIds = [
-    ...new Set(
-      [...workersBySession.values()].flat().flatMap((w) => (w.agentPageId ? [w.agentPageId] : [])),
-    ),
-  ];
-  const agentTitles = new Map<string, string>();
-  if (agentPageIds.length > 0) {
-    const agentRows = await db
-      .select({ id: pages.id, title: pages.title })
-      .from(pages)
-      .where(inArray(pages.id, agentPageIds));
-    for (const row of agentRows) agentTitles.set(row.id, row.title);
-  }
+  const agentTitles = await resolveAgentTitles(workersBySession);
 
   return sessions.map((session) => ({
     workspaceId: session.sessionId,
@@ -450,6 +456,143 @@ async function listOwnWorkspaces({
         worker.agentPageId !== null
           ? { agentId: worker.agentPageId, title: agentTitles.get(worker.agentPageId) ?? '' }
           : null,
+    })),
+  }));
+}
+
+/** The one batched agent-label lookup both cross-workspace listings share. */
+async function resolveAgentTitles(
+  workersBySession: Awaited<ReturnType<typeof listSessionConversationsBulk>>,
+): Promise<Map<string, string>> {
+  const agentPageIds = [
+    ...new Set(
+      [...workersBySession.values()].flat().flatMap((w) => (w.agentPageId ? [w.agentPageId] : [])),
+    ),
+  ];
+  const agentTitles = new Map<string, string>();
+  if (agentPageIds.length > 0) {
+    const agentRows = await db
+      .select({ id: pages.id, title: pages.title })
+      .from(pages)
+      .where(inArray(pages.id, agentPageIds));
+    for (const row of agentRows) agentTitles.set(row.id, row.title);
+  }
+  return agentTitles;
+}
+
+/**
+ * The most SHARED workspaces (other members' sessions in drives the caller
+ * belongs to) one `list_sessions` call reports. The caller's OWN set needs
+ * no such bound — `MAX_ACTIVE_WORKSPACES_PER_OWNER` is a structural spawn
+ * ceiling, so a listing can never truncate it — but the member-visible set
+ * has no structural ceiling behind it (N members × their own caps), so this
+ * cap is a REAL truncation bound: newest activity first, the rest silently
+ * beyond the horizon. Sized to the same figure as the own-set cap
+ * (`MAX_ACTIVE_WORKSPACES_PER_OWNER`) so one listing's total stays
+ * model-context-shaped.
+ */
+const MAX_MEMBER_VISIBLE_WORKSPACES = 100;
+
+/**
+ * Workspaces the caller can ACCESS as a drive member without owning them —
+ * the discovery HALF of the spawn gate, restoring symmetry PR #2336 flagged:
+ * `spawn_session`'s explicit-`workspaceId` path admits any caller
+ * `checkSessionAccess` allows (owner OR drive member), while discovery only
+ * enumerated owned workspaces — so a member could target a shared workspace
+ * by id but never learn the id from `list_sessions`.
+ *
+ * Per-row access is decided by the SAME one pure decision the spawn gate
+ * uses — `decideAgentSessionAccess`, fed by the same `resolveDriveMembership`
+ * gather (`checkAccessForSubject`'s exact composition) — never a second
+ * predicate. Candidate drives come from the caller's drive relationships
+ * (`getDriveIdsForUser`, deliberately over-broad: it includes
+ * page-permission-only drives whose membership resolves to `'none'`, which
+ * the decision then denies — an over-broad candidate set filtered by the one
+ * real gate beats a hand-rolled narrower query that could drift from it).
+ *
+ * Worker rows come from the same `listSessionConversationsBulk` primitive as
+ * every other listing, with titles routed through the ONE redaction rule
+ * (`redactConversationTitleForViewer`): the caller sees their own and
+ * deliberately-shared titles; another member's private thread keeps its row
+ * (agent + activity — the orchestration signal) as `(private thread)`.
+ * Bounded by {@link MAX_MEMBER_VISIBLE_WORKSPACES} (see its doc).
+ */
+async function listSharedWorkspaces({
+  userId,
+  excludeWorkspaceId,
+}: {
+  userId: string;
+  excludeWorkspaceId?: string;
+}): Promise<SharedWorkspaceSummary[]> {
+  const candidateDriveIds = await getDriveIdsForUser(userId);
+  if (candidateDriveIds.length === 0) return [];
+
+  const memberships = await Promise.all(
+    candidateDriveIds.map(async (driveId) => ({
+      driveId,
+      membership: await resolveDriveMembership({ userId, driveId }),
+    })),
+  );
+
+  const sessionsPerDrive = await Promise.all(
+    memberships
+      .filter(({ membership }) => membership !== 'none')
+      .map(async ({ driveId, membership }) => {
+        // The ownerless `{ driveId }` filter: every ACTIVE session in the
+        // drive, any owner — the sidebar's own store primitive, its per-query
+        // cap included.
+        const sessions = await listSessions({ driveId });
+        return sessions.filter(
+          (session) =>
+            // The caller's own sessions belong to the OWN listing; the
+            // current workspace is the top-level detail view.
+            session.ownerId !== userId &&
+            session.sessionId !== excludeWorkspaceId &&
+            // THE gate — the same pure decision `checkSessionAccess` applies
+            // on spawn_session's explicit-workspaceId path.
+            decideAgentSessionAccess({
+              requesterId: userId,
+              session: { ownerId: session.ownerId, driveId: session.driveId },
+              driveMembership: membership,
+            }).allowed,
+        );
+      }),
+  );
+
+  const shared = sessionsPerDrive
+    .flat()
+    .sort((a, b) => {
+      // Newest activity first, nulls last, then newest created — the store's
+      // own listing order, re-established across the merged drives.
+      const activity = (b.lastActiveAt ?? '').localeCompare(a.lastActiveAt ?? '');
+      return activity !== 0 ? activity : b.createdAt.localeCompare(a.createdAt);
+    })
+    .slice(0, MAX_MEMBER_VISIBLE_WORKSPACES);
+  if (shared.length === 0) return [];
+
+  const workersBySession = await listSessionConversationsBulk(shared.map((s) => s.sessionId));
+  const agentTitles = await resolveAgentTitles(workersBySession);
+
+  return shared.map((session) => ({
+    workspaceId: session.sessionId,
+    name: session.name,
+    // Non-null by construction: only drive-scoped sessions pass the filter
+    // (a global-assistant session is owner-only, and own rows are excluded).
+    driveId: session.driveId ?? '',
+    sandbox: session.sandboxStatus,
+    workers: (workersBySession.get(session.sessionId) ?? []).map((worker) => ({
+      sessionId: worker.conversationId,
+      name:
+        redactConversationTitleForViewer({
+          viewerId: userId,
+          workspaceOwnerId: session.ownerId,
+          conversation: { ownerId: worker.ownerId, isShared: worker.isShared, title: worker.title },
+        }) ?? '',
+      agent:
+        worker.agentPageId !== null
+          ? { agentId: worker.agentPageId, title: agentTitles.get(worker.agentPageId) ?? '' }
+          : null,
+      lastActiveAt: worker.lastMessageAt?.toISOString() ?? null,
     })),
   }));
 }
@@ -718,6 +861,7 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
     },
     listWorkspaceWorkers,
     listOwnWorkspaces,
+    listSharedWorkspaces,
 
     findWorker: async (conversationId) => {
       // The wire's "sessionId" is the WORKER's conversation id (what spawn

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -6,7 +6,9 @@
  *
  * Two verb families, EXACTLY nine tools, ONE address namespace each. You name
  * a thing once, at spawn; every verb after that takes the id the spawn
- * returned — and `list_sessions` re-lists exactly those ids:
+ * returned — and `list_sessions` re-lists those ids (plus, for awareness,
+ * other members' workers in SHARED workspaces, which are not the caller's to
+ * address — see `SharedWorkspaceSummary`):
  *
  *  - **Workers** — labeled sibling CONVERSATIONS in the caller's own session
  *    (same sandbox, same filesystem), addressed by their conversation id:
@@ -188,6 +190,45 @@ export interface OwnWorkspaceSummary {
   workers: Array<Omit<WorkerListingEntry, 'isCaller'>>;
 }
 
+/**
+ * One worker of a SHARED workspace, as `list_sessions` reports it. Same id
+ * namespace as every other listing (a conversation id) — but only the
+ * caller's OWN workers are addressable by the verbs (a foreign conversation
+ * reads as nonexistent to them), so this entry exists for AWARENESS: what is
+ * running in the shared workspace, under which agent, and how recently.
+ * `name` may be the fixed `(private thread)` redaction marker — another
+ * member's private thread keeps its row but never its title (see
+ * `redact-conversation-listing.ts` in `@pagespace/lib`).
+ */
+export interface SharedWorkspaceWorkerEntry {
+  sessionId: string;
+  /** The title, or the redaction marker for another member's private thread. */
+  name: string;
+  agent: { agentId: string; title: string } | null;
+  /** Last activity (ISO), kept even where the title is redacted — the orchestration signal. */
+  lastActiveAt: string | null;
+}
+
+/**
+ * A workspace the caller can reach as a DRIVE MEMBER without owning it —
+ * `list_sessions`' `sharedWorkspaces` section. Discovery symmetry with
+ * `spawn_session`'s explicit-`workspaceId` path: every workspace the spawn
+ * gate (`checkSessionAccess` — owner or drive member) would admit the caller
+ * into is discoverable here, labeled distinctly from their own so the model
+ * knows which are whose. Listed for two uses: a `spawn_session` `workspace`
+ * target, and awareness of what other members are running. No shells, no
+ * caller-owned rows (those live in `OwnWorkspaceSummary`).
+ */
+export interface SharedWorkspaceSummary {
+  workspaceId: string;
+  /** Display label only — never an address. */
+  name: string;
+  /** Always a real drive: sharing happens through drive membership, and global-assistant workspaces are owner-only. */
+  driveId: string;
+  sandbox: SandboxStatus;
+  workers: SharedWorkspaceWorkerEntry[];
+}
+
 /** The identity slice of a WORKER row — a conversation — the session verbs act on. */
 export interface WorkerRow {
   /** The worker's conversation id — the wire's `sessionId`, mapped at the zod boundary. */
@@ -249,10 +290,17 @@ export interface SessionToolsDeps {
    * everything the listing enumerates, hangs off this one resolution.
    */
   findOwnWorkspace: (conversationId: string) => Promise<{ workspaceId: string } | null>;
-  /** The workspace's workers + shells + sandbox status, labels resolved. */
+  /**
+   * The workspace's workers + shells + sandbox status, labels resolved.
+   * `callerUserId` is the VIEWER: a caller whose conversation lives in a
+   * workspace they do not own (spawned into a shared one) gets other
+   * members' private-thread titles redacted — the one listing redaction rule
+   * (`redact-conversation-listing.ts`).
+   */
   listWorkspaceWorkers: (input: {
     workspaceId: string;
     callerConversationId: string;
+    callerUserId: string;
   }) => Promise<SessionWorkspaceListing>;
   /**
    * ALL the caller's active workspaces (minus `excludeWorkspaceId`, their
@@ -264,6 +312,19 @@ export interface SessionToolsDeps {
     userId: string;
     excludeWorkspaceId?: string;
   }) => Promise<OwnWorkspaceSummary[]>;
+  /**
+   * Workspaces the caller can ACCESS as a drive member without owning —
+   * `listOwnWorkspaces`' discovery sibling, gated by the SAME access
+   * decision `spawn_session`'s explicit-`workspaceId` path enforces
+   * (`decideAgentSessionAccess` — never a second predicate), so anything
+   * spawnable-into is also discoverable (PR #2336's flagged asymmetry).
+   * Bounded by the runtime's own explicit member-visible cap — unlike the
+   * caller's OWN set, this one has no structural per-owner ceiling behind it.
+   */
+  listSharedWorkspaces: (input: {
+    userId: string;
+    excludeWorkspaceId?: string;
+  }) => Promise<SharedWorkspaceSummary[]>;
   /** One worker conversation's identity slice, or null. */
   findWorker: (conversationId: string) => Promise<WorkerRow | null>;
   /**
@@ -563,7 +624,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
   return {
     list_sessions: tool({
       description:
-        'List ALL your workspaces and their workers. Your current conversation\'s workspace comes with full detail (workers, shells, shared sandbox status); every other workspace lists its workspaceId (a spawn_session `workspace` target) and workers. Every worker\'s sessionId is the exact address send_session/read_session/kill_session take, from anywhere. Names are labels — always address by id.',
+        'List the workspaces you can reach, and their workers. Your current conversation\'s workspace comes with full detail (workers, shells, shared sandbox status); every other workspace you OWN lists its workspaceId (a spawn_session `workspace` target) and workers; sharedWorkspaces lists OTHER members\' workspaces in drives you belong to — equally valid spawn_session `workspace` targets, shown for awareness with other members\' private thread titles redacted to "(private thread)". Your own workers\' sessionIds are the exact addresses send_session/read_session/kill_session take, from anywhere; another member\'s worker is not yours to address. Names are labels — always address by id.',
       inputSchema: listSessionsInputSchema,
       execute: async (_input, options) => {
         const context = readContext(options);
@@ -572,10 +633,20 @@ export function createSessionTools(deps: SessionToolsDeps): {
         const conversationId = context?.conversationId;
 
         const workspace = conversationId ? await deps.findOwnWorkspace(conversationId) : null;
-        const otherWorkspaces = await deps.listOwnWorkspaces({
-          userId: actor.userId,
-          excludeWorkspaceId: workspace?.workspaceId,
-        });
+        // Own and member-visible sets in parallel — the SAME exclusion for
+        // both: the caller's current workspace is the top-level detail view
+        // whoever owns it (a caller spawned into a shared workspace has a
+        // current workspace they do not own).
+        const [otherWorkspaces, sharedWorkspaces] = await Promise.all([
+          deps.listOwnWorkspaces({
+            userId: actor.userId,
+            excludeWorkspaceId: workspace?.workspaceId,
+          }),
+          deps.listSharedWorkspaces({
+            userId: actor.userId,
+            excludeWorkspaceId: workspace?.workspaceId,
+          }),
+        ]);
 
         if (!conversationId || !workspace) {
           // No conversation, or a plain one with no workspace: nothing HERE,
@@ -592,14 +663,16 @@ export function createSessionTools(deps: SessionToolsDeps): {
             workers: [],
             shells: [],
             otherWorkspaces,
+            sharedWorkspaces,
             note: 'This conversation has no workspace yet — spawn_session starts one automatically (permission permitting). Workers in your other workspaces are addressable by their sessionId.',
           };
         }
         const listing = await deps.listWorkspaceWorkers({
           workspaceId: workspace.workspaceId,
           callerConversationId: conversationId,
+          callerUserId: actor.userId,
         });
-        return { success: true, workspaceId: workspace.workspaceId, ...listing, otherWorkspaces };
+        return { success: true, workspaceId: workspace.workspaceId, ...listing, otherWorkspaces, sharedWorkspaces };
       },
     }),
 

--- a/docs/2.0-architecture/agent-sessions.md
+++ b/docs/2.0-architecture/agent-sessions.md
@@ -107,9 +107,28 @@ finding 1's workspace confinement.
 5. **Cross-workspace orchestration is legitimate.** `spawn_session` takes `workspace`
    (omitted = caller's own, minted if needed; `'new'` = fresh isolated workspace;
    an id = spawn straight into it, gated by session access). `list_sessions` lists all
-   the caller's workspaces, every worker everywhere addressable by the verbs. The
+   the caller's workspaces, every worker the caller owns addressable by the verbs. The
    advisory cap pre-count applies only to own-workspace spawns — a full caller
    workspace can't refuse a spawn aimed somewhere with room.
+6. **Discovery is symmetric with the spawn gate.** Everything
+   `spawn_session`'s explicit-`workspaceId` path would admit the caller into
+   (`checkSessionAccess` → `decideAgentSessionAccess`: owner OR drive member) is
+   discoverable: `list_sessions` additionally reports `sharedWorkspaces` — other
+   members' sessions in drives the caller belongs to, gated per-row by that SAME
+   pure decision, labeled distinctly from the caller's own. The caller's own set
+   is never truncated (the spawn ceiling is structural); the member-visible set
+   has no structural ceiling, so it carries its own explicit bound
+   (`MAX_MEMBER_VISIBLE_WORKSPACES`, newest activity first).
+7. **Foreign private-thread titles redact in listings.** A viewer listing a
+   workspace they do not OWN sees a conversation's title only when the thread is
+   their own or deliberately shared (`conversations.isShared`); every other row
+   keeps its agent and activity time but reads `(private thread)`. The owner sees
+   everything in their own workspace. One pure mechanism —
+   `redactConversationTitleForViewer`
+   (`packages/lib/src/agent-sessions/redact-conversation-listing.ts`) — routed
+   through every viewer-facing mapping of session-conversation rows. This is a
+   deliberately conservative product decision, explicitly open to veto: adjusting
+   it is one function. Transcript content stays owner-gated regardless.
 
 Unchanged by the re-model: the conversation→session binding stays write-once and
 owner-only (the hijack surface stays closed); shells stay workspace-scoped

--- a/knip.json
+++ b/knip.json
@@ -176,6 +176,7 @@
         "src/agent-sessions/decide-session-access.ts",
         "src/agent-sessions/plan-session-lifecycle.ts",
         "src/agent-sessions/plan-spawn-session.ts",
+        "src/agent-sessions/redact-conversation-listing.ts",
         "src/agent-sessions/session-sprite-key.ts",
         "src/ai/context-window.ts",
         "src/ai/global-channel-id.ts",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -87,6 +87,11 @@
       "import": "./dist/agent-sessions/plan-spawn-session.js",
       "require": "./dist/agent-sessions/plan-spawn-session.js"
     },
+    "./agent-sessions/redact-conversation-listing": {
+      "types": "./dist/agent-sessions/redact-conversation-listing.d.ts",
+      "import": "./dist/agent-sessions/redact-conversation-listing.js",
+      "require": "./dist/agent-sessions/redact-conversation-listing.js"
+    },
     "./ai/model-defaults": {
       "types": "./dist/ai/model-defaults.d.ts",
       "import": "./dist/ai/model-defaults.js",

--- a/packages/lib/src/agent-sessions/__tests__/redact-conversation-listing.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/redact-conversation-listing.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pins the ONE shared-workspace listing redaction rule (issue #2262 finding
+ * 6): the workspace owner sees everything in their own workspace; any other
+ * viewer sees a title only for their own or deliberately-shared threads, and
+ * the fixed `(private thread)` marker for everyone else's. The rule is a
+ * product decision explicitly open to veto — this suite pins the MECHANISM
+ * (one function, fail-closed) so an adjustment is one deliberate edit here
+ * and there, never drift.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PRIVATE_THREAD_REDACTION,
+  redactConversationTitleForViewer,
+} from '../redact-conversation-listing';
+
+const OWNER = 'user-owner';
+const MEMBER = 'user-member';
+const OTHER_MEMBER = 'user-other';
+
+function title(viewerId: string, conversation: { ownerId: string; isShared: boolean; title: string | null }) {
+  return redactConversationTitleForViewer({
+    viewerId,
+    workspaceOwnerId: OWNER,
+    conversation,
+  });
+}
+
+describe('redactConversationTitleForViewer', () => {
+  it('the workspace OWNER sees every title in their own workspace, unchanged — including other members\' private threads', () => {
+    expect(title(OWNER, { ownerId: MEMBER, isShared: false, title: 'secret plans' })).toBe('secret plans');
+    expect(title(OWNER, { ownerId: OWNER, isShared: false, title: 'my own' })).toBe('my own');
+  });
+
+  it('a member sees their OWN thread\'s title in a workspace they do not own', () => {
+    expect(title(MEMBER, { ownerId: MEMBER, isShared: false, title: 'mine' })).toBe('mine');
+  });
+
+  it('a member sees a deliberately SHARED thread\'s title', () => {
+    expect(title(MEMBER, { ownerId: OTHER_MEMBER, isShared: true, title: 'team notes' })).toBe('team notes');
+  });
+
+  it('a member sees the fixed redaction marker for another member\'s private thread — never the real title', () => {
+    expect(title(MEMBER, { ownerId: OTHER_MEMBER, isShared: false, title: 'their secret' })).toBe(
+      PRIVATE_THREAD_REDACTION,
+    );
+    expect(title(MEMBER, { ownerId: OWNER, isShared: false, title: 'owner secret' })).toBe(
+      PRIVATE_THREAD_REDACTION,
+    );
+  });
+
+  it('a null title passes through where the viewer may see it, and still redacts to the marker where not', () => {
+    expect(title(MEMBER, { ownerId: MEMBER, isShared: false, title: null })).toBeNull();
+    expect(title(MEMBER, { ownerId: OTHER_MEMBER, isShared: false, title: null })).toBe(PRIVATE_THREAD_REDACTION);
+  });
+
+  it('fails CLOSED on a degenerate empty viewer id — an empty id matches no owner, so nothing private leaks', () => {
+    expect(title('', { ownerId: '', isShared: false, title: 'x' })).toBe(PRIVATE_THREAD_REDACTION);
+    expect(
+      redactConversationTitleForViewer({
+        viewerId: '',
+        workspaceOwnerId: '',
+        conversation: { ownerId: 'someone', isShared: false, title: 'x' },
+      }),
+    ).toBe(PRIVATE_THREAD_REDACTION);
+  });
+});

--- a/packages/lib/src/agent-sessions/redact-conversation-listing.ts
+++ b/packages/lib/src/agent-sessions/redact-conversation-listing.ts
@@ -1,0 +1,61 @@
+/**
+ * The ONE shared-workspace listing redaction rule (issue #2262 finding 6).
+ *
+ * A workspace listing shows every open conversation's title, agent, and
+ * activity time to every viewer with session access — deliberate
+ * shared-workspace semantics for the workspace's OWN owner, but a member
+ * looking into a workspace they do NOT own was also reading the titles of
+ * other members' private threads. The conservative rule, decided in
+ * PR "list_sessions discovers shared workspaces" and explicitly open to
+ * product veto (the mechanism is this one function):
+ *
+ *  - The workspace's OWNER sees every title in their own workspace, unchanged.
+ *  - Any other viewer sees a conversation's title only when the thread is
+ *    their own or deliberately shared (`conversations.isShared`); everything
+ *    else keeps its ROW (agent id + activity time — the orchestration signal
+ *    "something is running here" is the listing's point) but its title reads
+ *    as the fixed {@link PRIVATE_THREAD_REDACTION} marker.
+ *
+ * PURE and single-sourced on purpose: every listing surface that maps
+ * session conversations for a viewer (`listWorkspaceWorkers` /
+ * `listSharedWorkspaces` in `apps/web/src/lib/ai/tools/session-tools-runtime.ts`)
+ * must route titles through this function rather than re-deriving the rule.
+ * TRANSCRIPT content is a separate, stricter gate (`openOwnSession` — owner
+ * only) that this rule never widens.
+ */
+
+/** What a foreign private thread's title reads as. Fixed — never derived from the real title. */
+export const PRIVATE_THREAD_REDACTION = '(private thread)';
+
+export interface ConversationTitleRedactionInput {
+  /** Who is reading the listing. */
+  viewerId: string;
+  /** The `agent_sessions` row's owner. Empty/unknown never grants — treat as not-the-viewer. */
+  workspaceOwnerId: string;
+  conversation: {
+    /** The conversation's own owner (`conversations.userId`). */
+    ownerId: string;
+    /** The thread was deliberately shared (`conversations.isShared`). */
+    isShared: boolean;
+    title: string | null;
+  };
+}
+
+/**
+ * The title a viewer may see for one conversation in a workspace listing —
+ * either the real title or {@link PRIVATE_THREAD_REDACTION}. See module doc
+ * for the rule; fails CLOSED (an empty viewer id matches no owner, so it
+ * redacts everything that is not explicitly shared).
+ */
+export function redactConversationTitleForViewer({
+  viewerId,
+  workspaceOwnerId,
+  conversation,
+}: ConversationTitleRedactionInput): string | null {
+  const viewerIsWorkspaceOwner = viewerId.length > 0 && viewerId === workspaceOwnerId;
+  const viewerOwnsThread = viewerId.length > 0 && viewerId === conversation.ownerId;
+  if (viewerIsWorkspaceOwner || viewerOwnsThread || conversation.isShared) {
+    return conversation.title;
+  }
+  return PRIVATE_THREAD_REDACTION;
+}


### PR DESCRIPTION
Phase 2 of the **Agent-Session Single Source of Truth** epic: closes the discovery asymmetry PR #2336 explicitly flagged and deliberately deferred, and lands the shared-metadata decision from issue #2262 finding 6.

> ⚠️ **Product decision embedded: redaction of other members' private-thread titles in shared workspaces — veto/adjust before or after merge; the mechanism is one function** (`redactConversationTitleForViewer`, `packages/lib/src/agent-sessions/redact-conversation-listing.ts`). Details in §2.

## 1. Discovery symmetry — `list_sessions` now discovers shared workspaces

PR #2336 flagged: *"`list_sessions`'s cross-workspace listing is scoped to workspaces the caller OWNS, while `spawn_session`'s explicit-workspaceId path (correctly) also permits drive members into a shared workspace — so a member can target a shared workspace by id but won't discover it via `list_sessions`."*

Fixed by a sibling dep, `listSharedWorkspaces` (`session-tools-runtime.ts`): other members' sessions in drives the caller belongs to, reported as a **distinct `sharedWorkspaces` section** of the `list_sessions` output so the model always knows which workspaces are its own and which are shared.

- **Same predicate, never a second one.** Per-row access is decided by the exact pure decision the spawn gate applies on the explicit-`workspaceId` path (`checkSessionAccess` → `decideAgentSessionAccess`, fed by the same `resolveDriveMembership` gather — `checkAccessForSubject`'s composition). Candidate drives come from `getDriveIdsForUser`, deliberately over-broad (page-permission-only drives resolve to membership `'none'` and are denied by the one real gate) rather than a hand-rolled narrower query that could drift from it.
- **Cap semantics, made explicit.** The caller's OWN set keeps leaning on the structural `MAX_ACTIVE_WORKSPACES_PER_OWNER` spawn ceiling (a listing can never truncate it). The member-visible set has **no structural ceiling behind it** (N members × their own caps), so it carries its own documented bound: `MAX_MEMBER_VISIBLE_WORKSPACES = 100`, newest activity first — a real truncation bound, documented at the constant.
- **Deliberate description change, not drift.** `list_sessions`' tool description now names the `sharedWorkspaces` section, the redaction marker, and narrows the addressability claim to workers the caller owns (foreign workers always read as nonexistent to the verbs — unchanged behavior, previously overclaimed). The pinned literal in `session-tools-schema.test.ts` is re-pinned **in the same commit**, with a comment marking it as a contract edit. `docs/2.0-architecture/agent-sessions.md` §2 gains axioms 6–7 in the same PR, per §5's rule.

## 2. Shared-metadata decision (issue #2262 finding 6)

Shared-workspace listings showed titles of ALL conversations in the workspace — including other members' private threads. The conservative rule now in force:

- The workspace's **owner sees everything in their own workspace, unchanged**.
- Any other viewer sees a title only for threads that are **their own** or **deliberately shared** (`conversations.isShared`); every other row **keeps its row** — agent id + activity time, so the orchestration signal and the listing **count stay honest** — with the title replaced by the fixed marker `(private thread)`.
- Transcript content stays owner-gated regardless (`openOwnSession` — unchanged).

Implemented in the listing mapping layer in **one place**: the pure `redactConversationTitleForViewer` (fail-closed), routed through both viewer-facing mappings (`listWorkspaceWorkers` for the caller's current workspace — which can be a shared one they were spawned into — and `listSharedWorkspaces`). The rule is documented where the queries live (`listSessionConversationsBulk`'s doc, per the issue's own ask), and `SessionConversationEntry` now carries `ownerId`/`isShared` so mapping layers apply the rule without a second query. The sidebar/API surfaces only ever enumerate the caller's own sessions, where the owner rule makes redaction a no-op.

**This is a product decision, embedded conservatively and flagged for veto**: if product prefers full titles for drive members (shared-workspace-semantics-all-the-way) or full redaction, the change is one function + its pinned tests.

## Tests

- `packages/lib/src/agent-sessions/__tests__/redact-conversation-listing.test.ts` — the rule, including fail-closed degenerate inputs.
- `session-tools-runtime.test.ts` — `listSharedWorkspaces` runs the REAL pure gate + redaction over mocked IO: member discovery with own/current-workspace exclusion; non-member sees nothing (and the `'none'` drive is never queried); redacted titles with honest count and surviving activity time; the 100 bound, newest first.
- `session-tools-contract.test.ts` — the `sharedWorkspaces` section and "a workspaceId discovered in sharedWorkspaces is spawnable-into".
- `session-discovery-symmetry.integration.test.ts` (real migration-built Postgres) — a drive member **discovers** the owner's shared workspace, sees own + shared titles, `(private thread)` for the owner's private one (count honest, real title nowhere in the payload), and **spawns into** the discovered id; the owner sees everything unredacted; a **non-member's listing and spawn both refuse** — the same one decision.
- `session-tools.test.ts` / `session-tools-schema.test.ts` updated for the new dep, the viewer parameter, and the re-pinned description.

## Gates (run sequentially, real results)

- `bun run lint` — 14/14 tasks green.
- `bun run knip:check` — 4 issues, all within baseline (new lib module added to knip entries; the new bound stays module-local).
- `bun run typecheck` — 16/16 tasks green.
- Session-tools + agent-sessions suites (`src/lib/ai/tools/__tests__/` + `src/lib/agent-sessions/__tests__/`, DB on :5433): **54 files, 1251 tests passed**, including both integration suites.
- `bun run test:unit` — exit 0; web: **1,090 files passed, 16,167 tests passed** (1 file / 6 tests skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
