### PR TITLE
fix(db): migration integrity — client straddle, stale twins, pane dedupe, cascade net

### DIFF
--- a/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
@@ -16,7 +16,16 @@ vi.mock('@pagespace/db/db', () => ({
     },
     update: vi.fn(),
     delete: vi.fn(),
+    // The drive delete runs in a transaction now — its chat history has to go
+    // with it, and the two must not be able to half-happen. The tx exposes the
+    // same `delete` mock the assertions already inspect.
+    transaction: vi.fn(),
   },
+}));
+// A collaborator with its own live-DB coverage — see
+// `apps/web/src/lib/repositories/__tests__/chat-mutation-matrix.integration.test.ts`.
+vi.mock('@pagespace/lib/repositories/conversation-cleanup', () => ({
+  deleteConversationsForDrive: vi.fn().mockResolvedValue({ conversations: 0, messages: 0 }),
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
@@ -128,7 +137,9 @@ describe('POST /api/account/handle-drive', () => {
     return whereMock;
   };
 
-  // Helper to setup delete mock
+  // Helper to setup delete mock. The route deletes inside a transaction, so
+  // the tx handed to the callback carries the same `delete` chain — the
+  // assertions below inspect that one mock either way.
   const setupDeleteMock = () => {
     const whereMock = vi.fn().mockResolvedValue(undefined);
     vi.mocked(db.delete).mockReturnValue({ where: whereMock } as unknown as ReturnType<typeof db.delete>);
@@ -137,6 +148,10 @@ describe('POST /api/account/handle-drive', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    vi.mocked(db.transaction).mockImplementation(async (fn) =>
+      fn({ delete: db.delete } as unknown as Parameters<typeof fn>[0]),
+    );
 
     // Setup default auth success
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(

--- a/apps/web/src/app/api/account/handle-drive/route.ts
+++ b/apps/web/src/app/api/account/handle-drive/route.ts
@@ -7,6 +7,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { deleteConversationsForDrive } from '@pagespace/lib/repositories/conversation-cleanup';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -108,8 +109,16 @@ export async function POST(req: Request) {
     }
 
     if (action === 'delete') {
-      // Delete the drive (CASCADE will handle members and pages)
-      await db.delete(drives).where(eq(drives.id, driveId));
+      // Delete the drive (CASCADE will handle members and pages). Chat history
+      // is NOT part of that cascade — `conversations.contextId` is not a
+      // foreign key — so it goes first, explicitly, while the drive's pages
+      // still exist to be traced through. This route is account-deletion prep,
+      // which makes it an Article 17 path: leaving conversations behind would
+      // strand their messages and `ai_stream_sessions.parts` content.
+      await db.transaction(async (tx) => {
+        await deleteConversationsForDrive(tx, driveId);
+        await tx.delete(drives).where(eq(drives.id, driveId));
+      });
 
       loggers.auth.info(`Drive deleted during account deletion preparation: ${driveId} by ${userId}`);
 

--- a/apps/web/src/app/api/trash/[pageId]/route.ts
+++ b/apps/web/src/app/api/trash/[pageId]/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { and, eq, sql } from '@pagespace/db/operators'
+import { eq, sql } from '@pagespace/db/operators'
 import { pages, favorites, pageTags } from '@pagespace/db/schema/core'
 import { pagePermissions } from '@pagespace/db/schema/members'
-import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { channelMessages } from '@pagespace/db/schema/chat';
-import { inArray, or } from '@pagespace/db/operators'
+import { deleteConversationsForPages } from '@pagespace/lib/repositories/conversation-cleanup';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config'
@@ -32,25 +31,15 @@ async function recursivelyDelete(pageId: string, tx: typeof db) {
     // nothing else would do it: `conversations.contextId` has never been a
     // foreign key, `conversations.agentPageId`'s is ON DELETE SET NULL, and
     // the `chat_messages.pageId` cascade that used to cover this went with the
-    // table at PR 15. Without this statement a permanently deleted page's chat
-    // history would outlive it, still readable by conversation id.
+    // table at PR 15. Without this a permanently deleted page's chat history
+    // would outlive it, still readable by conversation id.
     //
-    // The conversation set is exactly `unifiedPageScope`'s two disjuncts: the
-    // page's own `type='page'` threads, plus the `type='client'` API threads
-    // that named it. Collected BEFORE the `pages` delete below, which is what
-    // clears `agentPageId`.
-    const pageConversationIds = await tx
-      .select({ id: conversations.id })
-      .from(conversations)
-      .where(or(
-        and(eq(conversations.type, 'page'), eq(conversations.contextId, pageId)),
-        and(eq(conversations.type, 'client'), eq(conversations.agentPageId, pageId)),
-      ));
-    if (pageConversationIds.length > 0) {
-      await tx.delete(messages).where(
-        inArray(messages.conversationId, pageConversationIds.map((c) => c.id)),
-      );
-    }
+    // Called BEFORE the `pages` delete below, which is what clears
+    // `agentPageId`. This statement used to be written inline here, which is
+    // why every OTHER deletion path — the cron purge and all four drive-delete
+    // sites — silently under-deleted; it now lives in one shared helper they
+    // all call. Recursion above means this node's own id is the whole scope.
+    await deleteConversationsForPages(tx, [pageId]);
 
     await tx.delete(channelMessages).where(eq(channelMessages.pageId, pageId));
 

--- a/apps/web/src/app/api/trash/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/trash/drives/[driveId]/__tests__/route.test.ts
@@ -10,6 +10,7 @@ const {
   mockGetRecipients,
   mockBroadcast,
   mockAuditRequest,
+  mockDeleteConversationsForDrive,
 } = vi.hoisted(() => ({
   mockFindDrive: vi.fn(),
   mockDeleteWhere: vi.fn(),
@@ -17,13 +18,25 @@ const {
   mockGetRecipients: vi.fn(),
   mockBroadcast: vi.fn(),
   mockAuditRequest: vi.fn(),
+  mockDeleteConversationsForDrive: vi.fn(),
 }));
 
+// The delete now runs in a transaction, because the drive's chat history has
+// to go with it and the two must not be able to half-happen. `transaction`
+// hands the callback a tx with the same `delete` chain the route used before.
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: { drives: { findFirst: (...args: unknown[]) => mockFindDrive(...args) } },
     delete: () => ({ where: (...args: unknown[]) => mockDeleteWhere(...args) }),
+    transaction: (fn: (tx: unknown) => unknown) => fn({
+      delete: () => ({ where: (...args: unknown[]) => mockDeleteWhere(...args) }),
+    }),
   },
+}));
+// A collaborator with its own live-DB coverage — see
+// `apps/web/src/lib/repositories/__tests__/chat-mutation-matrix.integration.test.ts`.
+vi.mock('@pagespace/lib/repositories/conversation-cleanup', () => ({
+  deleteConversationsForDrive: (...args: unknown[]) => mockDeleteConversationsForDrive(...args),
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((...args: unknown[]) => ({ eq: args })),
@@ -70,6 +83,7 @@ beforeEach(() => {
   mockGetRecipients.mockResolvedValue(['user-1']);
   mockBroadcast.mockResolvedValue(undefined);
   mockDeleteWhere.mockResolvedValue(undefined);
+  mockDeleteConversationsForDrive.mockResolvedValue({ conversations: 0, messages: 0 });
 });
 
 describe('DELETE /api/trash/drives/[driveId]', () => {
@@ -80,6 +94,13 @@ describe('DELETE /api/trash/drives/[driveId]', () => {
     expect(response.status).toBe(200);
     expect(body).toEqual({ success: true });
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    // The drive's chat history goes with it, and goes FIRST: `pages.driveId`
+    // cascades, so after the drive row is gone nothing can find the
+    // page-scoped conversations any more. Before this, permanently deleting a
+    // drive left its whole chat history behind.
+    expect(mockDeleteConversationsForDrive).toHaveBeenCalledWith(expect.anything(), 'drive-1');
+    expect(mockDeleteConversationsForDrive.mock.invocationCallOrder[0])
+      .toBeLessThan(mockDeleteWhere.mock.invocationCallOrder[0]);
     expect(mockBroadcast).toHaveBeenCalledTimes(1);
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/web/src/app/api/trash/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/trash/drives/[driveId]/route.ts
@@ -8,6 +8,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { deleteConversationsForDrive } from '@pagespace/lib/repositories/conversation-cleanup';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -49,10 +50,18 @@ export async function DELETE(
     // Get recipients BEFORE deleting (ensures we have valid member list)
     const recipientUserIds = await getDriveRecipientUserIds(drive.id);
 
-    // Permanently delete the drive (cascade will delete all pages)
-    await db
-      .delete(drives)
-      .where(eq(drives.id, drive.id));
+    // Permanently delete the drive (cascade will delete all pages).
+    //
+    // Chat history is NOT covered by that cascade and has to be deleted
+    // explicitly, BEFORE the drive goes: `conversations.contextId` is not a
+    // foreign key, and once `pages.driveId` cascades the drive's pages away
+    // there is nothing left to trace the page-scoped threads through. The
+    // `chat_messages.pageId` cascade that used to make this automatic was
+    // dropped with the table in migration 0252.
+    await db.transaction(async (tx) => {
+      await deleteConversationsForDrive(tx, drive.id);
+      await tx.delete(drives).where(eq(drives.id, drive.id));
+    });
 
     // Broadcast drive deletion event (permanent delete)
     await broadcastDriveEvent(

--- a/apps/web/src/lib/repositories/__tests__/chat-mutation-matrix.integration.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/chat-mutation-matrix.integration.test.ts
@@ -58,10 +58,16 @@ vi.mock('@/lib/channels/notify-mentioned-users', () => ({
 }));
 
 import { db } from '@pagespace/db/db';
-import { and, eq, inArray, or } from '@pagespace/db/operators';
-import { pages } from '@pagespace/db/schema/core';
+import { eq, inArray } from '@pagespace/db/operators';
+import { drives, pages } from '@pagespace/db/schema/core';
 import { conversations, messages } from '@pagespace/db/schema/conversations';
+import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { factories } from '@pagespace/db/test/factories';
+import {
+  deleteConversationsForDrive,
+  deleteConversationsForPages,
+} from '@pagespace/lib/repositories/conversation-cleanup';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { messageRepository } from '@/lib/repositories/message-repository';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { previewAiUndo, executeAiUndo } from '@/services/api/ai-undo-service';
@@ -496,7 +502,38 @@ describe('chat mutation matrix — one message table', () => {
   // -------------------------------------------------------------------------
 
   describe('permanent page delete', () => {
-    it('takes the unified rows with it — nothing else would', async () => {
+    /**
+     * Everything that must be gone once a page or drive is permanently
+     * deleted. `chat_messages.pageId REFERENCES pages ON DELETE CASCADE` was
+     * the physical net under all of this until migration 0252 dropped the
+     * table; what replaced it reaches none of it, because
+     * `conversations.contextId` is not a foreign key and `agentPageId`'s is
+     * ON DELETE SET NULL. Verified against a migrated database: before this
+     * fix, `DELETE FROM pages` left every one of these counts non-zero.
+     */
+    async function survivorsOf(conversationId: string) {
+      const [row] = await db.execute(
+        `SELECT
+           (SELECT count(*)::int FROM conversations WHERE id = '${conversationId}') AS conversations,
+           (SELECT count(*)::int FROM messages WHERE "conversationId" = '${conversationId}') AS messages,
+           (SELECT count(*)::int FROM ai_stream_sessions WHERE conversation_id = '${conversationId}') AS streams`,
+      ).then((r) => r.rows as Array<{ conversations: number; messages: number; streams: number }>);
+      return row;
+    }
+
+    /** A stream checkpoint — `parts` is message content, and it cascades from
+     *  `conversations` and from nothing else. The reason the shell must go. */
+    async function seedStreamCheckpoint(conversationId: string, userId: string) {
+      await db.insert(aiStreamSessions).values({
+        messageId: createId(),
+        channelId: `conversation:${conversationId}`,
+        conversationId,
+        userId,
+        parts: [{ type: 'text', text: 'half-streamed secret' }],
+      });
+    }
+
+    it('takes the unified rows AND the conversation shell with it — nothing else would', async () => {
       if (!dbAvailable) return;
       const thread = await seedPageThread({
         contents: [
@@ -504,50 +541,137 @@ describe('chat mutation matrix — one message table', () => {
           { role: 'assistant', content: 'also purged' },
         ],
       });
+      await seedStreamCheckpoint(thread.conversationId, thread.ownerId);
 
-      // The trash route's statement, verbatim (it is a route handler with auth
-      // and recursion around it; the DELETE is the part that matters here).
-      const pageConversationIds = await db
-        .select({ id: conversations.id })
-        .from(conversations)
-        .where(or(
-          and(eq(conversations.type, 'page'), eq(conversations.contextId, thread.pageId)),
-          and(eq(conversations.type, 'client'), eq(conversations.agentPageId, thread.pageId)),
-        ));
-      expect(pageConversationIds).toHaveLength(1);
-      await db.delete(messages).where(inArray(messages.conversationId, pageConversationIds.map((c) => c.id)));
+      // The SHARED helper the trash route now calls — not a re-implementation
+      // of its statement. This test used to inline the route's DELETE, which
+      // is precisely why the cron purge and the drive-delete paths could drift
+      // away from it unnoticed.
+      await db.transaction(async (tx) => {
+        await deleteConversationsForPages(tx, [thread.pageId]);
+        await tx.delete(pages).where(eq(pages.id, thread.pageId));
+      });
 
       expect(await messageRepository.getMessagesByConversationId(thread.conversationId)).toEqual([]);
-
-      // Nothing else would have done it. `conversations.contextId` has never
-      // been a foreign key, `conversations.agentPageId`'s is ON DELETE SET
-      // NULL, and the `chat_messages.pageId` cascade that used to cover this
-      // went with the table — so without the explicit DELETE above, a
-      // permanently deleted page's chat history would outlive it and stay
-      // readable by conversation id. The absence of any page-carrying column
-      // on `messages` is the other half of that statement.
-      const [pageColumn] = await db.execute(
-        `SELECT COUNT(*)::int AS n FROM information_schema.columns
-          WHERE table_name = 'messages' AND column_name = 'pageId'`,
-      ).then((r) => r.rows as Array<{ n: number }>);
-      expect(pageColumn.n).toBe(0);
+      expect(await survivorsOf(thread.conversationId)).toEqual({
+        conversations: 0, messages: 0, streams: 0,
+      });
     });
 
     it('takes an API thread that named the page with it too', async () => {
       if (!dbAvailable) return;
       const t = await seedClientThread();
+      await seedStreamCheckpoint(t.conversationId, t.ownerId);
 
-      const pageConversationIds = await db
-        .select({ id: conversations.id })
-        .from(conversations)
-        .where(or(
-          and(eq(conversations.type, 'page'), eq(conversations.contextId, t.pageId)),
-          and(eq(conversations.type, 'client'), eq(conversations.agentPageId, t.pageId)),
-        ));
-      expect(pageConversationIds.map((c) => c.id)).toEqual([t.conversationId]);
-      await db.delete(messages).where(inArray(messages.conversationId, pageConversationIds.map((c) => c.id)));
+      await db.transaction(async (tx) => {
+        await deleteConversationsForPages(tx, [t.pageId]);
+        await tx.delete(pages).where(eq(pages.id, t.pageId));
+      });
 
       expect(await messageRepository.getMessagesByConversationId(t.conversationId)).toEqual([]);
+      expect(await survivorsOf(t.conversationId)).toEqual({
+        conversations: 0, messages: 0, streams: 0,
+      });
+    });
+
+    it('DELETING THE DRIVE takes its pages\' chat history too, not just the drive', async () => {
+      if (!dbAvailable) return;
+      // A drive delete cascades `pages`, and page-scoped conversations were
+      // stranded by exactly that: once the pages are gone nothing can trace
+      // them. Both a page thread and a drive-scoped API thread must go.
+      const thread = await seedPageThread({ contents: [{ role: 'user', content: 'drive-scoped secret' }] });
+      await seedStreamCheckpoint(thread.conversationId, thread.ownerId);
+      const clientConversationId = createId();
+      await db.insert(conversations).values({
+        id: clientConversationId,
+        userId: thread.ownerId,
+        type: 'client',
+        contextId: thread.driveId,
+        isActive: true,
+        updatedAt: new Date(),
+      });
+      await db.insert(messages).values({
+        id: createId(),
+        conversationId: clientConversationId,
+        userId: thread.ownerId,
+        role: 'user',
+        content: 'api secret',
+        isActive: true,
+        status: 'complete' as const,
+        createdAt: new Date(),
+      });
+
+      await db.transaction(async (tx) => {
+        await deleteConversationsForDrive(tx, thread.driveId);
+        await tx.delete(drives).where(eq(drives.id, thread.driveId));
+      });
+
+      expect(await survivorsOf(thread.conversationId)).toEqual({
+        conversations: 0, messages: 0, streams: 0,
+      });
+      expect(await survivorsOf(clientConversationId)).toEqual({
+        conversations: 0, messages: 0, streams: 0,
+      });
+    });
+
+    it('the CRON purge cleans up the pages it deletes — and ONLY those', async () => {
+      if (!dbAvailable) return;
+      // `purgeExpiredTrashedPages` was a bare `DELETE FROM pages` — an
+      // automatic Article 17 path that cleaned up nothing at all.
+      //
+      // The child page pins the OTHER boundary. `pages.parentId` carries no
+      // foreign key, so purging a trashed parent orphans its children rather
+      // than cascading to them, and trashing marks only the page named. A fix
+      // that "helpfully" expanded to the subtree would delete the chat history
+      // of a page that still exists — an over-deletion strictly worse than the
+      // bug it replaced. The child's history must SURVIVE.
+      const parent = await seedPageThread({ contents: [{ role: 'user', content: 'parent secret' }] });
+      const childPage = await factories.createPage(parent.driveId, {
+        type: 'AI_CHAT', title: 'Child', parentId: parent.pageId,
+      });
+      const childConversationId = createId();
+      await db.insert(conversations).values({
+        id: childConversationId,
+        userId: parent.ownerId,
+        type: 'page',
+        contextId: childPage.id,
+        isActive: true,
+        updatedAt: new Date(),
+      });
+      await db.insert(messages).values({
+        id: createId(),
+        conversationId: childConversationId,
+        userId: parent.ownerId,
+        role: 'user',
+        content: 'child secret',
+        isActive: true,
+        status: 'complete' as const,
+        createdAt: new Date(),
+      });
+      await seedStreamCheckpoint(childConversationId, parent.ownerId);
+
+      // Trashed 31 days ago — past the cron's 30-day cutoff.
+      const longAgo = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+      await db.update(pages).set({ isTrashed: true, trashedAt: longAgo })
+        .where(eq(pages.id, parent.pageId));
+
+      const purged = await pageRepository.purgeExpiredTrashedPages(
+        new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      );
+      expect(purged).toBeGreaterThanOrEqual(1);
+
+      // The purged page is gone, and so is everything that referred to it.
+      const remaining = await db.select({ id: pages.id }).from(pages)
+        .where(inArray(pages.id, [parent.pageId, childPage.id]));
+      expect(remaining.map((p) => p.id)).toEqual([childPage.id]);
+      expect(await survivorsOf(parent.conversationId)).toEqual({
+        conversations: 0, messages: 0, streams: 0,
+      });
+      // The surviving child keeps its history — cleanup is scoped to the rows
+      // actually deleted.
+      expect(await survivorsOf(childConversationId)).toEqual({
+        conversations: 1, messages: 1, streams: 1,
+      });
     });
   });
 

--- a/packages/db/drizzle/0246_vengeful_veda.sql
+++ b/packages/db/drizzle/0246_vengeful_veda.sql
@@ -58,10 +58,29 @@ CREATE INDEX "agent_workspace_panes_workspace_idx" ON "agent_workspace_panes" US
 -- is simply never read. Session counts are small, so this in-migration sweep
 -- IS the backfill — no separate cloud script, which also covers
 -- version-skipping tenant/onprem upgrades that have no operator to run one.
+--
+-- DEDUPLICATION (`DISTINCT ON`) is load-bearing, not tidiness. The blob is
+-- CLIENT-AUTHORED and has never had a uniqueness constraint on pane or column
+-- ids, but the relational tables are keyed by the compound `(workspaceId, id)`.
+-- A blob that repeats one pane id in two columns therefore produces two rows
+-- that collide, and a bare `ON CONFLICT DO NOTHING` would SILENTLY DISCARD the
+-- second — leaving 0251's drop guard staring at a blob pane the rows lack, and
+-- refusing to drop the column over a pane THIS statement had just eaten.
+-- (0251's documented remedy, "delete the rows and let the sweep re-promote",
+-- re-ran the identical losing insert: an unrecoverable loop.)
+--
+-- Collapsing to the FIRST occurrence — ordered by column position, then pane
+-- position — matches how the client itself resolves a duplicate id when it
+-- renders the blob, so the row that survives is the pane the user was actually
+-- looking at. `ON CONFLICT DO NOTHING` is KEPT, but now only to make the
+-- statement re-runnable rather than to paper over in-batch collisions.
 DO $$
+DECLARE
+  dup_columns bigint;
+  dup_panes bigint;
 BEGIN
   INSERT INTO "agent_workspace_pane_columns" ("id", "workspaceId", "orderIndex", "createdAt", "updatedAt")
-  SELECT
+  SELECT DISTINCT ON (s."id", col.value ->> 'id')
     col.value ->> 'id',
     s."id",
     (col.ordinality - 1)::int,
@@ -73,10 +92,11 @@ BEGIN
     AND jsonb_typeof(s."workspaceState" -> 'columns') = 'array'
     AND jsonb_typeof(col.value) = 'object'
     AND col.value ->> 'id' IS NOT NULL
+  ORDER BY s."id", col.value ->> 'id', col.ordinality
   ON CONFLICT DO NOTHING;
 
   INSERT INTO "agent_workspace_panes" ("id", "workspaceId", "columnId", "orderIndex", "kind", "targetId", "createdAt", "updatedAt")
-  SELECT
+  SELECT DISTINCT ON (s."id", pane.value ->> 'id')
     pane.value ->> 'id',
     s."id",
     col.value ->> 'id',
@@ -95,7 +115,44 @@ BEGIN
     AND jsonb_typeof(col.value -> 'panes') = 'array'
     AND jsonb_typeof(pane.value) = 'object'
     AND pane.value ->> 'id' IS NOT NULL
+  ORDER BY s."id", pane.value ->> 'id', col.ordinality, pane.ordinality
   ON CONFLICT DO NOTHING;
+
+  -- Report what was collapsed. A silently deduplicated pane is still a pane
+  -- the user loses, so the number belongs on the deploy record even though
+  -- keeping one of the two is the only representable outcome.
+  SELECT count(*) INTO dup_columns FROM (
+    SELECT s."id" AS ws, col.value ->> 'id' AS cid
+    FROM "agent_sessions" s,
+      LATERAL jsonb_array_elements(s."workspaceState" -> 'columns') WITH ORDINALITY AS col(value, ordinality)
+    WHERE s."workspaceState" IS NOT NULL
+      AND jsonb_typeof(s."workspaceState" -> 'columns') = 'array'
+      AND jsonb_typeof(col.value) = 'object'
+      AND col.value ->> 'id' IS NOT NULL
+    GROUP BY 1, 2 HAVING count(*) > 1
+  ) d;
+
+  SELECT count(*) INTO dup_panes FROM (
+    SELECT s."id" AS ws, pane.value ->> 'id' AS pid
+    FROM "agent_sessions" s,
+      LATERAL jsonb_array_elements(s."workspaceState" -> 'columns') WITH ORDINALITY AS col(value, ordinality),
+      LATERAL jsonb_array_elements(col.value -> 'panes') WITH ORDINALITY AS pane(value, ordinality)
+    WHERE s."workspaceState" IS NOT NULL
+      AND jsonb_typeof(s."workspaceState" -> 'columns') = 'array'
+      AND jsonb_typeof(col.value) = 'object'
+      AND col.value ->> 'id' IS NOT NULL
+      AND jsonb_typeof(col.value -> 'panes') = 'array'
+      AND jsonb_typeof(pane.value) = 'object'
+      AND pane.value ->> 'id' IS NOT NULL
+    GROUP BY 1, 2 HAVING count(*) > 1
+  ) d;
+
+  IF dup_panes > 0 THEN
+    RAISE WARNING 'agent_workspace_panes backfill: % duplicate pane id(s) appeared more than once in their session blob; kept the first occurrence', dup_panes;
+  END IF;
+  IF dup_columns > 0 THEN
+    RAISE WARNING 'agent_workspace_panes backfill: % duplicate column id(s) appeared more than once in their session blob; kept the first occurrence', dup_columns;
+  END IF;
 
   RAISE NOTICE 'agent_workspace_panes backfill complete (agent-session SSoT epic, Phase 3)';
 END $$;

--- a/packages/db/drizzle/0248_yummy_rafael_vega.sql
+++ b/packages/db/drizzle/0248_yummy_rafael_vega.sql
@@ -38,11 +38,24 @@ ALTER TABLE "messages" ADD CONSTRAINT "messages_sourceAgentId_pages_id_fk" FOREI
 -- enforced that — `conversationId` is client-suppliable and self-minting — so
 -- it is asserted here, before a single row is written.
 --
--- Failing loudly on real data is the CORRECT outcome: a conversation whose
+-- Failing loudly on real data is the CORRECT outcome: a PAGE conversation whose
 -- messages straddle two pages cannot be synthesized into one row without
 -- guessing which page it belongs to, and a wrong guess silently relocates
 -- someone's history. The fix is a deliberate split (a data repair, reviewed on
 -- its own), not a default inside a migration.
+--
+-- SCOPE — `type='client'` threads are EXCLUDED from the abort, deliberately.
+-- An API thread is anchored to a DRIVE, not a page: its `contextId` is the
+-- drive id, so the "contextId must represent the page" premise above simply
+-- does not apply to it. Addressing more than one agent page over a thread's
+-- life is a DOCUMENTED, SUPPORTED shape (docs/2.0-architecture/
+-- agent-sessions.md), and 0252 already handles it gracefully downstream —
+-- it derives `conversations."agentPageId"` from the EARLIEST naming row and
+-- merely warns ('% client conversation(s) named more than one agent page;
+-- anchored to the earliest'). Aborting here would make the upgrade impossible
+-- for any deployment that ever served a two-agent API thread, to protect an
+-- invariant that thread never had to satisfy. These are still surfaced by the
+-- non-fatal audit immediately below (they trip its `c."type" <> 'page'` arm).
 DO $$
 DECLARE
   offender_count bigint;
@@ -50,19 +63,27 @@ DECLARE
 BEGIN
   SELECT count(*) INTO offender_count
   FROM (
-    SELECT "conversationId"
-    FROM "chat_messages"
-    GROUP BY "conversationId"
-    HAVING count(DISTINCT "pageId") > 1
+    SELECT cm."conversationId"
+    FROM "chat_messages" cm
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "conversations" c
+       WHERE c."id" = cm."conversationId" AND c."type" = 'client'
+    )
+    GROUP BY cm."conversationId"
+    HAVING count(DISTINCT cm."pageId") > 1
   ) straddling;
 
   IF offender_count > 0 THEN
     SELECT string_agg(c, ', ') INTO offender_sample
     FROM (
-      SELECT "conversationId" AS c
-      FROM "chat_messages"
-      GROUP BY "conversationId"
-      HAVING count(DISTINCT "pageId") > 1
+      SELECT cm."conversationId" AS c
+      FROM "chat_messages" cm
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "conversations" cv
+         WHERE cv."id" = cm."conversationId" AND cv."type" = 'client'
+      )
+      GROUP BY cm."conversationId"
+      HAVING count(DISTINCT cm."pageId") > 1
       ORDER BY 1
       LIMIT 50
     ) sample;

--- a/packages/db/drizzle/0251_mighty_shaman.sql
+++ b/packages/db/drizzle/0251_mighty_shaman.sql
@@ -50,8 +50,15 @@ BEGIN
   -- blob whose `columns` is a jsonb array is promoted, a pane's absent/null
   -- `scope` becomes an unbound row (NULL kind/target), and the retired `tabs`
   -- field is never read.
+  --
+  -- And the same `DISTINCT ON` deduplication as 0246, for the same reason: the
+  -- blob is client-authored and may repeat a pane id across two columns, while
+  -- the row tables are keyed `(workspaceId, id)`. Without it this sweep would
+  -- drop the second occurrence on the floor and the guard below would then
+  -- refuse to drop the column over the pane the sweep had just eaten. First
+  -- occurrence wins, ordered by column position then pane position.
   INSERT INTO "agent_workspace_pane_columns" ("id", "workspaceId", "orderIndex", "createdAt", "updatedAt")
-  SELECT
+  SELECT DISTINCT ON (s."id", col.value ->> 'id')
     col.value ->> 'id',
     s."id",
     (col.ordinality - 1)::int,
@@ -66,6 +73,7 @@ BEGIN
     AND NOT EXISTS (
       SELECT 1 FROM "agent_workspace_pane_columns" c WHERE c."workspaceId" = s."id"
     )
+  ORDER BY s."id", col.value ->> 'id', col.ordinality
   ON CONFLICT DO NOTHING;
   GET DIAGNOSTICS promoted_columns = ROW_COUNT;
 
@@ -73,7 +81,7 @@ BEGIN
   -- created this session's column rows, so re-using that anchor here would
   -- match nothing.
   INSERT INTO "agent_workspace_panes" ("id", "workspaceId", "columnId", "orderIndex", "kind", "targetId", "createdAt", "updatedAt")
-  SELECT
+  SELECT DISTINCT ON (s."id", pane.value ->> 'id')
     pane.value ->> 'id',
     s."id",
     col.value ->> 'id',
@@ -95,6 +103,7 @@ BEGIN
     AND NOT EXISTS (
       SELECT 1 FROM "agent_workspace_panes" p WHERE p."workspaceId" = s."id"
     )
+  ORDER BY s."id", pane.value ->> 'id', col.ordinality, pane.ordinality
   ON CONFLICT DO NOTHING;
   GET DIAGNOSTICS promoted_panes = ROW_COUNT;
 
@@ -105,6 +114,7 @@ DECLARE
   losing_panes int;
   losing_sessions int;
   sample text;
+  forced boolean;
 BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
@@ -119,7 +129,15 @@ BEGIN
     b."workspaceId",
     b."paneId"
   FROM (
-    SELECT
+    -- `DISTINCT ON` for the SAME reason the sweep has it: a pane id repeated
+    -- across two columns can only ever produce ONE row — the tables are keyed
+    -- `(workspaceId, id)` — so the second occurrence is not "data the rows
+    -- lost", it is data the schema cannot represent at all. Counting it as
+    -- drift made the guard refuse to drop over a pane no promotion could ever
+    -- satisfy, and its own HINT then looped the operator through a re-promotion
+    -- that failed identically. The guard must judge the blob by what a correct
+    -- promotion WOULD produce, which is exactly the first occurrence.
+    SELECT DISTINCT ON (s."id", pane.value ->> 'id')
       s."id" AS "workspaceId",
       pane.value ->> 'id' AS "paneId",
       pane.value -> 'scope' ->> 'kind' AS "kind",
@@ -133,6 +151,7 @@ BEGIN
       AND jsonb_typeof(col.value -> 'panes') = 'array'
       AND jsonb_typeof(pane.value) = 'object'
       AND pane.value ->> 'id' IS NOT NULL
+    ORDER BY s."id", pane.value ->> 'id', col.ordinality, pane.ordinality
   ) b
   -- A blob pane is "represented" when a row with the SAME id carries the SAME
   -- binding. `IS NOT DISTINCT FROM` because an unbound pane (picker) and a
@@ -154,13 +173,44 @@ BEGIN
     FROM (
       SELECT DISTINCT "workspaceId" FROM "_workspace_state_drift" ORDER BY "workspaceId" LIMIT 50
     ) s;
-    RAISE EXCEPTION
-      'Refusing to drop agent_sessions."workspaceState": % pane binding(s) across % session(s) exist ONLY in the blob. Dropping now would lose them. Session ids (up to 50): %',
-      losing_panes, losing_sessions, sample
-      USING HINT = 'Reconcile each session before re-running: open it in a current client (its verbs rewrite the rows), or DELETE its agent_workspace_pane_columns rows so this migration''s sweep promotes the blob wholesale.';
+
+    -- ESCAPE HATCH. The remaining drift shape is real: an old pod rewrote the
+    -- blob AFTER the promotion, so the blob genuinely holds a pane the rows
+    -- never saw. Halting is the right default — that pane is about to be
+    -- deleted forever.
+    --
+    -- But the original remedy ("open it in a current client") is CIRCULAR for
+    -- the operator who actually hits this: the current client is precisely the
+    -- deploy this migration is blocking, so a tenant/onprem upgrade can be
+    -- wedged with no way forward that does not involve hand-editing jsonb. An
+    -- explicitly-set database parameter breaks the loop without the app:
+    --
+    --   ALTER DATABASE <db> SET "pagespace.workspace_state_force_drop" = 'on';
+    --   -- re-run the migration, then:
+    --   ALTER DATABASE <db> RESET "pagespace.workspace_state_force_drop";
+    --
+    -- It is deliberately opt-in, never a default, and it still NAMES every
+    -- session it discards so the decision is on the deploy record.
+    forced := coalesce(
+      nullif(current_setting('pagespace.workspace_state_force_drop', true), ''),
+      'off'
+    ) IN ('on', 'true', '1', 'yes');
+
+    IF forced THEN
+      RAISE WARNING
+        'workspaceState drop FORCED by pagespace.workspace_state_force_drop: discarding % pane binding(s) across % session(s) that existed only in the blob. Session ids (up to 50): %',
+        losing_panes, losing_sessions, sample;
+    ELSE
+      RAISE EXCEPTION
+        'Refusing to drop agent_sessions."workspaceState": % pane binding(s) across % session(s) exist ONLY in the blob. Dropping now would lose them. Session ids (up to 50): %',
+        losing_panes, losing_sessions, sample
+        USING HINT = 'Reconcile each session before re-running: open it in a current client (its verbs rewrite the rows), or DELETE its agent_workspace_pane_columns AND agent_workspace_panes rows so this migration''s sweep promotes the blob wholesale. If the client is unavailable — a tenant/onprem upgrade this migration is itself blocking — accept the loss explicitly with: ALTER DATABASE <db> SET "pagespace.workspace_state_force_drop" = ''on''; then re-run, then RESET it.';
+    END IF;
   END IF;
 
   DROP TABLE "_workspace_state_drift";
-  RAISE NOTICE 'workspaceState drop guard: every persisted pane binding is represented in agent_workspace_panes';
+  IF losing_panes = 0 THEN
+    RAISE NOTICE 'workspaceState drop guard: every persisted pane binding is represented in agent_workspace_panes';
+  END IF;
 END $$;--> statement-breakpoint
 ALTER TABLE "agent_sessions" DROP COLUMN IF EXISTS "workspaceState";

--- a/packages/db/drizzle/0252_drop_chat_messages.sql
+++ b/packages/db/drizzle/0252_drop_chat_messages.sql
@@ -11,19 +11,22 @@
 --
 --   1. `conversations."agentPageId"` — the page link a `type='client'` (API)
 --      thread needs, because its `contextId` is a DRIVE and the transitional
---      `messages."pageId"` it used to answer through is dropped in step 6.
+--      `messages."pageId"` it used to answer through is dropped in step 7.
 --   2. FINAL SWEEP: copy any `chat_messages` row that has no `messages` twin.
 --      This is what protects a tenant/onprem operator who skipped the release
 --      carrying `scripts/backfill-unify-messages.ts` — those deployments have
 --      no operator to run a script, so the migration has to be the backfill.
 --   3. Backfill `agentPageId` from the page the thread's rows named, while
 --      that column still exists.
---   4. COMPLETENESS GUARD: refuse to drop the table if it still holds a row
+--   4. STALE-TWIN REPAIR: carry across an edit or a soft-delete that landed on
+--      the LEGACY leg alone during the dual-write window, before its evidence
+--      is dropped.
+--   5. COMPLETENESS GUARD: refuse to drop the table if it still holds a row
 --      `messages` does not represent.
---   5. `DROP TABLE chat_messages`.
---   6. `ALTER TABLE messages DROP COLUMN "pageId"` and its indexes.
+--   6. `DROP TABLE chat_messages`.
+--   7. `ALTER TABLE messages DROP COLUMN "pageId"` and its indexes.
 --
--- Steps 2–4 exist because the drop must be safe on a database this repository
+-- Steps 2–5 exist because the drop must be safe on a database this repository
 -- has never seen. On cloud they are all no-ops: PR 10's dual-write, the
 -- backfill script and PR 14's `VALIDATE CONSTRAINT` receipt already proved
 -- `messages` is a superset.
@@ -49,7 +52,7 @@ CREATE INDEX IF NOT EXISTS "conversations_agent_page_id_idx" ON "conversations" 
 -- the same column mapping the backfill script used. A row whose conversation
 -- does not exist CANNOT be copied — `messages."conversationId"` carries a
 -- validated, cascading FK — so it is left behind deliberately and named by the
--- guard in step 4 rather than aborting here with an opaque 23503. Migration
+-- guard in step 5 rather than aborting here with an opaque 23503. Migration
 -- 0250 already RAISEs on that shape, so reaching it here means 0250 was
 -- bypassed.
 DO $$
@@ -96,7 +99,7 @@ DECLARE
   ambiguous bigint;
   dead_page bigint;
 BEGIN
-  -- The source column is dropped by step 6, so on a re-run there is nothing
+  -- The source column is dropped by step 7, so on a re-run there is nothing
   -- left to derive FROM — and the stamps this block already wrote are still
   -- there. Returning before the UPDATE also stops PL/pgSQL from ever planning
   -- a statement that names a column that no longer exists.
@@ -151,7 +154,80 @@ BEGIN
   END IF;
 END $$;--> statement-breakpoint
 
--- ── 4. COMPLETENESS GUARD ─────────────────────────────────────────────────
+-- ── 4. STALE-TWIN REPAIR ──────────────────────────────────────────────────
+-- The completeness guard below asks only whether a ROW is represented. That is
+-- the right question after the PR 14 freeze, but it is blind to a row that HAS
+-- a twin whose twin is STALE — and the drop destroys the evidence.
+--
+-- HOW A TWIN GOES STALE. Not after the freeze; DURING PR 10's dual-write
+-- rolling deploy. A pod that has not yet picked up the dual-write serves an
+-- edit or a soft-delete and writes it to `chat_messages` ALONE. The documented
+-- `UNIFIED_MESSAGES_DUAL_WRITE=off` kill switch makes that window
+-- operator-controllable and arbitrarily long. Nothing downstream repairs it:
+-- `scripts/backfill-unify-messages.ts` only INSERTs rows that are missing and
+-- never updates one it already copied, the sweep in step 2 skips any row that
+-- already has a twin, and the retired reconcile cron compared only row counts
+-- and `MAX("createdAt")` — neither of which moves when a row is edited in
+-- place. So the divergence survives all the way to here, and dropping the
+-- table silently REVERTS the edit and RESURRECTS the soft-deleted message.
+--
+-- WHY THESE TWO SHAPES PROVE A LOST WRITE. Since PR 14 the legacy leg is
+-- IMMUTABLE — nothing writes it. So the legacy leg can only be ahead of the
+-- unified leg if the write predates the freeze and never crossed over:
+--   * `chat_messages."editedAt"` set, and the unified row's is NULL or OLDER
+--     → an edit the unified leg never received;
+--   * `chat_messages."isActive" = false` while the unified row is still true
+--     → a soft-delete the unified leg never received. Resurrecting a
+--       tombstoned message is the worse of the two failures.
+-- The REVERSE direction (unified newer) is the normal, healthy state and is
+-- deliberately left alone — see the guard's note below.
+--
+-- REPAIR, NOT RAISE. The direction here is unambiguous: there is exactly one
+-- newer value and it is about to be deleted. A RAISE would block the deploy on
+-- a condition the operator has no way to resolve by hand — the remedy would be
+-- "hand-merge two message tables", with the correct answer already computable
+-- right here. Refusing to deploy is only the right call when a human has to
+-- CHOOSE (that is the guard below, where a row cannot be represented at all).
+--
+-- Each field is repaired only on the condition that proves IT stale, so a row
+-- carrying a legacy soft-delete AND a legitimately newer unified edit keeps
+-- the edit and gains the deletion. Idempotent: after the UPDATE neither
+-- predicate can still hold, so a re-run matches nothing.
+DO $$
+DECLARE
+  repaired bigint;
+BEGIN
+  IF to_regclass('public.chat_messages') IS NULL THEN
+    RAISE NOTICE '0252: chat_messages is already gone — stale-twin repair skipped';
+    RETURN;
+  END IF;
+
+  UPDATE "messages" m
+     SET "content" = CASE
+           WHEN c."editedAt" IS NOT NULL AND (m."editedAt" IS NULL OR c."editedAt" > m."editedAt")
+           THEN c."content" ELSE m."content" END,
+         "editedAt" = CASE
+           WHEN c."editedAt" IS NOT NULL AND (m."editedAt" IS NULL OR c."editedAt" > m."editedAt")
+           THEN c."editedAt" ELSE m."editedAt" END,
+         "isActive" = CASE
+           WHEN c."isActive" = false AND m."isActive" = true
+           THEN false ELSE m."isActive" END
+    FROM "chat_messages" c
+   WHERE m."id" = c."id"
+     AND (
+       (c."editedAt" IS NOT NULL AND (m."editedAt" IS NULL OR c."editedAt" > m."editedAt"))
+       OR (c."isActive" = false AND m."isActive" = true)
+     );
+  GET DIAGNOSTICS repaired = ROW_COUNT;
+
+  IF repaired > 0 THEN
+    RAISE WARNING '0252: repaired % stale unified row(s) whose edit or soft-delete had landed only on chat_messages (dual-write window loss)', repaired;
+  ELSE
+    RAISE NOTICE '0252: no stale unified rows — every legacy edit/soft-delete had already crossed over';
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ── 5. COMPLETENESS GUARD ─────────────────────────────────────────────────
 -- The last chance to notice that dropping the table would lose something.
 --
 -- A "twin" is a `messages` row with the SAME id, in the SAME conversation,
@@ -162,7 +238,9 @@ END $$;--> statement-breakpoint
 -- healthy database — the unified row is the newer truth, and has been the only
 -- row anyone reads since PR 12 — so a content-equality guard would refuse to
 -- deploy on every database that has served an edit. What must not be lost is a
--- ROW, and that is what this checks.
+-- ROW, and that is what this checks. The narrow, PROVABLY-backwards subset of
+-- divergence is not left to this guard at all: step 4 above has already
+-- repaired it.
 DO $$
 DECLARE
   untwinned bigint;
@@ -210,10 +288,10 @@ BEGIN
   RAISE NOTICE '0252: completeness guard passed — every chat_messages row has a messages twin';
 END $$;--> statement-breakpoint
 
--- ── 5. THE DROP ───────────────────────────────────────────────────────────
+-- ── 6. THE DROP ───────────────────────────────────────────────────────────
 DROP TABLE IF EXISTS "chat_messages" CASCADE;--> statement-breakpoint
 
--- ── 6. The transitional column goes with it ───────────────────────────────
+-- ── 7. The transitional column goes with it ───────────────────────────────
 -- A message's page is its CONVERSATION's page now: `contextId` for
 -- `type='page'`, `agentPageId` for `type='client'`
 -- (apps/web/src/lib/repositories/unified-message-scope.ts is the one place

--- a/packages/db/src/__tests__/agent-workspace-layout-migration.test.ts
+++ b/packages/db/src/__tests__/agent-workspace-layout-migration.test.ts
@@ -2,12 +2,17 @@
  * Static invariants of the agent-workspace-layout migration (0246, epic
  * Phase 3 — the #2202 machine-panes pattern re-cut for sessions).
  *
- * The live behavior was verified against a scratch Postgres 17 (fresh
- * 247-migration full run; seeded-blob promotion incl. a legacy `tabs` pane,
- * a null scope, a malformed blob, and a NULL column; idempotent re-run;
- * FK-cascade teardown). These tests pin the migration SQL itself so CI
- * catches a regenerated or hand-edited migration losing the backfill, the
- * cascade topology, or the strictly-additive guarantee — without a database.
+ * These tests pin the migration SQL itself so CI catches a regenerated or
+ * hand-edited migration losing the backfill, the cascade topology, or the
+ * strictly-additive guarantee — without a database.
+ *
+ * The LIVE behavior of this promotion is exercised in
+ * `workspace-state-drop-migration.test.ts`, which drives the whole 0245 → 0251
+ * chain against a real Postgres. That matters: this file's header used to
+ * claim the promotion "was verified against a scratch Postgres 17" by hand,
+ * and the claim was wrong — the promotion silently ate a pane whose id
+ * appeared in two columns, which no string assertion here could have seen.
+ * A hand-run that nobody can re-run is not a test.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
@@ -100,6 +105,20 @@ describe('drizzle/0246 agent workspace layout promotion', () => {
     expect(code).toContain(`pane.value -> 'scope' ->> 'kind'`);
     expect(code).toContain(`pane.value -> 'scope' ->> 'targetId'`);
     expect(code).not.toContain(`'tabs'`);
+  });
+
+  it('should DEDUPLICATE client-minted ids before insert, not lean on ON CONFLICT to hide collisions', () => {
+    // The blob has never constrained pane/column id uniqueness while the row
+    // tables are keyed `(workspaceId, id)`. Without `DISTINCT ON` the second
+    // occurrence is silently swallowed by `ON CONFLICT DO NOTHING` and 0251
+    // then refuses to drop the column over the pane this migration ate.
+    expect(code).toContain(`SELECT DISTINCT ON (s."id", col.value ->> 'id')`);
+    expect(code).toContain(`SELECT DISTINCT ON (s."id", pane.value ->> 'id')`);
+    // First occurrence wins, in the client's own read order.
+    expect(code).toContain(`ORDER BY s."id", col.value ->> 'id', col.ordinality`);
+    expect(code).toContain(`ORDER BY s."id", pane.value ->> 'id', col.ordinality, pane.ordinality`);
+    // And a collapse is reported rather than silent.
+    expect(code).toMatch(/RAISE WARNING[^;]*duplicate pane id/);
   });
 
   it('should be strictly additive — 0246 EXPANDS only; the blob is dropped later, by 0250', () => {

--- a/packages/db/src/__tests__/drop-chat-messages-migration.test.ts
+++ b/packages/db/src/__tests__/drop-chat-messages-migration.test.ts
@@ -101,9 +101,10 @@ describe('drizzle/0252 — drop chat_messages', () => {
     expect(drop.code).toContain('CREATE INDEX IF NOT EXISTS');
     expect(drop.code).toContain('DROP INDEX IF EXISTS');
     expect(drop.code).toContain('DROP COLUMN IF EXISTS');
-    // The sweep and the guard both read a table this same migration drops;
-    // the client page-link backfill reads a COLUMN it drops.
-    expect(drop.code.match(/to_regclass\('public\.chat_messages'\) IS NULL/g)?.length).toBe(2);
+    // The sweep, the stale-twin repair and the guard all read a table this
+    // same migration drops; the client page-link backfill reads a COLUMN it
+    // drops.
+    expect(drop.code.match(/to_regclass\('public\.chat_messages'\) IS NULL/g)?.length).toBe(3);
     expect(drop.code).toMatch(/table_name = 'messages' AND column_name = 'pageId'/);
     expect(drop.code).toContain('ON CONFLICT ("id") DO NOTHING');
   });
@@ -449,6 +450,86 @@ describeLive('0252 against a real Postgres', () => {
       // be worse than one that refused.
       expect(await tableExists(s, 'chat_messages')).toBe(true);
       expect(await columnExists(s, 'messages', 'pageId')).toBe(true);
+    } finally {
+      await s.pool.end();
+    }
+  }, 180_000);
+
+  it('REPAIRS a write that landed on the legacy leg alone — the dual-write window loss', async () => {
+    const s = await openScenario('lostwrite');
+    try {
+      await seedFixtures(s);
+      await seedTwinnedCorpus(s);
+
+      // THE SHAPE THE ROW-ONLY GUARD CANNOT SEE. Both of these rows HAVE a
+      // twin (same id, conversation and role), so the completeness guard is
+      // satisfied and the table drops — but the twin is STALE.
+      //
+      // It gets this way during PR 10's dual-write window, not after the PR 14
+      // freeze: an old pod that has not yet picked up the dual-write serves an
+      // edit or a soft-delete and writes it to `chat_messages` ONLY. The
+      // documented `UNIFIED_MESSAGES_DUAL_WRITE=off` kill switch makes that
+      // window operator-controllable and arbitrarily long. Nothing repairs it
+      // afterwards: the backfill only ever INSERTs rows that are missing, and
+      // the 0252 sweep skips any row that already has a twin.
+      //
+      // After the freeze the legacy leg is immutable, so each of these shapes
+      // is positive proof of a lost write rather than normal divergence.
+
+      // (a) an edit that only the legacy leg received.
+      await s.query(`
+        UPDATE "chat_messages" SET "content" = 'EDITED TEXT', "editedAt" = now()
+         WHERE "id" = 'm_page_1'
+      `);
+      // (b) a soft-delete that only the legacy leg received. Dropping the
+      //     table without repairing this RESURRECTS a deleted message as live.
+      await s.query(`
+        UPDATE "chat_messages" SET "isActive" = false WHERE "id" = 'm_page_2'
+      `);
+
+      expect(await s.migrate()).toBeNull();
+      expect(await tableExists(s, 'chat_messages')).toBe(false);
+
+      const rows = await s.query<{
+        id: string; content: string; editedAt: Date | null; isActive: boolean;
+      }>(
+        `SELECT "id", "content", "editedAt", "isActive" FROM "messages"
+          WHERE "id" IN ('m_page_1', 'm_page_2') ORDER BY "id"`,
+      );
+
+      // The edit survived the drop instead of reverting to the original text.
+      expect(rows[0].content).toBe('EDITED TEXT');
+      expect(rows[0].editedAt).not.toBeNull();
+      // The deletion survived the drop instead of the message coming back.
+      expect(rows[1].isActive).toBe(false);
+
+      expect(s.notices.join('\n')).toMatch(/repaired 2 stale unified row\(s\)/);
+    } finally {
+      await s.pool.end();
+    }
+  }, 180_000);
+
+  it('is idempotent and SILENT when the unified leg is already the newer truth', async () => {
+    const s = await openScenario('norepair');
+    try {
+      await seedFixtures(s);
+      await seedTwinnedCorpus(s);
+      // The healthy post-freeze direction: `messages` carries the edit and the
+      // soft-delete, `chat_messages` is the frozen original. The repair must
+      // not fire here — running it backwards would undo real edits, which is
+      // the exact failure the row-only guard was trying to avoid.
+      await s.query(`UPDATE "messages" SET "content" = 'newer', "editedAt" = now() WHERE "id" = 'm_page_1'`);
+      await s.query(`UPDATE "messages" SET "isActive" = false WHERE "id" = 'm_page_2'`);
+
+      expect(await s.migrate()).toBeNull();
+
+      const rows = await s.query<{ id: string; content: string; isActive: boolean }>(
+        `SELECT "id", "content", "isActive" FROM "messages"
+          WHERE "id" IN ('m_page_1', 'm_page_2') ORDER BY "id"`,
+      );
+      expect(rows[0].content).toBe('newer');
+      expect(rows[1].isActive).toBe(false);
+      expect(s.notices.join('\n')).toMatch(/no stale unified rows/);
     } finally {
       await s.pool.end();
     }

--- a/packages/db/src/__tests__/messages-unification-expand-migration.test.ts
+++ b/packages/db/src/__tests__/messages-unification-expand-migration.test.ts
@@ -73,7 +73,7 @@ describe('drizzle/0248 messages unification — expand', () => {
   });
 
   it('should audit conversationId → pageId as 1:1 BEFORE writing anything, and raise on violation', () => {
-    const auditAt = expand.code.indexOf('count(DISTINCT "pageId") > 1');
+    const auditAt = expand.code.indexOf('count(DISTINCT cm."pageId") > 1');
     const insertAt = expand.code.indexOf('INSERT INTO "conversations"');
     expect(auditAt).toBeGreaterThan(-1);
     expect(insertAt).toBeGreaterThan(auditAt);
@@ -81,6 +81,19 @@ describe('drizzle/0248 messages unification — expand', () => {
     // The offending ids are listed, not merely counted — a migration that
     // fails without naming the rows to repair is a dead end.
     expect(expand.code).toContain('string_agg');
+  });
+
+  it('should scope the fatal straddle audit to NON-client conversations', () => {
+    // A `type='client'` (API) thread is anchored to a drive and may legitimately
+    // address several agent pages, so it can never satisfy the 1:1 premise and
+    // must not abort the upgrade. Both the count and the sample must carry the
+    // exclusion — a sample that still names excused threads would send the
+    // operator hunting for a straddle that is allowed.
+    const exclusions = expand.code.match(/c[v]?\."type" = 'client'\s*\)/g) ?? [];
+    expect(exclusions.length).toBe(2);
+    expect(expand.code).toMatch(
+      /NOT EXISTS \(\s*SELECT 1 FROM "conversations" c\s+WHERE c\."id" = cm\."conversationId" AND c\."type" = 'client'/,
+    );
   });
 
   it('should synthesize orphan conversations by the locked ownership ladder', () => {
@@ -479,6 +492,81 @@ describeLive('0248/0249 against a real Postgres', () => {
       expect(
         await s.query(`SELECT 1 FROM pg_constraint WHERE conname = 'chat_messages_conversationId_conversations_id_fk'`),
       ).toHaveLength(0);
+    } finally {
+      await s.pool.end();
+    }
+  }, 180_000);
+
+  it('lets a type=client thread that spoke to TWO agent pages through, instead of aborting the upgrade', async () => {
+    const s = await openScenario('clientstraddle');
+    try {
+      await seedFixtures(s);
+      // A `type='client'` (API) thread is anchored to a DRIVE, not a page, and
+      // is DOCUMENTED as being able to address more than one agent page over
+      // its life (docs/2.0-architecture/agent-sessions.md). Its rows therefore
+      // straddle two pageIds BY DESIGN — that is a supported production shape,
+      // not the drift the pre-audit exists to catch.
+      //
+      // The pre-audit's premise ("a conversationId must name exactly one page,
+      // because contextId has to represent it") simply does not apply here:
+      // this conversation's `contextId` is the drive, and 0252 later derives
+      // its page into `agentPageId`, anchoring to the earliest and merely
+      // WARNING (`% client conversation(s) named more than one agent page`).
+      // Aborting on it makes the upgrade impossible for any deployment that
+      // ever served a two-agent API thread.
+      await s.query(`
+        INSERT INTO "conversations" ("id", "userId", "type", "contextId", "isActive", "updatedAt") VALUES
+          ('c_client_multi', 'u_speaker', 'client', 'd_main', true, now());
+      `);
+      await insertChatMessage(s, { id: 'mc1', pageId: 'p_with_creator', conversationId: 'c_client_multi', role: 'user', userId: 'u_speaker', createdAt: '2024-01-01 10:00:00' });
+      await insertChatMessage(s, { id: 'mc2', pageId: 'p_no_creator', conversationId: 'c_client_multi', role: 'user', userId: 'u_speaker', createdAt: '2024-01-01 11:00:00' });
+
+      // THE ASSERTION: it survives.
+      expect(await s.migrate()).toBeNull();
+
+      // The client conversation is untouched — still a client thread, still
+      // anchored to its drive. Synthesis never had anything to do here.
+      const rows = await s.query<{ id: string; type: string; contextId: string | null }>(
+        `SELECT "id", "type", "contextId" FROM "conversations" WHERE "id" = 'c_client_multi'`,
+      );
+      expect(rows).toEqual([{ id: 'c_client_multi', type: 'client', contextId: 'd_main' }]);
+
+      // And the expand actually happened rather than being rolled back.
+      expect(
+        await s.query(`SELECT 1 FROM information_schema.columns WHERE table_name = 'messages' AND column_name = 'pageId'`),
+      ).toHaveLength(1);
+
+      // It is still REPORTED — a client straddle is expected, but the operator
+      // should see it on the deploy record (the second, non-fatal audit).
+      expect(s.notices.join('\n')).toMatch(/disagree with their chat_messages about the page/);
+    } finally {
+      await s.pool.end();
+    }
+  }, 180_000);
+
+  it('still ABORTS on a genuine page-conversation straddle even when a client straddle is present', async () => {
+    const s = await openScenario('mixedstraddle');
+    try {
+      await seedFixtures(s);
+      // Both shapes in one corpus. The client straddle must be excused; the
+      // page straddle must still stop the migration dead. Excusing the first
+      // must not blunt the guard for the second.
+      await s.query(`
+        INSERT INTO "conversations" ("id", "userId", "type", "contextId", "isActive", "updatedAt") VALUES
+          ('c_client_ok', 'u_speaker', 'client', 'd_main', true, now());
+      `);
+      await insertChatMessage(s, { id: 'mc1', pageId: 'p_with_creator', conversationId: 'c_client_ok', role: 'user', userId: 'u_speaker', createdAt: '2024-01-01 10:00:00' });
+      await insertChatMessage(s, { id: 'mc2', pageId: 'p_no_creator', conversationId: 'c_client_ok', role: 'user', userId: 'u_speaker', createdAt: '2024-01-01 11:00:00' });
+      // The genuine offender: no conversations row at all, so synthesis would
+      // have to GUESS which page it belongs to.
+      await insertChatMessage(s, { id: 'mp1', pageId: 'p_with_creator', conversationId: 'c_page_split', role: 'user', userId: 'u_speaker', createdAt: '2024-01-01 10:00:00' });
+      await insertChatMessage(s, { id: 'mp2', pageId: 'p_no_creator', conversationId: 'c_page_split', role: 'user', userId: 'u_speaker', createdAt: '2024-01-01 11:00:00' });
+
+      const reported = errorChain(await s.migrate());
+      expect(reported).toMatch(/span more than one pageId/);
+      expect(reported).toContain('c_page_split');
+      // The excused client thread is NOT named as an offender.
+      expect(reported).not.toContain('c_client_ok');
     } finally {
       await s.pool.end();
     }

--- a/packages/db/src/__tests__/workspace-state-drop-migration.test.ts
+++ b/packages/db/src/__tests__/workspace-state-drop-migration.test.ts
@@ -3,24 +3,24 @@
  * Phase 3 — the CONTRACT step of the relational pane-grid promotion started
  * in 0246).
  *
- * The live behavior was verified against a scratch Postgres 17 (fresh
- * full-migration run, then six seeded corpora replayed against the file):
- *   A. healthy (blob ≡ rows)         → sweep no-op, guard silent, column dropped
- *   B. blob never promoted (no rows) → sweep promoted 1 column / 1 pane, then dropped
- *   C. blob AHEAD of rows            → RAISE EXCEPTION naming 2 panes / 2 sessions
- *                                      (`ses-c, ses-c2`); the column SURVIVED
- *   D. re-run after a successful run → clean no-op, rows intact
- *   E. unbound + null-target panes   → NULL-safe compare, no false positive
- *   F. malformed blobs               → neither promoted nor blocking
- *
  * These tests pin the migration SQL itself so CI catches a regenerated or
  * hand-edited migration losing the sweep, the guard, or the ORDER of the
  * three — without a database. A drop that runs before its guard is a data
  * loss with extra steps.
+ *
+ * The header here used to list six scenarios a human had once replayed by
+ * hand against a scratch Postgres. They are now a LIVE suite at the bottom of
+ * this file, run by CI on every change, because the hand-run had missed the
+ * defect that mattered: 0246 ate a duplicate pane id and this migration then
+ * refused to deploy over it, in a loop its own HINT could not break.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
 import path from 'path';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import { runMigrations, type RunnableMigration } from '../migration-runner';
 
 const MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle');
 
@@ -123,4 +123,339 @@ describe('the schema no longer declares the blob', () => {
     // against any more.
     expect(Object.keys(agentWorkspaces)).not.toContain('workspaceState');
   });
+});
+
+// ───────────────────────────── live behavior ──────────────────────────────
+/**
+ * The static assertions above never open a database, so for a long time the
+ * ONLY evidence that 0246's promotion and 0251's guard behaved was a prose
+ * note in this file's header saying a human had once run them by hand. That
+ * note was wrong: the promotion silently DROPPED a pane whose id appeared in
+ * two columns (`ON CONFLICT DO NOTHING` on the compound PK), and 0251's guard
+ * then refused to deploy over the very pane 0246 had eaten — with a HINT whose
+ * documented remedy re-ran the same losing promotion and failed identically.
+ * Unrecoverable through any documented path, and invisible to a suite that
+ * only grepped the SQL.
+ *
+ * These scenarios drive the real chain (0245 → 0246 → … → 0251) against a real
+ * Postgres, which is the only thing that could have caught it.
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeLive = DATABASE_URL ? describe : describe.skip;
+
+const allMigrations: RunnableMigration[] = readMigrationFiles({ migrationsFolder: MIGRATIONS_DIR });
+/** Everything BEFORE the pane-grid promotion (… 0245). */
+const preGrid = allMigrations.slice(0, 246);
+/** Index one past 0251 — the contract step this file is named for. */
+const THROUGH_CONTRACT = 252;
+
+function errorChain(err: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = err;
+  while (current instanceof Error) {
+    parts.push(current.message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return parts.join('\n');
+}
+
+function urlForDatabase(name: string): string {
+  const parsed = new URL(DATABASE_URL as string);
+  parsed.pathname = `/${name}`;
+  return parsed.toString();
+}
+
+const suffix = `${process.pid}_${Date.now().toString(36)}`;
+const TEMPLATE_DB = `psx_wsdrop_tmpl_${suffix}`;
+const createdDatabases: string[] = [];
+let adminPool: Pool;
+
+interface Scenario {
+  dbName: string;
+  notices: string[];
+  /** Applies migrations up to (not including) index `upTo`. */
+  migrate: (upTo?: number) => Promise<Error | null>;
+  query: <T extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ) => Promise<T[]>;
+  /** Drops and re-opens the connection — needed to pick up ALTER DATABASE SET. */
+  reconnect: () => Promise<void>;
+  close: () => Promise<void>;
+}
+
+async function openScenario(name: string): Promise<Scenario> {
+  const dbName = `psx_wsdrop_${name}_${suffix}`;
+  await adminPool.query(`CREATE DATABASE "${dbName}" TEMPLATE "${TEMPLATE_DB}"`);
+  createdDatabases.push(dbName);
+
+  const notices: string[] = [];
+  const connect = () => {
+    const p = new Pool({ connectionString: urlForDatabase(dbName), max: 1 });
+    p.on('connect', (client) => {
+      client.on('notice', (n) => notices.push(`${n.severity}: ${n.message ?? ''}`));
+    });
+    return p;
+  };
+  // Mutable so `reconnect()` genuinely swaps the connection every method uses
+  // — a closure over the ORIGINAL pool would keep querying an ended one.
+  let pool = connect();
+
+  return {
+    dbName,
+    notices,
+    migrate: async (upTo = THROUGH_CONTRACT) => {
+      try {
+        await runMigrations(drizzle(pool), allMigrations.slice(0, upTo), {
+          migrationsSchema: 'drizzle',
+          migrationsTable: '__drizzle_migrations',
+        });
+        return null;
+      } catch (err) {
+        return err as Error;
+      }
+    },
+    query: async <T extends Record<string, unknown> = Record<string, unknown>>(
+      text: string,
+      values?: unknown[],
+    ) => (await pool.query(text, values)).rows as T[],
+    reconnect: async () => {
+      await pool.end();
+      pool = connect();
+    },
+    close: async () => {
+      await pool.end();
+    },
+  };
+}
+
+/** An owner and a drive for the sessions each scenario seeds. */
+async function seedFixtures(s: Scenario): Promise<void> {
+  await s.query(`
+    INSERT INTO "users" ("id", "name", "email", "createdAt", "updatedAt") VALUES
+      ('u_owner', 'Owner', 'owner@example.com', now(), now());
+    INSERT INTO "drives" ("id", "name", "slug", "ownerId", "createdAt", "updatedAt") VALUES
+      ('d_main', 'Main', 'main', 'u_owner', now(), now());
+  `);
+}
+
+/** A session carrying a client-authored `workspaceState` blob, pre-0246. */
+async function seedSession(s: Scenario, id: string, blob: unknown): Promise<void> {
+  await s.query(
+    `INSERT INTO "agent_sessions" ("id", "driveId", "ownerId", "name", "workspaceState", "createdAt", "updatedAt")
+     VALUES ($1, 'd_main', 'u_owner', $1, $2::jsonb, now(), now())`,
+    [id, JSON.stringify(blob)],
+  );
+}
+
+function pane(id: string, kind: string | null, targetId: string | null) {
+  return kind === null && targetId === null
+    ? { id }
+    : { id, scope: { kind, targetId } };
+}
+
+async function panesOf(s: Scenario, workspaceId: string) {
+  return s.query<{ id: string; columnId: string; kind: string | null; targetId: string | null }>(
+    `SELECT "id", "columnId", "kind", "targetId" FROM "agent_workspace_panes"
+      WHERE "workspaceId" = $1 ORDER BY "columnId", "orderIndex"`,
+    [workspaceId],
+  );
+}
+
+async function columnExists(s: Scenario, table: string, column: string): Promise<boolean> {
+  const rows = await s.query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM information_schema.columns
+      WHERE table_name = $1 AND column_name = $2`,
+    [table, column],
+  );
+  return rows[0].n > 0;
+}
+
+describeLive('0246 → 0251 pane grid against a real Postgres', () => {
+  beforeAll(async () => {
+    adminPool = new Pool({ connectionString: DATABASE_URL, max: 1 });
+    await adminPool.query(`CREATE DATABASE "${TEMPLATE_DB}"`);
+    createdDatabases.push(TEMPLATE_DB);
+
+    // Template at 0245 — BEFORE the pane grid exists, so each scenario can
+    // seed a blob and watch the promotion itself run.
+    const templatePool = new Pool({ connectionString: urlForDatabase(TEMPLATE_DB), max: 1 });
+    try {
+      await runMigrations(drizzle(templatePool), preGrid, {
+        migrationsSchema: 'drizzle',
+        migrationsTable: '__drizzle_migrations',
+      });
+    } finally {
+      await templatePool.end();
+    }
+  }, 600_000);
+
+  afterAll(async () => {
+    if (!adminPool) return;
+    for (const name of [...createdDatabases].reverse()) {
+      await adminPool.query(`DROP DATABASE IF EXISTS "${name}" WITH (FORCE)`).catch(() => {});
+    }
+    await adminPool.end();
+  }, 120_000);
+
+  it('pins the base: the template predates the pane grid', async () => {
+    const s = await openScenario('preflight');
+    try {
+      expect(await columnExists(s, 'agent_sessions', 'workspaceState')).toBe(true);
+      const rows = await s.query(`SELECT to_regclass('public.agent_workspace_panes') AS t`);
+      expect(rows[0].t).toBeNull();
+    } finally {
+      await s.close();
+    }
+  }, 120_000);
+
+  it('promotes a healthy blob and drops the column — the steady state', async () => {
+    const s = await openScenario('healthy');
+    try {
+      await seedFixtures(s);
+      await seedSession(s, 'ses_ok', {
+        columns: [
+          { id: 'col-a', panes: [pane('pane-1', 'page', 't1'), pane('pane-2', null, null)] },
+          { id: 'col-b', panes: [pane('pane-3', 'chat', 't3')] },
+        ],
+      });
+
+      expect(await s.migrate()).toBeNull();
+      expect(await columnExists(s, 'agent_sessions', 'workspaceState')).toBe(false);
+
+      expect(await panesOf(s, 'ses_ok')).toEqual([
+        { id: 'pane-1', columnId: 'col-a', kind: 'page', targetId: 't1' },
+        { id: 'pane-2', columnId: 'col-a', kind: null, targetId: null },
+        { id: 'pane-3', columnId: 'col-b', kind: 'chat', targetId: 't3' },
+      ]);
+    } finally {
+      await s.close();
+    }
+  }, 180_000);
+
+  it('KEEPS a pane whose id repeats across two columns, instead of eating it and then blocking on it', async () => {
+    const s = await openScenario('duppane');
+    try {
+      await seedFixtures(s);
+      // A client-authored blob is not constrained to unique pane ids, but the
+      // relational PK is `(workspaceId, id)`. 0246's `ON CONFLICT DO NOTHING`
+      // therefore silently DISCARDED the second occurrence — and 0251's guard
+      // then saw a blob pane binding the rows lacked and refused to deploy.
+      //
+      // Following 0251's own documented HINT ("DELETE its
+      // agent_workspace_pane_columns rows so the sweep promotes the blob
+      // wholesale") re-ran the identical losing INSERT and failed identically:
+      // an unrecoverable loop with no documented way out.
+      await seedSession(s, 'ses_dup', {
+        columns: [
+          { id: 'col-a', panes: [pane('pane-dup', 'page', 'target-first')] },
+          { id: 'col-b', panes: [pane('pane-dup', 'page', 'target-second')] },
+        ],
+      });
+
+      // THE ASSERTION: the chain completes rather than dead-ending.
+      expect(await s.migrate()).toBeNull();
+      expect(await columnExists(s, 'agent_sessions', 'workspaceState')).toBe(false);
+
+      // Exactly one row survives — the PK cannot hold two — and it is the
+      // FIRST occurrence, matching the client's own first-wins read order.
+      expect(await panesOf(s, 'ses_dup')).toEqual([
+        { id: 'pane-dup', columnId: 'col-a', kind: 'page', targetId: 'target-first' },
+      ]);
+
+      // And the collapse is REPORTED rather than silent — an operator must be
+      // able to see that a duplicate id was collapsed.
+      expect(s.notices.join('\n')).toMatch(/duplicate pane id/i);
+    } finally {
+      await s.close();
+    }
+  }, 180_000);
+
+  it('still REFUSES when an old pod genuinely wrote a new pane to the blob after the promotion', async () => {
+    const s = await openScenario('blobahead');
+    try {
+      await seedFixtures(s);
+      await seedSession(s, 'ses_ahead', {
+        columns: [{ id: 'col-a', panes: [pane('pane-1', 'page', 't1')] }],
+      });
+      // Promote, then let a stale pod rewrite the blob with a pane the rows
+      // have never seen. This is REAL data loss, and must still halt the drop.
+      expect(await s.migrate(251)).toBeNull();
+      await s.query(`
+        UPDATE "agent_sessions" SET "workspaceState" = $1::jsonb WHERE "id" = 'ses_ahead'
+      `, [JSON.stringify({
+        columns: [{ id: 'col-a', panes: [pane('pane-1', 'page', 't1'), pane('pane-new', 'page', 't9')] }],
+      })]);
+
+      const reported = errorChain(await s.migrate());
+      expect(reported).toMatch(/Refusing to drop/);
+      expect(reported).toContain('ses_ahead');
+      // The column SURVIVES — a half-run destructive step is worse than a
+      // refusal.
+      expect(await columnExists(s, 'agent_sessions', 'workspaceState')).toBe(true);
+    } finally {
+      await s.close();
+    }
+  }, 180_000);
+
+  it('offers an operator escape hatch for blob-ahead-of-rows that does not need the blocked client', async () => {
+    const s = await openScenario('escapehatch');
+    try {
+      await seedFixtures(s);
+      await seedSession(s, 'ses_ahead', {
+        columns: [{ id: 'col-a', panes: [pane('pane-1', 'page', 't1')] }],
+      });
+      expect(await s.migrate(251)).toBeNull();
+      await s.query(`
+        UPDATE "agent_sessions" SET "workspaceState" = $1::jsonb WHERE "id" = 'ses_ahead'
+      `, [JSON.stringify({
+        columns: [{ id: 'col-a', panes: [pane('pane-1', 'page', 't1'), pane('pane-new', 'page', 't9')] }],
+      })]);
+
+      // The guard's original HINT told the operator to "open it in a current
+      // client" — but the current client is exactly what this migration is
+      // blocking the deploy of, so that remedy is circular for a tenant/onprem
+      // operator mid-upgrade. A settable parameter breaks the loop WITHOUT
+      // needing the app, and is deliberately explicit rather than a default.
+      await adminPool.query(
+        `ALTER DATABASE "${s.dbName}" SET "pagespace.workspace_state_force_drop" = 'on'`,
+      );
+      // Reconnect so the new database-level setting is picked up.
+      await s.reconnect();
+
+      expect(await s.migrate()).toBeNull();
+      expect(await columnExists(s, 'agent_sessions', 'workspaceState')).toBe(false);
+      // Forcing is LOUD: the panes it knowingly discarded are named.
+      expect(s.notices.join('\n')).toMatch(/FORCED by pagespace\.workspace_state_force_drop/);
+      expect(s.notices.join('\n')).toContain('ses_ahead');
+    } finally {
+      await s.close();
+    }
+  }, 180_000);
+
+  it('rescues a session whose blob was never promoted, and re-runs as a no-op', async () => {
+    const s = await openScenario('sweep');
+    try {
+      await seedFixtures(s);
+      expect(await s.migrate(247)).toBeNull();
+      // Born on an old instance AFTER 0246 ran: blob written, rows never.
+      await seedSession(s, 'ses_late', {
+        columns: [{ id: 'col-a', panes: [pane('pane-late', 'page', 't1')] }],
+      });
+
+      expect(await s.migrate()).toBeNull();
+      expect(await panesOf(s, 'ses_late')).toEqual([
+        { id: 'pane-late', columnId: 'col-a', kind: 'page', targetId: 't1' },
+      ]);
+
+      // Re-running the file against an already-contracted database is clean.
+      const file = readdirSync(MIGRATIONS_DIR).find((f) => /^0251_.*\.sql$/.test(f)) as string;
+      await s.query(
+        readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8').split('--> statement-breakpoint').join(''),
+      );
+      expect(s.notices.join('\n')).toMatch(/already dropped/);
+    } finally {
+      await s.close();
+    }
+  }, 180_000);
 });

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -59,10 +59,18 @@ export const conversations = pgTable('conversations', {
    * re-point it, for the same reason `workspaceId` is write-once.
    *
    * `ON DELETE SET NULL`, matching `workspaceId` and NOT the
-   * `chat_messages.pageId` cascade it replaces: a permanently deleted page
-   * takes its chat MESSAGES with it (the trash route does that explicitly) but
-   * has never deleted `conversations` rows, and this column must not become
-   * the first thing that does.
+   * `chat_messages.pageId` cascade it replaces: this column must not become an
+   * implicit deleter of `conversations` rows, because SET NULL is also what
+   * makes a *soft*-deleted or moved page harmless.
+   *
+   * Permanent deletion is handled EXPLICITLY instead, in one place —
+   * `packages/lib/src/repositories/conversation-cleanup.ts` — which every page
+   * and drive delete path calls BEFORE deleting the rows (this FK nulls
+   * itself the moment the page goes, so the scope must be collected first).
+   * That helper deletes the `conversations` row as well as its messages: the
+   * shell used to survive, and with it `ai_stream_sessions.parts` — message
+   * content that cascades from `conversations` and from nothing else, leaving
+   * it alive and unreachable by any sweep after the page was erased.
    *
    * NULL for every other conversation type, and for a client thread that has
    * not yet run a completion. Read it through `derivedPageId()` /

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -447,6 +447,11 @@
       "import": "./dist/repositories/account-repository.js",
       "require": "./dist/repositories/account-repository.js"
     },
+    "./repositories/conversation-cleanup": {
+      "types": "./dist/repositories/conversation-cleanup.d.ts",
+      "import": "./dist/repositories/conversation-cleanup.js",
+      "require": "./dist/repositories/conversation-cleanup.js"
+    },
     "./repositories/activity-log-repository": {
       "types": "./dist/repositories/activity-log-repository.d.ts",
       "import": "./dist/repositories/activity-log-repository.js",

--- a/packages/lib/src/repositories/__tests__/account-repository.test.ts
+++ b/packages/lib/src/repositories/__tests__/account-repository.test.ts
@@ -31,6 +31,15 @@ vi.mock('@pagespace/db/operators', () => ({
     { placeholder: vi.fn() }
   ),
 }));
+// A collaborator, not this unit's job. Every drive delete here must take the
+// drive's chat history with it (the `chat_messages.pageId` cascade that used
+// to do that automatically went with the table in migration 0252), but WHAT
+// that cleanup selects is pinned against a real database in
+// `apps/web/src/lib/repositories/__tests__/chat-mutation-matrix.integration.test.ts`.
+// Here we only assert that it is called, and called BEFORE the drive row goes.
+vi.mock('../conversation-cleanup', () => ({
+  deleteConversationsForDrive: vi.fn().mockResolvedValue({ conversations: 0, messages: 0 }),
+}));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
@@ -38,6 +47,7 @@ vi.mock('@pagespace/db/operators', () => ({
 
 import { accountRepository } from '../account-repository';
 import { db } from '@pagespace/db/db';
+import { deleteConversationsForDrive } from '../conversation-cleanup';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,15 +144,37 @@ describe('accountRepository.getDriveMemberCount', () => {
 describe('accountRepository.deleteDrive', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
+  /** Runs the callback with a tx whose `delete` chain resolves as given. */
+  function setupTransaction(deleteResult: Promise<unknown>) {
+    const whereFn = vi.fn().mockReturnValue(deleteResult);
+    const deleteFn = vi.fn().mockReturnValue({ where: whereFn });
+    vi.mocked(db.transaction).mockImplementation(async (fn) =>
+      fn({ delete: deleteFn } as unknown as Parameters<typeof fn>[0]),
+    );
+    return { deleteFn, whereFn };
+  }
+
   it('resolves without error when DB succeeds', async () => {
-    setupDeleteChain();
+    setupTransaction(Promise.resolve(undefined));
 
     await expect(accountRepository.deleteDrive('drive-1')).resolves.toBeUndefined();
   });
 
+  it('takes the drive chat history with it, before the drive row', async () => {
+    const { deleteFn } = setupTransaction(Promise.resolve(undefined));
+
+    await accountRepository.deleteDrive('drive-1');
+
+    // Ordering is load-bearing: `pages.driveId` cascades, so once the drive is
+    // gone its pages are gone and the page-scoped conversations can no longer
+    // be traced. Cleanup must therefore precede the drive DELETE.
+    expect(deleteConversationsForDrive).toHaveBeenCalledWith(expect.anything(), 'drive-1');
+    const cleanupOrder = vi.mocked(deleteConversationsForDrive).mock.invocationCallOrder[0];
+    expect(cleanupOrder).toBeLessThan(deleteFn.mock.invocationCallOrder[0]);
+  });
+
   it('propagates DB errors', async () => {
-    const whereFn = vi.fn().mockRejectedValue(new Error('FK constraint'));
-    vi.mocked(db.delete).mockReturnValue({ where: whereFn } as unknown as ReturnType<typeof db.delete>);
+    setupTransaction(Promise.reject(new Error('FK constraint')));
 
     await expect(accountRepository.deleteDrive('drive-1')).rejects.toThrow('FK constraint');
   });

--- a/packages/lib/src/repositories/account-repository.ts
+++ b/packages/lib/src/repositories/account-repository.ts
@@ -10,6 +10,7 @@ import { eq, sql } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { drives } from '@pagespace/db/schema/core';
 import { driveMembers } from '@pagespace/db/schema/members';
+import { deleteConversationsForDrive } from './conversation-cleanup';
 import { decryptUserRow } from '../auth/user-repository';
 
 export interface UserAccount {
@@ -74,10 +75,18 @@ export const accountRepository = {
   },
 
   /**
-   * Delete a drive by ID
+   * Delete a drive by ID.
+   *
+   * Takes the drive's chat history with it, explicitly and first: the drive
+   * cascade reaches `pages` and `drive_members` but NOT `conversations`, whose
+   * `contextId` has never been a foreign key. The `chat_messages.pageId`
+   * cascade that used to make this automatic went with the table in 0252.
    */
   deleteDrive: async (driveId: string): Promise<void> => {
-    await db.delete(drives).where(eq(drives.id, driveId));
+    await db.transaction(async (tx) => {
+      await deleteConversationsForDrive(tx, driveId);
+      await tx.delete(drives).where(eq(drives.id, driveId));
+    });
   },
 
   /**
@@ -120,8 +129,11 @@ export const accountRepository = {
         return { multiMemberDriveNames: multiMemberNames };
       }
 
-      // Safe to delete — no multi-member drives
+      // Safe to delete — no multi-member drives. Chat history first, while the
+      // drive's pages still exist to trace the page-scoped threads through
+      // (the drive cascade does not reach `conversations`).
       for (const driveId of soloDriveIds) {
+        await deleteConversationsForDrive(tx, driveId);
         await tx.delete(drives).where(eq(drives.id, driveId));
       }
 

--- a/packages/lib/src/repositories/conversation-cleanup.ts
+++ b/packages/lib/src/repositories/conversation-cleanup.ts
@@ -1,0 +1,167 @@
+/**
+ * Conversation/message cleanup for PERMANENT deletion of a page or a drive.
+ *
+ * WHY THIS EXISTS AT ALL. `chat_messages.pageId` used to carry
+ * `REFERENCES pages(id) ON DELETE CASCADE`, and that FK was the physical net
+ * under every page- and drive-deletion path in the codebase: nothing had to
+ * remember to clean chat history up, because the database did it. Migration
+ * 0252 dropped `chat_messages`, and the net went with it. What replaced it
+ * does NOT cover the same ground:
+ *
+ *   * `conversations.contextId` — the page id for `type='page'`, the drive id
+ *     for `type='drive'`/`type='client'` — has never been a foreign key at
+ *     all. It is a bare, polymorphic text column.
+ *   * `conversations.agentPageId` is `ON DELETE SET NULL`, so deleting a page
+ *     merely FORGETS which agent a client thread spoke to.
+ *   * `messages.conversationId` cascades from `conversations`, and
+ *     `ai_stream_sessions.conversationId` cascades from `conversations` — but
+ *     neither fires, because nothing deletes the `conversations` row.
+ *
+ * The result, verified against a migrated database: `DELETE FROM pages` leaves
+ * the conversation and its messages, and `DELETE FROM drives` leaves them
+ * dangling behind cascaded-away pages. Chat history outlived both. Only the
+ * manual trash route had an explicit statement, and it was written inline, so
+ * the cron purge and all four drive-delete paths silently under-deleted.
+ *
+ * THE CONVERSATION ROW GOES TOO — this is a deliberate change of contract.
+ * The trash route previously deleted `messages` and left the `conversations`
+ * shell standing. That leaks: `ai_stream_sessions` holds partial message
+ * content in `parts`, cascades from `conversations` and from nothing else, so
+ * an orphaned shell keeps that content alive and UNREACHABLE — no sweep can
+ * find it, and no user can read it to request its deletion. For an Article 17
+ * erasure path that is the wrong trade. Deleting the shell takes the messages
+ * and the stream checkpoints with it in one cascade.
+ *
+ * SCOPE — which conversations belong to a page. Exactly `unifiedPageScope`'s
+ * two disjuncts, and no more:
+ *   1. the page's own threads (`type='page'` whose `contextId` IS the page);
+ *   2. the API threads anchored to it (`type='client'` whose `agentPageId` is
+ *      the page). `agentPageId` is write-once, so such a thread belongs to
+ *      that one agent for its whole life — taking it whole is right.
+ * A `type='drive'` or `type='global'` thread is NEVER page-scoped and is left
+ * alone.
+ *
+ * ORDERING IS LOAD-BEARING. Every function here must be called BEFORE the
+ * `pages`/`drives` rows are deleted. Deleting the page first nulls
+ * `agentPageId` (the FK is SET NULL) and deleting the drive first cascades its
+ * pages away — either way the scope query stops matching and the history is
+ * stranded. Call inside the same transaction as the delete it accompanies.
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, inArray, or } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { conversations, messages } from '@pagespace/db/schema/conversations';
+
+/** A `db` handle or a transaction handle — both satisfy the calls made here. */
+export type DbHandle = typeof db;
+
+export interface ConversationCleanupResult {
+  /** `conversations` rows deleted (each takes its messages + stream state). */
+  conversations: number;
+  /** `messages` rows deleted. */
+  messages: number;
+}
+
+const EMPTY: ConversationCleanupResult = { conversations: 0, messages: 0 };
+
+/** Delete the collected conversations and their messages. */
+async function deleteConversationSet(
+  tx: DbHandle,
+  conversationIds: string[],
+): Promise<ConversationCleanupResult> {
+  if (conversationIds.length === 0) return { ...EMPTY };
+
+  // Messages first and explicitly, rather than leaning on the cascade: the
+  // count is part of this function's contract (callers audit-log it), and an
+  // explicit statement keeps the deletion legible in a query log.
+  const deletedMessages = await tx
+    .delete(messages)
+    .where(inArray(messages.conversationId, conversationIds))
+    .returning({ id: messages.id });
+
+  // Takes `ai_stream_sessions` with it via that table's cascading FK — the
+  // whole reason the shell must not survive.
+  const deletedConversations = await tx
+    .delete(conversations)
+    .where(inArray(conversations.id, conversationIds))
+    .returning({ id: conversations.id });
+
+  return {
+    conversations: deletedConversations.length,
+    messages: deletedMessages.length,
+  };
+}
+
+/**
+ * Delete the chat history belonging to `pageIds`.
+ *
+ * MUST be called before the pages themselves are deleted.
+ *
+ * Pass exactly the pages that are actually being deleted — no more. There is
+ * deliberately no subtree expansion here: `pages.parentId` carries NO foreign
+ * key, so deleting a page ORPHANS its children rather than cascading to them.
+ * A caller that walks the tree (the manual trash route recurses) calls this
+ * once per node it deletes; a caller that deletes a flat set (the cron purge)
+ * passes that set. Expanding beyond it would erase history belonging to pages
+ * that still exist.
+ */
+export async function deleteConversationsForPages(
+  tx: DbHandle,
+  pageIds: string[],
+): Promise<ConversationCleanupResult> {
+  if (pageIds.length === 0) return { ...EMPTY };
+
+  const doomed = await tx
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      or(
+        and(eq(conversations.type, 'page'), inArray(conversations.contextId, pageIds)),
+        and(eq(conversations.type, 'client'), inArray(conversations.agentPageId, pageIds)),
+      ),
+    );
+
+  return deleteConversationSet(tx, doomed.map((c) => c.id));
+}
+
+/**
+ * Delete the chat history belonging to a whole drive.
+ *
+ * MUST be called before the drive is deleted, because `pages.driveId`
+ * cascades: once the drive is gone its pages are gone, and the page-scoped
+ * threads below can no longer be found.
+ *
+ * Covers both the drive's OWN threads (`type='drive'`, and the `type='client'`
+ * API threads whose `contextId` is the drive — that is the scope a drive-scoped
+ * MCP token authorizes against) and every thread belonging to any page in it.
+ */
+export async function deleteConversationsForDrive(
+  tx: DbHandle,
+  driveId: string,
+): Promise<ConversationCleanupResult> {
+  const drivePages = await tx
+    .select({ id: pages.id })
+    .from(pages)
+    .where(eq(pages.driveId, driveId));
+  const pageIds = drivePages.map((p) => p.id);
+
+  const scopes = [
+    and(eq(conversations.type, 'drive'), eq(conversations.contextId, driveId)),
+    and(eq(conversations.type, 'client'), eq(conversations.contextId, driveId)),
+  ];
+  if (pageIds.length > 0) {
+    scopes.push(
+      and(eq(conversations.type, 'page'), inArray(conversations.contextId, pageIds)),
+      and(eq(conversations.type, 'client'), inArray(conversations.agentPageId, pageIds)),
+    );
+  }
+
+  const doomed = await tx
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(or(...scopes));
+
+  return deleteConversationSet(tx, doomed.map((c) => c.id));
+}
+

--- a/packages/lib/src/repositories/page-repository.ts
+++ b/packages/lib/src/repositories/page-repository.ts
@@ -8,6 +8,7 @@
 import { db } from '@pagespace/db/db';
 import { eq, and, desc, isNull, inArray, isNotNull, lt } from '@pagespace/db/operators';
 import { pages, type PageTypeEnum } from '@pagespace/db/schema/core';
+import { deleteConversationsForPages } from './conversation-cleanup';
 
 export type PageTypeValue = PageTypeEnum;
 
@@ -271,20 +272,51 @@ export const pageRepository = {
   /**
    * Hard-delete pages that have been in the trash for longer than the cutoff date.
    * Returns the count of deleted pages.
+   *
+   * This is an AUTOMATIC Article 17 path (`api/cron/purge-trashed-pages` runs
+   * it on a schedule against rows a user asked to be rid of 30 days earlier),
+   * and until now it was a bare `DELETE FROM pages` with no chat cleanup at
+   * all — so every page it purged left its conversations, messages and stream
+   * checkpoints behind. The manual trash route did clean up; the automated
+   * sweep over the SAME rows did not, which is the worse half of the pair,
+   * because nobody is watching it.
+   *
+   * SCOPE is exactly the rows this DELETE removes, and no more. `pages.parentId`
+   * carries NO foreign key (it is a bare text column), so deleting a trashed
+   * parent does not touch its children — they are orphaned, not cascaded, and
+   * trashing a page marks only that page. Expanding to the subtree here would
+   * therefore delete the chat history of pages that SURVIVE the purge, turning
+   * an under-deletion bug into a worse over-deletion one.
+   *
+   * Runs in a transaction so history and pages go together or not at all.
    */
   purgeExpiredTrashedPages: async (olderThan: Date): Promise<number> => {
-    const result = await db
-      .delete(pages)
-      .where(
-        and(
-          eq(pages.isTrashed, true),
-          isNotNull(pages.trashedAt),
-          lt(pages.trashedAt, olderThan)
-        )
-      )
-      .returning({ id: pages.id });
+    return db.transaction(async (tx) => {
+      const expired = await tx
+        .select({ id: pages.id })
+        .from(pages)
+        .where(
+          and(
+            eq(pages.isTrashed, true),
+            isNotNull(pages.trashedAt),
+            lt(pages.trashedAt, olderThan)
+          )
+        );
+      if (expired.length === 0) return 0;
 
-    return result.length;
+      const expiredIds = expired.map((p) => p.id);
+
+      // BEFORE the delete: `agentPageId` is ON DELETE SET NULL, so a page
+      // deleted first can no longer be traced to the API threads that named it.
+      await deleteConversationsForPages(tx, expiredIds);
+
+      const result = await tx
+        .delete(pages)
+        .where(inArray(pages.id, expiredIds))
+        .returning({ id: pages.id });
+
+      return result.length;
+    });
   },
 
   /**


### PR DESCRIPTION
Four data-integrity defects found by an adversarial review that ran the `0246→0252` chain against a scratch Postgres. Each was reproduced on a live database **before** being fixed, and every test added here was verified to **fail against the unfixed code**.

Rebased onto the current `pu/broken-sessions`, which has since landed the `agent_sessions` → `agent_workspaces` rename (#2358, migration `0253`). The full `0 → 0253` chain applies clean on a fresh database.

## Migrations are corrected IN PLACE — and why that is allowed

The house rule is "never edit an applied migration". None of `0246`–`0252` exists on `origin/master` (its `drizzle/` directory tops out at `0245_low_kid_colt.sql`), so they have never run outside a scratch database and no deployed environment has recorded their hashes. Correcting them in place is strictly better than layering corrective migrations that would exist only to undo mistakes in migrations nobody has ever applied.

```
$ git log origin/master --oneline -- packages/db/drizzle/0248*   # empty, as for 0246–0252
$ git ls-tree --name-only origin/master packages/db/drizzle/ | tail -1
packages/db/drizzle/0245_low_kid_colt.sql
```

---

## CRITICAL 1 — `0248`'s pre-audit hard-failed on a documented, supported shape

**Defect.** The straddle pre-audit aborted whenever a `chat_messages.conversationId` spanned more than one `pageId`. It was not scoped by conversation type. A `type='client'` (API) thread is anchored to a **drive**, not a page, and is documented as able to address several agent pages over its life — its rows straddle two `pageId`s *by design*. `0252` already handles exactly that downstream, anchoring to the earliest and merely warning.

**Reproduced** (new scenario, against unfixed `0248`):

```
messages unification (0248) pre-audit failed: 1 chat_messages conversationId(s)
span more than one pageId ... c_client_multi
```

The whole migration rolled back — the upgrade was impossible for any deployment that had ever served a two-agent API thread.

**Fix.** The fatal audit now excludes conversations whose existing row is `type='client'`, in both the count and the sample (a sample still naming excused threads would send an operator hunting for a straddle that is allowed). Genuine page-conversation straddles still abort. Client straddles remain visible through the non-fatal audit, which already reports them.

**Tests.** `messages-unification-expand-migration.test.ts` gains a live scenario putting a two-page client thread through `0248` and asserting it **survives** with the expand applied, plus a mixed-corpus scenario proving a real page straddle still aborts *and* that the excused client thread is not named as an offender. Both failed before the fix.

---

## CRITICAL 2 — `0252`'s completeness guard missed stale twins; deleted messages were resurrected

**Defect.** The guard compared `id + conversationId + role` only. Its premise — "after the `0250` freeze the unified row is always newer" — holds for the freeze window and is **false for the dual-write window**: during PR 10's rolling deploy an old pod writes an edit or soft-delete to `chat_messages` alone, and the documented `UNIFIED_MESSAGES_DUAL_WRITE=off` kill switch makes that window operator-controllable and arbitrarily long. Nothing repaired it afterwards — the backfill only inserts rows that are missing, the `0252` sweep skips rows that already have twins, and the retired reconcile cron compared only counts and `MAX(createdAt)`, neither of which moves when a row is edited in place.

**Reproduced.** With a legacy-only edit and a legacy-only soft-delete, the guard **passed** and the table dropped:

```
AssertionError: expected 'page question' to be 'EDITED TEXT'
```

The edit silently reverted; the soft-deleted message came back **live**.

**Fix — repair, not RAISE.** A new step 4 runs before the guard. After the freeze the legacy leg is immutable, so each shape is positive proof of a lost write:

```sql
(c."editedAt" IS NOT NULL AND (m."editedAt" IS NULL OR c."editedAt" > m."editedAt"))
OR (c."isActive" = false AND m."isActive" = true)
```

Repair is the right call here rather than a RAISE: the direction is unambiguous — there is exactly one newer value and it is about to be deleted — and a RAISE would block the deploy on a condition no operator can resolve by hand, since the remedy would be "hand-merge two message tables" when the correct answer is computable right there. Refusing is reserved for the guard below it, where a human genuinely has to choose.

Each field is repaired **only** on the predicate that proves *it* stale, so a row carrying a legacy soft-delete alongside a legitimately newer unified edit keeps the edit and gains the deletion. Idempotent by construction: after the `UPDATE` neither predicate can still hold.

**Tests.** Both directions are now in the corpus — the existing test seeded only the safe one (unified fresher), which is why this slipped through. The new lost-write scenario asserts the edit and the deletion survive the drop; a companion asserts the repair stays silent and changes nothing when the unified leg is already newer.

---

## HIGH 3 — `0246` silently dropped a pane, then `0251` blocked the deploy with a no-op remedy

**Defect.** The blob is client-authored and has never constrained pane-id uniqueness, but the row tables are keyed `(workspaceId, id)`. A blob repeating one pane id across two columns lost the second occurrence to `ON CONFLICT DO NOTHING`. `0251`'s guard then saw a blob pane binding the rows lacked and refused to drop the column — **over the pane `0246` had just eaten**. Following `0251`'s own documented HINT (delete the rows, let the sweep re-promote) re-ran the identical losing insert and failed identically: unrecoverable through any documented path.

**Reproduced.** The new live scenario dead-ended on `Refusing to drop agent_sessions."workspaceState"`, exactly as described.

**Fix.**
- Both promotions (`0246` and `0251`'s sweep) now `DISTINCT ON` pane and column ids, keeping the **first** occurrence in the client's own read order, and report collapses via `RAISE WARNING`. `ON CONFLICT DO NOTHING` is kept, but only for re-runnability rather than to paper over in-batch collisions.
- `0251`'s guard applies the same `DISTINCT ON`, so it judges the blob by what a correct promotion *would* produce. A duplicate id is not "data the rows lost" — it is data the schema cannot represent.
- The guard gains an **opt-in escape hatch** for the genuine blob-ahead-of-rows case (an old pod rewrote the blob after `0246`). The old remedy, "open it in a current client", is circular for the tenant/onprem operator who hits it: the current client is the deploy this migration is blocking. A database-level parameter breaks the loop without the app, and still names every session it discards:

```sql
ALTER DATABASE <db> SET "pagespace.workspace_state_force_drop" = 'on';
-- re-run the migration, then:
ALTER DATABASE <db> RESET "pagespace.workspace_state_force_drop";
```

**Tests.** `0246` and `0251` had **string-matching-only** suites that never opened a database — `workspace-state-drop-migration.test.ts` asserted `expect(code).toContain('RAISE EXCEPTION')`, and both files' headers claimed live behavior "was verified" by a hand-run nobody could repeat. That hand-run had missed this defect entirely. They now drive the real `0245 → 0251` chain against live Postgres across six scenarios: healthy promotion, the duplicate-pane case, genuine blob-ahead still refusing, the escape hatch, the never-promoted sweep, and a clean re-run.

---

## HIGH 4 — under-deletion: chat history outlived page and drive deletion

**Defect.** `chat_messages.pageId → pages ON DELETE CASCADE` was the physical net under every deletion path; nothing had to remember to clean chat history up because the database did it. `0252` dropped the table. What replaced it reaches none of the same ground: `conversations.contextId` has never been a foreign key, `agentPageId`'s is `ON DELETE SET NULL`, and `messages` / `ai_stream_sessions` cascade from a `conversations` row that nothing deletes.

**Reproduced** against a migrated database:

```
=== after DELETE FROM pages ===     conversations_left | messages_left → 1 | 1
=== after DELETE FROM drives ===    conversations_left | messages_left → 1 | 1
```

Only the manual trash route had an explicit cleanup, written **inline** — which is precisely how every other path drifted away from it unnoticed, including `purgeExpiredTrashedPages`, an *automatic* Article 17 path driven by cron that cleaned up nothing at all.

**Fix.** The inline statement becomes one shared helper, `packages/lib/src/repositories/conversation-cleanup.ts`, called by the manual trash route, the cron purge, and all four drive-delete sites — each inside a transaction and **before** the rows it depends on are deleted (ordering is load-bearing: deleting the page first nulls `agentPageId`; deleting the drive first cascades its pages away).

It also deletes the `conversations` **shell**, which the trash route used to leave standing. This is a deliberate contract change, and the schema comment that documented the old behavior is updated: `ai_stream_sessions.parts` holds partial message content, cascades from `conversations` and from nothing else, so an orphaned shell kept that content alive and **unreachable by any sweep** after the page was erased — the wrong trade for an erasure path.

**Scope is exactly the rows each caller deletes, with no subtree expansion.** `pages.parentId` carries **no foreign key**, so purging a trashed parent orphans its children rather than cascading to them, and trashing marks only the page named. Expanding to the subtree would have erased the history of pages that still exist — an over-deletion strictly worse than the bug being fixed. A test pins that boundary in both directions.

**Tests.** The existing page-delete coverage re-implemented the route's `DELETE` inline; it now calls the shared helper and asserts conversations, messages **and** stream checkpoints are all gone. New scenarios cover drive deletion and the cron purge. All four fail against the unfixed helper.

---

## Gates

Run locally against a scratch Postgres 17 on the rebased branch:

| Suite | Result |
|---|---|
| `packages/db` (live `DATABASE_URL`, incl. new scenarios) | **42 files, 636 tests passed** |
| `packages/lib` | **400 files, 8792 passed**, 9 skipped |
| `apps/web` | **1102 files, 16469 passed**, 6 skipped |
| `typecheck` (db, lib, web) | clean |
| `lint` (db, lib, web) | clean |
| Full `0 → 0253` chain on a fresh database | applies clean |

`knip` exits non-zero on this branch for pre-existing findings only — 4 duplicate exports in `apps/realtime`, `apps/web/src/lib/auth`, `packages/cli`, and missing `dist` entry files for `packages/cli` / `packages/db`'s removed `schema/permissions`. None touch files in this diff.

## One thing to flag, not fixed here

`packages/db/vitest.integration.config.ts` exists but **no script or CI job ever invokes it**, and `packages/db/vitest.config.ts` excludes `*.integration.test.ts` from the default run — so five integration suites in that package (`accessible-page-ids`, `admin-grants`, `admin-login-users`, `admin-migrate`, `admin-partition`) run nowhere. Separately, several suites **skip silently** without `DATABASE_URL` rather than failing, which is the same class of problem that let this PR's defects through: a guard nobody has seen fail is not known to be a guard. Both feel worth a follow-up decision rather than a drive-by change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
