### PR TITLE
fix(agents): rev-bump every write, correct deploy order, stabilise message ordering

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -330,21 +330,37 @@ jobs:
           FLY_NO_UPDATE_CHECK: "true"
           ADMIN_DATABASE_URL_MIGRATE: ${{ secrets.ADMIN_DATABASE_URL_MIGRATE }}
 
-      - name: Deploy web
-        run: |
-          docker pull ghcr.io/2witstudios/pagespace-web:latest
-          docker tag ghcr.io/2witstudios/pagespace-web:latest registry.fly.io/pagespace-web:latest
-          docker push registry.fly.io/pagespace-web:latest
-          flyctl deploy --app pagespace-web --image registry.fly.io/pagespace-web:latest --wait-timeout 300
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
+      # REALTIME BEFORE WEB — order is load-bearing, do not swap.
+      #
+      # apps/realtime owns the socket room grammar and the event handlers
+      # (`join_conversation`, `join_session`) that apps/web's client code emits
+      # into, so the dependency runs one way: new web needs new realtime.
+      #
+      # Getting it backwards fails SILENTLY. Socket.IO drops an event with no
+      # registered listener — no error, no ack, no disconnect — so a new web
+      # client emitting `join_conversation` at an old realtime believes it
+      # joined, never enters the room, and receives none of the rev-carrying
+      # `conversation:*` events fanned out to it. Live delivery degrades to
+      # nothing for the whole deploy window with no signal to retry on.
+      #
+      # This way round, the stale case is benign: an old web client simply
+      # never emits the new joins, and the new handlers idle until it reloads.
+      # Pinned by apps/realtime/src/__tests__/deploy-order.guard.test.ts.
       - name: Deploy realtime
         run: |
           docker pull ghcr.io/2witstudios/pagespace-realtime:latest
           docker tag ghcr.io/2witstudios/pagespace-realtime:latest registry.fly.io/pagespace-realtime:latest
           docker push registry.fly.io/pagespace-realtime:latest
           flyctl deploy --app pagespace-realtime --image registry.fly.io/pagespace-realtime:latest --wait-timeout 300
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy web
+        run: |
+          docker pull ghcr.io/2witstudios/pagespace-web:latest
+          docker tag ghcr.io/2witstudios/pagespace-web:latest registry.fly.io/pagespace-web:latest
+          docker push registry.fly.io/pagespace-web:latest
+          flyctl deploy --app pagespace-web --image registry.fly.io/pagespace-web:latest --wait-timeout 300
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/apps/realtime/src/__tests__/deploy-order.guard.test.ts
+++ b/apps/realtime/src/__tests__/deploy-order.guard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * REALTIME DEPLOYS BEFORE WEB — pinned against the workflow that does it.
+ *
+ * This service owns the room grammar and the socket event handlers
+ * (`join_conversation`, `join_session`) that `apps/web`'s client code emits
+ * into. The dependency is therefore strictly one-way: NEW WEB NEEDS NEW
+ * REALTIME, never the reverse.
+ *
+ * Socket.IO makes the failure of the wrong order silent rather than loud. An
+ * old realtime that has no listener registered for `join_conversation` does
+ * not error, does not disconnect, and does not tell the client anything — it
+ * simply drops the event. So a new web client emitting a join it believes
+ * succeeded never enters the room, and every rev-carrying
+ * `conversation:*` event for that conversation fans out to a room the client
+ * is not in. Live delivery degrades to nothing, invisibly, for the whole
+ * deploy window, and the client has no signal to retry on.
+ *
+ * Deploying realtime FIRST inverts that into the benign case: an old web
+ * client simply never emits the new joins, and the new handlers sit idle
+ * until it reloads.
+ *
+ * Comments have already asserted this ordering as fact while the workflow did
+ * the opposite (see `src/terminal/shell-activity.ts`, which froze a wire field
+ * name on the strength of it). This test is the thing that makes the claim
+ * true instead of merely written down — cf. `docs/2.0-architecture/agent-sessions.md` §5.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// vitest runs with cwd = apps/realtime.
+const WORKFLOW = resolve(process.cwd(), '../../.github/workflows/docker-images.yml');
+const workflow = readFileSync(WORKFLOW, 'utf8');
+
+/** The line index of a `- name: <step>` deploy step, or -1. */
+function stepIndex(name: string): number {
+  return workflow.split('\n').findIndex((line) => line.trim() === `- name: ${name}`);
+}
+
+describe('Fly deploy order (docker-images.yml)', () => {
+  it('found the deploy steps (guard is actually scanning something)', () => {
+    expect(stepIndex('Deploy web')).toBeGreaterThan(-1);
+    expect(stepIndex('Deploy realtime')).toBeGreaterThan(-1);
+  });
+
+  it('deploys realtime BEFORE web', () => {
+    // Web's client code emits socket events this service must already be
+    // listening for. Reversing these two steps silently breaks live delivery
+    // for the duration of the deploy — see this file's header.
+    expect(stepIndex('Deploy realtime')).toBeLessThan(stepIndex('Deploy web'));
+  });
+});

--- a/apps/realtime/src/terminal/shell-activity.ts
+++ b/apps/realtime/src/terminal/shell-activity.ts
@@ -56,8 +56,12 @@ export interface ShellActivityPayload {
    * `agent_workspaces.id` — the workspace whose sandbox the agent acted on.
    *
    * The FIELD NAME is frozen at the old spelling on purpose: this is a
-   * cross-service wire contract and realtime deploys BEFORE web, so renaming
-   * it would need its own accept-both release. `apps/web` maps its
+   * cross-service wire contract and realtime deploys BEFORE web (pinned by
+   * `src/__tests__/deploy-order.guard.test.ts` — the workflow shipped the
+   * other way round while this comment already claimed otherwise), so a
+   * rename would spend a whole deploy window with new realtime reading a
+   * field old web does not send. It needs its own accept-both release.
+   * `apps/web` maps its
    * `workspaceId` onto this name at the boundary
    * (`sandbox-tools-runtime.ts`), the same way the sandbox billing and storage
    * paths do for `AIUsageData.sessionId`.

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -221,38 +221,42 @@ export async function POST(
       );
     }
 
-    // Record the undo through the repository choke point: bumps the
-    // conversation's rev, emits the legacy chat:undo_applied (moved in from
-    // this route) plus the authoritative conversation:undo_applied to the
-    // conv room. Page-event broadcasts below cover the page-domain side.
-    // Failure must never break the request.
-    void (async () => {
-      try {
-        const legacyTriggeredBy = await resolveTriggeredBy(userId, request);
-        const broadcastPageId = preview.source === 'page_chat' && preview.pageId
-          ? preview.pageId
-          : globalChannelId(userId);
-        const messageIdsFromActivities = preview.activitiesAffected
-          .filter((a) => a.resourceType === 'message')
-          .map((a) => a.resourceId);
-        const affectedMessageIds = Array.from(new Set([messageId, ...messageIdsFromActivities]));
-        await messageRepository.recordUndoApplied({
-          conversationId: preview.conversationId,
-          legacyChannelId: broadcastPageId,
-          scope: preview.source === 'page_chat' && preview.pageId
-            ? { kind: 'page', pageId: preview.pageId }
-            : { kind: 'global', ownerId: userId },
-          mode,
-          affectedMessageIds,
-          legacyTriggeredBy,
-        });
-      } catch (broadcastError) {
-        loggers.api.error('Failed to broadcast chat undo-applied', broadcastError as Error, {
-          messageId: maskIdentifier(messageId),
-          conversationId: maskIdentifier(preview.conversationId),
-        });
-      }
-    })();
+    // ANNOUNCE the undo. The rev bump already happened, inside the write
+    // transaction, via `messageRepository.softDeleteUndoRange` — this route
+    // only carries that post-write rev out to the rooms: the legacy
+    // chat:undo_applied (moved in from here) plus the authoritative
+    // conversation:undo_applied. Page-event broadcasts below cover the
+    // page-domain side.
+    //
+    // The route MUST NOT bump. It used to: `recordUndoApplied` opened its own
+    // transaction here, after the write had already committed, inside a
+    // swallowing try/catch. A single failure in that block meant a committed
+    // deletion with no rev movement and no event — permanent silent staleness
+    // in every open pane, because `syncWatchedConversationRevs` compares revs
+    // and nothing else, so it could never heal. Emission is still best-effort
+    // (it is delivery, not durability); the rev is what makes losing it
+    // recoverable.
+    if (result.bumpedConversation !== undefined) {
+      const legacyTriggeredBy = await resolveTriggeredBy(userId, request);
+      const broadcastPageId = preview.source === 'page_chat' && preview.pageId
+        ? preview.pageId
+        : globalChannelId(userId);
+      const messageIdsFromActivities = preview.activitiesAffected
+        .filter((a) => a.resourceType === 'message')
+        .map((a) => a.resourceId);
+      const affectedMessageIds = Array.from(new Set([messageId, ...messageIdsFromActivities]));
+      messageRepository.emitUndoApplied({
+        conversationId: preview.conversationId,
+        bumped: result.bumpedConversation,
+        legacyChannelId: broadcastPageId,
+        scope: preview.source === 'page_chat' && preview.pageId
+          ? { kind: 'page', pageId: preview.pageId }
+          : { kind: 'global', ownerId: userId },
+        mode,
+        affectedMessageIds,
+        legacyTriggeredBy,
+      });
+    }
 
     // Broadcast real-time updates for affected pages and channels
     if (mode === 'messages_and_changes') {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { eq, and, desc, gt, lt, ne } from '@pagespace/db/operators'
+import { eq, and, desc, ne, sql } from '@pagespace/db/operators'
 import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { convertGlobalAssistantMessageToUIMessage } from '@/lib/ai/core/message-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -75,33 +75,46 @@ export async function GET(
       ...(includeStreaming ? [] : [ne(messages.status, 'streaming')])
     ];
 
-    // Add cursor condition if provided
+    // Add cursor condition if provided - compound cursor (createdAt + id), the
+    // same keyset the page-agents messages route uses. A createdAt-only cursor
+    // is not just unstable but LOSSY: `createdAt` is a millisecond timestamp,
+    // so a burst of same-tick rows straddling a page boundary is either
+    // skipped entirely (strict `<`/`>` on a tie) or served twice. Paginating
+    // on the same total order the ORDER BY uses is what makes each row appear
+    // exactly once.
     if (cursor) {
-      // First, get the timestamp of the cursor message
+      // First, get the timestamp and id of the cursor message
       const [cursorMessage] = await db
-        .select({ createdAt: messages.createdAt })
+        .select({ createdAt: messages.createdAt, id: messages.id })
         .from(messages)
         .where(eq(messages.id, cursor))
         .limit(1);
 
       if (cursorMessage) {
         if (direction === 'before') {
-          // Get messages created before the cursor (older messages)
-          conditions.push(lt(messages.createdAt, cursorMessage.createdAt));
+          // Older: earlier timestamp, or same timestamp and a smaller id.
+          conditions.push(
+            sql`(${messages.createdAt} < ${cursorMessage.createdAt} OR (${messages.createdAt} = ${cursorMessage.createdAt} AND ${messages.id} < ${cursorMessage.id}))`
+          );
         } else {
-          // Get messages created after the cursor (newer messages)
-          conditions.push(gt(messages.createdAt, cursorMessage.createdAt));
+          // Newer: later timestamp, or same timestamp and a larger id.
+          conditions.push(
+            sql`(${messages.createdAt} > ${cursorMessage.createdAt} OR (${messages.createdAt} = ${cursorMessage.createdAt} AND ${messages.id} > ${cursorMessage.id}))`
+          );
         }
       }
     }
 
     // Get messages with pagination
-    // Order by createdAt DESC to get newest first, then reverse for chronological display
+    // Order by (createdAt DESC, id DESC) for a total order, then reverse for
+    // chronological display. Without the id tiebreak, WHICH same-tick rows
+    // survive the LIMIT is arbitrary and can differ between two identical
+    // requests.
     const conversationMessages = await db
       .select()
       .from(messages)
       .where(and(...conditions))
-      .orderBy(desc(messages.createdAt))
+      .orderBy(desc(messages.createdAt), desc(messages.id))
       .limit(limit + 1); // Get one extra to check if there are more
 
     // Check if there are more messages

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -590,7 +590,7 @@ async function buildAndPersistPulse(
         ne(messages.userId, userId)
       )
     )
-    .orderBy(desc(messages.createdAt))
+    .orderBy(desc(messages.createdAt), desc(messages.id))
     .limit(15) : [];
   // Decrypt PII at the edge so page-chat sender names in the prompt are
   // plaintext — batched once per unique stored value, not once per row.

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -460,7 +460,7 @@ export async function POST(req: Request) {
           ne(messages.userId, userId)
         )
       )
-      .orderBy(desc(messages.createdAt))
+      .orderBy(desc(messages.createdAt), desc(messages.id))
       .limit(15) : [];
     // Decrypt PII at the edge so page-chat sender names in the prompt are
     // plaintext — batched once per unique stored value, not once per row.

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -1029,7 +1029,7 @@ export const pageReadTools = {
                 eq(messages.conversationId, conv.conversationId),
                 eq(messages.isActive, true)
               ))
-              .orderBy(asc(messages.createdAt))
+              .orderBy(asc(messages.createdAt), asc(messages.id))
               .limit(1);
 
             // Get unique participants
@@ -1181,7 +1181,7 @@ export const pageReadTools = {
             eq(messages.isActive, true),
             ne(messages.status, 'streaming')
           ))
-          .orderBy(asc(messages.createdAt));
+          .orderBy(asc(messages.createdAt), asc(messages.id));
 
         if (conversationMessages.length === 0) {
           return {

--- a/apps/web/src/lib/ai/tools/search-tools.ts
+++ b/apps/web/src/lib/ai/tools/search-tools.ts
@@ -196,7 +196,7 @@ export const searchTools = {
                 eq(messages.isActive, true),
                 sql`${messages.content} ~ ${pgPattern}`
               ))
-              .orderBy(asc(messages.createdAt))
+              .orderBy(asc(messages.createdAt), asc(messages.id))
               .limit(maxResults);
 
             // Group by conversation and build results
@@ -220,7 +220,7 @@ export const searchTools = {
                     id: messages.id,
                     pageId: sql<string>`${conversations.contextId}`,
                     conversationId: messages.conversationId,
-                    lineNumber: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${conversations.contextId}, ${messages.conversationId} ORDER BY ${messages.createdAt})`.as('line_number'),
+                    lineNumber: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${conversations.contextId}, ${messages.conversationId} ORDER BY ${messages.createdAt}, ${messages.id})`.as('line_number'),
                   })
                   .from(messages)
                   .innerJoin(conversations, eq(conversations.id, messages.conversationId))

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -112,7 +112,7 @@ async function gatherRecentConversations(
         gte(messages.createdAt, lookbackDate)
       )
     )
-    .orderBy(desc(messages.createdAt))
+    .orderBy(desc(messages.createdAt), desc(messages.id))
     .limit(150);
 
   allMessages.push(
@@ -155,7 +155,7 @@ async function gatherRecentConversations(
           gte(messages.createdAt, lookbackDate)
         )
       )
-      .orderBy(desc(messages.createdAt))
+      .orderBy(desc(messages.createdAt), desc(messages.id))
       .limit(100);
 
     allMessages.push(

--- a/apps/web/src/lib/repositories/__tests__/message-order-stability.integration.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/message-order-stability.integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * MESSAGE READS ARE TOTALLY ORDERED.
+ *
+ * `ORDER BY "createdAt"` is a PARTIAL order over `messages`: the column is a
+ * millisecond timestamp, and a burst of writes inside one millisecond — a
+ * user turn and its tool rows, an interrupt and the resumed row that replaces
+ * it, any seeded fixture — produces rows Postgres is then free to return in
+ * any order it likes. Not a stable-but-arbitrary order: the planner may hand
+ * back heap order on one call and index order on the next, for the same rows.
+ *
+ * Every consumer of these readers treats the result as a TRANSCRIPT. The AI
+ * chat history is replayed into a model prompt in returned order; the pane
+ * renders it in returned order. A conversation whose last two turns swap
+ * between reloads is not a cosmetic defect — it is a different prompt.
+ *
+ * This surfaced as a rare, unreproducible failure in
+ * `chat-mutation-matrix.integration.test.ts > interrupt and resume`:
+ *
+ *     expected ['streaming','complete'] to deeply equal ['complete','streaming']
+ *
+ * The nondeterminism was in the READER, not the test.
+ *
+ * ── THE TIEBREAKER ─────────────────────────────────────────────────────────
+ * `messages.id` — a cuid2, and deliberately NOT sortable-by-creation-time
+ * (cuid2 dropped the k-sortable prefix of cuid v1 precisely to stop leaking
+ * creation order and volume). That is fine, and it is worth being explicit
+ * about why: rows tied on `createdAt` have no chronological truth left to
+ * preserve, so the tiebreaker's only job is to be TOTAL and STABLE, which a
+ * unique primary key is by construction. There is no monotonic sequence
+ * column on this table to prefer instead.
+ *
+ * DESC readers tiebreak DESC, so that `ORDER BY … DESC LIMIT n` selects a
+ * deterministic WINDOW and not merely a deterministic ordering of whichever
+ * rows it happened to select.
+ *
+ * Requires DATABASE_URL → a Postgres with migrations applied.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { conversations, messages } from '@pagespace/db/schema/conversations';
+import { factories } from '@pagespace/db/test/factories';
+import { messageRepository } from '@/lib/repositories/message-repository';
+
+let dbAvailable = false;
+
+/** How many rows share the tick. 8! = 40320 orderings — accidental agreement is not a risk. */
+const TIED = 8;
+
+/**
+ * A conversation whose messages ALL share one `createdAt`, seeded in an order
+ * that (with overwhelming probability) is not their id order — so a reader
+ * with no tiebreaker cannot accidentally satisfy the assertion.
+ */
+async function seedSameTickThread() {
+  const owner = await factories.createUser();
+  const drive = await factories.createDrive(owner.id);
+  const page = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent' });
+  const conversationId = createId();
+  const tick = new Date();
+
+  await db.insert(conversations).values({
+    id: conversationId,
+    userId: owner.id,
+    type: 'page',
+    contextId: page.id,
+    isActive: true,
+    lastMessageAt: tick,
+    updatedAt: new Date(),
+  });
+
+  const ids: string[] = [];
+  for (let i = 0; i < TIED; i++) {
+    const id = createId();
+    await db.insert(messages).values({
+      id,
+      conversationId,
+      userId: i % 2 === 0 ? owner.id : null,
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `m${i}`,
+      isActive: true,
+      status: 'complete' as const,
+      createdAt: tick,
+    });
+    ids.push(id);
+  }
+
+  return { ownerId: owner.id, pageId: page.id, conversationId, ids, tick };
+}
+
+/** The total order the readers must produce: createdAt ASC, then id ASC. */
+const expectedAsc = (ids: string[]) => [...ids].sort();
+
+describe('message read ordering is total and stable', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('getMessagesByConversationId breaks createdAt ties deterministically', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedSameTickThread();
+
+    const rows = await messageRepository.getMessagesByConversationId(thread.conversationId);
+    expect(rows.map((r) => r.id)).toEqual(expectedAsc(thread.ids));
+  });
+
+  it('getPageConversationMessages breaks createdAt ties deterministically', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedSameTickThread();
+
+    const rows = await messageRepository.getPageConversationMessages(thread.pageId, thread.conversationId);
+    expect(rows.map((r) => r.id)).toEqual(expectedAsc(thread.ids));
+  });
+
+  it('getMessagesForPage breaks createdAt ties deterministically', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedSameTickThread();
+
+    const rows = await messageRepository.getMessagesForPage(thread.pageId, thread.conversationId);
+    expect(rows.map((r) => r.id)).toEqual(expectedAsc(thread.ids));
+  });
+
+  it('getRecentPageMessages selects a deterministic WINDOW, not just a deterministic order', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedSameTickThread();
+
+    // DESC + LIMIT under a tie: without a DESC tiebreaker, WHICH rows survive
+    // the limit is itself arbitrary. The newest 3 by (createdAt, id) are the
+    // last 3 of the ascending order, returned oldest-first.
+    const rows = await messageRepository.getRecentPageMessages(thread.pageId, 3);
+    expect(rows.map((r) => r.id)).toEqual(expectedAsc(thread.ids).slice(-3));
+  });
+
+  it('repeated reads of the same tied rows agree with each other', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedSameTickThread();
+
+    const reads = await Promise.all(
+      Array.from({ length: 5 }, () => messageRepository.getMessagesByConversationId(thread.conversationId)),
+    );
+    const orders = reads.map((rows) => rows.map((r) => r.id).join(','));
+    expect(new Set(orders).size).toBe(1);
+  });
+});

--- a/apps/web/src/lib/repositories/__tests__/messages-write-site-classification.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/messages-write-site-classification.test.ts
@@ -1,0 +1,165 @@
+/**
+ * THE CHOKE-POINT GUARD — every `messages` write site is classified.
+ *
+ * Epic "Agent-Session Single Source of Truth", spec §3 clause 2: *every*
+ * durable message write bumps `conversations.rev` and emits, in the SAME
+ * transaction, from ONE repository choke point. A write that lands outside
+ * that choke point commits without a rev bump, so every open pane keeps
+ * showing pre-write content indefinitely: `syncWatchedConversationRevs`
+ * compares revs and nothing else, so an unbumped rev is indistinguishable
+ * from "nothing happened" and the panes never heal.
+ *
+ * That is not a property any single unit test can hold, because the failure
+ * mode is a NEW write site somewhere else in the tree. So this is a
+ * structural scan: it walks the shipped source, finds every statement that
+ * INSERTs / UPDATEs / DELETEs `messages`, and fails unless the file is
+ * either the choke point itself or a CLASSIFIED EXEMPTION with a written
+ * reason.
+ *
+ * This reinstates the pattern of the deleted
+ * `unified-message-dual-write-drift.test.ts` (the Phase 4 writer-classification
+ * / freeze guard). Its removal at the contract PR is precisely why three
+ * bypasses — the undo service, the trash path, and the retention sweep —
+ * shipped unnoticed.
+ *
+ * ── ADDING A WRITE SITE ────────────────────────────────────────────────────
+ * The default answer is "route it through `messageRepository`". Only add to
+ * EXEMPT_WRITERS if the write genuinely cannot bump a rev, and say why in the
+ * `reason` — the reason is the artifact this test exists to protect.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+// vitest runs with cwd = apps/web.
+const REPO_ROOT = resolve(process.cwd(), '../..');
+
+/** Trees that ship code. `apps/e2e` is a test harness, not shipped runtime. */
+const SCANNED_ROOTS = ['apps/web/src', 'apps/realtime/src', 'apps/processor/src', 'packages/lib/src', 'packages/db/src'];
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.next', 'coverage', 'drizzle', '__tests__']);
+
+/**
+ * THE CHOKE POINT. These two files, and only these two, are allowed to write
+ * `messages` without justification — they are the implementation of the
+ * invariant (`unified-message-leg.ts` is `message-repository.ts`'s own
+ * in-transaction statement helper, always called on the caller's `tx`).
+ */
+const CHOKE_POINT = [
+  'apps/web/src/lib/repositories/message-repository.ts',
+  'apps/web/src/lib/repositories/unified-message-leg.ts',
+];
+
+/**
+ * CLASSIFIED EXEMPTIONS. Each one is a deliberate product decision, not an
+ * oversight. The test pins the classification so that flipping it requires
+ * editing this list.
+ */
+const EXEMPT_WRITERS: Array<{ file: string; reason: string }> = [
+  {
+    file: 'packages/lib/src/repositories/conversation-cleanup.ts',
+    reason:
+      'DESTROYS the conversation row in the same transaction as its messages (page/drive permanent ' +
+      'delete). There is no surviving `conversations` row to bump a rev on, and no room to emit ' +
+      'into that outlives the statement — the conversation itself is the thing being deleted. ' +
+      'Panes are healed by the page/drive deletion events that this path already fans out, which ' +
+      'carry strictly more information than a rev bump would.',
+  },
+  {
+    file: 'packages/lib/src/compliance/retention/retention-engine.ts',
+    reason:
+      'BULK ADMINISTRATIVE SWEEP of rows that are ALREADY soft-deleted (`isActive: false`) and past ' +
+      'the retention cutoff. Every one of these rows was hidden from every reader — and had its rev ' +
+      'bumped and its event emitted — at soft-delete time, by the choke point. The hard delete ' +
+      'changes nothing any client can observe, so a per-row rev bump would emit pure noise (and a ' +
+      'nightly cron fanning out thousands of no-op events is a real cost). Exempt because the ' +
+      'user-visible transition already emitted, not because deletion is unimportant.',
+  },
+];
+
+const ALLOWED = new Set([...CHOKE_POINT, ...EXEMPT_WRITERS.map((e) => e.file)]);
+
+/** `.insert(messages)`, `.update(messages)`, `.delete(messages)` on any executor. */
+const WRITE_STATEMENT = /\.\s*(insert|update|delete)\s*\(\s*messages\s*\)/;
+
+/**
+ * Comments are not code. This module's whole subject is where `messages`
+ * writes live, so the files it guards are exactly the files whose doc comments
+ * quote statements like `tx.update(messages)` while explaining why they no
+ * longer do that — and a guard that flags its own documentation trains people
+ * to weaken it. Crude but sufficient: block comments, line comments, and the
+ * string/template bodies that could hide an apostrophe-laden `//`.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    // Trailing comments too, but never the `//` of a `https://` URL.
+    .replace(/(?<!:)\/\/.*$/gm, '');
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      out.push(...sourceFiles(join(dir, entry.name)));
+    } else if (/\.tsx?$/.test(entry.name) && !/\.(test|spec)\.tsx?$/.test(entry.name)) {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+const repoRel = (file: string) => relative(REPO_ROOT, file).split(sep).join('/');
+
+/** Every shipped file containing at least one `messages` write statement. */
+const WRITER_FILES: string[] = SCANNED_ROOTS.flatMap((root) => sourceFiles(join(REPO_ROOT, root)))
+  .filter((file) => {
+    const rel = repoRel(file);
+    // The db package's own test factories are seeding helpers, not runtime.
+    if (rel.startsWith('packages/db/src/test/')) return false;
+    return WRITE_STATEMENT.test(stripComments(readFileSync(file, 'utf8')));
+  })
+  .map(repoRel)
+  .sort();
+
+describe('messages write-site classification (choke-point guard)', () => {
+  it('is actually scanning something (the choke point is found)', () => {
+    // If the scan silently matched nothing — wrong root, renamed table — the
+    // whole guard would pass vacuously.
+    expect(WRITER_FILES).toContain('apps/web/src/lib/repositories/message-repository.ts');
+    expect(WRITER_FILES.length).toBeGreaterThanOrEqual(CHOKE_POINT.length);
+  });
+
+  it('every `messages` write site is the repository choke point or a classified exemption', () => {
+    const unclassified = WRITER_FILES.filter((file) => !ALLOWED.has(file));
+    expect(unclassified).toEqual([]);
+  });
+
+  it('the undo path is NOT exempt — it writes through the repository', () => {
+    // Undo soft-deletes a range of messages a user is very likely watching, in
+    // response to that user's own click. It is the single least exemptable
+    // write in the system: not bulk, not administrative, not invisible.
+    expect(WRITER_FILES).not.toContain('apps/web/src/services/api/ai-undo-service.ts');
+  });
+
+  it('every exemption states a reason', () => {
+    for (const { file, reason } of EXEMPT_WRITERS) {
+      expect(reason.length, `${file} needs a real classification reason`).toBeGreaterThan(80);
+    }
+  });
+
+  it('no exemption is stale (every classified file still writes `messages`)', () => {
+    // A file that stopped writing should lose its exemption rather than keep a
+    // standing licence nobody re-reads.
+    for (const { file } of EXEMPT_WRITERS) {
+      expect(WRITER_FILES, `${file} no longer writes messages — drop its exemption`).toContain(file);
+    }
+  });
+});

--- a/apps/web/src/lib/repositories/__tests__/undo-rev-atomicity.integration.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/undo-rev-atomicity.integration.test.ts
@@ -1,0 +1,209 @@
+/**
+ * UNDO BUMPS THE REV IN THE SAME TRANSACTION AS ITS WRITE.
+ *
+ * Epic "Agent-Session Single Source of Truth", spec §3 clause 2. Undo is a
+ * durable message write — it soft-deletes a whole RANGE of messages, in
+ * response to a click, in a pane the user is by definition looking at. So it
+ * owes the same contract as every other write in `message-repository.ts`:
+ *
+ *     write + `UPDATE conversations SET rev = rev + 1 RETURNING rev`
+ *     in ONE transaction; emit AFTER commit.
+ *
+ * ── WHAT THIS PINS, AND WHY IT MATTERS ─────────────────────────────────────
+ * The bump is not a nicety layered on top of the emit; it is the FALLBACK FOR
+ * the emit. `syncWatchedConversationRevs` compares revs and nothing else: on
+ * reconnect, refocus or poll, a client asks "is my rev still the server's
+ * rev?" and refetches when it is not. That is the only self-healing path in
+ * the system.
+ *
+ * Which means an emit that fails is survivable — the rev moved, the client
+ * notices on its next sync, the pane heals. A BUMP that fails is not: the
+ * server and the client agree on a rev that no longer describes the data, so
+ * the client has nothing to notice. The pane is stale until a manual reload,
+ * forever.
+ *
+ * Undo previously bumped from a fire-and-forget `void (async () => ...)` in
+ * the route, AFTER the write transaction had already committed, in a SEPARATE
+ * transaction, under a `catch` that logged and swallowed. Every one of those
+ * three properties independently converts a transient database or broadcast
+ * hiccup into permanent, silent staleness.
+ *
+ * Requires DATABASE_URL → a Postgres with migrations applied.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+
+vi.mock('@/lib/websocket/conversation-events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/websocket/conversation-events')>();
+  return {
+    ...actual,
+    conversationEvents: {
+      created: vi.fn().mockResolvedValue(undefined),
+      updated: vi.fn().mockResolvedValue(undefined),
+      messageCreated: vi.fn().mockResolvedValue(undefined),
+      messageUpdated: vi.fn().mockResolvedValue(undefined),
+      messageDeleted: vi.fn().mockResolvedValue(undefined),
+      undoApplied: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastAiMessageEdited: vi.fn().mockResolvedValue(undefined),
+  broadcastAiMessageDeleted: vi.fn().mockResolvedValue(undefined),
+  broadcastAiUndoApplied: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { conversations, messages } from '@pagespace/db/schema/conversations';
+import { factories } from '@pagespace/db/test/factories';
+import { previewAiUndo, executeAiUndo } from '@/services/api/ai-undo-service';
+import { messageRepository } from '@/lib/repositories/message-repository';
+import { broadcastAiUndoApplied } from '@/lib/websocket/socket-utils';
+import { conversationEvents } from '@/lib/websocket/conversation-events';
+
+let dbAvailable = false;
+
+async function seedThread(count = 4) {
+  const owner = await factories.createUser();
+  const drive = await factories.createDrive(owner.id);
+  const page = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Agent' });
+  const conversationId = createId();
+  const base = Date.now();
+
+  await db.insert(conversations).values({
+    id: conversationId,
+    userId: owner.id,
+    type: 'page',
+    contextId: page.id,
+    isActive: true,
+    lastMessageAt: new Date(base + (count - 1) * 1000),
+    updatedAt: new Date(),
+  });
+
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = createId();
+    await db.insert(messages).values({
+      id,
+      conversationId,
+      userId: i % 2 === 0 ? owner.id : null,
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `m${i}`,
+      isActive: true,
+      status: 'complete' as const,
+      createdAt: new Date(base + i * 1000),
+    });
+    ids.push(id);
+  }
+  return { ownerId: owner.id, pageId: page.id, conversationId, ids };
+}
+
+const revOf = async (conversationId: string): Promise<number> => {
+  const [row] = await db
+    .select({ rev: conversations.rev })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId));
+  return row.rev;
+};
+
+const activeCount = async (conversationId: string): Promise<number> => {
+  const rows = await db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(and(eq(messages.conversationId, conversationId), eq(messages.isActive, true)));
+  return rows.length;
+};
+
+describe('undo rev atomicity', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('executeAiUndo bumps the conversation rev in the same transaction as the soft-delete', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedThread();
+    const revBefore = await revOf(thread.conversationId);
+
+    const preview = await previewAiUndo(thread.ids[2], thread.ownerId);
+    const result = await executeAiUndo(thread.ids[2], thread.ownerId, 'messages_only', preview!);
+    expect(result.success).toBe(true);
+
+    // The write landed…
+    expect(await activeCount(thread.conversationId)).toBe(2);
+    // …and the rev moved WITH it, without any help from the route. This is the
+    // whole invariant: the write and the bump are one transaction, owned by
+    // the writer, not a follow-up the caller may or may not perform.
+    expect(await revOf(thread.conversationId)).toBe(revBefore + 1);
+  });
+
+  it('a throwing emit does not cost the rev bump — the client can still detect staleness', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedThread();
+    const revBefore = await revOf(thread.conversationId);
+
+    // The realtime service is down / the socket POST times out.
+    vi.mocked(broadcastAiUndoApplied).mockRejectedValueOnce(new Error('realtime unreachable'));
+    vi.mocked(conversationEvents.undoApplied).mockRejectedValueOnce(new Error('realtime unreachable'));
+
+    const preview = await previewAiUndo(thread.ids[2], thread.ownerId);
+    const result = await executeAiUndo(thread.ids[2], thread.ownerId, 'messages_only', preview!);
+
+    // The undo itself still succeeds — a broadcast is not part of the write's
+    // success condition.
+    expect(result.success).toBe(true);
+    expect(await activeCount(thread.conversationId)).toBe(2);
+
+    // And critically: the rev moved anyway. A pane that missed the event will
+    // see rev N+1 on its next sync, mismatch its own N, and refetch. Had the
+    // bump been coupled to the emit, this conversation would read as
+    // "unchanged" forever despite two deleted messages.
+    expect(await revOf(thread.conversationId)).toBe(revBefore + 1);
+
+    vi.mocked(broadcastAiUndoApplied).mockResolvedValue(undefined);
+    vi.mocked(conversationEvents.undoApplied).mockResolvedValue(undefined);
+  });
+
+  it('an aborted undo takes the rev bump with it (no event for an uncommitted write)', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedThread();
+    const revBefore = await revOf(thread.conversationId);
+
+    // Same transaction cuts both ways: if the write rolls back, so must the
+    // bump, or clients refetch to find nothing changed.
+    await expect(
+      db.transaction(async (tx) => {
+        await messageRepository.softDeleteUndoRange(tx, {
+          conversationId: thread.conversationId,
+          fromCreatedAt: new Date(0),
+        });
+        throw new Error('rollback');
+      }),
+    ).rejects.toThrow('rollback');
+
+    expect(await revOf(thread.conversationId)).toBe(revBefore);
+    expect(await activeCount(thread.conversationId)).toBe(4);
+  });
+
+  it('an idempotent re-undo neither writes nor bumps', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const thread = await seedThread();
+
+    const preview = await previewAiUndo(thread.ids[2], thread.ownerId);
+    await executeAiUndo(thread.ids[2], thread.ownerId, 'messages_only', preview!);
+    const revAfterFirst = await revOf(thread.conversationId);
+
+    // The already-inactive short-circuit returns success with zero counts; it
+    // must not spend a rev on a no-op, or every double-click would invalidate
+    // every watching pane for nothing.
+    const again = await executeAiUndo(thread.ids[2], thread.ownerId, 'messages_only');
+    expect(again.success).toBe(true);
+    expect(await revOf(thread.conversationId)).toBe(revAfterFirst);
+  });
+});

--- a/apps/web/src/lib/repositories/message-repository.ts
+++ b/apps/web/src/lib/repositories/message-repository.ts
@@ -46,7 +46,7 @@
 
 import type { UIMessage } from 'ai';
 import { db } from '@pagespace/db/db';
-import { eq, and, ne, lt, desc } from '@pagespace/db/operators';
+import { eq, and, ne, lt, gte, asc, desc } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { messages } from '@pagespace/db/schema/conversations';
 import { conversations } from '@pagespace/db/schema/conversations';
@@ -970,36 +970,88 @@ export const messageRepository = {
   },
 
   /**
-   * Record an executed undo: bump rev, emit the legacy `chat:undo_applied`
-   * (moved in from the undo route) plus the authoritative
-   * `conversation:undo_applied`. The undo's own message deletions happen in
-   * `executeAiUndo` (services layer); this is the one post-commit record +
-   * emission point for them.
+   * UNDO'S MESSAGE WRITE — soft-delete the undone range AND bump the rev, on
+   * the CALLER's transaction, in one statement pair. The choke point for undo,
+   * exactly as `editGlobalMessage` / `softDeleteGlobalMessage` are for theirs.
+   *
+   * Runs on `tx` rather than opening its own, because `executeAiUndo` wraps
+   * the activity rollbacks and this deletion in one all-or-nothing transaction
+   * — the rev must move with THAT transaction, so a failed rollback takes the
+   * bump with it and no event ever describes an uncommitted write.
+   *
+   * This used to be a bare `tx.update(messages)` in the services layer with
+   * the bump arriving later, post-commit, in a separate transaction, from a
+   * fire-and-forget block in the route. Any failure in that block committed
+   * the write with no rev bump — and since `syncWatchedConversationRevs`
+   * compares revs and nothing else, an unbumped rev is indistinguishable from
+   * "nothing changed", so every open pane stayed stale until a manual reload
+   * with no path to heal.
+   *
+   * Excludes `status: 'streaming'` rows, mirroring `previewAiUndo`'s
+   * affected-message query — the mutation and its preview must agree on scope.
+   *
+   * Returns the bumped conversation row (the rev the post-commit emission
+   * carries), or null for a conversation that no longer exists.
    */
-  async recordUndoApplied(args: {
+  async softDeleteUndoRange(
+    tx: DbExecutor,
+    args: { conversationId: string; fromCreatedAt: Date },
+  ): Promise<BumpedConversationRow | null> {
+    await tx
+      .update(messages)
+      .set({ isActive: false })
+      .where(and(
+        eq(messages.conversationId, args.conversationId),
+        gte(messages.createdAt, args.fromCreatedAt),
+        eq(messages.isActive, true),
+        ne(messages.status, 'streaming'),
+      ));
+
+    return bumpConversationRev(tx, args.conversationId);
+  },
+
+  /**
+   * POST-COMMIT emission for an executed undo: the legacy `chat:undo_applied`
+   * (moved in from the undo route) plus the authoritative
+   * `conversation:undo_applied`, both carrying the rev that
+   * `softDeleteUndoRange` already bumped inside the write transaction.
+   *
+   * Takes that bumped row rather than bumping again — the counter is the
+   * write's business, this is only delivery. Fire-and-forget and logged on
+   * failure, like every other emission in this module: a committed write must
+   * not un-succeed because a broadcast failed, and the rev watermark is what
+   * makes a dropped event survivable.
+   */
+  emitUndoApplied(args: {
     conversationId: string;
+    /** The row bumped in the write transaction; null when the conversation is gone. */
+    bumped: BumpedConversationRow | null;
     /** The legacy broadcast channel: the pageId for page chat, `user:<id>:global` otherwise. */
     legacyChannelId: string;
     scope: ConversationEmitContext['scope'];
     mode: 'messages_only' | 'messages_and_changes';
     affectedMessageIds: string[];
     legacyTriggeredBy: TriggeredBy;
-  }): Promise<void> {
-    const row = await bumpConversationRev(db, args.conversationId);
-
-    await broadcastAiUndoApplied({
-      conversationId: args.conversationId,
-      pageId: args.legacyChannelId,
-      mode: args.mode,
-      affectedMessageIds: args.affectedMessageIds,
-      triggeredBy: args.legacyTriggeredBy,
+  }): void {
+    void (async () => {
+      await broadcastAiUndoApplied({
+        conversationId: args.conversationId,
+        pageId: args.legacyChannelId,
+        mode: args.mode,
+        affectedMessageIds: args.affectedMessageIds,
+        triggeredBy: args.legacyTriggeredBy,
+      });
+      const ctx = contextForMutation(args.bumped, args.conversationId, args.scope, args.legacyTriggeredBy);
+      await conversationEvents.undoApplied(
+        ctx,
+        { mode: args.mode, affectedMessageIds: args.affectedMessageIds },
+        { skipDirectory: args.bumped === null },
+      );
+    })().catch((error) => {
+      loggers.api.error('messageRepository: undo-applied broadcast failed', error as Error, {
+        conversationId: args.conversationId,
+      });
     });
-    const ctx = contextForMutation(row, args.conversationId, args.scope, args.legacyTriggeredBy);
-    await conversationEvents.undoApplied(
-      ctx,
-      { mode: args.mode, affectedMessageIds: args.affectedMessageIds },
-      { skipDirectory: row === null },
-    );
   },
 
   /**
@@ -1031,7 +1083,7 @@ export const messageRepository = {
         eq(messages.isActive, true),
         ...(includeStreaming ? [] : [ne(messages.status, 'streaming')]),
       ))
-      .orderBy(messages.createdAt);
+      .orderBy(asc(messages.createdAt), asc(messages.id));
   },
 
   /**
@@ -1067,7 +1119,7 @@ export const messageRepository = {
         ...(conversationId ? [eq(messages.conversationId, conversationId)] : []),
         ...(includeStreaming ? [] : [ne(messages.status, 'streaming')]),
       ))
-      .orderBy(messages.createdAt);
+      .orderBy(asc(messages.createdAt), asc(messages.id));
 
     // Decrypt PII at the edge (GDPR #965) so the message author name is plaintext.
     return Promise.all(
@@ -1102,7 +1154,7 @@ export const messageRepository = {
         eq(messages.isActive, true),
         ...(includeStreaming ? [] : [ne(messages.status, 'streaming')]),
       ))
-      .orderBy(messages.createdAt);
+      .orderBy(asc(messages.createdAt), asc(messages.id));
   },
 
   /**
@@ -1121,7 +1173,7 @@ export const messageRepository = {
         eq(messages.isActive, true),
         ne(messages.status, 'streaming'),
       ))
-      .orderBy(desc(messages.createdAt))
+      .orderBy(desc(messages.createdAt), desc(messages.id))
       .limit(limit);
     return rows.reverse();
   },

--- a/apps/web/src/services/api/__tests__/ai-undo-service.test.ts
+++ b/apps/web/src/services/api/__tests__/ai-undo-service.test.ts
@@ -36,13 +36,21 @@ vi.mock('@pagespace/db/db', () => {
     db: mockDb,
   };
 });
+// `asc`/`sql` are pulled in transitively: the undo's soft-delete now runs
+// through `messageRepository.softDeleteUndoRange`, so this module's graph
+// includes the message repository and its scope helpers.
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ field: a, value: b })),
   and: vi.fn((...args) => args),
   gte: vi.fn((a, b) => ({ field: a, op: 'gte', value: b })),
   lt: vi.fn((a, b) => ({ field: a, op: 'lt', value: b })),
   ne: vi.fn((a, b) => ({ field: a, op: 'ne', value: b })),
+  asc: vi.fn((a) => ({ field: a, direction: 'asc' })),
   desc: vi.fn((a) => ({ field: a, direction: 'desc' })),
+  sql: Object.assign(
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+    { raw: vi.fn((s: string) => ({ raw: s })) },
+  ),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
 }));
@@ -102,6 +110,48 @@ interface MockDb {
 const mockDb = vi.mocked(db) as unknown as MockDb;
 const mockPreviewRollback = vi.mocked(previewRollback);
 const mockExecuteRollback = vi.mocked(executeRollback);
+
+/** The row `bumpConversationRev`'s RETURNING hands back. */
+const BUMPED_ROW = {
+  id: 'conv_123',
+  rev: 7,
+  userId: 'user_123',
+  isShared: false,
+  workspaceId: null,
+  type: 'page',
+  contextId: 'page_123',
+  title: null,
+  lastMessageAt: null,
+  createdAt: new Date(),
+  closedInWorkspaceAt: null,
+  isActive: true,
+};
+/**
+ * The transaction handle `executeAiUndo` gets. Both statements it now issues
+ * run on it: the `messages` soft-delete AND the `conversations` rev bump —
+ * `messageRepository.softDeleteUndoRange` performs them as one pair on the
+ * CALLER's tx, which is the invariant this suite's table assertions pin.
+ *
+ * `.where()` returns a plain object carrying `.returning()`: awaiting it in
+ * the soft-delete path yields the object (harmless), while the bump chains
+ * off it for its RETURNING.
+ *
+ * @param updatedTables optional sink recording each table passed to `update`.
+ */
+function makeUndoTx(updatedTables?: unknown[]) {
+  return {
+    update: vi.fn((table: unknown) => {
+      updatedTables?.push(table);
+      return {
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([BUMPED_ROW]),
+          }),
+        }),
+      };
+    }),
+  };
+}
 
 // Test fixtures
 const mockUserId = 'user_123';
@@ -342,25 +392,20 @@ describe('ai-undo-service', () => {
 
       // Mock transaction
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         await callback(tx);
       });
 
       const result = await executeAiUndo(mockMessageId, mockUserId, 'messages_only');
 
+      expect(result.errors).toEqual([]);
       expect(result.success).toBe(true);
       expect(result.messagesDeleted).toBe(2);
       expect(result.activitiesRolledBack).toBe(0);
       expect(executeRollback).not.toHaveBeenCalled();
     });
 
-    it('tombstones the unified table ONLY — the legacy leg is frozen', async () => {
+    it('tombstones the unified table and bumps the rev — one table, one transaction', async () => {
       const mockMessage = createMockMessage();
 
       mockDb.query.messages.findFirst.mockResolvedValue(mockMessage);
@@ -383,31 +428,34 @@ describe('ai-undo-service', () => {
 
       const updatedTables: unknown[] = [];
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn((table: unknown) => {
-            updatedTables.push(table);
-            return {
-              set: vi.fn().mockReturnValue({
-                where: vi.fn().mockResolvedValue(undefined),
-              }),
-            };
-          }),
-        };
+        const tx = makeUndoTx(updatedTables);
         await callback(tx);
       });
 
       await executeAiUndo(mockMessageId, mockUserId, 'messages_only');
 
-      // ONE table, and this assertion has been all three shapes the epic
-      // passed through: it used to be "the page table OR the global table"
-      // (chosen by `source`), then "both legs" during the dual-write, and now
-      // — since Phase 4 PR 14 froze `chat_messages` — the unified table alone.
-      // A second UPDATE reappearing here means the legacy tombstone came back,
-      // writing rows no reader has consulted since PR 12. Asserted on the
-      // tables themselves rather than on a debug log, because the tables are
-      // the contract.
-      const { messages: unifiedTable } = await import('@pagespace/db/schema/conversations');
-      expect(updatedTables).toEqual([unifiedTable]);
+      // ONE message table, and this assertion has been all four shapes the
+      // epic passed through: "the page table OR the global table" (chosen by
+      // `source`), then "both legs" during the dual-write, then — once Phase 4
+      // PR 14 froze `chat_messages` — the unified table alone, and now the
+      // unified table PLUS its conversation's rev bump.
+      //
+      // Both halves matter, in order:
+      //   - A THIRD table reappearing means the legacy tombstone came back,
+      //     writing rows no reader has consulted since PR 12.
+      //   - `conversations` missing means the rev bump has drifted back out of
+      //     the write transaction, which is the defect this pins: the undo
+      //     used to commit its deletion here and bump afterwards, in a
+      //     separate transaction, from a swallowing catch in the route — so a
+      //     failure there left every open pane permanently stale with no way
+      //     to detect it.
+      //
+      // Asserted on the tables themselves rather than on a debug log, because
+      // the tables are the contract — and on ONE transaction, because "same
+      // transaction" is the whole claim.
+      const { messages: unifiedTable, conversations: conversationsTable } =
+        await import('@pagespace/db/schema/conversations');
+      expect(updatedTables).toEqual([unifiedTable, conversationsTable]);
       expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     });
 
@@ -440,13 +488,7 @@ describe('ai-undo-service', () => {
       }));
 
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         await callback(tx);
       });
 
@@ -498,13 +540,7 @@ describe('ai-undo-service', () => {
       mockExecuteRollback.mockResolvedValue(createMockRollbackResult());
 
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         await callback(tx);
       });
 
@@ -547,13 +583,7 @@ describe('ai-undo-service', () => {
 
       // Transaction should abort on failure
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         try {
           await callback(tx);
         } catch (e) {
@@ -643,13 +673,7 @@ describe('ai-undo-service', () => {
       mockExecuteRollback.mockResolvedValue(createMockRollbackResult());
 
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         await callback(tx);
       });
 
@@ -727,13 +751,7 @@ describe('ai-undo-service', () => {
       mockExecuteRollback.mockResolvedValue(createMockRollbackResult());
 
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         await callback(tx);
       });
 
@@ -831,13 +849,7 @@ describe('ai-undo-service', () => {
       }));
 
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
+        const tx = makeUndoTx();
         await callback(tx);
       });
 
@@ -952,8 +964,14 @@ describe('ai-undo-service', () => {
     it('issues exactly ONE soft-delete update — the frozen legacy leg gets none', async () => {
       // This used to assert the SECOND update (the legacy mirror) carried the
       // same streaming exclusion. Phase 4 PR 14 removed that statement, so
-      // what is worth pinning is that it stayed removed: a second update here
-      // is a resurrected legacy writer.
+      // what is worth pinning is that it stayed removed: a second update to
+      // `messages` here is a resurrected legacy writer.
+      //
+      // Counted PER TABLE rather than in total, because the transaction now
+      // legitimately issues a second statement against a DIFFERENT table — the
+      // in-transaction `conversations` rev bump. A bare call count would have
+      // to be relaxed to 2 and would then stop noticing the legacy leg coming
+      // back at all.
       const mockMessage = createMockMessage();
       mockDb.query.messages.findFirst.mockResolvedValue(mockMessage);
       mockDb.query.pages.findFirst.mockResolvedValue({ driveId: mockDriveId });
@@ -969,16 +987,18 @@ describe('ai-undo-service', () => {
         }),
       }));
 
-      const updateWhereMock = vi.fn().mockResolvedValue(undefined);
-      const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
-      const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+      const updatedTables: unknown[] = [];
       mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
-        await callback({ update: updateMock });
+        await callback(makeUndoTx(updatedTables));
       });
 
       await executeAiUndo(mockMessageId, mockUserId, 'messages_only');
 
-      expect(updateWhereMock).toHaveBeenCalledTimes(1);
+      const { messages: unifiedTable, conversations: conversationsTable } =
+        await import('@pagespace/db/schema/conversations');
+      expect(updatedTables.filter((t) => t === unifiedTable)).toHaveLength(1);
+      // And the bump is in there with it, on the same transaction handle.
+      expect(updatedTables.filter((t) => t === conversationsTable)).toHaveLength(1);
     });
   });
 });

--- a/apps/web/src/services/api/ai-undo-service.ts
+++ b/apps/web/src/services/api/ai-undo-service.ts
@@ -22,6 +22,8 @@ import {
   type RollbackContext,
 } from './rollback-service';
 import type { ActivityActionPreview } from '@/types/activity-actions';
+import { messageRepository } from '@/lib/repositories/message-repository';
+import type { BumpedConversationRow } from '@/lib/repositories/conversation-rev';
 
 /**
  * Preview of what will be undone
@@ -61,6 +63,18 @@ export interface AiUndoResult {
   messagesDeleted: number;
   activitiesRolledBack: number;
   errors: string[];
+  /**
+   * The conversation row as it stood AFTER the write transaction bumped its
+   * rev — the post-write rev the undo's own event must carry (spec §3 clause
+   * 2). Absent when nothing was written (a failed or idempotent no-op undo),
+   * which is also the caller's signal that there is nothing to announce.
+   *
+   * Handed to the caller rather than emitted here because the emission needs
+   * request-scoped facts this layer does not have (the acting browser session,
+   * the legacy broadcast channel). The caller's only job is to pass it to
+   * `messageRepository.emitUndoApplied` — it must never bump a rev itself.
+   */
+  bumpedConversation?: BumpedConversationRow | null;
 }
 
 /**
@@ -462,6 +476,7 @@ export async function executeAiUndo(
     loggers.api.debug('[AiUndo:Execute] Starting transaction');
 
     const deferredTriggers: Array<() => void> = [];
+    let bumpedConversation: BumpedConversationRow | null = null;
 
     await db.transaction(async (tx) => {
       // If mode includes changes, rollback activities in reverse chronological order
@@ -534,23 +549,22 @@ export async function executeAiUndo(
         fromTimestamp: createdAt.toISOString(),
       });
 
-      // `messages` — the one table every reader consults and, since Phase 4
-      // PR 14, the only one anything writes. The mirrored `chat_messages`
-      // tombstone that used to follow this statement is gone with the rest of
-      // the legacy leg. Excludes 'streaming' rows: see the SAFE DEFAULT note
-      // on previewAiUndo's affectedMessages query above; the same exclusion
-      // must apply to the actual mutation, not just its preview count.
-      await tx
-        .update(messages)
-        .set({ isActive: false })
-        .where(
-          and(
-            eq(messages.conversationId, conversationId),
-            gte(messages.createdAt, createdAt),
-            eq(messages.isActive, true),
-            ne(messages.status, 'streaming')
-          )
-        );
+      // Through the repository choke point, on THIS transaction: the
+      // soft-delete and `conversations.rev = rev + 1` are one atomic pair, so
+      // a rollback above takes the bump with it and a commit here can never
+      // leave the counter behind (spec §3 clause 2).
+      //
+      // This was a bare `tx.update(messages)` until the rev-bump audit. The
+      // bump then arrived later, post-commit, in its own transaction, from a
+      // fire-and-forget block in the route — so any hiccup there committed the
+      // deletion with an unmoved rev, and every open pane stayed stale with no
+      // way to notice (`syncWatchedConversationRevs` compares revs and nothing
+      // else). The emission still happens after commit, below; only the
+      // counter moved inside.
+      bumpedConversation = await messageRepository.softDeleteUndoRange(tx, {
+        conversationId,
+        fromCreatedAt: createdAt,
+      });
 
       loggers.api.debug('[AiUndo:Execute] Transaction committing');
     });
@@ -593,6 +607,7 @@ export async function executeAiUndo(
       messagesDeleted,
       activitiesRolledBack,
       errors,
+      bumpedConversation,
     };
   } catch (error) {
     loggers.api.error('[AiUndoService] Error executing undo', {

--- a/docs/2.0-architecture/agent-sessions-evidence.json
+++ b/docs/2.0-architecture/agent-sessions-evidence.json
@@ -161,6 +161,62 @@
       "notes": "The property test is the load-bearing one — it drives seeded adversarial schedules (drops, reorders, duplicates, truncation, stale snapshots) rather than a handful of chosen cases. The rest pin the individual clauses it depends on."
     },
     {
+      "id": "every-message-write-bumps-the-rev",
+      "guarantee": "A pane the user is looking at never sits silently stale after a message write: every write bumps the conversation's rev in the same transaction, so the client's next rev sync notices even when the live event never arrives.",
+      "status": "proven",
+      "evidence": [
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/undo-rev-atomicity.integration.test.ts",
+          "name": "executeAiUndo bumps the conversation rev in the same transaction as the soft-delete",
+          "suite": "web-unit"
+        },
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/undo-rev-atomicity.integration.test.ts",
+          "name": "a throwing emit does not cost the rev bump — the client can still detect staleness",
+          "suite": "web-unit"
+        },
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/undo-rev-atomicity.integration.test.ts",
+          "name": "an aborted undo takes the rev bump with it (no event for an uncommitted write)",
+          "suite": "web-unit"
+        },
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/messages-write-site-classification.test.ts",
+          "name": "every `messages` write site is the repository choke point or a classified exemption",
+          "suite": "web-unit"
+        },
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/messages-write-site-classification.test.ts",
+          "name": "no exemption is stale (every classified file still writes `messages`)",
+          "suite": "web-unit"
+        }
+      ],
+      "notes": "The write-side counterpart to adversarial-delivery-converges-to-db-truth, and the reason that guarantee is worth anything: syncWatchedConversationRevs compares revs and nothing else, so a missed bump is worse than a missed emit — a missed emit self-heals on the next sync, a missed bump leaves server and client agreeing on a rev that no longer describes the data, stale until a manual reload. Added by #2366, which moved the undo write into messageRepository.softDeleteUndoRange; it previously bumped from a fire-and-forget block in the route, after commit, in a separate transaction, under a swallowing catch. The classification citations are what make this a claim about EVERY write rather than about undo: they enumerate every write site against the repository choke point and require each exemption to state a reason and still be real. Unlike the dbAvailable suites noted on gdpr-export-agent-authored-messages, the integration citations THROW when DATABASE_URL is absent rather than passing green with no assertions."
+    },
+    {
+      "id": "transcript-order-is-stable-across-reads",
+      "guarantee": "A conversation reads back in the same order every time — the last two turns cannot swap between reloads, and the model is not replayed a differently-ordered transcript.",
+      "status": "proven",
+      "evidence": [
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/message-order-stability.integration.test.ts",
+          "name": "getMessagesByConversationId breaks createdAt ties deterministically",
+          "suite": "web-unit"
+        },
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/message-order-stability.integration.test.ts",
+          "name": "getRecentPageMessages selects a deterministic WINDOW, not just a deterministic order",
+          "suite": "web-unit"
+        },
+        {
+          "file": "apps/web/src/lib/repositories/__tests__/message-order-stability.integration.test.ts",
+          "name": "repeated reads of the same tied rows agree with each other",
+          "suite": "web-unit"
+        }
+      ],
+      "notes": "ORDER BY \"createdAt\" alone is a PARTIAL order: the column is a millisecond timestamp, and a burst inside one millisecond (a user turn and its tool rows, an interrupt and the row that replaces it) leaves Postgres free to return heap order on one call and index order on the next. Consumers treat the result as a transcript — the pane renders it in returned order and the AI history is replayed into a prompt in returned order — so an unstable read is a different prompt, not a cosmetic defect. It surfaced as a rare unreproducible failure in chat-mutation-matrix.integration.test.ts > interrupt and resume; the nondeterminism was in the reader. The DESC-window citation is the non-obvious one: a DESC reader must tiebreak DESC or LIMIT n selects a deterministic ordering of a nondeterministic set of rows."
+    },
+    {
       "id": "no-wider-audience-than-pre-epic",
       "guarantee": "No event reaches a wider audience than pre-epic behaviour, except the owner's own devices.",
       "status": "proven",

--- a/docs/2.0-architecture/agent-sessions.md
+++ b/docs/2.0-architecture/agent-sessions.md
@@ -345,6 +345,69 @@ stream lifecycle and the `'streaming'` placeholder under a per-conversation advi
 — is shared outright in `start-chat-generation.ts`, because a lock protocol maintained
 twice is a lock protocol that drifts into double generation and double billing.
 
+### 3c. The choke point has a guard again
+
+Clause 1 is a property of the whole tree, not of one module: it holds only while NO
+other file writes `messages`. The coexistence window had a structural writer-classification
+test enforcing exactly that (`unified-message-dual-write-drift.test.ts`, later the freeze
+guard), and it was retired with the window at the contract PR. Three bypasses shipped in
+the gap — the undo service, and the two deletion paths below — and a
+requirements-traceability audit, not CI, is what found them.
+
+The guard is reinstated as
+`apps/web/src/lib/repositories/__tests__/messages-write-site-classification.test.ts`:
+it scans the shipped source for every `messages` INSERT / UPDATE / DELETE and fails
+unless the file is the repository choke point or a **classified exemption carrying a
+written reason**. Two exemptions stand, and the reasoning is the point:
+
+- **`conversation-cleanup.ts` (permanent page/drive delete) — EXEMPT.** It destroys the
+  `conversations` row in the same transaction as its messages. There is no surviving
+  row to bump a rev on and no room to emit into that outlives the statement; the
+  conversation *is* the thing being deleted. Panes heal on the page/drive deletion
+  events this path already fans out, which say strictly more than a rev bump would.
+- **`retention-engine.ts` (nightly retention sweep) — EXEMPT.** It hard-deletes rows
+  that are ALREADY `isActive: false` and past the cutoff. Every one of them was hidden
+  from every reader — and had its rev bumped and its event emitted — at soft-delete
+  time, by the choke point. The hard delete changes nothing any client can observe, so
+  a per-row bump would emit pure noise. Exempt because the user-visible transition
+  already emitted, not because bulk deletion is beneath the contract.
+- **Undo — NOT EXEMPT, and now fixed.** It soft-deletes a range of messages in response
+  to a user's own click, in a pane that user is by definition watching: not bulk, not
+  administrative, not invisible. Its write goes through
+  `messageRepository.softDeleteUndoRange`, which bumps the rev on the caller's
+  transaction; the route only emits.
+
+That last one is worth stating as a general rule, because it is the trap the original
+code fell into. **The bump is the fallback FOR the emit, not a companion to it.** An emit
+that fails is survivable: the rev moved, the client notices the mismatch on its next
+sync (clause 3) and refetches. A BUMP that fails is not: server and client agree on a rev
+that no longer describes the data, so there is nothing for the client to notice, and the
+pane is stale until a manual reload. A rev bump therefore belongs in the write's
+transaction and nowhere else — never in a post-commit block, never in a second
+transaction, and never under a `catch` that swallows.
+
+### 3d. Deploy order: realtime BEFORE web
+
+`apps/realtime` owns the room grammar and the socket handlers (`join_conversation`,
+`join_session`) that `apps/web`'s client code emits into, so the dependency is one-way:
+**new web needs new realtime**. `.github/workflows/docker-images.yml` deploys them in
+that order, and `apps/realtime/src/__tests__/deploy-order.guard.test.ts` pins it.
+
+It shipped the other way round for the whole epic while several PR bodies and a source
+comment (`apps/realtime/src/terminal/shell-activity.ts`) asserted this ordering as
+already-true. The failure mode of getting it backwards is why the claim mattered and why
+nobody noticed it was false: Socket.IO **silently drops** an event with no registered
+listener — no error, no ack, no disconnect. A new web client emitting `join_conversation`
+at an old realtime therefore believes it joined, never enters the room, and receives none
+of the rev-carrying `conversation:*` events fanned out to it. Live delivery degrades to
+nothing for the length of the deploy, invisibly, with no signal the client could retry
+on.
+
+Realtime-first inverts that into the benign case: an old web client simply never emits
+the new joins, and the new handlers idle until it reloads. Nothing depends on web-first —
+realtime makes no outbound HTTP calls to web at all (`WEB_APP_URL` is a CORS origin),
+and both services deploy after the migration step they share.
+
 ## 4. Vocabulary
 
 "sessionId" carried five meanings. **The epic's final phase (Phase 5) landed the renames,

--- a/packages/lib/src/services/page-payload-service.ts
+++ b/packages/lib/src/services/page-payload-service.ts
@@ -210,7 +210,7 @@ async function fetchChatMessages(
       eq(messages.isActive, true),
       ne(messages.status, 'streaming')
     ))
-    .orderBy(desc(messages.createdAt))
+    .orderBy(desc(messages.createdAt), desc(messages.id))
     .limit(RECENT_MESSAGE_LIMIT);
 
   return rows


### PR DESCRIPTION
Four shipped defects found by a requirements-traceability audit of the **Agent-Session Single Source of Truth** epic (plus one nondeterminism bug a sibling agent hit). These are live bugs, not test gaps. Failing test written first in every case.

---

## Defect 1 — undo could commit without emitting, leaving panes permanently stale

The epic's central invariant is that every durable message write bumps `conversations.rev` and emits **in the same transaction, from one repository choke point**. Undo violated all three parts of it. `recordUndoApplied` ran **after** the write transaction committed, in a **separate** transaction, from a fire-and-forget `void (async () => …)` under a **swallowing `try/catch`**.

**Why that is worse than a dropped event.** The bump is not a companion to the emit — it is the *fallback for* it. An emit that fails is survivable: the rev moved, so the client's next `syncWatchedConversationRevs` sees the mismatch and refetches. A **bump** that fails is not: server and client agree on a rev that no longer describes the data, so there is nothing for the client to notice. `syncWatchedConversationRevs` compares revs and nothing else, so the pane is stale until a manual reload — forever.

**Failing test first** (`undo-rev-atomicity.integration.test.ts`, real Postgres):

```
× executeAiUndo bumps the conversation rev in the same transaction as the soft-delete
  → expected +0 to be 1
× a throwing emit does not cost the rev bump — the client can still detect staleness
  → expected +0 to be 1
```

The rev was `0` after a successful undo that deleted two messages.

**Fix.** The write moved into the choke point as `messageRepository.softDeleteUndoRange(tx, …)`, which issues the `messages` soft-delete and `UPDATE conversations SET rev = rev + 1 … RETURNING` as one pair **on the caller's transaction** — so a failed activity rollback takes the bump with it, and a commit can never leave the counter behind. The emit stays **after** commit (announcing before commit could announce a write that rolls back) and stays best-effort, but it is now `emitUndoApplied`, which *takes* the already-bumped row instead of bumping one itself. The route can no longer bump.

After: **4/4 passing**, including an abort test proving the bump rolls back with the write, and an idempotency test proving a re-undo spends no rev.

---

## Defect 2 — choke-point bypasses, and the guard that should have caught them

The audit found three sites mutating `messages` outside the repository. The deeper problem is that the structural writer-classification test (`unified-message-dual-write-drift.test.ts`, later the freeze guard) was **deleted at the contract PR** — which is exactly why these shipped unnoticed.

**Reinstated as** `messages-write-site-classification.test.ts`: it scans shipped source for every `messages` INSERT/UPDATE/DELETE and fails unless the file is the choke point or a **classified exemption carrying a written reason**.

**Failing test first** — the scan found 5 writer files, one unclassified:

```
× every `messages` write site is the repository choke point or a classified exemption
  + Array [ "apps/web/src/services/api/ai-undo-service.ts" ]
× the undo path is NOT exempt — it writes through the repository
```

### The judgment calls

| Site | Classification | Reason |
|---|---|---|
| `ai-undo-service.ts` | **NOT exempt** — fixed | Soft-deletes a range of messages in response to a user's own click, in a pane that user is by definition watching. Not bulk, not administrative, not invisible. The least exemptable write in the system. |
| `conversation-cleanup.ts` (permanent page/drive delete) | **Exempt** | Destroys the `conversations` row in the same transaction as its messages. There is no surviving row to bump a rev on and no room to emit into that outlives the statement — the conversation *is* the thing being deleted. Panes heal on the page/drive deletion events this path already fans out, which say strictly more than a rev bump would. |
| `retention-engine.ts` (nightly sweep) | **Exempt** | Hard-deletes rows that are **already** `isActive: false` and past the cutoff. Every one had its rev bumped and its event emitted at *soft-delete* time, by the choke point. The hard delete changes nothing any client can observe, so a per-row bump would emit pure noise (and a nightly cron fanning out thousands of no-op events is a real cost). Exempt because the user-visible transition already emitted — not because bulk deletion is beneath the contract. |

On the trash route specifically (`trash/[pageId]/route.ts`, cited in the audit as a bypass): it no longer writes `messages` directly — it delegates to the shared `deleteConversationsForPages` helper, which is the exempt `conversation-cleanup.ts`. The reasoning above is what the exemption rests on: a user watching a pane whose message is trashed *does* see stale content, but the healing signal is the page-deletion event, not a rev on a row that no longer exists.

The guard strips comments before scanning — its own subject matter is `messages` write statements, so the files it guards are exactly the files whose doc comments quote them. Verified the stripped scan still flags the pre-fix `ai-undo-service.ts` (`true`) and not the fixed one (`false`), so comment-stripping did not defang it.

---

## Defect 3 — the deploy-order premise was inverted

`docker-images.yml` deployed **web at line 333, realtime at 342** — web first. Meanwhile `apps/realtime/src/terminal/shell-activity.ts` froze a cross-service wire field name on the written premise that "realtime deploys BEFORE web". The premise was false, and had been for the whole epic.

**Why nobody noticed.** Socket.IO **silently drops** an event with no registered listener — no error, no ack, no disconnect. A new web client emitting `join_conversation` at an old realtime therefore believes it joined, never enters the room, and receives none of the rev-carrying `conversation:*` events fanned out to it. Live delivery degrades to nothing for the length of the deploy, invisibly, with no signal the client could retry on.

**Failing test first** (`deploy-order.guard.test.ts`):

```
× deploys realtime BEFORE web
  → expected 341 to be less than 332
```

**Fix — reordered**, realtime first. Verified nothing depends on web-first: realtime makes **no outbound HTTP calls to web at all** (`WEB_APP_URL` is used solely as a CORS origin), and both services deploy after the migration step they share. Realtime-first inverts the failure into the benign case — an old web client simply never emits the new joins, and the new handlers idle until it reloads.

Docs updated per the §5 rule: new **§3d** in `docs/2.0-architecture/agent-sessions.md`, plus the `shell-activity.ts` comment corrected to point at the guard rather than assert an unenforced premise.

---

## Defect 4 — nondeterministic ordering in shipped readers

`ORDER BY "createdAt"` is a **partial** order: the column is a millisecond timestamp, so same-tick rows come back in whatever order the planner likes — heap order on one call, index order on the next. Every consumer treats the result as a *transcript*: the AI chat history is replayed into a model prompt in returned order. A conversation whose last two turns swap between reloads is not cosmetic — it is a different prompt.

Surfaced as the rare `chat-mutation-matrix > interrupt and resume` failure (`expected ['streaming','complete'] to deeply equal ['complete','streaming']`). The nondeterminism was in the reader, not the test.

**Failing test first** (`message-order-stability.integration.test.ts`, 8 same-tick rows): **4 of 5 failed.** The fifth ("repeated reads agree") passed — worth noting, because it shows how this hides: Postgres was *consistent* for a small table while being *arbitrary*, so a naive stability test would have gone green.

**The tiebreaker: `id`.** Deliberately noting the cuid2 semantics — cuid2 dropped cuid v1's k-sortable prefix precisely to stop leaking creation order, so `id` is **not** chronological. That is fine and is the point: rows tied on `createdAt` have no chronological truth left to preserve, so the tiebreaker's only job is to be *total* and *stable*, which a unique primary key is by construction. There is no monotonic sequence column on the table to prefer. DESC readers tiebreak DESC, so `ORDER BY … DESC LIMIT n` selects a deterministic **window**, not merely a deterministic ordering of whichever rows it happened to select.

**Sibling audit** — fixed consistently across every message list reader:

- `message-repository.ts` — `getMessagesByConversationId`, `getMessagesForPage`, `getPageConversationMessages`, `getRecentPageMessages`
- `api/ai/global/[id]/messages` — had a **createdAt-only cursor**, which is not just unstable but *lossy*: same-tick rows straddling a page boundary are skipped (strict `</>` on a tie) or served twice. Given the compound `(createdAt, id)` keyset the sibling `page-agents` route already used — that route's existing fix is what confirmed `id` as the house convention.
- `ai/tools/search-tools.ts` — including the `ROW_NUMBER() OVER (… ORDER BY createdAt)` that assigns **line numbers the model cites back**
- `ai/tools/page-read-tools.ts`, `page-payload-service.ts`, `memory/discovery-service.ts`, both pulse routes

After: **5/5 passing.**

---

## Gates

All run with a live `DATABASE_URL` (scratch Postgres, migrated).

| Gate | Result |
|---|---|
| `typecheck` | 16/16 tasks |
| `lint` | 14/14 tasks, no warnings or errors |
| `knip:check` | 4 issues, all within baseline (4) |
| web — repositories / services / api/ai | **94 files, 1373 tests passed** |
| realtime (full) | **25 files, 960 tests passed** |
| `@pagespace/db` | **42 files, 636 tests passed** |
| lib — compliance / services / repositories | **120 files, 2415 passed, 3 skipped** |
| `test:security` | **exit 0** (63 files/1115 tests + 39 files/767 tests + per-app suites) |

### Collateral test updates

`ai-undo-service.test.ts` needed real changes, not just repair — the tx mock now supplies the `.returning()` the in-transaction bump chains off, and two assertions were tightened rather than relaxed:

- "tombstones the unified table ONLY" → **`[messages, conversations]`**, pinning that the bump is in the *same transaction*. A third table still means a resurrected legacy writer.
- "issues exactly ONE soft-delete update" now counts **per table** instead of in total. Relaxing the bare count to `2` would have stopped it noticing the legacy leg coming back at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
