### PR TITLE
feat(agents): complete the layout verb set and expose it to agents (closes #2208)

### DIFF
--- a/apps/web/src/app/api/agent-sessions/[sessionId]/workspace/verbs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-sessions/[sessionId]/workspace/verbs/__tests__/route.test.ts
@@ -157,3 +157,96 @@ describe('POST /api/agent-sessions/[sessionId]/workspace/verbs', () => {
     expect(mockCheckSessionAccess).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// The rearrange verbs (issue #2208) — the route's own surface for them
+// ---------------------------------------------------------------------------
+
+describe('POST .../workspace/verbs — the rearrange verbs', () => {
+  it.each([
+    ['resize_column', { type: 'resize_column', columnId: 'col-1', widthFraction: 0.4 }],
+    ['resize_pane', { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.6 }],
+    ['move_pane (append)', { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2' }],
+    ['move_pane (indexed)', { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2', toIndex: 0 }],
+    ['reorder_columns', { type: 'reorder_columns', columnIds: ['col-2', 'col-1'] }],
+  ])('accepts %s and hands it to the single writer verbatim', async (_label, rearrange) => {
+    const response = await post({ opId: 'op-r', baseRev: 3, verb: rearrange });
+
+    expect(response.status).toBe(200);
+    expect(mockApplyWorkspaceLayoutVerb).toHaveBeenCalledWith({
+      workspaceId: SESSION_ID,
+      opId: 'op-r',
+      baseRev: 3,
+      verb: rearrange,
+    });
+  });
+
+  it('audits an applied rearrange under its own verb name', async () => {
+    await post({ opId: 'op-r', baseRev: 0, verb: { type: 'reorder_columns', columnIds: ['col-2'] } });
+
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'data.write',
+        resourceType: 'agent_session',
+        resourceId: SESSION_ID,
+        details: expect.objectContaining({ op: 'workspace_layout_verb', verb: 'reorder_columns' }),
+      }),
+    );
+  });
+
+  it('answers a stale baseRev on a rearrange with 409 + truth, exactly like every other verb', async () => {
+    mockApplyWorkspaceLayoutVerb.mockResolvedValue({ status: 'stale', rev: 7, grid });
+    const response = await post({
+      opId: 'op-r',
+      baseRev: 2,
+      verb: { type: 'resize_column', columnId: 'col-1', widthFraction: 0.4 },
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ rev: 7, grid });
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a non-finite fraction', { type: 'resize_column', columnId: 'col-1', widthFraction: Number.POSITIVE_INFINITY }],
+    ['a NaN fraction', { type: 'resize_column', columnId: 'col-1', widthFraction: Number.NaN }],
+    ['a string fraction', { type: 'resize_pane', paneId: 'pane-1', heightFraction: '0.5' }],
+    ['a missing fraction', { type: 'resize_pane', paneId: 'pane-1' }],
+    ['an empty column id', { type: 'resize_column', columnId: '', widthFraction: 0.4 }],
+    ['a fractional toIndex', { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2', toIndex: 1.5 }],
+    ['a missing destination', { type: 'move_pane', paneId: 'pane-1' }],
+    ['an empty reorder list', { type: 'reorder_columns', columnIds: [] }],
+    ['a reorder list of non-strings', { type: 'reorder_columns', columnIds: [1, 2] }],
+  ])('400s %s rather than letting it reach the engine', async (_label, rearrange) => {
+    const response = await post({ opId: 'op-r', baseRev: 0, verb: rearrange });
+
+    expect(response.status).toBe(400);
+    expect(mockApplyWorkspaceLayoutVerb).not.toHaveBeenCalled();
+  });
+
+  it('refuses an oversized reorder list — the bound is on the schema, not on the reducer', async () => {
+    const response = await post({
+      opId: 'op-r',
+      baseRev: 0,
+      verb: { type: 'reorder_columns', columnIds: Array.from({ length: 65 }, (_, i) => `col-${i}`) },
+    });
+
+    expect(response.status).toBe(400);
+    expect(mockApplyWorkspaceLayoutVerb).not.toHaveBeenCalled();
+  });
+
+  it('404s a rearrange aimed at a session the requester cannot reach, and never touches the grid', async () => {
+    // Same anti-enumeration policy as every other verb: the new verbs open no
+    // new way to learn that someone else's session exists.
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'denied' });
+    const response = await post({
+      opId: 'op-r',
+      baseRev: 0,
+      verb: { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2' },
+    });
+
+    expect(response.status).toBe(404);
+    expect(mockApplyWorkspaceLayoutVerb).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/agents/panes/SessionPanes.tsx
+++ b/apps/web/src/components/agents/panes/SessionPanes.tsx
@@ -14,7 +14,8 @@
  * xterm.
  */
 
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, useEffect, useRef, type ReactNode } from 'react';
+import { usePanelRef } from 'react-resizable-panels';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
@@ -102,22 +103,88 @@ export default function SessionPanes({ workspace, onSelectPane, renderPane }: Se
         {columns.map((column, columnIndex) => (
           <Fragment key={column.id}>
             {columnIndex > 0 && <ResizableHandle variant="chrome-free" />}
-            <ResizablePanel defaultSize={100 / columns.length} minSize={15}>
+            <SizedPanel fraction={column.widthFraction} evenShare={100 / columns.length}>
               <ResizablePanelGroup orientation="vertical" className="h-full">
                 {column.panes.map((pane, paneIndex) => (
                   <Fragment key={pane.id}>
                     {paneIndex > 0 && <ResizableHandle variant="chrome-free" />}
-                    <ResizablePanel defaultSize={100 / column.panes.length} minSize={15}>
+                    <SizedPanel fraction={pane.heightFraction} evenShare={100 / column.panes.length}>
                       {renderPane({ pane, isActive: pane.id === activeId, canSplit: true })}
-                    </ResizablePanel>
+                    </SizedPanel>
                   </Fragment>
                 ))}
               </ResizablePanelGroup>
-            </ResizablePanel>
+            </SizedPanel>
           </Fragment>
         ))}
       </ResizablePanelGroup>
     </div>
+  );
+}
+
+/**
+ * A panel laid out at its PERSISTED share when the grid has one (issue #2208),
+ * and at the even split when it does not.
+ *
+ * Two mechanisms, because react-resizable-panels v4 has no controlled `size`
+ * prop — `defaultSize` is read once at mount and never again:
+ *
+ *  - `defaultSize` seats the share on the first render, so a grid opened on
+ *    another device (or an hour later) comes back laid out the way it was
+ *    left, straight from the pane rows.
+ *  - the imperative `resize()` applies a share that CHANGES while the grid is
+ *    already mounted — an agent's `resize_pane`, or another device's, arriving
+ *    over `workspace:updated`. Re-keying the group would achieve the same
+ *    thing by remounting, which is exactly what must not happen here: a
+ *    remounted terminal pane drops its PTY viewer and cold-starts a new shell.
+ *
+ * Deliberately ONE-WAY: dragging a separator is still local to the panel
+ * group and posts no verb. Writing drags back needs a debounce plus a story
+ * for the two panels one drag resizes (two verbs whose renormalizations do
+ * not compose to what the user sees), and getting that wrong shows up as
+ * visible jitter — so it is left out rather than half-built. Nothing
+ * regresses: a drag behaves exactly as it did before this change.
+ */
+function SizedPanel({
+  fraction,
+  evenShare,
+  children,
+}: {
+  fraction: number | null | undefined;
+  evenShare: number;
+  children: ReactNode;
+}) {
+  const panelRef = usePanelRef();
+  const sized = typeof fraction === 'number';
+  const percentage = sized ? fraction * 100 : evenShare;
+  // What we last pushed imperatively. Seeded with the mount value so the
+  // first effect run is a no-op — `defaultSize` already did that job, and
+  // re-applying it would fight the group's own initial layout pass.
+  const applied = useRef(percentage);
+
+  useEffect(() => {
+    // ONLY an explicitly persisted share is ever pushed. On an unsized grid
+    // the even split is the panel group's OWN default, and re-asserting it
+    // imperatively is both redundant and harmful: `evenShare` changes on every
+    // split and close, so the effect would fire mid-reconciliation against a
+    // group whose panel set React has not finished updating — which is exactly
+    // the "Panel constraints not found for index -1" throw.
+    if (!sized || applied.current === percentage) return;
+    try {
+      panelRef.current?.resize(`${percentage}%`);
+      applied.current = percentage;
+    } catch {
+      // Best-effort visual sync. A share that could not be applied right now
+      // (a panel being removed in the same commit) is not worth failing a
+      // render over — `applied` deliberately stays behind so a later commit
+      // retries, and a remount reads the same share from `defaultSize` anyway.
+    }
+  }, [sized, percentage, panelRef]);
+
+  return (
+    <ResizablePanel panelRef={panelRef} defaultSize={`${percentage}%`} minSize={15}>
+      {children}
+    </ResizablePanel>
   );
 }
 

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-coverage.test.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-coverage.test.ts
@@ -78,6 +78,14 @@ const PENDING_RICH_RENDERERS = new Set<string>([
   'send_shell',
   'read_shell',
   'kill_shell',
+  // pane-grid family (createSessionTools) — same surface, same gap: their
+  // results are a grid geometry, and a rich card for one is a layout-diagram
+  // design task rather than a payload reshuffle. Deferred with the rest of the
+  // family so all of it lands as one coherent renderer set.
+  'list_panes',
+  'resize_pane',
+  'move_pane',
+  'arrange_panes',
   // sandbox file family (createSandboxTools); its `bash` shares the CLI renderer
   'writeFile',
   'readFile',

--- a/apps/web/src/lib/agent-sessions/__tests__/workspace-layout-runtime.test.ts
+++ b/apps/web/src/lib/agent-sessions/__tests__/workspace-layout-runtime.test.ts
@@ -113,8 +113,11 @@ describe('applyWorkspaceLayoutVerb', () => {
       applied: true,
       grid: [{ id: 'col-1', panes: [{ id: 'pane-1', scope }] }],
     });
+    // Row projection carries CANONICAL null fractions on an unsized grid
+    // (issue #2208) — the store's content diff is a JSON.stringify compare,
+    // where an absent key and an explicit null are not the same bytes.
     expect(await store.getWorkspaceGrid(WORKSPACE_ID)).toEqual([
-      { id: 'col-1', panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1' }] },
+      { id: 'col-1', widthFraction: null, panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null }] },
     ]);
     expect(store.blobs.get(WORKSPACE_ID)?.activePaneId).toBe('pane-1');
     expect(mockBroadcast).toHaveBeenCalledWith({
@@ -201,8 +204,11 @@ describe('saveWorkspaceBlobReconciled (legacy PUT shim)', () => {
     };
     await saveWorkspaceBlobReconciled({ workspaceId: WORKSPACE_ID, workspace });
     expect(store.blobs.get(WORKSPACE_ID)).toEqual(workspace);
+    // Row projection carries CANONICAL null fractions on an unsized grid
+    // (issue #2208) — the store's content diff is a JSON.stringify compare,
+    // where an absent key and an explicit null are not the same bytes.
     expect(await store.getWorkspaceGrid(WORKSPACE_ID)).toEqual([
-      { id: 'col-1', panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1' }] },
+      { id: 'col-1', widthFraction: null, panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null }] },
     ]);
     expect(mockBroadcast).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: WORKSPACE_ID, rev: 1, verb: 'legacy_replace' }),

--- a/apps/web/src/lib/agent-sessions/workspace-layout-runtime.ts
+++ b/apps/web/src/lib/agent-sessions/workspace-layout-runtime.ts
@@ -179,10 +179,15 @@ export async function readWorkspaceLayoutSnapshot(workspaceId: string): Promise<
   const labels = await resolvePaneLabels(grid);
   return {
     rev,
+    // Fractions come straight off the rows (issue #2208) — unlike labels there
+    // is nothing to re-derive, and unlike focus they are not client-local. An
+    // unsized container carries no key, matching what the reducer produces.
     grid: grid.map((column) => ({
       id: column.id,
+      ...(column.widthFraction !== null ? { widthFraction: column.widthFraction } : {}),
       panes: column.panes.map((pane) => {
-        if (pane.kind === null) return { id: pane.id, scope: null };
+        const height = pane.heightFraction !== null ? { heightFraction: pane.heightFraction } : {};
+        if (pane.kind === null) return { id: pane.id, scope: null, ...height };
         const label = pane.targetId !== null ? labels.get(`${pane.kind}:${pane.targetId}`) : undefined;
         const scope: PaneScope = {
           kind: pane.kind,
@@ -190,7 +195,7 @@ export async function readWorkspaceLayoutSnapshot(workspaceId: string): Promise<
           name: label?.name ?? '',
           agentPageId: label?.agentPageId ?? null,
         };
-        return { id: pane.id, scope };
+        return { id: pane.id, scope, ...height };
       }),
     })),
   };

--- a/apps/web/src/lib/agent-sessions/workspace-placement.ts
+++ b/apps/web/src/lib/agent-sessions/workspace-placement.ts
@@ -27,6 +27,7 @@ import { conversations } from '@pagespace/db/schema/conversations';
 import { pages } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { PaneScope } from '@pagespace/lib/agent-sessions/contract';
+import type { WorkspaceLayoutVerb } from '@pagespace/lib/agent-sessions/workspace-layout-verbs';
 import { createId } from '@paralleldrive/cuid2';
 import { applyWorkspaceLayoutVerb, readWorkspaceLayoutSnapshot } from './workspace-layout-runtime';
 
@@ -45,6 +46,52 @@ const MAX_PLACEMENT_ATTEMPTS = 3;
  * attempts: a rebase is the same op, and reusing the key is what stops a
  * retry from double-placing if an earlier attempt actually landed.
  */
+/**
+ * Apply ONE arbitrary layout verb to a workspace, rebasing while the server
+ * answers `stale` — the general form of {@link placePane}'s loop, and the ONE
+ * path the agent-facing rearrange tools (issue #2208) take into the grid.
+ *
+ * They go through `applyWorkspaceLayoutVerb` exactly like a browser's POST
+ * does: same single writer, same per-workspace lock, same op memory. The
+ * `opId` is CONSTANT across attempts (a rebase is the same op) so an SDK
+ * retry replays instead of applying twice.
+ *
+ * Unlike the placement helpers, this REPORTS its outcome: a rearrange is
+ * something the model asked for explicitly and must be told the truth about,
+ * where a pane placement is a courtesy riding along on other work. It still
+ * never throws — the caller maps the result to a tool answer.
+ */
+export async function applyLayoutVerbForWorkspace(input: {
+  workspaceId: string;
+  opId: string;
+  verb: WorkspaceLayoutVerb;
+}): Promise<{ ok: true; applied: boolean } | { ok: false; reason: 'contended' | 'failed' }> {
+  try {
+    for (let attempt = 0; attempt < MAX_PLACEMENT_ATTEMPTS; attempt += 1) {
+      const snapshot = await readWorkspaceLayoutSnapshot(input.workspaceId);
+      const result = await applyWorkspaceLayoutVerb({
+        workspaceId: input.workspaceId,
+        opId: input.opId,
+        baseRev: snapshot.rev,
+        verb: input.verb,
+      });
+      if (result.status === 'ok') return { ok: true, applied: result.applied };
+    }
+    loggers.api.warn('Agent layout verb gave up after repeated rev conflicts', {
+      workspaceId: input.workspaceId,
+      verb: input.verb.type,
+    });
+    return { ok: false, reason: 'contended' };
+  } catch (error) {
+    loggers.api.error(
+      'Agent layout verb failed',
+      error instanceof Error ? error : undefined,
+      { workspaceId: input.workspaceId, verb: input.verb.type },
+    );
+    return { ok: false, reason: 'failed' };
+  }
+}
+
 async function placePane(input: {
   workspaceId: string;
   scope: PaneScope;

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -205,7 +205,19 @@ describe('ai-tools', () => {
     });
 
     it('equals the merged object of all tool modules plus the chat-only session family', () => {
-      const chatOnlySessionToolNames = ['list_sessions', 'spawn_session', 'send_session', 'read_session', 'kill_session'];
+      // Worker verbs plus the LAYOUT family (issue #2208) — both chat-only,
+      // both outside TOOL_MODULES, so neither counts as a workspace tool.
+      const chatOnlySessionToolNames = [
+        'list_sessions',
+        'spawn_session',
+        'send_session',
+        'read_session',
+        'kill_session',
+        'list_panes',
+        'resize_pane',
+        'move_pane',
+        'arrange_panes',
+      ];
       const workspaceOnly = Object.fromEntries(
         Object.entries(pageSpaceTools).filter(([name]) => !chatOnlySessionToolNames.includes(name)),
       );

--- a/apps/web/src/lib/ai/core/__tests__/tool-registry-docs.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-registry-docs.test.ts
@@ -52,7 +52,22 @@ describe('tool registry — internal consistency', () => {
     const workspaceNames = new Set(WORKSPACE_TOOL_NAMES);
     const extras = Object.keys(base).filter((name) => !workspaceNames.has(name));
     expect(new Set(extras)).toEqual(
-      new Set(['list_sessions', 'spawn_session', 'send_session', 'read_session', 'kill_session']),
+      new Set([
+        'list_sessions',
+        'spawn_session',
+        'send_session',
+        'read_session',
+        'kill_session',
+        // The LAYOUT family (issue #2208) is chat-only for the same reason the
+        // worker verbs are: arranging your own pane grid touches no sandbox,
+        // so gating it on the compute kill-switch would hide a chat capability
+        // behind a compute flag. Outside TOOL_MODULES too, so the public
+        // workspace-tool count (and every doc that cites it) is unchanged.
+        'list_panes',
+        'resize_pane',
+        'move_pane',
+        'arrange_panes',
+      ]),
     );
     expect(WORKSPACE_TOOL_COUNT).toBe(Object.keys(base).length - extras.length);
     expect(WORKSPACE_TOOL_COUNT).toBe(WORKSPACE_TOOL_NAMES.length);

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-contract.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-contract.test.ts
@@ -420,3 +420,189 @@ describe('kill_shell description: "The session\'s sandbox (and every other shell
     expect(deps.ensureOwnSessionSandbox).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// The LAYOUT family (issue #2208) — every claim its descriptions make
+// ---------------------------------------------------------------------------
+
+const GRID = {
+  columns: [
+    {
+      columnId: 'col-1',
+      widthFraction: 0.6,
+      panes: [
+        { paneId: 'pane-1', kind: 'chat' as const, targetId: 'conv-1', name: 'Planning', heightFraction: 0.7 },
+        { paneId: 'pane-1b', kind: null, targetId: null, name: '', heightFraction: 0.3 },
+      ],
+    },
+    {
+      columnId: 'col-2',
+      widthFraction: 0.4,
+      panes: [{ paneId: 'pane-2', kind: 'terminal' as const, targetId: 'shell-1', name: 'shell-1', heightFraction: null }],
+    },
+  ],
+};
+
+/** Layout deps on top of the shared fakes — both are OPTIONAL on the interface. */
+function layoutDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
+  return makeDeps({
+    readPaneGrid: vi.fn(async () => GRID),
+    applyLayoutVerb: vi.fn(async () => ({ ok: true as const, applied: true })),
+    ...over,
+  });
+}
+
+/** The tool-call options a layout tool needs: context PLUS the id its opId derives from. */
+function layoutOptions(overrides: Partial<ToolExecutionContext> = {}) {
+  return { ...contextOptions(overrides), toolCallId: 'call-abc' };
+}
+
+describe('list_panes description: "Returns the columnIds and paneIds that resize_pane/move_pane/arrange_panes address"', () => {
+  it('returns the grid keyed by exactly the ids the three rearrange verbs take', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+    const result = await run(tools.list_panes, {}, layoutOptions());
+
+    expect(result).toEqual(expect.objectContaining({ success: true, workspaceId: WORKSPACE_ID, columns: GRID.columns }));
+    expect(deps.readPaneGrid).toHaveBeenCalledWith(WORKSPACE_ID);
+    // The addressability claim, checked rather than assumed: every id the
+    // listing hands out is one the rearrange tools accept.
+    const columnIds = GRID.columns.map((column) => column.columnId);
+    const paneIds = GRID.columns.flatMap((column) => column.panes.map((pane) => pane.paneId));
+    expect(columnIds).toEqual(['col-1', 'col-2']);
+    expect(paneIds).toEqual(['pane-1', 'pane-1b', 'pane-2']);
+  });
+
+  it('a workspace with no grid yet is a reportable state, not an error', async () => {
+    const tools = createSessionTools(layoutDeps({ readPaneGrid: vi.fn(async () => null) }));
+    const result = await run(tools.list_panes, {}, layoutOptions());
+    expect(result).toEqual(expect.objectContaining({ success: true, columns: [] }));
+  });
+});
+
+describe('the layout family description: "Only meaningful inside an agent session with an open pane grid"', () => {
+  it.each(['list_panes', 'resize_pane', 'move_pane', 'arrange_panes'] as const)(
+    '%s refuses a conversation with no workspace, and writes nothing',
+    async (name) => {
+      const deps = layoutDeps({ findOwnWorkspace: vi.fn(async () => null) });
+      const tools = createSessionTools(deps);
+      const input =
+        name === 'list_panes'
+          ? {}
+          : name === 'resize_pane'
+            ? { columnId: 'col-1', size: 0.5 }
+            : name === 'move_pane'
+              ? { paneId: 'pane-1', toColumnId: 'col-2' }
+              : { columnIds: ['col-2'] };
+
+      const result = await run(tools[name], input, layoutOptions());
+      expect(result.success).toBe(false);
+      expect(deps.applyLayoutVerb).not.toHaveBeenCalled();
+    },
+  );
+
+  it('refuses an unauthenticated caller before resolving any workspace', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+    const result = await run(tools.arrange_panes, { columnIds: ['col-2'] }, layoutOptions({ userId: undefined }));
+    expect(result.success).toBe(false);
+    expect(deps.findOwnWorkspace).not.toHaveBeenCalled();
+    expect(deps.applyLayoutVerb).not.toHaveBeenCalled();
+  });
+
+  it('addresses ONLY the caller own workspace — a model cannot name someone else grid', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+    // There is no workspaceId input on any of these tools; the grid is
+    // resolved from the caller's own conversation, which is what makes the
+    // verbs route's access check already satisfied by construction.
+    await run(tools.move_pane, { paneId: 'pane-1', toColumnId: 'col-2' }, layoutOptions());
+    expect(deps.findOwnWorkspace).toHaveBeenCalledWith(CALLER_CONVERSATION);
+    expect(deps.applyLayoutVerb).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: WORKSPACE_ID }));
+  });
+});
+
+describe('resize_pane description: "pass a columnId to set that column\'s width, or a paneId to set that pane\'s height"', () => {
+  it('a columnId becomes resize_column; a paneId becomes resize_pane', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+
+    await run(tools.resize_pane, { columnId: 'col-1', size: 0.35 }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ verb: { type: 'resize_column', columnId: 'col-1', widthFraction: 0.35 } }),
+    );
+
+    await run(tools.resize_pane, { paneId: 'pane-1', size: 0.9 }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ verb: { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.9 } }),
+    );
+  });
+
+  it('refuses BOTH targets and NEITHER — an ambiguous call must not silently pick an axis', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+
+    expect((await run(tools.resize_pane, { paneId: 'p', columnId: 'c', size: 0.5 }, layoutOptions())).success).toBe(false);
+    expect((await run(tools.resize_pane, { size: 0.5 }, layoutOptions())).success).toBe(false);
+    expect(deps.applyLayoutVerb).not.toHaveBeenCalled();
+  });
+});
+
+describe('move_pane / arrange_panes descriptions: what they promise the verb does', () => {
+  it('move_pane omits toIndex when the caller did — the reducer reads that as "append"', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+
+    await run(tools.move_pane, { paneId: 'pane-1', toColumnId: 'col-2' }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ verb: { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2' } }),
+    );
+
+    await run(tools.move_pane, { paneId: 'pane-1', toColumnId: 'col-2', toIndex: 0 }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ verb: { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2', toIndex: 0 } }),
+    );
+  });
+
+  it('arrange_panes sends the partial list through verbatim — the reducer owns the prefix rule', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+    await run(tools.arrange_panes, { columnIds: ['col-2'] }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ verb: { type: 'reorder_columns', columnIds: ['col-2'] } }),
+    );
+  });
+});
+
+describe('the layout family is idempotent per tool call, and never overstates what happened', () => {
+  it('derives the opId from the tool call id, so an SDK retry replays instead of rearranging twice', async () => {
+    const deps = layoutDeps();
+    const tools = createSessionTools(deps);
+    await run(tools.move_pane, { paneId: 'pane-1', toColumnId: 'col-2' }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenCalledWith(expect.objectContaining({ opId: 'move_pane:call-abc' }));
+
+    await run(tools.arrange_panes, { columnIds: ['col-2'] }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenCalledWith(expect.objectContaining({ opId: 'arrange_panes:call-abc' }));
+
+    await run(tools.resize_pane, { columnId: 'col-1', size: 0.5 }, layoutOptions());
+    expect(deps.applyLayoutVerb).toHaveBeenCalledWith(expect.objectContaining({ opId: 'resize_pane:call-abc' }));
+  });
+
+  it('a total no-op answers success with changed: false and says the grid may have moved on', async () => {
+    const tools = createSessionTools(
+      layoutDeps({ applyLayoutVerb: vi.fn(async () => ({ ok: true as const, applied: false })) }),
+    );
+    const result = await run(tools.move_pane, { paneId: 'stale', toColumnId: 'col-2' }, layoutOptions());
+
+    expect(result).toEqual(expect.objectContaining({ success: true, changed: false }));
+    expect(String((result as { note?: string }).note)).toContain('list_panes');
+  });
+
+  it('a contended write reports failure rather than claiming a rearrange that never landed', async () => {
+    const tools = createSessionTools(
+      layoutDeps({ applyLayoutVerb: vi.fn(async () => ({ ok: false as const, reason: 'contended' })) }),
+    );
+    const result = await run(tools.arrange_panes, { columnIds: ['col-2'] }, layoutOptions());
+    expect(result).toEqual(expect.objectContaining({ success: false, reason: 'contended' }));
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-schema.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-schema.test.ts
@@ -37,14 +37,23 @@ function wireSurface() {
   );
 }
 
-describe('session + shell tools — frozen wire contract', () => {
-  it('exposes exactly the nine tool names', () => {
+describe('session + shell + layout tools — frozen wire contract', () => {
+  it('exposes exactly the thirteen tool names', () => {
+    // The nine worker/shell verbs have been frozen since Phase 1. The four
+    // LAYOUT verbs are the deliberate addition of issue #2208 — the grid
+    // rearrange surface that had to wait for the pane entities to become
+    // relational rows with a verb API. They are ADDITIVE: nothing above them
+    // changed name, description, or schema, which is what the freeze protects.
     expect(Object.keys(wireSurface()).sort()).toEqual([
+      'arrange_panes',
       'kill_session',
       'kill_shell',
+      'list_panes',
       'list_sessions',
+      'move_pane',
       'read_session',
       'read_shell',
+      'resize_pane',
       'send_session',
       'send_shell',
       'spawn_session',
@@ -180,6 +189,71 @@ describe('session + shell tools — frozen wire contract', () => {
             shellId: { type: 'string', minLength: 1 },
           },
           required: ['shellId'],
+          additionalProperties: false,
+        },
+      },
+      // --- The LAYOUT family (issue #2208) -----------------------------
+      // Vocabulary check, per spec §4: these say "pane"/"column" and
+      // "workspace" — never "session", which on this wire is always a worker
+      // you talk to. `list_panes` is what makes the other three usable: an
+      // agent cannot address a paneId it was never told.
+      list_panes: {
+        description:
+          'Show the pane grid of THIS conversation\'s workspace: a left-to-right row of columns, each a top-to-bottom stack of panes. Returns the columnIds and paneIds that resize_pane/move_pane/arrange_panes address, what each pane is showing, and the current size shares (null means that container is split evenly). Read this before rearranging anything — ids change as panes open and close. Only meaningful inside an agent session with an open pane grid.',
+        inputSchema: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+      resize_pane: {
+        description:
+          'Resize part of this workspace\'s pane grid: pass a columnId to set that column\'s width, or a paneId to set that pane\'s height within its own column. size is a share of the container from 0 to 1, and the siblings absorb the difference in proportion. A size that would squeeze a sibling below its minimum is clamped rather than refused. Heights are always column-local — a pane\'s height says nothing about panes in other columns. Get the ids from list_panes. A container with only one member cannot be resized: it already fills its space.',
+        inputSchema: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            paneId: { type: 'string', minLength: 1 },
+            columnId: { type: 'string', minLength: 1 },
+            // Shares are 0..1 exclusive, matching the `real` row column — a 0
+            // or 1 share is a degenerate layout the reducer would clamp away.
+            size: { type: 'number', exclusiveMinimum: 0, exclusiveMaximum: 1 },
+          },
+          required: ['size'],
+          additionalProperties: false,
+        },
+      },
+      move_pane: {
+        description:
+          'Move a pane to a different column in this workspace\'s grid, or to a different position within its own column. Pass toColumnId (from list_panes) and, optionally, toIndex — the 0-based slot in the destination stack; omit it to append at the bottom, and out-of-range values clamp to the ends. The pane keeps showing exactly what it was showing; only its position changes. A column left empty by the move is removed.',
+        inputSchema: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            paneId: { type: 'string', minLength: 1 },
+            toColumnId: { type: 'string', minLength: 1 },
+            toIndex: { type: 'integer', minimum: 0, maximum: 64 },
+          },
+          required: ['paneId', 'toColumnId'],
+          additionalProperties: false,
+        },
+      },
+      arrange_panes: {
+        description:
+          'Reorder this workspace\'s columns left to right. Pass columnIds (from list_panes) in the order you want them; you do NOT have to list them all — the ones you name go first, in your order, and every column you leave out keeps its current relative position behind them. Ids that no longer exist are skipped rather than failing the call. Panes and sizes travel with their column.',
+        inputSchema: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            columnIds: {
+              minItems: 1,
+              maxItems: 64,
+              type: 'array',
+              items: { type: 'string', minLength: 1 },
+            },
+          },
+          required: ['columnIds'],
           additionalProperties: false,
         },
       },

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -82,15 +82,21 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('the nine-tool surface', () => {
-  it('should export EXACTLY the nine tools of the two verb families', () => {
+describe('the thirteen-tool surface', () => {
+  it('should export EXACTLY the thirteen tools of the three verb families', () => {
     const tools = createSessionTools(makeDeps());
+    // Workers + shells (frozen since Phase 1) plus the LAYOUT family that
+    // issue #2208 added once the pane grid became relational entities.
     expect(Object.keys(tools).sort()).toEqual([
+      'arrange_panes',
       'kill_session',
       'kill_shell',
+      'list_panes',
       'list_sessions',
+      'move_pane',
       'read_session',
       'read_shell',
+      'resize_pane',
       'send_session',
       'send_shell',
       'spawn_session',

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -48,7 +48,8 @@ import {
   getAgentSessionStore,
 } from '@/lib/agent-sessions/agent-sessions-runtime';
 import { countOpenConversations } from '@/lib/agent-sessions/conversation-cap';
-import { placeWorkerPane } from '@/lib/agent-sessions/workspace-placement';
+import { applyLayoutVerbForWorkspace, placeWorkerPane } from '@/lib/agent-sessions/workspace-placement';
+import { readWorkspaceLayoutSnapshot } from '@/lib/agent-sessions/workspace-layout-runtime';
 import {
   AgentNotInSessionDriveError,
   SessionFullError,
@@ -958,6 +959,32 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
     },
 
     placeWorkerPane,
+
+    // The layout family's two seams (issue #2208). The read is the SAME
+    // label-joining snapshot the layout GET serves, so a model and a browser
+    // never see different names for the same pane; the write is the same
+    // single writer (`applyWorkspaceLayoutVerb`) behind the verbs route.
+    readPaneGrid: async (workspaceId) => {
+      const snapshot = await readWorkspaceLayoutSnapshot(workspaceId);
+      if (!snapshot.grid || snapshot.grid.length === 0) return null;
+      return {
+        columns: snapshot.grid.map((column) => ({
+          columnId: column.id,
+          widthFraction: column.widthFraction ?? null,
+          panes: column.panes.map((pane) => ({
+            paneId: pane.id,
+            kind: pane.scope?.kind ?? null,
+            targetId: pane.scope?.targetId ?? null,
+            // Labels are display-only and the snapshot already re-derived them
+            // from the live rows — an unbound pane has none at all.
+            name: pane.scope?.name ?? '',
+            heightFraction: pane.heightFraction ?? null,
+          })),
+        })),
+      };
+    },
+
+    applyLayoutVerb: applyLayoutVerbForWorkspace,
 
     dispatch: dispatchThroughChatPipeline,
 

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -4,8 +4,8 @@
  * invariant 1: a session hosts many conversations and owns their shared
  * sandbox).
  *
- * Two verb families, EXACTLY nine tools, ONE address namespace each. You name
- * a thing once, at spawn; every verb after that takes the id the spawn
+ * THREE verb families, EXACTLY thirteen tools, ONE address namespace each. You
+ * name a thing once, at spawn; every verb after that takes the id the spawn
  * returned — and `list_sessions` re-lists those ids (plus, for awareness,
  * other members' workers in SHARED workspaces, which are not the caller's to
  * address — see `SharedWorkspaceSummary`):
@@ -19,6 +19,16 @@
  *  - **Shells** — PTYs in the caller's session's ONE sandbox, addressed by
  *    shellId: `spawn_shell` → shellId · `send_shell` (keystrokes) ·
  *    `read_shell` (scrollback) · `kill_shell`.
+ *  - **Layout** (issue #2208) — the caller's own workspace's PANE GRID,
+ *    addressed by paneId/columnId: `list_panes` (the grid, with its ids and
+ *    size shares) · `resize_pane` · `move_pane` · `arrange_panes` (column
+ *    order). These write through `applyWorkspaceLayoutVerb`, the same single
+ *    writer the browser's verb POST uses, so an agent rearranging its
+ *    workspace lands in the pane ROWS and broadcasts live rather than
+ *    reaching only whichever browsers happen to be rendering the grid. They
+ *    were blocked until the grid became relational entities with a verb API
+ *    (epic Phase 3) — as blob writes they would have been yet another writer
+ *    of a client-authored JSONB.
  *
  * `wait: true` on spawn/send blocks for the worker's reply — this absorbs the
  * old `ask_agent` tool's synchronous consult (the inline invoke-an-agent
@@ -53,7 +63,8 @@ import {
   MAX_SESSION_CONVERSATIONS,
   planSpawnWorkerSession,
 } from '@pagespace/lib/agent-sessions/plan-spawn-session';
-import type { SandboxStatus, ShellDTO } from '@pagespace/lib/agent-sessions/contract';
+import type { PaneKind, SandboxStatus, ShellDTO } from '@pagespace/lib/agent-sessions/contract';
+import type { WorkspaceLayoutVerb } from '@pagespace/lib/agent-sessions/workspace-layout-verbs';
 import type { ToolExecutionContext } from '../core/types';
 
 /** Upper bound on one dispatched input — a task brief or a keystroke burst, not a file. */
@@ -145,6 +156,45 @@ export const readShellInputSchema = z
   .strict();
 
 export const killShellInputSchema = z.object({ shellId: z.string().min(1) }).strict();
+
+// --- Layout (issue #2208) ---------------------------------------------------
+// The workspace's PANE GRID, addressed by the paneId/columnId `list_panes`
+// returns. Vocabulary: "pane" and "column" are the environment's furniture, so
+// these sit on the WORKSPACE side of the frozen split — never "session", which
+// on this wire always means a worker you talk to.
+
+export const listPanesInputSchema = z.object({}).strict();
+
+/** Shares are 0..1 of the container, matching the row column exactly — no percentages on the wire. */
+const fraction = z.number().gt(0).lt(1);
+
+export const resizePaneInputSchema = z
+  .object({
+    /** A paneId from list_panes. Give this to set the pane's height within its column. */
+    paneId: z.string().min(1).optional(),
+    /** A columnId from list_panes. Give this to set the column's width in the grid. */
+    columnId: z.string().min(1).optional(),
+    /** The new share of the container, 0..1. Siblings absorb the difference. */
+    size: fraction,
+  })
+  .strict();
+
+export const movePaneInputSchema = z
+  .object({
+    paneId: z.string().min(1),
+    /** The columnId to move it into — its own column reorders it in place. */
+    toColumnId: z.string().min(1),
+    /** 0-based position in the destination. Omit to append. Out-of-range values clamp. */
+    toIndex: z.number().int().min(0).max(64).optional(),
+  })
+  .strict();
+
+export const arrangePanesInputSchema = z
+  .object({
+    /** columnIds in the left-to-right order you want. Unlisted columns keep their order behind these. */
+    columnIds: z.array(z.string().min(1)).min(1).max(64),
+  })
+  .strict();
 
 // ---------------------------------------------------------------------------
 // Injected IO
@@ -437,8 +487,58 @@ export interface SessionToolsDeps {
     }) => Promise<ShellReadOutcome>;
     send: (input: { shellId: string; keystrokes: string; userId: string }) => Promise<ShellSendOutcome>;
   };
+  /**
+   * The caller's workspace's PANE GRID, as `list_panes` reports it (issue
+   * #2208) — the ids the three rearrange tools address, plus enough of each
+   * pane's binding for the model to tell one rectangle from another. `null`
+   * for a workspace with no grid at all.
+   */
+  readPaneGrid?: (workspaceId: string) => Promise<PaneGridListing | null>;
+  /**
+   * Apply ONE layout verb to the caller's workspace grid, through the same
+   * single writer (`applyWorkspaceLayoutVerb`) the verbs route uses — same
+   * per-workspace lock, same op memory, same broadcast. `opId` is derived
+   * from the tool call id, so an SDK retry of one call replays rather than
+   * rearranging twice.
+   *
+   * `applied: false` is a real, successful answer: the reducer is total, so a
+   * stale pane id or a resize that resolves to the size already in force
+   * changes nothing rather than failing. OPTIONAL, like `placeWorkerPane` —
+   * a harness with no grid simply omits it and the tools say so.
+   */
+  applyLayoutVerb?: (input: {
+    workspaceId: string;
+    opId: string;
+    verb: WorkspaceLayoutVerb;
+  }) => Promise<{ ok: true; applied: boolean } | { ok: false; reason: string }>;
   /** Fresh conversation ids (client-mint discipline: the id exists before the row). */
   newId: () => string;
+}
+
+/** One pane of the caller's grid, as `list_panes` reports it. */
+export interface PaneGridPaneEntry {
+  paneId: string;
+  /** `'chat' | 'terminal' | 'page'`, or null for an unbound pane still showing the picker. */
+  kind: PaneKind | null;
+  /** The conversationId / shellId / pageId this pane shows, or null when unbound or still minting. */
+  targetId: string | null;
+  /** Display label only — never an address. */
+  name: string;
+  /** This pane's share of its column's height (0..1), or null when the column is evenly split. */
+  heightFraction: number | null;
+}
+
+/** One column of the caller's grid — a vertical stack of panes. */
+export interface PaneGridColumnEntry {
+  columnId: string;
+  /** This column's share of the grid width (0..1), or null when the grid is evenly split. */
+  widthFraction: number | null;
+  panes: PaneGridPaneEntry[];
+}
+
+/** The caller's whole pane grid: a left-to-right row of columns. */
+export interface PaneGridListing {
+  columns: PaneGridColumnEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -500,6 +600,19 @@ function workerListingClosed(sessionId: string): { success: false; error: string
   };
 }
 
+/**
+ * The layout family's "there is nothing here to arrange". Deliberately ONE
+ * message for every way that can be true — no workspace, no grid yet, or a
+ * surface with no layout wiring at all — because the model's remedy is the
+ * same in all of them, and the distinctions are about server plumbing it
+ * cannot act on.
+ */
+const NO_GRID = {
+  success: false as const,
+  error:
+    'This conversation has no pane grid to arrange. Pane layout only exists inside an agent session with an open workspace; elsewhere there is nothing to move or resize.',
+};
+
 function notYourShell(shellId: string): { success: false; error: string } {
   return {
     success: false,
@@ -560,6 +673,10 @@ export function createSessionTools(deps: SessionToolsDeps): {
   send_shell: Tool;
   read_shell: Tool;
   kill_shell: Tool;
+  list_panes: Tool;
+  resize_pane: Tool;
+  move_pane: Tool;
+  arrange_panes: Tool;
 } {
   /**
    * A session verb's shared open — RESOURCE-addressed, like `read_page`: the
@@ -608,6 +725,85 @@ export function createSessionTools(deps: SessionToolsDeps): {
       return { ok: false, error: workerListingClosed(conversationId) };
     }
     return { ok: true, actor, row };
+  };
+
+  /**
+   * A LAYOUT verb's shared open (issue #2208): resolve the caller's own
+   * workspace, which is the only grid these tools can reach.
+   *
+   * Access control is structural rather than a second predicate — the grid is
+   * addressed by resolving the CALLER'S OWN conversation to its workspace
+   * (`findOwnWorkspace`), never by a workspaceId the model supplies, so there
+   * is no id here for a caller to point somewhere it does not belong. That is
+   * the same footing the shell family stands on, and it means the check the
+   * verbs route runs (`checkSessionAccess`) has already been satisfied by the
+   * time this conversation exists in this workspace at all; the runtime
+   * re-runs it anyway on the way in, so the gate is one function in one place
+   * for both entry points.
+   *
+   * Refuses, distinctly, the three ways there is nothing to arrange: no auth,
+   * no conversation, and a conversation with no workspace (a plain thread).
+   */
+  const openOwnGrid = async (
+    context: ToolExecutionContext | undefined,
+  ): Promise<
+    | { ok: true; workspaceId: string }
+    | { ok: false; error: { success: false; error: string } }
+  > => {
+    const actor = readActor(context);
+    if (!actor) return { ok: false, error: NEEDS_AUTH };
+    const conversationId = context?.conversationId;
+    if (!conversationId) return { ok: false, error: NEEDS_CONVERSATION };
+    const workspace = await deps.findOwnWorkspace(conversationId);
+    if (!workspace) return { ok: false, error: NO_GRID };
+    return { ok: true, workspaceId: workspace.workspaceId };
+  };
+
+  /**
+   * Every rearrange tool's tail: derive the idempotency key from the tool call
+   * id, apply the verb through the single writer, and map the outcome to an
+   * answer that never overstates what happened. `applied: false` reports
+   * `changed: false` and SAYS why it might be — a total reducer's no-op is not
+   * an error, but a model told "success" after nothing moved would keep
+   * arranging a grid it has already lost track of.
+   */
+  const runLayoutVerb = async (
+    context: ToolExecutionContext | undefined,
+    options: unknown,
+    toolName: string,
+    verb: WorkspaceLayoutVerb,
+  ): Promise<Record<string, unknown>> => {
+    const opened = await openOwnGrid(context);
+    if (!opened.ok) return opened.error;
+    if (!deps.applyLayoutVerb) return NO_GRID;
+
+    const toolCallId = (options as { toolCallId?: string } | undefined)?.toolCallId;
+    if (!toolCallId) return NO_GRID;
+
+    const result = await deps.applyLayoutVerb({
+      workspaceId: opened.workspaceId,
+      // `toolCallId` is stable across the SDK's own retries of one call, so a
+      // retried rearrange replays through the verb engine's op memory instead
+      // of moving the pane twice.
+      opId: `${toolName}:${toolCallId}`,
+      verb,
+    });
+    if (!result.ok) {
+      return {
+        success: false,
+        error: `Could not rearrange the panes (${result.reason}). Call list_panes to re-read the grid and try again.`,
+        reason: result.reason,
+      };
+    }
+    return {
+      success: true,
+      changed: result.applied,
+      ...(result.applied
+        ? {}
+        : {
+            note: 'Nothing changed — the pane or column id may no longer exist, or the layout was already exactly this. Call list_panes to see the grid as it is now.',
+          }),
+    };
   };
 
   /** A shell verb's shared open: the shell must exist IN the caller's own session. */
@@ -1028,6 +1224,84 @@ export function createSessionTools(deps: SessionToolsDeps): {
         }
         return { success: true, shellId, killed: killed.killed };
       },
+    }),
+
+    // --- Layout (issue #2208) --------------------------------------------
+    // An agent arranging its OWN workspace. Every one of these goes through
+    // `applyWorkspaceLayoutVerb` — the same single writer, lock, and op memory
+    // a browser's verb POST uses — so a rearrange lands in the pane ROWS and
+    // broadcasts live, instead of reaching only whichever browsers happen to
+    // be rendering the grid.
+
+    list_panes: tool({
+      description:
+        'Show the pane grid of THIS conversation\'s workspace: a left-to-right row of columns, each a top-to-bottom stack of panes. Returns the columnIds and paneIds that resize_pane/move_pane/arrange_panes address, what each pane is showing, and the current size shares (null means that container is split evenly). Read this before rearranging anything — ids change as panes open and close. Only meaningful inside an agent session with an open pane grid.',
+      inputSchema: listPanesInputSchema,
+      execute: async (_input, options) => {
+        const opened = await openOwnGrid(readContext(options));
+        if (!opened.ok) return opened.error;
+        if (!deps.readPaneGrid) return NO_GRID;
+
+        const grid = await deps.readPaneGrid(opened.workspaceId);
+        // A workspace whose grid has never been opened is a real, reportable
+        // state — not an error, and not the same as having no workspace.
+        if (!grid) {
+          return {
+            success: true,
+            workspaceId: opened.workspaceId,
+            columns: [],
+            note: 'This workspace has no pane grid open yet — there is nothing laid out to rearrange.',
+          };
+        }
+        return { success: true, workspaceId: opened.workspaceId, columns: grid.columns };
+      },
+    }),
+
+    resize_pane: tool({
+      description:
+        'Resize part of this workspace\'s pane grid: pass a columnId to set that column\'s width, or a paneId to set that pane\'s height within its own column. size is a share of the container from 0 to 1, and the siblings absorb the difference in proportion. A size that would squeeze a sibling below its minimum is clamped rather than refused. Heights are always column-local — a pane\'s height says nothing about panes in other columns. Get the ids from list_panes. A container with only one member cannot be resized: it already fills its space.',
+      inputSchema: resizePaneInputSchema,
+      execute: async ({ paneId, columnId, size }, options) => {
+        const context = readContext(options);
+        // Exactly one target. Accepting both and silently preferring one would
+        // make a model's ambiguous call look like it worked on the axis it
+        // did not mean.
+        if ((paneId === undefined) === (columnId === undefined)) {
+          return {
+            success: false,
+            error: 'Pass exactly one of paneId (to set a pane\'s height in its column) or columnId (to set a column\'s width).',
+          };
+        }
+        const verb: WorkspaceLayoutVerb =
+          columnId !== undefined
+            ? { type: 'resize_column', columnId, widthFraction: size }
+            : { type: 'resize_pane', paneId: paneId!, heightFraction: size };
+        return runLayoutVerb(context, options, 'resize_pane', verb);
+      },
+    }),
+
+    move_pane: tool({
+      description:
+        'Move a pane to a different column in this workspace\'s grid, or to a different position within its own column. Pass toColumnId (from list_panes) and, optionally, toIndex — the 0-based slot in the destination stack; omit it to append at the bottom, and out-of-range values clamp to the ends. The pane keeps showing exactly what it was showing; only its position changes. A column left empty by the move is removed.',
+      inputSchema: movePaneInputSchema,
+      execute: async ({ paneId, toColumnId, toIndex }, options) =>
+        runLayoutVerb(readContext(options), options, 'move_pane', {
+          type: 'move_pane',
+          paneId,
+          toColumnId,
+          ...(toIndex === undefined ? {} : { toIndex }),
+        }),
+    }),
+
+    arrange_panes: tool({
+      description:
+        'Reorder this workspace\'s columns left to right. Pass columnIds (from list_panes) in the order you want them; you do NOT have to list them all — the ones you name go first, in your order, and every column you leave out keeps its current relative position behind them. Ids that no longer exist are skipped rather than failing the call. Panes and sizes travel with their column.',
+      inputSchema: arrangePanesInputSchema,
+      execute: async ({ columnIds }, options) =>
+        runLayoutVerb(readContext(options), options, 'arrange_panes', {
+          type: 'reorder_columns',
+          columnIds,
+        }),
     }),
   };
 }

--- a/apps/web/src/stores/agent-workspace/__tests__/workspace-verb-queue.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/workspace-verb-queue.test.ts
@@ -387,3 +387,122 @@ describe('give-up', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// The rearrange verbs (issue #2208)
+// ---------------------------------------------------------------------------
+
+/** A two-column grid as the wire carries it, optionally sized. */
+function twoColumnWireGrid(widths?: [number, number]): PersistedColumnState[] {
+  return [
+    {
+      id: 'col-a',
+      ...(widths ? { widthFraction: widths[0] } : {}),
+      panes: [{ id: 'pane-a', scope: scope('Left', 'conv-a') }, { id: 'pane-a2', scope: scope('Lower', 'conv-a2') }],
+    },
+    {
+      id: 'col-b',
+      ...(widths ? { widthFraction: widths[1] } : {}),
+      panes: [{ id: 'pane-b', scope: scope('Right', 'conv-b') }],
+    },
+  ];
+}
+
+describe('rearrange verbs: optimistic apply', () => {
+  beforeEach(() => {
+    mockFetchWithAuth.mockImplementation(() => new Promise<Response>(() => {}));
+    store().hydrateFromServer('ses-1', { rev: 4, grid: twoColumnWireGrid() });
+  });
+
+  it('resizeColumn renders the new share immediately and posts one resize_column verb', () => {
+    store().resizeColumn('ses-1', 'col-a', 0.7);
+
+    expect(grid().columns[0].widthFraction).toBeCloseTo(0.7, 5);
+    expect(grid().columns[1].widthFraction).toBeCloseTo(0.3, 5);
+    const posted = postedVerbs().at(-1)!;
+    expect(posted.verb).toEqual({ type: 'resize_column', columnId: 'col-a', widthFraction: 0.7 });
+    expect(posted.baseRev).toBe(4);
+  });
+
+  it('resizePane sizes within the pane own column only', () => {
+    store().resizePane('ses-1', 'pane-a', 0.8);
+
+    expect(grid().columns[0].panes.map((pane) => pane.heightFraction?.toFixed(2))).toEqual(['0.80', '0.20']);
+    // A single-pane sibling column is untouched — heights are column-local.
+    expect(grid().columns[1].panes[0].heightFraction).toBeUndefined();
+    expect(postedVerbs().at(-1)!.verb).toEqual({ type: 'resize_pane', paneId: 'pane-a', heightFraction: 0.8 });
+  });
+
+  it('movePane relocates optimistically, dropping a column the move emptied', () => {
+    store().movePane('ses-1', 'pane-b', 'col-a', 0);
+
+    expect(grid().columns).toHaveLength(1);
+    expect(grid().columns[0].panes.map((pane) => pane.id)).toEqual(['pane-b', 'pane-a', 'pane-a2']);
+    expect(postedVerbs().at(-1)!.verb).toEqual({ type: 'move_pane', paneId: 'pane-b', toColumnId: 'col-a', toIndex: 0 });
+  });
+
+  it('movePane omits toIndex from the payload when the caller did (append)', () => {
+    store().movePane('ses-1', 'pane-b', 'col-a');
+    expect(postedVerbs().at(-1)!.verb).toEqual({ type: 'move_pane', paneId: 'pane-b', toColumnId: 'col-a' });
+  });
+
+  it('reorderColumns permutes optimistically', () => {
+    store().reorderColumns('ses-1', ['col-b', 'col-a']);
+
+    expect(grid().columns.map((column) => column.id)).toEqual(['col-b', 'col-a']);
+    expect(postedVerbs().at(-1)!.verb).toEqual({ type: 'reorder_columns', columnIds: ['col-b', 'col-a'] });
+  });
+
+  it('never posts a rearrange the reducer declined', () => {
+    const before = postedVerbs().length;
+    // A ghost id, a single-member container, and an order already in force —
+    // all total no-ops in the shared reducer, so none reaches the queue.
+    store().resizeColumn('ses-1', 'col-ghost', 0.5);
+    store().resizePane('ses-1', 'pane-b', 0.5);
+    store().reorderColumns('ses-1', ['col-a', 'col-b']);
+    store().movePane('ses-1', 'pane-b', 'col-b');
+
+    expect(postedVerbs()).toHaveLength(before);
+    expect(sync().pending).toHaveLength(0);
+  });
+});
+
+describe('rearrange verbs: 409 rebase', () => {
+  it('replays an unacked resize on top of the truth the 409 carried', async () => {
+    // The server has since been resized by someone else (col-a to 0.8) AND is
+    // a rev ahead — the exact shape a 409 exists to report.
+    mockFetchWithAuth
+      .mockResolvedValueOnce(reply(409, { rev: 9, grid: twoColumnWireGrid([0.8, 0.2]) }))
+      .mockResolvedValue(reply(200, { rev: 10, grid: twoColumnWireGrid([0.35, 0.65]) }));
+
+    store().hydrateFromServer('ses-1', { rev: 4, grid: twoColumnWireGrid() });
+    store().resizeColumn('ses-1', 'col-b', 0.65);
+    await settled();
+    await settled();
+
+    // Re-posted from the head against the rev the 409 handed back, then
+    // settled on the server's own answer.
+    const posts = postedVerbs();
+    expect(posts).toHaveLength(2);
+    expect(posts[0].verb.type).toBe('resize_column');
+    expect(posts[1].verb.type).toBe('resize_column');
+    expect(posts[0].opId, 'a rebase re-sends the SAME op').toBe(posts[1].opId);
+    expect(posts[1].baseRev).toBe(9);
+    expect(sync().rev).toBe(10);
+    expect(sync().pending).toHaveLength(0);
+    expect(grid().columns[1].widthFraction).toBeCloseTo(0.65, 5);
+  });
+
+  it('adopts fractions arriving on a remote broadcast without stealing focus', () => {
+    store().hydrateFromServer('ses-1', { rev: 4, grid: twoColumnWireGrid() });
+    store().selectPane('ses-1', 'pane-a2');
+
+    // An agent's resize_pane, or another device's — sizing IS a row, so it
+    // must land here, unlike focus, which must not move.
+    store().applyRemoteUpdate({ workspaceId: 'ses-1', rev: 5, grid: twoColumnWireGrid([0.25, 0.75]) });
+
+    expect(grid().columns.map((column) => column.widthFraction)).toEqual([0.25, 0.75]);
+    expect(grid().activePaneId).toBe('pane-a2');
+    expect(sync().rev).toBe(5);
+  });
+});

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -165,6 +165,19 @@ interface AgentWorkspaceState {
   /** Retire a pane's picker focus. CLIENT-LOCAL, like `selectPane`. */
   dismissPicker(sessionId: string, paneId: string): void;
   /**
+   * Give a column `widthFraction` of the grid's width (issue #2208). Unlike
+   * focus, sizing IS a row — it restores cross-device and an agent can set it
+   * — so this posts a verb like every other structural mutation, and the
+   * shared reducer owns the clamping and the sibling renormalization.
+   */
+  resizeColumn(sessionId: string, columnId: string, widthFraction: number): void;
+  /** Give a pane `heightFraction` of ITS COLUMN's height. Column-local; see {@link resizeColumn}. */
+  resizePane(sessionId: string, paneId: string, heightFraction: number): void;
+  /** Relocate a pane to another column and/or index. `toIndex` omitted = append. */
+  movePane(sessionId: string, paneId: string, toColumnId: string, toIndex?: number): void;
+  /** Reorder the grid's columns. The list is read as a PREFIX — see the reducer's `reorderColumns`. */
+  reorderColumns(sessionId: string, columnIds: string[]): void;
+  /**
    * Point whichever pane is showing `oldConversationId` at its replacement.
    * Used when the current conversation is deleted and re-minted into the
    * SAME session (`AgentPageView`'s delete flow) — a no-op if the deleted
@@ -730,6 +743,22 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
           pendingPickerPaneId: null,
         });
       },
+
+      // The four rearrange verbs (issue #2208). Each is a plain enqueue: the
+      // shared reducer applies it optimistically, decides whether it changed
+      // anything at all (a clamped-to-identical resize never reaches the
+      // queue), and the same 409-rebase path covers them as every other verb.
+      resizeColumn: (sessionId, columnId, widthFraction) =>
+        enqueueVerb(sessionId, { type: 'resize_column', columnId, widthFraction }),
+
+      resizePane: (sessionId, paneId, heightFraction) =>
+        enqueueVerb(sessionId, { type: 'resize_pane', paneId, heightFraction }),
+
+      movePane: (sessionId, paneId, toColumnId, toIndex) =>
+        enqueueVerb(sessionId, { type: 'move_pane', paneId, toColumnId, ...(toIndex === undefined ? {} : { toIndex }) }),
+
+      reorderColumns: (sessionId, columnIds) =>
+        enqueueVerb(sessionId, { type: 'reorder_columns', columnIds }),
 
       replaceConversation: (sessionId, oldConversationId, newScope) =>
         enqueueVerb(sessionId, {

--- a/apps/web/src/stores/agent-workspace/verb-queue.ts
+++ b/apps/web/src/stores/agent-workspace/verb-queue.ts
@@ -131,9 +131,18 @@ export function adoptServerGrid(
   grid: readonly PersistedColumnState[] | null | undefined,
 ): WorkspaceState | null {
   if (!grid || grid.length === 0) return null;
+  // Fractions ride along as first-class structure (issue #2208) — they are
+  // rows, not view state, so unlike focus they come straight off the wire. An
+  // unsized container carries no key at all, which is what keeps a hydrated
+  // grid byte-identical to one the reducer built.
   const columns = grid.map((column) => ({
     id: column.id,
-    panes: column.panes.map((pane) => ({ id: pane.id, scope: pane.scope })),
+    ...(typeof column.widthFraction === 'number' ? { widthFraction: column.widthFraction } : {}),
+    panes: column.panes.map((pane) => ({
+      id: pane.id,
+      scope: pane.scope,
+      ...(typeof pane.heightFraction === 'number' ? { heightFraction: pane.heightFraction } : {}),
+    })),
   }));
   const first = columns.find((column) => column.panes.length > 0);
   if (!first) return null;

--- a/docs/2.0-architecture/agent-sessions.md
+++ b/docs/2.0-architecture/agent-sessions.md
@@ -81,6 +81,35 @@ Shipped invariants (source: `packages/db/src/schema/agent-sessions.ts`,
   spawn placement) still cannot write placement. / Target: the client store
   rewritten onto the verbs + live `workspace:updated` application, tool paths
   posting verbs, then the blob + localStorage copy dying at contract.
+- **Pane REARRANGE (issue #2208): SHIPPED.** The verb set is complete —
+  `resize_column` / `resize_pane` / `move_pane` / `reorder_columns` join the
+  structural verbs in the same pure engine, and the `widthFraction` /
+  `heightFraction` columns reserved by the promotion are now written, read,
+  and round-tripped. This was blocked BY the promotion by design: as blob
+  writes, rearrange verbs would have added yet another writer of a
+  client-authored JSONB. **The fraction invariant** is stated and enforced in
+  the reducer, never at a call site (`rebalanceFractions`): a container (the
+  grid's columns, or one column's panes) is either wholly UNSIZED — no member
+  carries a fraction, and the renderer splits it evenly — or wholly SIZED,
+  with every member at or above `MIN_FRACTION` and the shares summing to 1
+  within `FRACTION_EPSILON`. Never mixed, in either direction: a resize
+  materializes the whole container from its even split, a membership change
+  re-establishes the invariant for the new membership (newcomers take an even
+  share, survivors keep their relative proportions), and wire input that
+  arrives mixed is read as unsized wholesale. Every verb stays TOTAL — an
+  unresolvable id, a lone-member container, and a re-sent identical resize are
+  no-ops, and an out-of-range fraction or index is clamped rather than
+  refused. Fractions are quantized to 1e-5 on both write and read, because the
+  storage type is `real` (float4) and the store's content diff is a byte
+  comparison — without a shared snap, every write would look like a change.
+- **Agent-facing layout tools (issue #2208): SHIPPED.** `list_panes` /
+  `resize_pane` / `move_pane` / `arrange_panes` on the session tool family —
+  an agent arranging its OWN workspace, addressed by the paneId/columnId
+  `list_panes` returns. They resolve the grid from the CALLER's own
+  conversation (never a workspaceId the model supplies), go through
+  `applyWorkspaceLayoutVerb` in-process — the same single writer, per-workspace
+  lock, and op memory the verbs route uses — and derive their `opId` from the
+  tool call id so an SDK retry replays instead of rearranging twice.
 
 ## 2. Authorization axioms (PR #2336 — product-locked)
 
@@ -195,6 +224,7 @@ get one shared writer.
 | `workspaceId` | An `agent_sessions` row — the working context / sandbox owner | Everywhere except the tool layer: `conversations.sessionId`, `agent_session_shells.sessionId`, `/api/agent-sessions/[sessionId]`, `?session=` URLs |
 | `conversationId` | A thread (`conversations` row) | The session-tool layer: the `sessionId` param of `send_session` / `read_session` / `kill_session` is a **worker's conversation id** (`apps/web/src/lib/ai/tools/session-tools.ts` — mapped to a `conversationId` local at the zod boundary; internally `WorkerRow.conversationId`, with `WorkerRow.workspaceId` naming the workspace) |
 | *(frozen)* `sessionId` | The model-facing tool param | The wire vocabulary is deliberately frozen at the zod boundary: to the model, a "session" is a worker you talk to and a "workspace" is the environment. Internal renames never touch these schemas |
+| `paneId` / `columnId` | One rectangle of a workspace's grid, and the vertical stack it sits in | The layout tools (`list_panes` / `resize_pane` / `move_pane` / `arrange_panes`, issue #2208). These sit on the WORKSPACE side of the frozen split — panes are furniture of the environment — so they deliberately say "pane"/"column"/"workspace" and never "session". They take no workspaceId at all: the grid is the caller's own, resolved from its conversation |
 | `spriteExecId` | The Sprite PTY exec stream a shell reattaches under | `agent_session_shells.streamSessionId` (rename lands in the epic's final phase) |
 | — | Auth login sessions (`sessions` table, `packages/db/src/schema/sessions.ts`) | Unrelated. Never mix with any of the above |
 

--- a/packages/lib/src/agent-sessions/__tests__/workspace-layout-rearrange.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/workspace-layout-rearrange.test.ts
@@ -1,0 +1,479 @@
+/**
+ * The REARRANGE half of the verb algebra (issue #2208) — `resize_column`,
+ * `resize_pane`, `move_pane`, `reorder_columns`, and the fraction invariant
+ * they all maintain.
+ *
+ * Split from `workspace-layout-verbs.test.ts` (which owns the structural
+ * verbs and the dual-write drift guard) because these four share one subject
+ * the others do not have at all: SIZING. The invariant is stated once, in
+ * `rebalanceFractions`' doc, and asserted here by a single predicate
+ * ({@link expectInvariant}) applied after every case — including the
+ * structural verbs, which must maintain it too now that a grid can be sized
+ * when they run.
+ *
+ * The closing property is the epic's acceptance shape for this PR: after ANY
+ * seeded sequence of the NEW verbs mixed with the old ones, the grid still
+ * satisfies every structural invariant — contiguous positions, valid
+ * fractions, no orphan panes, no empty columns. Seeded LCG rather than
+ * fast-check (not a dependency of this repo), matching the drift guard's own
+ * precedent so a failure reproduces from its logged seed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  applyVerbLocal,
+  gridFromWorkspaceState,
+  workspaceStateFromGrid,
+  newWorkspace,
+  panesOf,
+  workspaceLayoutVerbSchema,
+  FRACTION_EPSILON,
+  MIN_FRACTION,
+  type ColumnState,
+  type WorkspaceLayoutVerb,
+  type WorkspaceState,
+} from '../workspace-layout-verbs';
+import { persistedWorkspaceStateSchema, type PaneScope } from '../contract';
+
+const WORKSPACE_ID = 'ses-1';
+
+const chatScope = (targetId: string, name = 'Conversation'): PaneScope => ({
+  kind: 'chat',
+  name,
+  targetId,
+  agentPageId: null,
+});
+
+const opening = (): WorkspaceState =>
+  newWorkspace({ sessionId: WORKSPACE_ID, paneId: 'pane-1', columnId: 'col-1', scope: chatScope('conv-1') });
+
+/** Apply a verb, asserting it actually ran — the setup helper for every case below. */
+function apply(state: WorkspaceState | null, verb: WorkspaceLayoutVerb): WorkspaceState {
+  const outcome = applyVerbLocal(state, WORKSPACE_ID, verb);
+  expect(outcome.applied, `expected ${verb.type} to apply`).toBe(true);
+  return outcome.state!;
+}
+
+/**
+ * A three-column grid: `col-1` holds `pane-1` + `pane-1b`, `col-2` holds
+ * `pane-2`, `col-3` holds `pane-3`. Unsized — no verb here has touched a
+ * fraction yet.
+ */
+function threeColumns(): WorkspaceState {
+  let state = opening();
+  state = apply(state, { type: 'split_right', fromPaneId: 'pane-1', newColumnId: 'col-2', newPaneId: 'pane-2' });
+  state = apply(state, { type: 'split_right', fromPaneId: 'pane-2', newColumnId: 'col-3', newPaneId: 'pane-3' });
+  state = apply(state, { type: 'split_down', fromPaneId: 'pane-1', newPaneId: 'pane-1b' });
+  return state;
+}
+
+/** Fractions rounded for comparison — stored shares sit on a 1e-5 grid, so
+ *  their exact doubles carry representation noise (0.6 is `0.6000000000000001`). */
+const round5 = (value: number | null | undefined) =>
+  typeof value === 'number' ? Math.round(value * 1e5) / 1e5 : null;
+const widths = (state: WorkspaceState) => state.columns.map((column) => round5(column.widthFraction));
+const heights = (column: ColumnState) => column.panes.map((pane) => round5(pane.heightFraction));
+const columnIds = (state: WorkspaceState) => state.columns.map((column) => column.id);
+const paneIdsOf = (column: ColumnState) => column.panes.map((pane) => pane.id);
+
+/**
+ * THE fraction invariant, as one assertion: every container is either wholly
+ * unsized or wholly sized with each share at/above the floor and the shares
+ * summing to 1. Plus the structural invariants a rearrange must never break:
+ * no empty column, and no duplicated pane (a `move_pane` that copied instead
+ * of moving would show up here and nowhere else).
+ */
+function expectInvariant(state: WorkspaceState | null, label = ''): void {
+  if (state === null) return;
+  const containers: Array<Array<number | null | undefined>> = [
+    state.columns.map((column) => column.widthFraction),
+    ...state.columns.map((column) => column.panes.map((pane) => pane.heightFraction)),
+  ];
+  for (const container of containers) {
+    const sized = container.filter((value) => typeof value === 'number') as number[];
+    if (sized.length === 0) continue;
+    expect(sized.length, `${label}: container is MIXED (some members sized, some not)`).toBe(container.length);
+    for (const share of sized) {
+      expect(Number.isFinite(share), `${label}: non-finite share`).toBe(true);
+      // The floor itself relaxes for a container too crowded to honor it —
+      // `1 / n` is then the even split, which is all anyone can have.
+      expect(share, `${label}: share under the floor`).toBeGreaterThanOrEqual(
+        Math.min(MIN_FRACTION, 1 / container.length) - FRACTION_EPSILON,
+      );
+    }
+    const sum = sized.reduce((total, share) => total + share, 0);
+    expect(Math.abs(sum - 1), `${label}: shares sum to ${sum}, not 1`).toBeLessThan(FRACTION_EPSILON);
+  }
+
+  for (const column of state.columns) {
+    expect(column.panes.length, `${label}: empty column ${column.id}`).toBeGreaterThan(0);
+  }
+  const ids = panesOf(state).map((pane) => pane.id);
+  expect(new Set(ids).size, `${label}: duplicated pane id`).toBe(ids.length);
+}
+
+// ---------------------------------------------------------------------------
+// resize_column
+// ---------------------------------------------------------------------------
+
+describe('applyVerbLocal: resize_column', () => {
+  it('materializes an unsized grid: the resized column takes its share, siblings split the rest evenly', () => {
+    const state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-1', widthFraction: 0.5 });
+    expect(widths(state)).toEqual([0.5, 0.25, 0.25]);
+    expectInvariant(state);
+  });
+
+  it('siblings absorb the difference IN PROPORTION, not evenly', () => {
+    let state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-2', widthFraction: 0.6 });
+    expect(widths(state)).toEqual([0.2, 0.6, 0.2]);
+    // col-1 is now twice col-3; shrinking col-2 must preserve that ratio.
+    state = apply(state, { type: 'resize_column', columnId: 'col-1', widthFraction: 0.4 });
+    expect(state.columns[1].widthFraction! / state.columns[2].widthFraction!).toBeCloseTo(3, 5);
+    expectInvariant(state);
+  });
+
+  it('clamps a request beyond what the floor leaves available instead of refusing it', () => {
+    const wide = apply(threeColumns(), { type: 'resize_column', columnId: 'col-1', widthFraction: 5 });
+    expect(wide.columns[0].widthFraction).toBeCloseTo(1 - 2 * MIN_FRACTION, 5);
+    expect(wide.columns[1].widthFraction).toBeCloseTo(MIN_FRACTION, 5);
+    expectInvariant(wide);
+
+    const narrow = apply(threeColumns(), { type: 'resize_column', columnId: 'col-1', widthFraction: -3 });
+    expect(narrow.columns[0].widthFraction).toBeCloseTo(MIN_FRACTION, 5);
+    expectInvariant(narrow);
+  });
+
+  it('no-ops on an unresolvable column, on a single-column grid, and on a re-sent identical resize', () => {
+    const three = threeColumns();
+    expect(applyVerbLocal(three, WORKSPACE_ID, { type: 'resize_column', columnId: 'ghost', widthFraction: 0.5 }).applied).toBe(false);
+    // A lone column always owns the whole width — there is no share to state.
+    expect(applyVerbLocal(opening(), WORKSPACE_ID, { type: 'resize_column', columnId: 'col-1', widthFraction: 0.3 }).applied).toBe(false);
+
+    const sized = apply(three, { type: 'resize_column', columnId: 'col-1', widthFraction: 0.5 });
+    const replayed = applyVerbLocal(sized, WORKSPACE_ID, { type: 'resize_column', columnId: 'col-1', widthFraction: 0.5 });
+    expect(replayed.applied, 'a re-sent resize must not bump the rev').toBe(false);
+    expect(replayed.state).toBe(sized);
+  });
+
+  it('no-ops on a gridless session rather than inventing a grid to size', () => {
+    expect(applyVerbLocal(null, WORKSPACE_ID, { type: 'resize_column', columnId: 'col-1', widthFraction: 0.5 })).toEqual({
+      state: null,
+      applied: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resize_pane
+// ---------------------------------------------------------------------------
+
+describe('applyVerbLocal: resize_pane', () => {
+  it('sizes within the pane OWN column and leaves every other column alone', () => {
+    const state = apply(threeColumns(), { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.75 });
+    expect(heights(state.columns[0])).toEqual([0.75, 0.25]);
+    // Heights are column-local: a single-pane sibling column is untouched.
+    expect(heights(state.columns[1])).toEqual([null]);
+    expect(widths(state)).toEqual([null, null, null]);
+    expectInvariant(state);
+  });
+
+  it('clamps to the floor and no-ops for a pane alone in its column', () => {
+    const clamped = apply(threeColumns(), { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.999 });
+    expect(clamped.columns[0].panes[1].heightFraction).toBeCloseTo(MIN_FRACTION, 5);
+    expectInvariant(clamped);
+
+    expect(applyVerbLocal(threeColumns(), WORKSPACE_ID, { type: 'resize_pane', paneId: 'pane-2', heightFraction: 0.4 }).applied).toBe(false);
+    expect(applyVerbLocal(threeColumns(), WORKSPACE_ID, { type: 'resize_pane', paneId: 'ghost', heightFraction: 0.4 }).applied).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// move_pane
+// ---------------------------------------------------------------------------
+
+describe('applyVerbLocal: move_pane', () => {
+  it('moves a pane to another column, keeping its binding and appending by default', () => {
+    const state = apply(threeColumns(), { type: 'move_pane', paneId: 'pane-2', toColumnId: 'col-1' });
+    expect(paneIdsOf(state.columns[0])).toEqual(['pane-1', 'pane-1b', 'pane-2']);
+    // The column it emptied is gone — a grid never carries an empty column.
+    expect(columnIds(state)).toEqual(['col-1', 'col-3']);
+    // The binding rides along untouched — `pane-2` is the unbound picker pane
+    // `split_right` minted, and it is still exactly that after the move.
+    expect(panesOf(state).find((pane) => pane.id === 'pane-2')?.scope).toBe(null);
+    expectInvariant(state);
+  });
+
+  it('honors an explicit index and clamps one out of range', () => {
+    const first = apply(threeColumns(), { type: 'move_pane', paneId: 'pane-2', toColumnId: 'col-1', toIndex: 0 });
+    expect(paneIdsOf(first.columns[0])).toEqual(['pane-2', 'pane-1', 'pane-1b']);
+
+    const clampedHigh = apply(threeColumns(), { type: 'move_pane', paneId: 'pane-2', toColumnId: 'col-1', toIndex: 99 });
+    expect(paneIdsOf(clampedHigh.columns[0])).toEqual(['pane-1', 'pane-1b', 'pane-2']);
+
+    const clampedLow = apply(threeColumns(), { type: 'move_pane', paneId: 'pane-2', toColumnId: 'col-1', toIndex: -5 });
+    expect(paneIdsOf(clampedLow.columns[0])).toEqual(['pane-2', 'pane-1', 'pane-1b']);
+    expectInvariant(clampedLow);
+  });
+
+  it('reorders WITHIN a column, carrying each pane its own height along', () => {
+    let state = apply(threeColumns(), { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.7 });
+    state = apply(state, { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-1', toIndex: 1 });
+    expect(paneIdsOf(state.columns[0])).toEqual(['pane-1b', 'pane-1']);
+    // A same-column move is a pure permutation: shares travel with their pane.
+    expect(heights(state.columns[0])).toEqual([0.3, 0.7]);
+    expectInvariant(state);
+  });
+
+  it('arrives in a NEW column unsized — a height chosen against one stack means nothing in another', () => {
+    let state = threeColumns();
+    state = apply(state, { type: 'split_down', fromPaneId: 'pane-2', newPaneId: 'pane-2b' });
+    state = apply(state, { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.8 });
+    state = apply(state, { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-2', toIndex: 0 });
+    // col-2 was unsized and stays unsized; col-1's survivor takes the whole column.
+    expect(heights(state.columns[1])).toEqual([null, null, null]);
+    expect(heights(state.columns[0])).toEqual([null]);
+    expectInvariant(state);
+  });
+
+  it('no-ops on an unresolvable pane, an unresolvable destination, and a move to where it already is', () => {
+    const state = threeColumns();
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'move_pane', paneId: 'ghost', toColumnId: 'col-1' }).applied).toBe(false);
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'move_pane', paneId: 'pane-1', toColumnId: 'ghost' }).applied).toBe(false);
+    // pane-2 is already the only (hence last) pane of col-2.
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'move_pane', paneId: 'pane-2', toColumnId: 'col-2' }).applied).toBe(false);
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'move_pane', paneId: 'pane-1', toColumnId: 'col-1', toIndex: 0 }).applied).toBe(false);
+  });
+
+  it('renumbers positions contiguously through the row projection', () => {
+    const state = apply(threeColumns(), { type: 'move_pane', paneId: 'pane-3', toColumnId: 'col-1', toIndex: 1 });
+    const grid = gridFromWorkspaceState(state);
+    // `orderIndex` IS array order in the projection — the store derives it
+    // from `entries()`, so a contiguous array is a contiguous renumbering.
+    expect(grid[0].panes.map((pane) => pane.id)).toEqual(['pane-1', 'pane-3', 'pane-1b']);
+    expect(grid.map((column) => column.id)).toEqual(['col-1', 'col-2']);
+    expectInvariant(state);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorder_columns
+// ---------------------------------------------------------------------------
+
+describe('applyVerbLocal: reorder_columns', () => {
+  it('reorders to an explicit full permutation, carrying widths along', () => {
+    let state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-1', widthFraction: 0.5 });
+    state = apply(state, { type: 'reorder_columns', columnIds: ['col-3', 'col-2', 'col-1'] });
+    expect(columnIds(state)).toEqual(['col-3', 'col-2', 'col-1']);
+    expect(widths(state)).toEqual([0.25, 0.25, 0.5]);
+    expectInvariant(state);
+  });
+
+  it('reads a PARTIAL list as a prefix: named columns first, everything else in its current order', () => {
+    const state = apply(threeColumns(), { type: 'reorder_columns', columnIds: ['col-3'] });
+    expect(columnIds(state)).toEqual(['col-3', 'col-1', 'col-2']);
+    expectInvariant(state);
+  });
+
+  it('skips unknown ids and ignores repeats rather than refusing the whole request', () => {
+    const state = apply(threeColumns(), {
+      type: 'reorder_columns',
+      columnIds: ['ghost', 'col-2', 'col-2', 'also-ghost'],
+    });
+    expect(columnIds(state)).toEqual(['col-2', 'col-1', 'col-3']);
+    expectInvariant(state);
+  });
+
+  it('no-ops when the requested order is the order already in force', () => {
+    const state = threeColumns();
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'reorder_columns', columnIds: ['col-1', 'col-2', 'col-3'] }).applied).toBe(false);
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'reorder_columns', columnIds: ['col-1'] }).applied).toBe(false);
+    expect(applyVerbLocal(state, WORKSPACE_ID, { type: 'reorder_columns', columnIds: ['nobody'] }).applied).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural verbs maintain the invariant on an ALREADY-SIZED grid
+// ---------------------------------------------------------------------------
+
+describe('the structural verbs re-establish the invariant after a membership change', () => {
+  it('a split gives the newcomer an even share and shrinks the rest proportionally', () => {
+    let state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-1', widthFraction: 0.6 });
+    state = apply(state, { type: 'split_right', fromPaneId: 'pane-1', newColumnId: 'col-4', newPaneId: 'pane-4' });
+    expect(state.columns).toHaveLength(4);
+    // The newcomer takes 1/4; the incumbents keep their 0.6 : 0.2 : 0.2 ratio
+    // inside the remaining 3/4.
+    expect(state.columns[0].widthFraction).toBeCloseTo(0.45, 4);
+    expect(state.columns[1].widthFraction).toBeCloseTo(0.25, 4);
+    expectInvariant(state);
+  });
+
+  it('a close rescales the survivors to fill what the departure freed', () => {
+    let state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-2', widthFraction: 0.5 });
+    state = apply(state, { type: 'close_pane', paneId: 'pane-3' });
+    expect(columnIds(state)).toEqual(['col-1', 'col-2']);
+    // col-1 : col-2 was 0.25 : 0.5 before the close, so the survivors keep
+    // that 1 : 2 ratio while growing to fill the whole width.
+    expect(state.columns[0].widthFraction).toBeCloseTo(1 / 3, 4);
+    expect(state.columns[1].widthFraction).toBeCloseTo(2 / 3, 4);
+    expectInvariant(state);
+  });
+
+  it('leaves an UNSIZED grid untouched — a split on a grid nobody sized writes no fractions', () => {
+    const state = apply(threeColumns(), { type: 'split_down', fromPaneId: 'pane-2', newPaneId: 'pane-2b' });
+    expect(widths(state)).toEqual([null, null, null]);
+    expect(heights(state.columns[1])).toEqual([null, null]);
+    expectInvariant(state);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fractions survive the round trip the runtime actually performs
+// ---------------------------------------------------------------------------
+
+describe('fractions round-trip through the row projection and the blob', () => {
+  it('project to rows and rehydrate identically', () => {
+    let state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-1', widthFraction: 0.5 });
+    state = apply(state, { type: 'resize_pane', paneId: 'pane-1', heightFraction: 0.7 });
+
+    const grid = gridFromWorkspaceState(state);
+    expect(grid[0].widthFraction).toBeCloseTo(0.5, 5);
+    expect(grid[0].panes[0].heightFraction).toBeCloseTo(0.7, 5);
+    expect(grid[1].panes[0].heightFraction, 'an unsized column projects canonical nulls').toBe(null);
+
+    expect(workspaceStateFromGrid({ workspaceId: WORKSPACE_ID, grid, blob: state })).toEqual(state);
+  });
+
+  it('survive the legacy blob schema — the dual-write shim never drops a fraction', () => {
+    let state = apply(threeColumns(), { type: 'resize_column', columnId: 'col-2', widthFraction: 0.5 });
+    state = apply(state, { type: 'resize_pane', paneId: 'pane-1b', heightFraction: 0.3 });
+    const reparsed = persistedWorkspaceStateSchema.parse(JSON.parse(JSON.stringify(state)));
+    expect(gridFromWorkspaceState(reparsed)).toEqual(gridFromWorkspaceState(state));
+  });
+
+  it('reads a MIXED container from the wire as unsized rather than half-trusting it', () => {
+    // Hand-crafted: col-1 sized, col-2/col-3 not. No renderer can make sense
+    // of shares summing to 0.5, so the reducer treats the container as
+    // unsized and materializes from the even split on the next resize.
+    const mixed = workspaceStateFromGrid({
+      workspaceId: WORKSPACE_ID,
+      blob: null,
+      grid: [
+        { id: 'col-1', widthFraction: 0.5, panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null }] },
+        { id: 'col-2', widthFraction: null, panes: [{ id: 'pane-2', kind: null, targetId: null, heightFraction: null }] },
+      ],
+    })!;
+    const resized = apply(mixed, { type: 'resize_column', columnId: 'col-2', widthFraction: 0.8 });
+    expect(widths(resized)).toEqual([0.2, 0.8]);
+    expectInvariant(resized);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The property: any sequence of the NEW verbs preserves every invariant
+// ---------------------------------------------------------------------------
+
+/** Deterministic LCG so a failure reproduces from its logged seed. */
+function prng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+/**
+ * A random verb weighted toward the NEW four, mixed with enough structural
+ * verbs to keep membership churning — a rearrange invariant that only holds
+ * on a grid whose shape never changes would prove nothing.
+ */
+function randomVerb(rand: () => number, state: WorkspaceState | null, mint: () => string): WorkspaceLayoutVerb {
+  const panes = state ? panesOf(state) : [];
+  const columns = state?.columns ?? [];
+  // Mix resolvable and unresolvable targets so the no-op paths are exercised
+  // just as hard as the applying ones.
+  const paneId = rand() < 0.85 && panes.length > 0 ? panes[Math.floor(rand() * panes.length)].id : `ghost-${mint()}`;
+  const columnId = rand() < 0.85 && columns.length > 0 ? columns[Math.floor(rand() * columns.length)].id : `ghost-${mint()}`;
+  // Deliberately unclamped and occasionally absurd — the reducer owns the
+  // clamp, so the property must see what a buggy caller would send.
+  const fraction = rand() < 0.15 ? (rand() - 0.5) * 8 : rand();
+
+  switch (Math.floor(rand() * 10)) {
+    case 0:
+      return { type: 'resize_column', columnId, widthFraction: fraction };
+    case 1:
+      return { type: 'resize_pane', paneId, heightFraction: fraction };
+    case 2:
+      return { type: 'move_pane', paneId, toColumnId: columnId, toIndex: Math.floor(rand() * 6) - 1 };
+    case 3:
+      return { type: 'move_pane', paneId, toColumnId: columnId };
+    case 4: {
+      const shuffled = columns
+        .map((column) => column.id)
+        .filter(() => rand() < 0.7)
+        .sort(() => rand() - 0.5);
+      return { type: 'reorder_columns', columnIds: shuffled.length > 0 ? shuffled : [`ghost-${mint()}`] };
+    }
+    case 5:
+      return { type: 'split_right', fromPaneId: paneId, newColumnId: mint(), newPaneId: mint() };
+    case 6:
+      return { type: 'split_down', fromPaneId: paneId, newPaneId: mint() };
+    case 7:
+      return { type: 'close_pane', paneId };
+    case 8:
+      return { type: 'assign_pane', paneId, scope: chatScope(`conv-${Math.floor(rand() * 5)}`) };
+    default:
+      return { type: 'ensure', columnId: mint(), paneId: mint(), scope: chatScope('conv-0') };
+  }
+}
+
+describe('property: any sequence of the rearrange verbs preserves the structural invariants', () => {
+  it('holds across seeded random sequences — contiguous order, valid fractions, no orphan panes', () => {
+    for (let seed = 1; seed <= 40; seed += 1) {
+      const rand = prng(seed * 7919);
+      let minted = 0;
+      const mint = () => `id-${seed}-${(minted += 1)}`;
+      let state: WorkspaceState | null = rand() < 0.5 ? opening() : null;
+
+      for (let step = 0; step < 60; step += 1) {
+        const verb = randomVerb(rand, state, mint);
+        const label = `seed ${seed} step ${step} (${verb.type})`;
+        // The payload must be wire-legal: the schema and the engine cannot
+        // drift on what a verb is.
+        expect(workspaceLayoutVerbSchema.safeParse(verb).success, label).toBe(true);
+
+        const before = state;
+        const outcome = applyVerbLocal(state, WORKSPACE_ID, verb);
+        // Purity: a verb never mutates the state handed to it, and a verb that
+        // did not apply returns that exact state back.
+        expect(before, `${label}: reducer mutated its input`).toEqual(before);
+        if (!outcome.applied) {
+          expect(outcome.state, `${label}: a no-op must return the same reference`).toBe(before);
+        }
+        state = outcome.state;
+        expectInvariant(state, label);
+
+        if (state === null) continue;
+        // Every pane belongs to exactly one column, and the projection the
+        // store persists is contiguous in both dimensions by construction.
+        const grid = gridFromWorkspaceState(state);
+        expect(grid.length, `${label}: projection dropped a column`).toBe(state.columns.length);
+        expect(
+          grid.reduce((total, column) => total + column.panes.length, 0),
+          `${label}: projection dropped a pane`,
+        ).toBe(panesOf(state).length);
+        for (const column of grid) {
+          expect(column.panes.length, `${label}: projected an empty column`).toBeGreaterThan(0);
+        }
+        // Focus never dangles: `activePaneId` always names a live pane.
+        expect(
+          panesOf(state).some((pane) => pane.id === state!.activePaneId),
+          `${label}: activePaneId dangles`,
+        ).toBe(true);
+        // And the rows round-trip back to the same grid, fractions included.
+        expect(
+          gridFromWorkspaceState(workspaceStateFromGrid({ workspaceId: WORKSPACE_ID, grid, blob: state })!),
+          `${label}: row round-trip is not an identity`,
+        ).toEqual(grid);
+      }
+    }
+  });
+});

--- a/packages/lib/src/agent-sessions/__tests__/workspace-layout-verbs.test.ts
+++ b/packages/lib/src/agent-sessions/__tests__/workspace-layout-verbs.test.ts
@@ -217,9 +217,13 @@ describe('projections', () => {
     state = applyVerbLocal(state, WORKSPACE_ID, {
       type: 'split_right', fromPaneId: 'pane-1', newColumnId: 'col-2', newPaneId: 'pane-2',
     }).state!;
+    // Fractions project as CANONICAL null on an unsized grid — never absent.
+    // The store's content diff is a JSON.stringify comparison, and an
+    // `undefined` key vanishes from that string, so "no fraction" and "an
+    // explicit null fraction" would compare equal to two different rows.
     expect(gridFromWorkspaceState(state)).toEqual([
-      { id: 'col-1', panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1' }] },
-      { id: 'col-2', panes: [{ id: 'pane-2', kind: null, targetId: null }] },
+      { id: 'col-1', widthFraction: null, panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null }] },
+      { id: 'col-2', widthFraction: null, panes: [{ id: 'pane-2', kind: null, targetId: null, heightFraction: null }] },
     ]);
   });
 

--- a/packages/lib/src/agent-sessions/contract.ts
+++ b/packages/lib/src/agent-sessions/contract.ts
@@ -147,14 +147,36 @@ export const persistedPaneStateSchema = z
     id: z.string().min(1),
     scope: paneScopeSchema.nullable(),
     tabs: z.array(paneScopeSchema).optional(),
+    /**
+     * This pane's share of its column's height (issue #2208). Optional and
+     * nullable on the WIRE — an unsized column carries no fractions at all,
+     * and every grid written before the resize verbs shipped is exactly that
+     * — but never partially trusted: the reducer reads a container whose
+     * members are not ALL sized as unsized, and re-establishes the invariant
+     * itself. Preserved through the transform (unlike `tabs`) because it IS a
+     * live field, not a retired one.
+     */
+    heightFraction: z.number().nullable().optional(),
   })
-  .transform(({ id, scope }) => ({ id, scope }));
+  .transform(({ id, scope, heightFraction }) => ({
+    id,
+    scope,
+    ...(typeof heightFraction === 'number' ? { heightFraction } : {}),
+  }));
 export type PersistedPaneState = z.infer<typeof persistedPaneStateSchema>;
 
-export const persistedColumnStateSchema = z.object({
-  id: z.string().min(1),
-  panes: z.array(persistedPaneStateSchema).min(1),
-});
+export const persistedColumnStateSchema = z
+  .object({
+    id: z.string().min(1),
+    panes: z.array(persistedPaneStateSchema).min(1),
+    /** This column's share of the grid's width — {@link persistedPaneStateSchema}'s twin. */
+    widthFraction: z.number().nullable().optional(),
+  })
+  .transform(({ id, panes, widthFraction }) => ({
+    id,
+    panes,
+    ...(typeof widthFraction === 'number' ? { widthFraction } : {}),
+  }));
 export type PersistedColumnState = z.infer<typeof persistedColumnStateSchema>;
 
 export const persistedWorkspaceStateSchema = z.object({

--- a/packages/lib/src/agent-sessions/workspace-layout-verbs.ts
+++ b/packages/lib/src/agent-sessions/workspace-layout-verbs.ts
@@ -52,6 +52,12 @@
  *  - `close_pane` on the LAST pane is a structural no-op here exactly as in
  *    the reducer: emptying a session ends it, which is a session-lifecycle
  *    act (the end route), never a layout verb.
+ *
+ * **Sizing (issue #2208).** Beyond structure, a container's members may carry
+ * FRACTIONS — `widthFraction` per column, `heightFraction` per pane — the
+ * reserved-since-Phase-3 real columns the resize verbs finally write. The
+ * invariant is enforced HERE, never at a call site; see
+ * {@link rebalanceFractions} for its exact statement.
  */
 
 import { z } from 'zod';
@@ -65,11 +71,24 @@ export interface PaneState {
   id: string;
   /** `null` = unbound: the pane renders the picker. */
   scope: PaneScope | null;
+  /**
+   * This pane's share of its COLUMN's height. ABSENT when the column is
+   * unsized (every pane splits it evenly) — the absence IS the state, never
+   * an explicit null, so a grid the reducer built and one rehydrated from
+   * rows are byte-identical. Only ever written by the reducer; see
+   * {@link rebalanceFractions} for the invariant it maintains.
+   */
+  heightFraction?: number;
 }
 
 export interface ColumnState {
   id: string;
   panes: PaneState[];
+  /**
+   * This column's share of the grid's width. Absent when the grid is unsized,
+   * exactly like {@link PaneState.heightFraction}.
+   */
+  widthFraction?: number;
 }
 
 /** One session's pane grid. */
@@ -84,6 +103,260 @@ export interface WorkspaceState {
    * rectangle hunting for the next click. Cleared once bound or dismissed.
    */
   pendingPickerPaneId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Fractions — the sizing invariant, enforced in the reducer (issue #2208)
+// ---------------------------------------------------------------------------
+
+/**
+ * How far a fraction sum may drift from 1 and still count as satisfying the
+ * invariant. Float arithmetic makes exact equality untestable; every function
+ * here settles its own residual (see {@link settleToOne}), so real drift stays
+ * far below this.
+ */
+export const FRACTION_EPSILON = 1e-6;
+
+/**
+ * The smallest share a member may hold. A resize that would starve a sibling
+ * is CLAMPED to this rather than refused — a verb is total, and "you asked for
+ * something impossible" is not a failure mode a pane grid needs. The renderer
+ * enforces its own, stricter drag minimum on top; this is the structural floor
+ * that keeps a pane from becoming unclickable, not a UI constant.
+ */
+export const MIN_FRACTION = 0.05;
+
+/**
+ * The grid every stored fraction snaps to (1e-5 — a hundredth of a percent of
+ * a container, orders of magnitude finer than a pixel).
+ *
+ * This is NOT cosmetic rounding. The columns are Postgres `real` (float4), so
+ * a double written out does not read back bit-identical — and the store's
+ * "did anything actually change" test is a `JSON.stringify` comparison of the
+ * grid it just read against the grid it is about to write. Without a shared
+ * quantization every write would look like a change: a resize would never be
+ * idempotent, retries would bump the rev forever, and every unrelated verb on
+ * a sized grid would re-broadcast. Snapping both the reducer's output and the
+ * store's reads to the same coarse grid makes the round-trip an identity:
+ * float4's relative error (~6e-8) is ~80x smaller than the distance from a
+ * grid point to its rounding boundary (5e-6), so `q(float4(q(x))) === q(x)`
+ * with room to spare.
+ */
+const FRACTION_PRECISION = 1e-5;
+
+/** Snap a fraction to {@link FRACTION_PRECISION}. See its doc for why this exists. */
+export function quantizeFraction(value: number): number {
+  return Math.round(value / FRACTION_PRECISION) * FRACTION_PRECISION;
+}
+
+/**
+ * A stored fraction in canonical form, or `null` when it is absent,
+ * non-finite, or not positive. THE funnel through which an external number
+ * (a row, a wire payload, a hand-written blob) becomes a fraction this module
+ * will compare or persist.
+ */
+function readFraction(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? quantizeFraction(value) : null;
+}
+
+/**
+ * Put a container's shares in canonical form: every member snapped to the
+ * precision grid, and the residual folded into the LARGEST member so the sum
+ * is 1 to within float representation error.
+ *
+ * The residual lands on the largest, never on the last: whichever member
+ * happens to be final could be a small one, and pushing it under
+ * {@link MIN_FRACTION} would break the very invariant this exists to close.
+ * Recomputing the largest as `1 - everything else` (rather than adding a
+ * correction to it) keeps it ON the grid, since both terms already are.
+ */
+function settleToOne(values: number[]): number[] {
+  if (values.length === 0) return values;
+  const settled = values.map(quantizeFraction);
+  let largest = 0;
+  for (let index = 1; index < settled.length; index += 1) {
+    if (settled[index] > settled[largest]) largest = index;
+  }
+  const others = settled.reduce((sum, value, index) => (index === largest ? sum : sum + value), 0);
+  settled[largest] = quantizeFraction(1 - others);
+  return settled;
+}
+
+/**
+ * Scale `values` so they sum to `total`, with no member below the floor.
+ *
+ * Proportional scaling alone cannot honor a floor: squeezing a large sibling
+ * in can drive a small one under it. So this water-fills — pin whatever fell
+ * under the floor AT the floor, redistribute the remaining budget across the
+ * rest in proportion, repeat. The pinned set only ever grows (pinning shrinks
+ * the budget for everyone else), so this terminates in at most one pass per
+ * member; the loop bound is a statement of that, not a hope.
+ *
+ * `total / n` caps the floor, so a container too small to give everyone
+ * `MIN_FRACTION` degrades to an even split instead of demanding more than 100%.
+ */
+function scaleToTotal(values: number[], total: number): number[] {
+  const count = values.length;
+  if (count === 0) return [];
+  const floor = Math.min(MIN_FRACTION, total / count);
+  const sum = values.reduce((running, value) => running + value, 0);
+  let shares = sum > 0 ? values.map((value) => (value / sum) * total) : values.map(() => total / count);
+
+  for (let pass = 0; pass < count; pass += 1) {
+    const pinned = shares.map((share) => share < floor);
+    const pinnedCount = pinned.filter(Boolean).length;
+    if (pinnedCount === 0 || pinnedCount === count) break;
+    const budget = total - floor * pinnedCount;
+    const freeSum = shares.reduce((running, share, index) => (pinned[index] ? running : running + share), 0);
+    shares = shares.map((share, index) =>
+      pinned[index]
+        ? floor
+        : freeSum > 0
+          ? (share / freeSum) * budget
+          : budget / (count - pinnedCount),
+    );
+  }
+
+  return shares.map((share) => (share < floor ? floor : share));
+}
+
+/**
+ * THE FRACTION INVARIANT, and the one function that establishes it.
+ *
+ * For any container (the grid's columns, or one column's panes) exactly one of
+ * these holds:
+ *
+ *  - **Unsized** — EVERY member's fraction is absent. Nobody has ever resized
+ *    this container, and the renderer splits it evenly. This is the opening
+ *    state and it is deliberately not `1/n` rows: writing shares nobody chose
+ *    would make every split a sizing change.
+ *  - **Sized** — EVERY member's fraction is a finite number `>= MIN_FRACTION`,
+ *    and they sum to 1 within {@link FRACTION_EPSILON}.
+ *
+ * A container is never MIXED, in either direction: a resize materializes the
+ * whole container (unsized siblings start from their even share), and a
+ * membership change re-establishes the invariant for the new membership. Wire
+ * input that arrives mixed — hand-crafted, or written by some future partial
+ * writer — is read as UNSIZED wholesale rather than half-trusted, because a
+ * subset of fractions summing to less than 1 has no defensible rendering.
+ *
+ * `before` is what each member of the NEW membership carried; `null` marks a
+ * newcomer (a fresh split, or a pane moved in from another column). Newcomers
+ * take an even share of the new container and the survivors keep their
+ * relative proportions inside whatever is left.
+ */
+function rebalanceFractions(before: Array<number | null | undefined>): Array<number | null> {
+  const count = before.length;
+  if (count === 0) return [];
+  // A LONE member is always unsized: it owns its whole container, so a stored
+  // `1.0` states nothing the structure does not already say — and it would
+  // make a container that had shrunk to one look "sized", so the next split
+  // into it would rebalance against a share nobody chose. `resizeColumn` and
+  // `resizePane` refuse a one-member container for the same reason.
+  if (count === 1) return [null];
+  const known = before.map(readFraction);
+  if (known.every((fraction) => fraction === null)) return known;
+
+  const newcomerShare = 1 / count;
+  const newcomers = known.filter((fraction) => fraction === null).length;
+  // `newcomers < count` here (an all-null container returned above), so the
+  // survivors' budget is always positive.
+  const survivors = scaleToTotal(
+    known.filter((fraction): fraction is number => fraction !== null),
+    1 - newcomerShare * newcomers,
+  );
+  let survivorIndex = 0;
+  const merged = known.map((fraction) =>
+    fraction === null ? newcomerShare : survivors[survivorIndex++],
+  );
+  return settleToOne(merged);
+}
+
+/**
+ * The shares a container currently renders at: its stored fractions when it is
+ * sized, an even split when it is not. The starting point every resize
+ * materializes from.
+ */
+function currentShares(before: Array<number | null | undefined>): number[] {
+  const known = before.map(readFraction);
+  if (known.some((fraction) => fraction === null)) return known.map(() => 1 / known.length);
+  return settleToOne(scaleToTotal(known as number[], 1));
+}
+
+/**
+ * Give member `index` the share it asked for and let the others absorb the
+ * difference in proportion. The request is CLAMPED into what the floor leaves
+ * available rather than refused — see {@link MIN_FRACTION}.
+ */
+function resizeShare(shares: number[], index: number, requested: number): number[] {
+  const count = shares.length;
+  const floor = Math.min(MIN_FRACTION, 1 / count);
+  const ceiling = 1 - floor * (count - 1);
+  const target = Math.min(Math.max(requested, floor), ceiling);
+  const others = scaleToTotal(
+    shares.filter((_, other) => other !== index),
+    1 - target,
+  );
+  let otherIndex = 0;
+  return settleToOne(shares.map((_, member) => (member === index ? target : others[otherIndex++])));
+}
+
+/** Two fraction lists that render identically — the reducer's "nothing changed" test. */
+function sameFractions(a: Array<number | null | undefined>, b: Array<number | null>): boolean {
+  return a.every((value, index) => {
+    const left = readFraction(value);
+    const right = b[index];
+    if (left === null || right === null) return left === right;
+    return Math.abs(left - right) < FRACTION_EPSILON;
+  });
+}
+
+/**
+ * Re-seat a column's width, preserving object identity when the value is
+ * unchanged so the callers' `next !== state` applied-check stays honest. An
+ * unsized member carries NO key at all rather than an explicit null — the
+ * absence IS the state, and emitting nulls would churn every existing grid.
+ */
+function withWidthFraction(column: ColumnState, fraction: number | null): ColumnState {
+  if ((column.widthFraction ?? null) === fraction) return column;
+  if (fraction === null) {
+    const { widthFraction: _unsized, ...rest } = column;
+    return rest;
+  }
+  return { ...column, widthFraction: fraction };
+}
+
+/** {@link withWidthFraction}'s pane-height twin. */
+function withHeightFraction(pane: PaneState, fraction: number | null): PaneState {
+  if ((pane.heightFraction ?? null) === fraction) return pane;
+  if (fraction === null) {
+    const { heightFraction: _unsized, ...rest } = pane;
+    return rest;
+  }
+  return { ...pane, heightFraction: fraction };
+}
+
+/** Re-establish the width invariant across the grid's columns after any membership change. */
+function normalizeColumnWidths(columns: ColumnState[]): ColumnState[] {
+  const fractions = rebalanceFractions(columns.map((column) => column.widthFraction));
+  return columns.map((column, index) => withWidthFraction(column, fractions[index]));
+}
+
+/** Re-establish the height invariant inside ONE column after any membership change. */
+function normalizeColumnHeights(column: ColumnState): ColumnState {
+  const fractions = rebalanceFractions(column.panes.map((pane) => pane.heightFraction));
+  const panes = column.panes.map((pane, index) => withHeightFraction(pane, fractions[index]));
+  return panes.every((pane, index) => pane === column.panes[index]) ? column : { ...column, panes };
+}
+
+/**
+ * The one exit every structural transition takes: re-establish BOTH invariants
+ * over whatever membership the transition produced. Cheap and idempotent — an
+ * unsized grid passes through untouched (and identical by reference), which is
+ * why the pre-#2208 transitions could adopt it without changing behavior.
+ */
+function normalizeGrid(columns: ColumnState[]): ColumnState[] {
+  return normalizeColumnWidths(columns.map(normalizeColumnHeights));
 }
 
 interface PaneLocation {
@@ -163,7 +436,10 @@ export function splitRight(
   const columns = [...state.columns];
   columns.splice(location.columnIndex + 1, 0, { id: newColumnId, panes: [{ id: newPaneId, scope: null }] });
 
-  return { ...state, columns, activePaneId: newPaneId, pendingPickerPaneId: newPaneId };
+  // The new column is a NEWCOMER: on a grid nobody has sized this is a no-op,
+  // and on a sized one it takes an even share while its siblings keep their
+  // proportions inside the rest (the invariant's insert rule).
+  return { ...state, columns: normalizeGrid(columns), activePaneId: newPaneId, pendingPickerPaneId: newPaneId };
 }
 
 /** Split downward — a new pane appended to the source pane's existing column. */
@@ -177,7 +453,7 @@ export function splitDown(state: WorkspaceState, fromPaneId: string, newPaneId: 
       : column,
   );
 
-  return { ...state, columns, activePaneId: newPaneId, pendingPickerPaneId: newPaneId };
+  return { ...state, columns: normalizeGrid(columns), activePaneId: newPaneId, pendingPickerPaneId: newPaneId };
 }
 
 /**
@@ -207,7 +483,10 @@ export function closePane(state: WorkspaceState, id: string): WorkspaceState {
   const activePaneId = state.activePaneId === id ? columns[0].panes[0].id : state.activePaneId;
   const pendingPickerPaneId = state.pendingPickerPaneId === id ? null : state.pendingPickerPaneId;
 
-  return { ...state, columns, activePaneId, pendingPickerPaneId };
+  // Removal's side of the invariant: the survivors of both containers (the
+  // pane's column, and the grid if that column emptied out) rescale to fill
+  // what the departure freed, keeping their relative proportions.
+  return { ...state, columns: normalizeGrid(columns), activePaneId, pendingPickerPaneId };
 }
 
 export function selectPane(state: WorkspaceState, id: string): WorkspaceState {
@@ -276,6 +555,155 @@ export function assignPaneShowing(state: WorkspaceState, oldTargetId: string, ne
   return next;
 }
 
+/**
+ * Give a column `widthFraction` of the grid's width, and let its siblings
+ * absorb the difference in proportion.
+ *
+ * TOTAL, like every transition here:
+ *  - a column id that does not resolve is a no-op;
+ *  - a grid with ONE column is a no-op — a lone column always owns the whole
+ *    width, so there is no share to state and nothing to renormalize against;
+ *  - a request outside what {@link MIN_FRACTION} leaves available is CLAMPED,
+ *    not refused (a 200% column is a caller bug, not a reason to fail a grid);
+ *  - a request that resolves to what the column already renders at returns the
+ *    grid unchanged, so a re-sent resize does not bump the rev.
+ *
+ * A grid nobody has sized MATERIALIZES here: every column's even share becomes
+ * a stored fraction, because the moment one column is explicitly sized the
+ * others' shares stop being derivable from the count alone.
+ */
+export function resizeColumn(state: WorkspaceState, columnId: string, widthFraction: number): WorkspaceState {
+  const index = state.columns.findIndex((column) => column.id === columnId);
+  if (index === -1) return state;
+  if (state.columns.length < 2) return state;
+
+  const next = resizeShare(currentShares(state.columns.map((column) => column.widthFraction)), index, widthFraction);
+  if (sameFractions(state.columns.map((column) => column.widthFraction), next)) return state;
+  return { ...state, columns: state.columns.map((column, at) => withWidthFraction(column, next[at])) };
+}
+
+/**
+ * Give a pane `heightFraction` of ITS COLUMN's height, and let the panes
+ * stacked with it absorb the difference in proportion. Heights are always
+ * column-local: a pane's share says nothing about panes in other columns.
+ *
+ * Same totality rules as {@link resizeColumn} — an unresolvable pane, or a
+ * pane alone in its column, is a no-op; the request is clamped; an unchanged
+ * result returns the grid unchanged.
+ */
+export function resizePane(state: WorkspaceState, paneId: string, heightFraction: number): WorkspaceState {
+  const location = findPaneLocation(state, paneId);
+  if (!location) return state;
+  const column = state.columns[location.columnIndex];
+  if (column.panes.length < 2) return state;
+
+  const next = resizeShare(
+    currentShares(column.panes.map((pane) => pane.heightFraction)),
+    location.paneIndex,
+    heightFraction,
+  );
+  if (sameFractions(column.panes.map((pane) => pane.heightFraction), next)) return state;
+  const panes = column.panes.map((pane, at) => withHeightFraction(pane, next[at]));
+  return {
+    ...state,
+    columns: state.columns.map((existing, at) => (at === location.columnIndex ? { ...existing, panes } : existing)),
+  };
+}
+
+/**
+ * Relocate a pane to another column, another position, or both. The pane's
+ * BINDING is untouched — this moves a rectangle, never what it shows.
+ *
+ * `toIndex` is the destination's 0-based slot AFTER the pane has left its old
+ * one; omitted means "append". It is CLAMPED into range rather than refused,
+ * so `toIndex: 99` means "last" and a negative one means "first". Positions
+ * renumber contiguously by construction: order IS array order here, and the
+ * persistence layer derives `orderIndex` from it, so there is no gap to leave
+ * behind and no renumbering pass to forget.
+ *
+ * TOTAL:
+ *  - an unresolvable pane id or destination column id is a no-op (a stale
+ *    agent view of the grid must not be an error);
+ *  - a move that lands the pane exactly where it already is returns the grid
+ *    unchanged;
+ *  - a column emptied by the departure is REMOVED, exactly as `close_pane`
+ *    removes one — a grid never carries an empty column.
+ *
+ * Sizing: the pane arrives in its destination as a NEWCOMER (an even share of
+ * the column it joins), because a height chosen against one column's stack
+ * means nothing in another. A same-column reorder is a pure permutation and
+ * carries each pane's own fraction along with it.
+ */
+export function movePane(
+  state: WorkspaceState,
+  paneId: string,
+  toColumnId: string,
+  toIndex?: number,
+): WorkspaceState {
+  const location = findPaneLocation(state, paneId);
+  if (!location) return state;
+  const targetColumnIndex = state.columns.findIndex((column) => column.id === toColumnId);
+  if (targetColumnIndex === -1) return state;
+
+  const sourceColumn = state.columns[location.columnIndex];
+  const sameColumn = targetColumnIndex === location.columnIndex;
+  const pane = sourceColumn.panes[location.paneIndex];
+
+  // The destination's length once the pane has left it (only a same-column
+  // move shortens it), which is what `toIndex` is clamped against.
+  const destinationLength = state.columns[targetColumnIndex].panes.length - (sameColumn ? 1 : 0);
+  const desiredIndex = toIndex ?? destinationLength;
+  const insertAt = Math.min(Math.max(Math.trunc(desiredIndex), 0), destinationLength);
+  if (sameColumn && insertAt === location.paneIndex) return state;
+
+  const columns = state.columns
+    .map((column, index) => {
+      if (index !== location.columnIndex && index !== targetColumnIndex) return column;
+      let panes = column.panes;
+      if (index === location.columnIndex) panes = panes.filter((existing) => existing.id !== paneId);
+      if (index === targetColumnIndex) {
+        const arriving = sameColumn ? pane : withHeightFraction(pane, null);
+        panes = [...panes.slice(0, insertAt), arriving, ...panes.slice(insertAt)];
+      }
+      return { ...column, panes };
+    })
+    .filter((column) => column.panes.length > 0);
+
+  return { ...state, columns: normalizeGrid(columns) };
+}
+
+/**
+ * Reorder the grid's columns. Panes travel with their column, and each
+ * column's stored width travels with it too — a permutation moves shares
+ * around, it never changes them, so the invariant holds by construction.
+ *
+ * DELIBERATELY FORGIVING, and this is the interesting choice: `columnIds` is
+ * read as a PREFIX, not as a required permutation. Ids that resolve are placed
+ * first, in the order given; duplicates after the first mention are ignored;
+ * ids that resolve to nothing are skipped; and every column the caller did not
+ * mention keeps its current relative order behind them. So
+ * `reorder_columns(['c3'])` means "put c3 first, leave the rest alone" — the
+ * request an agent rearranging a workspace it only partly knows actually wants
+ * to make. Refusing anything short of a full permutation would make the verb
+ * unusable from a stale snapshot, which is the only kind an agent ever holds.
+ *
+ * An order identical to the current one returns the grid unchanged.
+ */
+export function reorderColumns(state: WorkspaceState, columnIds: readonly string[]): WorkspaceState {
+  const byId = new Map(state.columns.map((column) => [column.id, column]));
+  const placed = new Set<string>();
+  const leading: ColumnState[] = [];
+  for (const columnId of columnIds) {
+    const column = byId.get(columnId);
+    if (!column || placed.has(columnId)) continue;
+    placed.add(columnId);
+    leading.push(column);
+  }
+  const columns = [...leading, ...state.columns.filter((column) => !placed.has(column.id))];
+  if (columns.every((column, index) => column === state.columns[index])) return state;
+  return { ...state, columns };
+}
+
 /** Every pane, flattened in visual order (left-to-right, top-to-bottom). */
 export function panesOf(state: WorkspaceState): PaneState[] {
   return state.columns.flatMap((column) => column.panes);
@@ -337,6 +765,22 @@ export const workspaceLayoutVerbSchema = z.discriminatedUnion('type', [
   }),
   /** Repoint every pane showing `oldTargetId` at `scope` (delete-and-remint flows). */
   z.object({ type: z.literal('replace_conversation'), oldTargetId: id, scope: paneScopeSchema }),
+
+  // --- Rearrange (issue #2208) ------------------------------------------
+  // The four verbs the entity promotion unblocked. Each is total: see the
+  // transition it dispatches to for exactly what an odd-but-representable
+  // payload does. `z.number()` in zod v4 already rejects NaN and Infinity, so
+  // a fraction that reaches the reducer is always finite — and the reducer
+  // clamps it into range regardless, because the tool paths are not the only
+  // thing on the other end of this wire.
+  /** Set a column's share of the grid width; siblings absorb the difference. */
+  z.object({ type: z.literal('resize_column'), columnId: id, widthFraction: z.number() }),
+  /** Set a pane's share of ITS COLUMN's height; the panes stacked with it absorb the difference. */
+  z.object({ type: z.literal('resize_pane'), paneId: id, heightFraction: z.number() }),
+  /** Relocate a pane to another column and/or index. `toIndex` omitted = append. */
+  z.object({ type: z.literal('move_pane'), paneId: id, toColumnId: id, toIndex: z.number().int().optional() }),
+  /** Reorder columns; the list is a PREFIX, not a required permutation (see `reorderColumns`). */
+  z.object({ type: z.literal('reorder_columns'), columnIds: z.array(id).min(1).max(64) }),
 ]);
 
 export type WorkspaceLayoutVerb = z.infer<typeof workspaceLayoutVerbSchema>;
@@ -453,6 +897,30 @@ export function applyVerbLocal(
       const next = assignPaneShowing(state, verb.oldTargetId, verb.scope);
       return { state: next, applied: next !== state };
     }
+
+    case 'resize_column': {
+      if (!state) return NOT_APPLIED(state);
+      const next = resizeColumn(state, verb.columnId, verb.widthFraction);
+      return { state: next, applied: next !== state };
+    }
+
+    case 'resize_pane': {
+      if (!state) return NOT_APPLIED(state);
+      const next = resizePane(state, verb.paneId, verb.heightFraction);
+      return { state: next, applied: next !== state };
+    }
+
+    case 'move_pane': {
+      if (!state) return NOT_APPLIED(state);
+      const next = movePane(state, verb.paneId, verb.toColumnId, verb.toIndex);
+      return { state: next, applied: next !== state };
+    }
+
+    case 'reorder_columns': {
+      if (!state) return NOT_APPLIED(state);
+      const next = reorderColumns(state, verb.columnIds);
+      return { state: next, applied: next !== state };
+    }
   }
 }
 
@@ -461,18 +929,27 @@ export function applyVerbLocal(
 // (blob shape) and what rows persist. See module doc.
 // ---------------------------------------------------------------------------
 
-/** What one pane row owns: identity, binding kind, binding target. */
+/** What one pane row owns: identity, binding kind, binding target, height share. */
 export interface LayoutGridPane {
   id: string;
   /** `null` = unbound picker pane. */
   kind: PaneKind | null;
   targetId: string | null;
+  /**
+   * Share of the column's height, `null` when the column is unsized. CANONICAL
+   * `null` (never `undefined`): the store's content diff is a `JSON.stringify`
+   * comparison, and `undefined` keys vanish from that string — so an absent
+   * fraction and an explicit null would compare equal to a row that has one.
+   */
+  heightFraction: number | null;
 }
 
-/** What one column row owns: identity plus its panes in `orderIndex` order. */
+/** What one column row owns: identity, width share, and its panes in `orderIndex` order. */
 export interface LayoutGridColumn {
   id: string;
   panes: LayoutGridPane[];
+  /** Share of the grid's width, `null` when the grid is unsized. Canonical null — see {@link LayoutGridPane.heightFraction}. */
+  widthFraction: number | null;
 }
 
 /**
@@ -484,10 +961,12 @@ export interface LayoutGridColumn {
 export function gridFromWorkspaceState(state: WorkspaceState | PersistedWorkspaceState): LayoutGridColumn[] {
   return state.columns.map((column) => ({
     id: column.id,
+    widthFraction: readFraction(column.widthFraction),
     panes: column.panes.map((pane) => ({
       id: pane.id,
       kind: pane.scope?.kind ?? null,
       targetId: pane.scope?.targetId ?? null,
+      heightFraction: readFraction(pane.heightFraction),
     })),
   }));
 }
@@ -523,10 +1002,18 @@ export function workspaceStateFromGrid(params: {
     }
   }
 
-  const columns: ColumnState[] = grid.map((column) => ({
+  // Fractions come from the ROWS, like every other structural fact — and stay
+  // absent rather than explicitly null when unsized, so a hydrated grid is
+  // byte-identical to one the reducer built from scratch.
+  const columns: ColumnState[] = grid.map((column) => {
+    const width = readFraction(column.widthFraction);
+    return {
     id: column.id,
+    ...(width !== null ? { widthFraction: width } : {}),
     panes: column.panes.map((pane) => {
-      if (pane.kind === null) return { id: pane.id, scope: null };
+      const stored = readFraction(pane.heightFraction);
+      const height = stored !== null ? { heightFraction: stored } : {};
+      if (pane.kind === null) return { id: pane.id, scope: null, ...height };
       const known = blobPanes.get(pane.id);
       const display =
         known?.scope && known.scope.kind === pane.kind && known.scope.targetId === pane.targetId
@@ -535,9 +1022,11 @@ export function workspaceStateFromGrid(params: {
       return {
         id: pane.id,
         scope: { kind: pane.kind, targetId: pane.targetId, ...display },
+        ...height,
       };
     }),
-  }));
+    };
+  });
 
   const paneIds = new Set(columns.flatMap((column) => column.panes.map((pane) => pane.id)));
   const activePaneId =

--- a/packages/lib/src/services/agent-sessions/__tests__/workspace-layout-store.test.ts
+++ b/packages/lib/src/services/agent-sessions/__tests__/workspace-layout-store.test.ts
@@ -12,19 +12,35 @@ import type { PersistedWorkspaceState } from '../../../agent-sessions/contract';
 
 const WORKSPACE_ID = 'ses-1';
 
+// Fractions are CANONICAL null on an unsized grid — never absent. The store's
+// content diff is a `JSON.stringify` comparison, where an undefined key simply
+// vanishes from the string, so the projection type requires them (issue #2208).
 const GRID_A: LayoutGridColumn[] = [
   {
     id: 'col-1',
+    widthFraction: null,
     panes: [
-      { id: 'pane-1', kind: 'chat', targetId: 'conv-1' },
-      { id: 'pane-2', kind: null, targetId: null },
+      { id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null },
+      { id: 'pane-2', kind: null, targetId: null, heightFraction: null },
     ],
   },
 ];
 
 const GRID_B: LayoutGridColumn[] = [
-  { id: 'col-1', panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1' }] },
-  { id: 'col-2', panes: [{ id: 'pane-3', kind: 'terminal', targetId: 'shell-1' }] },
+  { id: 'col-1', widthFraction: null, panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null }] },
+  { id: 'col-2', widthFraction: null, panes: [{ id: 'pane-3', kind: 'terminal', targetId: 'shell-1', heightFraction: null }] },
+];
+
+/** GRID_A, sized — same structure, different shares. */
+const GRID_A_SIZED: LayoutGridColumn[] = [
+  {
+    id: 'col-1',
+    widthFraction: null,
+    panes: [
+      { id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: 0.75 },
+      { id: 'pane-2', kind: null, targetId: null, heightFraction: 0.25 },
+    ],
+  },
 ];
 
 const blobFor = (grid: LayoutGridColumn[]): PersistedWorkspaceState => ({
@@ -91,6 +107,21 @@ describe('workspace-layout-store: replaceWorkspaceGrid', () => {
     const retry = await store.replaceWorkspaceGrid({ workspaceId: WORKSPACE_ID, grid: GRID_A, workspaceState: blobStale });
     expect(retry.applied).toBe(false);
     expect(await store.getWorkspaceBlob(WORKSPACE_ID)).toEqual(blobA);
+  });
+
+  it('treats a SIZE-only change as a real change — a resize bumps rev like any other verb', async () => {
+    const store = createFakeWorkspaceLayoutStore();
+    await store.replaceWorkspaceGrid({ workspaceId: WORKSPACE_ID, grid: GRID_A });
+    // Identical structure, different shares. Fractions are rows, so this is a
+    // content change, not a view-state one.
+    const resized = await store.replaceWorkspaceGrid({ workspaceId: WORKSPACE_ID, grid: GRID_A_SIZED });
+    expect(resized).toEqual({ rev: 2, applied: true });
+    expect(await store.getWorkspaceGrid(WORKSPACE_ID)).toEqual(GRID_A_SIZED);
+
+    // And re-sending the same sizes is still an idempotent no-op — the whole
+    // reason both sides quantize to one precision grid.
+    const replay = await store.replaceWorkspaceGrid({ workspaceId: WORKSPACE_ID, grid: GRID_A_SIZED });
+    expect(replay).toEqual({ rev: 2, applied: false });
   });
 
   it('saveWorkspaceBlob writes the blob unconditionally (the legacy PUT leg)', async () => {

--- a/packages/lib/src/services/agent-sessions/workspace-layout-store.ts
+++ b/packages/lib/src/services/agent-sessions/workspace-layout-store.ts
@@ -45,7 +45,7 @@ import {
   type PaneKind,
   type PersistedWorkspaceState,
 } from '../../agent-sessions/contract';
-import type { LayoutGridColumn } from '../../agent-sessions/workspace-layout-verbs';
+import { quantizeFraction, type LayoutGridColumn } from '../../agent-sessions/workspace-layout-verbs';
 
 type DbTransactionCallback = Parameters<typeof DbType.transaction>[0];
 /** The real pooled `db`, OR a transaction obtained from it. Type-only, so
@@ -90,6 +90,17 @@ export interface WorkspaceLayoutStore {
 
 function gridsEqual(a: LayoutGridColumn[], b: LayoutGridColumn[]): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * A `real` (float4) fraction column, read back as the same value the reducer
+ * wrote. The column's storage type is narrower than a JS double, so the round
+ * trip is lossy — and {@link gridsEqual} is a byte comparison, so an unsnapped
+ * read would make every single write look like a change. See
+ * `quantizeFraction`'s own doc for why the snap is exact.
+ */
+function readStoredFraction(value: number | null): number | null {
+  return value === null ? null : quantizeFraction(value);
 }
 
 /**
@@ -158,11 +169,20 @@ export async function createDbWorkspaceLayoutStore(executor?: DbExecutor): Promi
     const panesByColumn = new Map<string, LayoutGridColumn['panes']>();
     for (const pane of paneRows) {
       const list = panesByColumn.get(pane.columnId) ?? [];
-      list.push({ id: pane.id, kind: (pane.kind as PaneKind | null) ?? null, targetId: pane.targetId });
+      list.push({
+        id: pane.id,
+        kind: (pane.kind as PaneKind | null) ?? null,
+        targetId: pane.targetId,
+        heightFraction: readStoredFraction(pane.heightFraction),
+      });
       panesByColumn.set(pane.columnId, list);
     }
 
-    return columnRows.map((col) => ({ id: col.id, panes: panesByColumn.get(col.id) ?? [] }));
+    return columnRows.map((col) => ({
+      id: col.id,
+      widthFraction: readStoredFraction(col.widthFraction),
+      panes: panesByColumn.get(col.id) ?? [],
+    }));
   }
 
   async function mintRev(exec: DbExecutor, workspaceId: string): Promise<number> {
@@ -221,6 +241,9 @@ export async function createDbWorkspaceLayoutStore(executor?: DbExecutor): Promi
             id: column.id,
             workspaceId,
             orderIndex: columnIndex,
+            // No longer reserved (issue #2208): the resize verbs write this,
+            // and `null` is the honest "this grid has never been sized".
+            widthFraction: column.widthFraction,
             createdAt: now,
             updatedAt: now,
           });
@@ -232,6 +255,7 @@ export async function createDbWorkspaceLayoutStore(executor?: DbExecutor): Promi
               orderIndex: paneIndex,
               kind: pane.kind,
               targetId: pane.targetId,
+              heightFraction: pane.heightFraction,
               createdAt: now,
               updatedAt: now,
             });


### PR DESCRIPTION
Closes #2208.

> **⚠️ MERGE AFTER #2345** (`feat/agent-workspace-client-verbs` — the client optimistic verb queue). This branch is built on top of it (`origin/pu/broken-sessions` + a merge of #2345) and its store tests extend the queue that PR introduces. Base is `pu/broken-sessions`.

Issue #2208 asked for layout-rearrange verbs and was deferred by design onto the entity promotion, which has now shipped: as blob writes, rearrange verbs would have added yet another writer of a client-authored JSONB. Now the pane grid is relational rows behind a rev + verb API, so they are simply four more verbs in the one shared reducer.

## 1. The four new verbs

All four live in the pure shared engine (`packages/lib/src/agent-sessions/workspace-layout-verbs.ts`) — the same one the browser's optimistic apply and the server's verb engine both call. Every one is **pure and total**: no throw on odd-but-representable input.

| Verb | Semantics | Totality (what odd input does) |
|---|---|---|
| `resize_column {columnId, widthFraction}` | Gives a column that share of the grid's width; siblings absorb the difference **in proportion**, not evenly. An unsized grid **materializes** here — every column's even share becomes stored, because once one column is explicitly sized the others stop being derivable from the count. | Unresolvable id → no-op. Single-column grid → no-op (a lone column owns the whole width; there is no share to state). Out-of-range → **clamped** into what `MIN_FRACTION` leaves available. A resize resolving to the size already in force → grid returned unchanged, so it never bumps the rev. |
| `resize_pane {paneId, heightFraction}` | Same, within the pane's **own column**. Heights are always column-local — a pane's share says nothing about panes in other columns. | Identical rules; a pane alone in its column is a no-op. |
| `move_pane {paneId, toColumnId, toIndex?}` | Relocates a pane to another column and/or index. The binding is untouched — this moves a rectangle, never what it shows. `orderIndex` renumbers contiguously by construction (order *is* array order; the store derives `orderIndex` from `entries()`). A column emptied by the move is removed, exactly as `close_pane` removes one. | Unresolvable pane or destination → no-op. A move landing where the pane already is → no-op. `toIndex` **clamped** (`99` → last, `-5` → first); omitted → append. |
| `reorder_columns {columnIds}` | Reorders columns left to right. Panes and widths travel with their column, so a permutation moves shares around without changing them. | **Deliberately forgiving — the interesting choice.** The list is read as a **prefix**, not a required permutation: named ids go first in the order given, unknown ids are skipped, repeats after the first are ignored, and every unmentioned column keeps its current relative order behind them. So `['col-3']` means "put col-3 first, leave the rest alone". Requiring a full permutation would make the verb unusable from a stale snapshot — which is the only kind an agent ever holds. Order already in force → no-op. |

## 2. The fraction invariant

Stated once, in `rebalanceFractions`, and enforced **in the reducer, never at a call site**. For any container (the grid's columns, or one column's panes) exactly one holds:

- **Unsized** — every member's fraction is *absent*. Nobody has resized it; the renderer splits evenly. Deliberately not `1/n` rows: writing shares nobody chose would make every split a sizing change.
- **Sized** — every member is finite and `>= MIN_FRACTION` (0.05), and they sum to 1 within `FRACTION_EPSILON` (1e-6).

Never **mixed**, in either direction: a resize materializes the whole container; a membership change re-establishes the invariant for the new membership (newcomers take an even share, survivors keep their relative proportions inside what's left); and wire input arriving mixed is read as *unsized wholesale*, because a subset of shares summing to less than 1 has no defensible rendering. A **lone member is always unsized** — a stored `1.0` states nothing the structure doesn't, and would make a shrunk-to-one container look "sized".

Clamping uses a bounded **water-fill** (pin below-floor members at the floor, redistribute proportionally, repeat) rather than naive proportional scaling, which cannot honor a floor: squeezing a large sibling in can drive a small one under it.

**Quantization (a real bug this closes, not cosmetics).** Fractions snap to a 1e-5 grid on **both** write and read. The columns are Postgres `real` (float4), so a double does not read back bit-identical — and `replaceWorkspaceGrid`'s "did anything change" test is a `JSON.stringify` comparison of the grid it just read against the grid it's about to write. Without a shared snap, *every* write would look like a change: resizes never idempotent, retries bumping the rev forever, every unrelated verb on a sized grid re-broadcasting. float4's relative error (~6e-8) is ~80× smaller than the distance from a grid point to its rounding boundary (5e-6), so `q(float4(q(x))) === q(x)` with room to spare.

Row projections use **canonical `null`**, never absent, for the same reason: an `undefined` key vanishes from `JSON.stringify`, so "no fraction" and "explicit null" would compare equal to two different rows. Internal state uses the opposite convention (absent = unsized) so a reducer-built grid and a rehydrated one are byte-identical.

## 3. What the UI honors vs. merely persists

Being precise here, per the brief:

**Honored (built and working):**
- Persisted fractions lay out the grid via `defaultSize` on mount/hydration — a grid opened on another device, or an hour later, comes back sized the way it was left, straight from the pane rows.
- A fraction that **changes while the grid is mounted** (an agent's `resize_pane`, or another device's, arriving over `workspace:updated`) is applied through react-resizable-panels v4's imperative `resize()`. Re-keying the group would achieve the same by remounting — which must not happen: a remounted terminal pane drops its PTY viewer and cold-starts a new shell. Only *explicit* shares are ever pushed; on an unsized grid the panel group's own even split is left alone (asserting it imperatively fires mid-reconciliation against a panel set React hasn't finished updating — that was a real `Panel constraints not found for index -1` crash caught by the `AgentPanes` suite).

**NOT honored — persisted and round-tripped only:**
- **Dragging a separator still posts no verb.** It remains local to the panel group, exactly as before this PR (no regression). Writing drags back needs a debounce plus a story for the two panels one drag resizes — two verbs whose renormalizations don't compose to what the user sees — and getting that wrong is visible jitter. Left out rather than half-built.

So today: **agents and other devices can size the grid and it is honored live; the user's own mouse drag is still ephemeral.** v4 has no controlled `size` prop, which is why both mechanisms are needed at all.

## 4. Agent-facing tools (the #2208 ask)

Four tools added to the **session tool family** (`session-tools.ts`), taking it from nine to thirteen. Names sit on the **workspace** side of the frozen vocabulary split — panes are furniture of the environment — so they say "pane"/"column"/"workspace" and never "session", which on this wire always means a worker you talk to. The nine existing tools are **untouched**: no name, description, or schema changed.

- **`list_panes`** — the grid with its columnIds/paneIds and current shares. Not optional garnish: an agent cannot address a paneId it was never told.
- **`resize_pane`** — `columnId` → width, `paneId` → height. Refuses both-or-neither rather than silently picking an axis.
- **`move_pane`** — relocate; `toIndex` omitted = append.
- **`arrange_panes`** — column order, partial lists welcome.

All three mutators go through **`applyWorkspaceLayoutVerb` in-process** — the same single writer, per-workspace advisory lock, op memory, and `workspace:updated` broadcast the verbs route uses. `opId` derives from the tool call id, so an SDK retry replays instead of rearranging twice.

**Gating:** these take **no workspaceId at all**. The grid is resolved from the *caller's own* conversation (`findOwnWorkspace`), so there is no id for a model to point somewhere it doesn't belong — the same footing the shell family stands on, and the check the verbs route runs (`checkSessionAccess`) is already satisfied by that conversation existing in that workspace. They're **chat-only** (not in `SANDBOX_COMPUTE_TOOL_NAMES`) for the same reason the worker verbs are: arranging your own panes touches no sandbox, so gating it on the compute kill-switch would hide a chat capability behind a compute flag. They sit outside `TOOL_MODULES`, so **`WORKSPACE_TOOL_COUNT` and every doc citing it are unchanged**.

A no-op answers `success: true, changed: false` **and says so** — a total reducer's no-op isn't an error, but a model told "success" after nothing moved would keep arranging a grid it has already lost track of.

## 5. Tests

- **`workspace-layout-rearrange.test.ts`** (new, 24 cases): per-verb units incl. every no-op and clamp edge; the structural verbs maintaining the invariant on an already-sized grid; fraction round-trips through rows and the legacy blob; mixed-container input read as unsized.
- **Property test** — any seeded sequence of the new verbs mixed with the old ones preserves every structural invariant: contiguous positions, valid fractions, no orphan/duplicated panes, no empty columns, non-dangling focus, and a row round-trip that is an identity. Also pins **purity** (no input mutation; a no-op returns the same reference) and that every generated payload is wire-legal. Seeded LCG per the repo's existing drift-guard precedent — fast-check is not a dependency.
- **Route** (+9 cases): all five payload shapes accepted and passed verbatim; audit under the right verb name; 409 rebase; nine 400 cases (non-finite/NaN/string/missing fraction, empty id, fractional `toIndex`, missing destination, empty and non-string reorder lists, oversized list); and **security** — a rearrange at a session the requester can't reach 404s (same anti-enumeration answer) and never touches the grid.
- **Store** (+8 cases): optimistic apply for each verb, payload shape (incl. `toIndex` omission), declined verbs never reaching the queue, **409 rebase re-sending the same opId**, and remote broadcasts adopting fractions without stealing focus.
- **Tools** (+14 cases in the contract suite): every description claim pinned to behavior, plus the schema snapshot extended deliberately with the four new tools as explicit literals.
- **Store contract**: a size-only change is a real change (bumps rev) while a re-sent identical size stays idempotent — the quantization's acceptance test.

## 6. Local gate results

GitHub Actions is in a **major outage**, so these are **real local runs** on this branch:

```
bun run lint          ✅ Tasks: 14 successful, 14 total   ("✔ No ESLint warnings or errors")
bun run knip:check    ✅ [ok] knip: 4 issue(s), all within baseline (4)
bun run typecheck     ✅ Tasks: 16 successful, 16 total
```

```
packages/lib  src/agent-sessions + src/services/agent-sessions
              ✅ Test Files 18 passed (18) · Tests 424 passed (424)
              (incl. workspace-layout-rearrange.test.ts — 24 passed, property test included)

apps/web      stores/agent-workspace · lib/agent-sessions · lib/ai/tools/session-tools*
              · api/agent-sessions/[sessionId]/workspace · components/agents/panes
              · lib/ai/core
              ✅ Test Files 100 passed (100) · Tests 1708 passed (1708)
```

The 4 knip issues are the known Capacitor false positive (`cordova.js` / `cordova_plugins.js` under gitignored `apps/{ios,android}/**/public/`, regenerated by a full build) — at baseline, not a regression.

## 7. Divergences / deliberate omissions

- **No drag→verb write-back** (§3) — persisted and honored on read; the user's own drag stays local. Called out rather than implied.
- **No `rename view`.** #2208 mentioned it, but columns carry no name field anywhere in the schema, so it is a data-model addition rather than a verb, and out of scope here.
- **`move_pane` does not create columns.** `split_right` already does; an unresolvable destination is a no-op rather than an implicit mint.
- **`reorder_columns` is prefix-semantics, not permutation-semantics** — argued in §1; the alternative is unusable from the stale snapshots agents actually hold.
- **Tool count 9 → 13.** The frozen wire contract protects existing tools from drift; these are additive and pinned as literals in the same snapshot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
