### PR TITLE
fix(scripts): carry every schema column through tenant export + drift guard

### DIFF
--- a/scripts/__tests__/setup.ts
+++ b/scripts/__tests__/setup.ts
@@ -49,6 +49,7 @@ export async function truncateAll(db: TestDb): Promise<void> {
       files,
       messages,
       conversations,
+      agent_sessions,
       channel_read_status,
       channel_message_reactions,
       channel_messages,
@@ -79,18 +80,21 @@ export const FIXTURES = {
       id: 'test_user_owner_001',
       name: 'Alice Owner',
       email: 'alice@test.local',
+      emailBidx: 'bidx_alice_test_local',
       provider: 'email' as const,
     },
     member: {
       id: 'test_user_member_002',
       name: 'Bob Member',
       email: 'bob@test.local',
+      emailBidx: 'bidx_bob_test_local',
       provider: 'email' as const,
     },
     outsider: {
       id: 'test_user_outsider_003',
       name: 'Eve Outsider',
       email: 'eve@test.local',
+      emailBidx: 'bidx_eve_test_local',
       provider: 'email' as const,
     },
   },
@@ -108,6 +112,7 @@ export const FIXTURES = {
       type: 'DOCUMENT' as const,
       position: 0,
       content: '<p>Root content</p>',
+      description: 'The drive landing page',
     },
     child: {
       id: 'test_page_child_002',
@@ -141,6 +146,30 @@ export const FIXTURES = {
       id: 'test_convo_inline_001',
       type: 'page' as const,
       title: 'Grandchild page chat',
+      /**
+       * Bound to a session, with a non-default `rev`, a closed-listing stamp
+       * and the shared flag set — the four columns the export used to drop on
+       * the floor. Every one of them has a non-default value here so the
+       * round-trip proves the value SURVIVED rather than that the tenant's
+       * column default happened to match.
+       */
+      sessionId: 'test_agent_session_001',
+      rev: 7,
+      isShared: true,
+    },
+  },
+  /**
+   * The working context `conversations.pageChat` is bound to. Carried by the
+   * export because `sessionId` is write-once — a migration that drops the
+   * binding cannot be repaired afterwards. Its Sprite-identity columns are
+   * seeded NON-NULL precisely so the round-trip can assert they DO NOT travel.
+   */
+  agentSessions: {
+    workspace: {
+      id: 'test_agent_session_001',
+      name: 'Team workspace',
+      sandboxId: 'sprite-source-fleet-001',
+      spriteInstanceId: 'sprite-instance-source-001',
     },
   },
   chatMessages: {
@@ -188,16 +217,18 @@ export const FIXTURES = {
  * Call after truncateAll() in beforeEach.
  */
 export async function seedFixtures(db: TestDb): Promise<void> {
-  const { users, drives, pages, conversations, chatMessages, files, pagePermissions, tags } = FIXTURES;
+  const { users, drives, pages, conversations, agentSessions, chatMessages, files, pagePermissions, tags } = FIXTURES;
   const now = new Date();
 
-  // Users
+  // Users. `emailBidx` is seeded because it is the LOOKUP KEY for an encrypted
+  // email (`users_email_bidx_idx`) — a migration that drops it leaves every
+  // migrated account unfindable by email, i.e. unable to log in.
   await db.execute(sql`
-    INSERT INTO users (id, name, email, provider, "createdAt", "updatedAt")
+    INSERT INTO users (id, name, email, "emailBidx", provider, "createdAt", "updatedAt")
     VALUES
-      (${users.owner.id}, ${users.owner.name}, ${users.owner.email}, ${users.owner.provider}, ${now}, ${now}),
-      (${users.member.id}, ${users.member.name}, ${users.member.email}, ${users.member.provider}, ${now}, ${now}),
-      (${users.outsider.id}, ${users.outsider.name}, ${users.outsider.email}, ${users.outsider.provider}, ${now}, ${now})
+      (${users.owner.id}, ${users.owner.name}, ${users.owner.email}, ${users.owner.emailBidx}, ${users.owner.provider}, ${now}, ${now}),
+      (${users.member.id}, ${users.member.name}, ${users.member.email}, ${users.member.emailBidx}, ${users.member.provider}, ${now}, ${now}),
+      (${users.outsider.id}, ${users.outsider.name}, ${users.outsider.email}, ${users.outsider.emailBidx}, ${users.outsider.provider}, ${now}, ${now})
   `);
 
   // User profiles
@@ -222,20 +253,38 @@ export async function seedFixtures(db: TestDb): Promise<void> {
       ('test_drivemember_002', ${drives.shared.id}, ${users.member.id}, 'MEMBER', ${now})
   `);
 
-  // Pages (tree: root -> child -> grandchild)
+  // Pages (tree: root -> child -> grandchild). The grandchild carries the
+  // AI_CHAT agent settings (`sandboxEnabled`, `userScopedAccess`,
+  // `toolExposureMode`) and the root carries `description`/`isPrivate`, all set
+  // AWAY from their column defaults so a round-trip can tell a carried value
+  // from a default one.
   await db.execute(sql`
-    INSERT INTO pages (id, title, type, content, position, "driveId", "parentId", "createdAt", "updatedAt")
+    INSERT INTO pages (id, title, type, content, position, "driveId", "parentId", "createdBy", description, "isPrivate", "toolExposureMode", "sandboxEnabled", "userScopedAccess", "createdAt", "updatedAt")
     VALUES
-      (${pages.root.id}, ${pages.root.title}, ${pages.root.type}, ${pages.root.content}, ${pages.root.position}, ${drives.shared.id}, NULL, ${now}, ${now}),
-      (${pages.child.id}, ${pages.child.title}, ${pages.child.type}, ${pages.child.content}, ${pages.child.position}, ${drives.shared.id}, ${pages.root.id}, ${now}, ${now}),
-      (${pages.grandchild.id}, ${pages.grandchild.title}, ${pages.grandchild.type}, ${pages.grandchild.content}, ${pages.grandchild.position}, ${drives.shared.id}, ${pages.child.id}, ${now}, ${now})
+      (${pages.root.id}, ${pages.root.title}, ${pages.root.type}, ${pages.root.content}, ${pages.root.position}, ${drives.shared.id}, NULL, ${users.owner.id}, ${pages.root.description}, TRUE, 'upfront', FALSE, FALSE, ${now}, ${now}),
+      (${pages.child.id}, ${pages.child.title}, ${pages.child.type}, ${pages.child.content}, ${pages.child.position}, ${drives.shared.id}, ${pages.root.id}, ${users.owner.id}, NULL, FALSE, 'upfront', FALSE, FALSE, ${now}, ${now}),
+      (${pages.grandchild.id}, ${pages.grandchild.title}, ${pages.grandchild.type}, ${pages.grandchild.content}, ${pages.grandchild.position}, ${drives.shared.id}, ${pages.child.id}, ${users.owner.id}, NULL, FALSE, 'search', TRUE, TRUE, ${now}, ${now})
+  `);
+
+  // The drive's landing page — a FORWARD reference from drives to pages, which
+  // is why the export emits it as a trailing UPDATE and why it can only be set
+  // here, after the pages exist.
+  await db.execute(sql`
+    UPDATE drives SET "homePageId" = ${pages.root.id} WHERE id = ${drives.shared.id}
+  `);
+
+  // The working context the conversation below is bound to. Its Sprite columns
+  // are deliberately non-NULL: the export must NOT carry them.
+  await db.execute(sql`
+    INSERT INTO agent_sessions (id, "driveId", "ownerId", name, "sandboxId", "spriteInstanceId", "createdAt", "updatedAt")
+    VALUES (${agentSessions.workspace.id}, ${drives.shared.id}, ${users.owner.id}, ${agentSessions.workspace.name}, ${agentSessions.workspace.sandboxId}, ${agentSessions.workspace.spriteInstanceId}, ${now}, ${now})
   `);
 
   // The page conversation the chat messages below belong to. Required since
   // 0248 gave chat_messages.conversationId a real FK — see FIXTURES.conversations.
   await db.execute(sql`
-    INSERT INTO conversations (id, "userId", title, type, "contextId", "lastMessageAt", "createdAt", "updatedAt")
-    VALUES (${conversations.pageChat.id}, ${users.owner.id}, ${conversations.pageChat.title}, ${conversations.pageChat.type}, ${pages.grandchild.id}, ${now}, ${now}, ${now})
+    INSERT INTO conversations (id, "userId", title, type, "contextId", "sessionId", "closedInSessionAt", rev, "isShared", "lastMessageAt", "createdAt", "updatedAt")
+    VALUES (${conversations.pageChat.id}, ${users.owner.id}, ${conversations.pageChat.title}, ${conversations.pageChat.type}, ${pages.grandchild.id}, ${conversations.pageChat.sessionId}, ${now}, ${conversations.pageChat.rev}, ${conversations.pageChat.isShared}, ${now}, ${now}, ${now})
   `);
 
   // Chat messages (on the grandchild AI_CHAT page)

--- a/scripts/__tests__/tenant-export-columns.test.ts
+++ b/scripts/__tests__/tenant-export-columns.test.ts
@@ -1,0 +1,174 @@
+/**
+ * DRIFT GUARD for the tenant export's column registry.
+ *
+ * `scripts/lib/tenant-export-columns.ts` is a forced copy of the Drizzle
+ * schema — the export builds hand-written INSERTs, so every carried column has
+ * to be named somewhere — and a forced copy drifts. When it does, the failure
+ * is SILENT in the worst possible way: the bundle still imports, and the
+ * un-named column's data is simply absent from the tenant forever.
+ *
+ * So this test derives the expected column set from the Drizzle table objects
+ * AT RUNTIME (`getTableColumns`) and requires the registry to account for every
+ * one of them, in both directions:
+ *
+ *   1. every schema column is carried or explicitly excluded  → catches an
+ *      ADDED column that nobody decided about (the actual historical failure);
+ *   2. every registry name exists in the schema               → catches a
+ *      RENAMED or DROPPED column left behind in the list, which would make the
+ *      import abort on an unknown column;
+ *   3. carried ∩ excluded = ∅, and every exclusion states a reason  → keeps
+ *      "not carried" a decision someone wrote down rather than an omission.
+ *
+ * It needs no database: the table objects describe themselves.
+ *
+ * SCOPE: this guards the COLUMNS of the tables the export carries. Whether the
+ * right set of TABLES is carried is a separate question, owned by
+ * `TABLE_IMPORT_ORDER`; the coverage test below only pins the two lists to
+ * each other so a new table cannot be added to one and forgotten in the other.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTableColumns, getTableName, is } from 'drizzle-orm';
+import { PgTable } from 'drizzle-orm/pg-core';
+import * as dbSchema from '@pagespace/db/schema';
+import { TABLE_IMPORT_ORDER, type ExportTableName } from '../lib/migration-types';
+import {
+  TENANT_EXPORT_COLUMNS,
+  carriedColumns,
+  exportColumns,
+  deferredColumns,
+} from '../lib/tenant-export-columns';
+
+/** Every pgTable the db package exports, keyed by its real SQL table name. */
+function schemaTablesByName(): Map<string, PgTable> {
+  const byName = new Map<string, PgTable>();
+  for (const value of Object.values(dbSchema as Record<string, unknown>)) {
+    if (value && is(value, PgTable)) {
+      byName.set(getTableName(value), value);
+    }
+  }
+  return byName;
+}
+
+const TABLES = schemaTablesByName();
+
+function schemaColumnNames(table: ExportTableName): string[] {
+  const pgTable = TABLES.get(table);
+  if (!pgTable) {
+    throw new Error(
+      `No Drizzle table named "${table}" is exported from @pagespace/db/schema — ` +
+      'the export bundle names a table the schema does not define.',
+    );
+  }
+  return Object.values(getTableColumns(pgTable)).map((c) => c.name);
+}
+
+describe('tenant export column registry', () => {
+  it('covers exactly the tables in TABLE_IMPORT_ORDER', () => {
+    expect(Object.keys(TENANT_EXPORT_COLUMNS).sort()).toEqual(
+      [...TABLE_IMPORT_ORDER].sort(),
+    );
+  });
+
+  it.each([...TABLE_IMPORT_ORDER])(
+    '%s: every schema column is carried or explicitly excluded',
+    (table) => {
+      const spec = TENANT_EXPORT_COLUMNS[table];
+      const accounted = new Set([
+        ...carriedColumns(table),
+        ...Object.keys(spec.excluded ?? {}),
+      ]);
+
+      const unaccounted = schemaColumnNames(table).filter((c) => !accounted.has(c));
+
+      expect(
+        unaccounted,
+        `${table}: ${unaccounted.join(', ')} exist in packages/db/src/schema but are ` +
+        'neither carried by the tenant export nor listed in its exclusion allowlist. ' +
+        'Add them to `columns` (or to `excluded` with a reason) in ' +
+        'scripts/lib/tenant-export-columns.ts — an unlisted column is dropped silently ' +
+        'by every tenant migration.',
+      ).toEqual([]);
+    },
+  );
+
+  it.each([...TABLE_IMPORT_ORDER])(
+    '%s: every registered column still exists in the schema',
+    (table) => {
+      const spec = TENANT_EXPORT_COLUMNS[table];
+      const schemaColumns = new Set(schemaColumnNames(table));
+      const registered = [...carriedColumns(table), ...Object.keys(spec.excluded ?? {})];
+
+      const phantom = registered.filter((c) => !schemaColumns.has(c));
+
+      expect(
+        phantom,
+        `${table}: ${phantom.join(', ')} are registered by the tenant export but no ` +
+        'longer exist in packages/db/src/schema. A dropped or renamed column left in ' +
+        'the list makes the generated INSERT fail against the tenant database.',
+      ).toEqual([]);
+    },
+  );
+
+  it.each([...TABLE_IMPORT_ORDER])(
+    '%s: carried and excluded columns do not overlap, and no name repeats',
+    (table) => {
+      const spec = TENANT_EXPORT_COLUMNS[table];
+      const carried = carriedColumns(table);
+      const excluded = Object.keys(spec.excluded ?? {});
+
+      expect(new Set(carried).size, `${table}: duplicate column in the carried list`)
+        .toBe(carried.length);
+      expect(
+        carried.filter((c) => excluded.includes(c)),
+        `${table}: a column cannot be both carried and excluded`,
+      ).toEqual([]);
+      // A deferred column is carried by a trailing UPDATE INSTEAD of the
+      // INSERT, never by both.
+      expect(
+        deferredColumns(table).filter((c) => exportColumns(table).includes(c)),
+        `${table}: a deferred column must not also ride the INSERT`,
+      ).toEqual([]);
+    },
+  );
+
+  it('states a reason for every deliberately excluded column', () => {
+    for (const table of TABLE_IMPORT_ORDER) {
+      for (const [column, reason] of Object.entries(TENANT_EXPORT_COLUMNS[table].excluded ?? {})) {
+        expect(
+          reason.trim().length,
+          `${table}.${column} is excluded from the tenant export with no stated reason`,
+        ).toBeGreaterThan(20);
+      }
+    }
+  });
+
+  it('only defers columns on tables that have an id to key the UPDATE on', () => {
+    for (const table of TABLE_IMPORT_ORDER) {
+      if (deferredColumns(table).length === 0) continue;
+      expect(
+        schemaColumnNames(table),
+        `${table} defers columns but has no "id" column for the trailing UPDATE`,
+      ).toContain('id');
+    }
+  });
+
+  it('carries the columns whose loss motivated this guard', () => {
+    // Regression pins for the eighteen columns the hand-maintained lists had
+    // silently dropped. Named individually so a future edit that removes one
+    // fails with the column, not just a set difference.
+    const pins: Partial<Record<ExportTableName, string[]>> = {
+      users: ['emailBidx', 'imageGenerationModel', 'activeUploads'],
+      drives: ['publishSubdomain', 'homePageId', 'not_found_page_id', 'publish_default_og_image_url', 'publish_favicon_url'],
+      pages: ['toolExposureMode', 'sandboxEnabled', 'userScopedAccess', 'description', 'isPrivate', 'createdBy'],
+      channel_messages: ['editedAt', 'parentId', 'replyCount', 'lastReplyAt', 'mirroredFromId', 'quotedMessageId'],
+      conversations: ['sessionId', 'closedInSessionAt', 'rev', 'isShared'],
+      messages: ['pageId', 'sourceAgentId'],
+    };
+
+    for (const [table, columns] of Object.entries(pins) as [ExportTableName, string[]][]) {
+      for (const column of columns) {
+        expect(carriedColumns(table), `${table}.${column}`).toContain(column);
+      }
+    }
+  });
+});

--- a/scripts/__tests__/tenant-import.test.ts
+++ b/scripts/__tests__/tenant-import.test.ts
@@ -106,6 +106,129 @@ describe('runImport', () => {
     expect(pagesResult.rows).toHaveLength(3);
   });
 
+  /**
+   * Round-trip proof for the columns the hand-maintained export lists used to
+   * drop silently. Every value asserted here is seeded AWAY from its column
+   * default (see `seedFixtures`), so a passing assertion means the value
+   * travelled — not that the tenant's default happened to agree.
+   *
+   * The drift guard (`tenant-export-columns.test.ts`) keeps the LIST honest
+   * against the schema; this keeps the bundle honest against a real database.
+   */
+  describe('carries every column through a full round trip', () => {
+    async function reimport(label: string): Promise<void> {
+      await truncateAll(db);
+      const targetFilePath = path.join(tmpDir, `target-files-${label}`);
+      await mkdir(targetFilePath, { recursive: true });
+      await runImport({
+        bundleDir,
+        databaseUrl: getTestDatabaseUrl(),
+        fileStoragePath: targetFilePath,
+        dryRun: false,
+      });
+    }
+
+    it('restores the conversation⇄session binding, rev, closed-listing stamp and shared flag', async () => {
+      await reimport('conversation');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT "sessionId", rev, "closedInSessionAt", "isShared" FROM conversations WHERE id = '${FIXTURES.conversations.pageChat.id}'`,
+      ))).rows as Record<string, unknown>[];
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].sessionId).toBe(FIXTURES.agentSessions.workspace.id);
+      expect(Number(rows[0].rev)).toBe(FIXTURES.conversations.pageChat.rev);
+      expect(rows[0].closedInSessionAt).not.toBeNull();
+      expect(rows[0].isShared).toBe(true);
+    });
+
+    it('carries the agent session the conversation is bound to, without its source-fleet Sprite identity', async () => {
+      await reimport('session');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT "driveId", "ownerId", name, "sandboxId", "spriteInstanceId", "sessionKey", "storageMeasuredBytes" FROM agent_sessions WHERE id = '${FIXTURES.agentSessions.workspace.id}'`,
+      ))).rows as Record<string, unknown>[];
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].driveId).toBe(FIXTURES.drives.shared.id);
+      expect(rows[0].ownerId).toBe(FIXTURES.users.owner.id);
+      expect(rows[0].name).toBe(FIXTURES.agentSessions.workspace.name);
+      // The exclusion allowlist in scripts/lib/tenant-export-columns.ts: these
+      // name a VM in the SOURCE fleet and must NOT reach the tenant, which
+      // provisions its own on first use.
+      expect(rows[0].sandboxId).toBeNull();
+      expect(rows[0].spriteInstanceId).toBeNull();
+      expect(rows[0].sessionKey).toBeNull();
+      expect(rows[0].storageMeasuredBytes).toBeNull();
+    });
+
+    it("restores the user's email blind index — the lookup key a migrated account logs in through", async () => {
+      await reimport('user');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT "emailBidx" FROM users WHERE id = '${FIXTURES.users.owner.id}'`,
+      ))).rows as Record<string, unknown>[];
+
+      expect(rows[0].emailBidx).toBe(FIXTURES.users.owner.emailBidx);
+    });
+
+    it("restores the drive's landing page, which FKs forward and rides a trailing UPDATE", async () => {
+      await reimport('drive');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT "homePageId" FROM drives WHERE id = '${FIXTURES.drives.shared.id}'`,
+      ))).rows as Record<string, unknown>[];
+
+      expect(rows[0].homePageId).toBe(FIXTURES.pages.root.id);
+    });
+
+    it("restores the pages' agent settings, privacy flag, description and author", async () => {
+      await reimport('pages');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT id, description, "isPrivate", "createdBy", "toolExposureMode", "sandboxEnabled", "userScopedAccess" FROM pages WHERE "driveId" = '${FIXTURES.drives.shared.id}'`,
+      ))).rows as Record<string, unknown>[];
+      const byId = new Map(rows.map((r) => [r.id as string, r]));
+
+      const root = byId.get(FIXTURES.pages.root.id)!;
+      expect(root.description).toBe(FIXTURES.pages.root.description);
+      expect(root.isPrivate).toBe(true);
+      expect(root.createdBy).toBe(FIXTURES.users.owner.id);
+
+      const agent = byId.get(FIXTURES.pages.grandchild.id)!;
+      expect(agent.toolExposureMode).toBe('search');
+      expect(agent.sandboxEnabled).toBe(true);
+      expect(agent.userScopedAccess).toBe(true);
+    });
+
+    it('carries the unified messages\' page and agent attribution', async () => {
+      // A conversation-scoped agent reply: NULL userId + a sourceAgentId, the
+      // exact shape 0248's attribution rule describes.
+      await db.execute(sql`
+        INSERT INTO messages (id, "conversationId", "userId", role, content, "pageId", "sourceAgentId", "createdAt")
+        VALUES ('test_message_attrib_001', ${FIXTURES.conversations.pageChat.id}, NULL, 'assistant', 'Agent reply', ${FIXTURES.pages.grandchild.id}, ${FIXTURES.pages.grandchild.id}, ${new Date()})
+      `);
+      await exportData(db as unknown as DbClient, {
+        userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+        outputDir: bundleDir,
+        fileStoragePath,
+        databaseUrl: getTestDatabaseUrl(),
+        dryRun: false,
+      });
+
+      await reimport('messages');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT "userId", "pageId", "sourceAgentId" FROM messages WHERE id = 'test_message_attrib_001'`,
+      ))).rows as Record<string, unknown>[];
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBeNull();
+      expect(rows[0].pageId).toBe(FIXTURES.pages.grandchild.id);
+      expect(rows[0].sourceAgentId).toBe(FIXTURES.pages.grandchild.id);
+    });
+  });
+
   it('preserves page tree structure (parent references)', async () => {
     await truncateAll(db);
 

--- a/scripts/lib/migration-types.ts
+++ b/scripts/lib/migration-types.ts
@@ -15,6 +15,7 @@ export interface ManifestTableCounts {
   channelMessages: number;
   channelMessageReactions: number;
   channelReadStatus: number;
+  agentSessions: number;
   conversations: number;
   messages: number;
   files: number;
@@ -111,6 +112,9 @@ export const TABLE_IMPORT_ORDER = [
   'channel_messages',
   'channel_message_reactions',
   'channel_read_status',
+  // Before `conversations`: `conversations.sessionId` FKs here, so the
+  // session rows have to exist before a bound thread can be inserted.
+  'agent_sessions',
   'conversations',
   'messages',
   'files',

--- a/scripts/lib/migration-utils.ts
+++ b/scripts/lib/migration-utils.ts
@@ -64,7 +64,7 @@ export function toSqlInList(ids: string[] | Set<string> | readonly string[]): st
  */
 export function buildInsert(
   tableName: string,
-  columns: string[],
+  columns: readonly string[],
   rows: Record<string, unknown>[],
 ): string {
   if (rows.length === 0) return '';
@@ -82,6 +82,40 @@ export function buildInsert(
     'ON CONFLICT DO NOTHING;',
     '',
   ].join('\n');
+}
+
+/**
+ * Build `UPDATE ... SET <cols> WHERE "id" = ...` statements for columns that
+ * are carried but cannot ride in their own table's INSERT because they
+ * reference a table inserted LATER (a forward FK — `drives.homePageId` and
+ * `drives.not_found_page_id` point at `pages`, while `pages.driveId` points
+ * back at `drives`, so no insert order satisfies both).
+ *
+ * Emitted after the referenced table has landed. Rows whose deferred columns
+ * are all NULL produce no statement — there is nothing to set, and the INSERT
+ * already left them NULL. Re-running the bundle re-applies identical values,
+ * so this stays as idempotent as the `ON CONFLICT DO NOTHING` inserts around it.
+ */
+export function buildDeferredUpdate(
+  tableName: string,
+  columns: readonly string[],
+  rows: Record<string, unknown>[],
+): string {
+  if (columns.length === 0 || rows.length === 0) return '';
+
+  const statements: string[] = [];
+  for (const row of rows) {
+    if (columns.every((col) => row[col] === null || row[col] === undefined)) continue;
+    const assignments = columns
+      .map((col) => `"${col}" = ${escapeSqlValue(row[col])}`)
+      .join(', ');
+    statements.push(
+      `UPDATE "${tableName}" SET ${assignments} WHERE "id" = ${escapeSqlValue(row.id)};`,
+    );
+  }
+
+  if (statements.length === 0) return '';
+  return `${statements.join('\n')}\n`;
 }
 
 /**

--- a/scripts/lib/tenant-export-columns.ts
+++ b/scripts/lib/tenant-export-columns.ts
@@ -1,0 +1,249 @@
+/**
+ * The tenant export's COLUMN REGISTRY — the single source of truth for which
+ * columns of which tables a tenant migration bundle carries.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The export builds hand-written `INSERT` statements, so every column it
+ * carries has to be named somewhere. That list is a forced copy of the Drizzle
+ * schema, and a forced copy drifts: a column added in
+ * `packages/db/src/schema/` and not added here is dropped by the export
+ * SILENTLY — the bundle imports cleanly and the data is simply gone. That had
+ * already happened to eighteen columns across six tables by the time this
+ * registry was introduced (users' blind index, the drives' publishing
+ * settings, pages' agent/privacy flags, channel threading, the whole
+ * conversation⇄session binding, and the unified messages' attribution).
+ *
+ * So the registry is paired with a drift guard —
+ * `scripts/__tests__/tenant-export-columns.test.ts` — which derives the
+ * expected column set from the Drizzle table objects at runtime and fails when
+ * the two disagree in EITHER direction. A new schema column therefore cannot
+ * reach `master` without someone deciding, here, whether the tenant gets it.
+ *
+ * THE RULE
+ * --------
+ * For every table in `TABLE_IMPORT_ORDER`, every column of the corresponding
+ * Drizzle table must appear in exactly one of:
+ *
+ *   - `columns`          — carried, emitted in that table's INSERT.
+ *   - `deferredColumns`  — carried, but emitted as a trailing UPDATE because
+ *                          the column FKs FORWARD to a table inserted later.
+ *   - `excluded`         — deliberately NOT carried, with a stated reason.
+ *
+ * `excluded` is an allowlist on purpose: dropping a column from a tenant
+ * migration must be a decision someone wrote down, never an omission nobody
+ * noticed.
+ *
+ * SCOPE NOTE: this registry guards the columns of the tables the export
+ * carries. It says nothing about which TABLES are carried — that set is
+ * `TABLE_IMPORT_ORDER`, and widening it is a separate, deliberate act.
+ */
+import type { ExportTableName } from './migration-types';
+
+export interface TableColumnSpec {
+  /** Columns emitted inline in this table's `INSERT`. */
+  columns: readonly string[];
+  /**
+   * Columns that are carried but CANNOT be emitted in the INSERT because they
+   * reference a table that is inserted later (a forward FK). They are emitted
+   * as a trailing `UPDATE ... WHERE id = ...` once the referenced table has
+   * landed. Keyed off the table's `id`, so only single-PK tables can use this.
+   */
+  deferredColumns?: readonly string[];
+  /**
+   * Columns deliberately left out of the bundle: column name → the reason.
+   * Every entry is a decision; the drift guard requires a non-empty reason.
+   */
+  excluded?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Sprite identity and per-sandbox accounting on `agent_sessions`. All of it
+ * describes a VM in the SOURCE instance's fleet, which the tenant has no
+ * access to and must never believe it owns. Left unset, the migrated session
+ * row reads as "never provisioned" (`sandboxId IS NULL`), so the tenant lazily
+ * provisions its own Sprite on first use — exactly the state a fresh session
+ * is born in — and the orphan reconciler's live-sprite predicate
+ * (`sandboxId IS NOT NULL AND spriteTornDownAt IS NULL`) never selects it.
+ */
+const AGENT_SESSION_SPRITE_EXCLUSIONS: Record<string, string> = {
+  sessionKey: 'Sprite provisioning key in the SOURCE fleet — meaningless to the tenant, which derives its own.',
+  sandboxId: 'Names a Sprite in the SOURCE fleet; carrying it would point the tenant at a VM it does not own.',
+  spriteInstanceId: 'Identity of a SOURCE-fleet Sprite instance — every teardown CAS keys on it, so a stale value is actively dangerous.',
+  egressPolicyToken: 'Proof of an egress lockdown confirmed for a SOURCE-fleet VM; unprovable and unusable in the tenant.',
+  teardownRequestedAt: 'Teardown intent against a SOURCE-fleet Sprite that the tenant will never see.',
+  spriteTornDownAt: 'Records the death of a SOURCE-fleet Sprite; with no `sandboxId` carried there is nothing for it to describe.',
+  storageLastBilledAt: 'Billing watermark for the SOURCE instance. Defaults to now() in the tenant so the first reconcile bills forward, never retroactively.',
+  storageMeasuredBytes: 'Measurement of a SOURCE-fleet filesystem that does not exist in the tenant; NULL correctly means "never measured".',
+  storageMeasuredAt: 'Timestamp of that same SOURCE-fleet measurement.',
+};
+
+export const TENANT_EXPORT_COLUMNS: Readonly<Record<ExportTableName, TableColumnSpec>> = {
+  users: {
+    columns: [
+      'id', 'name', 'email', 'emailBidx', 'emailVerified', 'image',
+      'googleId', 'appleId', 'provider', 'tokenVersion', 'role',
+      'adminRoleVersion', 'currentAiProvider', 'currentAiModel',
+      'imageGenerationModel', 'storageUsedBytes', 'activeUploads',
+      'lastStorageCalculated',
+      'stripeCustomerId', 'subscriptionTier', 'tosAcceptedAt',
+      'failedLoginAttempts', 'lockedUntil', 'suspendedAt', 'suspendedReason',
+      'timezone', 'createdAt', 'updatedAt',
+    ],
+    // NOTE: `suspendedAt`/`suspendedReason` are carried but ZEROED by the
+    // exporter — they may hold the migration's own read-only lock. That is a
+    // value transform, not an exclusion: the columns still travel.
+  },
+
+  user_profiles: {
+    columns: [
+      'userId', 'username', 'displayName', 'bio', 'avatarUrl', 'isPublic',
+      'createdAt', 'updatedAt',
+    ],
+  },
+
+  drives: {
+    columns: [
+      'id', 'name', 'slug', 'ownerId', 'kind', 'isTrashed', 'trashedAt',
+      'createdAt', 'updatedAt', 'drivePrompt', 'publishSubdomain',
+      'publish_default_og_image_url', 'publish_favicon_url',
+    ],
+    /**
+     * Both point at `pages`, which is inserted AFTER `drives` (pages.driveId
+     * points back the other way, so the two tables are mutually referential
+     * and no insert order satisfies both). Emitted as an UPDATE once the
+     * pages have landed.
+     */
+    deferredColumns: ['homePageId', 'not_found_page_id'],
+  },
+
+  drive_roles: {
+    columns: [
+      'id', 'driveId', 'name', 'description', 'color', 'isDefault',
+      'permissions', 'drive_wide_permissions', 'position', 'createdAt', 'updatedAt',
+    ],
+  },
+
+  drive_members: {
+    columns: [
+      'id', 'driveId', 'userId', 'role', 'customRoleId', 'invitedBy',
+      'invitedAt', 'acceptedAt', 'lastAccessedAt',
+    ],
+  },
+
+  pages: {
+    columns: [
+      'id', 'title', 'type', 'content', 'contentMode', 'isPaginated',
+      'position', 'isTrashed', 'aiProvider', 'aiModel', 'systemPrompt',
+      'enabledTools', 'includeDrivePrompt', 'agentDefinition',
+      'visibleToGlobalAssistant', 'includePageTree', 'pageTreeScope',
+      'toolExposureMode', 'sandboxEnabled', 'userScopedAccess', 'description',
+      'fileSize', 'mimeType', 'originalFileName', 'filePath', 'fileMetadata',
+      'processingStatus', 'processingError', 'processedAt', 'extractionMethod',
+      'extractionMetadata', 'contentHash', 'excludeFromSearch', 'isPrivate',
+      'createdBy', 'createdAt', 'updatedAt', 'trashedAt', 'revision', 'stateHash',
+      'driveId', 'parentId', 'originalParentId',
+    ],
+  },
+
+  tags: { columns: ['id', 'name', 'color'] },
+
+  page_tags: { columns: ['pageId', 'tagId'] },
+
+  chat_messages: {
+    columns: [
+      'id', 'pageId', 'conversationId', 'role', 'content', 'toolCalls',
+      'toolResults', 'createdAt', 'isActive', 'editedAt', 'userId',
+      'sourceAgentId', 'messageType', 'status',
+    ],
+  },
+
+  channel_messages: {
+    columns: [
+      'id', 'content', 'createdAt', 'pageId', 'userId', 'fileId',
+      'attachmentMeta', 'isActive', 'editedAt', 'aiMeta',
+      'parentId', 'replyCount', 'lastReplyAt', 'mirroredFromId', 'quotedMessageId',
+    ],
+    // The three self-references (`parentId`, `mirroredFromId`,
+    // `quotedMessageId`) resolve inside the table's own multi-row INSERT —
+    // Postgres queues RI checks as AFTER-ROW triggers that fire once the
+    // statement completes, so order within the VALUES list is irrelevant.
+    // Refs that leave the exported set are nulled by the exporter.
+  },
+
+  channel_message_reactions: {
+    columns: ['id', 'messageId', 'userId', 'emoji', 'createdAt'],
+  },
+
+  channel_read_status: { columns: ['userId', 'channelId', 'lastReadAt'] },
+
+  agent_sessions: {
+    columns: [
+      'id', 'driveId', 'ownerId', 'name', 'workspaceState',
+      'lastActiveAt', 'endedAt', 'createdAt', 'updatedAt',
+    ],
+    excluded: AGENT_SESSION_SPRITE_EXCLUSIONS,
+  },
+
+  conversations: {
+    columns: [
+      'id', 'userId', 'title', 'type', 'contextId', 'sessionId',
+      'closedInSessionAt', 'rev', 'lastMessageAt',
+      'createdAt', 'updatedAt', 'isActive', 'isShared',
+    ],
+  },
+
+  messages: {
+    columns: [
+      'id', 'conversationId', 'userId', 'role', 'messageType', 'content',
+      'toolCalls', 'toolResults', 'createdAt', 'isActive', 'editedAt', 'status',
+      'pageId', 'sourceAgentId',
+    ],
+  },
+
+  files: {
+    columns: [
+      'id', 'driveId', 'sizeBytes', 'mimeType', 'storagePath',
+      'checksumVersion', 'createdAt', 'updatedAt', 'createdBy',
+      'lastAccessedAt',
+    ],
+  },
+
+  file_pages: {
+    columns: ['fileId', 'pageId', 'linkedBy', 'linkedAt', 'linkSource'],
+  },
+
+  page_permissions: {
+    columns: [
+      'id', 'pageId', 'userId', 'canView', 'canEdit', 'canShare',
+      'canDelete', 'grantedBy', 'grantedAt', 'expiresAt', 'note',
+    ],
+  },
+
+  mentions: {
+    columns: ['id', 'createdAt', 'sourcePageId', 'targetPageId'],
+  },
+
+  user_mentions: {
+    columns: ['id', 'createdAt', 'sourcePageId', 'targetUserId', 'mentionedByUserId'],
+  },
+
+  favorites: {
+    columns: ['id', 'userId', 'itemType', 'pageId', 'driveId', 'position', 'createdAt'],
+  },
+};
+
+/** The columns emitted inline in `table`'s INSERT. */
+export function exportColumns(table: ExportTableName): readonly string[] {
+  return TENANT_EXPORT_COLUMNS[table].columns;
+}
+
+/** The columns of `table` emitted as a trailing UPDATE (forward FKs). */
+export function deferredColumns(table: ExportTableName): readonly string[] {
+  return TENANT_EXPORT_COLUMNS[table].deferredColumns ?? [];
+}
+
+/** Every column of `table` the bundle carries, however it is emitted. */
+export function carriedColumns(table: ExportTableName): readonly string[] {
+  return [...exportColumns(table), ...deferredColumns(table)];
+}

--- a/scripts/tenant-export.ts
+++ b/scripts/tenant-export.ts
@@ -28,111 +28,23 @@ import type {
 } from './lib/migration-types';
 import {
   buildInsert,
+  buildDeferredUpdate,
   computeFileChecksum,
   writeManifest,
   toSqlInList,
   validateIds,
 } from './lib/migration-utils';
+import {
+  exportColumns as cols,
+  deferredColumns,
+} from './lib/tenant-export-columns';
 
 // ─── Column definitions per table ──────────────────────────────
-// WARNING: These column lists must stay in sync with the Drizzle schema
-// in packages/db/src/schema/. If a column is added or renamed in the
-// schema, update the corresponding array here. A mismatch will cause
-// data loss (missing column) or an import error (extra column).
-
-const USER_COLUMNS = [
-  'id', 'name', 'email', 'emailVerified', 'image',
-  'googleId', 'appleId', 'provider', 'tokenVersion', 'role',
-  'adminRoleVersion', 'currentAiProvider', 'currentAiModel',
-  'storageUsedBytes', 'lastStorageCalculated',
-  'stripeCustomerId', 'subscriptionTier', 'tosAcceptedAt',
-  'failedLoginAttempts', 'lockedUntil', 'suspendedAt', 'suspendedReason',
-  'timezone', 'createdAt', 'updatedAt',
-];
-
-const USER_PROFILE_COLUMNS = [
-  'userId', 'username', 'displayName', 'bio', 'avatarUrl', 'isPublic',
-  'createdAt', 'updatedAt',
-];
-
-const DRIVE_COLUMNS = [
-  'id', 'name', 'slug', 'ownerId', 'kind', 'isTrashed', 'trashedAt',
-  'createdAt', 'updatedAt', 'drivePrompt',
-];
-
-const DRIVE_ROLE_COLUMNS = [
-  'id', 'driveId', 'name', 'description', 'color', 'isDefault',
-  'permissions', 'drive_wide_permissions', 'position', 'createdAt', 'updatedAt',
-];
-
-const DRIVE_MEMBER_COLUMNS = [
-  'id', 'driveId', 'userId', 'role', 'customRoleId', 'invitedBy',
-  'invitedAt', 'acceptedAt', 'lastAccessedAt',
-];
-
-const PAGE_COLUMNS = [
-  'id', 'title', 'type', 'content', 'contentMode', 'isPaginated',
-  'position', 'isTrashed', 'aiProvider', 'aiModel', 'systemPrompt',
-  'enabledTools', 'includeDrivePrompt', 'agentDefinition',
-  'visibleToGlobalAssistant', 'includePageTree', 'pageTreeScope',
-  'fileSize', 'mimeType', 'originalFileName', 'filePath', 'fileMetadata',
-  'processingStatus', 'processingError', 'processedAt', 'extractionMethod',
-  'extractionMetadata', 'contentHash', 'excludeFromSearch',
-  'createdAt', 'updatedAt', 'trashedAt', 'revision', 'stateHash',
-  'driveId', 'parentId', 'originalParentId',
-];
-
-const CHAT_MESSAGE_COLUMNS = [
-  'id', 'pageId', 'conversationId', 'role', 'content', 'toolCalls',
-  'toolResults', 'createdAt', 'isActive', 'editedAt', 'userId',
-  'sourceAgentId', 'messageType', 'status',
-];
-
-const CHANNEL_MESSAGE_COLUMNS = [
-  'id', 'content', 'createdAt', 'pageId', 'userId', 'fileId',
-  'attachmentMeta', 'isActive', 'aiMeta',
-];
-
-const CHANNEL_REACTION_COLUMNS = [
-  'id', 'messageId', 'userId', 'emoji', 'createdAt',
-];
-
-const CHANNEL_READ_STATUS_COLUMNS = ['userId', 'channelId', 'lastReadAt'];
-
-const CONVERSATION_COLUMNS = [
-  'id', 'userId', 'title', 'type', 'contextId', 'lastMessageAt',
-  'createdAt', 'updatedAt', 'isActive',
-];
-
-const MESSAGE_COLUMNS = [
-  'id', 'conversationId', 'userId', 'role', 'messageType', 'content',
-  'toolCalls', 'toolResults', 'createdAt', 'isActive', 'editedAt', 'status',
-];
-
-const FILE_COLUMNS = [
-  'id', 'driveId', 'sizeBytes', 'mimeType', 'storagePath',
-  'checksumVersion', 'createdAt', 'updatedAt', 'createdBy',
-  'lastAccessedAt',
-];
-
-const FILE_PAGE_COLUMNS = ['fileId', 'pageId', 'linkedBy', 'linkedAt', 'linkSource'];
-
-const PAGE_PERMISSION_COLUMNS = [
-  'id', 'pageId', 'userId', 'canView', 'canEdit', 'canShare',
-  'canDelete', 'grantedBy', 'grantedAt', 'expiresAt', 'note',
-];
-
-const TAG_COLUMNS = ['id', 'name', 'color'];
-const PAGE_TAG_COLUMNS = ['pageId', 'tagId'];
-
-const MENTION_COLUMNS = ['id', 'createdAt', 'sourcePageId', 'targetPageId'];
-const USER_MENTION_COLUMNS = [
-  'id', 'createdAt', 'sourcePageId', 'targetUserId', 'mentionedByUserId',
-];
-
-const FAVORITE_COLUMNS = [
-  'id', 'userId', 'itemType', 'pageId', 'driveId', 'position', 'createdAt',
-];
+// The per-table column lists live in ./lib/tenant-export-columns.ts, and are
+// checked against the live Drizzle schema by the drift guard in
+// scripts/__tests__/tenant-export-columns.test.ts. Add a column to the schema
+// without deciding there — carried or explicitly excluded — and that test goes
+// red. Do NOT re-introduce hand-maintained lists in this file.
 
 // ─── Query helpers ──────────────────────────────
 
@@ -159,38 +71,30 @@ export async function discoverDrives(
 }
 
 /**
- * Null out FK references to users not in the export set.
+ * Null out nullable FK references that point outside the export set.
+ * A ref that survives into the bundle but names a row the bundle does not
+ * carry aborts the whole import on its FK, so every carried FK column has to
+ * be either filtered, nulled here, or provably in-set.
  */
-function nullifyOrphanedUserRefs(
+function nullifyOrphanedRefs(
   rows: Record<string, unknown>[],
-  userIdSet: Set<string>,
+  idSet: Set<string>,
   ...columns: string[]
 ): void {
   for (const row of rows) {
     for (const col of columns) {
-      if (row[col] && !userIdSet.has(row[col] as string)) {
+      if (row[col] && !idSet.has(row[col] as string)) {
         row[col] = null;
       }
     }
   }
 }
 
-/**
- * Null out FK references to pages not in the export set.
- */
-function nullifyOrphanedPageRefs(
-  rows: Record<string, unknown>[],
-  pageIdSet: Set<string>,
-  ...columns: string[]
-): void {
-  for (const row of rows) {
-    for (const col of columns) {
-      if (row[col] && !pageIdSet.has(row[col] as string)) {
-        row[col] = null;
-      }
-    }
-  }
-}
+/** Null out FK references to users not in the export set. */
+const nullifyOrphanedUserRefs = nullifyOrphanedRefs;
+
+/** Null out FK references to pages not in the export set. */
+const nullifyOrphanedPageRefs = nullifyOrphanedRefs;
 
 export interface ExportResult {
   manifest: ExportManifest;
@@ -258,6 +162,12 @@ export async function exportData(
 
   // Null out parentId / originalParentId if they point outside exported pages
   nullifyOrphanedPageRefs(pagesData, pageIdSet, 'parentId', 'originalParentId');
+
+  // `drives.homePageId` / `drives.not_found_page_id` point FORWARD at pages,
+  // which is why they ride a trailing UPDATE rather than the drives INSERT
+  // (see `deferredColumns` in ./lib/tenant-export-columns.ts). Same orphan
+  // rule as any other page ref.
+  nullifyOrphanedPageRefs(drivesData, pageIdSet, 'homePageId', 'not_found_page_id');
 
   const chatMessagesData = await queryRows(db, sql.raw(
     `SELECT * FROM chat_messages WHERE "pageId" IN (${pageIn})`,
@@ -329,7 +239,27 @@ export async function exportData(
   const allExportedUserIdSet = new Set(usersData.map((u) => u.id as string));
   const allUserIn = toSqlInList(allExportedUserIdSet);
 
+  // `pages.createdBy` (ON DELETE SET NULL) — the author may be a drive member
+  // who is not part of this migration.
+  nullifyOrphanedUserRefs(pagesData, allExportedUserIdSet, 'createdBy');
+
   const channelMessageIds = channelMessagesData.map((r) => r.id as string);
+  const channelMessageIdSet = new Set(channelMessageIds);
+  /**
+   * The three channel-message self-references. `parentId` and `mirroredFromId`
+   * stay inside one channel by construction, but a QUOTE can name a message in
+   * a channel this migration does not carry, so all three are checked. Refs
+   * that DO resolve need no ordering care: Postgres queues RI checks as
+   * AFTER-ROW triggers fired once the statement finishes, so a self-reference
+   * inside a single multi-row INSERT resolves regardless of row order.
+   */
+  nullifyOrphanedRefs(
+    channelMessagesData,
+    channelMessageIdSet,
+    'parentId',
+    'mirroredFromId',
+    'quotedMessageId',
+  );
   // Filter reactions to only include those from exported users (userId is NOT NULL)
   const channelReactionsDataRaw = channelMessageIds.length > 0
     ? await queryRows(db, sql.raw(
@@ -344,6 +274,41 @@ export async function exportData(
     `SELECT * FROM channel_read_status WHERE "userId" IN (${userIn}) AND "channelId" IN (${pageIn})`,
   ));
 
+  /**
+   * Agent sessions — the working contexts the exported conversations are bound
+   * to (`conversations.sessionId`).
+   *
+   * Carried because the binding is otherwise unrecoverable: a session owns a
+   * thread's filesystem and its pane layout, and `sessionId` is write-once by
+   * design (moving a thread is a fork, never a rebind), so a migration that
+   * drops it cannot be repaired afterwards. Only the sessions an exported
+   * conversation actually names are pulled — a session is never empty, so
+   * this is the whole set that matters — and only those whose `ownerId`
+   * (NOT NULL, FK'd) is already in the export. The Sprite-identity columns do
+   * NOT travel; see the exclusion allowlist in ./lib/tenant-export-columns.ts.
+   */
+  const referencedSessionIds = new Set(
+    conversationsData
+      .map((r) => r.sessionId as string | null)
+      .filter((id): id is string => Boolean(id)),
+  );
+  const agentSessionsDataRaw = referencedSessionIds.size > 0
+    ? await queryRows(db, sql.raw(
+        `SELECT * FROM agent_sessions WHERE id IN (${toSqlInList(referencedSessionIds)})`,
+      ))
+    : [];
+  const agentSessionsData = agentSessionsDataRaw.filter(
+    (s) => allExportedUserIdSet.has(s.ownerId as string),
+  );
+  // A global-assistant session has no drive; a drive-scoped one whose drive is
+  // outside this migration degrades to the same shape rather than dangling.
+  nullifyOrphanedRefs(agentSessionsData, new Set(driveIds), 'driveId');
+
+  // Threads bound to a session that did not make the cut become plain history
+  // — exactly what `ON DELETE SET NULL` on this column already means.
+  const exportedSessionIdSet = new Set(agentSessionsData.map((s) => s.id as string));
+  nullifyOrphanedRefs(conversationsData, exportedSessionIdSet, 'sessionId');
+
   // Messages from exported users, plus the agent/system-authored rows.
   // `messages.userId` was relaxed to NULLABLE in 0248 (the attribution rule:
   // NULL userId = agent- or system-authored), so an `IN (…)` filter alone now
@@ -354,6 +319,12 @@ export async function exportData(
         `SELECT * FROM messages WHERE "conversationId" IN (${toSqlInList(conversationIds)}) AND ("userId" IS NULL OR "userId" IN (${allUserIn}))`,
       ))
     : [];
+  // `messages.sourceAgentId` FKs `pages` (ON DELETE SET NULL). `messages.pageId`
+  // deliberately has NO FK — it is transitional, dropped at the unification's
+  // contract PR — but a value naming a page the bundle does not carry would be
+  // a phantom reference in the tenant, and the authoritative page link is
+  // `conversations.contextId` anyway, so it gets the same treatment.
+  nullifyOrphanedPageRefs(messagesData, pageIdSet, 'sourceAgentId', 'pageId');
 
   const filesData = await queryRows(db, sql.raw(
     `SELECT * FROM files WHERE "driveId" IN (${driveIn})`,
@@ -408,31 +379,38 @@ export async function exportData(
     '',
     'BEGIN;',
     '',
-    buildInsert('users', USER_COLUMNS, usersData),
-    buildInsert('user_profiles', USER_PROFILE_COLUMNS, userProfilesData),
-    buildInsert('drives', DRIVE_COLUMNS, drivesData),
-    buildInsert('drive_roles', DRIVE_ROLE_COLUMNS, driveRolesData),
-    buildInsert('drive_members', DRIVE_MEMBER_COLUMNS, driveMembersData),
-    buildInsert('pages', PAGE_COLUMNS, pagesData),
-    buildInsert('tags', TAG_COLUMNS, tagsData),
-    buildInsert('page_tags', PAGE_TAG_COLUMNS, pageTagsData),
+    buildInsert('users', cols('users'), usersData),
+    buildInsert('user_profiles', cols('user_profiles'), userProfilesData),
+    buildInsert('drives', cols('drives'), drivesData),
+    buildInsert('drive_roles', cols('drive_roles'), driveRolesData),
+    buildInsert('drive_members', cols('drive_members'), driveMembersData),
+    buildInsert('pages', cols('pages'), pagesData),
+    // `drives` and `pages` reference each other, so neither insert can carry
+    // its forward FK. The drive's page pointers (`homePageId`,
+    // `not_found_page_id`) are set here, once the pages exist.
+    buildDeferredUpdate('drives', deferredColumns('drives'), drivesData),
+    buildInsert('tags', cols('tags'), tagsData),
+    buildInsert('page_tags', cols('page_tags'), pageTagsData),
+    // `agent_sessions` precedes `conversations`: `conversations.sessionId`
+    // FKs it, and a session row also needs its drive and owner, both above.
+    buildInsert('agent_sessions', cols('agent_sessions'), agentSessionsData),
     // `conversations` MUST precede `chat_messages`: since migration 0248 the
     // latter has a real (non-deferrable) FK onto the former, and the whole
     // bundle replays inside one BEGIN/COMMIT, so an out-of-order INSERT aborts
     // the entire import. It also precedes `messages`, which has always had
     // that FK. Insert order in this list is FK order, not table-name order.
-    buildInsert('conversations', CONVERSATION_COLUMNS, conversationsData),
-    buildInsert('chat_messages', CHAT_MESSAGE_COLUMNS, chatMessagesData),
-    buildInsert('messages', MESSAGE_COLUMNS, messagesData),
-    buildInsert('channel_messages', CHANNEL_MESSAGE_COLUMNS, channelMessagesData),
-    buildInsert('channel_message_reactions', CHANNEL_REACTION_COLUMNS, channelReactionsData),
-    buildInsert('channel_read_status', CHANNEL_READ_STATUS_COLUMNS, channelReadStatusData),
-    buildInsert('files', FILE_COLUMNS, filesData),
-    buildInsert('file_pages', FILE_PAGE_COLUMNS, filePagesData),
-    buildInsert('page_permissions', PAGE_PERMISSION_COLUMNS, pagePermissionsData),
-    buildInsert('mentions', MENTION_COLUMNS, mentionsData),
-    buildInsert('user_mentions', USER_MENTION_COLUMNS, userMentionsData),
-    buildInsert('favorites', FAVORITE_COLUMNS, favoritesData),
+    buildInsert('conversations', cols('conversations'), conversationsData),
+    buildInsert('chat_messages', cols('chat_messages'), chatMessagesData),
+    buildInsert('messages', cols('messages'), messagesData),
+    buildInsert('channel_messages', cols('channel_messages'), channelMessagesData),
+    buildInsert('channel_message_reactions', cols('channel_message_reactions'), channelReactionsData),
+    buildInsert('channel_read_status', cols('channel_read_status'), channelReadStatusData),
+    buildInsert('files', cols('files'), filesData),
+    buildInsert('file_pages', cols('file_pages'), filePagesData),
+    buildInsert('page_permissions', cols('page_permissions'), pagePermissionsData),
+    buildInsert('mentions', cols('mentions'), mentionsData),
+    buildInsert('user_mentions', cols('user_mentions'), userMentionsData),
+    buildInsert('favorites', cols('favorites'), favoritesData),
     '',
     'COMMIT;',
     '',
@@ -452,6 +430,7 @@ export async function exportData(
     channelMessages: channelMessagesData.length,
     channelMessageReactions: channelReactionsData.length,
     channelReadStatus: channelReadStatusData.length,
+    agentSessions: agentSessionsData.length,
     conversations: conversationsData.length,
     messages: messagesData.length,
     files: filesData.length,

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -160,6 +160,9 @@ export async function validateData(
     chat_messages: sql.raw(`SELECT id FROM chat_messages WHERE "pageId" IN (${pageIn})`),
     channel_messages: sql.raw(`SELECT id FROM channel_messages WHERE "pageId" IN (${pageIn})`),
     channel_message_reactions: sql.raw(`SELECT id FROM channel_message_reactions WHERE "messageId" IN (${channelMsgIn})`),
+    // Mirrors the export's rule: the sessions the migrated conversations are
+    // bound to, owned by a migrated user.
+    agent_sessions: sql.raw(`SELECT id FROM agent_sessions WHERE "ownerId" IN (${userIn}) AND id IN (SELECT "sessionId" FROM conversations WHERE "userId" IN (${userIn}) AND "sessionId" IS NOT NULL)`),
     conversations: sql.raw(`SELECT id FROM conversations WHERE "userId" IN (${userIn})`),
     messages: sql.raw(`SELECT id FROM messages WHERE "conversationId" IN (${convoIn})`),
     files: sql.raw(`SELECT id FROM files WHERE "driveId" IN (${driveIn})`),


### PR DESCRIPTION
Stacks on #2344 (`feat/messages-unification-expand`), which owns the tenant-export FK fixes this belongs with.

`scripts/tenant-export.ts` built its INSERTs from hand-maintained per-table column lists. Those lists are a forced copy of the Drizzle schema, and they had drifted: **18 columns across 6 tables** existed in `packages/db/src/schema/` and were dropped by every tenant migration. The failure mode is the worst kind — the bundle imports cleanly, and the data is just gone.

## Columns restored

| Table | Columns | What was being lost |
|---|---|---|
| `users` | `emailBidx`, `imageGenerationModel`, `activeUploads` | **`emailBidx` is the lookup key for an encrypted email** (`users_email_bidx_idx`). Every migrated account was unfindable by email — i.e. unable to log in. |
| `drives` | `publishSubdomain`, `homePageId`, `not_found_page_id`, `publish_default_og_image_url`, `publish_favicon_url` | The drive's entire published-site configuration: address, landing page, 404 page, default OG image, favicon. |
| `pages` | `toolExposureMode`, `sandboxEnabled`, `userScopedAccess`, `description`, `isPrivate`, `createdBy` | Agent tool/sandbox settings, page privacy, authorship. |
| `channel_messages` | `editedAt`, `parentId`, `replyCount`, `lastReplyAt`, `mirroredFromId`, `quotedMessageId` | All channel threading — every reply flattened to a top-level message, every quote dropped. |
| `conversations` | `sessionId`, `closedInSessionAt`, `rev`, `isShared` | *(as reported)* the workspace binding, closed-listing state, event revision, shared flag. |
| `messages` | `pageId`, `sourceAgentId` | *(as reported)* the unified messages' page and agent attribution. |

Two were **not** simple list additions:

- **`drives.homePageId` / `drives.not_found_page_id` FK forward to `pages`**, while `pages.driveId` points back — mutually referential, so no insert order satisfies both. They ride a new trailing `UPDATE drives SET … WHERE id = …` (`buildDeferredUpdate`) emitted once the pages have landed, and are declared `deferredColumns` in the registry so the guard still counts them as carried.
- **`conversations.sessionId` FKs `agent_sessions`, which the export did not carry at all.** Carrying the column verbatim would have aborted the import on the FK. `agent_sessions` is now exported (new `TABLE_IMPORT_ORDER` entry, placed before `conversations`), restricted to the sessions an exported conversation names and whose `ownerId` is already in the export set. The binding is write-once by design — moving a thread is a fork, never a rebind — so a migration that drops it cannot be repaired afterwards, which is why the table was worth adding rather than nulling the column.

## Other drift found

- `pages.createdBy`, `agent_sessions.driveId`, and the three `channel_messages` self-references are nullable FKs that can point outside the export set; each now gets the existing orphan-nulling treatment. The self-references need no ordering care — Postgres queues RI checks as AFTER-ROW triggers fired once the statement completes, so a self-reference inside one multi-row INSERT resolves regardless of row order.
- `tenant-validate.ts` gained an `agent_sessions` query mirroring the export's selection rule (its "validates all N exported tables" assertion is driven off `TABLE_IMPORT_ORDER`).
- The `messages.userId` NULL-attribution filter was **already fixed on this branch** by ddce0b6 — no change needed.

## The guard

`scripts/lib/tenant-export-columns.ts` is now the single registry; `tenant-export.ts` holds no column lists. `scripts/__tests__/tenant-export-columns.test.ts` derives the expected set from the **Drizzle table objects at runtime** (`getTableColumns` over every `pgTable` exported by `@pagespace/db/schema`) and fails in both directions:

1. every schema column is carried or explicitly excluded — catches an **added** column nobody decided about (the actual historical failure);
2. every registered name still exists in the schema — catches a **renamed/dropped** column left in the list, which would make the INSERT fail against the tenant;
3. carried ∩ excluded = ∅, no duplicates, a deferred column never also rides the INSERT;
4. the registry covers exactly `TABLE_IMPORT_ORDER`;
5. every exclusion states a reason.

No database required — the table objects describe themselves.

### The exclusion allowlist

Nine columns are deliberately not carried, all on `agent_sessions`, all for the same reason: **they describe a VM in the SOURCE instance's Sprite fleet**, which the tenant has no access to and must never believe it owns.

`sessionKey`, `sandboxId`, `spriteInstanceId`, `egressPolicyToken`, `teardownRequestedAt`, `spriteTornDownAt`, `storageLastBilledAt`, `storageMeasuredBytes`, `storageMeasuredAt`

Left unset, a migrated session reads as "never provisioned" (`sandboxId IS NULL`) — exactly the state a fresh session is born in — so the tenant lazily provisions its own Sprite on first use, and the orphan reconciler's live-sprite predicate (`sandboxId IS NOT NULL AND spriteTornDownAt IS NULL`) never selects it. `storageLastBilledAt` defaults to `now()` in the tenant, so the first reconcile bills forward rather than retroactively.

`users.suspendedAt`/`suspendedReason` are **not** exclusions: they are carried and zeroed by the exporter (they may hold the migration's own read-only lock). A value transform, not an omission — the columns still travel.

**Scope, stated honestly:** the guard pins the *columns* of the tables the export carries. Which *tables* are carried is `TABLE_IMPORT_ORDER`, a separate and deliberate decision; the guard only pins the two lists to each other so a table cannot be added to one and forgotten in the other.

## Import side

No structural change needed — `tenant-import.ts` replays the bundle's SQL verbatim, so it inherits the new columns and the trailing `UPDATE`. `rev` imports as-is (a `bigint` the pg driver returns as a string, which Postgres accepts as an unknown-typed literal). `buildDeferredUpdate` re-applies identical values on a re-import, so it is as idempotent as the `ON CONFLICT DO NOTHING` inserts around it.

## Evidence

Round-trip against a scratch Postgres (16-alpine, port 5451, migrated with `bun run --filter '@pagespace/db' db:migrate`, container removed after). Fixtures seed every restored column **away from its default**, so a passing assertion proves the value travelled rather than that the tenant's default agreed. Six new round-trip tests in `tenant-import.test.ts` assert the session binding + `rev`/`closedInSessionAt`/`isShared`, the carried `agent_sessions` row *with its Sprite columns NULL*, `emailBidx`, the deferred `homePageId`, the page settings, and the NULL-user/`sourceAgentId` message attribution.

**Both guards verified red.** Removing `sessionId` from the registry and adding a phantom column made the drift guard fail with the exact column names in both directions. Separately, moving `rev` from carried to excluded slipped past the drift guard (an explicit exclusion *is* a decision) and was caught by the round-trip test — `expected +0 to be 7`, i.e. the column came back as its default. The two layers cover each other.

Gates, all local (GitHub Actions is in a major outage): scripts suite **228 passed / 13 files**, drift guard **67 passed**, `lint`, `lint:scripts`, `typecheck`, `knip:check` (4 issues, within baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
