### PR TITLE
test(web): match the realtime host by origin, not string prefix

### DIFF
--- a/apps/web/src/lib/repositories/__tests__/conversation-created-emit.integration.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-created-emit.integration.test.ts
@@ -83,6 +83,25 @@ let originalFetch: typeof globalThis.fetch;
 const urlOf = (input: RequestInfo | URL): string =>
   typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
+const REALTIME_ORIGIN = new URL(REALTIME_URL).origin;
+
+/**
+ * Whether a captured request is aimed at the fake realtime host.
+ *
+ * Compares the PARSED origin rather than `url.startsWith(REALTIME_URL)`: a
+ * prefix test also matches `http://realtime.test.invalid.example.com`, so the
+ * interceptor could swallow a request bound for an entirely different host and
+ * push it into `broadcasts` — a false pass. CodeQL flags the prefix form as
+ * `js/incomplete-url-substring-sanitization` for exactly that reason.
+ */
+function isRealtimeRequest(url: string): boolean {
+  try {
+    return new URL(url).origin === REALTIME_ORIGIN;
+  } catch {
+    return false; // a relative or malformed URL is never the realtime host
+  }
+}
+
 /**
  * Emission is fire-and-forget (`void (async () => ...)`), so the awaited write
  * returns before the POST lands. Poll rather than sleep a fixed amount.
@@ -132,7 +151,7 @@ describe('conversation:created is genuinely EMITTED by every creation path (real
     originalFetch = globalThis.fetch;
     const captureFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = urlOf(input);
-      if (url.startsWith(REALTIME_URL)) {
+      if (isRealtimeRequest(url)) {
         const body = typeof init?.body === 'string' ? init.body : '';
         broadcasts.push(JSON.parse(body) as CapturedBroadcast);
         return { ok: true, status: 200 } as unknown as Response;


### PR DESCRIPTION
Closes the one high-severity CodeQL alert now sitting on `pu/broken-sessions`.

This fix was pushed to #2365 as `3b0fa876c`, but that PR merged at `e89cc088b` — a minute earlier — so it missed the merge. The alert is on the branch rather than in the PR that introduced it, which makes it easy to lose track of; hence this PR rather than a note.

## The finding

CodeQL failed #2365 with `js/incomplete-url-substring-sanitization`, **1 new high severity**:

```
apps/web/src/lib/repositories/__tests__/conversation-created-emit.integration.test.ts:135
'http://realtime.test.invalid' may be followed by an arbitrary host name
```

The suite installs a `fetch` interceptor to capture broadcasts, and decided what to capture with:

```ts
if (url.startsWith(REALTIME_URL)) { broadcasts.push(...) }
```

## Why it is worth fixing rather than dismissing

It is a test file, so there is no production exposure — but the assertion is genuinely weak, and in the direction that matters. `startsWith` also matches `http://realtime.test.invalid.example.com`, so the interceptor could swallow a request bound for an entirely different host and push it into `broadcasts`. This is the suite whose whole job is proving `conversation:created` really was emitted; a false capture there is a false PASS. Weak assertion first, alert second.

Now parses both sides and compares origins, with a malformed or relative URL answering `false` rather than throwing inside the interceptor:

```ts
const REALTIME_ORIGIN = new URL(REALTIME_URL).origin;

function isRealtimeRequest(url: string): boolean {
  try {
    return new URL(url).origin === REALTIME_ORIGIN;
  } catch {
    return false;
  }
}
```

## Verification

`conversation-created-emit.integration.test.ts` — **6/6** against a live Postgres 17, run from this branch (i.e. on top of current `pu/broken-sessions`). No other `startsWith(REALTIME_URL)` sites exist in `apps/web/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGK57tZTzogD7g6pL7fjM8