### PR TITLE
ci(e2e): gate the epic's user-story specs and add an evidence manifest

### DIFF
--- a/docs/2.0-architecture/agent-sessions-evidence.json
+++ b/docs/2.0-architecture/agent-sessions-evidence.json
@@ -60,7 +60,7 @@
           "suite": "e2e-playwright"
         }
       ],
-      "notes": "The epic's canonical bug written as an executable spec. The second citation is the harness pin: it proves the dispatch really wrote through the pipeline, so a green live-delivery assertion cannot be an artefact of a dispatch that did nothing. This spec only means what it says when realtime is same-origin — see the CSP note in the .md. STATUS WARNING: 'proven' here means cited, executing and gated by CI — NOT currently green. The live-delivery citation fails in every local run and in CI run 3, but passed on retry in CI run 4, so it is FLAKY rather than deterministic; the harness-pin citation passes everywhere. See the RED GATE table in the .md."
+      "notes": "The epic's canonical bug written as an executable spec. The second citation is the harness pin: it proves the dispatch really wrote through the pipeline, so a green live-delivery assertion cannot be an artefact of a dispatch that did nothing. This spec only means what it says when realtime is same-origin — see the CSP note in the .md. Both citations pass in CI as of run 5, the first run carrying #2363's socket-churn fix; the live-delivery one failed in every run before it. See the RED GATE table in the .md for the full history — 'proven' still means cited, executing and gated, not green, and the CI job remains the thing that reports green."
     },
     {
       "id": "two-windows-see-both-sides-live",
@@ -73,7 +73,7 @@
           "suite": "e2e-playwright"
         }
       ],
-      "notes": "STATUS WARNING: cited, executing and gated — and FAILING in all four recorded runs, local and CI. This is the one assertion that fails everywhere; see the RED GATE table in the .md."
+      "notes": "This was the last assertion still failing everywhere — all four runs, local and CI — and it passes as of CI run 5 with #2363's socket-churn fix. See the RED GATE table in the .md."
     },
     {
       "id": "server-created-conversation-reaches-sidebar",
@@ -125,7 +125,7 @@
           "suite": "e2e-playwright"
         }
       ],
-      "notes": "The durability citation is what separates 'the grid is server-authoritative' from 'both tabs happened to receive one message' — a fresh window reads the rows, not a broadcast. STATUS WARNING: all three citations FAILED locally (the durability one flakily) but all three PASS in both CI runs of the gate on the merged tree. The environment gap is unexplained, so treat these as unsettled rather than green — see the RED GATE table in the .md."
+      "notes": "The durability citation is what separates 'the grid is server-authoritative' from 'both tabs happened to receive one message' — a fresh window reads the rows, not a broadcast. All three citations failed locally (the durability one flakily) and passed in CI even before the fix — the reconnect storm made delivery a race a faster machine often won, which is why the CI passes were not accepted as evidence at the time. All three pass as of CI run 5 with #2363's socket-churn fix. See the RED GATE table in the .md."
     },
     {
       "id": "adversarial-delivery-converges-to-db-truth",

--- a/docs/2.0-architecture/agent-sessions-evidence.json
+++ b/docs/2.0-architecture/agent-sessions-evidence.json
@@ -60,7 +60,7 @@
           "suite": "e2e-playwright"
         }
       ],
-      "notes": "The epic's canonical bug written as an executable spec. The second citation is the harness pin: it proves the dispatch really wrote through the pipeline, so a green live-delivery assertion cannot be an artefact of a dispatch that did nothing. This spec only means what it says when realtime is same-origin — see the CSP note in the .md. STATUS WARNING: 'proven' here means cited, executing and gated by CI — NOT currently green. As of the PR that introduced this manifest, the live-delivery citation FAILS against a correct topology (see RED-GATE note in the .md); the harness-pin citation passes."
+      "notes": "The epic's canonical bug written as an executable spec. The second citation is the harness pin: it proves the dispatch really wrote through the pipeline, so a green live-delivery assertion cannot be an artefact of a dispatch that did nothing. This spec only means what it says when realtime is same-origin — see the CSP note in the .md. STATUS WARNING: 'proven' here means cited, executing and gated by CI — NOT currently green. The live-delivery citation fails in every local run and in CI run 3, but passed on retry in CI run 4, so it is FLAKY rather than deterministic; the harness-pin citation passes everywhere. See the RED GATE table in the .md."
     },
     {
       "id": "two-windows-see-both-sides-live",
@@ -73,7 +73,7 @@
           "suite": "e2e-playwright"
         }
       ],
-      "notes": "STATUS WARNING: cited, executing and gated — but FAILING as of the PR that introduced this manifest. See the RED-GATE note in the .md."
+      "notes": "STATUS WARNING: cited, executing and gated — and FAILING in all four recorded runs, local and CI. This is the one assertion that fails everywhere; see the RED GATE table in the .md."
     },
     {
       "id": "server-created-conversation-reaches-sidebar",
@@ -125,7 +125,7 @@
           "suite": "e2e-playwright"
         }
       ],
-      "notes": "The durability citation is what separates 'the grid is server-authoritative' from 'both tabs happened to receive one message' — a fresh window reads the rows, not a broadcast. STATUS WARNING: the durability citation passes; the two LIVE citations FAIL as of the PR that introduced this manifest — see the RED-GATE note in the .md."
+      "notes": "The durability citation is what separates 'the grid is server-authoritative' from 'both tabs happened to receive one message' — a fresh window reads the rows, not a broadcast. STATUS WARNING: all three citations FAILED locally (the durability one flakily) but all three PASS in both CI runs of the gate on the merged tree. The environment gap is unexplained, so treat these as unsettled rather than green — see the RED GATE table in the .md."
     },
     {
       "id": "adversarial-delivery-converges-to-db-truth",

--- a/docs/2.0-architecture/agent-sessions-evidence.json
+++ b/docs/2.0-architecture/agent-sessions-evidence.json
@@ -177,7 +177,7 @@
         },
         {
           "file": "apps/web/src/lib/websocket/__tests__/conversation-events-audience.test.ts",
-          "name": "no file outside conversation-events.ts emits a conversation:* socket event",
+          "name": "no file outside conversation-events.ts emits a conversation:* event",
           "suite": "web-unit"
         },
         {

--- a/docs/2.0-architecture/agent-sessions-evidence.md
+++ b/docs/2.0-architecture/agent-sessions-evidence.md
@@ -79,21 +79,35 @@ Worth knowing before trusting a green run:
 ## RED GATE: what turning the gate on immediately revealed
 
 Run these specs against a correctly-built topology and they fail — and the failures are exactly
-the live-delivery assertions the epic exists to make true. Two full runs on the same tree:
+the live-delivery assertions the epic exists to make true.
 
-| Spec | Run 1 | Run 2 |
-|---|---|---|
-| `16` — a server dispatch into an open pane renders live without reload | **FAIL** | **FAIL** |
-| `16` — two windows on one conversation both see both sides live | **FAIL** | **FAIL** |
-| `17` — a split in one window appears in the other LIVE, with no reload | **FAIL** | **FAIL** |
-| `17` — converges in BOTH directions: a close in the second window reaches the first | **FAIL** | **FAIL** |
-| `17` — convergence is DURABLE: a window opened afterwards sees the same grid | pass | **FAIL** |
-| **Totals** | 7 passed, 4 failed | 6 passed, 5 failed |
+Runs 1–2 are local, on the tree before this branch merged `pu/broken-sessions`. Runs 3–4 are the
+**CI job itself**, on the merged tree (workflow run `31156153232`, the second a re-run of the
+same job on the same commit). Read them together: the local pair is what turning the gate on
+revealed, the CI pair is what the gate currently reports.
 
-The four live-delivery specs fail deterministically. The durable-convergence spec is **flaky**,
-which is itself diagnostic: it reads the persisted rows rather than a broadcast, so a spec that
-should not depend on delivery timing failing intermittently points at the same instability.
-Everything with no live-socket dependency passed in both runs: both `16` persistence smokes and
+| Spec | Run 1 (local) | Run 2 (local) | Run 3 (CI) | Run 4 (CI) |
+|---|---|---|---|---|
+| `16` — a server dispatch into an open pane renders live without reload | **FAIL** | **FAIL** | **FAIL** | FAIL → pass on retry |
+| `16` — two windows on one conversation both see both sides live | **FAIL** | **FAIL** | **FAIL** | **FAIL** |
+| `17` — a split in one window appears in the other LIVE, with no reload | **FAIL** | **FAIL** | pass | pass |
+| `17` — converges in BOTH directions: a close in the second window reaches the first | **FAIL** | **FAIL** | pass | pass |
+| `17` — convergence is DURABLE: a window opened afterwards sees the same grid | pass | **FAIL** | pass | pass |
+| **Totals** | 7 passed, 4 failed | 6 passed, 5 failed | 9 passed, 2 failed | 9 passed, 1 failed |
+
+**The CI picture is materially better than the local one, and the difference is not yet
+explained.** All three `17` pane-grid specs pass in CI, twice, including the two the local runs
+recorded as deterministic failures; and `16`'s dispatch-renders-live spec passed on retry in run
+4, so it is flaky rather than deterministic there. Exactly **one** assertion fails in every run
+of both environments: `16` — two windows on one conversation both see both sides live.
+
+Do not read the CI columns as "mostly fixed". The gap between the two environments is itself
+unexplained and could as easily be a timing difference that masks the bug as a real improvement
+— a spec that passes for reasons nobody has identified is not evidence. What the CI columns do
+establish is that the local table can no longer be cited as the current state of the gate, and
+that the surviving failure is narrower than "four live-delivery specs".
+
+Everything with no live-socket dependency passed in every run: both `16` persistence smokes and
 all three `15` chat smokes.
 
 The server side was verified healthy in the same run — realtime logged **197**

--- a/docs/2.0-architecture/agent-sessions-evidence.md
+++ b/docs/2.0-architecture/agent-sessions-evidence.md
@@ -76,58 +76,59 @@ Worth knowing before trusting a green run:
   is what review is for — and why several entries cite a *harness pin* alongside the headline
   spec, so a green assertion cannot come from a no-op setup.
 
-## RED GATE: what turning the gate on immediately revealed
+## RED GATE: what turning the gate on revealed, and how it closed
 
-Run these specs against a correctly-built topology and they fail — and the failures are exactly
-the live-delivery assertions the epic exists to make true.
+This section is kept as a record. The gate went in red, the failure it exposed was real, and
+**it is now green** — the whole point of wiring it up, start to finish.
 
 Runs 1–2 are local, on the tree before this branch merged `pu/broken-sessions`. Runs 3–4 are the
-**CI job itself**, on the merged tree (workflow run `31156153232`, the second a re-run of the
-same job on the same commit). Read them together: the local pair is what turning the gate on
-revealed, the CI pair is what the gate currently reports.
+CI job on the merged tree (workflow `31156153232`, the second a re-run of the same job on the
+same commit). Run 5 is the CI job after the branch was refreshed onto the integration branch
+carrying **#2363, the socket-churn fix** (workflow `31160491225`).
 
-| Spec | Run 1 (local) | Run 2 (local) | Run 3 (CI) | Run 4 (CI) |
-|---|---|---|---|---|
-| `16` — a server dispatch into an open pane renders live without reload | **FAIL** | **FAIL** | **FAIL** | FAIL → pass on retry |
-| `16` — two windows on one conversation both see both sides live | **FAIL** | **FAIL** | **FAIL** | **FAIL** |
-| `17` — a split in one window appears in the other LIVE, with no reload | **FAIL** | **FAIL** | pass | pass |
-| `17` — converges in BOTH directions: a close in the second window reaches the first | **FAIL** | **FAIL** | pass | pass |
-| `17` — convergence is DURABLE: a window opened afterwards sees the same grid | pass | **FAIL** | pass | pass |
-| **Totals** | 7 passed, 4 failed | 6 passed, 5 failed | 9 passed, 2 failed | 9 passed, 1 failed |
+| Spec | 1 (local) | 2 (local) | 3 (CI) | 4 (CI) | 5 (CI, post-#2363) |
+|---|---|---|---|---|---|
+| `16` — a server dispatch into an open pane renders live without reload | **FAIL** | **FAIL** | **FAIL** | FAIL → pass on retry | **pass** |
+| `16` — two windows on one conversation both see both sides live | **FAIL** | **FAIL** | **FAIL** | **FAIL** | **pass** |
+| `17` — a split in one window appears in the other LIVE, with no reload | **FAIL** | **FAIL** | pass | pass | **pass** |
+| `17` — converges in BOTH directions: a close in the second window reaches the first | **FAIL** | **FAIL** | pass | pass | **pass** |
+| `17` — convergence is DURABLE: a window opened afterwards sees the same grid | pass | **FAIL** | pass | pass | **pass** |
+| **Totals** | 7 / 4 | 6 / 5 | 9 / 2 | 9 / 1 | **11 passed, 0 failed** |
 
-**The CI picture is materially better than the local one, and the difference is not yet
-explained.** All three `17` pane-grid specs pass in CI, twice, including the two the local runs
-recorded as deterministic failures; and `16`'s dispatch-renders-live spec passed on retry in run
-4, so it is flaky rather than deterministic there. Exactly **one** assertion fails in every run
-of both environments: `16` — two windows on one conversation both see both sides live.
+The clincher is not the column of passes, it is the **clock**. Runs 3 and 4 took 3.5 and 4.1
+minutes, with the failing assertions burning their full 15-second timeout. Run 5 took **34
+seconds** for all eleven, with the two `16` live-delivery specs settling in 2.1s and 3.1s. They
+are not passing by a narrower margin than before; the wait that used to expire is simply gone.
 
-Do not read the CI columns as "mostly fixed". The gap between the two environments is itself
-unexplained and could as easily be a timing difference that masks the bug as a real improvement
-— a spec that passes for reasons nobody has identified is not evidence. What the CI columns do
-establish is that the local table can no longer be cited as the current state of the gate, and
-that the surviving failure is narrower than "four live-delivery specs".
+That also explains the run 3–4 anomaly this table previously recorded as unexplained — the three
+`17` specs passing in CI while failing locally. The bug was a reconnect storm, so delivery was a
+race, not a brick wall: a faster machine won it often enough to look fixed. That is exactly why
+"passes in CI" was not accepted as evidence at the time, and the caution was right — the bug was
+still there.
 
-Everything with no live-socket dependency passed in every run: both `16` persistence smokes and
-all three `15` chat smokes.
+Everything with no live-socket dependency passed in every run, before and after: both `16`
+persistence smokes and all three `15` chat smokes.
 
 The server side was verified healthy in the same run — realtime logged **197**
 `User joined conversation room` entries for the correct `conv:<id>`, and **148** broadcasts were
 sent, including `conversation:message_created` / `conversation:message_updated` to that exact
 room, one second after the client joined it.
 
-The failure is on the client. A single test produced **33** `Creating new Socket.IO connection`
+The failure was on the client. A single test produced **33** `Creating new Socket.IO connection`
 log lines, 33 socket-token fetches and 11+ distinct socket ids, with **no** authentication
-errors and **no** disconnect reasons — the socket store churns connections. No socket survives
+errors and **no** disconnect reasons — the socket store churned connections. No socket survived
 long enough to upgrade off polling (the trace contains zero websocket upgrade attempts), so a
-broadcast lands in a window where the current socket has not yet re-joined, and the pane stays
-blank. This is `apps/web/src/stores/useSocketStore.ts` reconnect behaviour, not a transport or
-CSP problem.
+broadcast landed in a window where the current socket had not yet re-joined, and the pane stayed
+blank. That was `apps/web/src/stores/useSocketStore.ts` reconnect behaviour, not a transport or
+CSP problem — and it is what **#2363** fixed.
 
-`"status": "proven"` in the manifest therefore means **cited, executing, and gated by CI** — it
-does not mean currently green. The checker verifies that a named test exists, runs, and is in a
-suite CI executes; whether it *passes* is what the CI job itself reports. That separation is
-deliberate: a manifest that could only cite green tests would have quietly dropped these four
-the moment they broke, which is the precise failure it exists to prevent.
+`"status": "proven"` in the manifest means **cited, executing, and gated by CI**. It does not
+mean currently green, and that separation is deliberate even now that the gate is green: the
+checker verifies that a named test exists, runs, and is in a suite CI executes; whether it
+*passes* is what the CI job itself reports. A manifest that could only cite green tests would
+have quietly dropped these five the moment they broke — the precise failure it exists to
+prevent, and the reason the citations survived the whole red period above to be vindicated by
+run 5 rather than being deleted somewhere around run 2.
 
 ## Adding a guarantee
 

--- a/scripts/__tests__/check-evidence-manifest.test.ts
+++ b/scripts/__tests__/check-evidence-manifest.test.ts
@@ -127,6 +127,31 @@ describe('blankOutLiteralsAndComments', () => {
     expect(stripped).not.toContain('{');
     expect(stripped).not.toContain('}');
   });
+
+  // A regex is the one construct that can smuggle an unbalanced quote past a naive scanner.
+  // conversation-events-audience.test.ts really contains `/event:\s*(['"`])...;/g`, and
+  // without regex handling the lone `'` inside that class opened a string that swallowed the
+  // rest of the file — every test declared after it went invisible.
+  it('should not treat a quote inside a regex literal as opening a string', () => {
+    const source = [
+      `const EVENT_LITERAL = /event:\\s*(['"\`])((?:\\\\.|(?!\\1)[\\s\\S])*?)\\1/g;`,
+      `it('survives the regex above', () => {});`,
+    ].join('\n');
+
+    expect(parseDeclarations(source).map((d) => d.name)).toEqual(['survives the regex above']);
+  });
+
+  it('should still treat a slash between values as division, not a regex', () => {
+    // `(a) / b` then `c / d`: if either were read as a regex, everything up to the next
+    // slash would be blanked and the declaration after it would disappear.
+    const source = [
+      `const ratio = (total) / count;`,
+      `const other = size / 2;`,
+      `it('survives the divisions above', () => {});`,
+    ].join('\n');
+
+    expect(parseDeclarations(source).map((d) => d.name)).toEqual(['survives the divisions above']);
+  });
 });
 
 describe('checkManifest failure modes', () => {

--- a/scripts/check-evidence-manifest.ts
+++ b/scripts/check-evidence-manifest.ts
@@ -103,6 +103,33 @@ const SKIP_MODIFIERS = new Set(['skip', 'fixme', 'todo']);
  * counting for describe nesting never trips over a `{` inside a test name or a comment. Keeping
  * the length identical means offsets computed on the stripped copy still address the original.
  */
+/**
+ * Keywords after which a `/` opens a REGEX rather than dividing. Everything else that can
+ * precede a regex is punctuation (`=`, `(`, `[`, `,`, `:`, `&&`, …), which the check below
+ * accepts by default; the only ambiguity is a bare word, and a word is a regex prefix only
+ * when it is one of these.
+ */
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+  'case', 'do', 'else', 'yield', 'await', 'throw',
+]);
+
+/** Is the `/` at `index` the start of a regex literal, rather than a division operator? */
+function regexAllowedAt(source: string, index: number): boolean {
+  let k = index - 1;
+  while (k >= 0 && /\s/.test(source[k])) k--;
+  if (k < 0) return true; // start of file
+  const prev = source[k];
+  // A closing bracket ends a VALUE, so what follows is an operator: `f(x) / 2`, `a[i] / 2`.
+  if (prev === ')' || prev === ']' || prev === '}') return false;
+  if (/[A-Za-z0-9_$]/.test(prev)) {
+    let start = k;
+    while (start >= 0 && /[A-Za-z0-9_$]/.test(source[start])) start--;
+    return REGEX_PRECEDING_KEYWORDS.has(source.slice(start + 1, k + 1));
+  }
+  return true;
+}
+
 export function blankOutLiteralsAndComments(source: string): string {
   const out = source.split('');
   let i = 0;
@@ -122,6 +149,32 @@ export function blankOutLiteralsAndComments(source: string): string {
       const stop = end === -1 ? source.length : end + 2;
       blankTo(stop);
       i = stop;
+    } else if (ch === '/' && regexAllowedAt(source, i)) {
+      // A REGEX LITERAL. Without this branch a pattern containing a quote —
+      // `/event:\s*(['"`]).../g` in conversation-events-audience.test.ts — puts the scanner
+      // into string mode at that quote and desynchronises it for the rest of the file, so
+      // every test declared after it becomes invisible (a false MISSING_TEST, or worse, a
+      // `.skip` nobody notices). `/` inside a `[...]` class does not close the literal, and a
+      // regex cannot span a newline — hitting one means this was division after all.
+      let j = i + 1;
+      let inClass = false;
+      let closed = false;
+      while (j < source.length) {
+        const c = source[j];
+        if (c === '\\') { j += 2; continue; }
+        if (c === '\n') break;
+        if (c === '[') inClass = true;
+        else if (c === ']') inClass = false;
+        else if (c === '/' && !inClass) { closed = true; break; }
+        j++;
+      }
+      if (!closed) {
+        i++; // not a regex; leave the character alone
+      } else {
+        const stop = Math.min(j + 1, source.length);
+        blankTo(stop);
+        i = stop;
+      }
     } else if (ch === "'" || ch === '"' || ch === '`') {
       const quote = ch;
       let j = i + 1;


### PR DESCRIPTION
The epic's headline user-story proofs did not run in CI.

`apps/e2e` has the Playwright specs that prove the Agent-Session Single Source of Truth epic's core claims — a server dispatch rendering live in an open pane, two windows seeing both sides, the pane grid converging across two devices. **There was no e2e job in `.github/workflows/` at all.** The specs' own headers said so: *"There is no e2e job in CI, so these run locally."* They only ever ran when a human remembered.

This PR closes that, and adds a machine-checked manifest so the same class of gap becomes loud instead of silent.

---

## 1. The e2e job

Runs specs **15/16/17 only**, not the whole suite. The metering (09–14) and real-storage (08) specs need Stripe and S3 credentials and cost far more runner time than their regression risk justifies here. Widening the job means widening its spec list *and* the manifest's citations — `requiresFileListedInCi` ties the two together, so they can't drift apart.

The topology is not arbitrary. Each part is load-bearing, and getting it wrong **does not fail loudly** — it makes the specs pass for the wrong reason:

| Piece | Why it is required |
|---|---|
| **Production build** (`next build && next start`) | The app's own CSP has no `unsafe-eval` in `script-src`. The dev bundler needs eval to hydrate, so under `next dev` pages render but never become interactive and every spec fails looking like an app bug. |
| **Same-origin sockets via a reverse proxy** (`apps/e2e/support/e2e-proxy.ts`) | The CSP is `connect-src 'self' ws: wss:` and Socket.IO opens with an **XHR polling** handshake before it upgrades. A cross-origin realtime server gets that handshake blocked → **zero** room joins → and the live-delivery specs **still pass**, off the mount-time refetch. They'd be testing nothing, permanently. Production avoids this because Traefik path-routes `/socket.io` to realtime on the app's own host; the proxy is that rule in ~90 dependency-free lines. `NEXT_PUBLIC_REALTIME_URL` stays **unset** so the socket store falls back to same-origin. |
| **Readiness probed *through* the proxy** | The wait step requires a `"sid"` from `/socket.io/?EIO=4&transport=polling` **on the proxy port**. Probing realtime directly on `:3001` would pass with the proxy rule broken — the exact silent misconfiguration this job exists to rule out. |
| **Postgres + `bun run --filter '@pagespace/db' db:migrate`** | Must run from the package; drizzle resolves its migrations folder package-relative, so a repo-root invocation silently migrates nothing. |
| Playwright report + traces uploaded on failure; server logs tailed on failure | A silent socket is the failure mode that makes these specs meaningless, so the logs that reveal it are surfaced automatically. |

## 2. Proving the gate actually gates

A gate nobody has seen fail is not known to be a gate. Two deliberate breaks, both reverted:

**A — break the socket route.** Pointed the proxy's realtime target at a dead port and ran the CI readiness probe:

```
PROBE FAILED (correct - job would stop here)
web still 200 (so only the socket route is broken)
```

The app answers `200` while the socket path is dead — precisely the "passes for the wrong reason" state — and the job **stops at the wait step** instead of running specs against a dead socket.

**B — break the app under test.** Restarted web with `OPENROUTER_BASE_URL` on a dead port (app healthy, `/api/health` → `200`) and re-ran spec 15:

```
2 failed
  a send in slow mode grows an assistant bubble while streaming
  a held stream keeps the Stop affordance up until released
1 passed
```

The static-render spec still passes while both streaming specs fail — the assertions are genuinely end-to-end, not vacuous. Both breaks reverted; the committed config is the working one.

## 3. 🔴 Turning the gate on immediately found a real failure

Two full runs on the same tree, against a verified-correct topology:

| Spec | Run 1 | Run 2 |
|---|---|---|
| `16` — a server dispatch into an open pane renders live without reload | **FAIL** | **FAIL** |
| `16` — two windows on one conversation both see both sides live | **FAIL** | **FAIL** |
| `17` — a split in one window appears in the other LIVE, with no reload | **FAIL** | **FAIL** |
| `17` — converges in BOTH directions: a close in the second window reaches the first | **FAIL** | **FAIL** |
| `17` — convergence is DURABLE: a window opened afterwards sees the same grid | pass | **FAIL** |
| **Totals** | 7 passed, 4 failed | 6 passed, 5 failed |

The four live-delivery specs fail deterministically. The durable-convergence spec is **flaky**, which is itself diagnostic: it reads persisted rows rather than a broadcast, so a spec that should not depend on delivery timing failing intermittently points at the same instability. Everything with no live-socket dependency passed in both runs: both `16` persistence smokes and all three `15` chat smokes.

**The server side is healthy** — verified in the same run, so this is not the CSP/proxy trap:
- realtime logged **197** × `User joined conversation room` for the correct `conv:<id>`;
- **148** broadcasts sent, including `conversation:message_created` / `conversation:message_updated` to that exact room, one second *after* the client joined it.

**The failure is client-side.** A single test produced **33** `Creating new Socket.IO connection` lines, 33 socket-token fetches and 11+ distinct socket ids, with **no** authentication errors and **no** disconnect reasons. `apps/web/src/stores/useSocketStore.ts` is churning connections; no socket survives long enough to upgrade off polling (the Playwright trace contains **zero** websocket upgrade attempts), so a broadcast lands in a window where the current socket has not re-joined and the pane stays blank.

This is reported, not worked around. **Merging this makes CI red until that churn is fixed** — which is the point of having a gate. Please decide whether to fix the churn first or land the gate red deliberately.

## 4. The evidence manifest

`docs/2.0-architecture/agent-sessions-evidence.json` is the single source of truth; `agent-sessions-evidence.md` deliberately contains **no per-guarantee data**, so the doc cannot drift from the manifest. Enforced by `scripts/check-evidence-manifest.ts` in the `unit-tests` job.

Failure modes:

| Code | Fires when |
|---|---|
| `MISSING_FILE` | A cited test file moved or was deleted. |
| `MISSING_TEST` | The file declares no test with the cited name (someone reworded an `it(...)`). |
| `SKIPPED_TEST` | The cited test is `.skip` / `.fixme` / `.todo`, or inside a `describe.skip`. |
| `UNRUN_SUITE` | The cited test lives in a suite **no CI job runs**. |
| `MALFORMED` | A guarantee is neither honestly proven nor honestly an owned gap. |

`UNRUN_SUITE` is checked against the workflow files themselves, never a list hardcoded in the checker: each suite declares a workflow path plus a literal marker that must appear in it. Delete the e2e job and the marker vanishes and CI fails. Suites whose runner names each file by hand (`scripts/__tests__`) also set `requiresFileListedInCi`.

**It found a second live gap while being written:** `scripts/__tests__/tenant-export-columns.test.ts` — 64 passing tests never named in `ci.yml`'s hand-maintained list, so never run in CI. Now listed (verified passing: `64 passed`).

`"status": "proven"` means **cited, executing, and gated** — not "currently green". Whether a cited test passes is what the CI job reports. A manifest that could only cite green tests would have quietly dropped the four failing specs the moment they broke.

## 5. Guarantees currently recorded as unproven gaps

Both carry `TODO(owner)` markers; the checker rejects a gap without one.

- **`sidebar-renders-server-created-conversation-end-to-end`** — the listener→SWR-key→`AgentsSidebar` seam has no test. The listener unit test proves the cache write happens with `revalidate: false` (no round-trip), but nothing asserts the listener's mutate key equals the key the sidebar subscribes to; that holds by construction only. `AgentsSidebar.test.tsx` mocks SWR data directly and contains nothing socket-driven, and the sidebar still carries a 120 s `refreshInterval` documented in-file as a backstop. So "appears without a poll tick" is proven one layer below the user-visible claim.
- **`gdpr-export-covers-agent-session-tables`** — **not implemented, therefore no evidence.** `packages/lib/src/compliance/export/gdpr-export.ts` has no collector for `agent_sessions`, `agent_session_shells` or `ai_stream_sessions`, so `GET /api/account/export` cannot return them: the epic moved user-visible work into tables the subject access request does not read. The existing route test (`appends all data categories to archive`) asserts the current category list and therefore **locks the omission in rather than catching it**. There is also no "every table is accounted for" drift guard for the GDPR export — the only such guard covers the separate tenant export. (Adjacent, not the same hole: `TABLE_IMPORT_ORDER` carries `agent_sessions` but not the other two.)

Also recorded as a caveat the checker structurally **cannot** see: several compliance integration suites gate every test body on a `dbAvailable` probe rather than reporting a skip, so with no reachable Postgres they pass with **zero assertions and no signal**. That is a silent green, not a skip.

## Gates

| Gate | Result |
|---|---|
| `bun run lint` | 14/14 tasks pass |
| `bun run typecheck` | 16/16 tasks pass |
| `bun run knip:check` | 4 issues, all within baseline (known Capacitor false positives) |
| `check-evidence-manifest.test.ts` | **25 passed** |
| `scripts/check-evidence-manifest.ts` | exit 0 — 13 guarantees, 11 proven, 2 gaps |
| `tenant-export-columns.test.ts` (newly wired) | **64 passed** |
| e2e specs 15/16/17 | **7 passed / 4 failed**, then **6 passed / 5 failed** — see §3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
