### PR TITLE
feat(compliance): export from the unified table, keep erasure and retention on both legs

### DIFF
--- a/apps/processor/src/workers/__tests__/account-erasure-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/account-erasure-worker.test.ts
@@ -76,6 +76,10 @@ vi.mock('@pagespace/lib/compliance/erasure/resend-suppression-client', () => ({
   createResendSuppressionClient: vi.fn().mockReturnValue({}),
 }));
 
+vi.mock('@pagespace/lib/compliance/erasure/purge-stream-state', () => ({
+  deleteStreamStateForUser: vi.fn().mockResolvedValue({ streamSessions: 0, abortIntents: 0 }),
+}));
+
 vi.mock('@pagespace/lib/compliance/erasure/ai-provider-erasure', () => ({
   eraseAiProviderData: vi.fn().mockResolvedValue({ evidence: [], forwarded: 0 }),
 }));

--- a/apps/processor/src/workers/account-erasure-worker.ts
+++ b/apps/processor/src/workers/account-erasure-worker.ts
@@ -30,6 +30,7 @@ import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/r
 import { syncEmailSuppression } from '@pagespace/lib/compliance/erasure/email-suppression';
 import { createResendSuppressionClient } from '@pagespace/lib/compliance/erasure/resend-suppression-client';
 import { eraseAiProviderData } from '@pagespace/lib/compliance/erasure/ai-provider-erasure';
+import { deleteStreamStateForUser } from '@pagespace/lib/compliance/erasure/purge-stream-state';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import { logActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { isClickHouseAnalyticsInPlay } from '@pagespace/lib/observability/clickhouse-client';
@@ -166,6 +167,13 @@ export async function runAccountErasureJob(data: AccountErasureJobData): Promise
       return ok(
         `providers=${result.evidence.length} forwarded=${result.forwarded} ` +
           `manualReview=${result.evidence.filter((e) => e.action === 'manual_review').length}`
+      );
+    },
+
+    'purge-stream-state': async () => {
+      const result = await deleteStreamStateForUser(userId);
+      return ok(
+        `streamSessions=${result.streamSessions} abortIntents=${result.abortIntents}`
       );
     },
 

--- a/apps/web/src/lib/repositories/__tests__/unified-compliance-legs.integration.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/unified-compliance-legs.integration.test.ts
@@ -1,0 +1,493 @@
+/**
+ * COMPLIANCE OVER A DUAL-WRITTEN CORPUS, against a REAL Postgres.
+ *
+ * Epic "Agent-Session Single Source of Truth", Phase 4 / D6, PR 13. The pure
+ * table-level contract lives in
+ * `packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts`;
+ * this suite proves the same three rules end to end, over a corpus written by
+ * the PRODUCTION dual-writer (`messageRepository`), because the claims are
+ * about what the data actually looks like once both legs exist:
+ *
+ *   RULE 1 — the GDPR export reads the UNIFIED table only, and that is
+ *            COMPLETE: every message appears EXACTLY ONCE (no duplicate from
+ *            double-reading, no omission).
+ *   RULE 2 — erasure and retention still reach BOTH legs, including rows the
+ *            FK graph only started reaching at 0248/0249.
+ *   RULE 3 — the new cascades (conversations → chat_messages,
+ *            conversations → ai_stream_sessions) delete what they claim to.
+ *
+ * It also pins the NULL-`userId` class of bug directly: `messages.userId` is
+ * the HUMAN author and is NULL for every agent-authored row, so any
+ * compliance query keyed on it alone silently skips the agent side of the
+ * subject's own conversations.
+ *
+ * Requires DATABASE_URL → a Postgres with migrations applied. Skipped when no
+ * DB is reachable, mirroring `unified-reader-parity.integration.test.ts`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { and, eq, inArray } from '@pagespace/db/operators';
+import { pages, chatMessages } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { conversations, messages } from '@pagespace/db/schema/conversations';
+import { aiStreamSessions, aiPendingAbortIntents } from '@pagespace/db/schema/ai-streams';
+import { factories } from '@pagespace/db/test/factories';
+import { collectUserMessages } from '@pagespace/lib/compliance/export/gdpr-export';
+import { cleanupSoftDeletedChatRecords } from '@pagespace/lib/compliance/retention/retention-engine';
+import { deleteStreamStateForUser } from '@pagespace/lib/compliance/erasure/purge-stream-state';
+import { messageRepository } from '@/lib/repositories/message-repository';
+
+let dbAvailable = false;
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+/** Minimal stream row — the shape whose `parts` checkpoint is message content. */
+async function seedStreamSession(args: {
+  conversationId: string;
+  userId: string;
+  messageId?: string;
+}): Promise<string> {
+  const messageId = args.messageId ?? createId();
+  await db.insert(aiStreamSessions).values({
+    messageId,
+    channelId: `chan-${args.conversationId}`,
+    conversationId: args.conversationId,
+    userId: args.userId,
+    parts: [{ type: 'text', text: 'checkpointed content' }],
+  });
+  return messageId;
+}
+
+describe('compliance over a dual-written message corpus (Phase 4 PR 13)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  // ==========================================================================
+  // RULE 1 — export the unified leg only, exactly once, and completely.
+  // ==========================================================================
+  describe('RULE 1 — GDPR export reads the unified table only', () => {
+    interface ExportCorpus {
+      ownerId: string;
+      bystanderId: string;
+      agentPageId: string;
+      pageConversationId: string;
+      globalConversationId: string;
+      ownerQuestionId: string;
+      agentReplyId: string;
+      bystanderMessageId: string;
+      globalQuestionId: string;
+      globalReplyId: string;
+    }
+    let corpus: ExportCorpus;
+
+    beforeAll(async () => {
+      if (!dbAvailable) return;
+
+      const owner = await factories.createUser();
+      const bystander = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent' });
+
+      const pageConversationId = createId();
+      const globalConversationId = createId();
+      await db.insert(conversations).values([
+        // SHARED: a page conversation the owner owns but any member with page
+        // access may also post into — the shape that makes "export everything
+        // in the subject's conversations" wrong.
+        { id: pageConversationId, userId: owner.id, type: 'page', contextId: agentPage.id, title: 'Thread', isShared: true, updatedAt: new Date() },
+        { id: globalConversationId, userId: owner.id, type: 'global', contextId: null, title: 'Global', updatedAt: new Date() },
+      ]);
+
+      const ownerQuestionId = createId();
+      const agentReplyId = createId();
+      const bystanderMessageId = createId();
+      const globalQuestionId = createId();
+      const globalReplyId = createId();
+
+      // THE DUAL-WRITE PATH — the production writer, both legs, one transaction.
+      await messageRepository.savePageMessage({
+        messageId: ownerQuestionId,
+        pageId: agentPage.id,
+        conversationId: pageConversationId,
+        userId: owner.id,
+        role: 'user',
+        content: 'owner question',
+      });
+      // Agent-authored: userId NULL, sourceAgentId set. The row the export
+      // used to drop on the floor.
+      await messageRepository.savePageMessage({
+        messageId: agentReplyId,
+        pageId: agentPage.id,
+        conversationId: pageConversationId,
+        userId: null,
+        role: 'assistant',
+        content: 'agent reply',
+        sourceAgentId: agentPage.id,
+      });
+      // Another HUMAN inside the subject's shared conversation.
+      await messageRepository.savePageMessage({
+        messageId: bystanderMessageId,
+        pageId: agentPage.id,
+        conversationId: pageConversationId,
+        userId: bystander.id,
+        role: 'user',
+        content: 'bystander question',
+      });
+
+      // Global history — one leg, always has been.
+      await messageRepository.saveGlobalMessage({
+        messageId: globalQuestionId,
+        conversationId: globalConversationId,
+        userId: owner.id,
+        role: 'user',
+        content: 'global question',
+      });
+      await messageRepository.saveGlobalMessage({
+        messageId: globalReplyId,
+        conversationId: globalConversationId,
+        userId: owner.id,
+        role: 'assistant',
+        content: 'global reply',
+      });
+
+      corpus = {
+        ownerId: owner.id,
+        bystanderId: bystander.id,
+        agentPageId: agentPage.id,
+        pageConversationId,
+        globalConversationId,
+        ownerQuestionId,
+        agentReplyId,
+        bystanderMessageId,
+        globalQuestionId,
+        globalReplyId,
+      };
+    });
+
+    it('the dual-writer really did populate BOTH legs — without this the rest of the suite proves nothing', async () => {
+      if (!dbAvailable) return;
+
+      const legacy = await db
+        .select({ id: chatMessages.id })
+        .from(chatMessages)
+        .where(eq(chatMessages.conversationId, corpus.pageConversationId));
+      const unified = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(eq(messages.conversationId, corpus.pageConversationId));
+
+      expect(legacy.map((r) => r.id).sort()).toEqual(unified.map((r) => r.id).sort());
+      expect(unified).toHaveLength(3);
+    });
+
+    it('exports every message EXACTLY ONCE — reading both legs would duplicate each page-chat row under its shared primary key', async () => {
+      if (!dbAvailable) return;
+
+      const exported = await collectUserMessages(db, corpus.ownerId);
+      const ids = exported.map((m) => m.id);
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('is COMPLETE for the subject: their own page question, the AGENT reply in their thread, and both global rows', async () => {
+      if (!dbAvailable) return;
+
+      const ids = (await collectUserMessages(db, corpus.ownerId)).map((m) => m.id);
+
+      expect(ids).toContain(corpus.ownerQuestionId);
+      expect(ids).toContain(corpus.globalQuestionId);
+      expect(ids).toContain(corpus.globalReplyId);
+      // THE GAP THIS PR CLOSES. `messages.userId` is NULL for an agent-authored
+      // row, so filtering on it alone exported the subject's questions and
+      // dropped every answer inside their own page chats — while the SAME
+      // answer in a global thread was exported, because the global writer
+      // stamps the owner's id on assistant rows.
+      expect(ids).toContain(corpus.agentReplyId);
+    });
+
+    it('does NOT export another human\'s message from the subject\'s shared conversation (Art 15(4) — the subject\'s access must not affect others\' rights)', async () => {
+      if (!dbAvailable) return;
+
+      const ids = (await collectUserMessages(db, corpus.ownerId)).map((m) => m.id);
+      expect(ids).not.toContain(corpus.bystanderMessageId);
+    });
+
+    it('exports the bystander\'s OWN message from that conversation, and none of its agent rows — authorship, not thread membership, is the key', async () => {
+      if (!dbAvailable) return;
+
+      const ids = (await collectUserMessages(db, corpus.bystanderId)).map((m) => m.id);
+      expect(ids).toContain(corpus.bystanderMessageId);
+      expect(ids).not.toContain(corpus.agentReplyId);
+      expect(ids).not.toContain(corpus.ownerQuestionId);
+    });
+
+    it('labels the page rows ai_chat with the pageId taken from conversations.contextId, and the global rows conversation', async () => {
+      if (!dbAvailable) return;
+
+      const exported = await collectUserMessages(db, corpus.ownerId);
+      const pageRow = exported.find((m) => m.id === corpus.agentReplyId);
+      const globalRow = exported.find((m) => m.id === corpus.globalReplyId);
+
+      expect(pageRow).toEqual(
+        expect.objectContaining({ source: 'ai_chat', pageId: corpus.agentPageId })
+      );
+      expect(globalRow?.source).toBe('conversation');
+      expect(globalRow?.pageId).toBeUndefined();
+    });
+
+    it('covers every legacy-leg row the subject authored — the unified leg is a SUPERSET, which is the premise of reading it alone', async () => {
+      if (!dbAvailable) return;
+
+      const legacyOwn = await db
+        .select({ id: chatMessages.id })
+        .from(chatMessages)
+        .where(
+          and(
+            eq(chatMessages.conversationId, corpus.pageConversationId),
+            eq(chatMessages.userId, corpus.ownerId)
+          )
+        );
+      const exportedIds = new Set((await collectUserMessages(db, corpus.ownerId)).map((m) => m.id));
+
+      expect(legacyOwn.length).toBeGreaterThan(0);
+      for (const row of legacyOwn) expect(exportedIds.has(row.id)).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // RULE 2 — erasure reaches BOTH legs, plus the stream state no FK reached.
+  // ==========================================================================
+  describe('RULE 2 — erasure reaches both message legs and the subject\'s stream state', () => {
+    it('deleting the user removes their rows from BOTH message tables — including the agent-authored (userId NULL) row, which only the 0248 conversations FK reaches', async () => {
+      if (!dbAvailable) return;
+
+      const subject = await factories.createUser();
+      const drive = await factories.createDrive(subject.id);
+      const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent' });
+      const conversationId = createId();
+      await db.insert(conversations).values({
+        id: conversationId, userId: subject.id, type: 'page', contextId: agentPage.id, updatedAt: new Date(),
+      });
+
+      const questionId = createId();
+      const agentReplyId = createId();
+      await messageRepository.savePageMessage({
+        messageId: questionId, pageId: agentPage.id, conversationId,
+        userId: subject.id, role: 'user', content: 'question',
+      });
+      await messageRepository.savePageMessage({
+        messageId: agentReplyId, pageId: agentPage.id, conversationId,
+        userId: null, role: 'assistant', content: 'reply', sourceAgentId: agentPage.id,
+      });
+
+      await db.delete(users).where(eq(users.id, subject.id));
+
+      const legacyLeft = await db
+        .select({ id: chatMessages.id })
+        .from(chatMessages)
+        .where(inArray(chatMessages.id, [questionId, agentReplyId]));
+      const unifiedLeft = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(inArray(messages.id, [questionId, agentReplyId]));
+
+      // The user-authored row goes via `userId → users` on BOTH legs; the
+      // agent-authored one has no userId at all and is reached only through
+      // `conversations` — on the unified leg by its long-standing FK, on the
+      // legacy leg by the FK migration 0248 added. Erasure must keep naming
+      // both tables until PR 15 drops chat_messages.
+      expect(legacyLeft).toEqual([]);
+      expect(unifiedLeft).toEqual([]);
+    });
+
+    it('deleting the user takes the stream checkpoints in their own conversation with it (0249 cascade)', async () => {
+      if (!dbAvailable) return;
+
+      const subject = await factories.createUser();
+      const conversationId = createId();
+      await db.insert(conversations).values({
+        id: conversationId, userId: subject.id, type: 'global', contextId: null, updatedAt: new Date(),
+      });
+      const streamMessageId = await seedStreamSession({ conversationId, userId: subject.id });
+
+      await db.delete(users).where(eq(users.id, subject.id));
+
+      const left = await db
+        .select({ messageId: aiStreamSessions.messageId })
+        .from(aiStreamSessions)
+        .where(eq(aiStreamSessions.messageId, streamMessageId));
+      expect(left).toEqual([]);
+    });
+
+    it('purge-stream-state removes the subject\'s stream rows inside SOMEONE ELSE\'S conversation — no cascade reaches those, and nothing else in the codebase ever deletes them', async () => {
+      if (!dbAvailable) return;
+
+      const owner = await factories.createUser();
+      const subject = await factories.createUser();
+      const hostConversationId = createId();
+      await db.insert(conversations).values({
+        id: hostConversationId, userId: owner.id, type: 'global', contextId: null, updatedAt: new Date(),
+      });
+      const strandedStreamId = await seedStreamSession({
+        conversationId: hostConversationId,
+        userId: subject.id,
+      });
+      await db.insert(aiPendingAbortIntents).values({
+        conversationId: hostConversationId,
+        userId: subject.id,
+      });
+
+      // Deleting the user alone leaves both rows behind: neither table
+      // references `users`, and the host conversation belongs to someone else.
+      await db.delete(users).where(eq(users.id, subject.id));
+      const survivedTheCascade = await db
+        .select({ messageId: aiStreamSessions.messageId })
+        .from(aiStreamSessions)
+        .where(eq(aiStreamSessions.messageId, strandedStreamId));
+      expect(survivedTheCascade).toHaveLength(1);
+
+      // The erasure step is what reaches them.
+      const result = await deleteStreamStateForUser(subject.id);
+      expect(result.streamSessions).toBe(1);
+      expect(result.abortIntents).toBe(1);
+
+      const streamsLeft = await db
+        .select({ messageId: aiStreamSessions.messageId })
+        .from(aiStreamSessions)
+        .where(eq(aiStreamSessions.messageId, strandedStreamId));
+      const intentsLeft = await db
+        .select({ userId: aiPendingAbortIntents.userId })
+        .from(aiPendingAbortIntents)
+        .where(eq(aiPendingAbortIntents.conversationId, hostConversationId));
+      expect(streamsLeft).toEqual([]);
+      expect(intentsLeft).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // RULE 2/3 — retention sweeps both legs, and its cascade is real.
+  // ==========================================================================
+  describe('RULE 2/3 — retention sweeps both legs and cascades as documented', () => {
+    it('hard-deletes soft-deleted rows from BOTH message tables, and a purged conversation takes its legacy rows and stream state with it', async () => {
+      if (!dbAvailable) return;
+
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent' });
+
+      // (a) a soft-deleted message pair in a conversation that stays ACTIVE —
+      //     only the age-based sweeps can reach these.
+      const liveConversationId = createId();
+      // (b) a soft-deleted CONVERSATION past its window — its rows are still
+      //     marked active, so ONLY the cascade can reach them.
+      const purgedConversationId = createId();
+      await db.insert(conversations).values([
+        { id: liveConversationId, userId: owner.id, type: 'page', contextId: agentPage.id, isActive: true, updatedAt: new Date() },
+        { id: purgedConversationId, userId: owner.id, type: 'page', contextId: agentPage.id, isActive: false, updatedAt: daysAgo(90) },
+      ]);
+
+      const staleLegacyOnlyId = createId();
+      const staleUnifiedId = createId();
+      const cascadedLegacyId = createId();
+      const cascadedUnifiedId = createId();
+      const old = daysAgo(90);
+
+      await db.insert(chatMessages).values([
+        { id: staleLegacyOnlyId, pageId: agentPage.id, conversationId: liveConversationId, role: 'user', content: 'soft-deleted', isActive: false, createdAt: old, userId: owner.id },
+        { id: cascadedLegacyId, pageId: agentPage.id, conversationId: purgedConversationId, role: 'user', content: 'still active', isActive: true, createdAt: old, userId: owner.id },
+      ]);
+      await db.insert(messages).values([
+        { id: staleUnifiedId, conversationId: liveConversationId, role: 'user', content: 'soft-deleted', isActive: false, createdAt: old, userId: owner.id },
+        { id: cascadedUnifiedId, conversationId: purgedConversationId, role: 'user', content: 'still active', isActive: true, createdAt: old, userId: owner.id },
+      ]);
+      const cascadedStreamId = await seedStreamSession({
+        conversationId: purgedConversationId,
+        userId: owner.id,
+      });
+
+      const results = await cleanupSoftDeletedChatRecords(db);
+
+      // Both legs are named in the report — the cron output is where a leg
+      // that silently stopped working would first be visible.
+      expect(results.map((r) => r.table)).toEqual(
+        expect.arrayContaining(['chat_messages', 'messages', 'conversations'])
+      );
+
+      const legacyLeft = await db
+        .select({ id: chatMessages.id })
+        .from(chatMessages)
+        .where(inArray(chatMessages.id, [staleLegacyOnlyId, cascadedLegacyId]));
+      const unifiedLeft = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(inArray(messages.id, [staleUnifiedId, cascadedUnifiedId]));
+      const conversationLeft = await db
+        .select({ id: conversations.id })
+        .from(conversations)
+        .where(eq(conversations.id, purgedConversationId));
+      const streamLeft = await db
+        .select({ messageId: aiStreamSessions.messageId })
+        .from(aiStreamSessions)
+        .where(eq(aiStreamSessions.messageId, cascadedStreamId));
+
+      // The age-based sweeps got the soft-deleted rows on both legs; the
+      // conversations delete cascaded into the still-active ones (0248) and
+      // into the stream checkpoints (0249). Nothing that was condemned
+      // survived, on either leg.
+      expect(legacyLeft).toEqual([]);
+      expect(unifiedLeft).toEqual([]);
+      expect(conversationLeft).toEqual([]);
+      expect(streamLeft).toEqual([]);
+
+      // The still-active conversation is untouched.
+      const liveLeft = await db
+        .select({ id: conversations.id })
+        .from(conversations)
+        .where(and(eq(conversations.id, liveConversationId), eq(conversations.isActive, true)));
+      expect(liveLeft).toHaveLength(1);
+    });
+
+    it('leaves recent soft-deleted rows alone on both legs — the grace period is not leg-dependent', async () => {
+      if (!dbAvailable) return;
+
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent' });
+      const conversationId = createId();
+      await db.insert(conversations).values({
+        id: conversationId, userId: owner.id, type: 'page', contextId: agentPage.id, isActive: true, updatedAt: new Date(),
+      });
+
+      const recentLegacyId = createId();
+      const recentUnifiedId = createId();
+      await db.insert(chatMessages).values({
+        id: recentLegacyId, pageId: agentPage.id, conversationId, role: 'user',
+        content: 'just deleted', isActive: false, createdAt: new Date(), userId: owner.id,
+      });
+      await db.insert(messages).values({
+        id: recentUnifiedId, conversationId, role: 'user',
+        content: 'just deleted', isActive: false, createdAt: new Date(), userId: owner.id,
+      });
+
+      await cleanupSoftDeletedChatRecords(db);
+
+      const legacyLeft = await db
+        .select({ id: chatMessages.id })
+        .from(chatMessages)
+        .where(eq(chatMessages.id, recentLegacyId));
+      const unifiedLeft = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(eq(messages.id, recentUnifiedId));
+      expect(legacyLeft).toHaveLength(1);
+      expect(unifiedLeft).toHaveLength(1);
+    });
+  });
+});

--- a/docs/2.0-architecture/agent-sessions.md
+++ b/docs/2.0-architecture/agent-sessions.md
@@ -235,6 +235,34 @@ textbook forced copy, so it runs under the rule above rather than around it:
   still read the legacy leg (Phase 4 PR 12), compliance keeps both tables until the
   contract PR (PR 13/15), and `chat_messages` + `messages.pageId` are dropped last
   (PR 15).
+- **Compliance legs — SHIPPED** (Phase 4 PR 13). The three compliance paths are
+  deliberately ASYMMETRIC while both tables exist:
+  - **GDPR export reads the UNIFIED table only.** Since the dual-write + backfill,
+    `messages` is a superset of `chat_messages` under the SAME primary keys, so
+    reading both exported every page-chat row twice. It also stopped keying on
+    `messages.userId` alone: that column is the HUMAN author and is NULL for every
+    agent-authored row, so the old query exported the subject's questions and dropped
+    every answer inside their own page chats — while the same answer in a GLOBAL
+    thread WAS exported, because the global writer stamps the owner's id on assistant
+    rows. The predicate is now "rows the subject authored, plus unattributed rows in a
+    conversation the subject OWNS", which never picks up another human's messages from
+    a shared thread (Art 15(4)).
+  - **Erasure and retention keep BOTH legs** until PR 15 drops `chat_messages`: while
+    rows physically exist there, an Art 17 request and the retention window must still
+    reach them. Pinned by
+    `packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts`.
+  - **The 0248/0249 cascades made both paths delete MORE, deliberately.** A
+    `conversations` delete now takes its `chat_messages` rows (0248) and its
+    `ai_stream_sessions` rows (0249) with it. The latter closed a real leak — `parts`
+    checkpoints are message content and nothing in the codebase had ever deleted one.
+    Retention's conversation sweep is consequently sequenced AFTER the two message-leg
+    sweeps, because a cascading DELETE running concurrently with a direct DELETE over
+    the same rows can deadlock.
+  - **A residual hole the cascade cannot close** got its own erasure step,
+    `purge-stream-state`: a shared conversation accepts streams from any member, so
+    `ai_stream_sessions`/`ai_pending_abort_intents` rows carrying the MEMBER's user_id
+    inside the OWNER's conversation survive the member's erasure. The step is
+    user-scoped and fatal.
 
 Until every reader cuts over, the legacy leg is authoritative and the unified leg must
 never be able to break a write that works today — which is why the unified INSERT paths

--- a/docs/security/data-subject-request-runbook.md
+++ b/docs/security/data-subject-request-runbook.md
@@ -22,7 +22,8 @@ processor worker (account-erasure, retry+backoff) ◄─────────
    runs the erasure plan, recording each step on the DSR row:
    drive-disposition → delete-avatar → log → anonymize-activity-logs →
    purge-ai-usage → purge-monitoring → revoke-integrations →
-   email-suppression (#913) → ai-provider-erasure (#912) → security-audit → delete-user
+   email-suppression (#913) → ai-provider-erasure (#912) → purge-stream-state →
+   security-audit → delete-user
    → status = completed | blocked | failed
 ```
 
@@ -91,6 +92,23 @@ evidence row is retained.
   providers the user actually invoked. Gateway-routed cloud providers are
   recorded as ZDR-reliant; local providers are skipped; unrecognised providers
   are flagged `manual_review` in the step evidence — follow up manually.
+
+## AI stream state (`purge-stream-state`)
+
+`ai_stream_sessions` rows hold `parts` — a checkpoint of the generated message
+buffer, i.e. message CONTENT — plus the streamer's id and display name.
+Migration 0249 gave the table an `ON DELETE CASCADE` to `conversations`, so
+erasing a user now takes the stream state inside THEIR OWN conversations with
+them. This step covers what that cascade cannot reach: a **shared** conversation
+accepts streams from any member with access, so rows carrying the subject's
+`user_id` inside SOMEONE ELSE's conversation survive the cascade, as do all
+`ai_pending_abort_intents` rows (that table has no foreign keys at all) and any
+row left dangling before 0249's `NOT VALID` constraint landed.
+
+The step is **fatal**: it is the only eraser these rows have — no TTL, no
+retention sweep — so a swallowed failure would report a completed erasure with
+the subject's checkpointed content still on disk. `stepResults` records
+`streamSessions=<n> abortIntents=<n>`.
 
 ## Audit-table pseudonymization
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1722,6 +1722,11 @@
       "import": "./dist/compliance/erasure/ai-provider-erasure.js",
       "require": "./dist/compliance/erasure/ai-provider-erasure.js"
     },
+    "./compliance/erasure/purge-stream-state": {
+      "types": "./dist/compliance/erasure/purge-stream-state.d.ts",
+      "import": "./dist/compliance/erasure/purge-stream-state.js",
+      "require": "./dist/compliance/erasure/purge-stream-state.js"
+    },
     "./compliance/erasure/pseudonymize": {
       "types": "./dist/compliance/erasure/pseudonymize.d.ts",
       "import": "./dist/compliance/erasure/pseudonymize.js",

--- a/packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts
+++ b/packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts
@@ -1,0 +1,153 @@
+/**
+ * THE COMPLIANCE-LEG CONTRACT while `messages` and `chat_messages` coexist.
+ *
+ * Epic "Agent-Session Single Source of Truth", Phase 4 / D6, PR 13. Three
+ * rules, deliberately asymmetric, each pinned here at the table level so a
+ * well-meant "cleanup" cannot quietly break one:
+ *
+ *   1. GDPR EXPORT reads the UNIFIED table ONLY. After the dual-write and the
+ *      backfill, `messages` is a SUPERSET of `chat_messages` under the SAME
+ *      primary keys, so reading both exports every page-chat row twice.
+ *   2. ERASURE and RETENTION keep BOTH LEGS until `chat_messages` is DROPPED.
+ *      This is a legal requirement, not a style preference: while rows
+ *      physically exist in that table, an Art 17 request and the retention
+ *      window must both still reach them. A table no sweep names is a table
+ *      whose personal data is retained forever.
+ *   3. The legacy leg may be removed ONLY by Phase 4 PR 15, in the same change
+ *      that runs `DROP TABLE chat_messages`.
+ *
+ * These are behavioural pins — the real functions run against a fake executor
+ * that records which drizzle tables were touched — so they answer "what does
+ * this code do to which table", not "does the source still contain a word".
+ * The end-to-end proof over a real dual-written corpus (export completeness,
+ * cascade coverage) lives in
+ * `apps/web/src/lib/repositories/__tests__/unified-compliance-legs.integration.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTableName, type Table } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { cleanupSoftDeletedChatRecords } from '../retention/retention-engine';
+import { collectUserMessages } from '../export/gdpr-export';
+
+type DB = NodePgDatabase<Record<string, unknown>>;
+
+const LEGACY_LEG = 'chat_messages';
+const UNIFIED_LEG = 'messages';
+
+/**
+ * Cite-the-reason failure messages. A future reader who deletes the legacy
+ * leg early sees WHY it is there and WHERE it is allowed to go, not just a
+ * red assertion.
+ */
+const PR15_ONLY =
+  `the LEGACY leg (${LEGACY_LEG}) must stay until Phase 4 PR 15 DROPs the table. ` +
+  'Rows physically exist there, so a right-to-erasure request and the retention ' +
+  'window must both still reach them. PR 15 — the only irreversible PR in the ' +
+  'epic — is the one place this leg may be removed, together with the table itself.';
+
+const EXPORT_IS_UNIFIED_ONLY =
+  `the GDPR export must read the UNIFIED leg (${UNIFIED_LEG}) ONLY. Since the ` +
+  `dual-write + backfill, ${UNIFIED_LEG} is a superset of ${LEGACY_LEG} under the ` +
+  'SAME primary keys — reading both exports every page-chat message TWICE, which ' +
+  'is a duplicate rather than extra coverage.';
+
+/** Records the tables a DELETE statement targets; resolves every chain to []. */
+function createDeleteRecorder() {
+  const deletedFrom: string[] = [];
+  const db = {
+    delete(table: Table) {
+      deletedFrom.push(getTableName(table));
+      const chain = {
+        where: () => chain,
+        returning: async () => [],
+      };
+      return chain;
+    },
+  };
+  return { db: db as unknown as DB, deletedFrom };
+}
+
+/**
+ * Records the tables a SELECT reads. The chain object IS a promise, so every
+ * `await database.select(...).from(x).where(y)` resolves to an empty result
+ * whatever shape the query takes.
+ */
+function createSelectRecorder() {
+  const readFrom: string[] = [];
+  const joined: string[] = [];
+  const chain = () => {
+    const p = Promise.resolve([]) as Promise<never[]> & Record<string, unknown>;
+    p.from = (table: Table) => {
+      readFrom.push(getTableName(table));
+      return p;
+    };
+    p.innerJoin = (table: Table) => {
+      joined.push(getTableName(table));
+      return p;
+    };
+    p.leftJoin = p.innerJoin;
+    p.where = () => p;
+    p.limit = () => p;
+    p.orderBy = () => p;
+    return p;
+  };
+  const db = { select: () => chain(), selectDistinct: () => chain() };
+  return { db: db as unknown as DB, readFrom, joined };
+}
+
+describe('compliance legs while chat_messages and messages coexist (Phase 4 PR 13)', () => {
+  describe('RETENTION — both legs, until PR 15', () => {
+    it(`sweeps the LEGACY leg: ${PR15_ONLY}`, async () => {
+      const { db, deletedFrom } = createDeleteRecorder();
+      await cleanupSoftDeletedChatRecords(db);
+      expect(deletedFrom).toContain(LEGACY_LEG);
+    });
+
+    it('sweeps the UNIFIED leg too — the two legs are swept independently, not one via the other', async () => {
+      const { db, deletedFrom } = createDeleteRecorder();
+      await cleanupSoftDeletedChatRecords(db);
+      expect(deletedFrom).toContain(UNIFIED_LEG);
+    });
+
+    it('reports a row count for BOTH message tables, so a leg that stops working is visible in the cron output', async () => {
+      const { db } = createDeleteRecorder();
+      const results = await cleanupSoftDeletedChatRecords(db);
+      const tables = results.map((r) => r.table);
+      expect(tables).toContain(LEGACY_LEG);
+      expect(tables).toContain(UNIFIED_LEG);
+    });
+
+    it('deletes conversations LAST — that statement cascades into both message legs and ai_stream_sessions (0248/0249), and running it alongside the direct sweeps can deadlock on the same rows', async () => {
+      const { db, deletedFrom } = createDeleteRecorder();
+      await cleanupSoftDeletedChatRecords(db);
+      expect(deletedFrom.indexOf('conversations')).toBeGreaterThan(deletedFrom.indexOf(LEGACY_LEG));
+      expect(deletedFrom.indexOf('conversations')).toBeGreaterThan(deletedFrom.indexOf(UNIFIED_LEG));
+    });
+  });
+
+  describe('GDPR EXPORT — the unified leg only', () => {
+    it(`reads ${UNIFIED_LEG}`, async () => {
+      const { db, readFrom } = createSelectRecorder();
+      await collectUserMessages(db, 'subject-1');
+      expect(readFrom).toContain(UNIFIED_LEG);
+    });
+
+    it(`does NOT read ${LEGACY_LEG}: ${EXPORT_IS_UNIFIED_ONLY}`, async () => {
+      const { db, readFrom } = createSelectRecorder();
+      await collectUserMessages(db, 'subject-1');
+      expect(readFrom).not.toContain(LEGACY_LEG);
+    });
+
+    it('joins conversations — an agent-authored row (userId NULL) is only reachable through its thread\'s owner, and without that join the export drops every assistant reply in the subject\'s own page chats', async () => {
+      const { db, joined } = createSelectRecorder();
+      await collectUserMessages(db, 'subject-1');
+      expect(joined).toContain('conversations');
+    });
+
+    it('reads the unified leg exactly once — a second pass would re-export the same rows under a different source label', async () => {
+      const { db, readFrom } = createSelectRecorder();
+      await collectUserMessages(db, 'subject-1');
+      expect(readFrom.filter((t) => t === UNIFIED_LEG)).toHaveLength(1);
+    });
+  });
+});

--- a/packages/lib/src/compliance/erasure/__tests__/erasure-plan.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/erasure-plan.test.ts
@@ -45,6 +45,22 @@ describe('buildErasurePlan', () => {
     expect(ids.indexOf('ai-provider-erasure')).toBeLessThan(ids.indexOf('purge-ai-usage'));
   });
 
+  describe('purge-stream-state (Phase 4 PR 13 — the cascade audit finding)', () => {
+    it('runs BEFORE delete-user, so the evidence lands on the DSR row while the subject still exists', () => {
+      const ids = cloudPlan().map((s) => s.id);
+      expect(ids.indexOf('purge-stream-state')).toBeLessThan(ids.indexOf('delete-user'));
+    });
+
+    it('is FATAL — it is the ONLY eraser ai_stream_sessions has (no TTL, no retention sweep, and no cascade for a shared conversation the subject does not own), so a swallowed failure would complete an erasure with the subject\'s checkpointed message content still on disk', () => {
+      expect(cloudPlan().find((s) => s.id === 'purge-stream-state')?.fatal).toBe(true);
+    });
+
+    it('runs on-prem too — the rows are in our own Postgres, not a sub-processor', () => {
+      const ids = buildErasurePlan({ deploymentMode: 'onprem', clickHouseInPlay: false }).map((s) => s.id);
+      expect(ids).toContain('purge-stream-state');
+    });
+  });
+
   it('every step id is unique', () => {
     const plan = cloudPlan();
     const ids = plan.map((s) => s.id);

--- a/packages/lib/src/compliance/erasure/erasure-plan.ts
+++ b/packages/lib/src/compliance/erasure/erasure-plan.ts
@@ -16,6 +16,7 @@ export type ErasureStepId =
   | 'anonymize-activity-logs'
   | 'purge-ai-usage'
   | 'purge-monitoring'
+  | 'purge-stream-state'
   | 'revoke-integrations'
   | 'email-suppression'
   | 'ai-provider-erasure'
@@ -36,6 +37,11 @@ export const ERASURE_STEPS: readonly ErasureStepId[] = [
   // always empty and no ZDR/manual-review evidence is recorded).
   'ai-provider-erasure',
   'purge-ai-usage',
+  // Stream state (`ai_stream_sessions.parts` checkpoints, abort intents) is
+  // keyed by user_id and reachable by no cascade for a shared conversation the
+  // subject does not own. Must run before delete-user so the evidence lands
+  // while the subject row still exists.
+  'purge-stream-state',
   'security-audit',
   'delete-user',
   'stripe-customer',
@@ -65,6 +71,12 @@ const STEP_DEFS: ErasureStep[] = [
   // providers the user touched.
   { id: 'ai-provider-erasure', fatal: false, cloudOnly: true },
   { id: 'purge-ai-usage', fatal: false, cloudOnly: false },
+  // FATAL, and for the same reason purge-monitoring becomes fatal with CH in
+  // play: this step is the ONLY eraser those rows have. `ai_stream_sessions`
+  // has no TTL, no retention sweep and (for a conversation the subject does
+  // not own) no cascade, so a swallowed failure would report a completed
+  // erasure with the subject's checkpointed message content still on disk.
+  { id: 'purge-stream-state', fatal: true, cloudOnly: false },
   { id: 'security-audit', fatal: false, cloudOnly: false },
   // Deleting the user row is the irreversible core — must succeed.
   { id: 'delete-user', fatal: true, cloudOnly: false },

--- a/packages/lib/src/compliance/erasure/purge-stream-state.ts
+++ b/packages/lib/src/compliance/erasure/purge-stream-state.ts
@@ -1,0 +1,70 @@
+/**
+ * Art 17 erasure of the subject's AI STREAM STATE — the half the FK graph
+ * cannot reach.
+ *
+ * Found while auditing the cascade paths that migrations 0248/0249 changed
+ * (epic "Agent-Session Single Source of Truth", Phase 4 / D6, PR 13).
+ *
+ * `ai_stream_sessions` rows carry `parts` — a periodic checkpoint of the
+ * generated `UIMessagePart[]` buffer, i.e. message CONTENT — plus the
+ * streamer's `user_id`, display name and browser session id. Nothing in this
+ * repository has ever deleted a row of that table: no retention sweep, no TTL,
+ * no erasure step, and (before 0249) no foreign key of any kind.
+ *
+ * 0249 gave it `conversation_id → conversations ON DELETE CASCADE`, which
+ * closed most of the hole: erasing a user deletes their `conversations` rows
+ * (`conversations.userId` cascades from `users`), and those now take the
+ * stream state with them. What it does NOT close is the CROSS-USER residue:
+ *
+ *   - a SHARED page conversation accepts messages, and therefore streams, from
+ *     any member who can access it (`apps/web/src/app/api/ai/chat/route.ts` —
+ *     "owner OR shared"). Those rows carry the MEMBER's `user_id` inside the
+ *     OWNER's conversation, so erasing the member leaves them behind;
+ *   - `ai_pending_abort_intents` has no foreign key at all — not to
+ *     `conversations`, not to `users` — so every intent row survives erasure
+ *     regardless of who owns the conversation;
+ *   - 0249's FK is `NOT VALID`, so rows whose conversation was hard-deleted
+ *     before it landed still dangle and are unreachable by any cascade.
+ *
+ * All three are keyed by `user_id`, which is exactly what this step deletes.
+ * It is deliberately user-scoped and NOT conversation-scoped: the cascade
+ * already covers the conversation-scoped case, and doing it twice is harmless
+ * (both are idempotent DELETEs) while doing neither retains content forever.
+ *
+ * Ordering: runs BEFORE `delete-user`, so the evidence lands on the DSR row
+ * while the subject still exists. Neither table references `users`, so the
+ * order is a reporting choice, not a referential requirement.
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { aiStreamSessions, aiPendingAbortIntents } from '@pagespace/db/schema/ai-streams';
+
+export interface StreamStateErasureResult {
+  /** `ai_stream_sessions` rows deleted (each may hold checkpointed content). */
+  streamSessions: number;
+  /** `ai_pending_abort_intents` rows deleted. */
+  abortIntents: number;
+}
+
+/**
+ * Delete every AI stream row the subject owns, in both stream tables.
+ *
+ * Sequential rather than concurrent: `ai_stream_sessions` is a cascade target
+ * of `conversations`, and running user-scoped deletes alongside other erasure
+ * statements over overlapping rows is the deadlock shape retention had to
+ * avoid too. Erasure is not latency-sensitive.
+ */
+export async function deleteStreamStateForUser(userId: string): Promise<StreamStateErasureResult> {
+  const streams = await db
+    .delete(aiStreamSessions)
+    .where(eq(aiStreamSessions.userId, userId))
+    .returning({ messageId: aiStreamSessions.messageId });
+
+  const intents = await db
+    .delete(aiPendingAbortIntents)
+    .where(eq(aiPendingAbortIntents.userId, userId))
+    .returning({ conversationId: aiPendingAbortIntents.conversationId });
+
+  return { streamSessions: streams.length, abortIntents: intents.length };
+}

--- a/packages/lib/src/compliance/export/gdpr-export.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.test.ts
@@ -31,6 +31,7 @@ const { mockTable } = vi.hoisted(() => {
     content: `${name}.content`,
     pageId: `${name}.pageId`,
     conversationId: `${name}.conversationId`,
+    contextId: `${name}.contextId`,
     sizeBytes: `${name}.sizeBytes`,
     mimeType: `${name}.mimeType`,
     storagePath: `${name}.storagePath`,
@@ -90,7 +91,6 @@ vi.mock('@pagespace/db/schema/auth', () => ({ users: mockTable('users') }));
 vi.mock('@pagespace/db/schema/core', () => ({
   drives: mockTable('drives'),
   pages: mockTable('pages'),
-  chatMessages: mockTable('chatMessages'),
 }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({
   activityLogs: mockTable('activityLogs'),
@@ -137,6 +137,7 @@ vi.mock('drizzle-orm', () => ({
   or: (...conditions: unknown[]) => ({ _op: 'or', conditions }),
   and: (...conditions: unknown[]) => ({ _op: 'and', conditions }),
   ne: (col: unknown, val: unknown) => ({ _op: 'ne', col, val }),
+  isNull: (col: unknown) => ({ _op: 'isNull', col }),
 }));
 
 import {
@@ -278,25 +279,53 @@ describe('collectUserPages', () => {
 });
 
 describe('collectUserMessages', () => {
+  /**
+   * The ladder is now FOUR queries, not five: channel, unified conversation
+   * messages, sent DMs, dm-conversation ids (+ a fifth for received DMs when
+   * that lookup is non-empty). The legacy `chat_messages` query is GONE —
+   * Phase 4 PR 13 cut the export over to the unified `messages` table alone,
+   * because the dual-write + backfill made it a superset under the same
+   * primary keys and reading both duplicated every page-chat row.
+   */
   it('given_messagesInAllSources_aggregatesWithCorrectSourceLabels', async () => {
-    const aiMsg = { id: 'm1', content: 'AI msg', role: 'user', pageId: 'p1', conversationId: 'c1', createdAt: new Date() };
     const channelMsg = { id: 'm2', content: 'Channel msg', pageId: 'p2', createdAt: new Date() };
-    const convMsg = { id: 'm3', content: 'Conv msg', role: 'user', conversationId: 'c2', createdAt: new Date() };
+    const pageChatMsg = { id: 'm1', content: 'Page chat msg', role: 'user', conversationId: 'c1', createdAt: new Date(), conversationType: 'page', conversationContextId: 'p1' };
+    const globalMsg = { id: 'm3', content: 'Conv msg', role: 'user', conversationId: 'c2', createdAt: new Date(), conversationType: 'global', conversationContextId: null };
     const dmMsg = { id: 'm4', content: 'DM msg', conversationId: 'c3', createdAt: new Date() };
-    // 5th call: dmConversations lookup returns [] so no 6th call for received DMs
-    const db = createChainDb([[aiMsg], [channelMsg], [convMsg], [dmMsg], []]);
+    // 4th call: dmConversations lookup returns [] so no 5th call for received DMs
+    const db = createChainDb([[channelMsg], [pageChatMsg, globalMsg], [dmMsg], []]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
     expect(result).toHaveLength(4);
     expect(result.map(r => r.source)).toEqual([
-      'ai_chat', 'channel', 'conversation', 'direct_message',
+      'channel', 'ai_chat', 'conversation', 'direct_message',
     ]);
   });
 
+  it('labels a page thread ai_chat and takes its pageId from conversations.contextId, not the transitional messages.pageId', async () => {
+    const pageChatMsg = { id: 'm1', content: 'Page chat msg', role: 'assistant', conversationId: 'c1', createdAt: new Date(), conversationType: 'page', conversationContextId: 'agent-page-1' };
+    const db = createChainDb([[], [pageChatMsg], [], []]);
+
+    const result = await collectUserMessages(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(expect.objectContaining({ source: 'ai_chat', pageId: 'agent-page-1' }));
+  });
+
+  it('reports no pageId for a type=client thread — its contextId is a DRIVE id, and a wrong page is worse than none', async () => {
+    const clientMsg = { id: 'm1', content: 'API thread msg', role: 'user', conversationId: 'c1', createdAt: new Date(), conversationType: 'client', conversationContextId: 'drive-1' };
+    const db = createChainDb([[], [clientMsg], [], []]);
+
+    const result = await collectUserMessages(db as never, 'user-1');
+
+    expect(result[0].source).toBe('ai_chat');
+    expect(result[0].pageId).toBeUndefined();
+  });
+
   it('given_noMessages_returnsEmptyArray', async () => {
-    // 5 calls: ai, channel, conv, sentDms, dmConversations
-    const db = createChainDb([[], [], [], [], []]);
+    // 4 calls: channel, conv, sentDms, dmConversations
+    const db = createChainDb([[], [], [], []]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
@@ -305,8 +334,8 @@ describe('collectUserMessages', () => {
 
   it('given_userHasSentDMs_setsDirectionSent', async () => {
     const sentDm = { id: 'm4', content: 'Sent DM', conversationId: 'conv-1', createdAt: new Date() };
-    // ai=[], channel=[], conv=[], sentDms=[sentDm], dmConvIds=[] (no received)
-    const db = createChainDb([[], [], [], [sentDm], []]);
+    // channel=[], conv=[], sentDms=[sentDm], dmConvIds=[] (no received)
+    const db = createChainDb([[], [], [sentDm], []]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
@@ -325,7 +354,7 @@ describe('collectUserMessages', () => {
       isActive: false,
       deletedAt,
     };
-    const db = createChainDb([[], [], [], [sentDm], []]);
+    const db = createChainDb([[], [], [sentDm], []]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
@@ -343,8 +372,8 @@ describe('collectUserMessages', () => {
   it('given_userHasReceivedDMs_includesThemWithDirectionReceived', async () => {
     const convId = { id: 'conv-1' };
     const receivedDm = { id: 'm5', content: 'Received DM', conversationId: 'conv-1', createdAt: new Date() };
-    // ai=[], channel=[], conv=[], sentDms=[], dmConvIds=[convId], receivedDms=[receivedDm]
-    const db = createChainDb([[], [], [], [], [convId], [receivedDm]]);
+    // channel=[], conv=[], sentDms=[], dmConvIds=[convId], receivedDms=[receivedDm]
+    const db = createChainDb([[], [], [], [convId], [receivedDm]]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
@@ -358,8 +387,8 @@ describe('collectUserMessages', () => {
     const sentDm = { id: 'm4', content: 'Sent DM', conversationId: 'conv-1', createdAt: new Date() };
     const convId = { id: 'conv-1' };
     const receivedDm = { id: 'm5', content: 'Received DM', conversationId: 'conv-1', createdAt: new Date() };
-    // ai=[], channel=[], conv=[], sentDms=[sentDm], dmConvIds=[convId], receivedDms=[receivedDm]
-    const db = createChainDb([[], [], [], [sentDm], [convId], [receivedDm]]);
+    // channel=[], conv=[], sentDms=[sentDm], dmConvIds=[convId], receivedDms=[receivedDm]
+    const db = createChainDb([[], [], [sentDm], [convId], [receivedDm]]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -1,7 +1,7 @@
-import { eq, inArray, or, and, ne } from 'drizzle-orm';
+import { eq, inArray, or, and, ne, isNull } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { users } from '@pagespace/db/schema/auth';
-import { drives, pages, chatMessages } from '@pagespace/db/schema/core';
+import { drives, pages } from '@pagespace/db/schema/core';
 import { aiUsageLogs, activityLogs, systemLogs, apiMetrics, errorLogs, errorResolutions } from '@pagespace/db/schema/monitoring';
 import { files, filePages } from '@pagespace/db/schema/storage';
 import { driveMembers } from '@pagespace/db/schema/members';
@@ -313,33 +313,6 @@ export async function collectUserPages(
 export async function collectUserMessages(database: DB, userId: string): Promise<UserMessageExport[]> {
   const result: UserMessageExport[] = [];
 
-  // AI chat messages (chatMessages table)
-  const aiChats = await database
-    .select({
-      id: chatMessages.id,
-      content: chatMessages.content,
-      role: chatMessages.role,
-      pageId: chatMessages.pageId,
-      conversationId: chatMessages.conversationId,
-      createdAt: chatMessages.createdAt,
-      status: chatMessages.status,
-    })
-    .from(chatMessages)
-    .where(eq(chatMessages.userId, userId));
-
-  for (const msg of aiChats) {
-    result.push({
-      id: msg.id,
-      source: 'ai_chat',
-      content: msg.content,
-      role: msg.role,
-      pageId: msg.pageId,
-      conversationId: msg.conversationId,
-      createdAt: msg.createdAt,
-      status: msg.status,
-    });
-  }
-
   // Channel messages
   const channelMsgs = await database
     .select({
@@ -361,10 +334,50 @@ export async function collectUserMessages(database: DB, userId: string): Promise
     });
   }
 
-  // Conversation messages (unified conversations table). Global assistant rows store the
-  // conversation OWNER's userId (not null, unlike chatMessages), so this query — unlike
-  // aiChats above — does surface assistant placeholders for the requesting user's own
-  // conversations; `status` is what makes an empty row explainable rather than data loss.
+  /**
+   * Chat messages — read from the UNIFIED `messages` table ONLY (epic
+   * "Agent-Session Single Source of Truth", Phase 4 / D6, PR 13).
+   *
+   * `chat_messages` is deliberately NOT read here, and this is the ONE
+   * compliance leg that drops the legacy table before PR 15 drops the table
+   * itself. Since the dual-write + backfill (PRs 9/10) `messages` is a
+   * SUPERSET of `chat_messages`: every page-chat row is written to both legs
+   * in one transaction under the SAME primary key, and the historical corpus
+   * was carried across by `scripts/backfill-unify-messages.ts`. Reading both
+   * would therefore export every page-chat message TWICE (same id, once as
+   * 'ai_chat' and once as 'conversation') — a duplicate, not extra coverage.
+   * Erasure and retention keep both legs for the opposite reason: rows
+   * physically exist in `chat_messages` and must still be reachable.
+   *
+   * ── Why the predicate is not just `messages.userId = :subject` ──────────
+   * `userId` is the HUMAN author and is NULL for every agent/system-authored
+   * row (page-chat assistant replies, `/help` answers, consult and worker
+   * dispatches; `sourceAgentId` names the agent when known). Filtering on
+   * `userId` alone exported the subject's questions and dropped every answer
+   * inside their own page chats — while the same answer in a GLOBAL
+   * conversation WAS exported, because the global writer stamps the owner's
+   * id on assistant rows. That asymmetry is an Art 15 completeness gap, and
+   * unification made it uniform rather than creating it.
+   *
+   * So the export is the union of:
+   *   1. rows the subject AUTHORED (`messages.userId = :subject`) — wherever
+   *      they live, including a conversation someone else owns (a shared
+   *      page conversation accepts messages from any member who can access
+   *      it), and
+   *   2. rows with NO human author that sit in a conversation the subject
+   *      OWNS — the agent/system side of the subject's own threads.
+   *
+   * It deliberately stops there. Rows authored by ANOTHER human inside the
+   * subject's shared conversation stay out: they are that person's data, and
+   * Art 15(4) says a subject's access right must not adversely affect the
+   * rights of others. `conversations.userId` alone would have swept them in
+   * (multi-author legacy conversations exist — 0248's orphan synthesis logs
+   * how many it found, "earliest human author wins").
+   *
+   * The join is INNER by design: `messages.conversationId` carries a real,
+   * VALIDATED FK to `conversations`, so a message with no conversation row
+   * cannot exist and the join cannot silently drop one.
+   */
   const convMsgs = await database
     .select({
       id: messages.id,
@@ -373,16 +386,36 @@ export async function collectUserMessages(database: DB, userId: string): Promise
       conversationId: messages.conversationId,
       createdAt: messages.createdAt,
       status: messages.status,
+      conversationType: conversations.type,
+      conversationContextId: conversations.contextId,
     })
     .from(messages)
-    .where(eq(messages.userId, userId));
+    .innerJoin(conversations, eq(messages.conversationId, conversations.id))
+    .where(
+      or(
+        eq(messages.userId, userId),
+        and(isNull(messages.userId), eq(conversations.userId, userId)),
+      )
+    );
 
   for (const msg of convMsgs) {
+    const isGlobal = msg.conversationType === 'global';
     result.push({
       id: msg.id,
-      source: 'conversation',
+      // The export vocabulary predates the merge and is kept: a page/client
+      // thread is still reported as 'ai_chat', a global thread as
+      // 'conversation'. One physical table, two documented sources.
+      source: isGlobal ? 'conversation' : 'ai_chat',
       content: msg.content,
       role: msg.role,
+      // The page comes from the CONVERSATION, never from `messages.pageId`
+      // (transitional, dropped at PR 15) — `conversations.contextId` is the
+      // end-state authority (Phase 4 PR 11's rule). Only `type='page'` has a
+      // page there; a `type='client'` row's contextId is a DRIVE id, so it
+      // reports no pageId rather than a wrong one.
+      ...(msg.conversationType === 'page' && msg.conversationContextId
+        ? { pageId: msg.conversationContextId }
+        : {}),
       conversationId: msg.conversationId,
       createdAt: msg.createdAt,
       status: msg.status,

--- a/packages/lib/src/compliance/retention/retention-engine.ts
+++ b/packages/lib/src/compliance/retention/retention-engine.ts
@@ -137,6 +137,40 @@ export async function cleanupExpiredAiUsageLogs(database: DB): Promise<CleanupRe
  *  - messages / chat_messages: `createdAt` (these tables carry no soft-delete
  *    timestamp; `editedAt` is only set on content edits). This matches the
  *    existing `purgeInactiveMessages` semantics.
+ *
+ * ── BOTH MESSAGE LEGS, DELIBERATELY (epic "Agent-Session Single Source of
+ *    Truth", Phase 4 / D6) ────────────────────────────────────────────────
+ * `chat_messages` is being merged into `messages`, and the GDPR EXPORT has
+ * already cut over to reading the unified table alone (it is a superset, so
+ * reading both would duplicate rows). RETENTION MUST NOT FOLLOW IT. While
+ * rows physically exist in `chat_messages`, a table this sweep stops naming
+ * is a table whose soft-deleted personal data is retained forever. The legacy
+ * leg may be removed ONLY by Phase 4 PR 15, in the same change that runs
+ * `DROP TABLE chat_messages` — see
+ * `packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts`,
+ * which fails if it disappears earlier.
+ *
+ * ── CASCADE (migrations 0248/0249) ─────────────────────────────────────────
+ * The `conversations` delete below is no longer a leaf. Three FKs now cascade
+ * from it: `messages.conversationId` (always did), `chat_messages
+ * .conversationId` (0248, NOT VALID — the referential triggers still fire, so
+ * it cascades for every row that names a real conversation), and
+ * `ai_stream_sessions.conversation_id` (0249). Purging one soft-deleted
+ * conversation therefore now also purges its legacy page-chat rows and its
+ * per-generation stream checkpoints — the latter being message CONTENT
+ * (`parts`) that nothing in this codebase has ever deleted. That is strictly
+ * MORE deletion than before, and it is the intended direction: retention's
+ * whole job is that nothing outlives its window.
+ *
+ * The three statements are consequently NO LONGER independent, which is why
+ * the conversations sweep runs AFTER the two message legs rather than
+ * alongside them: two concurrent DELETEs whose row sets overlap (the direct
+ * sweep and the cascade) can lock the same `chat_messages`/`messages` rows in
+ * different orders, and a deadlock aborts the retention run. Sequencing the
+ * cascading statement last costs one round trip and removes that class
+ * entirely. It also makes the reported counts stable: the message legs report
+ * what age-based sweeping removed, and whatever the cascade mops up
+ * afterwards was, by construction, already condemned.
  */
 export async function cleanupSoftDeletedChatRecords(database: DB): Promise<CleanupResult[]> {
   const cutoff = computeChatRetentionCutoff(
@@ -144,20 +178,25 @@ export async function cleanupSoftDeletedChatRecords(database: DB): Promise<Clean
     resolveChatRetentionDays(process.env.RETENTION_CHAT_SOFT_DELETE_DAYS),
   );
 
-  const [chatMsgs, globalMsgs, convos] = await Promise.all([
+  // Both message legs, in parallel: different tables, disjoint row sets.
+  const [chatMsgs, globalMsgs] = await Promise.all([
+    // THE LEGACY LEG. Removable only by Phase 4 PR 15 (see the doc above).
     database
       .delete(chatMessages)
       .where(and(eq(chatMessages.isActive, false), lt(chatMessages.createdAt, cutoff)))
       .returning({ id: chatMessages.id }),
+    // The unified leg.
     database
       .delete(messages)
       .where(and(eq(messages.isActive, false), lt(messages.createdAt, cutoff)))
       .returning({ id: messages.id }),
-    database
-      .delete(conversations)
-      .where(and(eq(conversations.isActive, false), lt(conversations.updatedAt, cutoff)))
-      .returning({ id: conversations.id }),
   ]);
+
+  // Cascades into both message tables and ai_stream_sessions — sequenced last.
+  const convos = await database
+    .delete(conversations)
+    .where(and(eq(conversations.isActive, false), lt(conversations.updatedAt, cutoff)))
+    .returning({ id: conversations.id });
 
   return [
     { table: 'chat_messages', deleted: chatMsgs.length },


### PR DESCRIPTION
Phase 4 PR 13 of the "Agent-Session Single Source of Truth" epic. This is the LEGAL-correctness PR of the message unification: GDPR export, Art 17 erasure and retention must all stay complete and correct while two message tables coexist.

## Merge-after ordering

Base is `pu/broken-sessions`. This branch merges the prerequisite chain locally, in order:

1. `feat/messages-unification-expand` (#2344) — migrations 0248/0249
2. `feat/messages-dual-write-backfill` (#2348) — the shared dual-writer + backfill
3. `feat/messages-reader-cutover-internal` (#2349) — internal reader cutover

**Merge those three first.** Two merge conflicts were resolved here (`docs/2.0-architecture/agent-sessions.md`, `unified-message-dual-write-drift.test.ts`) — both were the reader-cutover PR's version superseding the dual-write PR's, taken as-is.

Does NOT touch the chat routes, page-agents routes, consult, undo/edit or the message repositories — PR 12 (`feat/messages-reader-cutover-routes`) owns those.

---

## Rule 1 — GDPR export reads the UNIFIED table only

`collectUserMessages` no longer reads `chat_messages`.

After the dual-write + backfill, `messages` is a **superset** of `chat_messages` under the **same primary keys** (`unified-message-leg.ts` writes `id: row.messageId`). Reading both did not add coverage — it exported every page-chat row **twice**, once labelled `ai_chat` and once `conversation`, with identical ids. Pinned by `exports every message EXACTLY ONCE` over a corpus written by the production dual-writer.

The export vocabulary is preserved: page/client threads still report `source: 'ai_chat'`, global threads `'conversation'`. `pageId` now comes from `conversations.contextId` (the end-state authority, per PR 11's rule) rather than the transitional `messages.pageId` that PR 15 drops. One deliberate consequence: a `type='client'` thread reports no `pageId`, because its `contextId` is a DRIVE id and a wrong page is worse than none.

## Rule 2 — erasure and retention KEEP BOTH LEGS until PR 15

Not a style preference. While rows physically exist in `chat_messages`, a right-to-erasure request and the retention window must both still reach them; a table no sweep names is a table whose personal data is retained forever.

`packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts` pins this behaviourally (the real functions run against a fake executor that records which drizzle tables were touched, so it answers "what does this do to which table", not "does the source still contain a word"). The failure message names PR 15 as the only place the leg may be removed:

> the LEGACY leg (chat_messages) must stay until Phase 4 PR 15 DROPs the table. Rows physically exist there, so a right-to-erasure request and the retention window must both still reach them. PR 15 — the only irreversible PR in the epic — is the one place this leg may be removed, together with the table itself.

Erasure's legs are the FK graph, not a query, so they are pinned end-to-end instead: deleting a user removes rows from BOTH tables, including the agent-authored (`userId` NULL) row that only the 0248 conversations FK reaches.

## Rule 3 — cascade analysis (0248/0249)

Three cascades now fire from a `conversations` DELETE:

| FK | Added | Effect on compliance |
|---|---|---|
| `messages.conversationId` | pre-existing (validated) | unchanged |
| `chat_messages.conversationId` | **0248** (`NOT VALID`) | referential triggers still fire, so a conversation delete now takes its legacy page-chat rows with it instead of orphaning them |
| `ai_stream_sessions.conversation_id` | **0249** (`NOT VALID`) | per-generation stream state — including `parts`, a checkpoint of message CONTENT — now dies with its conversation |

**Everything deletes MORE, and every increase is intended:**

- **Erasure.** `users → conversations → {messages, chat_messages, ai_stream_sessions}`. The `chat_messages` leg is a genuine gap closure: an agent-authored row (`userId` NULL) in the subject's page conversation was previously reachable by NO cascade — `chat_messages.userId` is NULL, and the table had no FK to `conversations`. The `ai_stream_sessions` leg is a bigger one: **nothing in this repository has ever deleted a row of that table** — no TTL, no retention sweep, no erasure step, and before 0249 no foreign key at all.
- **Retention.** `purgeInactiveConversations` (cron) and `cleanupSoftDeletedChatRecords` now cascade the same way. Aging stays coherent: a conversation's grace period starts at its soft-delete (`updatedAt` is `$onUpdate`), messages age from `createdAt`, and `softDeleteConversation` already tombstones both legs' rows — so the cascade is a safety net that guarantees no message outlives its purged conversation, not an early deletion.
- **Nothing deletes LESS.** The export is the only path that dropped a leg, and it dropped a duplicate.

**One consequence worth stating plainly:** erasing user A now also destroys user B's page-chat messages inside A's *shared* conversation (they cascade with the conversation). That was already true for `messages`; 0248 extended it to `chat_messages`, so both legs now behave identically and match the soft-delete cascade's existing semantics.

**One ordering hazard fixed.** `cleanupSoftDeletedChatRecords` ran its three DELETEs in `Promise.all`. Now that the conversations statement cascades into the other two tables' row sets, two concurrent DELETEs can lock the same rows in different orders and deadlock, aborting the retention run. The conversations sweep is now sequenced **after** the two message-leg sweeps (which stay parallel — different tables, disjoint rows). Counts become deterministic as a side effect: each leg reports what age-based sweeping removed, and whatever the cascade mops up afterwards was already condemned.

## Rule 4 — NULL-`userId` audit, and the gap it found

`messages.userId` is the HUMAN author and is NULL for every agent/system-authored row (`sourceAgentId` names the agent when known). Auditing every compliance path that keys on it:

- **Export — BROKEN, fixed here.** `WHERE messages.userId = :subject` exported the subject's *questions* and dropped every *answer* inside their own page chats — while the same answer in a GLOBAL thread WAS exported, because the global writer stamps the owner's id on assistant rows. That asymmetry is an Art 15 completeness gap; unification made it uniform rather than creating it. The predicate is now the union of (1) rows the subject **authored**, wherever they live, and (2) rows with **no human author** in a conversation the subject **owns**.

  It deliberately stops there. `conversations.userId` alone would have swept in another human's messages from a shared thread — multi-author legacy conversations demonstrably exist (0248's orphan synthesis logs how many it found, "earliest human author wins") — and Art 15(4) says a subject's access right must not adversely affect the rights of others. Both directions are pinned by test.
- **Erasure — fine.** Never keyed on `userId`; the conversations cascade reaches NULL-author rows on both legs (now tested).
- **Retention — fine and consistent.** Both legs sweep on `isActive`/`createdAt`, never on authorship, and both are reported in the cron output so a leg that silently stops working is visible.

### The other gap: stream state no cascade can reach

0249 closed most of the `ai_stream_sessions` hole but not the cross-user residue. A **shared** conversation accepts messages — and therefore streams — from any member with access (`/api/ai/chat/route.ts`: "owner OR shared"). So:

- rows carrying a MEMBER's `user_id` inside the OWNER's conversation survive the member's erasure;
- `ai_pending_abort_intents` has **no foreign keys at all** — not to `conversations`, not to `users` — so every intent row survives erasure outright;
- 0249's FK is `NOT VALID`, so rows dangling from before it landed are unreachable by any cascade.

All three are keyed by `user_id`, so this PR adds an erasure step, `purge-stream-state`, that deletes exactly that. It runs before `delete-user` (so the evidence lands on the DSR row while the subject exists) and is **fatal**, for the same reason `purge-monitoring` becomes fatal with ClickHouse in play: it is the only eraser those rows have, so a swallowed failure would report a completed erasure with the subject's checkpointed message content still on disk.

---

## What PR 15 must change here

Checklist for the contract PR, in the same change that runs `DROP TABLE chat_messages`:

- [ ] `packages/lib/src/compliance/retention/retention-engine.ts` — delete the `chatMessages` import (line 9); delete the legacy `database.delete(chatMessages)` statement and the `chatMsgs` destructuring in `cleanupSoftDeletedChatRecords`; delete the `{ table: 'chat_messages', … }` entry from the returned results; trim the "BOTH MESSAGE LEGS" and "removable only by PR 15" paragraphs from the doc comment. The `Promise.all` becomes a single `await` — **keep the conversations sweep sequenced last** (the `ai_stream_sessions` cascade outlives `chat_messages`).
- [ ] `packages/lib/src/compliance/retention/retention-engine.test.ts` — the table-count assertion drops from 14 to 13, and `'chat_messages'` leaves the sorted `tableNames` list.
- [ ] `packages/lib/src/compliance/__tests__/message-unification-compliance-legs.test.ts` — **delete the whole file.** Its entire subject is the coexistence window. (`RETENTION — both legs, until PR 15` is the block that will fail first.)
- [ ] `apps/web/src/lib/repositories/__tests__/unified-compliance-legs.integration.test.ts` — delete the `chat_messages` halves: the "dual-writer really did populate BOTH legs" test, the `legacyLeft` assertions in the erasure and retention tests, and the "covers every legacy-leg row" test. **Keep** the export completeness/exactly-once tests, the NULL-`userId` and Art 15(4) tests, and the `ai_stream_sessions` tests — none of those depend on the legacy leg.
- [ ] Nothing to change in `gdpr-export.ts` — it already reads the unified table alone. Only the "why not both legs" paragraph becomes historical.
- [ ] Nothing to change in `purge-stream-state.ts` or the `purge-stream-state` erasure step — unrelated to the legacy leg, and still the only eraser those tables have.
- [ ] `docs/2.0-architecture/agent-sessions.md` — collapse the "Compliance legs — SHIPPED" bullet to its end state.

---

## Verification (GitHub Actions is in a major outage — all runs are local, on this branch)

| Gate | Result |
|---|---|
| `bun run lint` | **14 successful, 14 total** |
| `bun run knip:check` | **`[ok] knip: 4 issue(s), all within baseline (4)`** (the known gitignored Capacitor artifacts) |
| `bun run typecheck` | **16 successful, 16 total** |
| `packages/lib` full suite | **400 passed / 3 skipped (403 files), 8776 passed / 9 skipped** |
| `packages/lib/src/compliance` | **23 passed / 1 skipped (24 files), 268 passed / 3 skipped** |
| web `src/lib/repositories/__tests__` | **19 passed (19 files), 259 passed** — includes the new integration suite (12 tests) and PR 11's parity suite (21) |
| web compliance routes (`admin/gdpr`, `account`, `cron/retention-cleanup`, `cron/purge-deleted-messages`, `lib/erasure`) | **15 passed (15 files), 195 passed** |
| `apps/processor` erasure worker | **1 passed** |
| `bun run test:security` | **All 51 test suites passed** |

Integration tests ran against a scratch Postgres on port 5452 with `bun run --filter '@pagespace/db' db:migrate` applied; the container was removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
