### PR TITLE
test(agents): close the last evidence gaps and the tenant-export hole

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       # NEXT_PUBLIC_REALTIME_URL is deliberately UNSET. See the proxy step.
       E2E_WEB_TARGET: http://127.0.0.1:3100
       E2E_REALTIME_TARGET: http://127.0.0.1:3001
-      E2E_SPECS: tests/15-chat-fixture-smoke.spec.ts tests/16-dispatch-multiplayer.spec.ts tests/17-agent-workspace-grid.spec.ts
+      E2E_SPECS: tests/15-chat-fixture-smoke.spec.ts tests/16-dispatch-multiplayer.spec.ts tests/17-agent-workspace-grid.spec.ts tests/18-sidebar-directory-live.spec.ts
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/apps/e2e/fixtures/chat.fixture.ts
+++ b/apps/e2e/fixtures/chat.fixture.ts
@@ -36,14 +36,23 @@ const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
  * Opening TWO contexts on the same token is expected and safe (7.4 does exactly that): the
  * per-tab identity the app dedups on is the client-generated `X-Browser-Session-Id`, which
  * each context generates independently.
+ *
+ * `options` is merged into `newContext` for the rare spec that needs a context-level
+ * capability the cookie shape has nothing to do with — today only
+ * `18-sidebar-directory-live.spec.ts`'s `serviceWorkers: 'block'`, which it needs because the
+ * app registers `/sw.js` and Playwright's request interception cannot see a fetch that goes
+ * through a Service Worker. Keep it for capabilities, not for auth: `baseURL` and the cookies
+ * below are the contract this helper exists to own, and are applied after the spread so a
+ * caller cannot accidentally break them.
  */
 export async function authedContext(
   browser: Browser,
   sessionToken: string,
   baseURL: string,
+  options: Parameters<Browser['newContext']>[0] = {},
 ): Promise<BrowserContext> {
   const url = new URL(baseURL);
-  const context = await browser.newContext({ baseURL });
+  const context = await browser.newContext({ ...options, baseURL });
   await context.addCookies([
     {
       name: 'session',

--- a/apps/e2e/support/http.ts
+++ b/apps/e2e/support/http.ts
@@ -28,6 +28,23 @@ export function sessionPost(
 }
 
 /**
+ * DELETE as a session-authenticated user — same cookie + CSRF contract as `sessionPost`,
+ * since DELETE is inside the CSRF gate too.
+ */
+export function sessionDelete(
+  request: APIRequestContext,
+  path: string,
+  user: SeededUser,
+): Promise<APIResponse> {
+  return request.delete(path, {
+    headers: {
+      cookie: `session=${user.sessionToken}`,
+      'x-csrf-token': user.csrf,
+    },
+  });
+}
+
+/**
  * GET as a session-authenticated user. GETs are outside the CSRF gate, so the session
  * cookie alone is the whole contract.
  */

--- a/apps/e2e/tests/18-sidebar-directory-live.spec.ts
+++ b/apps/e2e/tests/18-sidebar-directory-live.spec.ts
@@ -1,0 +1,453 @@
+import { test, expect, type APIRequestContext, type BrowserContext, type Page } from '@playwright/test';
+import { seedUser, type SeededUser } from '../support/db';
+import { sessionPost, sessionDelete } from '../support/http';
+import { authedContext } from '../fixtures/chat.fixture';
+
+/**
+ * # A server-created conversation reaches the SIDEBAR, off the directory plane, not off a poll
+ *
+ * The user story: **a worker spawned server-side appears in your sidebar without
+ * you waiting for a poll tick.** Before the directory plane it took up to a poll
+ * interval, which is why "did that actually work?" was a question at all.
+ *
+ * ## Why this spec exists when the pieces were already tested
+ *
+ * Both ends of the seam were already proven, and the middle was not:
+ *
+ *  - the SERVER end — the directory events really are emitted to the owner's
+ *    `user:<id>:sessions` room on a session-scoped create
+ *    (`conversation-created-emit.integration.test.ts`);
+ *  - the CLIENT end — the listener really does apply them to the session
+ *    listing cache (`session-directory-listener.test.ts`).
+ *
+ * What nothing asserted is that the key the listener mutates is the key
+ * `AgentsSidebar` subscribes to. That held BY CONSTRUCTION only, and by a
+ * construction with a real fault line in it: the listener writes through the
+ * `isSessionListingKey` / `isAgentSessionsKey` PREDICATES
+ * (`session-conversations.ts`), while the sidebar builds its key as an inline
+ * template string rather than calling the shared `agentSessionsKey()` helper.
+ * `AgentsSidebar.test.tsx` cannot see that — it feeds SWR data in directly and
+ * contains nothing socket-driven. So the seam could break and the symptom would
+ * be a sidebar that still works, just slowly, off the 120s backstop poll. That
+ * is the failure this spec exists to make loud.
+ *
+ * ## What writing it revealed, and why the two tests are shaped differently
+ *
+ * The obvious spec — block the listing GET outright, spawn, assert the row
+ * appears — DOES NOT PASS, and it is right not to. Creation and session-binding
+ * are decoupled on purpose (`create-conversation-in-session.ts`: a sessionless
+ * conversation is an ordinary state), so the sequence on this path is:
+ *
+ *   1. `conversation:created` fires for a row that is not yet in any session,
+ *      i.e. with `workspaceId: null` — and the listener correctly declines to
+ *      insert it into a session listing, because it is not in one yet;
+ *   2. the claim lands and `conversation:updated { workspaceId }` fires, which
+ *      the listener answers with `revalidateSessionListings` — a REFETCH,
+ *      deliberately, because a re-binding moves a row between sessions and the
+ *      listing query owns that predicate.
+ *
+ * So on the spawn path the sidebar is updated by ONE EVENT-DRIVEN REQUEST, not
+ * by a request-free cache write. That is still the guarantee — event-driven, not
+ * a poll — but it is not the stronger thing "with no request" would claim, and
+ * the `upsertConversationInCache` branch is not what serves this story.
+ *
+ * Hence two tests:
+ *
+ *  - **the user story**, which cannot block the network (the refetch is the
+ *    mechanism) and instead rules the poll out with a CONTROL: a quiet period
+ *    of the same length as the assertion window, asserted to contain zero
+ *    listing fetches. A bare "20s assertion, 120s poll" argument rots silently
+ *    when someone demotes the interval; this one FAILS LOUDLY, because the
+ *    control period would see the tick.
+ *  - **the seam at its strongest**, on the CLOSE event, which really is a
+ *    request-free local write (`forgetConversationInCache`, `revalidate: false`).
+ *    There the listing GET is aborted at the network layer for the whole
+ *    assertion window, so nothing but the socket applying to the sidebar's own
+ *    SWR key can move the list. `data` from before the block survives (SWR keeps
+ *    the last successful value, and the sidebar's error branch only fires on an
+ *    EMPTY list), so the surface stays the one under test.
+ *
+ * ## Topology
+ *
+ * Same as `16-dispatch-multiplayer.spec.ts`, and required for the same reason:
+ * realtime must be reachable SAME-ORIGIN (a proxy forwarding `/socket.io`, with
+ * `NEXT_PUBLIC_REALTIME_URL` unset), because the shipped CSP is
+ * `connect-src 'self' ws: wss:` and Socket.IO's opening XHR handshake to
+ * another origin is blocked outright — no socket, no rooms. See that file's
+ * header, and the `e2e` job in `.github/workflows/ci.yml`. This spec does NOT
+ * set `bypassCSP`: it would relax the exact policy the topology exists to
+ * respect.
+ *
+ * TWO sessions, and which one is which matters. Session A is opened in the pane
+ * grid, only so the console is genuinely live. Session B — the one under test —
+ * is NEVER opened, so it has no persisted grid, and the sidebar renders its
+ * expansion from the flat `session.conversations` listing (the branch the
+ * directory events feed) rather than from pane rows.
+ */
+
+// The shared storageState user belongs to a drive this spec does not control;
+// seed our own, exactly as the dispatch and grid specs do. Also keeps the spec
+// order-independent under `workers: 1`.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// Booting the agents console is a production build, an auth round trip, a
+// listing fetch and a socket handshake before anything is assertable. The
+// per-assertion ceilings below stay the failure surface; passing runs are far
+// under this.
+test.setTimeout(120_000);
+
+const SESSION_PANES = 'session-panes';
+const PANE_BAR = 'pane-bar';
+const CONVERSATION_ROW = 'sidebar-conversation-row';
+
+/** The bulk session-listing endpoint — NOT its per-session sub-resources. */
+const LISTING_PATHNAME = '/api/agent-workspaces';
+
+/**
+ * Wide enough that the left sidebar is a PERSISTENT panel rather than an
+ * overlay sheet. `Layout.tsx` overlays it under `(max-width: 1279px)`, and the
+ * Desktop Chrome device preset is exactly 1280 — sitting on the boundary of the
+ * one media query that decides whether the surface under test is on screen at
+ * all. Stated explicitly so a preset change cannot silently turn this spec into
+ * a test of the mobile sheet.
+ */
+const DESKTOP_VIEWPORT = { width: 1600, height: 1000 };
+
+/**
+ * The quiet-period control AND the assertion ceiling — deliberately the same
+ * number, because that is what makes the control mean anything: observing zero
+ * listing fetches in a window of length N is only evidence about a later window
+ * of length N. Comfortably under the sidebar's 120s `refreshInterval`, and
+ * comfortably over the sub-second the directory plane actually takes.
+ */
+const POLL_CONTROL_MS = 10_000;
+
+// Closed in teardown, never inline, so a failing assertion cannot leak one.
+const openContexts: BrowserContext[] = [];
+
+test.afterEach(async () => {
+  await Promise.all(openContexts.map((context) => context.close()));
+  openContexts.length = 0;
+});
+
+/**
+ * Mint a session through the front door. `{ driveId }` with no `firstThing` is
+ * the assistant-first shape: the session plus its opening conversation, and NO
+ * sandbox — a real Sprite would make this spec slow and infrastructure-bound
+ * for a question about cache keys.
+ */
+async function createSession(
+  request: APIRequestContext,
+  user: SeededUser,
+  name: string,
+): Promise<{ sessionId: string; conversationId: string }> {
+  const response = await sessionPost(request, '/api/agent-workspaces', user, {
+    driveId: user.driveId,
+    name,
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `createSession(${name}): POST /api/agent-workspaces answered ${response.status()}: ${(await response.text()).slice(0, 500)}`,
+    );
+  }
+  const body = (await response.json()) as { session: { workspaceId: string }; conversationId: string };
+  return { sessionId: body.session.workspaceId, conversationId: body.conversationId };
+}
+
+/**
+ * Start a conversation inside an existing session FROM OUTSIDE THE BROWSER —
+ * Playwright's API context is a different HTTP client than the page under test,
+ * so the page has no optimistic write, no pending request and no local
+ * knowledge of this conversation. Exactly the shape of a worker an agent spawns
+ * on the user's behalf: the browser can only learn about it by being told.
+ */
+async function spawnConversationServerSide(
+  request: APIRequestContext,
+  user: SeededUser,
+  sessionId: string,
+): Promise<string> {
+  const response = await sessionPost(
+    request,
+    `/api/agent-workspaces/${encodeURIComponent(sessionId)}/conversations`,
+    user,
+    // `null` is the global assistant — the one counterpart that needs no agent
+    // page, so this spec does not have to seed and permission one.
+    { agentPageId: null },
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `spawnConversationServerSide: answered ${response.status()}: ${(await response.text()).slice(0, 500)}`,
+    );
+  }
+  return ((await response.json()) as { conversationId: string }).conversationId;
+}
+
+/** Close a conversation out of its session, again from outside the browser. */
+async function closeConversationServerSide(
+  request: APIRequestContext,
+  user: SeededUser,
+  sessionId: string,
+  conversationId: string,
+): Promise<void> {
+  const response = await sessionDelete(
+    request,
+    `/api/agent-workspaces/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversationId)}`,
+    user,
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `closeConversationServerSide: answered ${response.status()}: ${(await response.text()).slice(0, 500)}`,
+    );
+  }
+}
+
+/**
+ * Count session-listing GETs from now on, without interfering with them — the
+ * observational half, used for the poll CONTROL.
+ *
+ * `page.on('request')` sees requests that `page.route` cannot (see the Service
+ * Worker note in `openConsole`), and here we want to observe rather than block,
+ * so this is the right instrument for the control and `blockSessionListingFetches`
+ * is the right one for the seam test.
+ */
+function countSessionListingFetches(page: Page): () => number {
+  let seen = 0;
+  page.on('request', (request) => {
+    if (request.method() === 'GET' && new URL(request.url()).pathname === LISTING_PATHNAME) seen++;
+  });
+  return () => seen;
+}
+
+/**
+ * Cut the session-listing fetch off at the network layer, and report how many
+ * attempts were made.
+ *
+ * THIS IS THE ASSERTION'S TEETH, so it is worth saying what it must and must
+ * not catch. `isSessionListingKey`'s two keys are exactly `/api/agent-workspaces`
+ * and `/api/agent-workspaces?...`; `/api/agent-workspaces/<id>` and
+ * `/api/agent-workspaces/<id>/shells` are different cache entries (the latter on
+ * a 15s poll) that this spec has no business blocking. So the match is an exact
+ * PATHNAME equality, expressed as a URL PREDICATE rather than a glob — a
+ * `'**\/api/agent-workspaces**'` glob silently matched nothing here, and a
+ * matcher that quietly matches nothing turns this whole spec into a tautology
+ * that passes off the very refetch it claims to have ruled out. Confirmed
+ * against the failure case: with the socket seam severed this counter goes
+ * non-zero and the spec fails.
+ *
+ * WHY BLOCKING IS NECESSARY AT ALL, since it looks like belt-and-braces on a
+ * passing run: `conversation:created` is not the only directory event a
+ * session-scoped create produces, and the others (`session:*`, a
+ * `conversation:updated` carrying a workspace binding) deliberately answer with
+ * `revalidateSessionListings` — a REFETCH. That refetch also puts the row on
+ * screen, so without this block the spec would go green with the listener's
+ * cache write removed entirely. Verified: it did.
+ */
+async function blockSessionListingFetches(page: Page): Promise<() => number> {
+  let attempts = 0;
+  await page.route(
+    (url) => url.pathname === LISTING_PATHNAME,
+    async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      attempts++;
+      await route.abort();
+    },
+  );
+  return () => attempts;
+}
+
+/**
+ * Everything both specs need before they can assert anything: two sessions, a
+ * logged-in window with the agents console live on the first, and a socket
+ * proven to be connected.
+ */
+async function openConsole(
+  browser: Parameters<typeof authedContext>[0],
+  baseURL: string,
+  request: APIRequestContext,
+): Promise<{
+  user: SeededUser;
+  page: Page;
+  displayed: { sessionId: string; conversationId: string };
+  target: { sessionId: string; conversationId: string };
+}> {
+  const user = await seedUser();
+  // Session A is opened in the grid; session B is the one under test and is
+  // never opened, so it keeps `workspace: null` in the listing and the sidebar
+  // renders its expansion from the flat conversation list — the branch the
+  // directory events feed.
+  const displayed = await createSession(request, user, 'displayed session');
+  const target = await createSession(request, user, 'target session');
+
+  // `serviceWorkers: 'block'` is REQUIRED, not tidiness. The app registers
+  // `/sw.js` (`app/layout.tsx`), and Playwright's request interception cannot
+  // see a fetch that goes through a Service Worker — so with one installed,
+  // `blockSessionListingFetches` silently intercepts NOTHING: zero attempts
+  // counted, every refetch sailing through, and the spec passing off the very
+  // request it claims to have ruled out. That is not hypothetical; it is what
+  // this spec did until the severed-seam run refused to fail. Blocking the
+  // worker also removes it as a second, uncontrolled cache between the app and
+  // the assertion, which is worth having regardless.
+  const context = await authedContext(browser, user.sessionToken, baseURL, {
+    serviceWorkers: 'block',
+  });
+  openContexts.push(context);
+  const page = await context.newPage();
+  await page.setViewportSize(DESKTOP_VIEWPORT);
+
+  // Armed BEFORE navigation: the handshake starts during the first paint, so a
+  // listener attached afterwards can miss it entirely. A websocket existing
+  // means Socket.IO's polling handshake already completed, and the personal
+  // rooms — `user:<id>:sessions` among them — are joined AT CONNECT, server
+  // side, with no subscribe call. So this is the readiness signal for "the
+  // directory plane can reach this page", which the assertions below would
+  // otherwise be silently racing.
+  const socketConnected = page.waitForEvent('websocket', { timeout: 60_000 });
+
+  await page.goto(
+    `/dashboard/${user.driveId}/agents?workspace=${displayed.sessionId}&c=${displayed.conversationId}`,
+  );
+  await page.getByTestId(SESSION_PANES).waitFor({ state: 'visible', timeout: 60_000 });
+  await expect(page.getByTestId(PANE_BAR)).toHaveCount(1, { timeout: 60_000 });
+  await socketConnected;
+
+  return { user, page, displayed, target };
+}
+
+/**
+ * Expand a session's row — a purely local disclosure toggle (`setExpanded`), no
+ * fetch — and return a locator for its conversation rows, scoped to that
+ * session's own subtree so nothing depends on which other rows are expanded.
+ */
+async function expandSession(page: Page, sessionId: string) {
+  const row = page.getByTestId(`sidebar-session-${sessionId}`);
+  await row.waitFor({ state: 'visible', timeout: 60_000 });
+  await row.getByRole('button', { name: /^Expand / }).click();
+  return { row, conversationRows: row.getByTestId(CONVERSATION_ROW) };
+}
+
+test.describe('session directory — a server-created conversation reaches the sidebar', () => {
+  test('a server-spawned conversation reaches the sidebar off the directory plane, not off the backstop poll', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const { user, page, target } = await openConsole(browser, baseURL!, request);
+
+    const { conversationRows } = await expandSession(page, target.sessionId);
+    // The session's opening conversation, and only it. Pinning the count is
+    // what makes the assertion below a CHANGE rather than a coincidence.
+    await expect(conversationRows).toHaveCount(1, { timeout: 30_000 });
+
+    // THE CONTROL, and the thing that makes this more than a timing argument.
+    // Sit still for exactly as long as the assertion below is allowed to take,
+    // and require that the sidebar asked for NOTHING in that time. That is a
+    // measured fact about this build's poll behaviour, not an assumption about
+    // it: demote the 120s `refreshInterval` back to 20s and this fails here,
+    // loudly, instead of letting the assertion pass for the wrong reason.
+    const listingFetches = countSessionListingFetches(page);
+    await page.waitForTimeout(POLL_CONTROL_MS);
+    expect(
+      listingFetches(),
+      'the sidebar polled during the control window — the poll is now fast enough to be ' +
+      'what makes the assertion below pass, so this spec no longer proves the directory ' +
+      'plane delivered anything. Re-establish the separation before trusting it.',
+    ).toBe(0);
+
+    const quietFetches = listingFetches();
+    const spawnedConversationId = await spawnConversationServerSide(request, user, target.sessionId);
+    expect(spawnedConversationId).toBeTruthy();
+
+    // THE ASSERTION. A window this length was just shown to contain no poll, so
+    // a row appearing in one can only have come from the directory events the
+    // spawn produced — reaching the SWR key `AgentsSidebar` itself subscribes
+    // to. Diverge that key from the listener's predicates and the count stays
+    // at 1 until the 120s backstop, long past this timeout.
+    await expect(conversationRows).toHaveCount(2, { timeout: POLL_CONTROL_MS });
+
+    // …and it was EVENT-driven work, not a coincidence of an idle client: the
+    // claim's `conversation:updated { workspaceId }` is answered with
+    // `revalidateSessionListings`, so the spawn must have caused listing
+    // traffic that the quiet window did not have. Without this, a spec that
+    // somehow rendered the row from nothing would still read as green.
+    expect(listingFetches()).toBeGreaterThan(quietFetches);
+  });
+
+  /**
+   * The seam at its strongest: a directory event that needs NO request at all.
+   *
+   * `conversation:closed` is answered by `forgetConversationInCache` — a local
+   * `mutate(isSessionListingKey, updater, { revalidate: false })`. So here the
+   * listing GET can be cut off at the network layer for the whole assertion
+   * window, and the list still has to move. Nothing but the listener's write
+   * landing on the sidebar's own SWR key can do that; a key that drifted out of
+   * `isSessionListingKey`'s namespace leaves the row on screen forever.
+   *
+   * This is also the direction the spawn path cannot test, because create and
+   * claim are decoupled — see the file header.
+   */
+  test('a server-side close removes the row with the listing fetch cut off at the network', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const { user, page, target } = await openConsole(browser, baseURL!, request);
+
+    const { conversationRows } = await expandSession(page, target.sessionId);
+    await expect(conversationRows).toHaveCount(1, { timeout: 30_000 });
+
+    // A SECOND conversation, so the close below is an ordinary close rather
+    // than a collision with the never-empty invariant (the server refuses to
+    // close a session's last open listing with a 409).
+    const spawned = await spawnConversationServerSide(request, user, target.sessionId);
+    await expect(conversationRows).toHaveCount(2, { timeout: POLL_CONTROL_MS });
+
+    // From here the listing cannot be re-read at all.
+    const blockedFetches = await blockSessionListingFetches(page);
+
+    await closeConversationServerSide(request, user, target.sessionId, spawned);
+
+    // THE ASSERTION. The browser never asked and cannot ask; the row can only
+    // have left because `conversation:closed` → `forgetConversationInCache` →
+    // the sidebar's own SWR key.
+    await expect(conversationRows).toHaveCount(1, { timeout: POLL_CONTROL_MS });
+
+    // Diagnostic, not an assertion — a non-zero count means something still
+    // WANTED to refetch and was denied, which is worth knowing when the 120s
+    // backstop is finally deleted.
+    // eslint-disable-next-line no-console -- surfaced in the Playwright report, not app code
+    console.log(`listing fetches blocked during the close window: ${blockedFetches()}`);
+  });
+
+  /**
+   * The opposite error to the two above: a listener that inserted into EVERY
+   * session's row rather than the spawning one would keep a target-scoped count
+   * green. That is the mistake `upsertConversationInCache`'s
+   * `session.sessionId !== sessionId` guard — and the listing query behind the
+   * refetch — exist to prevent.
+   */
+  test('the row lands in the spawning session only, not in every session listing', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const { user, page, displayed, target } = await openConsole(browser, baseURL!, request);
+
+    // Expand BOTH, so a stray insert into the bystander would be VISIBLE rather
+    // than hidden behind a collapsed row.
+    const { conversationRows } = await expandSession(page, target.sessionId);
+    const { conversationRows: bystanderRows } = await expandSession(page, displayed.sessionId);
+    await expect(conversationRows).toHaveCount(1, { timeout: 30_000 });
+
+    await spawnConversationServerSide(request, user, target.sessionId);
+    await expect(conversationRows).toHaveCount(2, { timeout: POLL_CONTROL_MS });
+
+    // The displayed session HAS a persisted grid (a window is open on it), so
+    // it renders PANE rows rather than the flat conversation list — which is
+    // precisely why the check is "no conversation row appeared here" rather
+    // than a count of its threads.
+    await expect(bystanderRows).toHaveCount(0);
+  });
+});

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -912,7 +912,11 @@ function SessionRow({
   );
 
   return (
-    <div>
+    // Per-session test handle, wrapping BOTH the session's own row and its
+    // expanded children — so an end-to-end spec can scope "this session's
+    // conversation rows" without depending on which other sessions happen to
+    // be expanded. Used by `18-sidebar-directory-live.spec.ts`.
+    <div data-testid={`sidebar-session-${session.sessionId}`}>
       <RowMenu
         items={menuItems}
         menuLabel="Session actions"
@@ -983,6 +987,7 @@ function SessionRow({
                     },
                   ]}
                   menuLabel="Conversation actions"
+                  testId="sidebar-conversation-row"
                   className={cn(
                     'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
                     selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',

--- a/apps/web/src/components/layout/left-sidebar/RowMenu.tsx
+++ b/apps/web/src/components/layout/left-sidebar/RowMenu.tsx
@@ -65,24 +65,32 @@ function renderRowMenuItems(
  * on desktop via the row's own `group`) opens the same items as a dropdown.
  * `className` lands on the wrapping row element — the row's own layout
  * classes belong here, not on `children`.
+ *
+ * `testId` lands on that same wrapping element. A row is a composite (a
+ * disclosure button, a label button, a menu trigger) with no single element an
+ * end-to-end spec can address as "the row", and the label text is not a stable
+ * handle — a conversation row's label is the agent's name, which a user can
+ * rename. `18-sidebar-directory-live.spec.ts` counts these.
  */
 export function RowMenu({
   children,
   items,
   menuLabel,
   className,
+  testId,
 }: {
   children: ReactNode;
   items: RowMenuItem[];
   menuLabel: string;
   className?: string;
+  testId?: string;
 }) {
   const isTouchDevice = useTouchDevice();
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div className={cn('group flex w-full items-center', className)}>
+        <div className={cn('group flex w-full items-center', className)} data-testid={testId}>
           {children}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/docs/2.0-architecture/agent-sessions-evidence.json
+++ b/docs/2.0-architecture/agent-sessions-evidence.json
@@ -96,13 +96,30 @@
           "suite": "web-unit"
         }
       ],
-      "notes": "RESIDUAL SEAM, deliberately recorded rather than glossed: the listener test proves the cache write happens with `revalidate: false` (no round-trip), and the create test proves the payload carries the label the sidebar renders. Nothing asserts that the listener's mutate key equals the key AgentsSidebar subscribes to — that link holds by construction only. AgentsSidebar.test.tsx mocks SWR data directly and contains nothing socket-driven, and the sidebar still carries a 120s refreshInterval documented in-file as a backstop slated for deletion. A component-level or e2e test closing that seam is tracked as the gap `sidebar-renders-server-created-conversation-end-to-end`."
+      "notes": "These three prove the claim ONE LAYER BELOW the user-visible surface, and the seam above them is now covered end-to-end by `sidebar-renders-server-created-conversation-end-to-end`. CAVEAT WORTH KEEPING, found by writing that spec: the listener test drives `handleCreated` with a payload carrying a `workspaceId`, and on the session-spawn path no such payload is ever emitted. Creation and session-binding are decoupled by design (`create-conversation-in-session.ts` — a sessionless conversation is an ordinary state), so `conversation:created` fires first with `workspaceId: null`, which the listener correctly declines to insert anywhere, and it is the CLAIM's `conversation:updated { workspaceId }` that updates the sidebar, via `revalidateSessionListings`. So the no-round-trip property these tests pin is real for the branch they exercise, but the spawn story is served by one event-driven refetch rather than by that branch. Event-driven either way — which is the guarantee — but not request-free, and the difference is worth not overclaiming."
     },
     {
       "id": "sidebar-renders-server-created-conversation-end-to-end",
       "guarantee": "The sidebar component itself re-renders with a server-created conversation off the socket event (not merely the cache layer beneath it).",
-      "status": "gap",
-      "gap": "TODO(agent-sessions-epic): no executing evidence. The listener→SWR-key→AgentsSidebar seam is untested; add either an AgentsSidebar test driven by a real socket event or an e2e spec asserting the sidebar row appears with polling disabled. Until then `server-created-conversation-reaches-sidebar` is proven one layer below the user-visible claim."
+      "status": "proven",
+      "evidence": [
+        {
+          "file": "apps/e2e/tests/18-sidebar-directory-live.spec.ts",
+          "name": "a server-spawned conversation reaches the sidebar off the directory plane, not off the backstop poll",
+          "suite": "e2e-playwright"
+        },
+        {
+          "file": "apps/e2e/tests/18-sidebar-directory-live.spec.ts",
+          "name": "a server-side close removes the row with the listing fetch cut off at the network",
+          "suite": "e2e-playwright"
+        },
+        {
+          "file": "apps/e2e/tests/18-sidebar-directory-live.spec.ts",
+          "name": "the row lands in the spawning session only, not in every session listing",
+          "suite": "e2e-playwright"
+        }
+      ],
+      "notes": "The seam, closed against the real thing: a production build, a real socket on the shipped CSP (realtime same-origin behind the e2e proxy, `NEXT_PUBLIC_REALTIME_URL` unset — no `bypassCSP`), writes issued by a DIFFERENT HTTP client than the page (Playwright's API context, so the browser has no optimistic write and no pending request), and the real `AgentsSidebar` reading its own SWR key. That key is genuinely at risk of drifting, which is why this is not ceremony: the listener writes through the `isSessionListingKey` / `isAgentSessionsKey` PREDICATES while the sidebar builds its key as an inline template literal instead of calling the shared `agentSessionsKey()` helper. WHY THREE CITATIONS AND NOT ONE, which is the honest part: the first covers the user story but CANNOT cut the network, because on the spawn path the refetch IS the mechanism (create and claim are decoupled — see the note on `server-created-conversation-reaches-sidebar`). It rules the poll out with a control instead: a quiet window the same length as the assertion window, asserted to contain zero listing fetches, so demoting the 120s refreshInterval fails the control loudly rather than letting the assertion pass for the wrong reason. The second citation is the seam at full strength — `conversation:closed` is answered by `forgetConversationInCache`, a genuinely request-free local write, so there the listing GET IS aborted for the whole window and the row still has to leave. The third covers the opposite error, an insert into every session's row rather than the spawning one. VERIFIED THEY CAN FAIL: diverging the listener's key predicates from the sidebar's key fails all three on the assertion (Expected 2, Received 1), not on setup. TWO HARNESS TRAPS THIS SPEC HAD TO SURVIVE, recorded because both made it green while proving nothing: the app registers `/sw.js`, and Playwright cannot intercept a fetch that goes through a Service Worker, so the block silently intercepted NOTHING until the context set `serviceWorkers: 'block'`; and a `'**/api/agent-workspaces**'` URL glob matched nothing where an exact-pathname URL predicate matches. A blocker that quietly blocks nothing turns a spec like this into a tautology — the failure-case run is what caught both."
     },
     {
       "id": "pane-grid-converges-across-devices",
@@ -285,7 +302,7 @@
           "suite": "web-unit"
         }
       ],
-      "notes": "CLOSED BY #2365, which is why the gap text is gone rather than softened: gdpr-export.ts now has collectUserAgentWorkspaces and collectUserStreamState, and the route test that used to lock the omission in ('appends all data categories to archive') was replaced by one that asserts the bundle's file list exactly. The second half of the old gap — no 'every table is accounted for' drift guard for the GDPR export, the way the tenant export has one — is closed by gdpr-export-coverage.ts, which records a decision for all 128 schema tables and fails on a table that is neither exported nor excused. The Art 15/Art 17 citation is the one that keeps this honest over time: it pins the export against what the erasure purge deletes, so content the subject can have destroyed can never stop being content they can read. The integration citations REFUSE to skip without DATABASE_URL (they throw, with a comment saying why), so they do not share the silent-green caveat noted on gdpr-export-agent-authored-messages. Still open and worth not conflating: scripts/lib/migration-types.ts TABLE_IMPORT_ORDER carries agent_workspaces but not agent_workspace_shells or ai_stream_sessions, so the separate TENANT export has an adjacent hole this does not touch."
+      "notes": "CLOSED BY #2365, which is why the gap text is gone rather than softened: gdpr-export.ts now has collectUserAgentWorkspaces and collectUserStreamState, and the route test that used to lock the omission in ('appends all data categories to archive') was replaced by one that asserts the bundle's file list exactly. The second half of the old gap — no 'every table is accounted for' drift guard for the GDPR export, the way the tenant export has one — is closed by gdpr-export-coverage.ts, which records a decision for all 128 schema tables and fails on a table that is neither exported nor excused. The Art 15/Art 17 citation is the one that keeps this honest over time: it pins the export against what the erasure purge deletes, so content the subject can have destroyed can never stop being content they can read. The integration citations REFUSE to skip without DATABASE_URL (they throw, with a comment saying why), so they do not share the silent-green caveat noted on gdpr-export-agent-authored-messages. The adjacent TENANT-export hole this note used to flag as open — TABLE_IMPORT_ORDER carrying agent_workspaces but neither agent_workspace_shells nor ai_stream_sessions — is closed under `tenant-export-column-drift-guarded`, and closed with DIFFERENT answers on purpose: the shells now travel, ai_stream_sessions deliberately does not. Art 15 asks what data about you exists; a tenant bundle asks what a working instance should be reconstituted from, and a `status = streaming` checkpoint row answers the first question and not the second."
     },
     {
       "id": "erasure-reaches-stream-session-content",
@@ -335,7 +352,7 @@
     },
     {
       "id": "tenant-export-column-drift-guarded",
-      "guarantee": "The tenant export carries every schema column or explicitly excuses it, so a new column cannot silently stop being exported.",
+      "guarantee": "The tenant export carries every schema column or explicitly excuses it, and every table hanging off a migrated session or thread is a recorded carry-or-exclude decision — so neither a new column nor a whole new table can silently stop being exported.",
       "status": "proven",
       "evidence": [
         {
@@ -347,9 +364,29 @@
           "file": "scripts/__tests__/tenant-export-columns.test.ts",
           "name": "states a reason for every deliberately excluded column",
           "suite": "scripts-vitest"
+        },
+        {
+          "file": "scripts/__tests__/tenant-export-columns.test.ts",
+          "name": "records a carry-or-exclude decision for every table hanging off a session or a thread",
+          "suite": "scripts-vitest"
+        },
+        {
+          "file": "scripts/__tests__/tenant-export-columns.test.ts",
+          "name": "states a reason for every deliberately excluded table, and excludes nothing it also carries",
+          "suite": "scripts-vitest"
+        },
+        {
+          "file": "scripts/__tests__/tenant-import.test.ts",
+          "name": "carries the session's terminal AND its scrollback, without the source-fleet exec id",
+          "suite": "scripts-vitest"
+        },
+        {
+          "file": "scripts/__tests__/tenant-import.test.ts",
+          "name": "leaves ai_stream_sessions behind — a deliberate exclusion, not an omission",
+          "suite": "scripts-vitest"
         }
       ],
-      "notes": "Found independently twice: these 64 tests existed and passed but were absent from the hand-maintained file list in ci.yml, so they had never run in CI — and the drift they guard had in fact already reached a pushed branch (the agent_workspaces rename left spriteKey unaccounted). PR #2358 closed it by deleting that hand-list so the step runs the whole scripts vitest context, which is why this suite no longer sets requiresFileListedInCi: there is no list left for a file to be missing from."
+      "notes": "Found independently twice: these tests existed and passed but were absent from the hand-maintained file list in ci.yml, so they had never run in CI — and the drift they guard had in fact already reached a pushed branch (the agent_workspaces rename left spriteKey unaccounted). PR #2358 closed it by deleting that hand-list so the step runs the whole scripts vitest context, which is why this suite no longer sets requiresFileListedInCi: there is no list left for a file to be missing from. THE COLUMN GUARD IS STRUCTURALLY BLIND TO A MISSING TABLE — a table absent from TABLE_IMPORT_ORDER has no columns to check, so dropping the whole thing tripped nothing, which is how agent_workspace_shells came to be carried by the GDPR export and silently dropped by the tenant one (losing `coldTail`, a shell's scrollback, which is overwritten in place on every teardown and has no other home in the bundle). The table-level citations close that class over the agent-session FK closure, derived from the Drizzle schema at runtime rather than hand-listed: every table transitively reachable by foreign key from agent_workspaces or conversations must be in TABLE_IMPORT_ORDER or in TENANT_EXPORT_EXCLUDED_TABLES with a reason. Bounded there on purpose — a 'you forgot this table' assertion only means something where the bundle already carries the parent row; that is where an omission is data loss for a user who did migrate rather than a feature the bundle was never scoped to. The two round-trip citations are the behavioural half: one proves the shell scrollback survives export→import while its source-fleet `spriteExecId` does not, the other proves ai_stream_sessions is absent from a bundle that was asked for everything. VERIFIED THEY CAN FAIL: removing agent_workspace_shells from TABLE_IMPORT_ORDER fails the decision guard by name, and moving `coldTail` from carried to excluded fails the round trip."
     }
   ]
 }

--- a/docs/2.0-architecture/agent-sessions-evidence.md
+++ b/docs/2.0-architecture/agent-sessions-evidence.md
@@ -130,6 +130,35 @@ have quietly dropped these five the moment they broke — the precise failure it
 prevent, and the reason the citations survived the whole red period above to be vindicated by
 run 5 rather than being deleted somewhere around run 2.
 
+### Spec `18`, added after the gate went green
+
+`18-sidebar-directory-live.spec.ts` joined the same job to close the last recorded gap — the
+listener→SWR-key→`AgentsSidebar` seam, which every other test in the epic proved only either
+side of. It runs on the identical topology (production build, realtime same-origin behind the
+proxy, `NEXT_PUBLIC_REALTIME_URL` unset). All three of its assertions were confirmed to fail —
+on the assertion, not on setup — with the listener's key predicates diverged from the sidebar's
+key, which is the drift they exist to catch.
+
+It is also the clearest example so far of the section above this one: **a spec that cannot fail
+is worse than no spec.** The first draft blocked the session-listing GET and asserted the row
+appeared anyway. It passed. It also passed with the `conversation:created` subscription deleted
+— because two separate harness faults meant the "block" blocked nothing (the app registers
+`/sw.js`, and Playwright cannot intercept a fetch that goes through a Service Worker; and a
+`'**/api/agent-workspaces**'` URL glob matched nothing where an exact-pathname predicate
+matches), so the refetch it claimed to have ruled out was quietly delivering the row the whole
+time. Only running it against a deliberately broken build surfaced that. The rule this earns:
+**a spec whose assertion depends on suppressing something must prove the suppression happened,
+and the only reliable proof is a run that fails.**
+
+Fixing the harness then exposed a product fact worth recording rather than working around:
+creation and session-binding are decoupled (`create-conversation-in-session.ts`), so on the
+spawn path `conversation:created` carries `workspaceId: null` and the sidebar is updated by the
+claim's `conversation:updated` — one **event-driven refetch**, not a request-free cache write.
+The guarantee holds (event-driven, not a poll); the stronger "with no request" reading does not,
+and the spec now says so by shape: the spawn test rules the poll out with a quiet-window control
+instead of a network block, and a second test takes the seam to full strength on
+`conversation:closed`, which really is request-free.
+
 ## Adding a guarantee
 
 1. Add an entry to the JSON with an `id`, the user-facing `guarantee` (phrase it as something a

--- a/scripts/__tests__/setup.ts
+++ b/scripts/__tests__/setup.ts
@@ -49,6 +49,7 @@ export async function truncateAll(db: TestDb): Promise<void> {
       files,
       messages,
       conversations,
+      agent_workspace_shells,
       agent_workspaces,
       channel_read_status,
       channel_message_reactions,
@@ -170,6 +171,25 @@ export const FIXTURES = {
       spriteInstanceId: 'sprite-instance-source-001',
     },
   },
+  /**
+   * A terminal inside that session. `coldTail` is the scrollback of its last
+   * dead incarnation — user output with no other home in the bundle, and the
+   * reason this table is carried at all. `spriteExecId` is seeded non-NULL for
+   * the same reason the workspace's Sprite columns are: so the round-trip can
+   * assert it DOES NOT travel.
+   */
+  agentWorkspaceShells: {
+    shell: {
+      id: 'test_agent_shell_001',
+      workspaceId: 'test_agent_session_001',
+      name: 'build',
+      agentType: 'shell',
+      command: 'bun run dev',
+      coldTail: '$ bun run dev\nerror: port 3000 already in use\n',
+      coldTailHasOutput: true,
+      spriteExecId: 'sprite-exec-source-001',
+    },
+  },
   messages: {
     msg1: {
       id: 'test_chatmsg_001',
@@ -215,7 +235,7 @@ export const FIXTURES = {
  * Call after truncateAll() in beforeEach.
  */
 export async function seedFixtures(db: TestDb): Promise<void> {
-  const { users, drives, pages, conversations, agentWorkspaces, messages, files, pagePermissions, tags } = FIXTURES;
+  const { users, drives, pages, conversations, agentWorkspaces, agentWorkspaceShells, messages, files, pagePermissions, tags } = FIXTURES;
   const now = new Date();
 
   // Users. `emailBidx` is seeded because it is the LOOKUP KEY for an encrypted
@@ -276,6 +296,13 @@ export async function seedFixtures(db: TestDb): Promise<void> {
   await db.execute(sql`
     INSERT INTO agent_workspaces (id, "driveId", "ownerId", name, "sandboxId", "spriteInstanceId", "createdAt", "updatedAt")
     VALUES (${agentWorkspaces.workspace.id}, ${drives.shared.id}, ${users.owner.id}, ${agentWorkspaces.workspace.name}, ${agentWorkspaces.workspace.sandboxId}, ${agentWorkspaces.workspace.spriteInstanceId}, ${now}, ${now})
+  `);
+
+  // That session's terminal. `spriteExecId` is deliberately non-NULL: the
+  // export must NOT carry it, exactly as with the workspace's Sprite columns.
+  await db.execute(sql`
+    INSERT INTO agent_workspace_shells (id, "workspaceId", "ownerId", name, "agentType", command, "coldTail", "coldTailAt", "coldTailHasOutput", "spriteExecId", "createdAt", "updatedAt")
+    VALUES (${agentWorkspaceShells.shell.id}, ${agentWorkspaceShells.shell.workspaceId}, ${users.owner.id}, ${agentWorkspaceShells.shell.name}, ${agentWorkspaceShells.shell.agentType}, ${agentWorkspaceShells.shell.command}, ${agentWorkspaceShells.shell.coldTail}, ${now}, ${agentWorkspaceShells.shell.coldTailHasOutput}, ${agentWorkspaceShells.shell.spriteExecId}, ${now}, ${now})
   `);
 
   // The page conversation the chat messages below belong to. Required since

--- a/scripts/__tests__/tenant-export-columns.test.ts
+++ b/scripts/__tests__/tenant-export-columns.test.ts
@@ -21,18 +21,19 @@
  *
  * It needs no database: the table objects describe themselves.
  *
- * SCOPE: this guards the COLUMNS of the tables the export carries. Whether the
- * right set of TABLES is carried is a separate question, owned by
- * `TABLE_IMPORT_ORDER`; the coverage test below only pins the two lists to
- * each other so a new table cannot be added to one and forgotten in the other.
+ * SCOPE: the first describe below guards the COLUMNS of the tables the export
+ * carries. The second guards which TABLES are carried, over the agent-session
+ * FK closure — see its own header for why that boundary and not the whole
+ * schema.
  */
 import { describe, it, expect } from 'vitest';
 import { getTableColumns, getTableName, is } from 'drizzle-orm';
-import { PgTable } from 'drizzle-orm/pg-core';
+import { PgTable, getTableConfig } from 'drizzle-orm/pg-core';
 import * as dbSchema from '@pagespace/db/schema';
 import { TABLE_IMPORT_ORDER, type ExportTableName } from '../lib/migration-types';
 import {
   TENANT_EXPORT_COLUMNS,
+  TENANT_EXPORT_EXCLUDED_TABLES,
   carriedColumns,
   exportColumns,
   deferredColumns,
@@ -163,6 +164,11 @@ describe('tenant export column registry', () => {
       channel_messages: ['editedAt', 'parentId', 'replyCount', 'lastReplyAt', 'mirroredFromId', 'quotedMessageId'],
       conversations: ['workspaceId', 'closedInWorkspaceAt', 'rev', 'isShared', 'agentPageId'],
       messages: ['sourceAgentId'],
+      // The terminal half of a session. `coldTail` is the one carried column
+      // that is irreplaceable user OUTPUT rather than configuration: it is
+      // overwritten in place on every teardown and has no other home in the
+      // bundle, so a migration that drops it loses the scrollback outright.
+      agent_workspace_shells: ['coldTail', 'coldTailHasOutput', 'name', 'command'],
     };
 
     for (const [table, columns] of Object.entries(pins) as [ExportTableName, string[]][]) {
@@ -170,5 +176,99 @@ describe('tenant export column registry', () => {
         expect(carriedColumns(table), `${table}.${column}`).toContain(column);
       }
     }
+  });
+});
+
+/**
+ * The FK closure of the agent-session tables: every table reachable by foreign
+ * key from `agent_workspaces` or `conversations`, transitively. Derived from
+ * the schema at runtime for the same reason the column set is — a hand-written
+ * copy is what drifted in the first place.
+ */
+function agentSessionFkClosure(): string[] {
+  const referencesOf = new Map<string, string[]>();
+  for (const table of TABLES.values()) {
+    referencesOf.set(
+      getTableName(table),
+      getTableConfig(table).foreignKeys.map((fk) => getTableName(fk.reference().foreignTable)),
+    );
+  }
+
+  const closure = new Set(['agent_workspaces', 'conversations']);
+  // Bounded fixpoint: each pass can only add tables, and there are finitely
+  // many, so |TABLES| passes is guaranteed to saturate.
+  for (let pass = 0; pass < referencesOf.size; pass++) {
+    const before = closure.size;
+    for (const [table, references] of referencesOf) {
+      if (references.some((ref) => closure.has(ref))) closure.add(table);
+    }
+    if (closure.size === before) break;
+  }
+  return [...closure].sort();
+}
+
+/**
+ * DRIFT GUARD for which TABLES a tenant bundle carries.
+ *
+ * The column registry above cannot see this class of loss at all: a table
+ * absent from `TABLE_IMPORT_ORDER` has no columns to check, so dropping the
+ * whole thing is invisible to every assertion in it. That is exactly how
+ * `agent_workspace_shells` came to be carried by the GDPR export and dropped
+ * by the tenant one — the shell scrollback (`coldTail`) simply did not travel,
+ * and nothing said so.
+ *
+ * WHY THE FK CLOSURE AND NOT THE WHOLE SCHEMA. A "you forgot this table"
+ * assertion is only meaningful where the bundle already carries the PARENT
+ * row: those are the tables whose absence is silent data loss for a user who
+ * did migrate, rather than a feature the bundle was never scoped to
+ * (`credit_ledger`, `audit_logs`, `ai_usage_logs` — instance accounting that
+ * belongs to the source deployment). Anchoring on `agent_workspaces` and
+ * `conversations` makes the guard exactly as wide as the region this epic
+ * moved user work into, and it is derived, so a new child table added to
+ * either one is caught without anyone remembering to widen a list.
+ */
+describe('tenant export table registry', () => {
+  it('records a carry-or-exclude decision for every table hanging off a session or a thread', () => {
+    const decided = new Set<string>([
+      ...TABLE_IMPORT_ORDER,
+      ...Object.keys(TENANT_EXPORT_EXCLUDED_TABLES),
+    ]);
+
+    const undecided = agentSessionFkClosure().filter((table) => !decided.has(table));
+
+    expect(
+      undecided,
+      `${undecided.join(', ')} reference a table the tenant export carries, but nothing ` +
+      'says whether they travel. Add them to TABLE_IMPORT_ORDER (plus a spec in ' +
+      'TENANT_EXPORT_COLUMNS and a query in tenant-export.ts / tenant-validate.ts), or to ' +
+      'TENANT_EXPORT_EXCLUDED_TABLES with a reason. A table nobody decided about is ' +
+      'dropped from every tenant migration and no test notices.',
+    ).toEqual([]);
+  });
+
+  it('states a reason for every deliberately excluded table, and excludes nothing it also carries', () => {
+    const carried = new Set<string>(TABLE_IMPORT_ORDER);
+    for (const [table, reason] of Object.entries(TENANT_EXPORT_EXCLUDED_TABLES)) {
+      expect(TABLES.has(table), `${table} is excluded but no such table exists in the schema`).toBe(true);
+      expect(
+        carried.has(table),
+        `${table} is listed as excluded AND appears in TABLE_IMPORT_ORDER`,
+      ).toBe(false);
+      expect(
+        reason.trim().length,
+        `${table} is excluded from the tenant export with no stated reason`,
+      ).toBeGreaterThan(20);
+    }
+  });
+
+  it('carries the session tables whose loss motivated this guard', () => {
+    // The named half of the decision, pinned so a future edit that quietly
+    // drops the table fails with the table, not just a set difference.
+    expect(TABLE_IMPORT_ORDER).toContain('agent_workspace_shells');
+    // …and the excluded half, pinned for the same reason: `ai_stream_sessions`
+    // must stay a WRITTEN DOWN exclusion. Its content is reachable on Art 15
+    // through the GDPR export's `stream-state.json`; the two exports answer
+    // different questions and are allowed to differ, but only out loud.
+    expect(Object.keys(TENANT_EXPORT_EXCLUDED_TABLES)).toContain('ai_stream_sessions');
   });
 });

--- a/scripts/__tests__/tenant-import.test.ts
+++ b/scripts/__tests__/tenant-import.test.ts
@@ -24,6 +24,7 @@ import {
 import { exportData } from '../tenant-export';
 import { runImport } from '../tenant-import';
 import { validateChecksums } from '../lib/migration-utils';
+import { TENANT_EXPORT_EXCLUDED_TABLES } from '../lib/tenant-export-columns';
 import type { DbClient, ExportManifest } from '../lib/migration-types';
 
 let db: TestDb;
@@ -160,6 +161,53 @@ describe('runImport', () => {
       expect(rows[0].spriteInstanceId).toBeNull();
       expect(rows[0].spriteKey).toBeNull();
       expect(rows[0].storageMeasuredBytes).toBeNull();
+    });
+
+    it("carries the session's terminal AND its scrollback, without the source-fleet exec id", async () => {
+      await reimport('shell');
+
+      const rows = (await db.execute(sql.raw(
+        `SELECT "workspaceId", "ownerId", name, "agentType", command, "coldTail", "coldTailAt", "coldTailHasOutput", "spriteExecId" FROM agent_workspace_shells WHERE id = '${FIXTURES.agentWorkspaceShells.shell.id}'`,
+      ))).rows as Record<string, unknown>[];
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].workspaceId).toBe(FIXTURES.agentWorkspaces.workspace.id);
+      expect(rows[0].ownerId).toBe(FIXTURES.users.owner.id);
+      expect(rows[0].name).toBe(FIXTURES.agentWorkspaceShells.shell.name);
+      expect(rows[0].agentType).toBe(FIXTURES.agentWorkspaceShells.shell.agentType);
+      expect(rows[0].command).toBe(FIXTURES.agentWorkspaceShells.shell.command);
+      // THE POINT OF CARRYING THIS TABLE. `coldTail` is the scrollback of the
+      // shell's last dead incarnation — overwritten in place on every teardown
+      // and present nowhere else in the bundle, so if it does not survive the
+      // round trip it is gone for good. `coldTailHasOutput` travels with it
+      // because an empty tail is ambiguous alone (a burst larger than the ring
+      // also empties it), and "was screaming" must not migrate as "was silent".
+      expect(rows[0].coldTail).toBe(FIXTURES.agentWorkspaceShells.shell.coldTail);
+      expect(rows[0].coldTailHasOutput).toBe(true);
+      expect(rows[0].coldTailAt).not.toBeNull();
+      // Same rule as the parent session's Sprite columns: this names an exec
+      // session inside a SOURCE-fleet VM the tenant does not own.
+      expect(rows[0].spriteExecId).toBeNull();
+    });
+
+    it('leaves ai_stream_sessions behind — a deliberate exclusion, not an omission', async () => {
+      // The Art 17 purge and the Art 15 export both reach this table (see
+      // `packages/lib/src/compliance/export/gdpr-export-coverage.ts`); the
+      // TENANT bundle deliberately does not, because a `status = streaming`
+      // row would import as a phantom live stream in an instance that has no
+      // worker producing it and no abort registry that can reach it. The
+      // durable half of the turn is in `messages`, which the bundle carries.
+      //
+      // Asserted as an absence FROM A BUNDLE THAT WAS ASKED FOR EVERYTHING, so
+      // this fails the moment someone adds the table to TABLE_IMPORT_ORDER
+      // without also deleting the recorded exclusion.
+      expect(TENANT_EXPORT_EXCLUDED_TABLES).toHaveProperty('ai_stream_sessions');
+      const sqlContent = await readFile(path.join(bundleDir, 'data.sql'), 'utf-8');
+      expect(sqlContent).not.toContain('ai_stream_sessions');
+      // …and the conversation whose rows they would have been is present, so
+      // the absence above is a decision about this table rather than an empty
+      // bundle trivially satisfying it.
+      expect(sqlContent).toContain(FIXTURES.conversations.pageChat.id);
     });
 
     it("restores the user's email blind index — the lookup key a migrated account logs in through", async () => {

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -128,7 +128,7 @@ describe('validateData', () => {
     expect(result.fileResults.mismatches[0].reason).toContain('checksum mismatch');
   });
 
-  it('validates all 21 exported tables', async () => {
+  it('validates every table in TABLE_IMPORT_ORDER', async () => {
     const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
       sourceDatabaseUrl: getTestDatabaseUrl(),
       targetDatabaseUrl: getTestDatabaseUrl(),

--- a/scripts/lib/migration-types.ts
+++ b/scripts/lib/migration-types.ts
@@ -15,6 +15,7 @@ export interface ManifestTableCounts {
   channelMessageReactions: number;
   channelReadStatus: number;
   agentWorkspaces: number;
+  agentWorkspaceShells: number;
   conversations: number;
   messages: number;
   files: number;
@@ -113,6 +114,12 @@ export const TABLE_IMPORT_ORDER = [
   // Before `conversations`: `conversations.workspaceId` FKs here, so the
   // session rows have to exist before a bound thread can be inserted.
   'agent_workspaces',
+  // Immediately after its parent: `agent_workspace_shells.workspaceId` FKs
+  // `agent_workspaces` and `ownerId` FKs `users`, both already inserted. The
+  // shells carry a session's TERMINAL work — the tab names, the per-shell
+  // command, and `coldTail`, the scrollback of the last dead incarnation —
+  // which is user content with no other home in the bundle.
+  'agent_workspace_shells',
   'conversations',
   'messages',
   'files',

--- a/scripts/lib/tenant-export-columns.ts
+++ b/scripts/lib/tenant-export-columns.ts
@@ -34,9 +34,14 @@
  * migration must be a decision someone wrote down, never an omission nobody
  * noticed.
  *
- * SCOPE NOTE: this registry guards the columns of the tables the export
- * carries. It says nothing about which TABLES are carried — that set is
- * `TABLE_IMPORT_ORDER`, and widening it is a separate, deliberate act.
+ * SCOPE NOTE: `TENANT_EXPORT_COLUMNS` guards the COLUMNS of the tables the
+ * export carries. Which TABLES are carried is `TABLE_IMPORT_ORDER`, and
+ * widening that is a separate, deliberate act — but "deliberate" used to mean
+ * "nobody wrote anything down", which is how `agent_workspace_shells` came to
+ * be dropped from tenant bundles while the GDPR export carried it. So the
+ * second registry below, `TENANT_EXPORT_EXCLUDED_TABLES`, does for tables what
+ * `excluded` does for columns, over the one region where an omission is a data
+ * loss rather than a non-decision: the agent-session FK closure.
  */
 import type { ExportTableName } from './migration-types';
 
@@ -169,22 +174,45 @@ export const TENANT_EXPORT_COLUMNS: Readonly<Record<ExportTableName, TableColumn
 
   channel_read_status: { columns: ['userId', 'channelId', 'lastReadAt'] },
 
-  // KNOWN GAP (stated, not silent): the pane grid used to ride along in this
-  // table's `workspaceState` jsonb. That column was dropped at the
-  // agent-session SSoT epic's Phase 3 contract step and the grid now lives in
-  // `agent_workspace_pane_columns` / `agent_workspace_panes`, which are NOT
-  // in `TABLE_IMPORT_ORDER` — so a tenant bundle no longer carries pane
-  // LAYOUT. Nothing is orphaned by that: every conversation and shell in the
-  // session is carried and still bound (`conversations.workspaceId`), so the
-  // migrated user gets their threads with a fresh default grid instead of
-  // their arrangement. Closing it means WIDENING the carried table set, which
-  // this registry deliberately does not do on its own (see SCOPE NOTE above).
+  // The pane grid used to ride along in this table's `workspaceState` jsonb.
+  // That column was dropped at the agent-session SSoT epic's Phase 3 contract
+  // step and the grid now lives in `agent_workspace_pane_columns` /
+  // `agent_workspace_panes` — which are deliberately not carried, with the
+  // reasoning recorded in `TENANT_EXPORT_EXCLUDED_TABLES` below rather than
+  // in this comment. Nothing is orphaned by that: every conversation and
+  // every shell in the session is carried and still bound, so the migrated
+  // user gets their threads and their terminals with a fresh default grid
+  // instead of their arrangement.
   agent_workspaces: {
     columns: [
       'id', 'driveId', 'ownerId', 'name',
       'lastActiveAt', 'endedAt', 'createdAt', 'updatedAt',
     ],
     excluded: AGENT_WORKSPACE_SPRITE_EXCLUSIONS,
+  },
+
+  /**
+   * A session's TERMINALS. Everything here is either the user's own naming of
+   * their workspace (`name`, `command`, `agentType`) or their own output:
+   * `coldTail` is the scrollback tail of the shell's last dead incarnation,
+   * with `coldTailHasOutput` carried alongside it because an empty tail is
+   * ambiguous on its own (a burst larger than the ring buffer also leaves it
+   * empty, and "the shell was screaming" must not migrate as "the shell was
+   * silent").
+   *
+   * No Sprite/storage accounting lives on this table — unlike its parent it
+   * has exactly one source-fleet reference, `spriteExecId`, excluded below on
+   * the same grounds as `AGENT_WORKSPACE_SPRITE_EXCLUSIONS`.
+   */
+  agent_workspace_shells: {
+    columns: [
+      'id', 'workspaceId', 'ownerId', 'name', 'agentType', 'command',
+      'coldTail', 'coldTailAt', 'coldTailHasOutput', 'createdAt', 'updatedAt',
+    ],
+    excluded: {
+      spriteExecId:
+        'Names an exec session on a SOURCE-fleet Sprite. The parent session migrates with `sandboxId` NULL (never provisioned), so a carried exec id would address a PTY inside a VM the tenant does not own; NULL correctly means "not attached", which is what the reattach path already expects of a cold shell.',
+    },
   },
 
   conversations: {
@@ -233,6 +261,49 @@ export const TENANT_EXPORT_COLUMNS: Readonly<Record<ExportTableName, TableColumn
   favorites: {
     columns: ['id', 'userId', 'itemType', 'pageId', 'driveId', 'position', 'createdAt'],
   },
+};
+
+/**
+ * TABLES in the agent-session FK closure that the bundle deliberately does NOT
+ * carry — the table-level twin of a column `excluded` entry.
+ *
+ * The paired guard (`scripts/__tests__/tenant-export-columns.test.ts`) derives
+ * the closure from the Drizzle schema at runtime: every table reachable by
+ * foreign key from `agent_workspaces` or `conversations` must be either in
+ * `TABLE_IMPORT_ORDER` or keyed here with a reason. A new child table of a
+ * session or a thread therefore cannot reach `master` without someone deciding
+ * whether a migrating user takes it with them.
+ *
+ * WHY THIS CLOSURE AND NOT THE WHOLE SCHEMA. A table-level decision is only
+ * meaningful where the bundle already carries the parent: those are the rows
+ * whose absence is silent DATA LOSS for a user who did migrate, rather than a
+ * feature the bundle was never scoped to. That is exactly the region this
+ * epic's own tables live in, and it is the region where the loss had already
+ * happened — `agent_workspace_shells` was carried by the GDPR export and
+ * dropped by the tenant one. (`packages/lib/src/compliance/export/gdpr-export-coverage.ts`
+ * is the whole-schema analogue for Art 15; the two answer different questions
+ * and are allowed to differ — see `ai_stream_sessions` below.)
+ */
+export const TENANT_EXPORT_EXCLUDED_TABLES: Readonly<Record<string, string>> = {
+  /**
+   * The Art 15 export DOES carry this table (`stream-state.json`), and that is
+   * not an inconsistency: "every byte about you that exists" and "the state a
+   * working instance should be reconstituted from" are different questions.
+   */
+  ai_stream_sessions:
+    'A per-instance STREAMING CHECKPOINT, not a durable record: `parts` is the debounced replay buffer a reconnecting client resumes from, and a completed turn is committed to `messages`, which the bundle carries. Every other column names SOURCE-instance runtime — `stream_id` (the in-process abort-registry key, UNIQUE-indexed, so a carried duplicate also collides), `browser_session_id`, `last_heartbeat_at`, `abort_requested_at`, `raw_parts_count` (a replay cursor with no live multicast to count against). Carrying a `status = streaming` row would manufacture a phantom live stream in the tenant that no worker will ever finish and no abort can reach.',
+
+  agent_workspace_pane_columns:
+    'Pane LAYOUT — which columns the grid has and how wide. Deliberately not carried: the arrangement is per-device ergonomics, not content, and every artefact it arranges (conversations, shells) travels on its own and stays bound to the session. The migrated user opens their session on a fresh default grid holding all of their work rather than none of it.',
+
+  agent_workspace_panes:
+    'The other half of the pane layout, and the reason carrying half would be worse than carrying neither: `targetId` is polymorphic with NO foreign key (conversationId | shellId | pageId by `kind`), so a pane naming a page or conversation outside the bundle would import cleanly and then render an unresolvable pane. See `agent_workspace_pane_columns`.',
+
+  agent_workspace_layout_revs:
+    'The per-workspace monotonic rev counter for the pane grid. With no grid carried there is nothing for a rev to describe, and a carried non-zero rev would make the tenant reject its own first layout verb as stale until the client rebased through a 409.',
+
+  agent_workspace_layout_ops:
+    'The layout verb route\'s idempotency memory — one row per recently-processed (workspaceId, opId), pruned on a 24h window. It exists to short-circuit a retry that is seconds old; a migrated copy could only ever suppress a genuinely new op in the tenant that happened to reuse a client-minted id.',
 };
 
 /** The columns emitted inline in `table`'s INSERT. */

--- a/scripts/tenant-export.ts
+++ b/scripts/tenant-export.ts
@@ -297,6 +297,24 @@ export async function exportData(
   const exportedSessionIdSet = new Set(agentSessionsData.map((s) => s.id as string));
   nullifyOrphanedRefs(conversationsData, exportedSessionIdSet, 'workspaceId');
 
+  /**
+   * The sessions' TERMINALS. Scoped to the sessions that survived the owner
+   * filter above, then filtered again on `ownerId`: both of this table's FKs
+   * are NOT NULL with `ON DELETE CASCADE`, so unlike a conversation there is
+   * no "orphan it and carry it anyway" shape — a shell whose owner is outside
+   * the migration simply does not travel. In practice the second filter is a
+   * no-op (a session's shells are its owner's), and it is here so that stops
+   * being an assumption the export relies on silently.
+   */
+  const shellsDataRaw = exportedSessionIdSet.size > 0
+    ? await queryRows(db, sql.raw(
+        `SELECT * FROM agent_workspace_shells WHERE "workspaceId" IN (${toSqlInList(exportedSessionIdSet)})`,
+      ))
+    : [];
+  const agentShellsData = shellsDataRaw.filter(
+    (s) => allExportedUserIdSet.has(s.ownerId as string),
+  );
+
   // `conversations.agentPageId` FKs `pages` (ON DELETE SET NULL) and is a
   // `type='client'` thread's only page link. A thread whose agent page is
   // outside the bundle becomes page-less rather than a dangling reference —
@@ -387,6 +405,11 @@ export async function exportData(
     // `agent_workspaces` precedes `conversations`: `conversations.workspaceId`
     // FKs it, and a session row also needs its drive and owner, both above.
     buildInsert('agent_workspaces', cols('agent_workspaces'), agentSessionsData),
+    // Both of this table's FKs (`workspaceId`, `ownerId`) are NOT NULL, so it
+    // must follow `agent_workspaces` and `users`. It does NOT have to precede
+    // `conversations` — nothing references a shell — but it sits with its
+    // parent to keep the session's rows together.
+    buildInsert('agent_workspace_shells', cols('agent_workspace_shells'), agentShellsData),
     // `conversations` MUST precede `messages`: the latter has a real
     // (non-deferrable) FK onto the former, and the whole bundle replays inside
     // one BEGIN/COMMIT, so an out-of-order INSERT aborts the entire import.
@@ -421,6 +444,7 @@ export async function exportData(
     channelMessageReactions: channelReactionsData.length,
     channelReadStatus: channelReadStatusData.length,
     agentWorkspaces: agentSessionsData.length,
+    agentWorkspaceShells: agentShellsData.length,
     conversations: conversationsData.length,
     messages: messagesData.length,
     files: filesData.length,

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -162,6 +162,9 @@ export async function validateData(
     // Mirrors the export's rule: the sessions the migrated conversations are
     // bound to, owned by a migrated user.
     agent_workspaces: sql.raw(`SELECT id FROM agent_workspaces WHERE "ownerId" IN (${userIn}) AND id IN (SELECT "workspaceId" FROM conversations WHERE "userId" IN (${userIn}) AND "workspaceId" IS NOT NULL)`),
+    // Mirrors the export's rule: the shells of those same sessions, owned by a
+    // migrated user.
+    agent_workspace_shells: sql.raw(`SELECT id FROM agent_workspace_shells WHERE "ownerId" IN (${userIn}) AND "workspaceId" IN (SELECT id FROM agent_workspaces WHERE "ownerId" IN (${userIn}) AND id IN (SELECT "workspaceId" FROM conversations WHERE "userId" IN (${userIn}) AND "workspaceId" IS NOT NULL))`),
     // Mirrors the export's rule exactly: owned by a migrated user, OR
     // attached to a migrated page (`type='page'` names it in `contextId`,
     // `type='client'` in `agentPageId`).


### PR DESCRIPTION
Closes the last two gaps in the Agent-Session Single Source of Truth epic's evidence manifest, plus the adjacent tenant-export hole the manifest itself flagged.

**`bun run scripts/check-evidence-manifest.ts` → 13 guarantees, 13 proven, 0 gaps.**

Based on `pu/broken-sessions`, with `fix/gdpr-coverage-and-missing-tests` (#2365) merged in.

---

## GAP 1 — `sidebar-renders-server-created-conversation-end-to-end`

The seam nothing reached: the listener writes through the `isSessionListingKey` / `isAgentSessionsKey` **predicates**, while `AgentsSidebar` builds its SWR key as an inline template literal instead of calling the shared `agentSessionsKey()` helper. `AgentsSidebar.test.tsx` feeds SWR data in directly and contains nothing socket-driven, so that divergence could happen and the symptom would be a sidebar that still works, just slowly.

New spec `apps/e2e/tests/18-sidebar-directory-live.spec.ts`, added to the `E2E (agent-session user stories)` job (specs 15/16/17/**18**).

### The first version of this spec was a tautology, and only a failure run found it

The obvious spec — abort the session-listing GET, spawn server-side, assert the row appears — passed. It **also passed with the `conversation:created` subscription deleted from the listener**. Two independent harness faults meant the "block" blocked nothing:

1. the app registers `/sw.js`, and Playwright cannot intercept a fetch that goes through a Service Worker, so `page.route` saw **zero** requests;
2. a `'**/api/agent-workspaces**'` URL glob matched nothing where an exact-pathname URL predicate matches.

The refetch the spec claimed to have ruled out was quietly delivering the row the whole time. Fixed with `serviceWorkers: 'block'` on the context and a URL predicate.

### Fixing the harness then exposed a product fact worth recording, not working around

Creation and session-binding are **decoupled by design** (`create-conversation-in-session.ts` — a sessionless conversation is an ordinary state). So on the spawn path:

1. `conversation:created` fires with `workspaceId: null`, which the listener correctly declines to insert into any session listing;
2. the claim lands, `conversation:updated { workspaceId }` fires, and the listener answers with `revalidateSessionListings` — **a refetch**.

The sidebar is therefore updated by one *event-driven request*, not by a request-free cache write. That is still the guarantee (event-driven, not a poll), but it is not the stronger thing "with no request" would claim — and `upsertConversationInCache` is not what serves this story. Recorded in the manifest rather than papered over.

### So the spec is shaped around what is actually true — 3 tests

| Test | How the poll is ruled out |
|---|---|
| a server-spawned conversation reaches the sidebar off the directory plane, not off the backstop poll | **A control, not a timing argument.** Sit still for exactly the assertion window's length and require zero listing fetches, *then* spawn and assert within the same length. Demote the 120s `refreshInterval` and the control fails loudly instead of the assertion passing for the wrong reason. |
| a server-side close removes the row with the listing fetch cut off at the network | **The seam at full strength.** `conversation:closed` → `forgetConversationInCache` is genuinely request-free, so here the listing GET *is* aborted for the whole window. Observed: **0 fetches**, row still leaves. |
| the row lands in the spawning session only, not in every session listing | Covers the opposite error — an insert into every session's row would keep a target-scoped count green. |

### Proof it can fail

Diverging the listener's key predicates from the sidebar's key (the actual risk the manifest named) fails **all three, on the assertion, not on setup**:

```
✘ a server-spawned conversation reaches the sidebar off the directory plane…   Expected: 2  Received: 1
✘ a server-side close removes the row with the listing fetch cut off…          Expected: 2  Received: 1
✘ the row lands in the spawning session only…                                  Expected: 2  Received: 1
```

Restored → green. Earlier, with `conversation:created` unsubscribed, the *pre-fix* spec passed — which is what exposed fault (1) above.

Small production change: an optional `testId` on `RowMenu` and a per-session `data-testid` wrapper in `AgentsSidebar`. A sidebar row is a composite with no single addressable element, and its label is a user-renamable agent name.

---

## GAP 2 — `gdpr-export-covers-agent-session-tables`

Closed by merging #2365. Flipped to `proven` against citations verified by running the checker, not hand-written: the completeness case, the Art 15(4) boundary case, the 128-table coverage guard, the Art 15/Art 17 cross-pin, and the route test that no longer pins a hand-written list.

---

## Adjacent hole — the tenant export

`TABLE_IMPORT_ORDER` carried `agent_workspaces` but neither `agent_workspace_shells` nor `ai_stream_sessions`. Different answers, both written down.

### `agent_workspace_shells` — **carried**

It holds real user content with **no other home in the bundle**: `coldTail`, the scrollback of the shell's last dead incarnation, overwritten in place on every teardown. Plus the user's own naming (`name`, `command`, `agentType`). `coldTailHasOutput` travels with it because an empty tail is ambiguous alone — a burst larger than the ring buffer also empties it, and "was screaming" must not migrate as "was silent". `spriteExecId` is excluded on exactly the grounds `AGENT_WORKSPACE_SPRITE_EXCLUSIONS` uses: it names an exec session inside a SOURCE-fleet VM the tenant does not own.

Inserted directly after its parent (both FKs `NOT NULL`), with export scoping, a validate query, fixtures and truncation to match.

### `ai_stream_sessions` — **deliberately excluded, with the reasoning recorded**

It is a *per-instance streaming checkpoint*, not a durable record. `parts` is the debounced replay buffer a reconnecting client resumes from; the completed turn is committed to `messages`, which the bundle already carries. Every other column names SOURCE-instance runtime: `stream_id` (the in-process abort-registry key, UNIQUE-indexed, so a carried duplicate also collides), `browser_session_id`, `last_heartbeat_at`, `abort_requested_at`, `raw_parts_count` (a replay cursor with no live multicast to count against). Carrying a `status = streaming` row would manufacture a phantom live stream in the tenant that no worker will ever finish and no abort can reach.

**This is deliberately different from the GDPR answer, and that is not an inconsistency.** Art 15 asks *what data about you exists*; a tenant bundle asks *what a working instance should be reconstituted from*. A streaming checkpoint answers the first and not the second.

### The guard that makes this a decision instead of an omission

The column registry is **structurally blind to a missing table** — a table absent from `TABLE_IMPORT_ORDER` has no columns to check, which is exactly how the shells came to be carried by the GDPR export and silently dropped by the tenant one.

So: `TENANT_EXPORT_EXCLUDED_TABLES`, plus a guard that derives the **agent-session FK closure** from the Drizzle schema at runtime and requires every table transitively reachable from `agent_workspaces` or `conversations` to be either carried or excused with a reason. Bounded there on purpose — a "you forgot this table" assertion only means something where the bundle already carries the parent row. It also promotes the existing prose `KNOWN GAP` comment about pane layout into four machine-checked decisions.

### Proof it can fail

- Removing `agent_workspace_shells` from `TABLE_IMPORT_ORDER` → the decision guard names it: `agent_workspace_shells reference a table the tenant export carries, but nothing says whether they travel` (3 failures).
- Moving `coldTail` from carried to excluded → the round-trip and the regression pin both fail (2 failures).

Restored → green.

---

## Gates

| Gate | Result |
|---|---|
| Evidence manifest checker | **13 guarantees — 13 proven, 0 gaps**, `evidence manifest OK` |
| `bun run typecheck` | 17/17 tasks |
| `bun run lint` | 15/15 tasks, no warnings or errors |
| `bun run knip:check` | 4 issues, all within baseline (4) |
| scripts vitest (whole context, as CI runs it) | **14 files, 265 tests passed** |
| e2e job's spec set (15+16+17+18, production build, realtime same-origin behind the proxy) | **14 passed** in 30.7s |
| web unit — sidebar, RowMenu, directory listener | 3 files, 94 tests passed |
| web unit — GDPR route, agent-workspaces, created-emit | 19 files, 194 tests passed |
| lib unit — compliance/export | 4 files, 74 tests passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzUuAixdTJ8xDpP5S92Ts
