### PR TITLE
fix(agents): close pane-label, layout-tool, and revocation-kick authz leaks

### DIFF
--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/workspace/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/workspace/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: Request, context: RouteContext) {
     return NextResponse.json({ workspace: null, rev: 0, grid: null });
   }
 
-  const snapshot = await readWorkspaceLayoutSnapshot(workspaceId);
+  const snapshot = await readWorkspaceLayoutSnapshot(workspaceId, auth.userId);
   return NextResponse.json({
     workspace: workspaceListEntryFromGrid(workspaceId, snapshot.grid),
     rev: snapshot.rev,

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/workspace/verbs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/workspace/verbs/__tests__/route.test.ts
@@ -13,11 +13,13 @@ const {
   mockAuditRequest,
   mockCheckSessionAccess,
   mockApplyWorkspaceLayoutVerb,
+  mockAuthorizeVerbScopes,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAuditRequest: vi.fn(),
   mockCheckSessionAccess: vi.fn(),
   mockApplyWorkspaceLayoutVerb: vi.fn(),
+  mockAuthorizeVerbScopes: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -35,6 +37,9 @@ vi.mock('@/lib/agent-workspaces/agent-sessions-runtime', () => ({
 }));
 vi.mock('@/lib/agent-workspaces/workspace-layout-runtime', () => ({
   applyWorkspaceLayoutVerb: (...args: unknown[]) => mockApplyWorkspaceLayoutVerb(...args),
+}));
+vi.mock('@/lib/agent-workspaces/authorize-pane-scope', () => ({
+  authorizeVerbScopes: (...args: unknown[]) => mockAuthorizeVerbScopes(...args),
 }));
 
 import { POST } from '../route';
@@ -62,6 +67,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockAuthenticateRequest.mockResolvedValue(AUTH_USER);
   mockCheckSessionAccess.mockResolvedValue({ allowed: true });
+  mockAuthorizeVerbScopes.mockResolvedValue(true);
   mockApplyWorkspaceLayoutVerb.mockResolvedValue({ status: 'ok', rev: 1, grid, applied: true });
 });
 
@@ -75,6 +81,8 @@ describe('POST /api/agent-workspaces/[workspaceId]/workspace/verbs', () => {
       opId: 'op-1',
       baseRev: 0,
       verb,
+      // The response grid's labels are resolved for THIS caller and nobody else.
+      viewerId: AUTH_USER.userId,
     });
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
@@ -178,6 +186,7 @@ describe('POST .../workspace/verbs — the rearrange verbs', () => {
       opId: 'op-r',
       baseRev: 3,
       verb: rearrange,
+      viewerId: AUTH_USER.userId,
     });
   });
 
@@ -248,5 +257,40 @@ describe('POST .../workspace/verbs — the rearrange verbs', () => {
 
     expect(response.status).toBe(404);
     expect(mockApplyWorkspaceLayoutVerb).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Security review HIGH 1, attack B: session access is not target access. The
+ * route used to hand the engine whatever `scope.targetId` the body carried,
+ * so a caller with a workspace of their own could bind any conversation,
+ * shell, or page id and read the joined title back out of the 200 body.
+ */
+describe('pane-scope authorization (attack B)', () => {
+  it('REFUSES a verb whose scope target the caller has no authority over — and never reaches the engine', async () => {
+    mockAuthorizeVerbScopes.mockResolvedValue(false);
+    const response = await post({ opId: 'op-1', baseRev: 0, verb });
+    expect(response.status).toBe(403);
+    expect(mockApplyWorkspaceLayoutVerb).not.toHaveBeenCalled();
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+    // Nothing about the target leaks back — forbidden and non-existent read alike.
+    expect(await response.json()).toEqual({
+      error: 'You cannot show that in this workspace.',
+    });
+  });
+
+  it('asks about the scope only AFTER session access is settled', async () => {
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'not_a_member' });
+    await post({ opId: 'op-1', baseRev: 0, verb });
+    expect(mockAuthorizeVerbScopes).not.toHaveBeenCalled();
+  });
+
+  it('passes the caller and the addressed workspace to the gate', async () => {
+    await post({ opId: 'op-1', baseRev: 0, verb });
+    expect(mockAuthorizeVerbScopes).toHaveBeenCalledWith({
+      viewerId: AUTH_USER.userId,
+      workspaceId: SESSION_ID,
+      verb,
+    });
   });
 });

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/workspace/verbs/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/workspace/verbs/route.ts
@@ -15,6 +15,15 @@
  * Gated by the same session-access check the blob PUT uses, with the same
  * family policy: an unknown session and a denied session answer the SAME 404
  * (`sessionNotFoundOrDenied`) so a probe learns nothing from the difference.
+ *
+ * SESSION ACCESS IS NOT TARGET ACCESS (security review HIGH 1, attack B).
+ * Reaching a workspace says nothing about the `scope.targetId` a verb wants to
+ * bind into it — that id is free-form in the body — so a second gate
+ * (`authorizeVerbScopes`) settles the target before the engine ever sees it:
+ *
+ *   403 { error }              — the caller may use this workspace but not
+ *       show that target in it. Uniform across "forbidden" and "no such
+ *       target", so a caller probing ids learns nothing.
  */
 
 import { NextResponse } from 'next/server';
@@ -25,6 +34,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { workspaceLayoutVerbSchema } from '@pagespace/lib/agent-workspaces/workspace-layout-verbs';
 import { checkSessionAccess } from '@/lib/agent-workspaces/agent-sessions-runtime';
 import { applyWorkspaceLayoutVerb } from '@/lib/agent-workspaces/workspace-layout-runtime';
+import { authorizeVerbScopes } from '@/lib/agent-workspaces/authorize-pane-scope';
 import { sessionNotFoundOrDenied } from '@/lib/agent-workspaces/session-unavailable-response';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -63,6 +73,18 @@ export async function POST(request: Request, context: RouteContext) {
     return NextResponse.json({ error: 'Invalid verb payload', issues: parsed.error.issues }, { status: 400 });
   }
 
+  // The target gate runs on the PARSED verb — after the shape is known and
+  // after session access is settled, so a probe cannot use it to distinguish
+  // "workspace you cannot reach" from "target you cannot bind".
+  const scopesAllowed = await authorizeVerbScopes({
+    viewerId: auth.userId,
+    workspaceId,
+    verb: parsed.data.verb,
+  });
+  if (!scopesAllowed) {
+    return NextResponse.json({ error: 'You cannot show that in this workspace.' }, { status: 403 });
+  }
+
   let result;
   try {
     result = await applyWorkspaceLayoutVerb({
@@ -70,6 +92,9 @@ export async function POST(request: Request, context: RouteContext) {
       opId: parsed.data.opId,
       baseRev: parsed.data.baseRev,
       verb: parsed.data.verb,
+      // Labels on the way out are resolved for THIS caller alone; the
+      // broadcast that follows carries none at all.
+      viewerId: auth.userId,
     });
   } catch (error) {
     loggers.api.error('Workspace layout verb failed', error instanceof Error ? error : undefined, { workspaceId });

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -139,7 +139,9 @@ describe('GET /api/agent-workspaces', () => {
     expect(mockListSessionConversationsBulk).toHaveBeenCalledTimes(1);
     expect(mockListSessionConversationsBulk).toHaveBeenCalledWith(['ses-1']);
     expect(mockListShellsBulk).toHaveBeenCalledWith(['ses-1']);
-    expect(mockReadWorkspaceGridsBulk).toHaveBeenCalledWith(['ses-1']);
+    // Pane labels are a permissioned join (security review HIGH 1) — the bulk
+    // read names the viewer it is resolving for.
+    expect(mockReadWorkspaceGridsBulk).toHaveBeenCalledWith(['ses-1'], 'user-1');
   });
 
   it('given a session with pane rows, should attach the grid as `workspace` in the whole-state shape', async () => {

--- a/apps/web/src/app/api/agent-workspaces/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/route.ts
@@ -119,7 +119,7 @@ export async function GET(request: Request) {
     const [shellsBySession, conversationsBySession, gridBySession] = await Promise.all([
       listShellsBulk(workspaceIds),
       listSessionConversationsBulk(workspaceIds),
-      readWorkspaceGridsBulk(workspaceIds),
+      readWorkspaceGridsBulk(workspaceIds, auth.userId),
     ]);
     const withChildren = sessions.map((session) => ({
       ...session,

--- a/apps/web/src/lib/agent-workspaces/__tests__/authorize-pane-scope.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/authorize-pane-scope.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+/**
+ * BINDING A PANE IS A PERMISSION DECISION (security review HIGH 1, attack B).
+ *
+ * `workspaceLayoutVerbSchema` lets `ensure` / `assign_pane` /
+ * `open_conversation` / `replace_conversation` carry a free `targetId` +
+ * `kind`. The verbs route used to validate session access ONLY — never the
+ * scope target — so anyone with a workspace of their own could bind an
+ * arbitrary conversation, shell, or page id and read the resolved title back
+ * out of the response grid. This is the write half of that fix (the read half
+ * is `workspace-layout-labels.test.ts`); belt and braces, because the row a
+ * bad bind leaves behind outlives the request that made it.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { WorkspaceLayoutVerb } from '@pagespace/lib/agent-workspaces/workspace-layout-verbs';
+import { authorizePaneScope, paneScopesOfVerb, type PaneScopeAuthorityDeps } from '../authorize-pane-scope';
+
+const VIEWER = 'viewer-1';
+const WORKSPACE = 'ws-1';
+const OTHER_WORKSPACE = 'ws-2';
+
+const deps = (overrides: Partial<PaneScopeAuthorityDeps> = {}): PaneScopeAuthorityDeps => ({
+  findConversation: vi.fn(async () => null),
+  findShellWorkspace: vi.fn(async () => null),
+  canViewPage: vi.fn(async () => false),
+  ...overrides,
+});
+
+const scopeOf = (kind: 'chat' | 'terminal' | 'page', targetId: string | null) => ({
+  kind,
+  name: 'whatever the caller claims',
+  targetId,
+  agentPageId: null,
+});
+
+describe('paneScopesOfVerb — every verb that can bind a target', () => {
+  it('finds the scope on each of the four scope-carrying verbs', () => {
+    const scope = scopeOf('chat', 'conv-1');
+    const verbs: WorkspaceLayoutVerb[] = [
+      { type: 'ensure', columnId: 'c', paneId: 'p', scope },
+      { type: 'assign_pane', paneId: 'p', scope },
+      { type: 'open_conversation', scope, newColumnId: 'c', newPaneId: 'p' },
+      { type: 'replace_conversation', oldTargetId: 'conv-0', scope },
+    ];
+    for (const verb of verbs) {
+      expect(paneScopesOfVerb(verb), `${verb.type} must expose its scope`).toEqual([scope]);
+    }
+  });
+
+  it('finds nothing on a purely geometric verb', () => {
+    expect(paneScopesOfVerb({ type: 'resize_pane', paneId: 'p', heightFraction: 0.5 })).toEqual([]);
+    expect(paneScopesOfVerb({ type: 'close_pane', paneId: 'p' })).toEqual([]);
+  });
+});
+
+describe('page scopes', () => {
+  it('REFUSES a page the caller cannot view — the title oracle over pages', async () => {
+    const d = deps({ canViewPage: vi.fn(async () => false) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('page', 'page-secret') }, d),
+    ).toBe(false);
+    expect(d.canViewPage).toHaveBeenCalledWith(VIEWER, 'page-secret');
+  });
+
+  it('allows a page the caller can view', async () => {
+    const d = deps({ canViewPage: vi.fn(async () => true) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('page', 'page-ok') }, d),
+    ).toBe(true);
+  });
+});
+
+describe('terminal scopes', () => {
+  it('REFUSES a shell that lives in a different workspace', async () => {
+    const d = deps({ findShellWorkspace: vi.fn(async () => OTHER_WORKSPACE) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('terminal', 'shell-x') }, d),
+    ).toBe(false);
+  });
+
+  it('REFUSES a shell that does not exist', async () => {
+    const d = deps({ findShellWorkspace: vi.fn(async () => null) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('terminal', 'nope') }, d),
+    ).toBe(false);
+  });
+
+  it('allows a shell of THIS workspace', async () => {
+    const d = deps({ findShellWorkspace: vi.fn(async () => WORKSPACE) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('terminal', 'shell-own') }, d),
+    ).toBe(true);
+  });
+});
+
+describe('chat scopes', () => {
+  const conversation = (over: Partial<{ userId: string; isShared: boolean; type: string; contextId: string | null; workspaceId: string | null }>) => ({
+    userId: 'someone-else',
+    isShared: false,
+    type: 'global',
+    contextId: null,
+    workspaceId: null,
+    ...over,
+  });
+
+  it('REFUSES a foreign private conversation — the universal title oracle', async () => {
+    const d = deps({ findConversation: vi.fn(async () => conversation({ workspaceId: OTHER_WORKSPACE })) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', 'conv-victim') }, d),
+    ).toBe(false);
+  });
+
+  it('REFUSES a conversation that does not exist — no existence oracle either', async () => {
+    const d = deps({ findConversation: vi.fn(async () => null) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', 'made-up') }, d),
+    ).toBe(false);
+  });
+
+  it('allows a conversation already bound to THIS workspace', async () => {
+    const d = deps({ findConversation: vi.fn(async () => conversation({ workspaceId: WORKSPACE })) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', 'conv-here') }, d),
+    ).toBe(true);
+  });
+
+  it("allows the caller's OWN conversation from anywhere", async () => {
+    const d = deps({ findConversation: vi.fn(async () => conversation({ userId: VIEWER })) });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', 'conv-mine') }, d),
+    ).toBe(true);
+  });
+
+  it('allows a shared page conversation whose page the caller can view', async () => {
+    const d = deps({
+      findConversation: vi.fn(async () => conversation({ isShared: true, type: 'page', contextId: 'page-1' })),
+      canViewPage: vi.fn(async () => true),
+    });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', 'conv-shared') }, d),
+    ).toBe(true);
+  });
+
+  it('REFUSES a shared page conversation whose page the caller CANNOT view', async () => {
+    const d = deps({
+      findConversation: vi.fn(async () => conversation({ isShared: true, type: 'page', contextId: 'page-1' })),
+      canViewPage: vi.fn(async () => false),
+    });
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', 'conv-shared') }, d),
+    ).toBe(false);
+  });
+});
+
+describe('an unbound picker pane', () => {
+  it('needs no authority — there is no target yet', async () => {
+    const d = deps();
+    expect(
+      await authorizePaneScope({ viewerId: VIEWER, workspaceId: WORKSPACE, scope: scopeOf('chat', null) }, d),
+    ).toBe(true);
+    expect(d.findConversation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-labels.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-labels.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment node
+/**
+ * PANE LABELS ARE A PERMISSIONED JOIN (security review HIGH 1).
+ *
+ * The layout read path derives every pane's display label by joining the
+ * conversation title / shell name / page title at read time. Before this
+ * suite existed the join took NO viewer: `resolvePaneLabels` selected the
+ * titles by id and every consumer (`GET /workspace`, the verbs route's 200
+ * and its 409 body, the `workspace:updated` broadcast, and `list_panes`)
+ * returned them verbatim. Two disclosures followed:
+ *
+ *  - **Attack A (redaction bypass).** `list_sessions`' shared listing hands a
+ *    drive member the workspace ids of OTHER members' workspaces with the
+ *    conversation titles correctly redacted. Reading the same workspace's
+ *    layout returned the real titles in `grid[].panes[].scope.name` — the
+ *    redaction rule undone one HTTP call later.
+ *  - **Attack B (universal title oracle).** A pane's `targetId` is whatever
+ *    the verb that bound it supplied. Anyone with a workspace of their own
+ *    could bind an arbitrary conversation / shell / page id and read the
+ *    resolved title back out, over resources they have no access to at all.
+ *
+ * The rule these tests pin, per pane kind:
+ *  - `chat`   — resolve only when the conversation is genuinely IN this
+ *               workspace, or is one the viewer may access on its own footing
+ *               (`canAccessConversation`); then the title still passes through
+ *               `redactConversationTitleForViewer`, the epic's ONE listing rule.
+ *  - `terminal` — resolve only when the shell belongs to THIS workspace
+ *               (shells are workspace-scoped, so containment is exact and
+ *               matches what the shells route already serves).
+ *  - `page`   — resolve only when the viewer has page access
+ *               (`getUserAccessLevel`).
+ * Anything else keeps its pane ROW and resolves no label at all — the same
+ * empty-name treatment a deleted target has always had.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LayoutGridColumn } from '@pagespace/lib/agent-workspaces/workspace-layout-verbs';
+import type { WorkspaceLayoutStore } from '@pagespace/lib/services/agent-workspaces/workspace-layout-store';
+
+const { storeRef, rows, pageAccess, mockBroadcast } = vi.hoisted(() => ({
+  storeRef: { current: null as unknown },
+  rows: {
+    conversations: [] as unknown[],
+    shells: [] as unknown[],
+    pages: [] as unknown[],
+    workspaces: [] as unknown[],
+  },
+  /** `${viewerId}:${pageId}` the viewer may read. Everything else denies. */
+  pageAccess: new Set<string>(),
+  mockBroadcast: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/agent-workspaces/workspace-layout-store', () => ({
+  withWorkspaceLayoutLock: async (_workspaceId: string, fn: (tx: unknown) => Promise<unknown>) => fn({}),
+  createDbWorkspaceLayoutStore: async () => storeRef.current,
+}));
+vi.mock('@/lib/websocket/agent-workspace-events', () => ({
+  broadcastWorkspaceUpdated: (...args: unknown[]) => mockBroadcast(...args),
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: (table: { __name: keyof typeof rows }) => ({
+        where: async () => rows[table.__name],
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({ inArray: vi.fn() }));
+vi.mock('@pagespace/db/schema/conversations', () => ({ conversations: { __name: 'conversations' } }));
+vi.mock('@pagespace/db/schema/agent-workspaces', () => ({
+  agentWorkspaceShells: { __name: 'shells' },
+  agentWorkspaces: { __name: 'workspaces' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { __name: 'pages' } }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessLevel: async (userId: string, pageId: string) =>
+    pageAccess.has(`${userId}:${pageId}`) ? 'VIEW' : null,
+}));
+
+import { readWorkspaceLayoutSnapshot, readWorkspaceGridsBulk } from '../workspace-layout-runtime';
+
+const ALICE = 'alice';
+const MALLORY = 'mallory';
+const WORKSPACE = 'ws-alice';
+const MALLORY_WORKSPACE = 'ws-mallory';
+
+function createFakeStore(grids: Record<string, LayoutGridColumn[]>): WorkspaceLayoutStore {
+  return {
+    async getWorkspaceGrid(workspaceId) {
+      return structuredClone(grids[workspaceId] ?? []);
+    },
+    async getWorkspaceGridsBulk(workspaceIds) {
+      const out = new Map<string, LayoutGridColumn[]>();
+      for (const id of workspaceIds) {
+        const grid = grids[id];
+        if (grid && grid.length > 0) out.set(id, structuredClone(grid));
+      }
+      return out;
+    },
+    async replaceWorkspaceGrid() {
+      return { rev: 1, applied: true };
+    },
+    async currentRev() {
+      return 1;
+    },
+    async findOp() {
+      return null;
+    },
+    async recordOp() {},
+  };
+}
+
+/** One column, one pane, bound to `kind:targetId`. */
+const gridOf = (kind: 'chat' | 'terminal' | 'page', targetId: string): LayoutGridColumn[] => [
+  { id: 'col-1', widthFraction: null, panes: [{ id: 'pane-1', kind, targetId, heightFraction: null }] },
+];
+
+const nameOf = (grid: NonNullable<Awaited<ReturnType<typeof readWorkspaceLayoutSnapshot>>['grid']>): string =>
+  grid[0].panes[0].scope?.name ?? '<unbound>';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pageAccess.clear();
+  rows.conversations = [];
+  rows.shells = [];
+  rows.pages = [];
+  // Alice owns her workspace; Mallory owns his.
+  rows.workspaces = [
+    { id: WORKSPACE, ownerId: ALICE },
+    { id: MALLORY_WORKSPACE, ownerId: MALLORY },
+  ];
+});
+
+describe('Attack A — a drive member reading someone else\'s workspace layout', () => {
+  beforeEach(() => {
+    // A private thread of Alice's, genuinely living in Alice's workspace.
+    rows.conversations = [
+      {
+        id: 'conv-private',
+        title: 'Q3 layoffs plan',
+        type: 'global',
+        contextId: null,
+        userId: ALICE,
+        isShared: false,
+        workspaceId: WORKSPACE,
+      },
+    ];
+    storeRef.current = createFakeStore({ [WORKSPACE]: gridOf('chat', 'conv-private') });
+  });
+
+  it('gives the workspace OWNER the real title (shared-workspace semantics are unchanged)', async () => {
+    const snapshot = await readWorkspaceLayoutSnapshot(WORKSPACE, ALICE);
+    expect(nameOf(snapshot.grid!)).toBe('Q3 layoffs plan');
+  });
+
+  it('redacts the title for any other viewer — the SAME rule list_sessions applies', async () => {
+    const snapshot = await readWorkspaceLayoutSnapshot(WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('(private thread)');
+    // The pane ROW survives — redaction hides the title, not the layout.
+    expect(snapshot.grid![0].panes[0].scope?.targetId).toBe('conv-private');
+  });
+
+  it('still shows a DELIBERATELY SHARED thread to another viewer', async () => {
+    (rows.conversations[0] as { isShared: boolean }).isShared = true;
+    const snapshot = await readWorkspaceLayoutSnapshot(WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('Q3 layoffs plan');
+  });
+});
+
+describe('Attack B — an arbitrary targetId bound into the attacker\'s OWN workspace', () => {
+  it('resolves no conversation title for a foreign conversation, even for the workspace owner', async () => {
+    rows.conversations = [
+      {
+        id: 'conv-victim',
+        title: 'Board deck v4',
+        type: 'global',
+        contextId: null,
+        userId: ALICE,
+        isShared: false,
+        workspaceId: WORKSPACE,
+      },
+    ];
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('chat', 'conv-victim') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('');
+  });
+
+  it('resolves no shell name for a shell belonging to a different workspace', async () => {
+    rows.shells = [{ id: 'shell-victim', name: 'prod-deploy-key-rotation', workspaceId: WORKSPACE }];
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('terminal', 'shell-victim') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('');
+  });
+
+  it('resolves the shell name when the shell really belongs to the workspace being read', async () => {
+    rows.shells = [{ id: 'shell-own', name: 'build', workspaceId: MALLORY_WORKSPACE }];
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('terminal', 'shell-own') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('build');
+  });
+
+  it('resolves no page title for a page the viewer cannot read', async () => {
+    rows.pages = [{ id: 'page-secret', title: 'Acquisition targets' }];
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('page', 'page-secret') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('');
+  });
+
+  it('resolves the page title when the viewer CAN read the page', async () => {
+    rows.pages = [{ id: 'page-ok', title: 'Sprint notes' }];
+    pageAccess.add(`${MALLORY}:page-ok`);
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('page', 'page-ok') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('Sprint notes');
+  });
+});
+
+describe('a null viewer resolves NOTHING', () => {
+  it('returns a label-free grid — the shape the room broadcast ships', async () => {
+    rows.conversations = [
+      {
+        id: 'conv-1',
+        title: 'Anything',
+        type: 'global',
+        contextId: null,
+        userId: ALICE,
+        isShared: true,
+        workspaceId: WORKSPACE,
+      },
+    ];
+    storeRef.current = createFakeStore({ [WORKSPACE]: gridOf('chat', 'conv-1') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(WORKSPACE, null);
+    expect(nameOf(snapshot.grid!)).toBe('');
+    expect(snapshot.grid![0].panes[0].scope?.targetId).toBe('conv-1');
+  });
+});
+
+describe('the bulk read applies the same per-workspace rule', () => {
+  it('redacts per workspace, not per query — one viewer, two workspaces', async () => {
+    rows.conversations = [
+      {
+        id: 'conv-alice',
+        title: 'Alice private',
+        type: 'global',
+        contextId: null,
+        userId: ALICE,
+        isShared: false,
+        workspaceId: WORKSPACE,
+      },
+      {
+        id: 'conv-mallory',
+        title: 'Mallory own',
+        type: 'global',
+        contextId: null,
+        userId: MALLORY,
+        isShared: false,
+        workspaceId: MALLORY_WORKSPACE,
+      },
+    ];
+    storeRef.current = createFakeStore({
+      [WORKSPACE]: gridOf('chat', 'conv-alice'),
+      [MALLORY_WORKSPACE]: gridOf('chat', 'conv-mallory'),
+    });
+
+    const grids = await readWorkspaceGridsBulk([WORKSPACE, MALLORY_WORKSPACE], MALLORY);
+    expect(grids.get(WORKSPACE)![0].panes[0].scope?.name).toBe('(private thread)');
+    expect(grids.get(MALLORY_WORKSPACE)![0].panes[0].scope?.name).toBe('Mallory own');
+  });
+});

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-labels.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-labels.test.ts
@@ -186,6 +186,48 @@ describe('Attack B — an arbitrary targetId bound into the attacker\'s OWN work
     expect(nameOf(snapshot.grid!)).toBe('');
   });
 
+  it('DOES resolve a foreign conversation the viewer may access on its own footing', async () => {
+    // Not in Mallory's workspace, but deliberately shared on a page he can
+    // view — `canAccessConversation`'s rule, the same predicate the conv: room
+    // join and /stream-join enforce. Refusing this would break a legitimate
+    // pane; the gate is authority, not containment for its own sake.
+    rows.conversations = [
+      {
+        id: 'conv-shared',
+        title: 'Team retro',
+        type: 'page',
+        contextId: 'page-team',
+        userId: ALICE,
+        isShared: true,
+        workspaceId: WORKSPACE,
+      },
+    ];
+    pageAccess.add(`${MALLORY}:page-team`);
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('chat', 'conv-shared') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('Team retro');
+  });
+
+  it('refuses that same shared conversation once the viewer loses the page', async () => {
+    rows.conversations = [
+      {
+        id: 'conv-shared',
+        title: 'Team retro',
+        type: 'page',
+        contextId: 'page-team',
+        userId: ALICE,
+        isShared: true,
+        workspaceId: WORKSPACE,
+      },
+    ];
+    // No page access this time.
+    storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('chat', 'conv-shared') });
+
+    const snapshot = await readWorkspaceLayoutSnapshot(MALLORY_WORKSPACE, MALLORY);
+    expect(nameOf(snapshot.grid!)).toBe('');
+  });
+
   it('resolves no shell name for a shell belonging to a different workspace', async () => {
     rows.shells = [{ id: 'shell-victim', name: 'prod-deploy-key-rotation', workspaceId: WORKSPACE }];
     storeRef.current = createFakeStore({ [MALLORY_WORKSPACE]: gridOf('terminal', 'shell-victim') });

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-runtime.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-runtime.test.ts
@@ -62,7 +62,12 @@ const { mockBroadcast, storeRef, labelRows } = vi.hoisted(() => ({
   mockBroadcast: vi.fn(),
   storeRef: { current: null as unknown },
   /** What the label JOIN finds, per table — the live titles the rows do not store. */
-  labelRows: { conversations: [] as unknown[], shells: [] as unknown[], pages: [] as unknown[] },
+  labelRows: {
+    conversations: [] as unknown[],
+    shells: [] as unknown[],
+    pages: [] as unknown[],
+    workspaces: [] as unknown[],
+  },
 }));
 
 vi.mock('@pagespace/lib/services/agent-workspaces/workspace-layout-store', () => ({
@@ -80,7 +85,7 @@ vi.mock('@/lib/websocket/agent-workspace-events', () => ({
 vi.mock('@pagespace/db/db', () => ({
   db: {
     select: () => ({
-      from: (table: { __name: 'conversations' | 'shells' | 'pages' }) => ({
+      from: (table: { __name: 'conversations' | 'shells' | 'pages' | 'workspaces' }) => ({
         where: async () => labelRows[table.__name],
       }),
     }),
@@ -88,12 +93,17 @@ vi.mock('@pagespace/db/db', () => ({
 }));
 vi.mock('@pagespace/db/operators', () => ({ inArray: vi.fn() }));
 vi.mock('@pagespace/db/schema/conversations', () => ({ conversations: { __name: 'conversations' } }));
-vi.mock('@pagespace/db/schema/agent-workspaces', () => ({ agentWorkspaceShells: { __name: 'shells' } }));
+vi.mock('@pagespace/db/schema/agent-workspaces', () => ({
+  agentWorkspaceShells: { __name: 'shells' },
+  agentWorkspaces: { __name: 'workspaces' },
+}));
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { __name: 'pages' } }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({ getUserAccessLevel: async () => 'VIEW' }));
 
 import { applyWorkspaceLayoutVerb } from '../workspace-layout-runtime';
 
 const WORKSPACE_ID = 'ses-1';
+const VIEWER_ID = 'user-1';
 const scope = { kind: 'chat' as const, name: 'Conversation', targetId: 'conv-1', agentPageId: null };
 /** What the pane comes back as: the name is JOINED, never echoed from the verb. */
 const joinedScope = { ...scope, name: 'Live title' };
@@ -104,9 +114,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   store = createFakeWorkspaceLayoutStore();
   storeRef.current = store;
-  labelRows.conversations = [{ id: 'conv-1', title: 'Live title', type: 'global', contextId: null }];
+  labelRows.conversations = [
+    { id: 'conv-1', title: 'Live title', type: 'global', contextId: null, userId: VIEWER_ID, isShared: false, workspaceId: WORKSPACE_ID },
+  ];
   labelRows.shells = [];
   labelRows.pages = [];
+  labelRows.workspaces = [{ id: WORKSPACE_ID, ownerId: VIEWER_ID }];
 });
 
 const ensure = (opId = 'op-ensure', baseRev = 0) =>
@@ -115,10 +128,11 @@ const ensure = (opId = 'op-ensure', baseRev = 0) =>
     opId,
     baseRev,
     verb: { type: 'ensure', columnId: 'col-1', paneId: 'pane-1', scope },
+    viewerId: VIEWER_ID,
   });
 
 describe('applyWorkspaceLayoutVerb', () => {
-  it('applies a verb, persists rows, and broadcasts the post-write rev with JOINED labels', async () => {
+  it('applies a verb, answers the CALLER with joined labels, and broadcasts a LABEL-FREE grid', async () => {
     const result = await ensure();
     expect(result).toEqual({
       status: 'ok',
@@ -132,6 +146,10 @@ describe('applyWorkspaceLayoutVerb', () => {
     expect(await store.getWorkspaceGrid(WORKSPACE_ID)).toEqual([
       { id: 'col-1', widthFraction: null, panes: [{ id: 'pane-1', kind: 'chat', targetId: 'conv-1', heightFraction: null }] },
     ]);
+    // SECURITY (review HIGH 1): `session:<id>` is a room — one payload, every
+    // member — so there is no viewer to redact titles for and the broadcast
+    // carries structure only. Clients re-dress it from what they already know
+    // and read anything new under their own authority.
     expect(mockBroadcast).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
       rev: 1,
@@ -139,7 +157,7 @@ describe('applyWorkspaceLayoutVerb', () => {
       // The causing op's key rides along so a subscriber can recognize its
       // OWN echo and leave its still-queued verb alone.
       opId: 'op-ensure',
-      grid: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: joinedScope }] }],
+      grid: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { ...scope, name: '' } }] }],
     });
   });
 
@@ -147,12 +165,15 @@ describe('applyWorkspaceLayoutVerb', () => {
     await ensure('op-1');
     // The conversation is renamed elsewhere. Nothing rewrites the pane row —
     // and nothing needs to, which is the entire point of not storing names.
-    labelRows.conversations = [{ id: 'conv-1', title: 'Renamed', type: 'global', contextId: null }];
+    labelRows.conversations = [
+      { id: 'conv-1', title: 'Renamed', type: 'global', contextId: null, userId: VIEWER_ID, isShared: false, workspaceId: WORKSPACE_ID },
+    ];
     const next = await applyWorkspaceLayoutVerb({
       workspaceId: WORKSPACE_ID,
       opId: 'op-2',
       baseRev: 1,
       verb: { type: 'split_down', fromPaneId: 'pane-1', newPaneId: 'pane-2' },
+      viewerId: VIEWER_ID,
     });
     expect(next.status === 'ok' && next.grid[0].panes[0].scope?.name).toBe('Renamed');
   });
@@ -171,13 +192,13 @@ describe('applyWorkspaceLayoutVerb', () => {
       newColumnId: 'col-2',
       newPaneId: 'pane-2',
     };
-    const first = await applyWorkspaceLayoutVerb({ workspaceId: WORKSPACE_ID, opId: 'op-2', baseRev: 1, verb: split });
+    const first = await applyWorkspaceLayoutVerb({ workspaceId: WORKSPACE_ID, opId: 'op-2', baseRev: 1, verb: split, viewerId: VIEWER_ID });
     expect(first.status === 'ok' && first.applied).toBe(true);
     mockBroadcast.mockClear();
 
     // The retry: same opId, same (now stale) baseRev. It must short-circuit
     // on the op memory — NOT 409, NOT a second column — and not broadcast.
-    const retry = await applyWorkspaceLayoutVerb({ workspaceId: WORKSPACE_ID, opId: 'op-2', baseRev: 1, verb: split });
+    const retry = await applyWorkspaceLayoutVerb({ workspaceId: WORKSPACE_ID, opId: 'op-2', baseRev: 1, verb: split, viewerId: VIEWER_ID });
     expect(retry.status).toBe('ok');
     expect(retry.status === 'ok' && retry.applied).toBe(false);
     expect(retry.rev).toBe(2);
@@ -193,6 +214,7 @@ describe('applyWorkspaceLayoutVerb', () => {
       opId: 'op-stale',
       baseRev: 0,
       verb: { type: 'split_down', fromPaneId: 'pane-1', newPaneId: 'pane-2' },
+      viewerId: VIEWER_ID,
     });
     expect(result).toEqual({
       status: 'stale',
@@ -210,6 +232,7 @@ describe('applyWorkspaceLayoutVerb', () => {
       opId: 'op-noop',
       baseRev: 1,
       verb: { type: 'close_pane', paneId: 'ghost' },
+      viewerId: VIEWER_ID,
     });
     expect(result.status === 'ok' && result.applied).toBe(false);
     expect(result.rev).toBe(1);
@@ -221,6 +244,7 @@ describe('applyWorkspaceLayoutVerb', () => {
       opId: 'op-noop',
       baseRev: 99,
       verb: { type: 'close_pane', paneId: 'ghost' },
+      viewerId: VIEWER_ID,
     });
     expect(replay.status).toBe('ok');
   });

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-placement.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-placement.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+/**
+ * SERVER-SIDE PAGE PLACEMENT IS ACL'D (security review, MEDIUM on the HIGH 1
+ * surface).
+ *
+ * `open_page_pane` hands `placePagePaneForConversation` a MODEL-SUPPLIED
+ * pageId. It used to select that page's title with no access check at all and
+ * write it straight into the pane grid and the `workspace:updated` broadcast
+ * — so a prompt-injected agent could exfiltrate the titles of pages its own
+ * user cannot read, simply by naming ids.
+ *
+ * The rule: the ACTING USER must be able to view the page. Not the model's
+ * claim, not the conversation's mere existence — the same `getUserAccessLevel`
+ * gate every page read goes through.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockApplyVerb, mockReadSnapshot, rows, pageAccess } = vi.hoisted(() => ({
+  mockApplyVerb: vi.fn(),
+  mockReadSnapshot: vi.fn(),
+  rows: { conversations: [] as unknown[], pages: [] as unknown[] },
+  pageAccess: new Set<string>(),
+}));
+
+vi.mock('../workspace-layout-runtime', () => ({
+  applyWorkspaceLayoutVerb: (...args: unknown[]) => mockApplyVerb(...args),
+  readWorkspaceLayoutSnapshot: (...args: unknown[]) => mockReadSnapshot(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { warn: vi.fn(), error: vi.fn() } },
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: (table: { __name: 'conversations' | 'pages' }) => ({
+        where: () => ({ limit: async () => rows[table.__name] }),
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/schema/conversations', () => ({ conversations: { __name: 'conversations' } }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { __name: 'pages' } }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessLevel: async (userId: string, pageId: string) =>
+    pageAccess.has(`${userId}:${pageId}`) ? 'VIEW' : null,
+}));
+vi.mock('@paralleldrive/cuid2', () => ({ createId: () => 'minted' }));
+
+import { placePagePaneForConversation } from '../workspace-placement';
+
+const MALLORY = 'mallory';
+const CONVERSATION = 'conv-1';
+const WORKSPACE = 'ws-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pageAccess.clear();
+  rows.conversations = [{ workspaceId: WORKSPACE }];
+  rows.pages = [{ title: 'Acquisition targets' }];
+  mockReadSnapshot.mockResolvedValue({ rev: 3, grid: null });
+  mockApplyVerb.mockResolvedValue({ status: 'ok', rev: 4, grid: [], applied: true });
+});
+
+describe('placePagePaneForConversation', () => {
+  it('places NOTHING for a page the acting user cannot view', async () => {
+    await placePagePaneForConversation({
+      conversationId: CONVERSATION,
+      pageId: 'page-secret',
+      viewerId: MALLORY,
+      opId: 'op-1',
+    });
+    // No verb, therefore no pane row and no broadcast — the title never
+    // reaches the grid or the wire.
+    expect(mockApplyVerb).not.toHaveBeenCalled();
+  });
+
+  it('does not let the model\'s own `title` smuggle a label past the gate', async () => {
+    await placePagePaneForConversation({
+      conversationId: CONVERSATION,
+      pageId: 'page-secret',
+      title: 'Something the model made up',
+      viewerId: MALLORY,
+      opId: 'op-1',
+    });
+    expect(mockApplyVerb).not.toHaveBeenCalled();
+  });
+
+  it('places the pane, with the page\'s REAL title, when the user can view it', async () => {
+    pageAccess.add(`${MALLORY}:page-ok`);
+    rows.pages = [{ title: 'Sprint notes' }];
+    await placePagePaneForConversation({
+      conversationId: CONVERSATION,
+      pageId: 'page-ok',
+      title: 'a worse label',
+      viewerId: MALLORY,
+      opId: 'op-1',
+    });
+    expect(mockApplyVerb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: WORKSPACE,
+        verb: expect.objectContaining({
+          type: 'open_conversation',
+          scope: expect.objectContaining({ kind: 'page', targetId: 'page-ok', name: 'Sprint notes' }),
+        }),
+      }),
+    );
+  });
+
+  it('is still a harmless no-op for a conversation bound to no workspace', async () => {
+    pageAccess.add(`${MALLORY}:page-ok`);
+    rows.conversations = [];
+    await placePagePaneForConversation({
+      conversationId: CONVERSATION,
+      pageId: 'page-ok',
+      viewerId: MALLORY,
+      opId: 'op-1',
+    });
+    expect(mockApplyVerb).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/agent-workspaces/authorize-pane-scope.ts
+++ b/apps/web/src/lib/agent-workspaces/authorize-pane-scope.ts
@@ -1,0 +1,158 @@
+/**
+ * MAY THIS CALLER BIND THIS TARGET INTO THIS GRID? (security review HIGH 1,
+ * attack B.)
+ *
+ * A layout verb's `scope` is caller-supplied: `workspaceLayoutVerbSchema`
+ * validates that `ensure` / `assign_pane` / `open_conversation` /
+ * `replace_conversation` carry a `{kind, targetId}`, and nothing more. The
+ * verbs route checked only that the caller could reach the WORKSPACE, so any
+ * authenticated user could create a workspace of their own, bind an arbitrary
+ * conversation / shell / page id into it, and read the joined title back out
+ * of the response grid — a title oracle (and an existence oracle) over
+ * resources they have no access to whatsoever.
+ *
+ * This is the WRITE half of the fix. The read half (`resolvePaneLabels` in
+ * ./workspace-layout-runtime.ts) refuses to resolve a label the viewer has no
+ * authority for, and is what actually stops the disclosure; this gate stops
+ * the bad row from being written at all, which matters because a pane row
+ * outlives the request that created it and is re-read by every later viewer
+ * of that grid.
+ *
+ * The two halves share ONE rule per kind, deliberately:
+ *   - `page`     — the viewer must be able to view the page.
+ *   - `terminal` — the shell must belong to THIS workspace (shells are
+ *                  workspace-scoped rows, so containment is the whole rule).
+ *   - `chat`     — the conversation must already live in this workspace, or
+ *                  be one the viewer may access on its own footing
+ *                  (`canAccessConversation`: their own, or shared + page
+ *                  access).
+ *
+ * Refusal is UNIFORM across "forbidden" and "does not exist": every negative
+ * answer is a plain `false`, so a caller probing ids learns nothing from the
+ * difference — the same family policy the session-access routes apply.
+ *
+ * Functional core / imperative shell: the decision takes injected lookups so
+ * it is testable without a database, and the default deps are the only place
+ * that touches one.
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { agentWorkspaceShells } from '@pagespace/db/schema/agent-workspaces';
+import { canAccessConversation } from '@pagespace/lib/permissions/conversation-access';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
+import type { PaneScope } from '@pagespace/lib/agent-workspaces/contract';
+import type { WorkspaceLayoutVerb } from '@pagespace/lib/agent-workspaces/workspace-layout-verbs';
+
+/** The conversation facts the chat rule needs — a subset of a `conversations` row. */
+export interface PaneScopeConversationRow {
+  userId: string;
+  isShared: boolean;
+  type: string;
+  contextId: string | null;
+  /** The workspace this conversation is bound to, or `null` for a plain thread. */
+  workspaceId: string | null;
+}
+
+export interface PaneScopeAuthorityDeps {
+  findConversation: (conversationId: string) => Promise<PaneScopeConversationRow | null>;
+  /** The workspace a shell belongs to, or `null` when there is no such shell. */
+  findShellWorkspace: (shellId: string) => Promise<string | null>;
+  canViewPage: (userId: string, pageId: string) => Promise<boolean>;
+}
+
+/**
+ * PURE: every pane scope a verb would bind. Exhaustive over the verb union by
+ * construction — a new scope-carrying verb that is not listed here is a
+ * compile error rather than a silently ungated write path.
+ */
+export function paneScopesOfVerb(verb: WorkspaceLayoutVerb): PaneScope[] {
+  switch (verb.type) {
+    case 'ensure':
+    case 'assign_pane':
+    case 'open_conversation':
+    case 'replace_conversation':
+      return [verb.scope];
+    default:
+      return [];
+  }
+}
+
+const defaultDeps: PaneScopeAuthorityDeps = {
+  findConversation: async (conversationId) => {
+    const [row] = await db
+      .select({
+        userId: conversations.userId,
+        isShared: conversations.isShared,
+        type: conversations.type,
+        contextId: conversations.contextId,
+        workspaceId: conversations.workspaceId,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, conversationId))
+      .limit(1);
+    return row ? { ...row, isShared: row.isShared === true } : null;
+  },
+  findShellWorkspace: async (shellId) => {
+    const [row] = await db
+      .select({ workspaceId: agentWorkspaceShells.workspaceId })
+      .from(agentWorkspaceShells)
+      .where(eq(agentWorkspaceShells.id, shellId))
+      .limit(1);
+    return row?.workspaceId ?? null;
+  },
+  canViewPage: async (userId, pageId) => (await getUserAccessLevel(userId, pageId)) !== null,
+};
+
+/**
+ * May `viewerId` bind `scope` into `workspaceId`'s grid? See the module doc
+ * for the per-kind rule. An unbound scope (`targetId: null` — the picker just
+ * chose a kind) needs no authority: there is nothing to resolve yet.
+ */
+export async function authorizePaneScope(
+  input: { viewerId: string; workspaceId: string; scope: PaneScope },
+  deps: PaneScopeAuthorityDeps = defaultDeps,
+): Promise<boolean> {
+  const { viewerId, workspaceId, scope } = input;
+  if (scope.targetId === null) return true;
+
+  switch (scope.kind) {
+    case 'page':
+      return deps.canViewPage(viewerId, scope.targetId);
+
+    case 'terminal':
+      return (await deps.findShellWorkspace(scope.targetId)) === workspaceId;
+
+    case 'chat': {
+      const row = await deps.findConversation(scope.targetId);
+      if (!row) return false;
+      // Already in this grid: the caller passed the session-access gate to get
+      // here, so the conversation is one this workspace already lists to them
+      // (with its title redacted, if the listing rule says so).
+      if (row.workspaceId === workspaceId) return true;
+      return canAccessConversation(viewerId, row, {
+        getPageAccess: (userId, pageId) => deps.canViewPage(userId, pageId),
+      });
+    }
+  }
+}
+
+/**
+ * Authorize every scope a verb carries. `true` when the verb binds nothing —
+ * a resize or a close has no target to check.
+ */
+export async function authorizeVerbScopes(
+  input: { viewerId: string; workspaceId: string; verb: WorkspaceLayoutVerb },
+  deps: PaneScopeAuthorityDeps = defaultDeps,
+): Promise<boolean> {
+  const scopes = paneScopesOfVerb(input.verb);
+  for (const scope of scopes) {
+    const allowed = await authorizePaneScope(
+      { viewerId: input.viewerId, workspaceId: input.workspaceId, scope },
+      deps,
+    );
+    if (!allowed) return false;
+  }
+  return true;
+}

--- a/apps/web/src/lib/agent-workspaces/workspace-layout-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-layout-runtime.ts
@@ -47,6 +47,7 @@ import { conversations } from '@pagespace/db/schema/conversations';
 import { agentWorkspaceShells, agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
 import { pages } from '@pagespace/db/schema/core';
 import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
+import { canAccessConversation } from '@pagespace/lib/permissions/conversation-access';
 import { redactConversationTitleForViewer } from '@pagespace/lib/agent-workspaces/redact-conversation-listing';
 import {
   applyVerbLocal,
@@ -446,9 +447,10 @@ async function resolveReadablePages(
 /**
  * The subset of `chatRows` this viewer may access on the conversation's OWN
  * footing — their own thread, or a shared page thread whose page they can
- * view. Deliberately the same rule `canAccessConversation` enforces at the
- * `conv:` room join and at `/stream-join`, inlined over rows already in hand
- * so the whole set costs at most one page check per shared thread.
+ * view. Routed through `canAccessConversation`, the SAME predicate the `conv:`
+ * room join and `/stream-join` enforce, rather than a second copy of the rule:
+ * the owner branch short-circuits with no IO, so the whole set costs at most
+ * one page check per shared thread.
  */
 async function resolveAccessibleConversations(
   chatRows: ReadonlyArray<{ id: string; userId: string; isShared: boolean | null; type: string; contextId: string | null }>,
@@ -456,11 +458,12 @@ async function resolveAccessibleConversations(
 ): Promise<Set<string>> {
   const decided = await Promise.all(
     chatRows.map(async (row) => {
-      if (row.userId === viewerId) return row.id;
-      // Only a shared PAGE conversation has a page to share through; a shared
-      // global thread is owner-only, matching decide-session-access.ts.
-      if (row.isShared !== true || row.type !== 'page' || !row.contextId) return null;
-      return (await getUserAccessLevel(viewerId, row.contextId)) !== null ? row.id : null;
+      const allowed = await canAccessConversation(
+        viewerId,
+        { userId: row.userId, isShared: row.isShared === true, type: row.type, contextId: row.contextId },
+        { getPageAccess: async (userId, pageId) => (await getUserAccessLevel(userId, pageId)) !== null },
+      );
+      return allowed ? row.id : null;
     }),
   );
   return new Set(decided.filter((id): id is string => id !== null));

--- a/apps/web/src/lib/agent-workspaces/workspace-layout-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-layout-runtime.ts
@@ -30,15 +30,24 @@
  * **Concurrency.** A stale `baseRev` answers `status: 'stale'` with the
  * current rev + grid — truth to rebase against (the route maps it to 409).
  *
- * Access control is NOT this module's job — the verbs route runs
- * `checkSessionAccess` first, same as every other session-scoped route.
+ * **Access control is split, deliberately.** Reaching a workspace at all is
+ * NOT this module's job — the verbs route runs `checkSessionAccess` first,
+ * same as every other session-scoped route, and binding a pane to a target
+ * is gated there too (`authorize-pane-scope.ts`). But the LABEL join is this
+ * module's job and always was a permission decision: a pane's `targetId` is
+ * whatever the verb that bound it supplied, so every read path names the
+ * viewer it is resolving for and every kind has its own gate
+ * (`resolvePaneLabels`). The `session:<id>` broadcast has no single viewer
+ * and therefore carries no labels at all.
  */
 
 import { db } from '@pagespace/db/db';
 import { inArray } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
-import { agentWorkspaceShells } from '@pagespace/db/schema/agent-workspaces';
+import { agentWorkspaceShells, agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
 import { pages } from '@pagespace/db/schema/core';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
+import { redactConversationTitleForViewer } from '@pagespace/lib/agent-workspaces/redact-conversation-listing';
 import {
   applyVerbLocal,
   gridFromWorkspaceState,
@@ -70,8 +79,15 @@ export async function applyWorkspaceLayoutVerb(input: {
   opId: string;
   baseRev: number;
   verb: WorkspaceLayoutVerb;
+  /**
+   * Who the RESPONSE grid is labelled for. `null` labels nothing — correct
+   * for the server-side placement helpers, which discard the grid entirely.
+   * The broadcast never uses this: it has many viewers and gets its own
+   * label-free grid (see below).
+   */
+  viewerId: LabelViewerId;
 }): Promise<ApplyWorkspaceLayoutVerbResult> {
-  const { workspaceId, opId, baseRev, verb } = input;
+  const { workspaceId, opId, baseRev, verb, viewerId } = input;
 
   const outcome = await withWorkspaceLayoutLock(workspaceId, async (tx): Promise<VerbOutcomeRows> => {
     const store = await createDbWorkspaceLayoutStore(tx);
@@ -106,12 +122,34 @@ export async function applyWorkspaceLayoutVerb(input: {
   // Labels join OUTSIDE the lock: they are derived display data, so a racing
   // rename just means this response carries the title from a moment ago —
   // never a reason to hold the per-workspace serializing lock over more IO.
-  const grid = await labelGrid(outcome.rows);
+  //
+  // The response is labelled for the ONE caller who will read it; the 409
+  // stale body takes the same path, because "here is the truth to rebase
+  // against" is still an answer to that caller and must not say more than a
+  // GET would.
+  const grid = await labelGrid(workspaceId, outcome.rows, viewerId);
 
   if (outcome.status === 'stale') return { status: 'stale', rev: outcome.rev, grid };
 
   if (outcome.applied) {
-    broadcastWorkspaceUpdated({ workspaceId, rev: outcome.rev, verb: verb.type, opId, grid });
+    // THE BROADCAST IS LABEL-FREE (security review HIGH 1). `session:<id>` is
+    // a room: one payload reaches every member of a shared workspace at once,
+    // so there is no viewer to redact for and per-viewer redaction is not
+    // expressible on this wire. Shipping the structural grid — pane ids,
+    // kinds, targetIds, size shares, and the rev — keeps the live-apply that
+    // makes the layout feel shared (every geometry verb, which is most of
+    // them, lands with no refetch at all) while disclosing nothing a member
+    // could not already enumerate. Clients resolve names through their OWN
+    // authorized reads: the store carries labels forward for panes it already
+    // knows and calls `refreshWorkspaceSnapshot` — the access-checked
+    // `GET /workspace` — when a broadcast introduces a target it cannot name.
+    broadcastWorkspaceUpdated({
+      workspaceId,
+      rev: outcome.rev,
+      verb: verb.type,
+      opId,
+      grid: applyPaneLabels(outcome.rows, new Map()),
+    });
   }
   return { status: 'ok', rev: outcome.rev, grid, applied: outcome.applied };
 }
@@ -123,16 +161,40 @@ export interface WorkspaceLayoutSnapshot {
 }
 
 /**
+ * Who a labelled grid is being derived FOR.
+ *
+ * Labels are a PERMISSIONED join (security review HIGH 1), not free display
+ * data: a pane's `targetId` is whatever the verb that bound it supplied, so
+ * resolving a title without asking "may this viewer see it" turned the layout
+ * read into a title oracle over every conversation, shell, and page in the
+ * system. Every read path therefore names its viewer.
+ *
+ * `null` means NOBODY — the grid comes back label-free (structure, ids, and
+ * size shares only). That is the honest shape for the two paths that have no
+ * single viewer to redact for: the `session:<id>` room broadcast, which fans
+ * out to every member at once, and the server-side placement helpers, which
+ * discard the grid entirely.
+ */
+export type LabelViewerId = string | null;
+
+/**
  * Turn persisted rows into the wire grid, joining every bound pane's display
  * label at READ time — the conversation title, the shell name, the page
  * title, and the conversation's own `contextId` as `agentPageId`. This is
  * the whole reason rows carry no `name`: a renamed conversation can never
  * leave a stale pane label behind (the drift class the dead blob carried).
+ *
+ * Every label is gated on `viewerId`; see {@link resolvePaneLabels}.
  */
-async function labelGrid(grid: LayoutGridColumn[]): Promise<WorkspaceLayoutGridDTO> {
+async function labelGrid(
+  workspaceId: string,
+  grid: LayoutGridColumn[],
+  viewerId: LabelViewerId,
+): Promise<WorkspaceLayoutGridDTO> {
   if (grid.length === 0) return [];
-  const labels = await resolvePaneLabels(grid);
-  return applyPaneLabels(grid, labels);
+  if (viewerId === null) return applyPaneLabels(grid, new Map());
+  const labels = await resolvePaneLabels([{ workspaceId, grid }], viewerId);
+  return applyPaneLabels(grid, labels.get(workspaceId) ?? new Map());
 }
 
 /** The pure half of {@link labelGrid} — rows + resolved labels → the wire grid. */
@@ -164,11 +226,14 @@ function applyPaneLabels(grid: LayoutGridColumn[], labels: Map<string, PaneLabel
  * lock-free: a racing verb just means the snapshot is one rev behind, which
  * the rev itself reports.
  */
-export async function readWorkspaceLayoutSnapshot(workspaceId: string): Promise<WorkspaceLayoutSnapshot> {
+export async function readWorkspaceLayoutSnapshot(
+  workspaceId: string,
+  viewerId: LabelViewerId,
+): Promise<WorkspaceLayoutSnapshot> {
   const store = await createDbWorkspaceLayoutStore();
   const [grid, rev] = await Promise.all([store.getWorkspaceGrid(workspaceId), store.currentRev(workspaceId)]);
   if (grid.length === 0) return { rev, grid: null };
-  return { rev, grid: await labelGrid(grid) };
+  return { rev, grid: await labelGrid(workspaceId, grid, viewerId) };
 }
 
 /**
@@ -179,6 +244,7 @@ export async function readWorkspaceLayoutSnapshot(workspaceId: string): Promise<
  */
 export async function readWorkspaceGridsBulk(
   workspaceIds: string[],
+  viewerId: LabelViewerId,
 ): Promise<Map<string, WorkspaceLayoutGridDTO>> {
   const labelled = new Map<string, WorkspaceLayoutGridDTO>();
   if (workspaceIds.length === 0) return labelled;
@@ -187,9 +253,19 @@ export async function readWorkspaceGridsBulk(
   const grids = await store.getWorkspaceGridsBulk(workspaceIds);
   if (grids.size === 0) return labelled;
 
-  const labels = await resolvePaneLabels([...grids.values()].flat());
+  // One resolution across every listed workspace, but authorized PER
+  // workspace: the redaction rule turns on who owns the workspace a pane sits
+  // in, so a shared listing cannot borrow the viewer's authority in their own
+  // workspace to unmask a pane in someone else's.
+  const labels =
+    viewerId === null
+      ? new Map<string, Map<string, PaneLabel>>()
+      : await resolvePaneLabels(
+          [...grids].map(([workspaceId, grid]) => ({ workspaceId, grid })),
+          viewerId,
+        );
   for (const [workspaceId, grid] of grids) {
-    labelled.set(workspaceId, applyPaneLabels(grid, labels));
+    labelled.set(workspaceId, applyPaneLabels(grid, labels.get(workspaceId) ?? new Map()));
   }
   return labelled;
 }
@@ -217,57 +293,175 @@ interface PaneLabel {
   agentPageId: string | null;
 }
 
+/** One workspace's rows, for a label resolution that may span several of them. */
+interface LabelSubject {
+  workspaceId: string;
+  grid: LayoutGridColumn[];
+}
+
 /**
- * Bulk-resolve every bound pane's display label, one query per target kind
- * (grids are small; each list is a handful of ids). A target that no longer
- * exists simply resolves no label — the pane keeps its row and renders with
- * an empty name until the client repairs or rebinds it, exactly as the blob
- * behaved for deleted targets.
+ * Bulk-resolve every bound pane's display label FOR ONE VIEWER, across any
+ * number of workspaces at once — one query per target kind however many
+ * workspaces are in play (the bulk list read's whole point), then one
+ * authorization pass per workspace.
+ *
+ * **A label is authority, so every kind has a gate** (security review HIGH 1):
+ *
+ *  - `chat` — the conversation must be genuinely IN the workspace whose grid
+ *    this is, or be one the viewer may access on its own footing
+ *    (`canAccessConversation`'s rule: their own thread, or a shared page
+ *    thread whose page they can view). Containment is the load-bearing half:
+ *    without it, an attacker who binds a foreign conversation into a
+ *    workspace they OWN passes the redaction rule's owner branch and reads
+ *    the real title. The title that survives that gate still goes through
+ *    `redactConversationTitleForViewer` — the epic's ONE listing rule — so a
+ *    drive member looking into a shared workspace sees the same
+ *    `(private thread)` marker `list_sessions` shows them.
+ *  - `terminal` — the shell must belong to THIS workspace. Shells are
+ *    workspace-scoped rows, so containment is exact, and it lines up the pane
+ *    label with what the shells route (gated on session access alone) already
+ *    serves the same viewer.
+ *  - `page` — the viewer must have page access (`getUserAccessLevel`). Pages
+ *    are not workspace-scoped at all, so their own ACL is the only answer.
+ *
+ * A target that fails its gate — or no longer exists — simply resolves no
+ * label: the pane keeps its ROW and renders with an empty name, exactly as
+ * the blob behaved for deleted targets. Refusing to resolve is deliberately
+ * indistinguishable from "gone", so the label join is not an existence
+ * oracle either.
  */
-async function resolvePaneLabels(grid: LayoutGridColumn[]): Promise<Map<string, PaneLabel>> {
-  const targets = new Map<string, Set<string>>();
-  for (const column of grid) {
-    for (const pane of column.panes) {
-      if (pane.kind === null || pane.targetId === null) continue;
-      const set = targets.get(pane.kind) ?? new Set<string>();
-      set.add(pane.targetId);
-      targets.set(pane.kind, set);
+async function resolvePaneLabels(
+  subjects: readonly LabelSubject[],
+  viewerId: string,
+): Promise<Map<string, Map<string, PaneLabel>>> {
+  const chatIds = new Set<string>();
+  const shellIds = new Set<string>();
+  const pageIds = new Set<string>();
+  for (const subject of subjects) {
+    for (const column of subject.grid) {
+      for (const pane of column.panes) {
+        if (pane.kind === null || pane.targetId === null) continue;
+        if (pane.kind === 'chat') chatIds.add(pane.targetId);
+        else if (pane.kind === 'terminal') shellIds.add(pane.targetId);
+        else if (pane.kind === 'page') pageIds.add(pane.targetId);
+      }
     }
   }
 
-  const labels = new Map<string, PaneLabel>();
-  const chatIds = [...(targets.get('chat') ?? [])];
-  const shellIds = [...(targets.get('terminal') ?? [])];
-  const pageIds = [...(targets.get('page') ?? [])];
-
-  const [chatRows, shellRows, pageRows] = await Promise.all([
-    chatIds.length > 0
+  const workspaceIds = subjects.map((subject) => subject.workspaceId);
+  const [chatRows, shellRows, pageRows, workspaceRows] = await Promise.all([
+    chatIds.size > 0
       ? db
-          .select({ id: conversations.id, title: conversations.title, type: conversations.type, contextId: conversations.contextId })
+          .select({
+            id: conversations.id,
+            title: conversations.title,
+            type: conversations.type,
+            contextId: conversations.contextId,
+            // The two facts the redaction rule needs, plus the binding that
+            // decides whether this conversation belongs in the grid at all.
+            userId: conversations.userId,
+            isShared: conversations.isShared,
+            workspaceId: conversations.workspaceId,
+          })
           .from(conversations)
-          .where(inArray(conversations.id, chatIds))
+          .where(inArray(conversations.id, [...chatIds]))
       : Promise.resolve([]),
-    shellIds.length > 0
+    shellIds.size > 0
       ? db
-          .select({ id: agentWorkspaceShells.id, name: agentWorkspaceShells.name })
+          .select({
+            id: agentWorkspaceShells.id,
+            name: agentWorkspaceShells.name,
+            workspaceId: agentWorkspaceShells.workspaceId,
+          })
           .from(agentWorkspaceShells)
-          .where(inArray(agentWorkspaceShells.id, shellIds))
+          .where(inArray(agentWorkspaceShells.id, [...shellIds]))
       : Promise.resolve([]),
-    pageIds.length > 0
-      ? db.select({ id: pages.id, title: pages.title }).from(pages).where(inArray(pages.id, pageIds))
+    pageIds.size > 0
+      ? db.select({ id: pages.id, title: pages.title }).from(pages).where(inArray(pages.id, [...pageIds]))
+      : Promise.resolve([]),
+    workspaceIds.length > 0
+      ? db
+          .select({ id: agentWorkspaces.id, ownerId: agentWorkspaces.ownerId })
+          .from(agentWorkspaces)
+          .where(inArray(agentWorkspaces.id, workspaceIds))
       : Promise.resolve([]),
   ]);
 
-  for (const row of chatRows) {
-    labels.set(`chat:${row.id}`, {
-      name: row.title ?? '',
-      // Same derivation the session-conversation listings use: a page-agent
-      // conversation's contextId IS its agent page id; global has none.
-      agentPageId: row.type === 'page' ? row.contextId : null,
-    });
-  }
-  for (const row of shellRows) labels.set(`terminal:${row.id}`, { name: row.name, agentPageId: null });
-  for (const row of pageRows) labels.set(`page:${row.id}`, { name: row.title, agentPageId: null });
+  // Both viewer-scoped gates, resolved once per distinct target rather than
+  // once per pane — the same viewer answers the same question every time.
+  const [readablePages, accessibleConversations] = await Promise.all([
+    resolveReadablePages(pageRows, viewerId),
+    resolveAccessibleConversations(chatRows, viewerId),
+  ]);
 
-  return labels;
+  const owners = new Map(workspaceRows.map((row) => [row.id, row.ownerId]));
+  const byWorkspace = new Map<string, Map<string, PaneLabel>>();
+  for (const subject of subjects) {
+    // An unknown owner never matches a viewer, so the redaction rule's owner
+    // branch fails closed on a workspace row that has vanished.
+    const workspaceOwnerId = owners.get(subject.workspaceId) ?? '';
+    const labels = new Map<string, PaneLabel>();
+
+    for (const row of chatRows) {
+      const belongsHere = row.workspaceId === subject.workspaceId;
+      if (!belongsHere && !accessibleConversations.has(row.id)) continue;
+      labels.set(`chat:${row.id}`, {
+        name:
+          redactConversationTitleForViewer({
+            viewerId,
+            workspaceOwnerId,
+            conversation: { ownerId: row.userId, isShared: row.isShared === true, title: row.title },
+          }) ?? '',
+        // Same derivation the session-conversation listings use: a page-agent
+        // conversation's contextId IS its agent page id; global has none.
+        agentPageId: row.type === 'page' ? row.contextId : null,
+      });
+    }
+    for (const row of shellRows) {
+      if (row.workspaceId !== subject.workspaceId) continue;
+      labels.set(`terminal:${row.id}`, { name: row.name, agentPageId: null });
+    }
+    for (const row of pageRows) {
+      if (!readablePages.has(row.id)) continue;
+      labels.set(`page:${row.id}`, { name: row.title, agentPageId: null });
+    }
+
+    byWorkspace.set(subject.workspaceId, labels);
+  }
+
+  return byWorkspace;
+}
+
+/** The subset of `pageRows` this viewer may actually read. */
+async function resolveReadablePages(
+  pageRows: ReadonlyArray<{ id: string }>,
+  viewerId: string,
+): Promise<Set<string>> {
+  const decided = await Promise.all(
+    pageRows.map(async (row) => ((await getUserAccessLevel(viewerId, row.id)) !== null ? row.id : null)),
+  );
+  return new Set(decided.filter((id): id is string => id !== null));
+}
+
+/**
+ * The subset of `chatRows` this viewer may access on the conversation's OWN
+ * footing — their own thread, or a shared page thread whose page they can
+ * view. Deliberately the same rule `canAccessConversation` enforces at the
+ * `conv:` room join and at `/stream-join`, inlined over rows already in hand
+ * so the whole set costs at most one page check per shared thread.
+ */
+async function resolveAccessibleConversations(
+  chatRows: ReadonlyArray<{ id: string; userId: string; isShared: boolean | null; type: string; contextId: string | null }>,
+  viewerId: string,
+): Promise<Set<string>> {
+  const decided = await Promise.all(
+    chatRows.map(async (row) => {
+      if (row.userId === viewerId) return row.id;
+      // Only a shared PAGE conversation has a page to share through; a shared
+      // global thread is owner-only, matching decide-session-access.ts.
+      if (row.isShared !== true || row.type !== 'page' || !row.contextId) return null;
+      return (await getUserAccessLevel(viewerId, row.contextId)) !== null ? row.id : null;
+    }),
+  );
+  return new Set(decided.filter((id): id is string => id !== null));
 }

--- a/apps/web/src/lib/agent-workspaces/workspace-placement.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-placement.ts
@@ -26,6 +26,7 @@ import { eq } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { pages } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
 import type { PaneScope } from '@pagespace/lib/agent-workspaces/contract';
 import type { WorkspaceLayoutVerb } from '@pagespace/lib/agent-workspaces/workspace-layout-verbs';
 import { createId } from '@paralleldrive/cuid2';
@@ -68,12 +69,15 @@ export async function applyLayoutVerbForWorkspace(input: {
 }): Promise<{ ok: true; applied: boolean } | { ok: false; reason: 'contended' | 'failed' }> {
   try {
     for (let attempt = 0; attempt < MAX_PLACEMENT_ATTEMPTS; attempt += 1) {
-      const snapshot = await readWorkspaceLayoutSnapshot(input.workspaceId);
+      const snapshot = await readWorkspaceLayoutSnapshot(input.workspaceId, null);
       const result = await applyWorkspaceLayoutVerb({
         workspaceId: input.workspaceId,
         opId: input.opId,
         baseRev: snapshot.rev,
         verb: input.verb,
+        // This path reports only `applied` — it never returns a grid to
+        // anyone, so there is no viewer to label for and nothing to leak.
+        viewerId: null,
       });
       if (result.status === 'ok') return { ok: true, applied: result.applied };
     }
@@ -99,11 +103,14 @@ async function placePane(input: {
   excludeTargetId?: string;
 }): Promise<void> {
   for (let attempt = 0; attempt < MAX_PLACEMENT_ATTEMPTS; attempt += 1) {
-    const snapshot = await readWorkspaceLayoutSnapshot(input.workspaceId);
+    const snapshot = await readWorkspaceLayoutSnapshot(input.workspaceId, null);
     const result = await applyWorkspaceLayoutVerb({
       workspaceId: input.workspaceId,
       opId: input.opId,
       baseRev: snapshot.rev,
+      // A placement returns nothing to anybody; the live update rides the
+      // (label-free) broadcast.
+      viewerId: null,
       verb: {
         type: 'open_conversation',
         scope: input.scope,
@@ -145,11 +152,26 @@ export async function placePagePaneForConversation(input: {
   conversationId: string;
   pageId: string;
   title?: string;
+  /** The ACTING USER — the page ACL is checked against them, never the model's word. */
+  viewerId: string;
   opId: string;
 }): Promise<void> {
   try {
     const workspaceId = await findWorkspaceOfConversation(input.conversationId);
     if (!workspaceId) return;
+
+    // THE GATE (security review, MEDIUM on the HIGH 1 surface). `pageId` comes
+    // from the MODEL, and a prompt-injected agent naming ids it should not
+    // know must not be able to turn this into a page-title exfiltration
+    // channel — the title would land in the pane row and the broadcast. The
+    // acting user's own page access is the only thing that decides.
+    if ((await getUserAccessLevel(input.viewerId, input.pageId)) === null) {
+      loggers.api.warn('Refused a page-pane placement for a page the acting user cannot view', {
+        conversationId: input.conversationId,
+        pageId: input.pageId,
+      });
+      return;
+    }
 
     // Prefer the page's REAL title over the model's label: the pane header is
     // display-only, but a wrong label is still a lie, and the row is one

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-contract.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-contract.test.ts
@@ -45,6 +45,8 @@ const OWN_WORKER = {
 function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
   return {
     findOwnWorkspace: vi.fn(async () => ({ workspaceId: WORKSPACE_ID })),
+    // The layout family's session-access gate (security review HIGH 2).
+    checkWorkspaceAccess: vi.fn(async () => ({ allowed: true })),
     listWorkspaceWorkers: vi.fn(async () => ({ sandbox: 'running' as const, workers: [], shells: [] })),
     listOwnWorkspaces: vi.fn(async () => []),
     listSharedWorkspaces: vi.fn(async () => []),
@@ -465,7 +467,9 @@ describe('list_panes description: "Returns the columnIds and paneIds that resize
     const result = await run(tools.list_panes, {}, layoutOptions());
 
     expect(result).toEqual(expect.objectContaining({ success: true, workspaceId: WORKSPACE_ID, columns: GRID.columns }));
-    expect(deps.readPaneGrid).toHaveBeenCalledWith(WORKSPACE_ID);
+    // The read is per-viewer (security review HIGH 1): the model sees exactly
+    // what this user's own layout GET would return, redactions included.
+    expect(deps.readPaneGrid).toHaveBeenCalledWith(WORKSPACE_ID, USER_ID);
     // The addressability claim, checked rather than assumed: every id the
     // listing hands out is one the rearrange tools accept.
     const columnIds = GRID.columns.map((column) => column.columnId);

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-layout-authz.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-layout-authz.test.ts
@@ -1,0 +1,154 @@
+/**
+ * THE LAYOUT TOOLS RUN THE SESSION-ACCESS CHECK (security review HIGH 2).
+ *
+ * `openOwnGrid`'s docblock claimed "the runtime re-runs `checkSessionAccess`
+ * anyway on the way in, so the gate is one function in one place for both
+ * entry points." It did not. `openOwnGrid` resolved the caller's conversation
+ * to its workspace and stopped; neither wired dep checked anything
+ * (`readPaneGrid` → `readWorkspaceLayoutSnapshot`, `applyLayoutVerb` →
+ * `applyLayoutVerbForWorkspace`). `checkSessionAccess` was imported by the
+ * runtime and used only by `resolveWorkerPlacement`.
+ *
+ * The attack the structural argument misses: a conversation→workspace binding
+ * is PERMANENT by design, but drive membership is not. A member spawns a
+ * worker into a shared workspace (legitimate), then loses access to the
+ * drive. Every HTTP route 404s her afterwards — but the binding still
+ * resolves, so `list_panes` kept returning the whole labelled grid and
+ * `move_pane` / `resize_pane` / `arrange_panes` kept WRITING the victim's
+ * grid and broadcasting into their live UI. The tool surface was wider than
+ * the HTTP surface it claimed to mirror.
+ *
+ * The existing `session-tools-contract.test.ts` is single-workspace mocks
+ * where the caller always has access, and structurally cannot see this — so
+ * this suite carries a SECOND workspace and a REVOKED member.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Tool } from 'ai';
+import { createSessionTools, type SessionToolsDeps } from '../session-tools';
+import type { ToolExecutionContext } from '../../core/types';
+
+/** Alice's workspace. Mallory's worker conversation is bound into it. */
+const ALICE_WORKSPACE = 'ws-alice';
+const MALLORY = 'mallory';
+const MALLORY_WORKER_CONVERSATION = 'conv-mallory-worker';
+
+const GRID = {
+  columns: [
+    {
+      columnId: 'col-1',
+      widthFraction: null,
+      panes: [
+        { paneId: 'pane-1', kind: 'chat' as const, targetId: 'conv-alice-private', name: 'Q3 layoffs plan', heightFraction: null },
+      ],
+    },
+  ],
+};
+
+function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
+  return {
+    // The binding survives revocation — that is the whole point.
+    findOwnWorkspace: vi.fn(async () => ({ workspaceId: ALICE_WORKSPACE })),
+    // Mallory is no longer a member of the drive Alice's workspace lives in.
+    checkWorkspaceAccess: vi.fn(async () => ({ allowed: false, reason: 'not_a_member' })),
+    listWorkspaceWorkers: vi.fn(async () => ({ sandbox: 'running' as const, workers: [], shells: [] })),
+    listOwnWorkspaces: vi.fn(async () => []),
+    listSharedWorkspaces: vi.fn(async () => []),
+    findWorker: vi.fn(async () => null),
+    countOpenConversations: vi.fn(async () => 0),
+    canUseAgent: vi.fn(async () => true),
+    createWorkerSession: vi.fn(async () => ({ ok: true as const, workspaceId: ALICE_WORKSPACE })),
+    dispatch: vi.fn(async () => ({ ok: true as const, waited: false as const })),
+    readTranscript: vi.fn(async () => []),
+    killWorker: vi.fn(async () => ({ ok: true as const, spriteTornDown: false })),
+    ensureOwnSessionSandbox: vi.fn(async () => ({ ok: true as const })),
+    spawnShell: vi.fn(async () => ({ ok: false as const, reason: 'sandbox_unavailable' as const })),
+    findShell: vi.fn(async () => null),
+    killShell: vi.fn(async () => ({ ok: true as const, killed: true })),
+    shellIo: {
+      read: vi.fn(async () => ({ ok: true as const, live: true, hasOutput: false, output: '' })),
+      send: vi.fn(async () => ({ ok: true as const, delivered: true as const })),
+    },
+    readPaneGrid: vi.fn(async () => GRID),
+    applyLayoutVerb: vi.fn(async () => ({ ok: true as const, applied: true })),
+    newId: vi.fn(() => 'minted-id'),
+    ...over,
+  };
+}
+
+const options = { experimental_context: { userId: MALLORY, conversationId: MALLORY_WORKER_CONVERSATION } as ToolExecutionContext, toolCallId: 'call-1' };
+
+async function run(toolDef: Tool, input: unknown): Promise<Record<string, unknown>> {
+  const execute = toolDef.execute as (input: unknown, options: unknown) => Promise<Record<string, unknown>>;
+  return execute(input, options);
+}
+
+/** Every layout tool, with an input that would otherwise succeed. */
+const LAYOUT_CALLS: Array<[string, unknown]> = [
+  ['list_panes', {}],
+  ['resize_pane', { columnId: 'col-1', size: 0.5 }],
+  ['move_pane', { paneId: 'pane-1', toColumnId: 'col-1' }],
+  ['arrange_panes', { columnIds: ['col-1'] }],
+];
+
+let deps: SessionToolsDeps;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deps = makeDeps();
+});
+
+describe('a revoked member whose worker is still bound into the victim\'s workspace', () => {
+  for (const [toolName, input] of LAYOUT_CALLS) {
+    it(`${toolName}: refuses, and never touches the grid`, async () => {
+      const tools = createSessionTools(deps);
+      const result = await run((tools as Record<string, Tool>)[toolName], input);
+
+      expect(result.success, `${toolName} must refuse a revoked caller`).toBe(false);
+      // The reads and the writes both stop at the gate.
+      expect(deps.readPaneGrid).not.toHaveBeenCalled();
+      expect(deps.applyLayoutVerb).not.toHaveBeenCalled();
+      // Nothing about the victim's grid leaks into the refusal.
+      expect(JSON.stringify(result)).not.toContain('Q3 layoffs plan');
+      expect(JSON.stringify(result)).not.toContain('conv-alice-private');
+    });
+  }
+
+  it('asks the ONE session-access decision, for the caller and the bound workspace', async () => {
+    const tools = createSessionTools(deps);
+    await run(tools.list_panes as Tool, {});
+    expect(deps.checkWorkspaceAccess).toHaveBeenCalledWith(MALLORY, ALICE_WORKSPACE);
+  });
+});
+
+describe('a caller who still has session access', () => {
+  beforeEach(() => {
+    deps = makeDeps({ checkWorkspaceAccess: vi.fn(async () => ({ allowed: true })) });
+  });
+
+  it('list_panes reads the grid, labelled for THAT viewer', async () => {
+    const tools = createSessionTools(deps);
+    const result = await run(tools.list_panes as Tool, {});
+    expect(result.success).toBe(true);
+    expect(result.columns).toEqual(GRID.columns);
+    // The label join is per-viewer (review HIGH 1) — the tool must say who is
+    // reading, not just which workspace.
+    expect(deps.readPaneGrid).toHaveBeenCalledWith(ALICE_WORKSPACE, MALLORY);
+  });
+
+  it('a rearrange reaches the single writer', async () => {
+    const tools = createSessionTools(deps);
+    const result = await run(tools.resize_pane as Tool, { columnId: 'col-1', size: 0.5 });
+    expect(result.success).toBe(true);
+    expect(deps.applyLayoutVerb).toHaveBeenCalled();
+  });
+});
+
+describe('the gate is checked before anything else can answer', () => {
+  it('an unbound conversation still refuses without asking about access', async () => {
+    deps = makeDeps({ findOwnWorkspace: vi.fn(async () => null) });
+    const tools = createSessionTools(deps);
+    const result = await run(tools.list_panes as Tool, {});
+    expect(result.success).toBe(false);
+    expect(deps.checkWorkspaceAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -31,6 +31,8 @@ const SHELL = {
 function makeDeps(over: Partial<SessionToolsDeps> = {}): SessionToolsDeps {
   return {
     findOwnWorkspace: vi.fn(async () => ({ workspaceId: WORKSPACE_ID })),
+    // The layout family's session-access gate (security review HIGH 2).
+    checkWorkspaceAccess: vi.fn(async () => ({ allowed: true })),
     listWorkspaceWorkers: vi.fn(async () => ({ sandbox: 'running' as const, workers: [], shells: [] })),
     listOwnWorkspaces: vi.fn(async () => []),
     listSharedWorkspaces: vi.fn(async () => []),

--- a/apps/web/src/lib/ai/tools/page-pane-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-pane-tools.ts
@@ -37,6 +37,13 @@ export interface PagePaneToolDeps {
     conversationId: string;
     pageId: string;
     title?: string;
+    /**
+     * The ACTING USER. `pageId` is model-supplied, so the placement gates it
+     * on this user's own page access — otherwise a prompt-injected agent
+     * turns the pane header into a title-exfiltration channel (security
+     * review, MEDIUM on the HIGH 1 surface).
+     */
+    viewerId: string;
     /** Idempotency key derived from the tool call — a retried call must not place twice. */
     opId: string;
   }): Promise<void>;
@@ -74,19 +81,24 @@ export function createPagePaneTools(deps: PagePaneToolDeps) {
         'Only has a visible effect inside an agent session with an open pane grid; elsewhere it is a harmless no-op.',
       inputSchema: openPagePaneInputSchema,
       execute: async ({ pageId, title }, options): Promise<OpenPagePaneOutput> => {
-        const context = (options as { experimental_context?: { conversationId?: string } } | undefined)
-          ?.experimental_context;
+        const context = (
+          options as { experimental_context?: { conversationId?: string; userId?: string } } | undefined
+        )?.experimental_context;
         const conversationId = context?.conversationId;
+        const viewerId = context?.userId;
         // `toolCallId` is stable across the SDK's own retries of one call, so
         // deriving the opId from it is what makes a retried placement a
         // replay (the verb engine's op memory short-circuits it) instead of
         // a second pane.
         const toolCallId = (options as { toolCallId?: string } | undefined)?.toolCallId;
-        if (conversationId && toolCallId) {
+        // No acting user means no authority to place under — the ack below is
+        // still honest (the client fast path is a no-op without a grid too).
+        if (conversationId && toolCallId && viewerId) {
           await deps.placePagePane({
             conversationId,
             pageId,
             title,
+            viewerId,
             opId: `${OPEN_PAGE_PANE_TOOL_NAME}:${toolCallId}`,
           });
         }

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -859,6 +859,12 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       const row = await findSessionForConversation(conversationId);
       return row ? { workspaceId: row.id } : null;
     },
+
+    // THE session-access decision, wired for the tool surface exactly as the
+    // verbs route wires it (security review HIGH 2). Resolving a conversation's
+    // binding says the workspace is addressable, never that it is still usable
+    // — drive membership can be revoked out from under a permanent binding.
+    checkWorkspaceAccess: (userId, workspaceId) => checkSessionAccess(userId, workspaceId),
     listWorkspaceWorkers,
     listOwnWorkspaces,
     listSharedWorkspaces,
@@ -962,8 +968,8 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
     // label-joining snapshot the layout GET serves, so a model and a browser
     // never see different names for the same pane; the write is the same
     // single writer (`applyWorkspaceLayoutVerb`) behind the verbs route.
-    readPaneGrid: async (workspaceId) => {
-      const snapshot = await readWorkspaceLayoutSnapshot(workspaceId);
+    readPaneGrid: async (workspaceId, viewerId) => {
+      const snapshot = await readWorkspaceLayoutSnapshot(workspaceId, viewerId);
       if (!snapshot.grid || snapshot.grid.length === 0) return null;
       return {
         columns: snapshot.grid.map((column) => ({

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -341,6 +341,19 @@ export interface SessionToolsDeps {
    */
   findOwnWorkspace: (conversationId: string) => Promise<{ workspaceId: string } | null>;
   /**
+   * THE session-access decision (`checkSessionAccess` — owner or drive
+   * member), applied to a workspace the caller reached by resolving their own
+   * conversation's binding.
+   *
+   * Resolving the binding is NOT the gate (security review HIGH 2). A
+   * conversation→workspace binding is permanent by design, but drive
+   * membership is not: a member who spawns a worker into a shared workspace
+   * and is later removed from the drive still resolves to that workspace
+   * forever, while every HTTP route 404s her. Without this check the tool
+   * surface stayed open after the HTTP surface closed.
+   */
+  checkWorkspaceAccess: (userId: string, workspaceId: string) => Promise<{ allowed: boolean }>;
+  /**
    * The workspace's workers + shells + sandbox status, labels resolved.
    * `callerUserId` is the VIEWER: a caller whose conversation lives in a
    * workspace they do not own (spawned into a shared one) gets other
@@ -493,7 +506,7 @@ export interface SessionToolsDeps {
    * pane's binding for the model to tell one rectangle from another. `null`
    * for a workspace with no grid at all.
    */
-  readPaneGrid?: (workspaceId: string) => Promise<PaneGridListing | null>;
+  readPaneGrid?: (workspaceId: string, viewerId: string) => Promise<PaneGridListing | null>;
   /**
    * Apply ONE layout verb to the caller's workspace grid, through the same
    * single writer (`applyWorkspaceLayoutVerb`) the verbs route uses — same
@@ -611,6 +624,20 @@ const NO_GRID = {
   success: false as const,
   error:
     'This conversation has no pane grid to arrange. Pane layout only exists inside an agent session with an open workspace; elsewhere there is nothing to move or resize.',
+};
+
+/**
+ * The caller's conversation IS bound to a workspace, but they may no longer
+ * use it — the drive membership that admitted them was revoked (security
+ * review HIGH 2). Deliberately distinct from {@link NO_GRID}: this is not an
+ * oracle (the caller's own conversation lives there, so the workspace's
+ * existence was never a secret) and telling the model "you had access and
+ * lost it" is the only answer that stops it retrying forever.
+ */
+const GRID_ACCESS_LOST = {
+  success: false as const,
+  error:
+    'You no longer have access to the workspace this conversation belongs to, so its pane layout cannot be read or rearranged from here.',
 };
 
 function notYourShell(shellId: string): { success: false; error: string } {
@@ -731,23 +758,29 @@ export function createSessionTools(deps: SessionToolsDeps): {
    * A LAYOUT verb's shared open (issue #2208): resolve the caller's own
    * workspace, which is the only grid these tools can reach.
    *
-   * Access control is structural rather than a second predicate — the grid is
-   * addressed by resolving the CALLER'S OWN conversation to its workspace
-   * (`findOwnWorkspace`), never by a workspaceId the model supplies, so there
-   * is no id here for a caller to point somewhere it does not belong. That is
-   * the same footing the shell family stands on, and it means the check the
-   * verbs route runs (`checkSessionAccess`) has already been satisfied by the
-   * time this conversation exists in this workspace at all; the runtime
-   * re-runs it anyway on the way in, so the gate is one function in one place
-   * for both entry points.
+   * Addressing is structural — the grid is reached by resolving the CALLER'S
+   * OWN conversation to its workspace (`findOwnWorkspace`), never by a
+   * workspaceId the model supplies, so there is no id here for a caller to
+   * point somewhere it does not belong.
    *
-   * Refuses, distinctly, the three ways there is nothing to arrange: no auth,
-   * no conversation, and a conversation with no workspace (a plain thread).
+   * ADDRESSING IS NOT AUTHORIZATION, though, and this docblock used to claim
+   * the runtime "re-runs `checkSessionAccess` anyway on the way in" when
+   * nothing on the path checked anything (security review HIGH 2). The
+   * structural argument is unsound in one direction: a conversation→workspace
+   * binding is permanent, drive membership is not. A member who spawned a
+   * worker into a shared workspace and then lost the drive keeps resolving to
+   * it forever — so this now runs the SAME decision the verbs route runs
+   * (`checkWorkspaceAccess` → `checkSessionAccess`), and the gate really is
+   * one function in one place for both entry points.
+   *
+   * Refuses, distinctly, the four ways there is nothing to arrange: no auth,
+   * no conversation, a conversation with no workspace (a plain thread), and a
+   * workspace the caller may no longer use.
    */
   const openOwnGrid = async (
     context: ToolExecutionContext | undefined,
   ): Promise<
-    | { ok: true; workspaceId: string }
+    | { ok: true; workspaceId: string; viewerId: string }
     | { ok: false; error: { success: false; error: string } }
   > => {
     const actor = readActor(context);
@@ -756,7 +789,9 @@ export function createSessionTools(deps: SessionToolsDeps): {
     if (!conversationId) return { ok: false, error: NEEDS_CONVERSATION };
     const workspace = await deps.findOwnWorkspace(conversationId);
     if (!workspace) return { ok: false, error: NO_GRID };
-    return { ok: true, workspaceId: workspace.workspaceId };
+    const access = await deps.checkWorkspaceAccess(actor.userId, workspace.workspaceId);
+    if (!access.allowed) return { ok: false, error: GRID_ACCESS_LOST };
+    return { ok: true, workspaceId: workspace.workspaceId, viewerId: actor.userId };
   };
 
   /**
@@ -1242,7 +1277,9 @@ export function createSessionTools(deps: SessionToolsDeps): {
         if (!opened.ok) return opened.error;
         if (!deps.readPaneGrid) return NO_GRID;
 
-        const grid = await deps.readPaneGrid(opened.workspaceId);
+        // Labels are a permissioned join (review HIGH 1) — the read says who
+        // is reading, so the model sees exactly what this user's own GET would.
+        const grid = await deps.readPaneGrid(opened.workspaceId, opened.viewerId);
         // A workspace whose grid has never been opened is a real, reportable
         // state — not an error, and not the same as having no workspace.
         if (!grid) {

--- a/apps/web/src/lib/websocket/__tests__/conversation-events-audience.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/conversation-events-audience.test.ts
@@ -89,7 +89,7 @@ const allowedRooms = (isShared: boolean): Set<string> => {
   return rooms;
 };
 
-let capturedTargets: Array<{ channelId: string; event: string }>;
+let capturedTargets: Array<{ channelId: string; event: string; payload: unknown }>;
 
 beforeEach(() => {
   capturedTargets = [];
@@ -97,8 +97,11 @@ beforeEach(() => {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (_url: string, init?: { body?: string }) => {
-      const body = JSON.parse(init?.body ?? '{}') as { channelId: string; event: string };
-      capturedTargets.push({ channelId: body.channelId, event: body.event });
+      const body = JSON.parse(init?.body ?? '{}') as { channelId: string; event: string; payload: unknown };
+      // The PAYLOAD is kept, not discarded (security review, MEDIUM): a suite
+      // that records only {channelId, event} cannot notice a future emitter
+      // putting message content into a directory event.
+      capturedTargets.push({ channelId: body.channelId, event: body.event, payload: body.payload });
       return { ok: true } as Response;
     }),
   );
@@ -214,28 +217,175 @@ describe('payload shaping', () => {
   });
 });
 
-describe('emit-site containment (source scan)', () => {
-  it('no file outside conversation-events.ts emits a conversation:* socket event', () => {
-    const SRC_ROOT = path.resolve(__dirname, '../../..');
-    const offenders: string[] = [];
+/**
+ * PAYLOAD SHAPE, not just audience (security review, MEDIUM).
+ *
+ * The audience assertions above answer "which rooms?" — but the harness used
+ * to record `{channelId, event}` and throw the payload away, so an emitter
+ * that started putting message CONTENT into a directory event would have
+ * stayed green. Rooms and payloads are one invariant, so assert both.
+ */
+describe('content never rides a directory event', () => {
+  /** Keys that mean "this payload carries conversation content". */
+  const CONTENT_KEYS = ['message', 'messageRef', 'parts', 'content'];
+
+  const carriesContent = (payload: unknown): boolean =>
+    typeof payload === 'object' &&
+    payload !== null &&
+    CONTENT_KEYS.some((key) => key in (payload as Record<string, unknown>));
+
+  for (const [name, emit] of Object.entries(EMITTERS)) {
+    for (const isShared of [false, true]) {
+      it(`${name} (${isShared ? 'shared' : 'private'}): a content-bearing payload targets ONLY the conv room`, async () => {
+        await emit(ctxFor(isShared));
+        for (const t of capturedTargets) {
+          if (!carriesContent(t.payload)) continue;
+          expect(
+            t.channelId,
+            `${t.event} carried content to ${t.channelId}, which is not the content room`,
+          ).toBe(`conv:${CONVERSATION}`);
+        }
+      });
+    }
+  }
+
+  it('the directory bump reports only metadata — never the message that caused it', async () => {
+    await conversationEvents.messageCreated(ctxFor(true), message, new Date());
+    const directory = capturedTargets.filter((t) => t.channelId !== `conv:${CONVERSATION}`);
+    expect(directory.length).toBeGreaterThan(0);
+    for (const t of directory) {
+      expect(carriesContent(t.payload), `${t.event} leaked content to ${t.channelId}`).toBe(false);
+    }
+  });
+});
+
+/**
+ * THE BROADCAST EMIT-SITE REGISTRY — widened from a `conversation:`-only scan
+ * of `apps/web/src` to EVERY broadcast emitter in the repo (security review,
+ * MEDIUM).
+ *
+ * The old scan matched `event: 'conversation:...'` and walked `apps/web/src`
+ * only. `workspace:updated` (agent-workspace-events.ts) and the `chat:*`
+ * literals in socket-utils.ts were therefore outside its universe entirely —
+ * which is precisely why HIGH 1's labelled-grid broadcast was never
+ * audience-reviewed. A scan whose universe excludes the emitters that matter
+ * is not a guard.
+ *
+ * So the guard is now an inventory: every file that builds a broadcast body
+ * (it mentions `channelId` and names an event literal) must be registered
+ * here with the events it emits. Adding an emitter — or a new event to an
+ * existing one — fails this test until someone writes it down, and writing it
+ * down is the moment to ask who the room's audience is and whether the
+ * payload may reach them.
+ */
+describe('broadcast emit-site registry (repo-wide source scan)', () => {
+  const REPO_ROOT = path.resolve(__dirname, '../../../../../..');
+  const ROOTS = ['apps', 'packages'];
+  const SKIP_DIR = new Set(['node_modules', 'dist', '.next', '.turbo', 'coverage', '__tests__', 'build', 'out']);
+  const EVENT_LITERAL = /event:\s*(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
+
+  /** file → the event names it broadcasts. Sorted; template literals kept verbatim. */
+  const REGISTERED: Record<string, string[]> = {
+    // --- the conversation content/directory plane (this module) -------------
+    // Its `conversation:*` names are passed as arguments, so only the literal
+    // mirror event appears in source.
+    'apps/web/src/lib/websocket/conversation-events.ts': ['chat:stream_start'],
+    // --- the agent-session layout plane -------------------------------------
+    // Audience: the `session:<id>` room — every member of a shared workspace
+    // at once. Its grid is LABEL-FREE for exactly that reason (security review
+    // HIGH 1); see workspace-layout-runtime.ts.
+    'apps/web/src/lib/websocket/agent-workspace-events.ts': ['workspace:updated'],
+    // --- the pre-epic surfaces ----------------------------------------------
+    'apps/web/src/lib/websocket/calendar-events.ts': ['calendar', 'calendar:${payload.operation}'],
+    'apps/web/src/lib/websocket/socket-utils.ts': [
+      'activity',
+      'activity:logged',
+      'agent:grant_changed',
+      'ai_stream_complete',
+      'ai_stream_start',
+      'chat:conversation_added',
+      'chat:conversation_deleted',
+      'chat:conversation_renamed',
+      'chat:global_conversation_added',
+      'chat:message_deleted',
+      'chat:message_edited',
+      'chat:stream_complete',
+      'chat:stream_start',
+      'chat:undo_applied',
+      'chat:user_message',
+      'credits',
+      'credits:${payload.operation}',
+      'drive',
+      'drive:${payload.operation}',
+      'drive_member',
+      'inbox',
+      'inbox:${payload.operation}',
+      'page',
+      'page:${payload.operation}',
+      'shell_activity',
+      'task',
+      'thread_reply_count_updated',
+    ],
+    'apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts': ['message_deleted'],
+    'apps/web/src/app/api/channels/[pageId]/messages/route.ts': ['new_message'],
+    'apps/web/src/app/api/channels/[pageId]/messages/[messageId]/route.ts': ['message_deleted', 'message_edited'],
+    'apps/web/src/app/api/channels/[pageId]/messages/[messageId]/reactions/route.ts': [
+      'reaction_added',
+      'reaction_removed',
+    ],
+    'apps/web/src/app/api/messages/[conversationId]/route.ts': ['new_dm_message'],
+    'apps/web/src/app/api/messages/[conversationId]/[messageId]/route.ts': ['message_deleted', 'message_edited'],
+    'apps/web/src/app/api/messages/[conversationId]/[messageId]/reactions/route.ts': [
+      'reaction_added',
+      'reaction_removed',
+    ],
+    'apps/web/src/lib/ai/tools/channel-tools.ts': ['message_deleted', 'new_message'],
+    'apps/web/src/lib/channels/agent-mention-responder.ts': ['new_message'],
+    'packages/lib/src/billing/credit-emit.ts': ['credits:updated'],
+    'packages/lib/src/notifications/notifications.ts': ['notification:new'],
+    'packages/lib/src/services/page-webhook-service.ts': ['new_message'],
+  };
+
+  const scanEmitSites = (): Record<string, string[]> => {
+    const found: Record<string, string[]> = {};
     const walk = (dir: string): void => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        if (entry.name.startsWith('.') || SKIP_DIR.has(entry.name)) continue;
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
           walk(full);
-        } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
-          if (full.endsWith(`websocket${path.sep}conversation-events.ts`)) continue;
-          const content = fs.readFileSync(full, 'utf8');
-          // An emission is a broadcast body naming a conversation:* event —
-          // client-side *listeners* (`socket.on('conversation:*')`) are fine.
-          if (/event:\s*['"`]conversation:/.test(content)) {
-            offenders.push(path.relative(SRC_ROOT, full));
-          }
+          continue;
+        }
+        if (!/\.tsx?$/.test(entry.name)) continue;
+        if (/\.(test|spec)\.tsx?$/.test(entry.name) || /\.d\.ts$/.test(entry.name)) continue;
+        const content = fs.readFileSync(full, 'utf8');
+        // A broadcast body is `{ channelId, event, payload }` — requiring
+        // `channelId` in the file is what separates real emitters from the
+        // many unrelated `event:` fields (Capacitor typings, log metadata).
+        if (!content.includes('channelId')) continue;
+        const events = new Set<string>();
+        for (const match of content.matchAll(EVENT_LITERAL)) events.add(match[2]);
+        if (events.size > 0) {
+          found[path.relative(REPO_ROOT, full).split(path.sep).join('/')] = [...events].sort();
         }
       }
     };
-    walk(SRC_ROOT);
+    for (const root of ROOTS) {
+      const full = path.join(REPO_ROOT, root);
+      if (fs.existsSync(full)) walk(full);
+    }
+    return found;
+  };
+
+  it('every broadcast emitter in apps/ and packages/ is registered, with exactly the events it emits', () => {
+    expect(scanEmitSites()).toEqual(REGISTERED);
+  });
+
+  it('no file outside conversation-events.ts emits a conversation:* event', () => {
+    const offenders = Object.entries(scanEmitSites())
+      .filter(([file]) => file !== 'apps/web/src/lib/websocket/conversation-events.ts')
+      .filter(([, events]) => events.some((event) => event.startsWith('conversation:')))
+      .map(([file]) => file);
     expect(offenders).toEqual([]);
   });
 });

--- a/apps/web/src/stores/agent-workspace/__tests__/pane-labels.test.ts
+++ b/apps/web/src/stores/agent-workspace/__tests__/pane-labels.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+/**
+ * The client half of the label-free broadcast (security review HIGH 1).
+ *
+ * `workspace:updated` carries structure only, so this module has to make a
+ * nameless grid render like a named one without a round-trip in the common
+ * case, and ask for exactly one authorized read when it cannot.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  carryPaneLabelsForward,
+  hasUnknownBoundTarget,
+  paneLabelIndex,
+  paneLabelKey,
+} from '../pane-labels';
+import type { WorkspaceState } from '../pane-reducer';
+
+const scope = (kind: 'chat' | 'terminal' | 'page', targetId: string | null, name = '', agentPageId: string | null = null) => ({
+  kind,
+  targetId,
+  name,
+  agentPageId,
+});
+
+const stateOf = (panes: Array<{ id: string; scope: ReturnType<typeof scope> | null }>): WorkspaceState =>
+  ({
+    id: 'ws-1',
+    columns: [{ id: 'col-1', panes }],
+    activePaneId: panes[0]?.id ?? null,
+    pendingPickerPaneId: null,
+  }) as unknown as WorkspaceState;
+
+describe('paneLabelKey', () => {
+  it('keys on kind + targetId, and refuses an unbound pane', () => {
+    expect(paneLabelKey(scope('chat', 'c1'))).toBe('chat:c1');
+    expect(paneLabelKey(scope('chat', null))).toBeNull();
+    expect(paneLabelKey(null)).toBeNull();
+  });
+});
+
+describe('carryPaneLabelsForward', () => {
+  it('re-dresses a label-free broadcast from what the client already knows', () => {
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Design review', 'agent-1') }]));
+    // The broadcast: same binding, moved, and carrying no name.
+    const incoming = stateOf([{ id: 'p1', scope: scope('chat', 'c1') }]);
+
+    const dressed = carryPaneLabelsForward(known, incoming);
+    expect(dressed.columns[0].panes[0].scope).toMatchObject({
+      name: 'Design review',
+      agentPageId: 'agent-1',
+    });
+  });
+
+  it('leaves a target it has never seen exactly as it arrived', () => {
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Known') }]));
+    const incoming = stateOf([
+      { id: 'p1', scope: scope('chat', 'c1') },
+      { id: 'p2', scope: scope('page', 'page-new') },
+    ]);
+
+    const dressed = carryPaneLabelsForward(known, incoming);
+    expect(dressed.columns[0].panes[1].scope?.name).toBe('');
+  });
+
+  it('returns the same object when nothing needed filling (no churn on geometry)', () => {
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Same') }]));
+    const incoming = stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Same') }]);
+    expect(carryPaneLabelsForward(known, incoming)).toBe(incoming);
+  });
+
+  it('leaves unbound picker panes alone', () => {
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Known') }]));
+    const incoming = stateOf([{ id: 'p2', scope: null }]);
+    expect(carryPaneLabelsForward(known, incoming).columns[0].panes[0].scope).toBeNull();
+  });
+});
+
+describe('hasUnknownBoundTarget — when the client must go read', () => {
+  it('is false for a pure geometry change over known bindings', () => {
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Known') }]));
+    expect(hasUnknownBoundTarget(known, stateOf([{ id: 'p1', scope: scope('chat', 'c1') }]))).toBe(false);
+  });
+
+  it('is true when a broadcast introduces a target this client has never labelled', () => {
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('chat', 'c1', 'Known') }]));
+    expect(hasUnknownBoundTarget(known, stateOf([{ id: 'p2', scope: scope('chat', 'c2') }]))).toBe(true);
+  });
+
+  it('is FALSE for a target already known to be unlabellable — no refetch loop', () => {
+    // The viewer may not read this target, so the authorized GET returns an
+    // empty name too. Treating that as "unknown" would fetch on every single
+    // broadcast, forever.
+    const known = paneLabelIndex(stateOf([{ id: 'p1', scope: scope('page', 'secret', '') }]));
+    expect(hasUnknownBoundTarget(known, stateOf([{ id: 'p1', scope: scope('page', 'secret') }]))).toBe(false);
+  });
+
+  it('ignores unbound panes', () => {
+    const known = paneLabelIndex(null);
+    expect(hasUnknownBoundTarget(known, stateOf([{ id: 'p1', scope: null }]))).toBe(false);
+  });
+});

--- a/apps/web/src/stores/agent-workspace/pane-labels.ts
+++ b/apps/web/src/stores/agent-workspace/pane-labels.ts
@@ -1,0 +1,95 @@
+/**
+ * Client-side pane LABELS, now that the room broadcast carries none
+ * (security review HIGH 1).
+ *
+ * `workspace:updated` fans out to `session:<id>` — one payload, every member
+ * of a shared workspace. There is no viewer to redact for on that wire, so
+ * the server ships the STRUCTURAL grid (pane ids, kinds, targetIds, size
+ * shares, rev) and no names at all. Names come from each client's own
+ * authorized reads instead: the access-checked `GET /workspace`, whose
+ * labels are resolved for exactly that viewer.
+ *
+ * That leaves this module with one job: make a label-free broadcast render
+ * like a labelled one, without a network round-trip for the common case.
+ *
+ *   - A pane the client ALREADY knows keeps its name (`carryPaneLabelsForward`)
+ *     — which covers every geometry verb (move, resize, reorder, close), i.e.
+ *     the overwhelming majority of broadcasts. Those apply live, exactly as
+ *     before.
+ *   - A broadcast that introduces a target this client has never labelled
+ *     (`hasUnknownBoundTarget`) is the only case that needs a read, and the
+ *     store answers it with `refreshWorkspaceSnapshot`.
+ *
+ * The "already knows" index deliberately records EMPTY names too: a pane
+ * whose target the viewer genuinely may not read resolves no label on the GET
+ * either, and treating that as unknown would make every subsequent broadcast
+ * fire a fetch that can never fill it in.
+ *
+ * Everything here is pure.
+ */
+
+import type { WorkspaceState } from './pane-reducer';
+
+/** A pane's label facts, keyed by what the pane is bound to. */
+export interface PaneLabelIndex {
+  get(key: string): { name: string; agentPageId: string | null } | undefined;
+  has(key: string): boolean;
+}
+
+/** The index key for a binding. `null` for an unbound (picker) pane. */
+export function paneLabelKey(scope: { kind: string; targetId: string | null } | null): string | null {
+  if (!scope || scope.targetId === null) return null;
+  return `${scope.kind}:${scope.targetId}`;
+}
+
+/** Every label this client currently knows, empty names included. */
+export function paneLabelIndex(state: WorkspaceState | null): PaneLabelIndex {
+  const index = new Map<string, { name: string; agentPageId: string | null }>();
+  if (!state) return index;
+  for (const column of state.columns) {
+    for (const pane of column.panes) {
+      const key = paneLabelKey(pane.scope);
+      if (key === null || !pane.scope) continue;
+      index.set(key, { name: pane.scope.name, agentPageId: pane.scope.agentPageId });
+    }
+  }
+  return index;
+}
+
+/**
+ * Fill each bound pane's label from `index`, leaving a pane the index does
+ * not know exactly as it arrived (an empty name the caller will go resolve).
+ * Returns `next` UNCHANGED by identity when nothing needed filling, so a
+ * broadcast that changed only geometry does not churn referential equality.
+ */
+export function carryPaneLabelsForward(index: PaneLabelIndex, next: WorkspaceState): WorkspaceState {
+  let changed = false;
+  const columns = next.columns.map((column) => ({
+    ...column,
+    panes: column.panes.map((pane) => {
+      const key = paneLabelKey(pane.scope);
+      if (key === null || !pane.scope) return pane;
+      const known = index.get(key);
+      if (!known) return pane;
+      if (pane.scope.name === known.name && pane.scope.agentPageId === known.agentPageId) return pane;
+      changed = true;
+      return { ...pane, scope: { ...pane.scope, name: known.name, agentPageId: known.agentPageId } };
+    }),
+  }));
+  return changed ? { ...next, columns } : next;
+}
+
+/**
+ * Does `next` bind a target this client has never had a label for? That — and
+ * only that — is worth an authorized read; a pane whose label is known to be
+ * empty is already as resolved as it will ever get for this viewer.
+ */
+export function hasUnknownBoundTarget(index: PaneLabelIndex, next: WorkspaceState): boolean {
+  for (const column of next.columns) {
+    for (const pane of column.panes) {
+      const key = paneLabelKey(pane.scope);
+      if (key !== null && !index.has(key)) return true;
+    }
+  }
+  return false;
+}

--- a/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
+++ b/apps/web/src/stores/agent-workspace/useAgentWorkspaceStore.ts
@@ -18,6 +18,7 @@ import {
   type WorkspaceState,
 } from './pane-reducer';
 import { adoptServerGrid, replayPending, type PendingVerbOp } from './verb-queue';
+import { carryPaneLabelsForward, hasUnknownBoundTarget, paneLabelIndex } from './pane-labels';
 
 /**
  * Where each session's pane layout lives — as a DERIVED CACHE of the server's
@@ -44,6 +45,15 @@ import { adoptServerGrid, replayPending, type PendingVerbOp } from './verb-queue
  *     → drop if `rev <= known`; no-op if it carries an opId we still have in
  *     flight (our own echo — our POST's own answer is the authoritative one
  *     and is already on its way); otherwise adopt + replay.
+ *
+ * **Broadcasts carry no labels** (security review HIGH 1). `session:<id>` is
+ * a room, so one payload reaches every member of a shared workspace at once
+ * and per-viewer title redaction is not expressible on it; the server ships
+ * structure only. Names are this client's own business: known bindings keep
+ * their label across a broadcast (`pane-labels.ts`), and a broadcast that
+ * introduces a target we have never labelled triggers one
+ * `refreshWorkspaceSnapshot` — the access-checked GET, whose labels are
+ * resolved for THIS viewer and nobody else.
  *
  * **What this replaced, and why it is gone.** The blob era arbitrated between
  * three copies of the same fact with a debounced PUT, two hydration latches
@@ -822,11 +832,19 @@ export const useAgentWorkspaceStore = create<AgentWorkspaceState>()(
         ) {
           return;
         }
-        commit(
-          sessionId,
-          { ...sync, base: adoptServerGrid(sessionId, payload.grid), rev: payload.rev },
-          'preserve',
-        );
+        // The broadcast is label-free, so re-dress it from what this client
+        // already knows before it reaches the renderer — otherwise a pure
+        // resize would blank every pane header it touched.
+        const known = paneLabelIndex(sync.base);
+        const server = adoptServerGrid(sessionId, payload.grid);
+        // An emptied grid has no labels to carry and nothing to go read.
+        const adopted = server === null ? null : carryPaneLabelsForward(known, server);
+        commit(sessionId, { ...sync, base: adopted, rev: payload.rev }, 'preserve');
+        // A target we have never labelled is the ONE case a broadcast cannot
+        // dress itself: go read it under this viewer's own authority.
+        if (adopted !== null && hasUnknownBoundTarget(known, adopted)) {
+          void get().refreshWorkspaceSnapshot(sessionId);
+        }
       },
 
       refreshWorkspaceSnapshot: async (sessionId) => {

--- a/packages/lib/src/permissions/__tests__/revocation-kick.test.ts
+++ b/packages/lib/src/permissions/__tests__/revocation-kick.test.ts
@@ -18,6 +18,8 @@ import {
   driveRevocationKickPayloads,
   kickForPagePermissionRevocation,
   kickForDriveMembershipRevocation,
+  conversationRevocationKickPayloads,
+  workspaceRevocationKickPayloads,
   type RevocationKickDeps,
 } from '../revocation-kick';
 
@@ -90,18 +92,31 @@ describe('driveRevocationKickPayloads (pure)', () => {
   });
 });
 
+const convA = 'ac6bzmkmd014706rfda898tp';
+const convB = 'bd6bzmkmd014706rfda898tq';
+const workspaceA = 'we6bzmkmd014706rfda898tr';
+
 const makeDeps = (overrides: Partial<RevocationKickDeps> = {}): RevocationKickDeps => ({
   kick: vi.fn().mockResolvedValue({ success: true, kickedCount: 1, rooms: [] }),
   listDrivePageIds: vi.fn().mockResolvedValue([pageA, pageB]),
+  // Mirrors the real dep: no pages, no conversations.
+  listRevocableConversationIds: vi.fn(async ({ pageIds }: { pageIds: string[] }) =>
+    pageIds.length === 0 ? [] : [convA, convB],
+  ),
+  listRevocableWorkspaceIds: vi.fn().mockResolvedValue([workspaceA]),
   ...overrides,
 });
 
 describe('kickForPagePermissionRevocation (shell)', () => {
-  it('issues one kick per page room', async () => {
+  it('issues one kick per page room, plus the conversation content rooms that page carries', () => {
+    // The conv: half is asserted in its own describe below; this pins that the
+    // page rooms are still first and still exactly two.
     const deps = makeDeps();
-    await kickForPagePermissionRevocation({ userId, pageId: pageA, reason: 'permission_revoked' }, deps);
-    expect(deps.kick).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([pageA, `activity:page:${pageA}`]);
+    return kickForPagePermissionRevocation({ userId, pageId: pageA, reason: 'permission_revoked' }, deps).then(() => {
+      const rooms = vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern);
+      expect(rooms.slice(0, 2)).toEqual([pageA, `activity:page:${pageA}`]);
+      expect(rooms).toHaveLength(4);
+    });
   });
 
   it('is best-effort: never throws when a kick fails', async () => {
@@ -118,15 +133,20 @@ describe('kickForDriveMembershipRevocation (shell)', () => {
     await kickForDriveMembershipRevocation({ userId, driveId, driveName: 'Team', reason: 'member_removed' }, deps);
 
     expect(deps.listDrivePageIds).toHaveBeenCalledWith(driveId);
-    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([
-      `drive:${driveId}`,
-      `drive:${driveId}:calendar`,
-      `activity:drive:${driveId}`,
-      pageA,
-      `activity:page:${pageA}`,
-      pageB,
-      `activity:page:${pageB}`,
-    ]);
+    // Set-wise, not order-wise: the conv:/session: enumerations (asserted in
+    // their own describe below) run alongside these, so their interleaving is
+    // not a fact worth pinning.
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual(
+      expect.arrayContaining([
+        `drive:${driveId}`,
+        `drive:${driveId}:calendar`,
+        `activity:drive:${driveId}`,
+        pageA,
+        `activity:page:${pageA}`,
+        pageB,
+        `activity:page:${pageB}`,
+      ]),
+    );
   });
 
   it('is best-effort: never throws when page enumeration fails, still kicks drive rooms', async () => {
@@ -134,11 +154,13 @@ describe('kickForDriveMembershipRevocation (shell)', () => {
     await expect(
       kickForDriveMembershipRevocation({ userId, driveId, reason: 'member_removed' }, deps)
     ).resolves.toBeUndefined();
-    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([
-      `drive:${driveId}`,
-      `drive:${driveId}:calendar`,
-      `activity:drive:${driveId}`,
-    ]);
+    const rooms = vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern);
+    expect(rooms).toEqual(
+      expect.arrayContaining([`drive:${driveId}`, `drive:${driveId}:calendar`, `activity:drive:${driveId}`]),
+    );
+    // No pages enumerated means no page rooms and no conversation rooms.
+    expect(rooms).not.toContain(pageA);
+    expect(rooms).not.toContain(`conv:${convA}`);
   });
 
   it('is best-effort: never throws when kicks fail', async () => {
@@ -159,22 +181,147 @@ describe('kickForDriveMembershipRevocation (shell)', () => {
 
     const kickPromise = kickForDriveMembershipRevocation({ userId, driveId, reason: 'member_removed' }, deps);
 
-    // Drain the microtask queue up to (but not past) resolving pageIds.
+    // Drain the microtask queue up to (but not past) resolving pageIds. The
+    // drive-scoped kicks — and the workspace kicks, which do not depend on the
+    // page list either — must already have fired; nothing page-derived has.
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([
-      `drive:${driveId}`,
-      `drive:${driveId}:calendar`,
-      `activity:drive:${driveId}`,
-    ]);
+    const early = vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern);
+    expect(early).toEqual(
+      expect.arrayContaining([`drive:${driveId}`, `drive:${driveId}:calendar`, `activity:drive:${driveId}`]),
+    );
+    expect(early).not.toContain(pageA);
 
     resolvePageIds!([pageA]);
     await kickPromise;
-    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([
-      `drive:${driveId}`,
-      `drive:${driveId}:calendar`,
-      `activity:drive:${driveId}`,
-      pageA,
-      `activity:page:${pageA}`,
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual(
+      expect.arrayContaining([
+        `drive:${driveId}`,
+        `drive:${driveId}:calendar`,
+        `activity:drive:${driveId}`,
+        pageA,
+        `activity:page:${pageA}`,
+      ]),
+    );
+  });
+});
+
+/**
+ * THE EPIC'S ROOMS WERE IN NO KICK SET (security review HIGH 3).
+ *
+ * Pre-epic, page-chat content rode the page room — which a page revocation
+ * kicks. The Agent-Session SSoT epic moved content to `conv:<id>` and layout
+ * to `session:<id>` and extended nothing, and outbound fan-out has no
+ * re-check by design (room membership IS the authz). So:
+ *
+ *   Bob has view on page P. Alice shares conversation C on P; Bob joins
+ *   `conv:C`. Alice revokes Bob's page access. Bob is evicted from the page
+ *   and activity rooms — and keeps receiving every
+ *   `conversation:message_created` with FULL message content, plus
+ *   `workspace:updated` grids, until his socket happens to reconnect.
+ *
+ * Note the asymmetry the finding calls out: conversation UN-SHARE got a
+ * bespoke wildcard kick; permission revocation — the wider case — did not.
+ *
+ * WHY ENUMERATION, not periodic re-auth. `/stream-join`'s 5s re-auth is the
+ * right tool for a long-lived SUBSCRIPTION the server already polls; these
+ * are ordinary rooms whose fan-out is the hot path, and re-authorizing every
+ * `conv:`/`session:` member on a timer would put a permission query per
+ * member per interval on the realtime server forever, to shorten a window
+ * that a kick closes immediately. Enumeration costs two bounded queries ONCE,
+ * at the revocation — which is also the moment the user is watching. The
+ * per-event recheck in apps/realtime/src/per-event-auth.ts remains the actual
+ * enforcement boundary either way; this only shrinks the stale window, as the
+ * TRUST MODEL in ../realtime/rooms.ts requires.
+ */
+describe('conversationRevocationKickPayloads (pure)', () => {
+  it('targets each conversation content room, carrying the page that lost access', () => {
+    const payloads = conversationRevocationKickPayloads({
+      userId,
+      conversationIds: [convA, convB],
+      pageId: pageA,
+      reason: 'permission_revoked',
+    });
+    expect(payloads).toEqual([
+      { userId, roomPattern: `conv:${convA}`, reason: 'permission_revoked', metadata: { pageId: pageA } },
+      { userId, roomPattern: `conv:${convB}`, reason: 'permission_revoked', metadata: { pageId: pageA } },
     ]);
+  });
+
+  it('is empty when nothing was enumerated', () => {
+    expect(conversationRevocationKickPayloads({ userId, conversationIds: [], reason: 'member_removed' })).toEqual([]);
+  });
+});
+
+describe('workspaceRevocationKickPayloads (pure)', () => {
+  it('targets each workspace layout room, carrying the drive that lost access', () => {
+    expect(
+      workspaceRevocationKickPayloads({ userId, workspaceIds: [workspaceA], driveId, reason: 'member_removed' }),
+    ).toEqual([
+      { userId, roomPattern: `session:${workspaceA}`, reason: 'member_removed', metadata: { driveId } },
+    ]);
+  });
+});
+
+describe('kickForPagePermissionRevocation — the conv: rooms', () => {
+  it('evicts the conversation content rooms of the revoked page, not just the page room', async () => {
+    const deps = makeDeps();
+    await kickForPagePermissionRevocation({ userId, pageId: pageA, reason: 'permission_revoked' }, deps);
+
+    expect(deps.listRevocableConversationIds).toHaveBeenCalledWith({ pageIds: [pageA], userId });
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern).sort()).toEqual(
+      [pageA, `activity:page:${pageA}`, `conv:${convA}`, `conv:${convB}`].sort(),
+    );
+  });
+
+  it('kicks the page rooms without waiting on conversation enumeration', async () => {
+    let resolveIds: (ids: string[]) => void;
+    const pending = new Promise<string[]>((resolve) => { resolveIds = resolve; });
+    const deps = makeDeps({ listRevocableConversationIds: vi.fn().mockReturnValue(pending) });
+
+    const kickPromise = kickForPagePermissionRevocation({ userId, pageId: pageA, reason: 'permission_revoked' }, deps);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([pageA, `activity:page:${pageA}`]);
+
+    resolveIds!([convA]);
+    await kickPromise;
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toContain(`conv:${convA}`);
+  });
+
+  it('is best-effort: conversation enumeration failing still leaves the page rooms kicked', async () => {
+    const deps = makeDeps({ listRevocableConversationIds: vi.fn().mockRejectedValue(new Error('db down')) });
+    await expect(
+      kickForPagePermissionRevocation({ userId, pageId: pageA, reason: 'permission_revoked' }, deps),
+    ).resolves.toBeUndefined();
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toEqual([pageA, `activity:page:${pageA}`]);
+  });
+});
+
+describe('kickForDriveMembershipRevocation — the conv: and session: rooms', () => {
+  it('evicts every conversation room in the drive\'s pages and every workspace room in the drive', async () => {
+    const deps = makeDeps();
+    await kickForDriveMembershipRevocation({ userId, driveId, driveName: 'Team', reason: 'member_removed' }, deps);
+
+    expect(deps.listRevocableConversationIds).toHaveBeenCalledWith({ pageIds: [pageA, pageB], userId });
+    expect(deps.listRevocableWorkspaceIds).toHaveBeenCalledWith({ driveId, userId });
+    const rooms = vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern);
+    expect(rooms).toContain(`conv:${convA}`);
+    expect(rooms).toContain(`conv:${convB}`);
+    expect(rooms).toContain(`session:${workspaceA}`);
+  });
+
+  it('kicks the session rooms even when page enumeration fails', async () => {
+    const deps = makeDeps({ listDrivePageIds: vi.fn().mockRejectedValue(new Error('db down')) });
+    await kickForDriveMembershipRevocation({ userId, driveId, reason: 'member_removed' }, deps);
+    const rooms = vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern);
+    expect(rooms).toContain(`session:${workspaceA}`);
+    expect(rooms).not.toContain(`conv:${convA}`);
+  });
+
+  it('is best-effort: workspace enumeration failing never throws', async () => {
+    const deps = makeDeps({ listRevocableWorkspaceIds: vi.fn().mockRejectedValue(new Error('db down')) });
+    await expect(
+      kickForDriveMembershipRevocation({ userId, driveId, reason: 'member_removed' }, deps),
+    ).resolves.toBeUndefined();
+    expect(vi.mocked(deps.kick).mock.calls.map(([p]) => p.roomPattern)).toContain(`drive:${driveId}`);
   });
 });

--- a/packages/lib/src/permissions/revocation-kick.ts
+++ b/packages/lib/src/permissions/revocation-kick.ts
@@ -20,15 +20,44 @@
  *
  * Functional core / imperative shell: the payload builders are pure and fully
  * branch-covered; the exported hooks are thin shells over injected deps
- * (kick transport + drive-page enumeration).
+ * (kick transport + enumeration).
+ *
+ * **THE EPIC'S ROOMS ARE ENUMERATED** (security review HIGH 3). Drive- and
+ * page-scoped rooms are DERIVABLE from the revoked id; the Agent-Session SSoT
+ * epic's two new rooms are not. `conv:<conversationId>` carries full message
+ * content and `session:<workspaceId>` carries pane grids, both keyed by ids a
+ * revocation does not know — so both hooks now enumerate what the revoked
+ * grant covered and kick those rooms too. Before this, a member who lost page
+ * access (or the whole drive) was evicted from the page/drive rooms and kept
+ * receiving `conversation:message_created` payloads and `workspace:updated`
+ * grids until their socket happened to reconnect, because outbound fan-out
+ * has no re-check by design. Note the asymmetry that gave it away:
+ * conversation UN-SHARE got a bespoke wildcard kick; permission revocation —
+ * the wider case — did not.
+ *
+ * Enumeration rather than periodic re-auth, deliberately: `/stream-join`'s 5s
+ * re-auth suits a subscription the server already polls, but re-authorizing
+ * every `conv:`/`session:` room member on a timer would put a permission query
+ * per member per interval on the realtime server forever — to shorten a window
+ * a kick closes at once. Two bounded queries at the revocation is the cheaper
+ * and more immediate answer. Both enumerations EXCLUDE rows the user still
+ * owns: an owner's access to their own conversation or workspace does not come
+ * from the grant being revoked, so kicking them would be a bug, not caution.
  */
 
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { and, eq, inArray, ne } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
 import { loggers } from '../logging/logger-config';
 import { kickUserFromRooms, type KickPayload, type KickReason, type KickResult } from '../realtime/kick-client';
-import { roomsForDriveKick, roomsForPageKick } from '../realtime/rooms';
+import {
+  roomsForConversationKick,
+  roomsForDriveKick,
+  roomsForPageKick,
+  roomsForWorkspaceKick,
+} from '../realtime/rooms';
 
 /** Reasons a user can lose page-scoped access. */
 export type PageRevocationReason = Extract<KickReason, 'permission_revoked' | 'page_private' | 'member_removed'>;
@@ -102,6 +131,56 @@ export function driveRevocationKickPayloads({
   return [...driveScopedKickPayloads({ userId, driveId, driveName, reason }), ...pagePayloads];
 }
 
+/**
+ * One kick payload per conversation CONTENT room a revocation reached. These
+ * ids come from enumeration (see the module doc): `conv:<id>` is keyed by
+ * conversation, so neither a page id nor a drive id can produce it.
+ */
+export function conversationRevocationKickPayloads({
+  userId,
+  conversationIds,
+  pageId,
+  reason,
+}: {
+  userId: string;
+  conversationIds: string[];
+  /** The page whose revocation reached these conversations, when there is one. */
+  pageId?: string;
+  reason: KickReason;
+}): KickPayload[] {
+  const metadata = pageId === undefined ? undefined : { pageId };
+  return conversationIds.flatMap((conversationId) =>
+    roomsForConversationKick(conversationId).map((roomPattern) => ({
+      userId,
+      roomPattern,
+      reason,
+      ...(metadata ? { metadata } : {}),
+    })),
+  );
+}
+
+/** One kick payload per agent-workspace LAYOUT room in the revoked drive. */
+export function workspaceRevocationKickPayloads({
+  userId,
+  workspaceIds,
+  driveId,
+  reason,
+}: {
+  userId: string;
+  workspaceIds: string[];
+  driveId: string;
+  reason: DriveRevocationReason;
+}): KickPayload[] {
+  return workspaceIds.flatMap((workspaceId) =>
+    roomsForWorkspaceKick(workspaceId).map((roomPattern) => ({
+      userId,
+      roomPattern,
+      reason,
+      metadata: { driveId },
+    })),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Imperative shell — injected deps, best-effort execution
 // ---------------------------------------------------------------------------
@@ -109,6 +188,20 @@ export function driveRevocationKickPayloads({
 export interface RevocationKickDeps {
   kick: (payload: KickPayload) => Promise<KickResult>;
   listDrivePageIds: (driveId: string) => Promise<string[]>;
+  /**
+   * Conversations hanging off these pages that `userId` does NOT own — the
+   * `conv:` rooms a page (or drive) revocation must evict them from. Their own
+   * conversations are excluded because ownership, not the revoked grant, is
+   * what admits them there.
+   */
+  listRevocableConversationIds: (input: { pageIds: string[]; userId: string }) => Promise<string[]>;
+  /**
+   * Agent workspaces in this drive that `userId` does NOT own — the `session:`
+   * rooms a drive-membership revocation must evict them from. Same ownership
+   * carve-out: `decideAgentSessionAccess` admits the owner regardless of
+   * membership.
+   */
+  listRevocableWorkspaceIds: (input: { driveId: string; userId: string }) => Promise<string[]>;
 }
 
 const defaultDeps: RevocationKickDeps = {
@@ -117,7 +210,47 @@ const defaultDeps: RevocationKickDeps = {
     const rows = await db.select({ id: pages.id }).from(pages).where(eq(pages.driveId, driveId));
     return rows.map((row) => row.id);
   },
+  listRevocableConversationIds: async ({ pageIds, userId }) => {
+    if (pageIds.length === 0) return [];
+    const rows = await db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.type, 'page'),
+          inArray(conversations.contextId, pageIds),
+          // Their own threads are theirs regardless of the revoked grant.
+          ne(conversations.userId, userId),
+        ),
+      );
+    return rows.map((row) => row.id);
+  },
+  listRevocableWorkspaceIds: async ({ driveId, userId }) => {
+    const rows = await db
+      .select({ id: agentWorkspaces.id })
+      .from(agentWorkspaces)
+      .where(and(eq(agentWorkspaces.driveId, driveId), ne(agentWorkspaces.ownerId, userId)));
+    return rows.map((row) => row.id);
+  },
 };
+
+/**
+ * Run one enumeration, swallowing (and logging) its failure as an empty list.
+ * An enumeration that fails must never stop the kicks that do not depend on
+ * it, and must never throw out of a best-effort hook.
+ */
+async function enumerateOrNone<T>(
+  enumerate: () => Promise<T[]>,
+  message: string,
+  context: Record<string, string>,
+): Promise<T[]> {
+  try {
+    return await enumerate();
+  } catch (error) {
+    loggers.realtime.error(message, error instanceof Error ? error : undefined, context);
+    return [];
+  }
+}
 
 /** Fire every kick; swallow (and log) any failure — kicks are best-effort. */
 async function executeKicks(payloads: KickPayload[], deps: RevocationKickDeps, context: Record<string, string>): Promise<void> {
@@ -139,13 +272,40 @@ export async function kickForPagePermissionRevocation(
   args: { userId: string; pageId: string; reason: PageRevocationReason },
   deps: RevocationKickDeps = defaultDeps,
 ): Promise<void> {
-  await executeKicks(pageRevocationKickPayloads(args), deps, { pageId: args.pageId, reason: args.reason });
+  const context = { pageId: args.pageId, reason: args.reason };
+  // The page rooms need no lookup, so they fire immediately rather than
+  // queueing behind the conversation enumeration — same reasoning the drive
+  // hook below applies to its own page enumeration.
+  const pageKicks = executeKicks(pageRevocationKickPayloads(args), deps, context);
+
+  // The `conv:` rooms this page's conversations carry. Pre-epic, page-chat
+  // content rode the page room above; the epic moved it here and this is what
+  // keeps revocation reaching it.
+  const conversationKicks = enumerateOrNone(
+    () => deps.listRevocableConversationIds({ pageIds: [args.pageId], userId: args.userId }),
+    'Revocation kick: conversation enumeration failed; kicking page rooms only',
+    context,
+  ).then((conversationIds) =>
+    executeKicks(
+      conversationRevocationKickPayloads({
+        userId: args.userId,
+        conversationIds,
+        pageId: args.pageId,
+        reason: args.reason,
+      }),
+      deps,
+      context,
+    ),
+  );
+
+  await Promise.all([pageKicks, conversationKicks]);
 }
 
 /**
  * Kick a user from every room a drive membership granted — the drive-scoped
- * rooms plus every page room in the drive — after their membership was
- * revoked. Never throws.
+ * rooms, every page room in the drive, every `conv:` content room those pages
+ * carry, and every `session:` layout room in the drive — after their
+ * membership was revoked. Never throws.
  *
  * The drive-scoped kicks don't need the page list, so they fire immediately
  * rather than waiting on the page-enumeration DB query: for "immediately
@@ -163,21 +323,51 @@ export async function kickForDriveMembershipRevocation(
     { driveId: args.driveId, reason: args.reason },
   );
 
-  const pageKicks = deps.listDrivePageIds(args.driveId)
-    .catch((error): string[] => {
-      loggers.realtime.error('Revocation kick: drive page enumeration failed; kicking drive rooms only',
-        error instanceof Error ? error : undefined,
-        { driveId: args.driveId },
-      );
-      return [];
-    })
-    .then((pageIds) =>
-      executeKicks(
-        pageIds.flatMap((pageId) => pageRevocationKickPayloads({ userId: args.userId, pageId, reason: args.reason })),
-        deps,
-        { driveId: args.driveId, reason: args.reason },
-      )
-    );
+  const context = { driveId: args.driveId, reason: args.reason };
 
-  await Promise.all([driveKicks, pageKicks]);
+  // Pages, then the page rooms AND the conversation content rooms those pages
+  // carry — `conv:` is keyed by conversation, so this is the only route to it.
+  const pageAndConversationKicks = enumerateOrNone(
+    () => deps.listDrivePageIds(args.driveId),
+    'Revocation kick: drive page enumeration failed; kicking drive rooms only',
+    { driveId: args.driveId },
+  ).then(async (pageIds) => {
+    const pageKicks = executeKicks(
+      pageIds.flatMap((pageId) => pageRevocationKickPayloads({ userId: args.userId, pageId, reason: args.reason })),
+      deps,
+      context,
+    );
+    const conversationIds = await enumerateOrNone(
+      () => deps.listRevocableConversationIds({ pageIds, userId: args.userId }),
+      'Revocation kick: conversation enumeration failed; kicking drive and page rooms only',
+      { driveId: args.driveId },
+    );
+    const conversationKicks = executeKicks(
+      conversationRevocationKickPayloads({ userId: args.userId, conversationIds, reason: args.reason }),
+      deps,
+      context,
+    );
+    await Promise.all([pageKicks, conversationKicks]);
+  });
+
+  // Workspace layout rooms hang off the DRIVE, not off its pages, so they run
+  // independently — a page enumeration failure must not cost them.
+  const workspaceKicks = enumerateOrNone(
+    () => deps.listRevocableWorkspaceIds({ driveId: args.driveId, userId: args.userId }),
+    'Revocation kick: workspace enumeration failed; kicking drive rooms only',
+    { driveId: args.driveId },
+  ).then((workspaceIds) =>
+    executeKicks(
+      workspaceRevocationKickPayloads({
+        userId: args.userId,
+        workspaceIds,
+        driveId: args.driveId,
+        reason: args.reason,
+      }),
+      deps,
+      context,
+    ),
+  );
+
+  await Promise.all([driveKicks, pageAndConversationKicks, workspaceKicks]);
 }

--- a/packages/lib/src/realtime/__tests__/rooms.test.ts
+++ b/packages/lib/src/realtime/__tests__/rooms.test.ts
@@ -28,6 +28,8 @@ import {
   isKnownRoomId,
   roomsForDriveKick,
   roomsForPageKick,
+  roomsForConversationKick,
+  roomsForWorkspaceKick,
   ALL_ROOM_BUILDERS,
 } from '../rooms';
 
@@ -119,5 +121,55 @@ describe('kick room sets', () => {
 
   it('page kick covers the page room and the page activity room', () => {
     expect(roomsForPageKick(id)).toEqual([id, `activity:page:${id}`]);
+  });
+
+  it('conversation kick covers the conv content room', () => {
+    expect(roomsForConversationKick(id)).toEqual([`conv:${id}`]);
+  });
+
+  it('workspace kick covers the session layout room', () => {
+    expect(roomsForWorkspaceKick(id)).toEqual([`session:${id}`]);
+  });
+
+  /**
+   * THE GUARD THAT WAS MISSING (security review HIGH 3).
+   *
+   * These four sets used to be asserted one at a time, which pinned the
+   * `conv:` and `session:` rooms' ABSENCE as correct: the epic moved chat
+   * content off the page room onto `conv:<id>` and layout onto
+   * `session:<id>`, neither of which any revocation path kicked, and the
+   * suite stayed green because nothing ever asked "is every room shape
+   * accounted for?".
+   *
+   * So ask it. Every builder in the grammar is either revocation-scoped —
+   * some kick set must produce it — or explicitly PERSONAL: a room whose only
+   * member is the user it is named after, which no third party's revocation
+   * can ever need to evict them from. A new room shape is a compile-and-test
+   * failure here until it is classified.
+   */
+  it('every room shape in the grammar is either revocation-scoped or explicitly personal', () => {
+    const kickable = new Set([
+      ...roomsForDriveKick(id),
+      ...roomsForPageKick(id),
+      ...roomsForConversationKick(id),
+      ...roomsForWorkspaceKick(id),
+    ]);
+    /** Rooms named after the user themself — revoking someone else's grant never touches them. */
+    const personal = new Set([
+      notificationsRoom(id),
+      userTasksRoom(id),
+      userCalendarRoom(id),
+      userDrivesRoom(id),
+      userGlobalRoom(id),
+      userSessionsRoom(id),
+      // A DM room's membership is the participant list; leaving a drive does
+      // not end a direct message between two people.
+      dmRoom(id),
+    ]);
+
+    const unclassified = ALL_ROOM_BUILDERS.map((build) => build(id)).filter(
+      (room) => !kickable.has(room) && !personal.has(room),
+    );
+    expect(unclassified, 'every room shape must be kickable on revocation or personal').toEqual([]);
   });
 });

--- a/packages/lib/src/realtime/rooms.ts
+++ b/packages/lib/src/realtime/rooms.ts
@@ -197,6 +197,26 @@ export function isKnownRoomId(roomId: string): boolean {
 // Kick room sets — the rooms a revocation must evict a user from
 // ---------------------------------------------------------------------------
 
+/**
+ * The kick sets come in two shapes, and the difference is load-bearing
+ * (security review HIGH 3).
+ *
+ * A DRIVE or PAGE revocation names one id, and the drive/page/activity rooms
+ * are all DERIVABLE from it — one pure function, no IO. The rooms the
+ * agent-session epic added are not: `conv:<conversationId>` and
+ * `session:<workspaceId>` are keyed by ids the revocation does not know, so
+ * they can only be reached by ENUMERATING what the revoked grant covered.
+ * That is why they are separate builders, fed by the enumeration in
+ * ../permissions/revocation-kick.ts, rather than extra entries below.
+ *
+ * The trap that produced the finding: because the two static sets were the
+ * ONLY sets, adding a room shape that these functions could not express meant
+ * silently adding a room no revocation kicked. `rooms.test.ts` now asserts
+ * that every shape in {@link ALL_ROOM_BUILDERS} is either covered by some
+ * kick set or explicitly personal, so a future shape cannot slip through the
+ * same gap.
+ */
+
 /** Every drive-scoped room a user must leave when their drive access is revoked. */
 export const roomsForDriveKick = (driveId: string): string[] => [
   driveRoom(driveId),
@@ -209,3 +229,24 @@ export const roomsForPageKick = (pageId: string): string[] => [
   pageRoom(pageId),
   pageActivityRoom(pageId),
 ];
+
+/**
+ * The content room of ONE conversation a revocation reached. Enumerated, not
+ * derived: a page revocation must find the conversations that page carried,
+ * because `conv:<id>` is keyed by conversation and the page id cannot produce
+ * it. Pre-epic this room did not exist and page-chat content rode the page
+ * room, which {@link roomsForPageKick} already covers — moving the content
+ * plane here without extending revocation is exactly what left a revoked
+ * member receiving full `conversation:message_created` payloads.
+ */
+export const roomsForConversationKick = (conversationId: string): string[] => [
+  conversationRoom(conversationId),
+];
+
+/**
+ * The layout room of ONE agent workspace a revocation reached. Enumerated for
+ * the same reason: `session:<workspaceId>` carries `workspace:updated` grids
+ * for a workspace in the drive whose membership was just revoked, and the
+ * drive id alone cannot name it.
+ */
+export const roomsForWorkspaceKick = (workspaceId: string): string[] => [sessionRoom(workspaceId)];


### PR DESCRIPTION
Three HIGH findings from the adversarial review of the Agent-Session Single Source of Truth epic, all epic-introduced, all leaking data — plus two MEDIUMs on the same surface. Every fix was written test-first: the reproduction test was watched failing against the unfixed code before the fix went in.

Based on `pu/broken-sessions` with `refactor/agent-workspace-renames` (#2358) merged in first; #2358 has since landed on the base, and the base is merged in here.

---

## HIGH 1 — pane label joins had no permission check

`resolvePaneLabels` (`apps/web/src/lib/agent-workspaces/workspace-layout-runtime.ts`) selected `conversations.title`, shell `name`, and `pages.title` by id with **no viewer parameter anywhere on the path**. Every consumer returned the result verbatim: `GET /workspace`, the verbs route's 200 **and its 409 stale body**, the `workspace:updated` broadcast, and the `list_panes` tool.

- **Attack A — redaction bypass.** `decideAgentSessionAccess` admits any accepted drive member to any drive session, and `list_sessions`' shared listing hands out other members' workspace ids with titles correctly redacted. Mallory takes the id, calls `GET .../workspace`, and reads the real titles out of `grid[].panes[].scope.name`. The epic's own redaction rule, undone one HTTP call later.
- **Attack B — universal title oracle.** A pane's `targetId` is free-form in the verb body. Any authenticated user creates their own workspace, binds an arbitrary `targetId`, and reads the resolved title back — over pages, conversations, and shells they have no access to. Also an existence oracle.

### Reproduction

`apps/web/src/lib/agent-workspaces/__tests__/workspace-layout-labels.test.ts` — a second user, a foreign workspace, and foreign `targetId`s of all three kinds. **6 of 10 failed against the unfixed code**, e.g.:

```
AssertionError: expected 'Q3 layoffs plan' to be '(private thread)'
AssertionError: expected 'Acquisition targets' to be ''
AssertionError: expected 'prod-deploy-key-rotation' to be ''
```

`apps/web/src/lib/agent-workspaces/__tests__/authorize-pane-scope.test.ts` (14 tests) covers the write gate, and the verbs-route suite gained three attack-B cases — 3 failed unfixed, including the engine being reached at all with an unauthorized target.

### Fix

**Read side.** `viewerId` is threaded through `labelGrid` / `readWorkspaceLayoutSnapshot` / `readWorkspaceGridsBulk` / `applyWorkspaceLayoutVerb`, and every kind gets its own gate:

| kind | rule |
|---|---|
| `chat` | the conversation must be genuinely **in this workspace**, or accessible on its own footing (`canAccessConversation`); the surviving title then passes through the existing `redactConversationTitleForViewer` |
| `terminal` | the shell must belong to **this workspace** (shells are workspace-scoped, so containment is exact and matches what the shells route already serves) |
| `page` | `getUserAccessLevel(viewerId, pageId) !== null` |

The containment half of the `chat` rule is load-bearing: redaction alone does **not** close attack B, because an attacker binding a foreign conversation into a workspace they own passes the rule's `viewerIsWorkspaceOwner` branch. A target that fails its gate resolves no label at all — indistinguishable from a deleted target, so the join is not an existence oracle either.

`readWorkspaceGridsBulk` keeps its one-query-per-kind bulk shape but authorizes **per workspace**, so a viewer's authority in their own workspace cannot unmask a pane in someone else's.

**Write side.** New `apps/web/src/lib/agent-workspaces/authorize-pane-scope.ts` validates `scope.targetId` at the verbs route — after session access is settled, before the engine sees the verb — with the same per-kind rule. `403` with a fixed message, uniform across "forbidden" and "no such target". `paneScopesOfVerb` is exhaustive over the verb union, so a future scope-carrying verb is a compile error rather than a silently ungated path.

### The broadcast: a different answer, as required

**Decision: the `workspace:updated` wire grid is label-free.** Structure only — pane ids, kinds, `targetId`s, size shares, and the rev.

**Why.** `session:<id>` is a *room*: one payload reaches every member of a shared workspace simultaneously, so there is no viewer to redact for and per-viewer redaction is not expressible on that wire. The two options were (a) ids + rev only, forcing a refetch on every event, or (b) the structural grid without labels. Option (b) wins: it discloses nothing a room member could not already enumerate, and it preserves live-apply for **every geometry verb** (move, resize, reorder, close — the overwhelming majority of broadcasts), which option (a) would have turned into a network round-trip each.

**Clients resolve labels through their own authorized reads.** New pure module `apps/web/src/stores/agent-workspace/pane-labels.ts`: `carryPaneLabelsForward` re-dresses a broadcast from labels the client already holds, and `hasUnknownBoundTarget` triggers exactly one `refreshWorkspaceSnapshot` — the access-checked `GET /workspace`, whose labels are resolved for that viewer — when a broadcast introduces a target the client has never named. The index deliberately records **empty** names as known, so a pane whose target the viewer genuinely may not read does not fire a fetch on every subsequent broadcast forever.

The existing runtime suite now pins the label-free broadcast explicitly, and the e2e grid spec is unaffected (its live assertions are structural: pane counts and picker visibility).

---

## HIGH 2 — agent layout tools ran no session-access check, and the docblock claimed they did

`openOwnGrid` (`apps/web/src/lib/ai/tools/session-tools.ts`) did `readActor` + `findOwnWorkspace` only. Neither wired dep checked anything. `checkSessionAccess` was imported by the runtime and used only by `resolveWorkerPlacement`. The docblock asserted the opposite — the "tool guidance lied to the model" bug class §5 of the spec exists for.

**Attack.** A conversation→workspace binding is permanent by design; drive membership is not. A member spawns a worker into a shared workspace (legitimate), then loses the drive. Every HTTP route 404s her — but the binding still resolves, so `list_panes` returned the whole labelled grid and `move_pane` / `resize_pane` / `arrange_panes` **wrote** the victim's grid and broadcast into their live UI.

### Reproduction

`apps/web/src/lib/ai/tools/__tests__/session-tools-layout-authz.test.ts` — a second workspace and a revoked member, which the existing single-workspace `session-tools-contract.test.ts` structurally cannot see. **6 of 8 failed unfixed**: all four layout tools returned `success: true` for the revoked caller, reading and writing the victim's grid.

### Fix

New `checkWorkspaceAccess` dep on `SessionToolsDeps`, wired in `buildSessionToolsDeps` to the same `checkSessionAccess` the verbs route uses. `openOwnGrid` calls it, so the gate really is one function in one place for both entry points. The docblock now says what the code does. Refusal is a distinct `GRID_ACCESS_LOST` message rather than the no-grid one: the caller's own conversation lives there, so the workspace's existence was never a secret, and telling the model it *had* access and lost it is the only answer that stops it retrying.

`readPaneGrid` also gained the viewer, so `list_panes` shows the model exactly what that user's own GET would return, redactions included.

---

## HIGH 3 — the new `conv:` and `session:` rooms were in no revocation kick set

`roomsForDriveKick` / `roomsForPageKick` listed only drive/page/activity/calendar rooms, and both revocation hooks built kicks solely from those. Pre-epic, page-chat content rode the page room, which **is** kicked; the epic moved content to `conv:<id>` and layout to `session:<id>` and extended nothing. Outbound fan-out has no re-check (room membership *is* the authz, by design).

**Attack.** Bob has view on page P. Alice shares conversation C on P; Bob joins `conv:C`. Alice revokes Bob's page access — Bob is evicted from the page/drive rooms and **keeps receiving every `conversation:message_created` with full message content**, plus `workspace:updated` grids, until his socket happens to reconnect.

### Reproduction

`packages/lib/src/realtime/__tests__/rooms.test.ts` and `packages/lib/src/permissions/__tests__/revocation-kick.test.ts`. The rooms suite **pinned the incomplete sets as correct**, so it was fixed too: the per-set assertions are now backed by a completeness guard asserting every shape in `ALL_ROOM_BUILDERS` is either revocation-scoped or explicitly *personal* (a room named after the user themself). **7 tests failed unfixed** across the two files; the completeness guard is the one that would have caught the original omission.

### Fix, and why enumeration rather than periodic re-auth

Chosen: **enumerate at the revocation.** `/stream-join`'s 5s re-auth is right for a long-lived subscription the server already polls; `conv:`/`session:` are ordinary rooms whose fan-out is the hot path, and re-authorizing every member on a timer would add a permission query per member per interval **forever**, to shorten a window a kick closes immediately. Enumeration costs two bounded queries **once**, at the moment the user is watching. Kick patterns are exact-match only (`roomMatchesPattern`), so a wildcard shortcut was not available either.

- New builders `roomsForConversationKick` / `roomsForWorkspaceKick`, documented as enumerated-not-derived.
- New deps `listRevocableConversationIds({pageIds, userId})` and `listRevocableWorkspaceIds({driveId, userId})`, both **excluding rows the user still owns** — an owner's access does not come from the revoked grant, so kicking them would be a bug, not caution.
- `kickForPagePermissionRevocation` kicks the page's `conv:` rooms; `kickForDriveMembershipRevocation` kicks every `conv:` room its pages carry and every `session:` room in the drive.
- Every enumeration is independently best-effort: the rooms that need no lookup still fire first, and a failed enumeration never blocks the kicks that do not depend on it (pinned by tests, including the deferred-promise ordering ones).

---

## MEDIUM — `open_page_pane` selected a page title with zero ACL

`placePagePaneForConversation` took a **model-supplied** `pageId`, selected its title, and wrote it into the pane row and the broadcast. A prompt-injected agent could exfiltrate titles of pages its own user cannot read.

Reproduction: `apps/web/src/lib/agent-workspaces/__tests__/workspace-placement.test.ts` — **2 of 4 failed unfixed** (the verb was applied for a page the acting user cannot view). Fixed by threading the acting user from `experimental_context` and gating on `getUserAccessLevel` before anything is read or placed.

## MEDIUM — the audience scan could not see the emitter that leaked

`conversation-events-audience.test.ts` scanned `/event:\s*['"\`]conversation:/` under `apps/web/src` only, so `workspace:updated` and the five `chat:*` literals in `socket-utils.ts` were outside its universe — which is precisely why HIGH 1 went uncaught. It also recorded only `{channelId, event}` and discarded payloads.

Now:
- **Repo-wide emit-site registry** across `apps/` and `packages/`: every file that builds a broadcast body (mentions `channelId`, names an event literal) must be registered with exactly the events it emits. Adding an emitter fails CI until someone writes it down — and writing it down is the moment to ask who the room's audience is. Verified as a real guard: a throwaway `{channelId, event: 'sneaky:leak'}` file in `packages/lib` fails it.
- **Payload-shape assertions**: the harness keeps payloads, and any content-bearing payload (`message` / `messageRef` / `parts` / `content`) must target only the `conv:` room. 49 tests, up from 25.

---

## Gates

| gate | result |
|---|---|
| `bun run lint` | 14/14 tasks, no warnings or errors |
| `bun run knip:check` | 4 issues, all within baseline (4) |
| `bun run typecheck` | 16/16 tasks |
| `bun run test:security` | **51/51 suites**, 767 tests + 4 audit-coverage |
| `apps/web` full unit suite | **1107 files passed**, 1 skipped — 16537 tests passed, 6 skipped |
| `packages/lib` full suite | **400 files passed**, 3 skipped — 8803 tests passed, 9 skipped |
| `apps/realtime` (98% branch gate) | **24 files, 958 tests passed** |
| `packages/lib` permissions + realtime + agent-workspaces | 29 files, 685 tests passed |
| targeted web suites (workspace-layout / session-tools / routes / store / websocket) | 48 files, 1027 tests passed |

Run against a live `DATABASE_URL` (scratch Postgres, migrated) so no integration suite skipped silently. Scratch container removed and `.next` deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
