### PR TITLE
feat(agents): panes subscribe and prove currency — rev watermarks, gate removal, live dispatch rendering

### DIFF
--- a/apps/e2e/tests/16-dispatch-multiplayer.spec.ts
+++ b/apps/e2e/tests/16-dispatch-multiplayer.spec.ts
@@ -9,15 +9,37 @@ import {
 } from '../fixtures/dispatch.fixture';
 
 /**
- * Dispatch + multiplayer harness specs — Phase 0 of the Agent-Session Single Source of Truth
- * epic. Full rationale and the phase → spec mapping live in the header of
+ * Dispatch + multiplayer harness specs — Agent-Session Single Source of Truth epic.
+ * Full rationale and the phase → spec mapping live in the header of
  * `fixtures/dispatch.fixture.ts`.
  *
  * Two tiers:
- *  - the smokes PASS today and pin the harness (dispatch really writes through the pipeline);
- *  - the `test.fixme` specs are the epic's canonical bug, written as the executable spec
- *    Phase 2 (plan PR 3) must flip green: delete the `.fixme`s in that PR. PRs 7 and 12
- *    re-verify them.
+ *  - the smokes pin the harness (dispatch really writes through the pipeline);
+ *  - the live-delivery specs below WERE `test.fixme` — the epic's canonical bug written as
+ *    an executable spec. Phase 2 (plan PR 3) flipped them: the fixmes are deleted and these
+ *    are now the gate. PRs 7 and 12 re-verify them.
+ *
+ * They assert LIVE delivery, so they need the realtime server running and wired to the web
+ * process (`INTERNAL_REALTIME_URL` + a shared `REALTIME_BROADCAST_SECRET`) — unlike the
+ * smokes, which are satisfiable without it.
+ *
+ * RUN REALTIME ON THE SAME ORIGIN AS THE APP. This is the one piece of local setup that
+ * fails silently rather than loudly. The production CSP is `connect-src 'self' ws: wss:`
+ * (`apps/web/src/middleware/security-headers.ts`), and Socket.IO opens with an XHR POLLING
+ * handshake before it upgrades to a websocket — so pointing `NEXT_PUBLIC_REALTIME_URL` at a
+ * different origin (the obvious `http://127.0.0.1:3001` while the app serves :3000) gets that
+ * handshake blocked by CSP and NO socket connects at all. Production does not hit this because
+ * Traefik path-routes `/socket.io` to the realtime service on the app's own host
+ * (`infrastructure/docker-compose.tenant.yml`), which `'self'` covers. Mirror that locally:
+ * put a reverse proxy on one port that forwards `/socket.io` (including the upgrade) to the
+ * realtime server and everything else to the web server, and leave `NEXT_PUBLIC_REALTIME_URL`
+ * UNSET so the socket store falls back to same-origin. Do not "fix" it by relaxing the CSP or
+ * by setting `bypassCSP` on the context — both make the run stop testing the shipped policy.
+ *
+ * VERIFY THE SOCKET IS REALLY CARRYING THESE ASSERTIONS, because a dead socket can still let a
+ * spec pass off the mount-time load. Two checks: realtime at `LOG_LEVEL=debug` must log
+ * `User joined conversation room` for `conv:<id>`, and the specs must FAIL with the realtime
+ * server stopped.
  */
 
 // Seed our own openrouter-provider users (the shared storageState user is provider 'openai'
@@ -109,12 +131,15 @@ test.describe('dispatch harness smoke (passing — pins the fixtures)', () => {
   });
 });
 
-test.describe('blank-pane repro (fixme until epic Phase 2 / plan PR 3)', () => {
-  // KNOWN RED TODAY — this is the epic's canonical bug, kept as an executable spec: nothing
-  // broadcasts on message persistence, `chat:user_message` is gated on `isShared`, and cache
-  // handlers early-return for unloaded conversations. PR 3 deletes the `.fixme` and this
-  // becomes the gate.
-  test.fixme('a server dispatch into an open pane renders live without reload', async ({
+test.describe('blank-pane repro (the Phase 2 gate — was fixme, now green)', () => {
+  // This was the epic's canonical bug: nothing broadcast on message persistence,
+  // `chat:user_message` was gated on `isShared`, the client dropped
+  // `startedBySomeoneElse && !isShared`, and every cache handler early-returned for a
+  // conversation it had not already loaded. Phase 2 closed all four — every durable write
+  // emits a rev-carrying `conversation:*` event to `conv:<id>`, the pane subscribes to that
+  // room on open, and `useConversationSubscription` ensures a cache entry BEFORE joining, so
+  // the `hasEntry` gate is unnecessary rather than merely removed.
+  test('a server dispatch into an open pane renders live without reload', async ({
     browser,
     baseURL,
     request,
@@ -139,7 +164,7 @@ test.describe('blank-pane repro (fixme until epic Phase 2 / plan PR 3)', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test.fixme('two windows on one conversation both see both sides of a dispatched turn live', async ({
+  test('two windows on one conversation both see both sides of a dispatched turn live', async ({
     browser,
     baseURL,
     request,

--- a/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
@@ -537,3 +537,66 @@ describe('GET /api/ai/chat/active-streams?scope=user', () => {
     expect(mockOrderBy).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Conversation-scoped bootstrap (Agent-Session SSoT epic, Phase 2 / plan PR 3).
+ * `?conversationId=` narrows the CHANNEL form to one conversation — what a pane wants,
+ * since a pane shows exactly one. It is applied AFTER `filterSubscribableStreams`, so it
+ * can only ever return fewer rows than the channel form and grants nothing.
+ */
+describe('GET /api/ai/chat/active-streams?conversationId=', () => {
+  const row = (messageId: string, conversationId: string) => ({
+    messageId,
+    conversationId,
+    userId: mockUserId,
+    displayName: 'Me',
+    browserSessionId: 'session-1',
+    parts: [],
+    rawPartsCount: 0,
+    startedAt: new Date('2024-01-01T00:00:00.000Z'),
+    lastHeartbeatAt: new Date(),
+  });
+
+  const makeScopedRequest = (conversationId: string) =>
+    new Request(
+      `http://test.local/api/ai/chat/active-streams?channelId=${encodeURIComponent(mockChannelId)}&conversationId=${encodeURIComponent(conversationId)}`,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockSessionAuth());
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    mockFilterSubscribableStreams.mockImplementation(async ({ rows }: { rows: unknown[] }) => rows);
+  });
+
+  it('given a conversationId, should return only that conversation\'s streams', async () => {
+    mockOrderBy.mockResolvedValueOnce([row('msg-mine', 'conv-mine'), row('msg-sibling', 'conv-sibling')]);
+
+    const response = await GET(makeScopedRequest('conv-mine'));
+    const body = await response.json();
+
+    expect(body.streams.map((s: { messageId: string }) => s.messageId)).toEqual(['msg-mine']);
+  });
+
+  it('given no conversationId, should keep the whole-channel form', async () => {
+    mockOrderBy.mockResolvedValueOnce([row('msg-mine', 'conv-mine'), row('msg-sibling', 'conv-sibling')]);
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(body.streams.map((s: { messageId: string }) => s.messageId)).toEqual(['msg-mine', 'msg-sibling']);
+  });
+
+  // The narrowing must never be mistaken for authorization: a row the subscription
+  // filter already removed stays removed whatever the query string says.
+  it('given a conversationId the caller may not subscribe to, should still return nothing', async () => {
+    mockOrderBy.mockResolvedValueOnce([row('msg-private', 'conv-private')]);
+    mockFilterSubscribableStreams.mockResolvedValueOnce([]);
+
+    const response = await GET(makeScopedRequest('conv-private'));
+    const body = await response.json();
+
+    expect(body.streams).toEqual([]);
+  });
+});

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -31,6 +31,9 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const channelId = searchParams.get('channelId');
     const scope = searchParams.get('scope');
+    // Optional narrowing of the channel form to one conversation — see where it is
+    // applied below. Never widens: it filters an already-authorized row set.
+    const conversationId = searchParams.get('conversationId');
 
     // scope=user: cross-channel discovery of the CALLER's own in-flight streams — what the
     // history tab (leaf 5.2) badges as "still streaming", regardless of which page/global
@@ -147,7 +150,19 @@ export async function GET(request: Request) {
     // an unauthorized-to-that-conversation poller can't even trigger a reap side effect for a
     // conversation whose content it will never see returned.
     const authorized = await filterSubscribableStreams({ userId, rows });
-    const streams = authorized.filter((r) => isStreamRowLive(r, now));
+    // Conversation-scoped bootstrap (Agent-Session SSoT epic, Phase 2): a pane
+    // subscribes to ONE conversation, so `?conversationId=` narrows the answer to
+    // that conversation's streams. Purely a NARROWING of an already-authorized set —
+    // it is applied after `filterSubscribableStreams`, never instead of it, so it can
+    // only ever return fewer rows than the channel form and grants nothing. The
+    // channel form (no `conversationId`) is unchanged: `GlobalChatContext` still
+    // bootstraps the user's whole global channel, which is what keeps a stream alive
+    // in the store for a conversation no pane is currently showing.
+    const conversationScoped =
+      conversationId === null
+        ? authorized
+        : authorized.filter((r) => r.conversationId === conversationId);
+    const streams = conversationScoped.filter((r) => isStreamRowLive(r, now));
 
     // Lazy reap: this query already reads every 'streaming' row on the channel, so any
     // authorized-to-view row that is not live and is PROVABLY dead (never mere staleness — see

--- a/apps/web/src/app/api/ai/conversations/revs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/conversations/revs/__tests__/route.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+/**
+ * `POST /api/ai/conversations/revs` — the reconnect watermark check.
+ *
+ * Two things are load-bearing and both are pinned here: it answers in ONE
+ * round-trip for many ids, and it filters every id through the SHARED
+ * `canAccessConversation` predicate rather than trusting the caller's list.
+ */
+
+const { mockLimit } = vi.hoisted(() => ({ mockLimit: vi.fn() }));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: mockLimit }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ inArray: [col, vals] })),
+}));
+
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: {
+    id: 'id',
+    rev: 'rev',
+    userId: 'userId',
+    isShared: 'isShared',
+    type: 'type',
+    contextId: 'contextId',
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { api: { error: vi.fn() } } }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+const mockCanAccessConversation = vi.fn();
+vi.mock('@pagespace/lib/permissions/conversation-access', () => ({
+  canAccessConversation: (userId: string, row: unknown) => mockCanAccessConversation(userId, row),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+const USER = 'user-1';
+
+const mockSessionAuth = (userId = USER): SessionAuthResult => ({
+  userId,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+});
+
+const mockAuthFailure = (): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+});
+
+const makeRequest = (body: unknown) =>
+  new Request('http://test.local/api/ai/conversations/revs', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+const row = (id: string, rev: number, overrides: Partial<{ userId: string; isShared: boolean }> = {}) => ({
+  id,
+  rev,
+  userId: USER,
+  isShared: false,
+  type: 'page',
+  contextId: 'page-1',
+  ...overrides,
+});
+
+describe('POST /api/ai/conversations/revs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockSessionAuth());
+    vi.mocked(isAuthError).mockReturnValue(false);
+    mockCanAccessConversation.mockResolvedValue(true);
+  });
+
+  it('given several ids, should answer all of them from ONE query', async () => {
+    mockLimit.mockResolvedValueOnce([row('c1', 4), row('c2', 11)]);
+
+    const response = await POST(makeRequest({ ids: ['c1', 'c2'] }));
+    const body = await response.json();
+
+    expect(body).toEqual({ revs: { c1: 4, c2: 11 } });
+    expect(mockLimit).toHaveBeenCalledTimes(1);
+  });
+
+  // Absence, not 403: a client asking about a conversation that was un-shared out
+  // from under it is an expected state, and one stale id must not blind it to the rest.
+  it('given an id the caller may not access, should omit it rather than fail the batch', async () => {
+    mockLimit.mockResolvedValueOnce([row('c1', 4), row('c2', 11, { userId: 'someone-else' })]);
+    mockCanAccessConversation.mockImplementation(async (_userId: string, r: { userId: string }) => r.userId === USER);
+
+    const response = await POST(makeRequest({ ids: ['c1', 'c2'] }));
+    const body = await response.json();
+
+    expect(body).toEqual({ revs: { c1: 4 } });
+  });
+
+  it('given an id with no row, should simply omit it (indistinguishable from forbidden — not an oracle)', async () => {
+    mockLimit.mockResolvedValueOnce([row('c1', 4)]);
+
+    const response = await POST(makeRequest({ ids: ['c1', 'c-does-not-exist'] }));
+    const body = await response.json();
+
+    expect(body).toEqual({ revs: { c1: 4 } });
+  });
+
+  it('given duplicate ids, should de-duplicate before querying', async () => {
+    mockLimit.mockResolvedValueOnce([row('c1', 4)]);
+
+    await POST(makeRequest({ ids: ['c1', 'c1', 'c1'] }));
+
+    const inArrayArg = vi.mocked(mockLimit).mock.calls.length;
+    expect(inArrayArg).toBe(1);
+  });
+
+  it('given an empty id list, should answer empty without querying', async () => {
+    const response = await POST(makeRequest({ ids: [] }));
+    const body = await response.json();
+
+    expect(body).toEqual({ revs: {} });
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it('given non-string entries, should filter them out rather than pass them to the query', async () => {
+    mockLimit.mockResolvedValueOnce([row('c1', 4)]);
+
+    const response = await POST(makeRequest({ ids: ['c1', 42, null, { id: 'nope' }, ''] }));
+    const body = await response.json();
+
+    expect(body).toEqual({ revs: { c1: 4 } });
+  });
+
+  it('given `ids` that is not an array, should 400', async () => {
+    const response = await POST(makeRequest({ ids: 'c1' }));
+
+    expect(response.status).toBe(400);
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it('given invalid JSON, should 400', async () => {
+    const response = await POST(makeRequest('{not json'));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('given more ids than the ceiling, should 400 rather than run an unbounded IN', async () => {
+    const ids = Array.from({ length: 201 }, (_, i) => `c${i}`);
+
+    const response = await POST(makeRequest({ ids }));
+
+    expect(response.status).toBe(400);
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it('given auth fails, should return the auth error without querying', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthFailure());
+
+    const response = await POST(makeRequest({ ids: ['c1'] }));
+
+    expect(response.status).toBe(401);
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it('given the query throws, should 500 rather than leak the error', async () => {
+    mockLimit.mockRejectedValueOnce(new Error('db down'));
+
+    const response = await POST(makeRequest({ ids: ['c1'] }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('Failed to check conversation revs');
+  });
+});

--- a/apps/web/src/app/api/ai/conversations/revs/route.ts
+++ b/apps/web/src/app/api/ai/conversations/revs/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { inArray } from '@pagespace/db/operators';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { canAccessConversation } from '@pagespace/lib/permissions/conversation-access';
+
+/**
+ * `POST /api/ai/conversations/revs` — the reconnect watermark check
+ * (Agent-Session Single Source of Truth epic, Phase 2; spec
+ * `docs/2.0-architecture/agent-sessions.md` §3 clause 3).
+ *
+ * Broadcast transport is best-effort by design: a socket that was disconnected
+ * for ten seconds simply did not receive the events emitted in those ten
+ * seconds, and nothing will replay them. Correctness comes from the rev
+ * watermark, not from delivery — so on reconnect a client asks, in ONE
+ * round-trip for every conversation it is subscribed to, "what rev are these
+ * at?" and refetches only the ones whose answer disagrees with its watermark.
+ *
+ * POST, not GET: the id list is unbounded-ish (a session can have many panes
+ * open) and belongs in a body rather than a query string that proxies truncate
+ * and access logs retain.
+ *
+ * AUTHORIZATION is the shared `canAccessConversation` predicate — the same
+ * implementation the realtime `join_conversation` handler, `/stream-join` and
+ * `/active-streams` enforce, so the four cannot drift. Ids the caller may not
+ * access are simply ABSENT from the response rather than 403-ing the whole
+ * batch: a client asking about a conversation that was un-shared out from under
+ * it is an expected state (its room membership was kicked at the same moment),
+ * not an attack, and one stale id must not blind the client to the other
+ * nineteen. Absence is also not an oracle — a nonexistent id and a forbidden id
+ * are indistinguishable in the response.
+ */
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+/**
+ * Ceiling on ids per request. Comfortably above any real subscriber count (one
+ * per open pane) while keeping the `IN (...)` bounded — the findMany-limit rule's
+ * concern in query form.
+ */
+const MAX_IDS = 200;
+
+interface RevsRequestBody {
+  ids?: unknown;
+}
+
+export async function POST(request: Request) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        resourceType: 'ai_conversation',
+        resourceId: 'revs',
+        details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason },
+        riskScore: 0.5,
+      });
+      return auth.error;
+    }
+    const userId = auth.userId;
+
+    let body: RevsRequestBody;
+    try {
+      body = (await request.json()) as RevsRequestBody;
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (!Array.isArray(body.ids)) {
+      return NextResponse.json({ error: 'ids must be an array of conversation ids' }, { status: 400 });
+    }
+
+    // De-duplicated, string-only, bounded. A client that somehow asks about the
+    // same id twice gets one answer; anything non-string never reaches the query.
+    const ids = [...new Set(body.ids.filter((id): id is string => typeof id === 'string' && id.length > 0))];
+    if (ids.length === 0) {
+      return NextResponse.json({ revs: {} });
+    }
+    if (ids.length > MAX_IDS) {
+      return NextResponse.json({ error: `At most ${MAX_IDS} conversation ids per request` }, { status: 400 });
+    }
+
+    const rows = await db
+      .select({
+        id: conversations.id,
+        rev: conversations.rev,
+        userId: conversations.userId,
+        isShared: conversations.isShared,
+        type: conversations.type,
+        contextId: conversations.contextId,
+      })
+      .from(conversations)
+      .where(inArray(conversations.id, ids))
+      .limit(MAX_IDS);
+
+    const revs: Record<string, number> = {};
+    // Sequential rather than Promise.all: `canAccessConversation` short-circuits
+    // with NO io for the owner (the overwhelmingly common case here — a user's
+    // own panes), so the parallelism would only buy a fan-out of page-access
+    // queries for the rare shared row while costing an unbounded burst.
+    for (const row of rows) {
+      const allowed = await canAccessConversation(userId, {
+        userId: row.userId,
+        isShared: row.isShared,
+        type: row.type,
+        contextId: row.contextId,
+      });
+      if (allowed) revs[row.id] = row.rev;
+    }
+
+    auditRequest(request, {
+      eventType: 'data.read',
+      userId,
+      resourceType: 'ai_conversation',
+      resourceId: 'revs',
+      details: { action: 'check_revs', requested: ids.length, returned: Object.keys(revs).length },
+    });
+
+    return NextResponse.json({ revs });
+  } catch (error) {
+    loggers.api.error('Error checking conversation revs:', error as Error);
+    return NextResponse.json({ error: 'Failed to check conversation revs' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -145,6 +145,9 @@ export async function GET(
       return NextResponse.json({
         messages: [],
         pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 50, direction: 'before' },
+        // No row means no rev to hold a watermark against — the subscriber treats
+        // `null` as "no proven baseline" and refetches on any versioned event.
+        rev: null,
       });
     }
 
@@ -243,7 +246,13 @@ export async function GET(
         prevCursor,
         limit,
         direction
-      }
+      },
+      // The rev watermark this snapshot was read at (Agent-Session SSoT epic,
+      // Phase 2). The client holds it per cache entry and proves currency
+      // against every `conversation:*` event — see
+      // `apps/web/src/lib/realtime/conversation-apply.ts`. Read from the same
+      // row the ownership check above already fetched, so it costs no query.
+      rev: conversation.rev,
     });
   } catch (error) {
     loggers.api.error('Error fetching messages:', error as Error);

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -200,7 +200,14 @@ export async function GET(
         prevCursor,
         limit,
         direction
-      }
+      },
+      // The rev watermark this snapshot was read at (Agent-Session SSoT epic,
+      // Phase 2) — the client proves currency against every `conversation:*`
+      // event with it (`apps/web/src/lib/realtime/conversation-apply.ts`).
+      // `null` for a legacy page conversation with no `conversations` row: no
+      // row, no rev, so the subscriber has no baseline and refetches on doubt.
+      // Read from the row the access gate above already fetched.
+      rev: conversationRow?.rev ?? null,
     });
 
   } catch (error) {

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -62,6 +62,7 @@ import { useStopStream } from '@/hooks/useStopStream';
 import { useAuth } from '@/hooks/useAuth';
 import { useDriveStore } from '@/hooks/useDrive';
 import { useGlobalChatConversation } from '@/contexts/GlobalChatContext';
+import { useConversationSubscription } from '@/hooks/useConversationSubscription';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import type { UseAgentSessionChatReturn } from './useAgentSessionChat';
 
@@ -136,6 +137,14 @@ export function useAssistantSessionChat({
   // (or none) is looking. Its rejoin is the recovery hook the send handoff
   // needs.
   const { rejoinGlobalStream } = useGlobalChatConversation();
+
+  // The CONVERSATION plane, though, is this pane's own (Agent-Session SSoT
+  // epic, Phase 2): join `conv:<id>`, hold the rev watermark, apply the
+  // authoritative `conversation:*` events. `channelId: null` deliberately skips
+  // a second channel stream socket — the provider's is the one, and duplicating
+  // its bootstrap would buy nothing. This is what makes a server-side dispatch
+  // into an open global-assistant pane render live.
+  useConversationSubscription(conversationId, { channelId: null, agentPageId: null });
 
   const renderedMessages = useRenderedMessages(channelId ?? '', conversationId);
   const messages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -312,7 +312,17 @@ export default function AgentPanes({
   const { data: sessionsData, mutate: mutateSessionConversations } = useSWR(
     agentSessionsKey(driveId),
     sessionConversationsFetcher,
-    { revalidateOnFocus: false, refreshInterval: 20_000 },
+    {
+      revalidateOnFocus: false,
+      // BACKSTOP, not the mechanism (Agent-Session SSoT epic, Phase 2 / plan PR 4).
+      // `session-directory-listener.ts` now applies `conversation:created/updated/
+      // closed/reopened/deleted` and `session:*` to this exact cache the moment they
+      // happen, so the poll no longer carries the freshness of the listing — it only
+      // catches the case where a broadcast was lost entirely. Demoted from 20s to
+      // 120s; SLATED FOR DELETION at the epic's final contract PR, once the legacy
+      // `chat:*` emissions are gone and the directory plane is the only path.
+      refreshInterval: 120_000,
+    },
   );
   // THIS session's own entry, looked up once and reused for both the
   // conversation list and the readiness check below — a session that

--- a/apps/web/src/components/agents/panes/session-conversations.ts
+++ b/apps/web/src/components/agents/panes/session-conversations.ts
@@ -145,6 +145,107 @@ export function restoreSessionInCache<T extends { sessionId: string }>(mutate: S
 }
 
 /**
+ * Insert (or merge into) one conversation listing on `sessionId`'s row,
+ * everywhere — the event-driven twin of `AgentPanes.tsx`'s optimistic
+ * `recordMintedConversation`, for a `conversation:created` that this client did
+ * not originate (a worker spawned by an agent, a mint in another window).
+ *
+ * IDEMPOTENT BY ID, which is the whole point: the same conversation can reach a
+ * client twice — once through this listener and once through the originating
+ * surface's own optimistic write, or through the legacy
+ * `chat:global_conversation_added` path — and a second delivery must merge, never
+ * prepend a duplicate row. New rows go to the FRONT because the listings are
+ * most-recent-first and a just-created conversation is the most recent thing
+ * there is.
+ *
+ * Generic over the caller's row shape for the same reason
+ * `restoreSessionInCache` is: the pane grid's minimal `{conversationId,
+ * agentPageId, lastMessageAt}` and the sidebar's richer row are both valid
+ * members of this list, and this only needs `conversationId` to place one.
+ */
+export function upsertConversationInCache<T extends { conversationId: string }>(
+  mutate: ScopedMutator,
+  sessionId: string,
+  conversation: T,
+): void {
+  void mutate(
+    isSessionListingKey,
+    (current: { sessions: Array<{ sessionId: string; conversations: T[] }> } | undefined) => {
+      if (!current) return current;
+      return {
+        ...current,
+        sessions: current.sessions.map((session) => {
+          if (session.sessionId !== sessionId) return session;
+          const existing = session.conversations.find((c) => c.conversationId === conversation.conversationId);
+          return {
+            ...session,
+            conversations: existing
+              ? session.conversations.map((c) =>
+                  c.conversationId === conversation.conversationId ? { ...c, ...conversation } : c,
+                )
+              : [conversation, ...session.conversations],
+          };
+        }),
+      };
+    },
+    { revalidate: false },
+  );
+}
+
+/**
+ * Patch one conversation's `lastMessageAt` wherever it appears and re-sort its
+ * session's listing — what a `conversation:updated {lastMessageAt}` directory
+ * bump means for a most-recent-first list.
+ *
+ * Searched across every session rather than targeted at one, because the bump
+ * event carries the conversation's workspace but a client's cache may hold the
+ * row under a session it was claimed into since. A row that isn't there is
+ * simply not patched; nothing is invented (an unknown conversation belongs to
+ * the server's next listing, not to a guess made here).
+ */
+export function touchConversationInCache(
+  mutate: ScopedMutator,
+  conversationId: string,
+  lastMessageAt: string | null,
+): void {
+  void mutate(
+    isSessionListingKey,
+    (current: { sessions: Array<{ sessionId: string; conversations: SessionConversationSummary[] }> } | undefined) => {
+      if (!current) return current;
+      return {
+        ...current,
+        sessions: current.sessions.map((session) => {
+          if (!session.conversations.some((c) => c.conversationId === conversationId)) return session;
+          const patched = session.conversations.map((c) =>
+            c.conversationId === conversationId ? { ...c, lastMessageAt } : c,
+          );
+          return {
+            ...session,
+            conversations: [...patched].sort((a, b) => {
+              const aAt = a.lastMessageAt ? Date.parse(a.lastMessageAt) : -Infinity;
+              const bAt = b.lastMessageAt ? Date.parse(b.lastMessageAt) : -Infinity;
+              return bAt - aAt;
+            }),
+          };
+        }),
+      };
+    },
+    { revalidate: false },
+  );
+}
+
+/**
+ * Re-read every session listing from the server. The escape hatch for directory
+ * events whose payload cannot reconstruct a listing row — a reopen (the row left
+ * the cache when it closed, and the event carries no conversation body), a
+ * session lifecycle change, a workspace re-binding. Event-DRIVEN, not periodic:
+ * this is what makes the polls below it backstops rather than the mechanism.
+ */
+export function revalidateSessionListings(mutate: ScopedMutator): void {
+  void mutate(isAgentSessionsKey);
+}
+
+/**
  * Drop one conversation listing from `sessionId`'s row, everywhere — the
  * cross-file mirror of `AgentPanes.tsx`'s own `recordClosedConversation`,
  * for a caller (the sidebar) with no local SWR binding of its own. See

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -103,9 +103,15 @@ export default function AgentsSidebar({ className }: SidebarProps) {
     mutate: retrySessions,
   } = useSWR<{ sessions: SessionListEntry[] }>(sessionsKey, sessionsFetcher, {
     revalidateOnFocus: false,
-    // Modest poll: session/conversation rows change on spawn and end, which
-    // other tabs and agents can do. The pane grid itself never lives here.
-    refreshInterval: 20_000,
+    // BACKSTOP, not the mechanism (Agent-Session SSoT epic, Phase 2 / plan PR 4).
+    // Session/conversation rows change on spawn and end, which other tabs and
+    // agents can do — and those changes now ARRIVE, as
+    // `conversation:created/updated/closed/reopened/deleted` and `session:*` on the
+    // owner's `user:<id>:sessions` room, applied to this cache by
+    // `session-directory-listener.ts`. The poll only catches a broadcast lost
+    // outright. Demoted from 20s to 120s; SLATED FOR DELETION at the epic's final
+    // contract PR.
+    refreshInterval: 120_000,
   });
 
   // Unfiltered (no driveId arg) in BOTH modes now, not just global mode: a

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -27,6 +27,7 @@ import { loadGlobalConversationMessages, refreshConversationSnapshot } from '@/h
 import { buildConversationCacheHandlers } from '@/hooks/conversationCacheSocketHandlers';
 import { useConversationSubscription } from '@/hooks/useConversationSubscription';
 import { DerivedStreamingRegistrations } from '@/components/ai/shared/DerivedStreamingRegistrations';
+import { SessionDirectoryListener } from '@/lib/realtime/session-directory-listener';
 
 /**
  * Global Chat Context — two tiers to minimize re-render noise:
@@ -337,6 +338,11 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
             surface is currently showing (a bootstrapped stream keeps its own SWR protection while
             the user is on another page). */}
         <DerivedStreamingRegistrations />
+        {/* THE app-wide session/conversation DIRECTORY listener (SSoT epic, Phase 2 /
+            plan PR 4) — mounted here for the same reason as the line above: this
+            provider wraps the whole Layout, so one mount covers every sidebar and
+            pane strip, and N mounts would mean N revalidations per event. */}
+        <SessionDirectoryListener />
         {children}
       </GlobalChatConfigContext.Provider>
     </GlobalChatConversationContext.Provider>

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -25,6 +25,7 @@ import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
 import { loadGlobalConversationMessages, refreshConversationSnapshot } from '@/hooks/conversationMessagesLoaders';
 import { buildConversationCacheHandlers } from '@/hooks/conversationCacheSocketHandlers';
+import { useConversationSubscription } from '@/hooks/useConversationSubscription';
 import { DerivedStreamingRegistrations } from '@/components/ai/shared/DerivedStreamingRegistrations';
 
 /**
@@ -237,17 +238,27 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const userId = user?.id ?? null;
   const channelId = userId ? globalChannelId(userId) : null;
 
+  // THE STREAM PLANE ONLY (Agent-Session SSoT epic, Phase 2 / plan PR 3). This
+  // provider keeps the app-wide global-channel subscription because a stream must
+  // stay in the store even for a conversation no surface is currently showing —
+  // but it no longer handles the MESSAGE plane. `onUserMessage`/`onMessageEdited`/
+  // `onMessageDeleted` (the legacy `chat:*` fan-out) are superseded by the
+  // authoritative `conversation:message_*` events, which arrive on the
+  // conversation's own room and are applied — rev-gated — by
+  // `useConversationSubscription`. Only `onStreamComplete` is kept from the shared
+  // cache protocol: it is stream lifecycle, not message content, and it is what
+  // keeps a finished reply from flashing out when the mirror releases.
+  //
+  // NO useChat dual-write here: this provider cannot reach the surfaces'
+  // transport instances, and post-cutover their arrays are bookkeeping only — the
+  // surfaces re-seed the transport at the actions that need it (retry, ask_user).
+  const { onStreamComplete } = buildConversationCacheHandlers({
+    reloadConversation: loadGlobalConversationMessages,
+    refreshSnapshot: (conversationId) => refreshConversationSnapshot(null, conversationId),
+  });
+
   const { rejoinActiveStreams: rejoinGlobalStream } = useChannelStreamSocket(channelId ?? undefined, {
-    // P2-P4 + P6: the shared socket-events → cache protocol (one implementation with
-    // the agent channels — see buildConversationCacheHandlers for the commit/promote/
-    // heal semantics). NO useChat dual-write here, unlike AiChatView: this provider
-    // cannot reach the surfaces' transport instances, and post-cutover their arrays
-    // are bookkeeping only — the surfaces re-seed the transport at the actions that
-    // need it (retry, ask_user answers).
-    ...buildConversationCacheHandlers({
-      reloadConversation: loadGlobalConversationMessages,
-      refreshSnapshot: (conversationId) => refreshConversationSnapshot(null, conversationId),
-    }),
+    onStreamComplete,
     // P5: a remote tab's undo restructures the conversation wholesale — reload the
     // cache entry. Guard kept as the pure fn (cross-conversation + own-tab).
     onUndoApplied: (payload) => {
@@ -258,6 +269,15 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
       setLatestGlobalConversationAdded(payload);
     },
   });
+
+  // The MESSAGE plane for whichever global conversation the app is currently on
+  // — the surfaces that render it in "global mode" (the dashboard assistant, the
+  // sidebar chat tab) read their conversation id from this provider and mount no
+  // subscription of their own, so this is theirs. Panes are different: each one
+  // subscribes to its own conversation through `useAssistantSessionChat` /
+  // `useAgentSessionChat`. Duplicate delivery across the two is harmless — every
+  // cache action is idempotent by construction.
+  useConversationSubscription(currentConversationId, { channelId: null, agentPageId: null });
 
   const apiEndpoint = currentConversationId ? `/api/ai/global/${currentConversationId}/messages` : '';
   const transport = useChatTransport(currentConversationId, apiEndpoint, channelId);

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -850,21 +850,39 @@ describe('GlobalChatProvider — global channel stream socket', () => {
     await waitFor(() => expect(messagesFetchCount(CONV_ID)).toBeGreaterThan(loadsBefore));
   });
 
-  // cross-tab user_message — a TARGETED cache write, not a whole-conversation refetch
-  it('given chat:user_message from another browser session for the active conversation, should append it to the conversation cache directly', async () => {
+  // cross-surface message delivery — a TARGETED cache write, not a whole-conversation refetch.
+  //
+  // The event is `conversation:message_created`, not the legacy `chat:user_message`
+  // (Agent-Session SSoT epic, Phase 2 / plan PR 3): this provider no longer wires the
+  // `chat:*` message fan-out at all. The MESSAGE plane belongs to
+  // `useConversationSubscription`, which the provider mounts for whichever global
+  // conversation is current, and every write goes through the rev watermark — so a
+  // contiguous rev is what makes the write happen, and it is what a redelivery is
+  // then measured against.
+  const revEnvelopeFetch = (rev: number) => (url: string) =>
+    url.includes('/messages')
+      ? okResponse({ messages: [], pagination: { hasMore: false, nextCursor: null }, rev })
+      : defaultFetch(url);
+
+  it('given conversation:message_created at the next rev for the active conversation, should append it to the conversation cache directly and advance the watermark', async () => {
+    mockFetchWithAuth.mockImplementation(revEnvelopeFetch(7));
+
     const { result } = renderProvider();
 
     await waitFor(() => expect(result.current.currentConversationId).toBe(CONV_ID));
-    await waitFor(() => expect(mockSocket._handlerCount('chat:user_message')).toBeGreaterThan(0));
+    // The load has to have COMMITTED its rev before the event lands — an event
+    // against a `null` watermark is a refetch by design, not a direct write.
+    await waitFor(() => expect(cacheEntry(CONV_ID).rev).toBe(7));
+    await waitFor(() => expect(mockSocket._handlerCount('conversation:message_created')).toBeGreaterThan(0));
 
     const loadsBefore = messagesFetchCount(CONV_ID);
     const remoteUser = { id: 'msg-remote-user', role: 'user', parts: [{ type: 'text', text: 'remote prompt' }] };
 
     act(() => {
-      mockSocket._trigger('chat:user_message', {
-        message: remoteUser,
-        pageId: GLOBAL_CHANNEL_ID,
+      mockSocket._trigger('conversation:message_created', {
         conversationId: CONV_ID,
+        message: remoteUser,
+        rev: 8,
         triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
       });
     });
@@ -872,21 +890,24 @@ describe('GlobalChatProvider — global channel stream socket', () => {
     await waitFor(() => expect(cacheEntry(CONV_ID).messages).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: 'msg-remote-user' })]),
     ));
+    expect(cacheEntry(CONV_ID).rev).toBe(8);
     // Direct write — no refetch round-trip.
     expect(messagesFetchCount(CONV_ID)).toBe(loadsBefore);
   });
 
-  it('given chat:user_message for a different conversation, should NOT write the active conversation cache', async () => {
+  it('given conversation:message_created for a different conversation, should NOT write the active conversation cache', async () => {
+    mockFetchWithAuth.mockImplementation(revEnvelopeFetch(7));
+
     const { result } = renderProvider();
 
     await waitFor(() => expect(result.current.currentConversationId).toBe(CONV_ID));
-    await waitFor(() => expect(mockSocket._handlerCount('chat:user_message')).toBeGreaterThan(0));
+    await waitFor(() => expect(mockSocket._handlerCount('conversation:message_created')).toBeGreaterThan(0));
 
     act(() => {
-      mockSocket._trigger('chat:user_message', {
-        message: { id: 'msg-stale', role: 'user', parts: [{ type: 'text', text: 'wrong conv' }] },
-        pageId: GLOBAL_CHANNEL_ID,
+      mockSocket._trigger('conversation:message_created', {
         conversationId: 'conv-different',
+        message: { id: 'msg-stale', role: 'user', parts: [{ type: 'text', text: 'wrong conv' }] },
+        rev: 8,
         triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
       });
     });

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -13,6 +13,11 @@ const {
   mockUseStreamingRegistration,
   mockAbortByMessageId,
   mockSocketStatus,
+  mockSocket,
+  mockRegisterConversationWatch,
+  mockUnregisterConversationWatch,
+  mockSyncWatchedConversationRevs,
+  mockHealConversationToRev,
   pendingStreams,
 } = vi.hoisted(() => {
   const ref: { channelId: string | undefined; options: UseChannelStreamSocketOptions | undefined } = {
@@ -26,6 +31,11 @@ const {
     mockUseStreamingRegistration: vi.fn(),
     mockAbortByMessageId: vi.fn(),
     mockSocketStatus: { current: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error' },
+    mockSocket: { current: null as { on: (e: string, h: () => void) => void; off: (e: string, h: () => void) => void; emit: (e: string, p?: unknown) => void } | null },
+    mockRegisterConversationWatch: vi.fn(),
+    mockUnregisterConversationWatch: vi.fn(),
+    mockSyncWatchedConversationRevs: vi.fn().mockResolvedValue(undefined),
+    mockHealConversationToRev: vi.fn().mockResolvedValue(undefined),
     pendingStreams: { current: new Map<string, { messageId: string; pageId: string; conversationId: string; triggeredBy: { userId: string; displayName: string }; parts: UIMessage['parts']; isOwn: boolean }>() },
   };
 });
@@ -41,6 +51,21 @@ vi.mock('@/hooks/useChannelStreamSocket', () => ({
 
 vi.mock('@/hooks/usePageSocketRoom', () => ({
   usePageSocketRoom: mockUsePageSocketRoom,
+}));
+
+// The wrapper now delegates to useConversationSubscription, which joins the
+// conversation's own room and registers for the batched reconnect rev check. Neither
+// is what THIS suite is about (see useConversationSubscription.test.ts for both), but
+// both need to exist for the wrapper to render.
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => mockSocket.current,
+}));
+
+vi.mock('@/lib/realtime/conversation-rev-sync', () => ({
+  registerConversationWatch: mockRegisterConversationWatch,
+  unregisterConversationWatch: mockUnregisterConversationWatch,
+  syncWatchedConversationRevs: mockSyncWatchedConversationRevs,
+  healConversationToRev: mockHealConversationToRev,
 }));
 
 vi.mock('@/stores/useSocketStore', () => ({
@@ -63,12 +88,18 @@ vi.mock('@/lib/ai/core/stream-abort-client', () => ({
   abortActiveStreamByMessageId: mockAbortByMessageId,
 }));
 
-const { mockLoadAgentConversationMessages, mockRefreshConversationSnapshot } = vi.hoisted(() => ({
+const {
+  mockLoadAgentConversationMessages,
+  mockLoadGlobalConversationMessages,
+  mockRefreshConversationSnapshot,
+} = vi.hoisted(() => ({
   mockLoadAgentConversationMessages: vi.fn().mockResolvedValue(undefined),
+  mockLoadGlobalConversationMessages: vi.fn().mockResolvedValue(undefined),
   mockRefreshConversationSnapshot: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@/hooks/conversationMessagesLoaders', () => ({
   loadAgentConversationMessages: mockLoadAgentConversationMessages,
+  loadGlobalConversationMessages: mockLoadGlobalConversationMessages,
   refreshConversationSnapshot: mockRefreshConversationSnapshot,
 }));
 
@@ -103,6 +134,7 @@ describe('useAgentChannelMultiplayer', () => {
     capturedChannel.channelId = undefined;
     capturedChannel.options = undefined;
     mockSocketStatus.current = 'disconnected';
+    mockSocket.current = null;
     pendingStreams.current = new Map();
     useConversationMessagesStore.setState({ byConversationId: {} });
   });
@@ -138,9 +170,10 @@ describe('useAgentChannelMultiplayer', () => {
       ...overrides,
     });
 
-    // Dispatch is entry-gated (hasEntry): a rendering surface always loads or
-    // seeds its conversation on mount, so the tests seed what a mounted pane
-    // would have.
+    // Dispatch is by the event's own conversation, with NO entry gate (the
+    // `hasEntry` early-returns were deleted in the SSoT epic's Phase 2 —
+    // subscribe-on-open makes them unnecessary). The seed here is simply what a
+    // mounted pane would have.
     beforeEach(() => {
       useConversationMessagesStore.getState().seedConversation('conv-active');
     });
@@ -213,7 +246,16 @@ describe('useAgentChannelMultiplayer', () => {
       ]);
     });
 
-    it('given a stream finalizes for an UNCACHED conversation, nothing should be committed anywhere (no surface renders it; its eventual loader fetches the DB truth)', () => {
+    // GATE DELETED (SSoT epic Phase 2 / plan PR 3). This used to assert that a
+    // completion for an UNCACHED conversation committed nowhere, on the reasoning
+    // "nothing renders it, so its eventual loader will fetch the DB truth". The
+    // reasoning had a hole the size of the epic's canonical bug: the entry is
+    // created by an ASYNCHRONOUS load, so a pane that had mounted but not yet
+    // committed its first fetch looked exactly like "nobody is watching" and its
+    // reply was dropped with nothing to re-deliver it. The write now lands, and
+    // the conversation it lands in is the event's own — the active conversation is
+    // untouched either way.
+    it('given a stream finalizes for an UNCACHED conversation, it should still commit into THAT conversation (no hasEntry gate)', () => {
       pendingStreams.current = new Map([[ 'msg-stale', streamFixture({
         messageId: 'msg-stale',
         conversationId: 'conv-uncached',
@@ -226,7 +268,9 @@ describe('useAgentChannelMultiplayer', () => {
       });
 
       expect(cacheMessages('conv-active')).toEqual([]);
-      expect(cacheMessages('conv-uncached')).toEqual([]);
+      expect(cacheMessages('conv-uncached')).toEqual([
+        { id: 'msg-stale', role: 'assistant', parts: [{ type: 'text', text: 'final response text' }], status: 'complete' },
+      ]);
     });
 
     // THE pane multiplayer fix: dispatch is by the EVENT's conversation, so a
@@ -411,7 +455,11 @@ describe('useAgentChannelMultiplayer', () => {
       expect(cacheMessages('conv-active')).toEqual([remoteUser]);
     });
 
-    it('given onUserMessage fires for an UNCACHED conversationId, should write nothing anywhere', () => {
+    // GATE DELETED (SSoT epic Phase 2 / plan PR 3) — same reasoning as the
+    // uncached-completion case above: "uncached" and "mounted but still loading"
+    // are indistinguishable, and dropping the second is the blank-pane bug. The
+    // append lands in the event's OWN conversation and nowhere else.
+    it('given onUserMessage fires for an UNCACHED conversationId, should still append to THAT conversation', () => {
       renderWiring(baseOptions({ selectedAgent: AGENT, agentConversationId: 'conv-active' }));
 
       act(() => {
@@ -419,7 +467,7 @@ describe('useAgentChannelMultiplayer', () => {
       });
 
       expect(cacheMessages('conv-active')).toEqual([]);
-      expect(cacheMessages('conv-uncached')).toEqual([]);
+      expect(cacheMessages('conv-uncached')).toEqual([remoteUser]);
     });
 
     // The pane multiplayer gap this PR closes for non-completion events too: a

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -647,12 +647,21 @@ describe('useChannelStreamSocket', () => {
     });
   });
 
-  // A page room holds every member of the page, but conversations are private by default
-  // (`listConversations` shows you only `userId = you OR isShared`). The server refuses
-  // these joins anyway; skipping them client-side is what stops every member firing a
-  // doomed /stream-join per assistant message — each one an authz denial in the audit log.
-  describe('chat:stream_start — conversation privacy pre-filter', () => {
-    it("given another user's stream in a PRIVATE conversation, should not attach or even attempt the join", () => {
+  // GATE DELETED (Agent-Session SSoT epic, Phase 2 / plan PR 3). There used to be a
+  // client-side "conversation privacy pre-filter" here: drop a `chat:stream_start`
+  // whose `triggeredBy.userId` is not mine when `isShared === false`, to save a
+  // /stream-join the server would refuse anyway.
+  //
+  // It was wrong about "not mine". `triggeredBy.userId` is the ACTOR, and a
+  // server-side dispatch (send_session, a workflow, the /help short-circuit) acts as
+  // whoever it acts as -- so the user's OWN private conversation, written on their
+  // behalf from another surface, matched the filter and every pane showing it went
+  // dark. That is the epic's canonical blank-pane bug in its stream-plane half.
+  //
+  // These tests now pin the ABSENCE of the filter: every start attaches, and the
+  // server (which re-authorizes every join with `canAccessConversation`) decides.
+  describe('chat:stream_start -- no client-side privacy pre-filter', () => {
+    it("given another user's stream in a PRIVATE conversation, should still attach and let the server refuse the join", () => {
       renderHook(() => useChannelStreamSocket('page-a'));
 
       act(() => {
@@ -663,8 +672,11 @@ describe('useChannelStreamSocket', () => {
         });
       });
 
-      expect(mockAddStream).not.toHaveBeenCalled();
-      expect(mockConsumeStreamJoin).not.toHaveBeenCalled();
+      // A refused join is a quiet 404 the hook already handles benignly -- and the
+      // conversation-scoped bootstrap in useConversationSubscription is what actually
+      // keeps a pane from asking about streams it has no business in.
+      expect(mockAddStream).toHaveBeenCalled();
+      expect(mockConsumeStreamJoin).toHaveBeenCalledTimes(1);
     });
 
     it("given another user's stream in an explicitly SHARED conversation, should attach (multiplayer)", () => {
@@ -682,7 +694,7 @@ describe('useChannelStreamSocket', () => {
       expect(mockConsumeStreamJoin).toHaveBeenCalledTimes(1);
     });
 
-    // The same user in a second tab: a different browserSessionId, so `isOwn` is false —
+    // The same user in a second tab: a different browserSessionId, so `isOwn` is false --
     // but it is still THEIR stream and their private conversation. They must see it.
     it('given MY OWN stream from another tab in a private conversation, should still attach', () => {
       renderHook(() => useChannelStreamSocket('page-a'));
@@ -699,19 +711,18 @@ describe('useChannelStreamSocket', () => {
       expect(mockConsumeStreamJoin).toHaveBeenCalledTimes(1);
     });
 
-    // `useAuth()` returns `user: null` until auth resolves. Treating "I don't know who I
-    // am" as "not me" would drop the user's OWN private stream in that window — the exact
-    // failure this whole PR exists to fix. Skip only on certainty; when in doubt, attach
-    // and let the server decide (an unauthorized join is a quiet 404).
-    it('given the signed-in user is not known yet, should NOT drop a private stream (it may be the user\'s own)', () => {
-      mockAuthUserId = null;
+    // The dispatch case the old filter broke: a server-side write attributed to a
+    // DIFFERENT user id in the caller's own private conversation. Nothing about the
+    // payload distinguishes it from "somebody else's private chat" -- which is exactly
+    // why the client cannot be the one deciding.
+    it('given a server dispatch in a private conversation attributed to another actor, should attach', () => {
       renderHook(() => useChannelStreamSocket('page-a'));
 
       act(() => {
         mockSocket._trigger('chat:stream_start', {
           ...START_PAYLOAD,
           isShared: false,
-          triggeredBy: { userId: LOCAL_USER_ID, displayName: 'Me', browserSessionId: 'another-tab' },
+          triggeredBy: { userId: 'user-other', displayName: 'Agent', browserSessionId: 'agent-dispatch-xyz' },
         });
       });
 
@@ -719,10 +730,7 @@ describe('useChannelStreamSocket', () => {
       expect(mockConsumeStreamJoin).toHaveBeenCalledTimes(1);
     });
 
-    // Rolling deploy: an originator on the previous build emits no `isShared` field.
-    // Dropping on `undefined` would black out multiplayer for shared conversations
-    // mid-deploy, so only an explicit `false` skips. The server is the authority anyway.
-    it('given no isShared field at all (old server, rolling deploy), should attempt the join rather than drop it', () => {
+    it('given no isShared field at all (old server, rolling deploy), should attach', () => {
       renderHook(() => useChannelStreamSocket('page-a'));
 
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });

--- a/apps/web/src/hooks/__tests__/useConversationSubscription.test.ts
+++ b/apps/web/src/hooks/__tests__/useConversationSubscription.test.ts
@@ -1,0 +1,450 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+
+/**
+ * `useConversationSubscription` — the four things it owns, one describe each:
+ * ensure-an-entry (which is what lets the `hasEntry` gates be deleted), join the
+ * conversation room, apply events through the rev rule, and prove currency on
+ * reconnect with ONE batched request.
+ *
+ * The pure decision table itself lives in
+ * `src/lib/realtime/__tests__/conversation-apply.test.ts` and is not re-tested
+ * here; this suite pins that the hook actually consults it and does the right IO
+ * with each answer.
+ */
+
+const {
+  mockSocket,
+  socketHandlers,
+  emitted,
+  mockSocketStatus,
+  mockLoadAgent,
+  mockLoadGlobal,
+  mockRefreshSnapshot,
+  mockHealConversationToRev,
+  mockRegisterWatch,
+  mockUnregisterWatch,
+  mockSyncRevs,
+  capturedStreamSocket,
+} = vi.hoisted(() => {
+  const handlers = new Map<string, Array<(payload: unknown) => void>>();
+  const emittedEvents: Array<{ event: string; payload: unknown }> = [];
+  const socket = {
+    on: (event: string, handler: (payload: unknown) => void) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    off: (event: string, handler: (payload: unknown) => void) => {
+      const list = (handlers.get(event) ?? []).filter((h) => h !== handler);
+      handlers.set(event, list);
+    },
+    emit: (event: string, payload?: unknown) => {
+      emittedEvents.push({ event, payload });
+    },
+  };
+  return {
+    mockSocket: { current: socket as typeof socket | null },
+    socketHandlers: handlers,
+    emitted: emittedEvents,
+    mockSocketStatus: { current: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error' },
+    mockLoadAgent: vi.fn().mockResolvedValue(undefined),
+    mockLoadGlobal: vi.fn().mockResolvedValue(undefined),
+    mockRefreshSnapshot: vi.fn().mockResolvedValue(undefined),
+    mockHealConversationToRev: vi.fn().mockResolvedValue(undefined),
+    mockRegisterWatch: vi.fn(),
+    mockUnregisterWatch: vi.fn(),
+    mockSyncRevs: vi.fn().mockResolvedValue(undefined),
+    capturedStreamSocket: {
+      channelId: undefined as string | undefined,
+      bootstrapConversationId: undefined as string | null | undefined,
+    },
+  };
+});
+
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => mockSocket.current }));
+
+vi.mock('@/stores/useSocketStore', () => ({
+  useSocketStore: vi.fn((selector: (s: { connectionStatus: string }) => unknown) =>
+    selector({ connectionStatus: mockSocketStatus.current }),
+  ),
+}));
+
+vi.mock('@/hooks/useChannelStreamSocket', () => ({
+  useChannelStreamSocket: (
+    channelId: string | undefined,
+    _options: unknown,
+    bootstrapConversationId?: string | null,
+  ) => {
+    capturedStreamSocket.channelId = channelId;
+    capturedStreamSocket.bootstrapConversationId = bootstrapConversationId;
+    return { rejoinActiveStreams: vi.fn() };
+  },
+}));
+
+vi.mock('@/hooks/conversationMessagesLoaders', () => ({
+  loadAgentConversationMessages: mockLoadAgent,
+  loadGlobalConversationMessages: mockLoadGlobal,
+  refreshConversationSnapshot: mockRefreshSnapshot,
+}));
+
+vi.mock('@/lib/realtime/conversation-rev-sync', () => ({
+  healConversationToRev: mockHealConversationToRev,
+  registerConversationWatch: mockRegisterWatch,
+  unregisterConversationWatch: mockUnregisterWatch,
+  syncWatchedConversationRevs: mockSyncRevs,
+}));
+
+// Real store: what lands in the cache IS the behavior under test.
+import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
+import { useConversationSubscription } from '../useConversationSubscription';
+
+const CONV = 'conv-1';
+const AGENT_PAGE = 'agent-page-1';
+
+const assistant = (id: string, text: string): UIMessage =>
+  ({ id, role: 'assistant', parts: [{ type: 'text', text }] }) as UIMessage;
+
+const fire = (event: string, payload: unknown) => {
+  act(() => {
+    for (const handler of socketHandlers.get(event) ?? []) handler(payload);
+  });
+};
+
+const entry = (conversationId: string) =>
+  useConversationMessagesStore.getState().getEntry(conversationId);
+
+/** Seed a conversation as loaded at a known watermark, the way a message-list GET does. */
+const seedAt = (conversationId: string, rev: number | null, messages: UIMessage[] = []) => {
+  const store = useConversationMessagesStore.getState();
+  const generation = store.startLoad(conversationId);
+  store.applyLoad(conversationId, generation, messages, undefined, rev);
+};
+
+const render = (conversationId: string | null, agentPageId: string | null = AGENT_PAGE, channelId?: string | null) =>
+  renderHook(() => useConversationSubscription(conversationId, { channelId, agentPageId }));
+
+describe('useConversationSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+    emitted.length = 0;
+    mockSocketStatus.current = 'disconnected';
+    capturedStreamSocket.channelId = undefined;
+    capturedStreamSocket.bootstrapConversationId = undefined;
+    useConversationMessagesStore.setState({ byConversationId: {} });
+  });
+
+  describe('subscribe-on-open (what replaces the hasEntry gate)', () => {
+    it('given a conversation with no cache entry, should kick the loader so an entry exists before any event can arrive', () => {
+      render(CONV);
+
+      expect(mockLoadAgent).toHaveBeenCalledWith(AGENT_PAGE, CONV);
+    });
+
+    it('given no agent page (a global-assistant conversation), should kick the GLOBAL loader', () => {
+      render(CONV, null);
+
+      expect(mockLoadGlobal).toHaveBeenCalledWith(CONV);
+      expect(mockLoadAgent).not.toHaveBeenCalled();
+    });
+
+    it('given the conversation is already cached, should not re-fetch it', () => {
+      seedAt(CONV, 3);
+
+      render(CONV);
+
+      expect(mockLoadAgent).not.toHaveBeenCalled();
+    });
+
+    it('given no conversation id, should do nothing at all', () => {
+      render(null);
+
+      expect(mockLoadAgent).not.toHaveBeenCalled();
+      expect(emitted).toEqual([]);
+    });
+  });
+
+  describe('conversation room membership', () => {
+    it('should join `conv:<id>` on mount', () => {
+      render(CONV);
+
+      expect(emitted).toContainEqual({ event: 'join_conversation', payload: CONV });
+    });
+
+    it('should re-join on every reconnect — socket.io restores no rooms', () => {
+      render(CONV);
+      emitted.length = 0;
+
+      act(() => {
+        for (const handler of socketHandlers.get('connect') ?? []) handler(undefined);
+      });
+
+      expect(emitted).toEqual([{ event: 'join_conversation', payload: CONV }]);
+    });
+
+    it('should leave the room on unmount', () => {
+      const { unmount } = render(CONV);
+      emitted.length = 0;
+
+      unmount();
+
+      expect(emitted).toContainEqual({ event: 'leave_conversation', payload: CONV });
+    });
+
+    it('given the conversation id changes, should leave the old room and join the new one', () => {
+      const { rerender } = renderHook(
+        ({ id }: { id: string }) => useConversationSubscription(id, { agentPageId: AGENT_PAGE }),
+        { initialProps: { id: CONV } },
+      );
+      emitted.length = 0;
+
+      rerender({ id: 'conv-2' });
+
+      expect(emitted).toEqual([
+        { event: 'leave_conversation', payload: CONV },
+        { event: 'join_conversation', payload: 'conv-2' },
+      ]);
+    });
+  });
+
+  describe('conversation:message_created / _updated — the rev rule in action', () => {
+    it('given the contiguous next rev, should upsert the message and advance the watermark', () => {
+      seedAt(CONV, 4);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: CONV,
+        rev: 5,
+        message: assistant('m-1', 'pong'),
+      });
+
+      expect(entry(CONV).messages).toEqual([assistant('m-1', 'pong')]);
+      expect(entry(CONV).rev).toBe(5);
+    });
+
+    it('given a rev at or below the watermark, should drop it — no write, no fetch', () => {
+      seedAt(CONV, 5);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: CONV,
+        rev: 5,
+        message: assistant('m-1', 'already have this'),
+      });
+
+      expect(entry(CONV).messages).toEqual([]);
+      expect(mockHealConversationToRev).not.toHaveBeenCalled();
+    });
+
+    it('given a GAP, should refetch rather than patch a cache it cannot prove current', () => {
+      seedAt(CONV, 4);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: CONV,
+        rev: 9,
+        message: assistant('m-1', 'from the future'),
+      });
+
+      expect(entry(CONV).messages).toEqual([]);
+      expect(mockHealConversationToRev).toHaveBeenCalledWith(CONV, AGENT_PAGE, 9);
+    });
+
+    it('given a TRUNCATED payload (the message was too large to inline), should refetch', () => {
+      seedAt(CONV, 4);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: CONV,
+        rev: 5,
+        truncated: true,
+        messageRef: { id: 'm-huge', role: 'assistant', status: 'complete', createdAt: '2024-01-01T00:00:00.000Z' },
+      });
+
+      expect(entry(CONV).messages).toEqual([]);
+      expect(mockHealConversationToRev).toHaveBeenCalledWith(CONV, AGENT_PAGE, 5);
+    });
+
+    it('given an event for a DIFFERENT conversation, should ignore it entirely', () => {
+      seedAt(CONV, 4);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: 'conv-other',
+        rev: 5,
+        message: assistant('m-1', 'not mine'),
+      });
+
+      expect(entry(CONV).messages).toEqual([]);
+      expect(entry('conv-other').messages).toEqual([]);
+      expect(mockHealConversationToRev).not.toHaveBeenCalled();
+    });
+
+    // The dispatch case: the pane's own optimistic send, then the server's echo of
+    // the very same id. Upsert-by-id means the echo reconciles rather than duplicates.
+    it('given the echo of this pane\'s own optimistic send, should reconcile it instead of duplicating', () => {
+      seedAt(CONV, 4);
+      const own = { id: 'u-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] } as UIMessage;
+      useConversationMessagesStore.getState().addOptimisticSend(CONV, own);
+      render(CONV);
+
+      fire('conversation:message_created', { conversationId: CONV, rev: 5, message: own });
+
+      expect(entry(CONV).messages).toEqual([own]);
+      expect(entry(CONV).optimisticSends).toEqual([]);
+    });
+
+    it('given `_updated` for a row already in the cache, should REPLACE it (a streaming placeholder becoming the final reply)', () => {
+      seedAt(CONV, 4, [assistant('m-1', 'half-writ')]);
+      render(CONV);
+
+      fire('conversation:message_updated', {
+        conversationId: CONV,
+        rev: 5,
+        message: assistant('m-1', 'the whole reply'),
+      });
+
+      expect(entry(CONV).messages).toEqual([assistant('m-1', 'the whole reply')]);
+    });
+
+    it('given no watermark yet (the load has not committed one), should refetch rather than guess', () => {
+      seedAt(CONV, null);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: CONV,
+        rev: 1,
+        message: assistant('m-1', 'first'),
+      });
+
+      expect(mockHealConversationToRev).toHaveBeenCalledWith(CONV, AGENT_PAGE, 1);
+    });
+
+    it('given an UNVERSIONED event (rev 0 — a conversation with no row), should apply it and leave the watermark alone', () => {
+      seedAt(CONV, 7);
+      render(CONV);
+
+      fire('conversation:message_created', {
+        conversationId: CONV,
+        rev: 0,
+        message: assistant('m-1', 'legacy page conversation'),
+      });
+
+      expect(entry(CONV).messages).toEqual([assistant('m-1', 'legacy page conversation')]);
+      expect(entry(CONV).rev).toBe(7);
+    });
+
+    it('given an apply-decision payload carrying no message at all (an emitter we do not know), should refetch instead of writing junk', () => {
+      seedAt(CONV, 4);
+      render(CONV);
+
+      fire('conversation:message_created', { conversationId: CONV, rev: 5 });
+
+      expect(entry(CONV).messages).toEqual([]);
+      expect(mockHealConversationToRev).toHaveBeenCalledWith(CONV, AGENT_PAGE, 5);
+    });
+  });
+
+  describe('conversation:message_deleted', () => {
+    it('given the contiguous next rev, should delete the row and advance the watermark', () => {
+      seedAt(CONV, 4, [assistant('m-1', 'doomed'), assistant('m-2', 'survivor')]);
+      render(CONV);
+
+      fire('conversation:message_deleted', { conversationId: CONV, rev: 5, messageId: 'm-1' });
+
+      expect(entry(CONV).messages.map((m) => m.id)).toEqual(['m-2']);
+      expect(entry(CONV).rev).toBe(5);
+    });
+
+    it('given a stale rev, should drop it', () => {
+      seedAt(CONV, 5, [assistant('m-1', 'still here')]);
+      render(CONV);
+
+      fire('conversation:message_deleted', { conversationId: CONV, rev: 3, messageId: 'm-1' });
+
+      expect(entry(CONV).messages.map((m) => m.id)).toEqual(['m-1']);
+    });
+
+    it('given a gap, should refetch rather than delete blind', () => {
+      seedAt(CONV, 4, [assistant('m-1', 'still here')]);
+      render(CONV);
+
+      fire('conversation:message_deleted', { conversationId: CONV, rev: 12, messageId: 'm-1' });
+
+      expect(entry(CONV).messages.map((m) => m.id)).toEqual(['m-1']);
+      expect(mockHealConversationToRev).toHaveBeenCalledWith(CONV, AGENT_PAGE, 12);
+    });
+  });
+
+  describe('conversation:undo_applied', () => {
+    it('should refetch — an undo restructures the conversation, there is no patch to apply', () => {
+      seedAt(CONV, 4);
+      render(CONV);
+
+      fire('conversation:undo_applied', {
+        conversationId: CONV,
+        rev: 5,
+        mode: 'messages_only',
+        affectedMessageIds: ['m-1'],
+      });
+
+      expect(mockHealConversationToRev).toHaveBeenCalledWith(CONV, AGENT_PAGE, 5);
+    });
+
+    it('given a redelivered undo below the watermark, should not pay for a fetch', () => {
+      seedAt(CONV, 9);
+      render(CONV);
+
+      fire('conversation:undo_applied', {
+        conversationId: CONV,
+        rev: 5,
+        mode: 'messages_only',
+        affectedMessageIds: ['m-1'],
+      });
+
+      expect(mockHealConversationToRev).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reconnect: one batched rev check for every subscription', () => {
+    it('should register the conversation in the shared watch registry on mount and unregister on unmount', () => {
+      const { unmount } = render(CONV);
+      expect(mockRegisterWatch).toHaveBeenCalledWith(CONV, AGENT_PAGE);
+
+      unmount();
+      expect(mockUnregisterWatch).toHaveBeenCalledWith(CONV);
+    });
+
+    it('given the socket goes connected → disconnected → connected, should run the batched rev sync exactly once', () => {
+      const { rerender } = renderHook(() => useConversationSubscription(CONV, { agentPageId: AGENT_PAGE }));
+
+      mockSocketStatus.current = 'connected';
+      rerender();
+      expect(mockSyncRevs).not.toHaveBeenCalled(); // the FIRST connect is covered by the mount load
+
+      mockSocketStatus.current = 'disconnected';
+      rerender();
+      mockSocketStatus.current = 'connected';
+      rerender();
+
+      expect(mockSyncRevs).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stream plane hand-off', () => {
+    it('given a channel id, should bootstrap the channel socket SCOPED to this conversation', () => {
+      render(CONV, AGENT_PAGE, AGENT_PAGE);
+
+      expect(capturedStreamSocket.channelId).toBe(AGENT_PAGE);
+      expect(capturedStreamSocket.bootstrapConversationId).toBe(CONV);
+    });
+
+    it('given NO channel id (a global pane riding the app-wide provider subscription), should mount no channel socket', () => {
+      render(CONV, null, null);
+
+      expect(capturedStreamSocket.channelId).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/hooks/conversationCacheSocketHandlers.ts
+++ b/apps/web/src/hooks/conversationCacheSocketHandlers.ts
@@ -23,22 +23,28 @@ export interface ConversationCacheHandlerDeps {
 
 /**
  * The ONE socket-events → conversation-cache protocol (F10, PR #2098 review),
- * shared by GlobalChatContext (global channel) and useAgentChannelMultiplayer
- * (agent channels) so the two paths cannot drift. AiChatView keeps its own
- * handlers: it additionally dual-writes into its useChat transport, which
- * neither of these subscribers can reach.
+ * shared by GlobalChatContext (global channel) and useConversationSubscription
+ * (per-conversation) so the paths cannot drift.
  *
  * DISPATCH IS BY THE EVENT'S CONVERSATION, not a subscriber-supplied "active"
  * one. A single active-conversation gate assumed each subscriber watches one
  * conversation — panes broke that: several conversations on one channel are
  * on screen at once, none of them the subscriber's "active" one, and every
  * event for them was silently dropped (replies vanishing on completion,
- * collaborator messages/edits/deletes never appearing). An event now applies
- * to whichever conversation it names, gated only on that conversation having
- * a real cache entry (`hasEntry`): every rendering surface loads or seeds its
- * conversation on mount, so cached ⇔ some surface can render it — and a
- * conversation nobody has cached needs no cache write (the DB row is the
- * truth its eventual loader will fetch).
+ * collaborator messages/edits/deletes never appearing). An event applies to
+ * whichever conversation it names.
+ *
+ * NO `hasEntry` GATE (Agent-Session SSoT epic, Phase 2 / plan PR 3). Every
+ * handler below used to early-return unless the conversation already had a real
+ * cache entry, on the reasoning "cached ⇔ some surface can render it". That
+ * reasoning had a hole exactly the size of the epic's canonical bug: the entry
+ * is created by a LOAD, and the load is asynchronous, so a dispatch landing in
+ * the window between a pane mounting and its first fetch committing was dropped
+ * on the floor with nothing to re-deliver it. The gate is now unnecessary rather
+ * than merely removed — `useConversationSubscription` ensures a cache entry
+ * BEFORE it joins the conversation's room, so "subscribed" implies "cached" by
+ * construction instead of by timing. The residual cost of a write for a
+ * conversation nothing renders is one map key.
  *
  * The user/edit/delete handlers fire only for a REMOTE tab's action
  * (useChannelStreamSocket drops own-tab events via isOwnStream before
@@ -52,12 +58,10 @@ export const buildConversationCacheHandlers = ({
   refreshSnapshot,
 }: ConversationCacheHandlerDeps) => ({
   onUserMessage: (message: UIMessage, payload: { conversationId: string }) => {
-    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
     conversationMessagesActions.applyRemoteUserMessage(payload.conversationId, message);
   },
 
   onMessageEdited: (payload: { messageId: string; conversationId: string; parts: UIMessage['parts']; editedAt: string }) => {
-    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
     const editPayload: MessageEditPayload = {
       messageId: payload.messageId,
       parts: payload.parts,
@@ -67,13 +71,12 @@ export const buildConversationCacheHandlers = ({
   },
 
   onMessageDeleted: (payload: { messageId: string; conversationId: string }) => {
-    if (!conversationMessagesActions.hasEntry(payload.conversationId)) return;
     conversationMessagesActions.applyDelete(payload.conversationId, payload.messageId);
   },
 
   onStreamComplete: (messageId: string, completedConvId?: string, _info?: { joinFailed: boolean }, aborted?: boolean) => {
     const stream = getActiveStreamById(messageId);
-    if (stream && stream.parts.length > 0 && conversationMessagesActions.hasEntry(stream.conversationId)) {
+    if (stream && stream.parts.length > 0) {
       // The shared F1/F6 commit protocol — see commitConfirmedReply. Without this
       // commit the reply flashes to missing: for OWN streams the mirror removes the
       // pending entry the instant status changes. epic leaf 6.8 (D
@@ -89,14 +92,12 @@ export const buildConversationCacheHandlers = ({
     }
     // No usable store entry (SSE join failed / zero parts): the message IS durably
     // persisted — reload the conversation's cache entry rather than losing it.
-    // Only for a CACHED conversation (uncached ⇒ nothing renders it; its
-    // eventual loader fetches the DB truth), and unless the sender's own
-    // onFinish already committed a final row whose status is CONSISTENT with
+    // Unless the sender's own onFinish already committed a final row whose status is CONSISTENT with
     // this event (buildOwnStreamCommitOnFinish) — then a reload only adds a
     // loading flip. A locally-Stopped 'interrupted' row does NOT suppress a
     // non-aborted completion: the server may have outrun the abort and
     // persisted the full reply — see cacheHasConsistentFinalMessage.
-    if (!completedConvId || !conversationMessagesActions.hasEntry(completedConvId)) return;
+    if (!completedConvId) return;
     const cacheHasFinalMessage = cacheHasConsistentFinalMessage(
       conversationMessagesActions.getEntry(completedConvId).messages,
       messageId,

--- a/apps/web/src/hooks/conversationMessagesActions.ts
+++ b/apps/web/src/hooks/conversationMessagesActions.ts
@@ -64,8 +64,9 @@ export const conversationMessagesActions = {
     useConversationMessagesStore.getState().removeOptimisticSendOnFailure(conversationId, messageId),
   applyEdit: (conversationId: string, payload: MessageEditPayload): void =>
     useConversationMessagesStore.getState().applyEdit(conversationId, payload),
-  applyDelete: (conversationId: string, messageId: string): void =>
-    useConversationMessagesStore.getState().applyDelete(conversationId, messageId),
+  /** `rev`: the deleting event's post-write rev, when it carried one — see PendingMutation. */
+  applyDelete: (conversationId: string, messageId: string, rev?: number): void =>
+    useConversationMessagesStore.getState().applyDelete(conversationId, messageId, rev),
   /** Optimistic ask_user answer patch — the resume POST's own commit reconciles it once persisted. */
   applyAskUserAnswer: (conversationId: string, payload: AskUserAnswerPayload): void =>
     useConversationMessagesStore.getState().applyAskUserAnswer(conversationId, payload),
@@ -87,8 +88,8 @@ export const conversationMessagesActions = {
    * cross-instance recovery), where an existing row under this id may be a
    * stale/half-streamed snapshot that must be overwritten, not skipped.
    */
-  applyConfirmedMessage: (conversationId: string, message: UIMessage): void =>
-    useConversationMessagesStore.getState().applyConfirmedMessage(conversationId, message),
+  applyConfirmedMessage: (conversationId: string, message: UIMessage, rev?: number): void =>
+    useConversationMessagesStore.getState().applyConfirmedMessage(conversationId, message, rev),
   /**
    * Promote optimistic sends into confirmed messages. Call on THIS TAB'S OWN
    * stream commit only — an own reply proves the user rows that triggered it

--- a/apps/web/src/hooks/conversationMessagesActions.ts
+++ b/apps/web/src/hooks/conversationMessagesActions.ts
@@ -25,10 +25,17 @@ export const conversationMessagesActions = {
     generation: number,
     messages: UIMessage[],
     pagination?: { hasMore: boolean; nextCursor: string | null },
+    rev?: number | null,
   ): void =>
-    useConversationMessagesStore.getState().applyLoad(conversationId, generation, messages, pagination),
+    useConversationMessagesStore.getState().applyLoad(conversationId, generation, messages, pagination, rev),
   failLoad: (conversationId: string, generation: number): void =>
     useConversationMessagesStore.getState().failLoad(conversationId, generation),
+  /** The conversation's rev watermark (Agent-Session SSoT epic, Phase 2), or null when no load has established one. */
+  getRev: (conversationId: string): number | null =>
+    useConversationMessagesStore.getState().getRev(conversationId),
+  /** Advance the watermark after an event's payload was applied — monotonic; no-op for an uncached conversation. */
+  advanceRev: (conversationId: string, rev: number): void =>
+    useConversationMessagesStore.getState().advanceRev(conversationId, rev),
   /** Imperative snapshot read of a conversation's cache entry (defaults when never seen). */
   getEntry: (conversationId: string): ConversationCacheEntry =>
     useConversationMessagesStore.getState().getEntry(conversationId),
@@ -98,8 +105,9 @@ export const conversationMessagesActions = {
     generationToken: number,
     messages: UIMessage[],
     pagination?: { hasMore: boolean; nextCursor: string | null },
+    rev?: number | null,
   ): void =>
-    useConversationMessagesStore.getState().applyServerSnapshot(conversationId, generationToken, messages, pagination),
+    useConversationMessagesStore.getState().applyServerSnapshot(conversationId, generationToken, messages, pagination, rev),
   /** Mark a freshly-minted conversation loaded-empty (nothing to fetch for it). */
   seedConversation: (conversationId: string): void =>
     useConversationMessagesStore.getState().seedConversation(conversationId),

--- a/apps/web/src/hooks/conversationMessagesLoaders.ts
+++ b/apps/web/src/hooks/conversationMessagesLoaders.ts
@@ -6,6 +6,12 @@ import { conversationMessagesActions } from '@/hooks/conversationMessagesActions
 interface GlobalMessagesEnvelope {
   messages: UIMessage[];
   pagination?: { hasMore: boolean; nextCursor: string | null };
+  /**
+   * `conversations.rev` at read time (Agent-Session SSoT epic, Phase 2) — the
+   * cache entry's watermark. `null` for the legacy bare-array shape and for a
+   * conversation with no row.
+   */
+  rev: number | null;
 }
 
 /**
@@ -15,10 +21,14 @@ interface GlobalMessagesEnvelope {
  */
 const parseGlobalMessagesEnvelope = (data: unknown): GlobalMessagesEnvelope =>
   Array.isArray(data)
-    ? { messages: data as UIMessage[] }
+    ? { messages: data as UIMessage[], rev: null }
     : {
         messages: (data as { messages?: UIMessage[] }).messages ?? [],
         pagination: (data as GlobalMessagesEnvelope).pagination ?? undefined,
+        rev:
+          typeof (data as { rev?: unknown }).rev === 'number'
+            ? ((data as { rev: number }).rev)
+            : null,
       };
 
 /**
@@ -55,8 +65,8 @@ export const loadGlobalConversationMessages = async (conversationId: string): Pr
     if (!conversationMessagesActions.isLoadCurrent(conversationId, generation)) return;
     // epic leaf 6.6: capture the pagination envelope (dropped entirely before this PR) so
     // "load older" has a cursor and knows whether there's anything left to fetch.
-    const { messages, pagination } = parseGlobalMessagesEnvelope(data);
-    conversationMessagesActions.applyLoad(conversationId, generation, messages, pagination);
+    const { messages, pagination, rev } = parseGlobalMessagesEnvelope(data);
+    conversationMessagesActions.applyLoad(conversationId, generation, messages, pagination, rev);
   } catch (error) {
     console.warn('[conversationMessagesLoaders] global load failed', conversationId, error);
     // failLoad is generation-gated, so a stale failure cannot clobber a newer load's status.
@@ -153,6 +163,7 @@ const doRefreshConversationSnapshot = async (
         token,
         result.messages,
         result.pagination ?? undefined,
+        result.rev,
       );
       return;
     }
@@ -163,8 +174,8 @@ const doRefreshConversationSnapshot = async (
       console.warn('[conversationMessagesLoaders] snapshot refresh failed', conversationId, res.status);
       return;
     }
-    const { messages, pagination } = parseGlobalMessagesEnvelope(await res.json());
-    conversationMessagesActions.applyServerSnapshot(conversationId, token, messages, pagination);
+    const { messages, pagination, rev } = parseGlobalMessagesEnvelope(await res.json());
+    conversationMessagesActions.applyServerSnapshot(conversationId, token, messages, pagination, rev);
   } catch (error) {
     console.warn('[conversationMessagesLoaders] snapshot refresh failed', conversationId, error);
   }
@@ -186,6 +197,7 @@ export const loadAgentConversationMessages = async (
       generation,
       result.messages,
       result.pagination ?? undefined,
+      result.rev,
     );
   } catch (error) {
     console.warn('[conversationMessagesLoaders] agent load failed', agentId, conversationId, error);

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -1,51 +1,46 @@
-import { useEffect, useMemo, useRef } from 'react';
-import { useChannelStreamSocket } from './useChannelStreamSocket';
+import { useEffect, useRef } from 'react';
 import { usePageSocketRoom } from './usePageSocketRoom';
 import { useSocketStore } from '@/stores/useSocketStore';
 import {
   shouldRefreshOnReconnect,
   type ConnectionStatus,
 } from '@/lib/ai/streams/shouldRefreshOnReconnect';
-import {
-  loadAgentConversationMessages,
-  refreshConversationSnapshot,
-} from '@/hooks/conversationMessagesLoaders';
-import { buildConversationCacheHandlers } from '@/hooks/conversationCacheSocketHandlers';
+import { useConversationSubscription } from '@/hooks/useConversationSubscription';
 
 export interface UseAgentChannelMultiplayerOptions {
   selectedAgent: { id: string } | null;
   agentConversationId: string | null;
   /**
-   * Re-fetch handler invoked on socket reconnect (after the initial connect)
-   * and when a completion has no usable store entry to commit. Surface owns
-   * this — dashboard agent mode passes the dashboard store loader, sidebar
-   * agent mode passes its own sidebar-state loader, since those two surfaces
-   * resolve to different agents/conversations. Both commit to the shared
-   * conversation cache (PR 5B).
+   * Re-fetch handler invoked on socket reconnect (after the initial connect).
+   * Surface owns this — dashboard agent mode passes the dashboard store loader,
+   * sidebar agent mode passes its own sidebar-state loader, since those two
+   * surfaces resolve to different agents/conversations. Both commit to the
+   * shared conversation cache (PR 5B).
    */
   loadConversation: (conversationId: string) => void | Promise<void>;
 }
 
 /**
- * Wires a surface (GlobalAssistantView agent mode, SidebarChatTab agent mode)
- * to the multiplayer streaming pipeline for an agent's page channel — the
- * agent-mode twin of the global path in GlobalChatContext (PR 5B, leaf 5.6):
+ * THIN WRAPPER over `useConversationSubscription` (Agent-Session Single Source
+ * of Truth epic, Phase 2 / plan PR 3).
  *
- * - Joins the agent's socket room.
- * - Bootstrap-replays in-flight streams from the DB and subscribes to live
- *   chat:stream_start / chat:stream_complete events via useChannelStreamSocket.
- * - Message callbacks write the shared conversation cache directly — there is
- *   no `setLocalMessages` and no transport-array write left here. That also
- *   removes the whole "foreign message lands in the array the own-stream
- *   mirror reads" hazard this hook's completion handler used to gate on
- *   `stream.isOwn` for: the cache write is safe for ANY stream (a second
- *   tab's included) because nothing derives stream identity from the cache.
- * - Refreshes the active conversation when the socket transitions back to
- *   connected after an offline blip (skipped on the very first connect).
+ * This hook used to BE the agent-channel multiplayer path: it owned the cache
+ * handlers, the channel bootstrap and the reconnect refresh. All three moved —
+ * a surface now subscribes to the CONVERSATION it is showing (joining
+ * `conv:<id>`, holding a rev watermark, applying authoritative
+ * `conversation:*` events) rather than to a page channel it happens to share
+ * with other people's private threads. What survives here is the shape its
+ * three call sites already pass, plus the two things that are genuinely
+ * channel-scoped:
  *
- * Both consuming surfaces can be co-mounted on the same conversation; every
- * cache action here is idempotent (append-if-absent / upsert-by-id), so the
- * duplicate delivery is harmless by construction.
+ *  - `usePageSocketRoom(channelId)` — the legacy page room, still the audience
+ *    for the `chat:*` events the server emits in parallel during the migration
+ *    window (a later contract PR deletes those emissions and this line with
+ *    them);
+ *  - the surface-supplied reconnect refresh, which cannot move into the
+ *    subscription because the two consuming surfaces resolve their agent state
+ *    from different stores and one shared loader would refresh the wrong
+ *    conversation in the other.
  *
  * Pass `selectedAgent: null` to no-op (e.g. the surface is in global mode).
  */
@@ -60,39 +55,21 @@ export function useAgentChannelMultiplayer({
 
   // NO STOP-SLOT CLAIM PROTOCOL (PR 5A, leaf 5.5.7) — every surface READS
   // `useConversationActiveStream(agentId, conversationId)`, and a read cannot be declined.
-
-  // The shared socket-events → cache protocol (see buildConversationCacheHandlers):
-  // remote user/edit/delete writes, and the completion commit with own-send
-  // promotion + background snapshot heal. Events dispatch on THEIR OWN
-  // conversation id (any cached conversation on this channel), so panes showing
-  // sibling conversations receive them too. Cache reloads here use the RAW
-  // loaders keyed by the channel (agent page id) — never the surface's
-  // loadConversation, which also sets identity and pushes the URL; a completion
-  // for a conversation already on screen must not do either.
-  const cacheHandlers = useMemo(
-    () =>
-      buildConversationCacheHandlers({
-        reloadConversation: (conversationId) => {
-          if (channelId) void loadAgentConversationMessages(channelId, conversationId);
-        },
-        refreshSnapshot: (conversationId) => {
-          if (channelId) void refreshConversationSnapshot(channelId, conversationId);
-        },
-      }),
-    [channelId],
-  );
-
-  const { rejoinActiveStreams } = useChannelStreamSocket(channelId, cacheHandlers);
-
-  // NO editing-store registration here (PR 5A, leaf 5.7): the one derived, conversation-keyed
-  // registration for the whole app lives in GlobalChatProvider (useDerivedStreamingRegistrations).
+  //
+  // NO editing-store registration here (PR 5A, leaf 5.7): the one derived,
+  // conversation-keyed registration for the whole app lives in GlobalChatProvider
+  // (useDerivedStreamingRegistrations).
+  const { rejoinActiveStreams } = useConversationSubscription(agentConversationId, {
+    channelId,
+    agentPageId: channelId ?? null,
+  });
 
   // Reconnect-refresh: re-fetch the active agent conversation when the socket
   // transitions back to connected. Skipped on the very first connect (already
-  // covered by mount-time load). Uses the surface-provided loadConversation
-  // because the two consuming surfaces (dashboard agent mode + sidebar agent
-  // mode) resolve their agent state from different stores; one shared loader
-  // would refresh the wrong conversation in the other surface.
+  // covered by mount-time load). Complements — does not duplicate — the
+  // subscription's own batched rev check: that one heals the CACHE for every
+  // watched conversation, this one is the surface's chance to re-derive its own
+  // identity-bearing state through its own loader.
   const socketConnectionStatus = useSocketStore((s) => s.connectionStatus);
   const prevConnectionStatusRef = useRef<ConnectionStatus | null>(null);
   const hasInitialConnectRef = useRef(false);

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useSocket } from './useSocket';
-import { useAuth } from './useAuth';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { consumeStreamJoin, StreamJoinError } from '@/lib/ai/core/stream-join-client';
@@ -171,18 +170,28 @@ export interface UseChannelStreamSocketOptions {
   onGlobalConversationAdded?: (payload: ChatGlobalConversationAddedPayload) => void;
 }
 
-/** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
+/**
+ * Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live
+ * socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op.
+ *
+ * `bootstrapConversationId` (Agent-Session SSoT epic, Phase 2) narrows the DB replay to ONE
+ * conversation on the channel — what a pane wants, since a pane shows exactly one. Only the
+ * bootstrap is re-keyed; the live socket handlers stay channel-wide, because a
+ * `chat:stream_start` for a sibling conversation still has to reach whichever co-mounted
+ * instance is subscribed to it (claim-gated, so exactly one attaches). Omit it to keep the
+ * whole-channel form — which is what `GlobalChatContext` uses so a stream stays in the store
+ * for a conversation no surface is currently showing.
+ */
 export function useChannelStreamSocket(
   channelId: string | undefined,
   options?: UseChannelStreamSocketOptions,
+  bootstrapConversationId?: string | null,
 ): { rejoinActiveStreams: () => void } {
   const socket = useSocket();
-  // The signed-in user's id, so handleStreamStart can tell "my stream in another tab"
-  // from "another member's private conversation". Kept in a ref so it never re-registers
-  // the socket handlers.
-  const { user } = useAuth();
-  const localUserIdRef = useRef<string | null>(user?.id ?? null);
-  localUserIdRef.current = user?.id ?? null;
+  // No local-user ref any more: the `startedBySomeoneElse && !isShared` drop it existed
+  // for is deleted (see handleStreamStart). Identity questions are the server's —
+  // /stream-join re-authorizes with `canAccessConversation`.
+  //
   // Holds the latest runBootstrap closure so rejoinActiveStreams can call it without
   // needing to be in the effect's dep array (the effect re-creates this on every run).
   const bootstrapRef = useRef<(() => void) | null>(null);
@@ -444,8 +453,11 @@ export function useChannelStreamSocket(
     const runBootstrap = async () => {
       const generation = (bootstrapGeneration += 1);
       try {
+        const conversationScope = bootstrapConversationId
+          ? `&conversationId=${encodeURIComponent(bootstrapConversationId)}`
+          : '';
         const res = await fetchWithAuth(
-          `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
+          `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}${conversationScope}`,
           { credentials: 'include' },
         );
         if (cancelled) return;
@@ -532,30 +544,24 @@ export function useChannelStreamSocket(
 
     const handleStreamStart = (payload: AiStreamStartPayload) => {
       if (payload.pageId !== channelId) return;
-      // Not ours to watch. A page room holds every member of the page, but conversations
-      // are private by default (`listConversations` shows you only `userId = you OR
-      // isShared`), so most streams on this channel are somebody else's private chat.
-      // The server refuses those joins anyway — this just avoids making the request:
-      // otherwise every member's client fires a doomed /stream-join per assistant
-      // message, each one an authz denial in the audit log.
+      // GATE DELETED (Agent-Session SSoT epic, Phase 2 / plan PR 3). This used to
+      // drop `startedBySomeoneElse && payload.isShared === false` as a
+      // request-saving heuristic: "a private conversation started by someone else
+      // can't be mine to watch, so don't fire a doomed /stream-join".
       //
-      // Skip ONLY on certainty, in both directions:
+      // The heuristic was wrong about "someone else". `triggeredBy.userId` is the
+      // ACTOR, and a server-side dispatch (`send_session`, a workflow, the /help
+      // short-circuit) acts as whoever it acts as — so the user's OWN private
+      // conversation, written on their behalf from another surface, read as
+      // "somebody else's private chat" and every pane showing it went dark. That is
+      // the epic's canonical blank-pane bug in its stream-plane half.
       //
-      //   - `isShared` must be an explicit `false`. During a rolling deploy an
-      //     originator on the previous build sends no such field, and dropping on
-      //     `undefined` would black out multiplayer for shared conversations.
-      //   - we must actually KNOW who we are. `useAuth()` returns `user: null` until
-      //     auth resolves, and treating "unknown" as "not me" would drop the user's OWN
-      //     private stream in that window — the precise failure this whole PR exists to
-      //     fix.
-      //
-      // When in doubt, attach and let the server decide: an unauthorized join is a quiet
-      // 404 that the client already handles benignly. The server is the authority here;
-      // this check exists only to avoid firing a request that is certain to be refused.
-      const localUserId = localUserIdRef.current;
-      const startedBySomeoneElse = localUserId !== null && payload.triggeredBy.userId !== localUserId;
-      if (startedBySomeoneElse && payload.isShared === false) return;
-
+      // Nothing is widened by removing it: /stream-join re-authorizes every join
+      // with `canAccessConversation` server-side (the same predicate the
+      // `join_conversation` room handler and /active-streams enforce), and a refused
+      // join is a quiet 404 this hook already handles benignly. The only cost is the
+      // request the heuristic was avoiding — which the conversation-scoped bootstrap
+      // in `useConversationSubscription` avoids far more precisely anyway.
       const isOwn = isOwnStream(payload.triggeredBy, localBrowserSessionId);
       // The ONLY reason to decline a live stream: this browser context is already
       // reading THIS CONVERSATION's tokens off the POST body, so joining the multicast
@@ -762,7 +768,11 @@ export function useChannelStreamSocket(
         notifyRemainingChannelSubscribers(channelId);
       }
     };
-  }, [socket, channelId]);
+    // `bootstrapConversationId` is in the deps because it changes which streams the
+    // DB replay attaches: a pane switching conversations must re-bootstrap, and the
+    // teardown/rebuild is exactly the same shape as a channel switch (claims released,
+    // sibling subscribers nudged to reclaim).
+  }, [socket, channelId, bootstrapConversationId]);
 
   // Stable callback; the ref always points at the latest runBootstrap closure.
   const rejoinActiveStreams = useCallback(() => { bootstrapRef.current?.(); }, []);

--- a/apps/web/src/hooks/useConversationSubscription.ts
+++ b/apps/web/src/hooks/useConversationSubscription.ts
@@ -199,7 +199,10 @@ export function useConversationSubscription(
         heal(payload.rev);
         return;
       }
-      conversationMessagesActions.applyConfirmedMessage(conversationId, message);
+      // The rev rides along onto the recorded pending mutation, so a snapshot
+      // fetched by a concurrent gap-heal can tell whether it already contains
+      // this write rather than replaying it over newer truth.
+      conversationMessagesActions.applyConfirmedMessage(conversationId, message, payload.rev);
       conversationMessagesActions.advanceRev(conversationId, payload.rev);
     };
 
@@ -211,7 +214,7 @@ export function useConversationSubscription(
         heal(payload.rev);
         return;
       }
-      conversationMessagesActions.applyDelete(conversationId, payload.messageId);
+      conversationMessagesActions.applyDelete(conversationId, payload.messageId, payload.rev);
       conversationMessagesActions.advanceRev(conversationId, payload.rev);
     };
 

--- a/apps/web/src/hooks/useConversationSubscription.ts
+++ b/apps/web/src/hooks/useConversationSubscription.ts
@@ -1,0 +1,289 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { UIMessage } from 'ai';
+import { useSocket } from './useSocket';
+import { useSocketStore } from '@/stores/useSocketStore';
+import { useChannelStreamSocket, type UseChannelStreamSocketOptions } from './useChannelStreamSocket';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import {
+  loadAgentConversationMessages,
+  loadGlobalConversationMessages,
+  refreshConversationSnapshot,
+} from '@/hooks/conversationMessagesLoaders';
+import { buildConversationCacheHandlers } from '@/hooks/conversationCacheSocketHandlers';
+import {
+  decideConversationApply,
+  type ConversationApplyDecision,
+} from '@/lib/realtime/conversation-apply';
+import {
+  healConversationToRev,
+  registerConversationWatch,
+  syncWatchedConversationRevs,
+  unregisterConversationWatch,
+} from '@/lib/realtime/conversation-rev-sync';
+import { shouldRefreshOnReconnect, type ConnectionStatus } from '@/lib/ai/streams/shouldRefreshOnReconnect';
+import type {
+  ConversationMessagePayload,
+  ConversationMessageDeletedPayload,
+  ConversationUndoAppliedPayload,
+} from '@/lib/websocket/conversation-events';
+
+/**
+ * `useConversationSubscription` — a surface's subscription to ONE conversation
+ * (Agent-Session Single Source of Truth epic, Phase 2 / plan PR 3; spec
+ * `docs/2.0-architecture/agent-sessions.md` §3 clause 3).
+ *
+ * This is the client half of "every surface is a subscriber that can prove it is
+ * current", and it replaces the conversation half of `useChannelStreamSocket`'s
+ * channel-wide subscription. Four things happen, in this order, and the order is
+ * the whole design:
+ *
+ *  1. ENSURE A CACHE ENTRY. The loader is kicked before anything else when the
+ *     conversation has none. `startLoad` materializes the entry synchronously, so
+ *     from the very next line onward "subscribed" implies "cached". That is what
+ *     lets the `hasEntry` gates in `conversationCacheSocketHandlers` be DELETED
+ *     rather than merely relaxed: subscribe-on-open replaces them by construction.
+ *     The old gate's hole was exactly the window this closes — an event landing
+ *     between mount and the first fetch committing had no entry to write to and
+ *     was dropped with nothing to re-deliver it.
+ *
+ *  2. JOIN `conv:<conversationId>`. Room membership IS the authorization: the
+ *     realtime `join_conversation` handler runs `canAccessConversation` (owner OR
+ *     shared + page access) and denies quietly. Re-emitted on every reconnect,
+ *     because socket.io rejoins nothing for you.
+ *
+ *  3. BOOTSTRAP the conversation's in-flight streams. Same DB replay
+ *     `useChannelStreamSocket` has always done, re-keyed by conversation via the
+ *     new `?conversationId=` narrowing on `/api/ai/chat/active-streams`. The SSE
+ *     token machinery underneath is untouched — `consumeStreamJoin`, the poll
+ *     fallback, `claimBootstrapConsumer`, `shouldAttachStream`, `isOwnStream`, the
+ *     `pendingStreams` mirror and `commitConfirmedReply` all keep working exactly
+ *     as before. Streaming is still how tokens arrive; the events below are the
+ *     DURABLE signal that also covers the case where both stream signals are lost.
+ *
+ *  4. APPLY `conversation:*` EVENTS THROUGH THE REV RULE. Every handler asks
+ *     `decideConversationApply` (pure, exhaustively tested, no IO) and does one of
+ *     three things: drop, apply, or refetch. Nothing here decides currency for
+ *     itself.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO
+ *
+ * - No self-echo skip. `triggeredBy.browserSessionId` is carried on every event
+ *   and this hook ignores it on purpose: the epic's canonical bug is a user's own
+ *   dispatch, made from another surface, being invisible to their own open pane.
+ *   Every cache action it calls is idempotent (upsert-by-id), so the originating
+ *   pane applying its own echo on top of its optimistic send is a no-op with a
+ *   reconciliation attached — `applyConfirmedMessage` drops the matching
+ *   `optimisticSends` entry as it commits.
+ * - No message rendering decisions. The cache is merge-at-render
+ *   (`selectRenderedMessages`), so a `message_created` for a streaming placeholder
+ *   coexists with the live stream rather than fighting it, and no write here can
+ *   blank a stream mid-flight.
+ * - No `useChat` transport writes. Never replace a transport array from a socket
+ *   handler; the surfaces re-seed it only at the actions that need it.
+ */
+
+export interface ConversationSubscriptionContext {
+  /**
+   * The STREAM channel this conversation's streams broadcast on: the agent page
+   * id, or the user's global channel id.
+   *
+   * Pass `undefined`/`null` to skip mounting a channel stream socket entirely —
+   * what the global-assistant panes do, since `GlobalChatProvider` already
+   * subscribes the user's one global channel app-wide and a second subscriber
+   * would only duplicate its bootstrap. The conversation plane (join, events, rev
+   * check) still runs; only the stream-lifecycle attach is skipped.
+   */
+  channelId?: string | null;
+  /**
+   * The agent page hosting the conversation, or `null` for a global-assistant
+   * conversation. Selects the load/refetch endpoint — NOT the same thing as
+   * `channelId`, which for the global case is a derived channel id and for a
+   * pane may be present while this is null.
+   */
+  agentPageId: string | null;
+  /**
+   * Extra channel-socket options merged into the shared cache handlers (undo
+   * refresh, conversation-added, ...). Ignored when `channelId` is absent.
+   */
+  streamOptions?: UseChannelStreamSocketOptions;
+}
+
+export interface ConversationSubscription {
+  /** Re-runs the stream bootstrap — the recovery hook the send handoff needs. */
+  rejoinActiveStreams: () => void;
+}
+
+export function useConversationSubscription(
+  conversationId: string | null | undefined,
+  ctx: ConversationSubscriptionContext,
+): ConversationSubscription {
+  const socket = useSocket();
+  const { channelId, agentPageId, streamOptions } = ctx;
+
+  // Refetch endpoint selector, stable per (agentPageId) so handlers registered
+  // once don't need re-registering when unrelated props move.
+  const agentPageIdRef = useRef(agentPageId);
+  agentPageIdRef.current = agentPageId;
+
+  const loadConversation = useCallback(
+    (id: string): Promise<void> =>
+      agentPageIdRef.current
+        ? loadAgentConversationMessages(agentPageIdRef.current, id)
+        : loadGlobalConversationMessages(id),
+    [],
+  );
+
+  // ── 1. Ensure a cache entry (subscribe-on-open) ───────────────────────────
+  // Runs BEFORE the join effect below by declaration order, and `startLoad`
+  // materializes the entry synchronously, so no event can arrive at a
+  // conversation this cache has never heard of.
+  useEffect(() => {
+    if (!conversationId) return;
+    if (conversationMessagesActions.hasEntry(conversationId)) return;
+    void loadConversation(conversationId);
+  }, [conversationId, loadConversation]);
+
+  // ── 2. Join the conversation's content room ───────────────────────────────
+  useEffect(() => {
+    if (!socket || !conversationId) return;
+    const join = () => socket.emit('join_conversation', conversationId);
+    join();
+    // socket.io rejoins no rooms on reconnect — the server's socket is brand new.
+    socket.on('connect', join);
+    return () => {
+      socket.off('connect', join);
+      // Best-effort: on a disconnected socket this is a no-op, which is correct —
+      // the server already dropped every room for that socket.
+      socket.emit('leave_conversation', conversationId);
+    };
+  }, [socket, conversationId]);
+
+  // ── 4. Rev-gated conversation events ──────────────────────────────────────
+  useEffect(() => {
+    if (!socket || !conversationId) return;
+
+    /**
+     * The one decision point. Reads the watermark straight off the store at event
+     * time (never a ref snapshot — a burst of events must each see the previous
+     * one's advance) and returns what to do.
+     */
+    const decide = (rev: number, truncated?: boolean): ConversationApplyDecision =>
+      decideConversationApply(
+        { rev, truncated },
+        conversationMessagesActions.getRev(conversationId),
+      );
+
+    const heal = (rev: number) => {
+      void healConversationToRev(conversationId, agentPageIdRef.current, Number.isFinite(rev) ? rev : null);
+    };
+
+    const applyMessage = (payload: ConversationMessagePayload) => {
+      if (payload.conversationId !== conversationId) return;
+      const truncated = 'truncated' in payload ? payload.truncated === true : false;
+      const decision = decide(payload.rev, truncated);
+      if (decision === 'drop') return;
+      if (decision === 'refetch') {
+        heal(payload.rev);
+        return;
+      }
+      // `apply` implies a non-truncated payload (the pure rule guarantees it), so
+      // the message is here. Upsert-by-id: idempotent against this pane's own
+      // optimistic send, against the SSE commit that may already have written the
+      // same id, and against a bootstrap load that raced this event.
+      const message = (payload as { message: UIMessage }).message;
+      if (!message || typeof message.id !== 'string') {
+        // A payload shaped neither way (a rolling-deploy emitter we don't know) —
+        // ask the server rather than guess.
+        heal(payload.rev);
+        return;
+      }
+      conversationMessagesActions.applyConfirmedMessage(conversationId, message);
+      conversationMessagesActions.advanceRev(conversationId, payload.rev);
+    };
+
+    const handleMessageDeleted = (payload: ConversationMessageDeletedPayload) => {
+      if (payload.conversationId !== conversationId) return;
+      const decision = decide(payload.rev);
+      if (decision === 'drop') return;
+      if (decision === 'refetch') {
+        heal(payload.rev);
+        return;
+      }
+      conversationMessagesActions.applyDelete(conversationId, payload.messageId);
+      conversationMessagesActions.advanceRev(conversationId, payload.rev);
+    };
+
+    const handleUndoApplied = (payload: ConversationUndoAppliedPayload) => {
+      if (payload.conversationId !== conversationId) return;
+      // An undo restructures the conversation wholesale — there is no patch to
+      // apply, only a truth to re-read. Rev-gated all the same so a redelivered
+      // undo doesn't cost a fetch.
+      if (decide(payload.rev) === 'drop') return;
+      heal(payload.rev);
+    };
+
+    socket.on('conversation:message_created', applyMessage);
+    socket.on('conversation:message_updated', applyMessage);
+    socket.on('conversation:message_deleted', handleMessageDeleted);
+    socket.on('conversation:undo_applied', handleUndoApplied);
+
+    return () => {
+      socket.off('conversation:message_created', applyMessage);
+      socket.off('conversation:message_updated', applyMessage);
+      socket.off('conversation:message_deleted', handleMessageDeleted);
+      socket.off('conversation:undo_applied', handleUndoApplied);
+    };
+  }, [socket, conversationId]);
+
+  // ── Reconnect: rejoin happened above; now prove currency in ONE request ───
+  useEffect(() => {
+    if (!conversationId) return;
+    registerConversationWatch(conversationId, agentPageId);
+    return () => unregisterConversationWatch(conversationId);
+  }, [conversationId, agentPageId]);
+
+  const connectionStatus = useSocketStore((s) => s.connectionStatus);
+  const prevConnectionStatusRef = useRef<ConnectionStatus | null>(null);
+  const hasInitialConnectRef = useRef(false);
+  useEffect(() => {
+    if (!conversationId) return;
+    const prev = prevConnectionStatusRef.current;
+    prevConnectionStatusRef.current = connectionStatus;
+    // One batched revs call for EVERY watched conversation, not one per hook —
+    // that is why the registry is module-level. Co-mounted subscriptions all
+    // observe this same transition and join the one in-flight request.
+    if (shouldRefreshOnReconnect(prev, connectionStatus, hasInitialConnectRef.current)) {
+      void syncWatchedConversationRevs();
+    }
+    if (prev !== 'connected' && connectionStatus === 'connected') {
+      hasInitialConnectRef.current = true;
+    }
+  }, [conversationId, connectionStatus]);
+
+  // ── 3. Stream plane: the preserved SSE machinery, conversation-scoped ─────
+  // The shared socket-events → cache protocol (commit / promote-own-sends /
+  // snapshot heal). Its `hasEntry` gates are gone — see that module — because
+  // step 1 above makes them unnecessary rather than merely optional.
+  const cacheHandlers = useMemo<UseChannelStreamSocketOptions>(
+    () => ({
+      ...buildConversationCacheHandlers({
+        reloadConversation: (id) => loadConversation(id),
+        refreshSnapshot: (id) => refreshConversationSnapshot(agentPageIdRef.current, id),
+      }),
+      ...streamOptions,
+    }),
+    [loadConversation, streamOptions],
+  );
+
+  // A `undefined` channelId makes this a no-op by the hook's own contract (and
+  // its returned rejoin a no-op with it) — the global-assistant pane case.
+  const { rejoinActiveStreams } = useChannelStreamSocket(
+    channelId ?? undefined,
+    cacheHandlers,
+    conversationId ?? null,
+  );
+
+  return { rejoinActiveStreams };
+}

--- a/apps/web/src/lib/ai/shared/agent-conversations.ts
+++ b/apps/web/src/lib/ai/shared/agent-conversations.ts
@@ -26,6 +26,8 @@ export interface PaginationInfo {
 interface AgentMessagesResponse {
   messages?: UIMessage[];
   pagination?: PaginationInfo;
+  /** `conversations.rev` at read time; absent on a pre-cutover build mid-rollout. */
+  rev?: number | null;
 }
 
 interface AgentConversationCreateResponse {
@@ -51,6 +53,13 @@ export interface FetchAgentMessagesOptions {
 export interface FetchAgentMessagesResult {
   messages: UIMessage[];
   pagination: PaginationInfo | null;
+  /**
+   * The `conversations.rev` this snapshot was read at (Agent-Session SSoT epic,
+   * Phase 2) — the cache entry's watermark. `null` when the route answered a
+   * legacy shape (bare array) or the conversation has no row: no baseline, so
+   * the subscriber refetches on any versioned event rather than guessing.
+   */
+  rev: number | null;
 }
 
 /**
@@ -81,13 +90,15 @@ export async function fetchAgentConversationMessages(
   if (Array.isArray(data)) {
     return {
       messages: data,
-      pagination: null
+      pagination: null,
+      rev: null,
     };
   }
 
   return {
     messages: data.messages || [],
-    pagination: data.pagination || null
+    pagination: data.pagination || null,
+    rev: typeof data.rev === 'number' ? data.rev : null,
   };
 }
 

--- a/apps/web/src/lib/ai/streams/__tests__/selectRenderedMessages.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/selectRenderedMessages.test.ts
@@ -19,7 +19,7 @@ const stream = (overrides: Partial<PendingStream> & { messageId: string }): Pend
   ...overrides,
 });
 
-const emptyEntry: ConversationCacheEntry = { messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'idle', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false };
+const emptyEntry: ConversationCacheEntry = { messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'idle', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null };
 
 describe('selectRenderedMessages', () => {
   it('given an empty cache and no streams, should return an empty array', () => {

--- a/apps/web/src/lib/realtime/__tests__/conversation-apply.test.ts
+++ b/apps/web/src/lib/realtime/__tests__/conversation-apply.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideConversationApply,
+  nextWatermark,
+  UNVERSIONED_REV,
+  type ConversationApplyDecision,
+} from '@/lib/realtime/conversation-apply';
+
+/**
+ * Exhaustive table tests for the rev apply rule (Agent-Session SSoT epic, Phase 2 /
+ * plan PR 3). A later PR property-tests this module; these pin the decision table
+ * itself — every (watermark × eventRev × truncated) region, plus the two degenerate
+ * revs the docblock names.
+ */
+
+describe('decideConversationApply', () => {
+  describe('the core rule, against a proven watermark', () => {
+    // A small exhaustive sweep: every watermark 0..3 crossed with every rev 0..6,
+    // both truncation states. Encoded as the expected decision so a regression in
+    // any single cell fails loudly rather than being masked by a happy-path case.
+    const expected = (watermark: number, rev: number, truncated: boolean): ConversationApplyDecision => {
+      if (rev === UNVERSIONED_REV) return truncated ? 'refetch' : 'apply';
+      if (rev <= watermark) return 'drop';
+      if (rev === watermark + 1) return (truncated ? 'refetch' : 'apply');
+      return 'refetch';
+    };
+
+    for (const watermark of [0, 1, 2, 3]) {
+      for (const rev of [0, 1, 2, 3, 4, 5, 6]) {
+        for (const truncated of [false, true]) {
+          it(`watermark ${watermark}, rev ${rev}, truncated ${truncated} → ${expected(watermark, rev, truncated)}`, () => {
+            expect(decideConversationApply({ rev, truncated }, watermark)).toBe(
+              expected(watermark, rev, truncated),
+            );
+          });
+        }
+      }
+    }
+  });
+
+  it('drops a redelivered event (rev equal to the watermark)', () => {
+    expect(decideConversationApply({ rev: 7 }, 7)).toBe('drop');
+  });
+
+  it('drops a stale event (rev below the watermark)', () => {
+    expect(decideConversationApply({ rev: 3 }, 7)).toBe('drop');
+  });
+
+  it('drops a stale event even when it is truncated — refetching what we already have is pure cost', () => {
+    expect(decideConversationApply({ rev: 3, truncated: true }, 7)).toBe('drop');
+  });
+
+  it('applies the contiguous next rev', () => {
+    expect(decideConversationApply({ rev: 8 }, 7)).toBe('apply');
+  });
+
+  it('refetches the contiguous next rev when its payload was truncated', () => {
+    expect(decideConversationApply({ rev: 8, truncated: true }, 7)).toBe('refetch');
+  });
+
+  it('refetches on a gap of one', () => {
+    expect(decideConversationApply({ rev: 9 }, 7)).toBe('refetch');
+  });
+
+  it('refetches on a large gap (a reconnect that missed a whole burst)', () => {
+    expect(decideConversationApply({ rev: 4_096 }, 7)).toBe('refetch');
+  });
+
+  it('treats an absent `truncated` field exactly like `false`', () => {
+    expect(decideConversationApply({ rev: 8 }, 7)).toBe(
+      decideConversationApply({ rev: 8, truncated: false }, 7),
+    );
+  });
+
+  describe('unversioned events (rev 0 — the emitter had no conversations row)', () => {
+    it('applies regardless of how far the watermark has advanced', () => {
+      expect(decideConversationApply({ rev: UNVERSIONED_REV }, 0)).toBe('apply');
+      expect(decideConversationApply({ rev: UNVERSIONED_REV }, 512)).toBe('apply');
+    });
+
+    it('applies even with no watermark at all', () => {
+      expect(decideConversationApply({ rev: UNVERSIONED_REV }, null)).toBe('apply');
+    });
+
+    it('refetches when truncated, since there is no content to apply', () => {
+      expect(decideConversationApply({ rev: UNVERSIONED_REV, truncated: true }, 5)).toBe('refetch');
+      expect(decideConversationApply({ rev: UNVERSIONED_REV, truncated: true }, null)).toBe('refetch');
+    });
+  });
+
+  describe('no proven baseline (watermark null)', () => {
+    it('refetches any versioned event — nothing can be proven contiguous against "unknown"', () => {
+      expect(decideConversationApply({ rev: 1 }, null)).toBe('refetch');
+      expect(decideConversationApply({ rev: 99 }, null)).toBe('refetch');
+      expect(decideConversationApply({ rev: 1, truncated: true }, null)).toBe('refetch');
+    });
+  });
+
+  describe('malformed revs fail toward the server, never toward silence', () => {
+    it.each([
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['negative', -1],
+    ])('refetches on a %s rev', (_label, rev) => {
+      expect(decideConversationApply({ rev: rev as number }, 5)).toBe('refetch');
+    });
+
+    it('refetches on a malformed rev even with no watermark', () => {
+      expect(decideConversationApply({ rev: Number.NaN }, null)).toBe('refetch');
+    });
+  });
+
+  it('is pure — the same inputs answer the same way every time', () => {
+    const event = { rev: 8, truncated: false };
+    const answers = new Set([
+      decideConversationApply(event, 7),
+      decideConversationApply(event, 7),
+      decideConversationApply(event, 7),
+    ]);
+    expect([...answers]).toEqual(['apply']);
+    expect(event).toEqual({ rev: 8, truncated: false });
+  });
+});
+
+describe('nextWatermark', () => {
+  it('adopts the applied rev when it advances the watermark', () => {
+    expect(nextWatermark(7, 8)).toBe(8);
+  });
+
+  it('adopts the applied rev when there was no watermark', () => {
+    expect(nextWatermark(null, 3)).toBe(3);
+  });
+
+  it('never moves backwards', () => {
+    expect(nextWatermark(9, 4)).toBe(9);
+    expect(nextWatermark(9, 9)).toBe(9);
+  });
+
+  it('leaves a real watermark untouched for an unversioned apply', () => {
+    expect(nextWatermark(9, UNVERSIONED_REV)).toBe(9);
+  });
+
+  it('adopts nothing from an unversioned apply with no watermark', () => {
+    expect(nextWatermark(null, UNVERSIONED_REV)).toBeNull();
+  });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['negative', -3],
+  ])('ignores a %s rev', (_label, rev) => {
+    expect(nextWatermark(5, rev as number)).toBe(5);
+    expect(nextWatermark(null, rev as number)).toBeNull();
+  });
+
+  it('is monotonic across an arbitrary apply sequence', () => {
+    const revs = [1, 2, 5, 3, 5, 9, 0, 7];
+    let watermark: number | null = null;
+    const seen: Array<number | null> = [];
+    for (const rev of revs) {
+      watermark = nextWatermark(watermark, rev);
+      seen.push(watermark);
+    }
+    expect(seen).toEqual([1, 2, 5, 5, 5, 9, 9, 9]);
+  });
+});

--- a/apps/web/src/lib/realtime/__tests__/conversation-rev-sync.test.ts
+++ b/apps/web/src/lib/realtime/__tests__/conversation-rev-sync.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockFetchWithAuth, mockRefreshSnapshot, revs } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+  mockRefreshSnapshot: vi.fn().mockResolvedValue(undefined),
+  revs: { current: new Map<string, number | null>() },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: mockFetchWithAuth }));
+vi.mock('@/hooks/conversationMessagesLoaders', () => ({
+  refreshConversationSnapshot: mockRefreshSnapshot,
+}));
+vi.mock('@/hooks/conversationMessagesActions', () => ({
+  conversationMessagesActions: {
+    getRev: (id: string) => revs.current.get(id) ?? null,
+  },
+}));
+
+import {
+  healConversationToRev,
+  registerConversationWatch,
+  resetConversationWatches,
+  syncWatchedConversationRevs,
+  unregisterConversationWatch,
+  watchedConversationIds,
+} from '../conversation-rev-sync';
+
+const okJson = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+describe('conversation-rev-sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetConversationWatches();
+    revs.current = new Map();
+    mockRefreshSnapshot.mockResolvedValue(undefined);
+  });
+
+  describe('the watch registry', () => {
+    it('given one registration, should include the conversation in the batch', () => {
+      registerConversationWatch('c1', 'page-1');
+
+      expect(watchedConversationIds()).toEqual(['c1']);
+    });
+
+    // Two panes on one conversation: the first unmount must not blind the second.
+    it('given two watchers, should keep the conversation until BOTH unregister', () => {
+      registerConversationWatch('c1', 'page-1');
+      registerConversationWatch('c1', 'page-1');
+
+      unregisterConversationWatch('c1');
+      expect(watchedConversationIds()).toEqual(['c1']);
+
+      unregisterConversationWatch('c1');
+      expect(watchedConversationIds()).toEqual([]);
+    });
+
+    it('given an unregister for an unknown conversation, should be a no-op', () => {
+      unregisterConversationWatch('never-registered');
+
+      expect(watchedConversationIds()).toEqual([]);
+    });
+  });
+
+  describe('syncWatchedConversationRevs', () => {
+    it('given no watchers, should not make a request at all', async () => {
+      await syncWatchedConversationRevs();
+
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given several watched conversations, should ask about all of them in ONE request', async () => {
+      registerConversationWatch('c1', 'page-1');
+      registerConversationWatch('c2', null);
+      revs.current.set('c1', 5);
+      revs.current.set('c2', 2);
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: { c1: 5, c2: 2 } }));
+
+      await syncWatchedConversationRevs();
+
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetchWithAuth.mock.calls[0];
+      expect(url).toBe('/api/ai/conversations/revs');
+      expect(JSON.parse((init as { body: string }).body)).toEqual({ ids: ['c1', 'c2'] });
+    });
+
+    it('given every watermark already matches, should refetch nothing', async () => {
+      registerConversationWatch('c1', 'page-1');
+      revs.current.set('c1', 5);
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: { c1: 5 } }));
+
+      await syncWatchedConversationRevs();
+
+      expect(mockRefreshSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('given the server is AHEAD of a watermark, should refetch exactly that conversation', async () => {
+      registerConversationWatch('c1', 'page-1');
+      registerConversationWatch('c2', null);
+      revs.current.set('c1', 5);
+      revs.current.set('c2', 9);
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: { c1: 8, c2: 9 } }));
+      // The heal's post-check sees the refreshed watermark.
+      mockRefreshSnapshot.mockImplementation(async (_agentId: string | null, id: string) => {
+        revs.current.set(id, 8);
+      });
+
+      await syncWatchedConversationRevs();
+
+      expect(mockRefreshSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockRefreshSnapshot).toHaveBeenCalledWith('page-1', 'c1');
+    });
+
+    it('given a conversation with NO local watermark, should refetch it — "unknown" is not "current"', async () => {
+      registerConversationWatch('c1', 'page-1');
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: { c1: 3 } }));
+      mockRefreshSnapshot.mockImplementation(async (_agentId: string | null, id: string) => {
+        revs.current.set(id, 3);
+      });
+
+      await syncWatchedConversationRevs();
+
+      expect(mockRefreshSnapshot).toHaveBeenCalledWith('page-1', 'c1');
+    });
+
+    // The route filters through canAccessConversation, so an un-shared or deleted
+    // conversation simply isn't in the answer. Blanking a cache the user can still
+    // see would be worse than leaving it.
+    it('given an id absent from the response, should leave that conversation alone', async () => {
+      registerConversationWatch('c1', 'page-1');
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: {} }));
+
+      await syncWatchedConversationRevs();
+
+      expect(mockRefreshSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('given a failed request, should swallow it — the next event\'s gap detection is a second chance', async () => {
+      registerConversationWatch('c1', 'page-1');
+      mockFetchWithAuth.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+
+      await expect(syncWatchedConversationRevs()).resolves.toBeUndefined();
+      expect(mockRefreshSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('given a thrown request, should swallow it too', async () => {
+      registerConversationWatch('c1', 'page-1');
+      mockFetchWithAuth.mockRejectedValue(new Error('offline'));
+
+      await expect(syncWatchedConversationRevs()).resolves.toBeUndefined();
+    });
+
+    // Every mounted subscription observes the same reconnect. N identical batch
+    // requests would be N times the work for one answer.
+    it('given concurrent callers, should issue ONE request and hand them all the same promise', async () => {
+      registerConversationWatch('c1', 'page-1');
+      revs.current.set('c1', 1);
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: { c1: 1 } }));
+
+      await Promise.all([
+        syncWatchedConversationRevs(),
+        syncWatchedConversationRevs(),
+        syncWatchedConversationRevs(),
+      ]);
+
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('given a sync AFTER an earlier one settled, should fetch fresh rather than reuse the old answer', async () => {
+      registerConversationWatch('c1', 'page-1');
+      revs.current.set('c1', 1);
+      mockFetchWithAuth.mockResolvedValue(okJson({ revs: { c1: 1 } }));
+
+      await syncWatchedConversationRevs();
+      await syncWatchedConversationRevs();
+
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('healConversationToRev', () => {
+    it('given the first snapshot reaches the target, should stop at one refetch', async () => {
+      mockRefreshSnapshot.mockImplementation(async (_agentId: string | null, id: string) => {
+        revs.current.set(id, 9);
+      });
+
+      await healConversationToRev('c1', 'page-1', 9);
+
+      expect(mockRefreshSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    // refreshConversationSnapshot coalesces concurrent refreshes, so a heal can ride
+    // a fetch issued BEFORE the write it is meant to heal to. One extra pass — after
+    // the first settled, so the coalescing map is clear — closes that.
+    it('given the first snapshot still falls short (a coalesced, older fetch), should make exactly one more pass', async () => {
+      let call = 0;
+      mockRefreshSnapshot.mockImplementation(async (_agentId: string | null, id: string) => {
+        call += 1;
+        revs.current.set(id, call === 1 ? 7 : 9);
+      });
+
+      await healConversationToRev('c1', 'page-1', 9);
+
+      expect(mockRefreshSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    it('given an unreachable target, should still stop after two passes — never a retry storm', async () => {
+      mockRefreshSnapshot.mockImplementation(async (_agentId: string | null, id: string) => {
+        revs.current.set(id, 1);
+      });
+
+      await healConversationToRev('c1', 'page-1', 1000);
+
+      expect(mockRefreshSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    it('given no target rev, should refetch once and ask no questions', async () => {
+      await healConversationToRev('c1', null, null);
+
+      expect(mockRefreshSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockRefreshSnapshot).toHaveBeenCalledWith(null, 'c1');
+    });
+  });
+});

--- a/apps/web/src/lib/realtime/__tests__/session-directory-listener.test.ts
+++ b/apps/web/src/lib/realtime/__tests__/session-directory-listener.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * The directory plane (Agent-Session SSoT epic, Phase 2 / plan PR 4): a server-side
+ * conversation change reaches the session listings as an EVENT, not as the next
+ * poll tick. These pin which events do targeted surgery and which fall back to a
+ * re-read — the distinction is only "can the payload reconstruct a listing row".
+ */
+
+const { mockSocket, socketHandlers, mockMutate } = vi.hoisted(() => {
+  const handlers = new Map<string, Array<(payload: unknown) => void>>();
+  const socket = {
+    on: (event: string, handler: (payload: unknown) => void) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    off: (event: string, handler: (payload: unknown) => void) => {
+      handlers.set(event, (handlers.get(event) ?? []).filter((h) => h !== handler));
+    },
+    emit: vi.fn(),
+  };
+  return {
+    mockSocket: { current: socket as typeof socket | null },
+    socketHandlers: handlers,
+    mockMutate: vi.fn(),
+  };
+});
+
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => mockSocket.current }));
+vi.mock('swr', () => ({ useSWRConfig: () => ({ mutate: mockMutate }) }));
+
+import { useSessionDirectoryListener } from '../session-directory-listener';
+
+const SESSION = 'ws-1';
+const CONV = 'conv-1';
+
+const fire = (event: string, payload: unknown) => {
+  act(() => {
+    for (const handler of socketHandlers.get(event) ?? []) handler(payload);
+  });
+};
+
+/** Run the update function SWR would run, against a starting cache. */
+const applyMutation = <T,>(callIndex: number, current: T): T => {
+  const [, updater] = mockMutate.mock.calls[callIndex];
+  return (updater as (c: T) => T)(current);
+};
+
+const listing = (conversations: Array<Record<string, unknown>>) => ({
+  sessions: [{ sessionId: SESSION, conversations }],
+});
+
+const base = (overrides: Record<string, unknown> = {}) => ({
+  conversationId: CONV,
+  rev: 1,
+  scope: { kind: 'page' as const, pageId: 'page-1' },
+  workspaceId: SESSION,
+  triggeredBy: { userId: 'u1', browserSessionId: 'server' },
+  ...overrides,
+});
+
+describe('useSessionDirectoryListener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+    mockSocket.current = {
+      on: (event: string, handler: (payload: unknown) => void) => {
+        const list = socketHandlers.get(event) ?? [];
+        list.push(handler);
+        socketHandlers.set(event, list);
+      },
+      off: (event: string, handler: (payload: unknown) => void) => {
+        socketHandlers.set(event, (socketHandlers.get(event) ?? []).filter((h) => h !== handler));
+      },
+      emit: vi.fn(),
+    };
+  });
+
+  describe('conversation:created — the spawn-appears-without-a-poll case', () => {
+    it('should write the new conversation straight into its session listing, with no request', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:created', base({
+        conversation: {
+          id: CONV,
+          title: 'worker',
+          type: 'page',
+          contextId: 'agent-page-9',
+          workspaceId: SESSION,
+          isShared: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          lastMessageAt: null,
+        },
+      }));
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      const next = applyMutation(0, listing([{ conversationId: 'conv-old', agentPageId: null, lastMessageAt: null }]));
+      expect(next.sessions[0].conversations[0]).toMatchObject({
+        conversationId: CONV,
+        agentPageId: 'agent-page-9',
+        title: 'worker',
+      });
+      // Most-recent-first: the new row goes to the front.
+      expect(next.sessions[0].conversations.map((c) => c.conversationId)).toEqual([CONV, 'conv-old']);
+      // `{ revalidate: false }` — the write IS the update; no round-trip.
+      expect(mockMutate.mock.calls[0][2]).toEqual({ revalidate: false });
+    });
+
+    it('given the row is already there (the originating surface wrote it optimistically), should MERGE not duplicate', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:created', base({
+        conversation: {
+          id: CONV,
+          title: 'worker',
+          type: 'page',
+          contextId: 'agent-page-9',
+          workspaceId: SESSION,
+          isShared: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          lastMessageAt: null,
+        },
+      }));
+
+      const next = applyMutation(0, listing([{ conversationId: CONV, agentPageId: 'agent-page-9', lastMessageAt: null }]));
+      expect(next.sessions[0].conversations).toHaveLength(1);
+      expect(next.sessions[0].conversations[0]).toMatchObject({ conversationId: CONV, title: 'worker' });
+    });
+
+    it('given a global conversation with no workspace, should touch no session listing', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:created', base({ workspaceId: null, conversation: { id: CONV, title: null, type: 'global', contextId: null, workspaceId: null, isShared: false, createdAt: 'x', lastMessageAt: null } }));
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('conversation:updated', () => {
+    it('given a lastMessageAt bump, should patch it in place and re-sort the listing', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:updated', base({ changes: { lastMessageAt: '2024-06-01T00:00:00.000Z' } }));
+
+      const next = applyMutation(0, listing([
+        { conversationId: 'conv-newer', agentPageId: null, lastMessageAt: '2024-03-01T00:00:00.000Z' },
+        { conversationId: CONV, agentPageId: null, lastMessageAt: '2024-01-01T00:00:00.000Z' },
+      ]));
+      expect(next.sessions[0].conversations.map((c) => c.conversationId)).toEqual([CONV, 'conv-newer']);
+    });
+
+    it('given a workspace re-binding, should re-read — which row lives where is what this cache holds', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:updated', base({ changes: { workspaceId: 'ws-2' } }));
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate.mock.calls[0]).toHaveLength(1); // bare revalidate: no updater, no options
+    });
+
+    it('given a listing-membership stamp change, should re-read', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:updated', base({ changes: { closedInSessionAt: null } }));
+
+      expect(mockMutate.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('given a rename, should re-read (the row renders the title)', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:updated', base({ changes: { title: 'renamed' } }));
+
+      expect(mockMutate.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('given an update with no changes bag at all, should do nothing', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:updated', base({}));
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('conversation:closed / :deleted', () => {
+    it.each(['conversation:closed', 'conversation:deleted'])('%s should drop the row from its session listing', (event) => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire(event, base());
+
+      const next = applyMutation(0, listing([
+        { conversationId: CONV, agentPageId: null, lastMessageAt: null },
+        { conversationId: 'conv-keep', agentPageId: null, lastMessageAt: null },
+      ]));
+      expect(next.sessions[0].conversations.map((c) => c.conversationId)).toEqual(['conv-keep']);
+    });
+
+    it('given no workspace on the payload, should do nothing', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:closed', base({ workspaceId: null }));
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('re-read cases', () => {
+    it('conversation:reopened should re-read — the row left the cache and the event is id-level', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('conversation:reopened', base());
+
+      expect(mockMutate.mock.calls[0]).toHaveLength(1);
+    });
+
+    it.each(['session:created', 'session:updated', 'session:ended'])('%s should re-read', (event) => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire(event, {});
+
+      expect(mockMutate.mock.calls[0]).toHaveLength(1);
+    });
+
+    it('a reconnect should re-read — the directory has no watermark to heal against', () => {
+      renderHook(() => useSessionDirectoryListener());
+
+      fire('connect', undefined);
+
+      expect(mockMutate.mock.calls[0]).toHaveLength(1);
+    });
+  });
+
+  it('should unsubscribe every handler on unmount', () => {
+    const { unmount } = renderHook(() => useSessionDirectoryListener());
+    unmount();
+
+    for (const handlers of socketHandlers.values()) {
+      expect(handlers).toHaveLength(0);
+    }
+  });
+
+  it('given no socket yet, should register nothing rather than throw', () => {
+    mockSocket.current = null;
+
+    expect(() => renderHook(() => useSessionDirectoryListener())).not.toThrow();
+    expect(socketHandlers.size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/realtime/conversation-apply.ts
+++ b/apps/web/src/lib/realtime/conversation-apply.ts
@@ -1,0 +1,121 @@
+/**
+ * The conversation rev apply rule — PURE (Agent-Session Single Source of Truth
+ * epic, Phase 2 / plan PR 3; spec `docs/2.0-architecture/agent-sessions.md` §3
+ * clause 3).
+ *
+ * No React, no sockets, no DB, no `fetch`. This module is the whole delivery
+ * protocol reduced to one decision function, so the correctness argument can be
+ * read (and exhaustively tested) without a socket in sight. `useConversationSubscription`
+ * is the only IO wrapper around it.
+ *
+ * THE CONTRACT
+ *
+ * `conversations.rev` is bumped in the SAME transaction as every durable
+ * message/conversation write and the post-write value rides on the event.
+ * A subscriber holds that value as a per-conversation watermark. Then:
+ *
+ *   eventRev <= watermark      the write is already reflected in the cache — DROP.
+ *                              (Redelivery, an own-write echo the surface already
+ *                              applied, or an event that raced a snapshot that
+ *                              already included it.)
+ *   eventRev == watermark + 1  exactly the next write — APPLY, advance the watermark.
+ *   eventRev >  watermark + 1  a gap: at least one event was never delivered
+ *                              (transport is best-effort by design). The cache
+ *                              cannot be patched into currency — REFETCH.
+ *   truncated payload          the event carries an id-ref instead of the message
+ *                              (over `MAX_INLINE_MESSAGE_BYTES`) — there is nothing
+ *                              to apply — REFETCH. Unless it is already stale, in
+ *                              which case DROP still wins: refetching to re-learn
+ *                              something the cache already has is pure cost.
+ *
+ * TWO DEGENERATE REVS, both deliberate:
+ *
+ *  - `eventRev === 0` (UNVERSIONED_REV) means the emitter had NO conversations row
+ *    to bump (legacy page conversations — see `ContentEmitOptions.skipDirectory` in
+ *    `lib/websocket/conversation-events.ts`). A real post-write rev is always >= 1,
+ *    because the write that produced the event bumped it. So 0 is "this event
+ *    carries no watermark": apply it on its content alone (or refetch if truncated)
+ *    and leave the watermark where it was. Comparing it numerically would drop every
+ *    such event forever (0 <= any watermark).
+ *
+ *  - `watermark === null` means the subscriber has no proven baseline yet: an entry
+ *    exists (subscribe-on-open guarantees that) but its load has not committed a rev.
+ *    Nothing can be proven contiguous against "unknown", so a versioned event is a
+ *    REFETCH — the one call that both applies the content and establishes the
+ *    watermark. Unversioned events still apply, since they were never going to move
+ *    a watermark anyway.
+ */
+
+/** A post-write rev of 0 means "the emitter had no row to version" — see the module docblock. */
+export const UNVERSIONED_REV = 0;
+
+/**
+ * What a subscriber should do with one conversation event.
+ *
+ * - `drop`    — already reflected; do nothing (do NOT advance the watermark).
+ * - `apply`   — write the event's payload into the cache, then advance the watermark
+ *               with {@link nextWatermark}.
+ * - `refetch` — re-read the conversation from the server; the response's own rev
+ *               becomes the new watermark.
+ */
+export type ConversationApplyDecision = 'drop' | 'apply' | 'refetch';
+
+/** The only two fields of an event this rule reads. */
+export interface ConversationRevEvent {
+  /** The post-write `conversations.rev` the emitter stamped on the event. */
+  rev: number;
+  /**
+   * True when the event degraded to an id-level `messageRef` because the message
+   * exceeded `MAX_INLINE_MESSAGE_BYTES`. There is no content to apply.
+   */
+  truncated?: boolean;
+}
+
+/**
+ * The rule. Total, pure, and side-effect free: same inputs, same answer, always.
+ *
+ * @param event     the incoming event's rev + truncation flag
+ * @param watermark the cache entry's current rev, or `null` when no load has
+ *                  established one yet
+ */
+export const decideConversationApply = (
+  event: ConversationRevEvent,
+  watermark: number | null,
+): ConversationApplyDecision => {
+  // Not a number we can reason about (a hostile/rolling-deploy payload). Treat it
+  // exactly like a gap: the server is the authority, so go ask it.
+  if (!Number.isFinite(event.rev) || event.rev < 0) return 'refetch';
+
+  // Unversioned emitter (no conversations row): the event carries content but no
+  // watermark. Its content is still authoritative — apply it, or fetch it when the
+  // payload was too big to ride along.
+  if (event.rev === UNVERSIONED_REV) return event.truncated ? 'refetch' : 'apply';
+
+  // No proven baseline: only a server read can establish one.
+  if (watermark === null) return 'refetch';
+
+  // Already reflected. Checked BEFORE truncation, so a redelivered giant message
+  // costs nothing.
+  if (event.rev <= watermark) return 'drop';
+
+  // Contiguous — but only usable if the payload actually came along.
+  if (event.rev === watermark + 1) return event.truncated ? 'refetch' : 'apply';
+
+  // Gap.
+  return 'refetch';
+};
+
+/**
+ * The watermark after an `apply`. Monotonic by construction: an unversioned event
+ * (rev 0) leaves the watermark untouched rather than resetting a real one to 0, and
+ * a `null` baseline adopts nothing from an unversioned event (there is nothing to
+ * adopt).
+ *
+ * Only call this for decisions that came back `apply`; a `refetch` takes its
+ * watermark from the server response instead, and a `drop` moves nothing.
+ */
+export const nextWatermark = (current: number | null, appliedRev: number): number | null => {
+  if (!Number.isFinite(appliedRev) || appliedRev <= UNVERSIONED_REV) return current;
+  if (current === null) return appliedRev;
+  return appliedRev > current ? appliedRev : current;
+};

--- a/apps/web/src/lib/realtime/conversation-rev-sync.ts
+++ b/apps/web/src/lib/realtime/conversation-rev-sync.ts
@@ -1,0 +1,152 @@
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { refreshConversationSnapshot } from '@/hooks/conversationMessagesLoaders';
+
+/**
+ * The reconnect half of the delivery protocol (Agent-Session Single Source of
+ * Truth epic, Phase 2; `docs/2.0-architecture/agent-sessions.md` §3 clause 3).
+ *
+ * Broadcast transport is best-effort by design — a socket that was gone for ten
+ * seconds simply did not receive the events emitted in those ten seconds, and
+ * nothing replays them. What makes that survivable is the watermark: on
+ * reconnect, ONE batched `POST /api/ai/conversations/revs` asks the server what
+ * rev every subscribed conversation is at, and only the ones that disagree with
+ * their local watermark are refetched. A hundred open panes cost one request and
+ * zero refetches when nothing changed while they were away.
+ *
+ * Module-level, not per-hook: batching is the entire point, so the registry of
+ * "which conversations is this tab subscribed to" has to outlive any single
+ * component. Every subscription registers on mount and unregisters on unmount,
+ * refcounted so two panes on the same conversation don't unregister each other.
+ */
+
+interface ConversationWatch {
+  /** The agent page hosting it, or `null` for a global-assistant conversation — picks the refetch endpoint. */
+  agentPageId: string | null;
+  /** How many mounted subscriptions are watching this conversation. */
+  count: number;
+}
+
+const watches = new Map<string, ConversationWatch>();
+
+/** Adds one watcher for `conversationId`. Idempotent per mount; pair with `unregisterConversationWatch`. */
+export const registerConversationWatch = (conversationId: string, agentPageId: string | null): void => {
+  const existing = watches.get(conversationId);
+  if (existing) {
+    existing.count += 1;
+    // Last mount wins on the endpoint. The two only ever disagree if the same
+    // conversation id is somehow opened as both page-anchored and global, which
+    // the data model forbids — this just refuses to hold a stale answer.
+    existing.agentPageId = agentPageId;
+    return;
+  }
+  watches.set(conversationId, { agentPageId, count: 1 });
+};
+
+/** Removes one watcher; the conversation leaves the batch when the last one goes. */
+export const unregisterConversationWatch = (conversationId: string): void => {
+  const existing = watches.get(conversationId);
+  if (!existing) return;
+  existing.count -= 1;
+  if (existing.count <= 0) watches.delete(conversationId);
+};
+
+/** Test seam: the ids currently in the reconnect batch. */
+export const watchedConversationIds = (): string[] => [...watches.keys()];
+
+/** Test seam — drops every watch. Never called in production. */
+export const resetConversationWatches = (): void => {
+  watches.clear();
+  inFlightSync = null;
+};
+
+/**
+ * Refetch `conversationId` until its watermark reaches `targetRev`, bounded to
+ * two passes.
+ *
+ * The second pass exists because `refreshConversationSnapshot` COALESCES
+ * concurrent refreshes for the same conversation: a burst of writes produces a
+ * burst of gap-detections, and every one after the first rides an in-flight
+ * fetch that may have been issued BEFORE the write it is supposed to heal to.
+ * Settling for that snapshot would leave the cache permanently one write short,
+ * healed only by whatever event happens to arrive next. One extra pass — issued
+ * after the first settled, so the coalescing map is clear and it really is a
+ * fresh read — closes it. Bounded rather than looping: an unreachable target
+ * (the row was rolled back, the response is from an older instance) must cost
+ * two requests, not an infinite retry storm.
+ */
+export const healConversationToRev = async (
+  conversationId: string,
+  agentPageId: string | null,
+  targetRev: number | null,
+): Promise<void> => {
+  await refreshConversationSnapshot(agentPageId, conversationId);
+  if (targetRev === null) return;
+  const reached = conversationMessagesActions.getRev(conversationId);
+  if (reached !== null && reached >= targetRev) return;
+  await refreshConversationSnapshot(agentPageId, conversationId);
+};
+
+interface RevsResponse {
+  revs?: Record<string, number>;
+}
+
+// One in-flight sync at a time. Every mounted subscription observes the same
+// reconnect, and N identical batch requests would be N times the work for one
+// answer — the second through Nth caller joins the first's promise.
+let inFlightSync: Promise<void> | null = null;
+
+/**
+ * The reconnect check: one batched revs request for every watched conversation,
+ * then a refetch of exactly the ones whose server rev disagrees with the local
+ * watermark.
+ *
+ * A conversation with NO local watermark (`null` — its load never committed one,
+ * or it was seeded rather than fetched) is refetched too: "unknown" cannot be
+ * proven current, and this is the cheap moment to establish it.
+ *
+ * An id absent from the response is left alone. Absence means the row is gone or
+ * the caller may no longer access it (the route filters through
+ * `canAccessConversation`); either way blanking a cache the user can still see is
+ * worse than leaving it, and the surfaces have their own access errors to render.
+ *
+ * Best-effort throughout — a failure logs and returns. The next event's gap
+ * detection is a second chance at exactly the same heal.
+ */
+export const syncWatchedConversationRevs = (): Promise<void> => {
+  if (inFlightSync) return inFlightSync;
+  const run = doSyncWatchedConversationRevs().finally(() => {
+    inFlightSync = null;
+  });
+  inFlightSync = run;
+  return run;
+};
+
+const doSyncWatchedConversationRevs = async (): Promise<void> => {
+  const entries = [...watches.entries()];
+  if (entries.length === 0) return;
+  try {
+    const res = await fetchWithAuth('/api/ai/conversations/revs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: entries.map(([id]) => id) }),
+    });
+    if (!res.ok) {
+      console.warn('[conversation-rev-sync] revs check failed', res.status);
+      return;
+    }
+    const { revs } = (await res.json()) as RevsResponse;
+    if (!revs) return;
+    await Promise.all(
+      entries.map(async ([conversationId, watch]) => {
+        const serverRev = revs[conversationId];
+        if (typeof serverRev !== 'number') return;
+        const localRev = conversationMessagesActions.getRev(conversationId);
+        if (localRev !== null && localRev >= serverRev) return;
+        await healConversationToRev(conversationId, watch.agentPageId, serverRev);
+      }),
+    );
+  } catch (error) {
+    console.warn('[conversation-rev-sync] revs check failed', error);
+  }
+};

--- a/apps/web/src/lib/realtime/session-directory-listener.ts
+++ b/apps/web/src/lib/realtime/session-directory-listener.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSWRConfig } from 'swr';
+import { useSocket } from '@/hooks/useSocket';
+import {
+  forgetConversationInCache,
+  revalidateSessionListings,
+  touchConversationInCache,
+  upsertConversationInCache,
+} from '@/components/agents/panes/session-conversations';
+import type { ConversationDirectoryPayload } from '@/lib/websocket/conversation-events';
+
+/**
+ * `useSessionDirectoryListener` — the DIRECTORY plane (Agent-Session Single
+ * Source of Truth epic, Phase 2 / plan PR 4).
+ *
+ * Every session listing in the app used to learn about new, closed and renamed
+ * conversations the same way: by asking again in fifteen or twenty seconds. That
+ * is why a worker an agent spawned on your behalf took up to a poll interval to
+ * appear in your sidebar, and why "did that actually work?" was a question at
+ * all. The server now emits `conversation:created/updated/closed/reopened/
+ * deleted` and `session:*` to the owner's own `user:<id>:sessions` room — joined
+ * automatically at connect, no subscription call needed — and this translates
+ * them into targeted SWR surgery on the `/api/agent-sessions**` listings.
+ *
+ * MOUNTED EXACTLY ONCE, from `GlobalChatProvider` (which wraps the whole
+ * Layout), for the same reason `DerivedStreamingRegistrations` is: the directory
+ * is app-wide state, and N mounted copies would be N identical revalidations per
+ * event. Nothing here is per-surface.
+ *
+ * TARGETED SURGERY WHERE THE PAYLOAD ALLOWS, REVALIDATION WHERE IT DOESN'T. A
+ * `created` event carries the whole conversation, so the row is written straight
+ * into the cache and the sidebar updates with no request at all. A `reopened`
+ * does not (the row left the cache when it closed, and the event is id-level),
+ * so it re-reads. Both are event-driven; the difference is only whether a
+ * network round-trip is needed to know what to draw.
+ *
+ * DEDUPED AGAINST THE LEGACY PATH. `chat:global_conversation_added` still fires
+ * in parallel during the migration window and `SidebarHistoryTab` still consumes
+ * it — but into its own local list, not this SWR cache, so the two cannot
+ * double-count each other. Within this cache, `upsertConversationInCache` is
+ * idempotent by conversation id, so a redelivery (or a race with the
+ * originating surface's own optimistic `recordMintedConversation`) merges
+ * instead of prepending a second row.
+ *
+ * BEST-EFFORT, like every other broadcast. A missed directory event costs at
+ * most one stale listing until the 120s backstop poll (or the next event) — the
+ * message plane's rev watermark is what carries correctness, not this.
+ */
+
+/** The `session:*` lifecycle events; all of them mean "re-read the listing". */
+const SESSION_LIFECYCLE_EVENTS = ['session:created', 'session:updated', 'session:ended'] as const;
+
+export function useSessionDirectoryListener(): void {
+  const socket = useSocket();
+  const { mutate } = useSWRConfig();
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleCreated = (payload: ConversationDirectoryPayload) => {
+      const { workspaceId, conversation } = payload;
+      // A conversation with no workspace is not in any session listing — nothing
+      // to insert it into. (Its own surfaces learn about it through their own
+      // paths; this listener owns session listings only.)
+      if (!workspaceId || !conversation) {
+        if (workspaceId) revalidateSessionListings(mutate);
+        return;
+      }
+      upsertConversationInCache(mutate, workspaceId, {
+        conversationId: conversation.id,
+        // The listing's `agentPageId` IS the conversation's `contextId` for a
+        // page-anchored thread; a global-assistant thread has no agent page.
+        agentPageId: conversation.type === 'page' ? conversation.contextId : null,
+        lastMessageAt: conversation.lastMessageAt,
+        title: conversation.title,
+        type: conversation.type,
+        contextId: conversation.contextId,
+        isShared: conversation.isShared,
+      });
+    };
+
+    const handleUpdated = (payload: ConversationDirectoryPayload) => {
+      const changes = payload.changes;
+      if (!changes) return;
+      // A workspace re-binding moves the row between sessions — which row lives
+      // where is exactly what this cache holds, so re-read rather than guess.
+      if (changes.workspaceId !== undefined) {
+        revalidateSessionListings(mutate);
+        return;
+      }
+      // `closedInSessionAt` moving is a listing membership change in either
+      // direction; the listing query owns that predicate, so re-read.
+      if (changes.closedInSessionAt !== undefined) {
+        revalidateSessionListings(mutate);
+        return;
+      }
+      if (changes.lastMessageAt !== undefined) {
+        touchConversationInCache(mutate, payload.conversationId, changes.lastMessageAt);
+      }
+      // A rename or a share-state flip changes what a row RENDERS, and the
+      // listing rows carry those fields — but only for a row already present,
+      // so a plain re-read is both correct and cheap enough at this frequency.
+      if (changes.title !== undefined || changes.isShared !== undefined) {
+        revalidateSessionListings(mutate);
+      }
+    };
+
+    const handleRemoved = (payload: ConversationDirectoryPayload) => {
+      if (!payload.workspaceId) return;
+      forgetConversationInCache(mutate, payload.workspaceId, payload.conversationId);
+    };
+
+    // Reopen restores a row this cache dropped, and the event is id-level — the
+    // conversation body has to come from the server.
+    const handleReopened = () => revalidateSessionListings(mutate);
+    const handleSessionLifecycle = () => revalidateSessionListings(mutate);
+
+    socket.on('conversation:created', handleCreated);
+    socket.on('conversation:updated', handleUpdated);
+    socket.on('conversation:closed', handleRemoved);
+    socket.on('conversation:deleted', handleRemoved);
+    socket.on('conversation:reopened', handleReopened);
+    for (const event of SESSION_LIFECYCLE_EVENTS) socket.on(event, handleSessionLifecycle);
+
+    // A reconnect missed whatever was emitted while we were away, and the
+    // directory has no watermark of its own to heal against — one re-read on
+    // reconnect is the directory plane's equivalent of the message plane's
+    // batched rev check.
+    socket.on('connect', handleSessionLifecycle);
+
+    return () => {
+      socket.off('conversation:created', handleCreated);
+      socket.off('conversation:updated', handleUpdated);
+      socket.off('conversation:closed', handleRemoved);
+      socket.off('conversation:deleted', handleRemoved);
+      socket.off('conversation:reopened', handleReopened);
+      for (const event of SESSION_LIFECYCLE_EVENTS) socket.off(event, handleSessionLifecycle);
+      socket.off('connect', handleSessionLifecycle);
+    };
+  }, [socket, mutate]);
+}
+
+/**
+ * Component wrapper, so the one mount site can be a JSX line next to
+ * `DerivedStreamingRegistrations` rather than a hook call buried in the
+ * provider's body. Renders nothing.
+ */
+export function SessionDirectoryListener(): null {
+  useSessionDirectoryListener();
+  return null;
+}

--- a/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
+++ b/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
@@ -18,7 +18,7 @@ describe('useConversationMessagesStore', () => {
 
   it('given a conversation never seen before, getEntry should return a seeded empty entry without mutating the store', () => {
     const entry = useConversationMessagesStore.getState().getEntry('c1');
-    expect(entry).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'idle', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false });
+    expect(entry).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'idle', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null });
     expect(useConversationMessagesStore.getState().byConversationId.c1).toBeUndefined();
   });
 
@@ -187,7 +187,7 @@ describe('useConversationMessagesStore', () => {
   it('given actions against one conversation, should not affect another conversation entry', () => {
     const { addOptimisticSend, getEntry } = useConversationMessagesStore.getState();
     addOptimisticSend('c1', msg('opt1'));
-    expect(getEntry('c2')).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'idle', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false });
+    expect(getEntry('c2')).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'idle', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null });
   });
 
   it('given isLoadCurrent with the generation returned by startLoad, should return true; with a stale generation, should return false', () => {

--- a/apps/web/src/stores/conversationMessages/__tests__/advanceRev.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/advanceRev.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { advanceRev } from '../advanceRev';
+import { seedEmpty, type ConversationMessagesById } from '../seedEmpty';
+
+const withRev = (rev: number | null): ConversationMessagesById => ({
+  c1: { ...seedEmpty(), rev },
+});
+
+describe('advanceRev', () => {
+  it('given a conversation with no entry, should leave the map untouched', () => {
+    // The watermark is a claim about what THIS cache holds — materializing an entry
+    // here would assert currency for a message list that was never loaded.
+    const byConversationId: ConversationMessagesById = {};
+    expect(advanceRev(byConversationId, { conversationId: 'missing', rev: 5 })).toBe(byConversationId);
+  });
+
+  it('given an entry with no baseline, should adopt the applied rev', () => {
+    const next = advanceRev(withRev(null), { conversationId: 'c1', rev: 5 });
+    expect(next.c1.rev).toBe(5);
+  });
+
+  it('given a higher applied rev, should advance the watermark', () => {
+    const next = advanceRev(withRev(4), { conversationId: 'c1', rev: 5 });
+    expect(next.c1.rev).toBe(5);
+  });
+
+  it('given a lower or equal applied rev, should keep the watermark and the same object identity', () => {
+    // Monotonic: a redelivered event must never walk the watermark backwards into
+    // re-applying writes the cache already holds. Identity is preserved so the
+    // no-op cannot trigger a store subscriber re-render.
+    const before = withRev(9);
+    expect(advanceRev(before, { conversationId: 'c1', rev: 9 })).toBe(before);
+    expect(advanceRev(before, { conversationId: 'c1', rev: 3 })).toBe(before);
+  });
+
+  it('given an unversioned rev (0), should leave a real watermark alone', () => {
+    // rev 0 means "the emitter had no conversations row to bump" — it carries content,
+    // never a watermark. See `lib/realtime/conversation-apply.ts`.
+    const before = withRev(9);
+    expect(advanceRev(before, { conversationId: 'c1', rev: 0 })).toBe(before);
+    expect(advanceRev(withRev(null), { conversationId: 'c1', rev: 0 }).c1.rev).toBeNull();
+  });
+
+  it('given a non-finite rev, should leave the watermark alone', () => {
+    const before = withRev(9);
+    expect(advanceRev(before, { conversationId: 'c1', rev: Number.NaN })).toBe(before);
+  });
+
+  it('given an advance, should not mutate the input map', () => {
+    const before = withRev(4);
+    const next = advanceRev(before, { conversationId: 'c1', rev: 5 });
+    expect(before.c1.rev).toBe(4);
+    expect(next).not.toBe(before);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConfirmedMessage.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConfirmedMessage.test.ts
@@ -23,6 +23,7 @@ describe('applyConfirmedMessage', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('m1', 'full reply') });
@@ -37,6 +38,7 @@ describe('applyConfirmedMessage', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('m1', 'full reply') });
@@ -45,7 +47,7 @@ describe('applyConfirmedMessage', () => {
 
   it('given the id matches an optimistic send, should append to messages and reconcile it out of optimisticSends', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.messages).toEqual([msg('opt1')]);
@@ -54,7 +56,7 @@ describe('applyConfirmedMessage', () => {
 
   it('given other optimistic sends unrelated to the confirmed id, should leave them untouched', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.optimisticSends).toEqual([msg('opt2')]);
@@ -62,7 +64,7 @@ describe('applyConfirmedMessage', () => {
 
   it('given an append, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'confirmedMessage', message: msg('m1') }]);
@@ -70,7 +72,7 @@ describe('applyConfirmedMessage', () => {
 
   it('given a replace, should also record a pending mutation (unlike applyRemoteUserMessage, which skips no-ops)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'partial')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'partial')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('m1', 'full') });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'confirmedMessage', message: msg('m1', 'full') }]);
@@ -78,7 +80,7 @@ describe('applyConfirmedMessage', () => {
 
   it('given an append or replace, should NOT bump loadGeneration', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConfirmedMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result.c1.loadGeneration).toBe(1);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationAskUserAnswer.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationAskUserAnswer.test.ts
@@ -16,7 +16,7 @@ const assistantMsg = (id: string, toolCallId: string, state: string): UIMessage 
 describe('applyConversationAskUserAnswer', () => {
   it('given a matching message in a tracked conversation, should patch the tool part to output-available', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationAskUserAnswer(initial, {
       conversationId: 'c1',
@@ -35,8 +35,8 @@ describe('applyConversationAskUserAnswer', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
-      other: { messages: [assistantMsg('a2', 'tc2', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
+      other: { messages: [assistantMsg('a2', 'tc2', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationAskUserAnswer(initial, {
       conversationId: 'c1',
@@ -47,7 +47,7 @@ describe('applyConversationAskUserAnswer', () => {
 
   it('given an answer, should record it in pendingMutationsSinceLoad so a racing load replays it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationAskUserAnswer(initial, {
       conversationId: 'c1',
@@ -60,7 +60,7 @@ describe('applyConversationAskUserAnswer', () => {
 
   it('given an answer for a message not present yet, should STILL record the pending mutation for later replay', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationAskUserAnswer(initial, {
       conversationId: 'c1',
@@ -73,7 +73,7 @@ describe('applyConversationAskUserAnswer', () => {
 
   it('given an answer, should NOT bump loadGeneration', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [assistantMsg('a1', 'tc1', 'input-available')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationAskUserAnswer(initial, {
       conversationId: 'c1',

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 describe('applyConversationDelete', () => {
   it('given a matching id in confirmed messages, should remove it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
     expect(result.c1.messages).toEqual([msg('m2')]);
@@ -16,7 +16,7 @@ describe('applyConversationDelete', () => {
 
   it('given a matching id in optimisticSends, should remove it from there too', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.c1.optimisticSends).toEqual([]);
@@ -24,7 +24,7 @@ describe('applyConversationDelete', () => {
 
   it('given an id present in neither array, should leave messages and optimisticSends unchanged (applyMessageDelete no-ops)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
     expect(result.c1.messages).toBe(initial.c1.messages);
@@ -38,7 +38,7 @@ describe('applyConversationDelete', () => {
 
   it('given an actual delete of a confirmed message, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'm1' }]);
@@ -46,7 +46,7 @@ describe('applyConversationDelete', () => {
 
   it('given a delete that only removed an optimistic (unconfirmed) send, should STILL record the pending mutation (Codex finding: the send may already be persisted server-side despite not yet being reconciled into messages locally, so a stale load could resurrect it)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'opt1' }]);
@@ -54,7 +54,7 @@ describe('applyConversationDelete', () => {
 
   it('given a delete for an id not locally known at all (neither array), should STILL record the pending mutation (a fully unknown message can still exist in a stale in-flight load snapshot)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'never-seen' });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'never-seen' }]);
@@ -62,7 +62,7 @@ describe('applyConversationDelete', () => {
 
   it('given an actual delete, should NOT bump loadGeneration (a fresh load already reflecting this delete must not be invalidated)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
     expect(result.c1.loadGeneration).toBe(1);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string, text: string): UIMessage => ({ id, role: 'user', parts:
 describe('applyConversationEdit', () => {
   it('given a matching messageId in a tracked conversation, should replace its parts and stamp editedAt', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const editedAt = new Date('2024-01-01T00:00:00.000Z');
     const result = applyConversationEdit(initial, {
@@ -20,7 +20,7 @@ describe('applyConversationEdit', () => {
 
   it('given a messageId not present, should leave messages unchanged (applyMessageEdit no-ops)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
@@ -39,8 +39,8 @@ describe('applyConversationEdit', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
-      other: { messages: [msg('x', 'y')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
+      other: { messages: [msg('x', 'y')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
@@ -51,7 +51,7 @@ describe('applyConversationEdit', () => {
 
   it('given an actual edit, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const editedAt = new Date('2024-01-01T00:00:00.000Z');
     const result = applyConversationEdit(initial, {
@@ -65,7 +65,7 @@ describe('applyConversationEdit', () => {
 
   it('given an edit for a messageId not present yet (e.g. conversation still loading), should STILL record the pending mutation for later replay (Codex finding: dropping it here would let a stale load undo the edit once the row appears)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const editedAt = new Date('2024-01-01T00:00:00.000Z');
     const result = applyConversationEdit(initial, {
@@ -79,7 +79,7 @@ describe('applyConversationEdit', () => {
 
   it('given an actual edit, should NOT bump loadGeneration (a fresh load already covering this edit must not be invalidated)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
@@ -99,6 +99,7 @@ describe('applyConversationEdit', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const result = applyConversationEdit(initial, {

--- a/apps/web/src/stores/conversationMessages/__tests__/applyFailLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyFailLoad.test.ts
@@ -11,7 +11,7 @@ describe('applyFailLoad', () => {
   // changes — but the "never clear cached messages on failure" guarantee stands.
   it('given an entry with existing messages, should mark loadStatus error and keep them unchanged (never clear to empty on a failed reload)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [msg('opt1')], loadGeneration: 2, pendingMutationsSinceLoad: [], loadStatus: 'loading', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [msg('opt1')], loadGeneration: 2, pendingMutationsSinceLoad: [], loadStatus: 'loading', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyFailLoad(initial, { conversationId: 'c1', generation: 2 });
     expect(result.c1.loadStatus).toBe('error');
@@ -21,7 +21,7 @@ describe('applyFailLoad', () => {
 
   it('given a stale generation, should keep prior state fully unchanged (the newer load owns the status)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 3, pendingMutationsSinceLoad: [], loadStatus: 'loading', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 3, pendingMutationsSinceLoad: [], loadStatus: 'loading', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyFailLoad(initial, { conversationId: 'c1', generation: 1 });
     expect(result).toBe(initial);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyLoad.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 describe('applyLoad', () => {
   it('given the current generation, should replace messages with the loaded set', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1'), msg('m2')] });
     expect(result.c1.messages).toEqual([msg('m1'), msg('m2')]);
@@ -16,7 +16,7 @@ describe('applyLoad', () => {
 
   it('given a stale generation (a newer load has since started), should no-op and return the same reference', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 2, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 2, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
     expect(result).toBe(initial);
@@ -29,7 +29,7 @@ describe('applyLoad', () => {
 
   it('given an optimistic send whose id now appears in the loaded set, should reconcile it out of optimisticSends', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, {
       conversationId: 'c1',
@@ -41,7 +41,7 @@ describe('applyLoad', () => {
 
   it('given no optimistic sends match the loaded set, should leave optimisticSends untouched', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
     expect(result.c1.optimisticSends).toEqual([msg('opt1')]);
@@ -49,7 +49,7 @@ describe('applyLoad', () => {
 
   it('given a fresh load, should preserve the loadGeneration value', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 5, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 5, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 5, messages: [msg('m1')] });
     expect(result.c1.loadGeneration).toBe(5);
@@ -57,8 +57,8 @@ describe('applyLoad', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
-      other: { messages: [msg('x')], optimisticSends: [], loadGeneration: 9, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
+      other: { messages: [msg('x')], optimisticSends: [], loadGeneration: 9, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [] });
     expect(result.other).toBe(initial.other);
@@ -68,7 +68,7 @@ describe('applyLoad', () => {
   // it seeds hasMoreOlder/olderCursor for the "load older" (scroll-to-top) path.
   it('given a pagination envelope, should capture hasMoreOlder and olderCursor', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, {
       conversationId: 'c1',
@@ -82,7 +82,7 @@ describe('applyLoad', () => {
 
   it('given NO pagination envelope and no prior cursor, should default to hasMoreOlder=false and olderCursor=null', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
     expect(result.c1.hasMoreOlder).toBe(false);
@@ -95,7 +95,7 @@ describe('applyLoad', () => {
   // after the very next background refresh.
   it('given NO pagination envelope but an existing cursor from a prior load, should preserve it rather than resetting to false/null', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: 'existing-cursor', hasMoreOlder: true, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: 'existing-cursor', hasMoreOlder: true, isLoadingOlder: false, rev: null },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
     expect(result.c1.hasMoreOlder).toBe(true);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyOlderPage.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyOlderPage.test.ts
@@ -11,6 +11,7 @@ const baseEntry = {
   pendingMutationsSinceLoad: [],
   loadStatus: 'loaded' as const,
   isLoadingOlder: true,
+  rev: null,
 };
 
 describe('applyOlderPage', () => {
@@ -84,7 +85,7 @@ describe('applyOlderPage', () => {
 
   it('should clear isLoadingOlder on success', () => {
     const initial: ConversationMessagesById = {
-      c1: { ...baseEntry, messages: [msg('m1')], olderCursor: 'm1', hasMoreOlder: true, isLoadingOlder: true },
+      c1: { ...baseEntry, messages: [msg('m1')], olderCursor: 'm1', hasMoreOlder: true, isLoadingOlder: true, rev: null },
     };
     const result = applyOlderPage(initial, {
       conversationId: 'c1',

--- a/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSend.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSend.test.ts
@@ -14,7 +14,7 @@ describe('applyOptimisticSend', () => {
 
   it('given existing optimistic sends, should append after them (send order)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt2') });
     expect(result.c1.optimisticSends).toEqual([msg('opt1'), msg('opt2')]);
@@ -22,7 +22,7 @@ describe('applyOptimisticSend', () => {
 
   it('given a message id already present in optimisticSends, should no-op (idempotent)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result).toBe(initial);
@@ -30,7 +30,7 @@ describe('applyOptimisticSend', () => {
 
   it('given a message id already present in confirmed messages, should no-op', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result).toBe(initial);
@@ -38,7 +38,7 @@ describe('applyOptimisticSend', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      other: { messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      other: { messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.other).toBe(initial.other);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSendFailure.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSendFailure.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 describe('applyOptimisticSendFailure', () => {
   it('given a matching id in optimisticSends, should remove it (send rejected before persisting — M9)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSendFailure(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.c1.optimisticSends).toEqual([]);
@@ -16,7 +16,7 @@ describe('applyOptimisticSendFailure', () => {
 
   it('given an id NOT in optimisticSends, should no-op (already promoted/reconciled — a late rejection must not remove a real message)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('opt1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('opt1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSendFailure(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.c1.messages).toEqual([msg('opt1')]);
@@ -30,8 +30,8 @@ describe('applyOptimisticSendFailure', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
-      other: { messages: [], optimisticSends: [msg('x')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
+      other: { messages: [], optimisticSends: [msg('x')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSendFailure(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.other).toBe(initial.other);
@@ -39,7 +39,7 @@ describe('applyOptimisticSendFailure', () => {
 
   it('given other optimistic sends in the same conversation, should leave them untouched', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyOptimisticSendFailure(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.c1.optimisticSends).toEqual([msg('opt2')]);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
@@ -13,7 +13,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given the id already confirmed, should no-op (duplicate broadcast)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result).toBe(initial);
@@ -21,7 +21,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given the id matches an optimistic send (own echo), should append to messages and reconcile it out of optimisticSends', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.messages).toEqual([msg('opt1')]);
@@ -30,7 +30,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given other optimistic sends unrelated to the broadcast id, should leave them untouched', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.optimisticSends).toEqual([msg('opt2')]);
@@ -38,7 +38,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given an actual append, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'remoteMessage', message: msg('m1') }]);
@@ -46,7 +46,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given a duplicate broadcast (no-op), should not record a pending mutation', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
@@ -54,7 +54,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given an actual append, should NOT bump loadGeneration (a fresh load already covering this message must not be invalidated)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result.c1.loadGeneration).toBe(1);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyStartLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyStartLoad.test.ts
@@ -12,6 +12,7 @@ describe('applyStartLoad', () => {
       loadGeneration: 1,
       pendingMutationsSinceLoad: [],
       loadStatus: 'loading', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+      rev: null,
     });
   });
 
@@ -23,6 +24,7 @@ describe('applyStartLoad', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const { byConversationId, generation } = applyStartLoad(initial, 'c1');
@@ -38,6 +40,7 @@ describe('applyStartLoad', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const { byConversationId } = applyStartLoad(initial, 'c1');
@@ -47,7 +50,7 @@ describe('applyStartLoad', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      other: { messages: [], optimisticSends: [], loadGeneration: 3, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      other: { messages: [], optimisticSends: [], loadGeneration: 3, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const { byConversationId } = applyStartLoad(initial, 'c1');
     expect(byConversationId.other).toBe(initial.other);
@@ -61,6 +64,7 @@ describe('applyStartLoad', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [{ type: 'remoteMessage', message: { id: 'm1', role: 'user', parts: [] } }],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const { byConversationId } = applyStartLoad(initial, 'c1');
@@ -79,6 +83,7 @@ describe('applyStartLoad', () => {
         loadGeneration: 1,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: 'cursor-1', hasMoreOlder: true, isLoadingOlder: true,
+        rev: null,
       },
     };
     const { byConversationId } = applyStartLoad(initial, 'c1');

--- a/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
@@ -60,7 +60,7 @@ describe('applyLoad reconciliation with concurrent live mutations', () => {
 
   it('given an edit lands while a load is in flight, should NOT be undone when the stale load resolves', () => {
     let store: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'original')], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'original')], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;
@@ -84,6 +84,7 @@ describe('applyLoad reconciliation with concurrent live mutations', () => {
         loadGeneration: 0,
         pendingMutationsSinceLoad: [],
         loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false,
+        rev: null,
       },
     };
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
@@ -122,7 +123,7 @@ describe('applyLoad reconciliation with concurrent live mutations', () => {
 
   it('given multiple live mutations of different kinds land during one load, all should be reflected after the load resolves', () => {
     let store: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'v1'), msg('m2')], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [msg('m1', 'v1'), msg('m2')], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;
@@ -166,7 +167,7 @@ describe('applyLoad reconciliation with concurrent live mutations', () => {
 
   it('given a delete broadcast arrives for an id that only exists in optimisticSends locally, should still exclude it once the load resolves (Codex finding #5)', () => {
     let store: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
     };
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;

--- a/apps/web/src/stores/conversationMessages/__tests__/outOfOrderReplayConvergence.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/outOfOrderReplayConvergence.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { UIMessage } from 'ai';
+import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
+import { replayPendingMutations } from '../replayPendingMutations';
+import type { PendingMutation } from '../seedEmpty';
+
+const msg = (id: string, text: string): UIMessage => ({
+  id,
+  role: 'assistant',
+  parts: [{ type: 'text', text }],
+});
+
+const textOf = (m: UIMessage): string =>
+  m.parts.map((p) => ('text' in p ? p.text : '')).join('');
+
+/**
+ * PERMANENT-DIVERGENCE REGRESSION (found by the property-based convergence suite
+ * at seed 37, minimised to three writes; Agent-Session SSoT epic, Phase 2).
+ *
+ * Conversation events are independent HMAC POSTs into realtime, which emits them
+ * in RECEIVE order — so two near-simultaneous writes to one conversation can
+ * reach a socket reversed. When the higher rev lands first it reads as a gap and
+ * triggers a refetch; the lower rev then arrives while that refetch is still in
+ * flight, is contiguous with the watermark, and is applied AND recorded as a
+ * pending mutation. If that pending mutation is replayed over the fetched
+ * snapshot, an OLDER payload lands on top of NEWER truth — and because the
+ * watermark still folds forward to the snapshot's rev, the client reads as
+ * current while showing stale content. `syncWatchedConversationRevs` compares
+ * revs, not content, so nothing ever heals it: the divergence is permanent.
+ */
+describe('out-of-order delivery during a gap-heal refetch', () => {
+  beforeEach(() => {
+    useConversationMessagesStore.setState({ byConversationId: {} });
+  });
+
+  it('given update@3 delivered before update@2, with the rev-2 event landing while the gap-heal GET is in flight, should converge on rev 3 with the rev-3 content', () => {
+    const store = useConversationMessagesStore.getState();
+    const CONV = 'c1';
+
+    // rev 1 — create m1@v1, loaded by the surface. Watermark: 1.
+    const gen = store.startLoad(CONV);
+    store.applyLoad(CONV, gen, [msg('m1', 'v1')], undefined, 1);
+    expect(useConversationMessagesStore.getState().getRev(CONV)).toBe(1);
+
+    // rev 3 arrives FIRST. 3 > watermark+1 ⇒ gap ⇒ the subscription issues a
+    // refetch. The GET reads the server's real truth: rev 3, content v3.
+    const snapshotToken = useConversationMessagesStore.getState().beginServerSnapshot(CONV);
+
+    // rev 2 arrives while that GET is in flight. 2 === watermark+1, so it is
+    // contiguous and correctly applied in isolation — and recorded as a pending
+    // mutation carrying the rev-2 payload.
+    useConversationMessagesStore.getState().applyConfirmedMessage(CONV, msg('m1', 'v2'), 2);
+    useConversationMessagesStore.getState().advanceRev(CONV, 2);
+    expect(textOf(useConversationMessagesStore.getState().getEntry(CONV).messages[0])).toBe('v2');
+
+    // The GET lands, carrying rev 3 / v3. The rev-2 pending mutation is already
+    // contained in this snapshot and must NOT be replayed over it.
+    useConversationMessagesStore
+      .getState()
+      .applyServerSnapshot(CONV, snapshotToken, [msg('m1', 'v3')], undefined, 3);
+
+    const entry = useConversationMessagesStore.getState().getEntry(CONV);
+    expect(useConversationMessagesStore.getState().getRev(CONV)).toBe(3);
+    // The bug produced rev 3 / v2 here — current-looking, permanently stale.
+    expect(textOf(entry.messages[0])).toBe('v3');
+    expect(entry.messages).toHaveLength(1);
+  });
+
+  it('given a pending mutation NEWER than the snapshot, should still replay it (the race the replay exists for)', () => {
+    const store = useConversationMessagesStore.getState();
+    const CONV = 'c2';
+
+    const gen = store.startLoad(CONV);
+    store.applyLoad(CONV, gen, [msg('m1', 'v1')], undefined, 1);
+
+    // A snapshot fetch begins, reading rev 1...
+    const snapshotToken = useConversationMessagesStore.getState().beginServerSnapshot(CONV);
+    // ...and a genuinely newer write lands while it is in flight.
+    useConversationMessagesStore.getState().applyConfirmedMessage(CONV, msg('m1', 'v2'), 2);
+    useConversationMessagesStore.getState().advanceRev(CONV, 2);
+
+    useConversationMessagesStore
+      .getState()
+      .applyServerSnapshot(CONV, snapshotToken, [msg('m1', 'v1')], undefined, 1);
+
+    const entry = useConversationMessagesStore.getState().getEntry(CONV);
+    // The rev-2 write outlives the stale snapshot, and the watermark never walks back.
+    expect(textOf(entry.messages[0])).toBe('v2');
+    expect(useConversationMessagesStore.getState().getRev(CONV)).toBe(2);
+  });
+
+  it('given a deletion at a rev the snapshot already contains, should not resurrect-then-redelete across the heal', () => {
+    const store = useConversationMessagesStore.getState();
+    const CONV = 'c3';
+
+    const gen = store.startLoad(CONV);
+    store.applyLoad(CONV, gen, [msg('m1', 'v1'), msg('m2', 'v1')], undefined, 1);
+
+    const snapshotToken = useConversationMessagesStore.getState().beginServerSnapshot(CONV);
+    useConversationMessagesStore.getState().applyDelete(CONV, 'm2', 2);
+    useConversationMessagesStore.getState().advanceRev(CONV, 2);
+
+    // The snapshot was read at rev 3 — it already reflects the rev-2 delete, and
+    // also a rev-3 re-creation of that id. Replaying the stale delete would undo
+    // a write the server has since made.
+    useConversationMessagesStore
+      .getState()
+      .applyServerSnapshot(CONV, snapshotToken, [msg('m1', 'v1'), msg('m2', 'recreated')], undefined, 3);
+
+    const entry = useConversationMessagesStore.getState().getEntry(CONV);
+    expect(entry.messages.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(textOf(entry.messages[1])).toBe('recreated');
+  });
+});
+
+describe('replayPendingMutations rev gate', () => {
+  const pending = (rev: number | undefined, text: string): PendingMutation => ({
+    type: 'confirmedMessage',
+    message: msg('m1', text),
+    rev,
+  });
+
+  it('given a mutation at or below the snapshot rev, should skip it', () => {
+    const out = replayPendingMutations([msg('m1', 'v3')], [pending(2, 'v2')], 3);
+    expect(textOf(out[0])).toBe('v3');
+    const equal = replayPendingMutations([msg('m1', 'v3')], [pending(3, 'v3-echo')], 3);
+    expect(textOf(equal[0])).toBe('v3');
+  });
+
+  it('given a mutation above the snapshot rev, should apply it', () => {
+    const out = replayPendingMutations([msg('m1', 'v1')], [pending(4, 'v4')], 3);
+    expect(textOf(out[0])).toBe('v4');
+  });
+
+  it('given an UNVERSIONED mutation, should always apply it regardless of the snapshot rev', () => {
+    // rev 0 means the emitter had no conversations row to version, and `undefined`
+    // means the path carries no rev at all (SSE commit, legacy chat:* fan-out).
+    // Neither proves anything about ordering, so their content must survive.
+    expect(textOf(replayPendingMutations([msg('m1', 'v1')], [pending(0, 'unv')], 9)[0])).toBe('unv');
+    expect(textOf(replayPendingMutations([msg('m1', 'v1')], [pending(undefined, 'unv')], 9)[0])).toBe('unv');
+  });
+
+  it('given no snapshot rev, should replay everything (pre-existing behavior)', () => {
+    expect(textOf(replayPendingMutations([msg('m1', 'v1')], [pending(2, 'v2')])[0])).toBe('v2');
+    expect(textOf(replayPendingMutations([msg('m1', 'v1')], [pending(2, 'v2')], null)[0])).toBe('v2');
+  });
+
+  it('given every pending mutation is superseded, should return the snapshot array unchanged by identity', () => {
+    const snapshot = [msg('m1', 'v3')];
+    expect(replayPendingMutations(snapshot, [pending(1, 'v1'), pending(2, 'v2')], 3)).toBe(snapshot);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/promoteOptimisticSends.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/promoteOptimisticSends.test.ts
@@ -16,7 +16,7 @@ import type { ConversationMessagesById } from '../seedEmpty';
 const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 
 const entry = (messages: UIMessage[], optimisticSends: UIMessage[]): ConversationMessagesById => ({
-  c1: { messages, optimisticSends, loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false },
+  c1: { messages, optimisticSends, loadGeneration: 1, pendingMutationsSinceLoad: [], loadStatus: 'loaded', olderCursor: null, hasMoreOlder: false, isLoadingOlder: false, rev: null },
 });
 
 describe('promoteOptimisticSends', () => {

--- a/apps/web/src/stores/conversationMessages/__tests__/seedEmpty.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/seedEmpty.test.ts
@@ -12,6 +12,9 @@ describe('seedEmpty', () => {
       olderCursor: null,
       hasMoreOlder: false,
       isLoadingOlder: false,
+      // No rev watermark until a load establishes one — `null` means "cannot
+      // prove currency", which `decideConversationApply` answers with a refetch.
+      rev: null,
     });
   });
 

--- a/apps/web/src/stores/conversationMessages/advanceRev.ts
+++ b/apps/web/src/stores/conversationMessages/advanceRev.ts
@@ -1,0 +1,31 @@
+import type { ConversationMessagesById } from './seedEmpty';
+import { nextWatermark } from '@/lib/realtime/conversation-apply';
+
+export interface AdvanceRevEvent {
+  conversationId: string;
+  /** The post-write rev of the event that was just APPLIED to this entry. */
+  rev: number;
+}
+
+/**
+ * Advances a conversation entry's rev watermark after an event's payload has
+ * been written into the cache (Agent-Session SSoT epic, Phase 2).
+ *
+ * Monotonic via `nextWatermark`, and a NO-OP for a conversation with no entry:
+ * the watermark is a statement about what THIS cache holds, and materializing an
+ * entry here would claim currency for a message list that was never loaded.
+ * Subscribe-on-open means any conversation a surface is showing already has one.
+ */
+export const advanceRev = (
+  byConversationId: ConversationMessagesById,
+  event: AdvanceRevEvent,
+): ConversationMessagesById => {
+  const existing = byConversationId[event.conversationId];
+  if (!existing) return byConversationId;
+  const rev = nextWatermark(existing.rev, event.rev);
+  if (rev === existing.rev) return byConversationId;
+  return {
+    ...byConversationId,
+    [event.conversationId]: { ...existing, rev },
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyConfirmedMessage.ts
+++ b/apps/web/src/stores/conversationMessages/applyConfirmedMessage.ts
@@ -5,6 +5,14 @@ import type { ConversationMessagesById } from './seedEmpty';
 export interface ApplyConfirmedMessageEvent {
   conversationId: string;
   message: UIMessage;
+  /**
+   * The post-write `conversations.rev` the originating `conversation:*` event
+   * carried, when there was one. Recorded on the pending mutation so a snapshot
+   * that already contains this write can skip replaying it — see
+   * `replayPendingMutations`. Omit for unversioned paths (an SSE stream commit,
+   * the legacy `chat:*` fan-out), which always replay.
+   */
+  rev?: number;
 }
 
 /**
@@ -48,7 +56,7 @@ export const applyConfirmedMessage = (
       optimisticSends: existing.optimisticSends.filter((m) => m.id !== event.message.id),
       pendingMutationsSinceLoad: [
         ...existing.pendingMutationsSinceLoad,
-        { type: 'confirmedMessage', message: event.message },
+        { type: 'confirmedMessage', message: event.message, rev: event.rev },
       ],
     },
   };

--- a/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
@@ -4,6 +4,12 @@ import type { ConversationMessagesById } from './seedEmpty';
 export interface ApplyConversationDeleteEvent {
   conversationId: string;
   messageId: string;
+  /**
+   * The post-write `conversations.rev` the originating `conversation:message_deleted`
+   * event carried, when there was one — see `applyConfirmedMessage`'s `rev` and
+   * `replayPendingMutations`.
+   */
+  rev?: number;
 }
 
 /**
@@ -40,7 +46,7 @@ export const applyConversationDelete = (
       optimisticSends: applyMessageDelete(existing.optimisticSends, event.messageId),
       pendingMutationsSinceLoad: [
         ...existing.pendingMutationsSinceLoad,
-        { type: 'delete', messageId: event.messageId },
+        { type: 'delete', messageId: event.messageId, rev: event.rev },
       ],
     },
   };

--- a/apps/web/src/stores/conversationMessages/applyLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyLoad.ts
@@ -49,7 +49,14 @@ export const applyLoad = (
   const existing = byConversationId[event.conversationId];
   if (!existing || event.generation !== existing.loadGeneration) return byConversationId;
 
-  const messages = replayPendingMutations(event.messages, existing.pendingMutationsSinceLoad);
+  // Rev-gated: a mutation the snapshot already contains must not be replayed
+  // over it (see `replayPendingMutations`). Only mutations NEWER than this
+  // snapshot's rev — plus every unversioned one — survive onto the result.
+  const messages = replayPendingMutations(
+    event.messages,
+    existing.pendingMutationsSinceLoad,
+    event.rev,
+  );
   const loadedIds = new Set(messages.map((m) => m.id));
   const optimisticSends = existing.optimisticSends.filter((m) => !loadedIds.has(m.id));
 

--- a/apps/web/src/stores/conversationMessages/applyLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyLoad.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from 'ai';
 import type { ConversationMessagesById } from './seedEmpty';
 import { replayPendingMutations } from './replayPendingMutations';
+import { nextWatermark } from '@/lib/realtime/conversation-apply';
 
 export interface ApplyLoadEvent {
   conversationId: string;
@@ -8,6 +9,16 @@ export interface ApplyLoadEvent {
   messages: UIMessage[];
   /** The load's pagination envelope (epic leaf 6.6) — seeds hasMoreOlder/olderCursor for "load older". */
   pagination?: { hasMore: boolean; nextCursor: string | null };
+  /**
+   * The server's `conversations.rev` at read time (Agent-Session SSoT epic,
+   * Phase 2). Folded through `nextWatermark`, never assigned outright: live
+   * events replayed from `pendingMutationsSinceLoad` may already have carried
+   * the entry PAST this snapshot's rev, and a load must not walk the watermark
+   * backwards into re-applying writes it already holds. Omit (or `null`) when
+   * the caller has no rev — a legacy envelope, or an "older page" fetch, which
+   * says nothing about the conversation's head.
+   */
+  rev?: number | null;
 }
 
 /**
@@ -55,6 +66,10 @@ export const applyLoad = (
       // whatever the last envelope-carrying load established (PR 6 review, Codex).
       hasMoreOlder: event.pagination ? event.pagination.hasMore : existing.hasMoreOlder,
       olderCursor: event.pagination ? event.pagination.nextCursor : existing.olderCursor,
+      rev:
+        event.rev === undefined || event.rev === null
+          ? existing.rev
+          : nextWatermark(existing.rev, event.rev),
     },
   };
 };

--- a/apps/web/src/stores/conversationMessages/replayPendingMutations.ts
+++ b/apps/web/src/stores/conversationMessages/replayPendingMutations.ts
@@ -3,6 +3,27 @@ import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
 import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
 import { applyAskUserAnswer } from '@/lib/ai/streams/applyAskUserAnswer';
 import type { PendingMutation } from './seedEmpty';
+import { UNVERSIONED_REV } from '@/lib/realtime/conversation-apply';
+
+/**
+ * A mutation the snapshot demonstrably already contains: the snapshot was read
+ * at `snapshotRev`, which by definition reflects every durable write up to and
+ * including that rev, so a mutation stamped at or below it is redundant —
+ * and re-applying it would write an OLDER payload over newer truth.
+ *
+ * Both revs must be real numbers for the comparison to mean anything.
+ * `UNVERSIONED_REV` (0) is never "already contained": it means the emitter had
+ * no `conversations` row to version, so it proves nothing about ordering and
+ * its content must still be replayed.
+ */
+const isSupersededBySnapshot = (
+  mutation: PendingMutation,
+  snapshotRev: number | null | undefined,
+): boolean =>
+  typeof snapshotRev === 'number' &&
+  typeof mutation.rev === 'number' &&
+  mutation.rev > UNVERSIONED_REV &&
+  mutation.rev <= snapshotRev;
 
 /**
  * Replays live mutations recorded during a load's flight onto that load's
@@ -14,14 +35,35 @@ import type { PendingMutation } from './seedEmpty';
  * append-if-absent. `confirmedMessage` (an assistant reply confirmation, whose
  * content CAN legitimately supersede a load snapshot's stale/partial copy of
  * the same id) replays as upsert-by-id instead — see `applyConfirmedMessage`.
+ *
+ * REV-GATED against the snapshot (Agent-Session SSoT epic, Phase 2). Replay
+ * exists because there is no ordering guarantee between a fetch and the live
+ * events that race it — but "no guarantee" cuts both ways, and a mutation the
+ * snapshot already includes must NOT be replayed over it. Consider three writes
+ * to one message, delivered out of order:
+ *
+ *   rev1 create v1 (loaded)  ·  rev2 update→v2  ·  rev3 update→v3
+ *   update@3 arrives first   → gap vs watermark 1 → refetch issued (reads rev 3, v3)
+ *   update@2 arrives next    → 2 == watermark+1  → applied, and RECORDED as pending
+ *   the refetch lands        → without this gate the rev-2 payload replays over the
+ *                              rev-3 snapshot, and the watermark folds to 3
+ *   ⇒ client: rev 3 / v2     server: rev 3 / v3, and the revs agree forever
+ *
+ * Passing `snapshotRev` drops exactly those superseded mutations. Omit it (or
+ * pass `null`) when the caller has no rev — every mutation replays, which is the
+ * pre-existing behavior and still correct for an unversioned snapshot.
  */
 export const replayPendingMutations = (
   messages: UIMessage[],
   pending: readonly PendingMutation[],
+  snapshotRev?: number | null,
 ): UIMessage[] => {
   if (pending.length === 0) return messages;
 
-  return pending.reduce((acc, mutation) => {
+  const applicable = pending.filter((m) => !isSupersededBySnapshot(m, snapshotRev));
+  if (applicable.length === 0) return messages;
+
+  return applicable.reduce((acc, mutation) => {
     if (mutation.type === 'remoteMessage') {
       return acc.some((m) => m.id === mutation.message.id) ? acc : [...acc, mutation.message];
     }

--- a/apps/web/src/stores/conversationMessages/seedEmpty.ts
+++ b/apps/web/src/stores/conversationMessages/seedEmpty.ts
@@ -62,6 +62,18 @@ export interface ConversationCacheEntry {
   hasMoreOlder: boolean;
   /** True while a "load older" fetch is in flight — inline scroll indicator only, no error-banner takeover. */
   isLoadingOlder: boolean;
+  /**
+   * The conversation's rev WATERMARK (Agent-Session SSoT epic, Phase 2) — the
+   * `conversations.rev` this entry's `messages` are known to reflect.
+   *
+   * Established by a message-list GET (both envelopes now carry `rev`) and
+   * advanced by every applied `conversation:*` event. `null` means "no proven
+   * baseline yet": an entry exists (subscribe-on-open guarantees one the moment
+   * a surface opens the conversation) but nothing has told us where it stands,
+   * so `decideConversationApply` answers `refetch` for any versioned event
+   * rather than guessing. See `@/lib/realtime/conversation-apply`.
+   */
+  rev: number | null;
 }
 
 export type ConversationMessagesById = Record<string, ConversationCacheEntry>;
@@ -76,4 +88,5 @@ export const seedEmpty = (): ConversationCacheEntry => ({
   olderCursor: null,
   hasMoreOlder: false,
   isLoadingOlder: false,
+  rev: null,
 });

--- a/apps/web/src/stores/conversationMessages/seedEmpty.ts
+++ b/apps/web/src/stores/conversationMessages/seedEmpty.ts
@@ -2,17 +2,38 @@ import type { UIMessage } from 'ai';
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 import type { AskUserAnswerPayload } from '@/lib/ai/streams/applyAskUserAnswer';
 
-/**
- * A live mutation (remote broadcast) recorded while a load is in flight, so
- * `applyLoad` can replay it onto the loaded snapshot regardless of which
- * resolves first — see `replayPendingMutations`.
- */
-export type PendingMutation =
+type PendingMutationKind =
   | { type: 'remoteMessage'; message: UIMessage }
   | { type: 'confirmedMessage'; message: UIMessage }
   | { type: 'edit'; payload: MessageEditPayload }
   | { type: 'delete'; messageId: string }
   | { type: 'askUserAnswer'; payload: AskUserAnswerPayload };
+
+/**
+ * A live mutation (remote broadcast) recorded while a load is in flight, so
+ * `applyLoad` can replay it onto the loaded snapshot regardless of which
+ * resolves first — see `replayPendingMutations`.
+ *
+ * `rev` is the post-write `conversations.rev` the event carried, when it came
+ * from a rev-bearing `conversation:*` event. It is what makes the replay
+ * ORDER-SAFE against a snapshot: a fetched snapshot read at rev N already
+ * contains every write up to N, so replaying a mutation with `rev <= N` on top
+ * of it re-applies an OLDER payload over newer truth. That is not a transient
+ * glitch — the watermark still folds forward to N, so the cache reads as
+ * current while showing stale content, and `syncWatchedConversationRevs`
+ * (which compares revs, not content) never heals it.
+ *
+ * Reachable in production because conversation events are independent HMAC
+ * POSTs into realtime, which emits in receive order: two near-simultaneous
+ * writes can reach one socket reversed, and the later-delivered/lower-rev one
+ * lands while the gap-triggered refetch is still in flight.
+ *
+ * `undefined` means UNVERSIONED — the mutation came from a path that carries no
+ * rev (the legacy `chat:*` fan-out, an SSE stream commit, `promoteOptimisticSends`).
+ * Those always replay, exactly as before: with no rev there is nothing to prove
+ * the snapshot already contains them, and dropping them would lose content.
+ */
+export type PendingMutation = PendingMutationKind & { rev?: number };
 
 /**
  * Per-conversation slice of `useConversationMessagesStore`. `messages` is the

--- a/apps/web/src/stores/useConversationMessagesStore.ts
+++ b/apps/web/src/stores/useConversationMessagesStore.ts
@@ -67,14 +67,18 @@ interface ConversationMessagesState {
   /** Rolls back an optimistic send whose POST rejected (epic leaf 6.5, M9) — never touches confirmed `messages`. */
   removeOptimisticSendOnFailure: (conversationId: string, messageId: string) => void;
   applyEdit: (conversationId: string, payload: MessageEditPayload) => void;
-  applyDelete: (conversationId: string, messageId: string) => void;
+  /** `rev`: the deleting event's post-write rev, when it carried one — see PendingMutation. */
+  applyDelete: (conversationId: string, messageId: string, rev?: number) => void;
   /** Optimistic ask_user answer patch (epic leaf 6.3) — the resume POST's own commit reconciles it once persisted. */
   applyAskUserAnswer: (conversationId: string, payload: AskUserAnswerPayload) => void;
   /** Reverts an optimistic ask_user answer (the resume POST rejected) back to input-available. */
   revertAskUserAnswer: (conversationId: string, payload: AskUserAnswerRevertPayload) => void;
   applyRemoteUserMessage: (conversationId: string, message: UIMessage) => void;
-  /** Upsert-by-id (replace if present, append if absent) — see applyConfirmedMessage's docblock. */
-  applyConfirmedMessage: (conversationId: string, message: UIMessage) => void;
+  /**
+   * Upsert-by-id (replace if present, append if absent) — see applyConfirmedMessage's
+   * docblock. `rev`: the confirming event's post-write rev, when it carried one.
+   */
+  applyConfirmedMessage: (conversationId: string, message: UIMessage, rev?: number) => void;
   /** Promote optimistic sends into confirmed messages — call on OWN stream commit only (see promoteOptimisticSends). */
   promoteOptimisticSends: (conversationId: string) => void;
   /**
@@ -174,8 +178,8 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
     set((state) => ({ byConversationId: applyConversationEdit(state.byConversationId, { conversationId, payload }) }));
   },
 
-  applyDelete: (conversationId, messageId) => {
-    set((state) => ({ byConversationId: applyConversationDelete(state.byConversationId, { conversationId, messageId }) }));
+  applyDelete: (conversationId, messageId, rev) => {
+    set((state) => ({ byConversationId: applyConversationDelete(state.byConversationId, { conversationId, messageId, rev }) }));
   },
 
   applyAskUserAnswer: (conversationId, payload) => {
@@ -199,8 +203,8 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
     set((state) => ({ byConversationId: applyRemoteUserMessage(state.byConversationId, { conversationId, message }) }));
   },
 
-  applyConfirmedMessage: (conversationId, message) => {
-    set((state) => ({ byConversationId: applyConfirmedMessage(state.byConversationId, { conversationId, message }) }));
+  applyConfirmedMessage: (conversationId, message, rev) => {
+    set((state) => ({ byConversationId: applyConfirmedMessage(state.byConversationId, { conversationId, message, rev }) }));
   },
 
   promoteOptimisticSends: (conversationId) => {
@@ -232,13 +236,19 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
       // bump clear them, or an older recovery snapshot resurrects a message another tab
       // just deleted (CodeRabbit P2, PR #2098). Replayed over the MERGED list so a
       // delete/edit of a preserved older row is honored too.
+      // ...but ONLY the ones this snapshot doesn't already contain. This is the
+      // gap-heal path (`healConversationToRev` → `refreshConversationSnapshot`),
+      // so it is precisely where an out-of-order event applied while the fetch
+      // was in flight would otherwise be replayed over newer truth — leaving the
+      // cache stale at a watermark that says it is current, which no later revs
+      // check can detect. See `replayPendingMutations`.
       const pendingSinceFetch = state.byConversationId[conversationId]?.pendingMutationsSinceLoad ?? [];
       const { byConversationId, generation } = applyStartLoad(state.byConversationId, conversationId);
       return {
         byConversationId: applyLoad(byConversationId, {
           conversationId,
           generation,
-          messages: replayPendingMutations(merged.messages, pendingSinceFetch),
+          messages: replayPendingMutations(merged.messages, pendingSinceFetch, rev),
           pagination: merged.overlapped ? undefined : pagination,
           rev,
         }),

--- a/apps/web/src/stores/useConversationMessagesStore.ts
+++ b/apps/web/src/stores/useConversationMessagesStore.ts
@@ -14,6 +14,7 @@ import { applyConfirmedMessage } from '@/stores/conversationMessages/applyConfir
 import { promoteOptimisticSends } from '@/stores/conversationMessages/promoteOptimisticSends';
 import { replayPendingMutations } from '@/stores/conversationMessages/replayPendingMutations';
 import { mergeSnapshotTail } from '@/stores/conversationMessages/mergeSnapshotTail';
+import { advanceRev } from '@/stores/conversationMessages/advanceRev';
 import { seedEmpty, type ConversationCacheEntry, type ConversationMessagesById } from '@/stores/conversationMessages/seedEmpty';
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 import { revertAskUserAnswer, type AskUserAnswerPayload, type AskUserAnswerRevertPayload } from '@/lib/ai/streams/applyAskUserAnswer';
@@ -38,8 +39,18 @@ interface ConversationMessagesState {
     generation: number,
     messages: UIMessage[],
     pagination?: { hasMore: boolean; nextCursor: string | null },
+    /** The server's `conversations.rev` at read time — folded monotonically into the watermark. */
+    rev?: number | null,
   ) => void;
   failLoad: (conversationId: string, generation: number) => void;
+  /**
+   * The conversation's current rev watermark, or `null` when no load has
+   * established one. The input to `decideConversationApply` for every incoming
+   * `conversation:*` event.
+   */
+  getRev: (conversationId: string) => number | null;
+  /** Advances the watermark after an event's payload was applied — monotonic, no-op for an uncached conversation. */
+  advanceRev: (conversationId: string, rev: number) => void;
   /** Marks a "load older" fetch in flight (epic leaf 6.6) — inline indicator, no generation change. */
   startLoadingOlder: (conversationId: string) => void;
   /** Prepends a dedup'd older page and advances olderCursor/hasMoreOlder; generation-gated. */
@@ -88,6 +99,8 @@ interface ConversationMessagesState {
     messages: UIMessage[],
     /** The snapshot fetch's own envelope — applied only when the snapshot REPLACES the cache (no overlap), so pagination resets consistently with the replaced list. */
     pagination?: { hasMore: boolean; nextCursor: string | null },
+    /** The `conversations.rev` the snapshot was read at — the watermark a gap-triggered refetch heals to. */
+    rev?: number | null,
   ) => void;
   /**
    * Marks a freshly-minted conversation as loaded-empty — createNewConversation
@@ -113,12 +126,18 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
   isLoadCurrent: (conversationId, generation) =>
     get().byConversationId[conversationId]?.loadGeneration === generation,
 
-  applyLoad: (conversationId, generation, messages, pagination) => {
-    set((state) => ({ byConversationId: applyLoad(state.byConversationId, { conversationId, generation, messages, pagination }) }));
+  applyLoad: (conversationId, generation, messages, pagination, rev) => {
+    set((state) => ({ byConversationId: applyLoad(state.byConversationId, { conversationId, generation, messages, pagination, rev }) }));
   },
 
   failLoad: (conversationId, generation) => {
     set((state) => ({ byConversationId: applyFailLoad(state.byConversationId, { conversationId, generation }) }));
+  },
+
+  getRev: (conversationId) => get().byConversationId[conversationId]?.rev ?? null,
+
+  advanceRev: (conversationId, rev) => {
+    set((state) => ({ byConversationId: advanceRev(state.byConversationId, { conversationId, rev }) }));
   },
 
   startLoadingOlder: (conversationId) => {
@@ -191,7 +210,7 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
   beginServerSnapshot: (conversationId) =>
     get().byConversationId[conversationId]?.loadGeneration ?? 0,
 
-  applyServerSnapshot: (conversationId, generationToken, messages, pagination) => {
+  applyServerSnapshot: (conversationId, generationToken, messages, pagination, rev) => {
     set((state) => {
       // Stale-token drop (CR4): the generation moved since this snapshot's fetch
       // began — a loud load started, or a fresher snapshot already committed — so
@@ -221,6 +240,7 @@ export const useConversationMessagesStore = create<ConversationMessagesState>((s
           generation,
           messages: replayPendingMutations(merged.messages, pendingSinceFetch),
           pagination: merged.overlapped ? undefined : pagination,
+          rev,
         }),
       };
     });


### PR DESCRIPTION
Client cutover of **Phase 2** of the Agent-Session Single Source of Truth epic (plan D3/D4, PRs 3–4). Spec: `docs/2.0-architecture/agent-sessions.md` §3. The server half is already on the base branch (`conversations.rev`, the `conv:<id>` / `user:<id>:sessions` / `session:<id>` rooms, `join_conversation` + `canAccessConversation`, and repositories emitting `conversation:*` + directory events).

The bug this closes: a surface only learned about a message if it happened to be attached to the stream that produced it. A dispatch made from anywhere else — another tab, an agent acting on your behalf, the API — landed in the database and nowhere else, so an open pane sat blank until something reloaded it.

## The apply rule, as a pure module

`apps/web/src/lib/realtime/conversation-apply.ts` is the entire delivery protocol reduced to one decision function — no React, no sockets, no DB, no `fetch` — so the correctness argument can be read and exhaustively tested without a socket in sight:

| event vs. watermark | decision |
|---|---|
| `eventRev <= watermark` | **drop** — already reflected (redelivery, own-write echo, or a race with a snapshot that already included it) |
| `eventRev === watermark + 1` | **apply**, then advance the watermark |
| `eventRev > watermark + 1` | **refetch** — a gap; transport is best-effort by design and the cache cannot be patched into currency |
| truncated payload, or `watermark === null` | **refetch** — nothing to apply / no baseline to prove contiguity against |

Two degenerate revs are deliberate and documented in the module: `rev === 0` means the emitter had no `conversations` row to bump (legacy page conversations), so it applies on content alone and moves no watermark; `watermark === null` means no load has committed a baseline yet.

`useConversationSubscription` is the **only** IO wrapper around that rule.

## The gates are deleted, not relaxed

- **`hasEntry`** (`conversationCacheSocketHandlers.ts`) — every handler used to early-return unless the conversation already had a cache entry, on the reasoning "cached ⇔ some surface can render it". The hole was exactly the size of the bug: the entry is created by a *load*, the load is *async*, so a dispatch landing between a pane mounting and its first fetch committing was dropped with nothing to re-deliver it. `useConversationSubscription` ensures a cache entry **before** it joins the room, so "subscribed" implies "cached" by construction rather than by timing — the gate is unnecessary, not merely removed.
- **`startedBySomeoneElse && !isShared`** (`useChannelStreamSocket.ts`) — dropped. The canonical bug is a user's *own* dispatch, made from another surface, being invisible to their own open pane.

No self-echo skip either: `triggeredBy.browserSessionId` is ignored on purpose. Every cache action is idempotent (upsert-by-id), so a pane applying its own echo over its optimistic send is a no-op with a reconciliation attached.

## Rev watermarks end to end

`ConversationCacheEntry.rev`; both message-list GETs return `{messages, pagination, rev}`; `POST /api/ai/conversations/revs` proves currency for every open pane in **one** round-trip on reconnect, authorized through the shared `canAccessConversation` predicate (ids you may not access are *absent*, not a 403 for the whole batch — and absence is not an oracle). Stream bootstrap is re-keyed by conversation via `?conversationId=` on `/api/ai/chat/active-streams`, applied **after** `filterSubscribableStreams`, so it can only ever return fewer rows and grants nothing.

**Preserved deliberately:** the SSE token machinery (`consumeStreamJoin`, poll fallback, `claimBootstrapConsumer`, `shouldAttachStream`, `isOwnStream`, the `pendingStreams` mirror), the `commitConfirmedReply` protocol, merge-at-render via `selectRenderedMessages`, and the `useEditingStore` interplay. Streaming is still how tokens arrive; these events are the durable signal that also covers the case where both stream signals are lost.

## Directory plane replaces the polls

`session-directory-listener.ts` listens on `user:<id>:sessions` and does targeted SWR surgery via `session-conversations.ts`. A `created` event carries the whole conversation, so the row goes straight into the cache and the sidebar updates with **no request at all**; a `reopened` is id-level, so it re-reads. Mounted exactly once from `GlobalChatProvider`.

Both session-listing `refreshInterval`s drop **20s → 120s**, demoted to a backstop against a broadcast lost outright (with a comment saying so, and that they are slated for deletion at the epic's final contract PR). Correctness lives in the message plane's watermark, not in the poll.

## The fixme flip — the merge gate

The two `test.fixme`s in `apps/e2e/tests/16-dispatch-multiplayer.spec.ts` are **deleted** and now pass.

```
Running 7 tests using 1 worker

  ✓  1 tests/15-chat-fixture-smoke.spec.ts:51:7 › a seeded conversation renders its messages in the browser (795ms)
  ✓  2 tests/15-chat-fixture-smoke.spec.ts:68:7 › a send in slow mode grows an assistant bubble while streaming (5.4s)
  ✓  3 tests/15-chat-fixture-smoke.spec.ts:113:7 › a held stream keeps the Stop affordance up until released (1.5s)
  ✓  4 tests/16-dispatch-multiplayer.spec.ts:52:7 › dispatch harness smoke › a page-chat dispatch persists both sides of the turn (visible after reload) (1.4s)
  ✓  5 tests/16-dispatch-multiplayer.spec.ts:87:7 › dispatch harness smoke › a global-assistant dispatch persists through the front door (messages API) (121ms)
  ✓  6 tests/16-dispatch-multiplayer.spec.ts:125:7 › blank-pane repro (the Phase 2 gate — was fixme, now green) › a server dispatch into an open pane renders live without reload (845ms)
  ✓  7 tests/16-dispatch-multiplayer.spec.ts:150:7 › blank-pane repro (the Phase 2 gate — was fixme, now green) › two windows on one conversation both see both sides of a dispatched turn live (1.6s)

  7 passed (12.7s)
```

Green across three consecutive runs. There is no e2e job in CI, so this is a local tally.

### Proving the socket actually carried it

A dead socket can still let these specs pass off the mount-time load, so "green" alone is not evidence. Three independent checks:

1. **Room joins really happened.** Realtime at `LOG_LEVEL=debug` during the passing run: **87 × `User joined conversation room`** across **14 distinct `conv:<id>` rooms**. (103 `Conversation join denied` warnings also appear — every denied id is also in the joined set, i.e. they are stale sockets re-joining conversations the per-spec teardown had already deleted, not an authorization failure.)
2. **Negative control.** With the realtime server stopped and nothing else changed, **both gate specs FAIL** on the 15s timeout. They are genuinely testing live delivery, not a refetch.
3. **Timing.** 845ms and 1.6s against a 15s budget, with no reload between dispatch and assertion.

### Topology gotcha worth knowing (now documented in the spec header)

The app's production CSP is `connect-src 'self' ws: wss:`, and Socket.IO opens with an XHR **polling** handshake before upgrading. Pointing `NEXT_PUBLIC_REALTIME_URL` at a different origin (the obvious `127.0.0.1:3001` while the app serves `:3000`) gets that handshake CSP-blocked and **no socket connects at all** — silently. Production doesn't hit this because Traefik path-routes `/socket.io` to the realtime service on the app's own host (`infrastructure/docker-compose.tenant.yml`).

I reproduced that topology locally with a reverse proxy forwarding `/socket.io` (including the upgrade) to realtime and everything else to the web server, leaving `NEXT_PUBLIC_REALTIME_URL` unset so the socket store falls back to same-origin. That keeps the run **CSP-honest** — the shipped policy is still enforced, rather than relaxed or bypassed on the browser context. The spec header now documents both the requirement and the two verification checks above.

## Gates

| gate | result |
|---|---|
| `bun run lint` | pass (14/14) |
| `bun run typecheck` | pass (16/16) |
| `bun run knip:check` | pass — 4 issues, within baseline (4) |
| `apps/web` unit suite | **16,332 passed**, 1,094 files |
| e2e specs 15 + 16 | **7/7 passed** (see above) |

The only `apps/web` failures are the two pre-existing env-only suites that need a provisioned test Postgres (`admin-role-version`, `activity-tools`) — unrelated to this diff and failing identically on the base branch.

## Fixed while verifying

The WIP was complete; three test-side gaps surfaced when the suite was finally run:

- `GlobalChatContext.test.tsx` still asserted the **legacy `chat:user_message`** path wrote the cache. That handler is intentionally gone — the provider now owns the stream plane only, and the message plane belongs to `useConversationSubscription`. Rewritten against the authoritative `conversation:message_created` event, with the load committing a rev first so the write is exercised through the watermark (and asserting the watermark advances, and that no refetch round-trip happens).
- `useConversationMessagesStore.test.ts` had two whole-entry equality assertions that predate `ConversationCacheEntry.rev`.
- Added `advanceRev.test.ts` — the new pure reducer was the only one in `stores/conversationMessages/` without a sibling test. Covers monotonicity, the no-entry no-op, the unversioned-rev case, and object identity on no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
