### PR TITLE
fix(ai): plan-binding correctness follow-ups missed by the #2359 merge

### DIFF
--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
@@ -76,6 +76,9 @@ vi.mock('@/lib/websocket/socket-utils', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
+  // Session auth = unscoped, which is all this route accepts. Stubbed because
+  // the route passes the scope ceiling into the Home-drive hint.
+  getAllowedDriveIds: vi.fn(() => []),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -74,6 +74,9 @@ vi.mock('@/lib/websocket/socket-utils', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
+  // Session auth = unscoped, which is all this route accepts. Stubbed because
+  // the route passes the scope ceiling into the Home-drive hint.
+  getAllowedDriveIds: vi.fn(() => []),
 }));
 
 vi.mock('@/lib/ai/core/stream-takeover', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -78,6 +78,9 @@ vi.mock('@/lib/websocket/socket-utils', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
+  // Session auth = unscoped, which is all this route accepts. Stubbed because
+  // the route passes the scope ceiling into the Home-drive hint.
+  getAllowedDriveIds: vi.fn(() => []),
 }));
 
 vi.mock('@/lib/ai/core/stream-takeover', () => ({

--- a/apps/web/src/components/ai/shared/PlanChip.tsx
+++ b/apps/web/src/components/ai/shared/PlanChip.tsx
@@ -31,6 +31,25 @@ interface MessagePart {
   type?: string;
   toolName?: string;
   state?: string;
+  input?: unknown;
+}
+
+/**
+ * The tool name a part represents, unwrapping `execute_tool`.
+ *
+ * Unwrapping is not an edge case: `set_plan`/`clear_plan` are not in
+ * `CORE_TOOL_NAMES`, and the Global Assistant route always splits its toolset,
+ * so on that surface the agent can ONLY reach them as
+ * `execute_tool({ tool_name: 'set_plan' })`. Matching the top-level part name
+ * alone would make this component's revalidation dead code exactly where the
+ * chip is mounted.
+ */
+function resolveToolName(part: MessagePart): string | undefined {
+  const direct =
+    part.toolName ?? (part.type?.startsWith('tool-') ? part.type.slice('tool-'.length) : undefined);
+  if (direct !== 'execute_tool') return direct;
+  const wrapped = (part.input as { tool_name?: unknown } | undefined)?.tool_name;
+  return typeof wrapped === 'string' ? wrapped : undefined;
 }
 
 /**
@@ -50,8 +69,7 @@ function useCompletedPlanToolCount(messages: UIMessage[] | undefined): number {
     let count = 0;
     for (const message of messages) {
       for (const part of ((message as { parts?: MessagePart[] }).parts ?? [])) {
-        const toolName =
-          part.toolName ?? (part.type?.startsWith('tool-') ? part.type.slice('tool-'.length) : undefined);
+        const toolName = resolveToolName(part);
         if (!toolName || !PLAN_TOOL_NAMES.has(toolName)) continue;
         if (part.state === 'output-available' || part.state === 'done') count += 1;
       }

--- a/apps/web/src/components/ai/shared/__tests__/PlanChip.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/PlanChip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import type { UIMessage } from 'ai';
 
 const fetchWithAuthMock = vi.fn();
@@ -29,6 +29,18 @@ const toolPart = (toolName: string, state = 'output-available') => ({
 
 const messagesWith = (...parts: unknown[]): UIMessage[] =>
   [{ id: 'm1', role: 'assistant', parts }] as unknown as UIMessage[];
+
+/**
+ * Flush pending effects and microtasks deterministically.
+ *
+ * The "no extra fetch happened" assertions below are negative, so they need a
+ * point at which any fetch that WAS going to fire already has. A fixed sleep
+ * gets that wrong in both directions — it can pass before a slightly-late
+ * request lands, and it can flake on a loaded CI worker. `act` drains React's
+ * effect queue and the microtask queue instead, which is exactly the boundary
+ * these assertions care about, with no wall-clock dependency.
+ */
+const flushEffects = () => act(async () => {});
 
 /**
  * How a plan tool actually reaches the model on the Global Assistant: set_plan
@@ -110,7 +122,7 @@ describe('PlanChip', () => {
     rerender(
       <PlanChip conversationId="conv-6" messages={messagesWith(toolPart('set_plan', 'input-streaming'))} />,
     );
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushEffects();
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });
 
@@ -120,7 +132,7 @@ describe('PlanChip', () => {
     await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
 
     rerender(<PlanChip conversationId="conv-7" messages={messagesWith(toolPart('create_page'))} />);
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushEffects();
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });
 });
@@ -138,7 +150,7 @@ describe('PlanChip revalidation is not wasteful', () => {
     respondWith(BOUND);
     render(<PlanChip conversationId="conv-8" messages={messagesWith(toolPart('set_plan'))} />);
     await screen.findByTitle('Active plan');
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushEffects();
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });
 
@@ -148,7 +160,7 @@ describe('PlanChip revalidation is not wasteful', () => {
     await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
 
     rerender(<PlanChip conversationId="conv-9" messages={messagesWith(toolPart('read_page'))} />);
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushEffects();
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });
 });
@@ -178,7 +190,7 @@ describe('PlanChip sees plan tools wrapped in execute_tool', () => {
     await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
 
     rerender(<PlanChip conversationId="conv-11" messages={messagesWith(wrappedToolPart('create_page'))} />);
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await flushEffects();
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/ai/shared/__tests__/PlanChip.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/PlanChip.test.tsx
@@ -30,6 +30,18 @@ const toolPart = (toolName: string, state = 'output-available') => ({
 const messagesWith = (...parts: unknown[]): UIMessage[] =>
   [{ id: 'm1', role: 'assistant', parts }] as unknown as UIMessage[];
 
+/**
+ * How a plan tool actually reaches the model on the Global Assistant: set_plan
+ * is not a CORE tool and that route always splits its toolset, so the agent can
+ * only call it wrapped in execute_tool.
+ */
+const wrappedToolPart = (toolName: string, state = 'output-available') => ({
+  type: 'tool-execute_tool',
+  toolName: 'execute_tool',
+  state,
+  input: { tool_name: toolName, parameters: {} },
+});
+
 describe('PlanChip', () => {
   beforeEach(() => {
     fetchWithAuthMock.mockReset();
@@ -136,6 +148,36 @@ describe('PlanChip revalidation is not wasteful', () => {
     await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
 
     rerender(<PlanChip conversationId="conv-9" messages={messagesWith(toolPart('read_page'))} />);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PlanChip sees plan tools wrapped in execute_tool', () => {
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset();
+    delMock.mockReset();
+  });
+
+  it('re-fetches when set_plan completes via execute_tool', async () => {
+    // Without unwrapping, this component's revalidation is dead code on the
+    // Global Assistant — the one surface where the chip is most visible.
+    respondWith(UNBOUND);
+    const { rerender } = render(<PlanChip conversationId="conv-10" messages={[]} />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    respondWith(BOUND);
+    rerender(<PlanChip conversationId="conv-10" messages={messagesWith(wrappedToolPart('set_plan'))} />);
+
+    expect(await screen.findByTitle('Active plan')).toBeTruthy();
+  });
+
+  it('ignores execute_tool wrapping an unrelated tool', async () => {
+    respondWith(UNBOUND);
+    const { rerender } = render(<PlanChip conversationId="conv-11" messages={[]} />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    rerender(<PlanChip conversationId="conv-11" messages={messagesWith(wrappedToolPart('create_page'))} />);
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/lib/ai/chat-pipeline/global-chat-turn.ts
+++ b/apps/web/src/lib/ai/chat-pipeline/global-chat-turn.ts
@@ -47,7 +47,7 @@ import { takeOverConversationStreams } from '@/lib/ai/core/stream-takeover';
 import { startGenerationExclusive } from '@/lib/ai/core/start-generation-exclusive';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
-import type { AuthResult } from '@/lib/auth';
+import { getAllowedDriveIds, type AuthResult } from '@/lib/auth';
 import { createAIProvider, updateUserProviderSettings, createProviderErrorResponse, isProviderError, type ProviderRequest } from '@/lib/ai/core/provider-factory';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { extractMessageContent, extractToolCalls, extractToolResults, sanitizeMessagesForModel, convertGlobalAssistantMessageToUIMessage } from '@/lib/ai/core/message-utils';
@@ -836,7 +836,10 @@ export async function runGlobalChatTurn(ctx: GlobalChatTurnContext): Promise<Res
     );
 
     const hasLocation = Boolean(locationContext?.currentPage || locationContext?.currentDrive);
-    const locationHomeDriveId = await resolveHomeDriveHint(userId, hasLocation);
+    // Session-only surface (AUTH_OPTIONS_WRITE allows 'session' only), so the scope
+    // ceiling is always empty here. Passed explicitly anyway so this stays correct
+    // by construction if the allowed auth methods ever widen.
+    const locationHomeDriveId = await resolveHomeDriveHint(userId, hasLocation, getAllowedDriveIds(auth));
 
     const locationPrompt = buildLocationTurnPrompt(locationContext ? {
       currentPage: locationContext.currentPage,

--- a/apps/web/src/lib/ai/chat-pipeline/page-chat-turn.ts
+++ b/apps/web/src/lib/ai/chat-pipeline/page-chat-turn.ts
@@ -1537,7 +1537,7 @@ export async function runPageChatTurn(ctx: PageChatTurnContext): Promise<Respons
     }
 
     const hasTurnLocation = Boolean(turnLocation?.currentPage || turnLocation?.currentDrive);
-    const locationHomeDriveId = await resolveHomeDriveHint(userId, hasTurnLocation);
+    const locationHomeDriveId = await resolveHomeDriveHint(userId, hasTurnLocation, getAllowedDriveIds(authResult));
 
     const locationPrompt = buildLocationTurnPrompt(turnLocation ? {
       currentPage: turnLocation.currentPage,

--- a/apps/web/src/lib/ai/core/__tests__/home-drive-hint.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/home-drive-hint.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getHomeDriveMock = vi.fn();
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getHomeDrive: (...args: unknown[]) => getHomeDriveMock(...args),
+}));
+
+import { resolveHomeDriveHint } from '../home-drive-hint';
+
+const HOME = { id: 'drv_home' };
+
+describe('resolveHomeDriveHint', () => {
+  beforeEach(() => {
+    getHomeDriveMock.mockReset().mockResolvedValue(HOME);
+  });
+
+  it('returns the Home drive id when the caller is standing nowhere', async () => {
+    expect(await resolveHomeDriveHint('user-1', false)).toBe('drv_home');
+  });
+
+  it('skips the lookup entirely when a location is already in view', async () => {
+    // The hint only renders in the no-location branch, so the common
+    // in-a-drive path must not pay a query.
+    expect(await resolveHomeDriveHint('user-1', true)).toBeUndefined();
+    expect(getHomeDriveMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the user has no Home drive', async () => {
+    getHomeDriveMock.mockResolvedValue(null);
+    expect(await resolveHomeDriveHint('user-1', false)).toBeUndefined();
+  });
+
+  it('treats an empty scope as unscoped (session auth)', async () => {
+    expect(await resolveHomeDriveHint('user-1', false, [])).toBe('drv_home');
+  });
+
+  it('returns the id when the scope includes the Home drive', async () => {
+    expect(await resolveHomeDriveHint('user-1', false, ['drv_other', 'drv_home'])).toBe('drv_home');
+  });
+
+  it('withholds the id from a token scoped away from Home', async () => {
+    // Two harms without this. The id is disclosed to a principal that may not
+    // reach that drive; and because the /plan body sends driveless plans to
+    // Home, the agent would be steered into a create_page that
+    // driveOutsideMcpScope rejects every time.
+    expect(await resolveHomeDriveHint('user-1', false, ['drv_other'])).toBeUndefined();
+  });
+
+  it('degrades to undefined rather than throwing when the lookup fails', async () => {
+    // A convenience hint must never fail a chat request.
+    getHomeDriveMock.mockRejectedValue(new Error('db down'));
+    await expect(resolveHomeDriveHint('user-1', false)).resolves.toBeUndefined();
+  });
+
+  it('degrades to undefined on a synchronous throw', async () => {
+    // try/catch rather than .catch() precisely so this case is covered.
+    getHomeDriveMock.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    await expect(resolveHomeDriveHint('user-1', false)).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/location-prompt.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/location-prompt.test.ts
@@ -96,3 +96,23 @@ describe('buildLocationTurnPrompt — "here" guidance', () => {
     expect(result.toLowerCase()).toContain('"here"');
   });
 });
+
+describe('no-location Home drive hint', () => {
+  it('omits any Home reference when no hint is supplied', () => {
+    const result = buildLocationTurnPrompt(undefined);
+    expect(result).not.toContain('driveId:');
+    expect(result).toContain('Do NOT default to the Home drive');
+  });
+
+  it('labels the Home id as off-limits rather than contradicting the guard', () => {
+    // The guard and the hint must read as ONE rule. "Do NOT assume the Home
+    // drive" sitting next to a bare Home driveId leaves the model to resolve a
+    // contradiction, and resolving it wrongly is the exact bug the guard exists
+    // to prevent.
+    const result = buildLocationTurnPrompt({ homeDriveId: 'drv_home' });
+    expect(result).toContain('drv_home');
+    expect(result).toContain('do NOT write here unless');
+    // The guard itself is scoped, not deleted.
+    expect(result).toContain('Do NOT default to the Home drive for general work');
+  });
+});

--- a/apps/web/src/lib/ai/core/home-drive-hint.ts
+++ b/apps/web/src/lib/ai/core/home-drive-hint.ts
@@ -4,8 +4,8 @@
  * agent standing nowhere otherwise has no way to name Home, which the /plan
  * skill needs as the destination for a personal plan artifact.
  *
- * Shared by both chat routes so the two surfaces can't drift on when the hint
- * appears.
+ * Shared by both chat turn pipelines so the two surfaces can't drift on when the
+ * hint appears.
  *
  * Fail-closed to `undefined`, never throw: this is a convenience hint, and no
  * chat request should fail because a drive lookup did. The try/catch (rather
@@ -29,9 +29,10 @@ export async function resolveHomeDriveHint(
 
     // Ceiling the hint to the caller's drive scope. Empty = session auth =
     // unscoped; non-empty = a scoped MCP/OAuth token that may only reach those
-    // drives. This mirrors what the route already does for the member-drive
+    // drives. This mirrors what page-chat-turn already does for the member-drive
     // context block, which filters the same way for the same reason: it is a
-    // value the ROUTE reads directly, so the tool layer's ceiling never sees it.
+    // value the PROMPT layer reads directly, so the tool layer's ceiling — which
+    // only gates tool calls — never sees it.
     //
     // Two things go wrong without it. The id itself is disclosed to a token
     // that may not reach that drive. And it is actively misleading: the /plan

--- a/apps/web/src/lib/ai/core/home-drive-hint.ts
+++ b/apps/web/src/lib/ai/core/home-drive-hint.ts
@@ -18,13 +18,29 @@ import { getHomeDrive } from '@pagespace/lib/services/drive-service';
 export async function resolveHomeDriveHint(
   userId: string,
   hasLocation: boolean,
+  allowedDriveIds: readonly string[] = [],
 ): Promise<string | undefined> {
   // Only the no-location branch renders it, so the common in-a-drive path pays
   // no query at all.
   if (hasLocation) return undefined;
   try {
     const drive = await getHomeDrive(userId);
-    return drive?.id;
+    if (!drive) return undefined;
+
+    // Ceiling the hint to the caller's drive scope. Empty = session auth =
+    // unscoped; non-empty = a scoped MCP/OAuth token that may only reach those
+    // drives. This mirrors what the route already does for the member-drive
+    // context block, which filters the same way for the same reason: it is a
+    // value the ROUTE reads directly, so the tool layer's ceiling never sees it.
+    //
+    // Two things go wrong without it. The id itself is disclosed to a token
+    // that may not reach that drive. And it is actively misleading: the /plan
+    // body tells the agent to create driveless plans in Home, so the agent
+    // would be steered into a `create_page` call that `driveOutsideMcpScope`
+    // rejects every time.
+    if (allowedDriveIds.length > 0 && !allowedDriveIds.includes(drive.id)) return undefined;
+
+    return drive.id;
   } catch {
     return undefined;
   }

--- a/apps/web/src/lib/ai/core/location-prompt.ts
+++ b/apps/web/src/lib/ai/core/location-prompt.ts
@@ -41,14 +41,21 @@ export interface LocationPromptInput {
 
 export function buildLocationTurnPrompt(input: LocationPromptInput | undefined): string {
   if (!input || (!input.currentPage && !input.currentDrive)) {
+    // The guard and the hint have to be worded as one rule, not two adjacent
+    // ones. "Do NOT assume the Home drive" followed immediately by the Home
+    // driveId reads as a contradiction the model has to resolve on its own —
+    // and resolving it the wrong way is exactly the bug the guard was added to
+    // prevent (agents dumping content into Home instead of the user's
+    // workspace). So the guard is scoped to general work, and the id is
+    // labelled as reference data that is off-limits unless something names it.
     const homeLine = input?.homeDriveId
-      ? `\n• Your Home drive (private to this user) is driveId: ${input.homeDriveId} — use it only when a skill or the user explicitly calls for it`
+      ? `\n• Home drive reference (private to this user), driveId: ${input.homeDriveId} — do NOT write here unless a loaded skill or the user explicitly names Home as the destination`
       : '';
     return `LOCATION (current, this turn):
 • Operating from the dashboard — no specific workspace or page is currently in view
 • Use list_drives to discover available workspaces before suggesting new drive creation
 • When the user says "here" or "this", ask which workspace/page they mean, or use list_drives/list_pages to find out
-• Do NOT assume the Home drive — ask which workspace, or use list_drives${homeLine}`;
+• Do NOT default to the Home drive for general work — ask which workspace, or use list_drives${homeLine}`;
   }
 
   const lines: string[] = ['LOCATION (current, this turn):'];

--- a/apps/web/src/lib/ai/core/plan-binding.ts
+++ b/apps/web/src/lib/ai/core/plan-binding.ts
@@ -15,6 +15,23 @@
  * construction — and a re-read of the page is exact where a summary only
  * approximates.
  *
+ * Precisely: the section changes on `set_plan`/`clear_plan`, on a RENAME of the
+ * bound page (the title is rendered, so a rename costs one prefix invalidation
+ * too), and on a permission or trash change that flips the visibility check.
+ * None of those track navigation, which is the property that makes the stable
+ * half correct — but "only on set_plan/clear_plan" would be an understatement of
+ * the invalidation budget. The title is rendered deliberately: a bare pageId
+ * gives the model nothing to reason about when deciding whether to re-read.
+ *
+ * SURFACE COVERAGE: this section is rendered by the page-chat and Global
+ * Assistant routes only. `set_plan` ships in the shared `pageSpaceTools` set, so
+ * it is callable on `/api/v1/chat/completions`, the page-agents messages route
+ * and workflow runs, where the binding persists and shows up in the UI and on
+ * later chat turns but is NOT echoed back into that surface's own prompt. That
+ * mirrors how `load_skill` is deliberately callable-but-unadvertised on the same
+ * surfaces (docs/specs/agent-skills.md, "Surfaces"); wiring them is additive
+ * follow-up, not a correctness fix.
+ *
  * Fail-open throughout: a broken lookup must degrade to "no plan section",
  * never fail the turn.
  */
@@ -62,6 +79,14 @@ export interface ActivePlan {
  * drive, whereas a plan binding can point at a page in a completely different
  * drive. Without a principal-aware check, a token scoped to drive A would see
  * the title and id of a plan the user bound in drive B.
+ *
+ * KNOWN ASYMMETRY: `set_plan` authorizes with `canActorViewPage`, which also
+ * considers the acting page-agent, while this render-time check considers the
+ * principal only. So an agent that binds a plan and is LATER removed from that
+ * page's drive keeps seeing the title here (the owner can still view it) and
+ * then fails when it follows the instruction to re-read. Closing that needs one
+ * actor abstraction shared by the prompt and tool layers — the prompt layer has
+ * no ToolExecutionContext today — which is a refactor beyond this feature.
  */
 export async function getActivePlan(
   conversationId: string | undefined,

--- a/apps/web/src/lib/ai/core/plan-binding.ts
+++ b/apps/web/src/lib/ai/core/plan-binding.ts
@@ -59,6 +59,20 @@ export interface ActivePlan {
 }
 
 /**
+ * NOTE FOR EDITORS: the suppression rules below (unbound → trashed → not
+ * visible) are mirrored by `loadPlan` in
+ * `app/api/ai/conversations/[conversationId]/plan/route.ts`, which the PlanChip
+ * reads. Change one and change the other, or the chip and the prompt will
+ * disagree about whether a plan is still live.
+ *
+ * They are deliberately NOT one function: the route additionally enforces
+ * conversation ownership with 404-not-403 semantics and returns `driveId` for
+ * the chip's link, while this one takes an injected principal check. Folding
+ * both into a single helper would add more branching than the ~15 duplicated
+ * lines cost.
+ */
+
+/**
  * Resolve the plan bound to `conversationId`, or null when unbound, trashed,
  * not visible to the caller, or on any error.
  *

--- a/apps/web/src/lib/ai/core/plan-binding.ts
+++ b/apps/web/src/lib/ai/core/plan-binding.ts
@@ -24,7 +24,8 @@
  * gives the model nothing to reason about when deciding whether to re-read.
  *
  * SURFACE COVERAGE: this section is rendered by the page-chat and Global
- * Assistant routes only. `set_plan` ships in the shared `pageSpaceTools` set, so
+ * Assistant turn pipelines only (`lib/ai/chat-pipeline/{page,global}-chat-turn`).
+ * `set_plan` ships in the shared `pageSpaceTools` set, so
  * it is callable on `/api/v1/chat/completions`, the page-agents messages route
  * and workflow runs, where the binding persists and shows up in the UI and on
  * later chat turns but is NOT echoed back into that surface's own prompt. That
@@ -57,20 +58,6 @@ export interface ActivePlan {
   /** The plan page's drive — unused by the prompt, needed by the chip's link. */
   driveId: string;
 }
-
-/**
- * NOTE FOR EDITORS: the suppression rules below (unbound → trashed → not
- * visible) are mirrored by `loadPlan` in
- * `app/api/ai/conversations/[conversationId]/plan/route.ts`, which the PlanChip
- * reads. Change one and change the other, or the chip and the prompt will
- * disagree about whether a plan is still live.
- *
- * They are deliberately NOT one function: the route additionally enforces
- * conversation ownership with 404-not-403 semantics and returns `driveId` for
- * the chip's link, while this one takes an injected principal check. Folding
- * both into a single helper would add more branching than the ~15 duplicated
- * lines cost.
- */
 
 /**
  * Resolve the plan bound to `conversationId`, or null when unbound, trashed,

--- a/apps/web/src/lib/ai/skills/__tests__/starter-skill-tool-references.test.ts
+++ b/apps/web/src/lib/ai/skills/__tests__/starter-skill-tool-references.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Guards that starter skill bodies only name tools that actually exist.
+ *
+ * A skill body is instructions the model follows literally, so a stale tool name
+ * is worse than a typo: the agent confidently calls something that isn't there
+ * and has to recover mid-task. Nothing else catches this — the bodies live in
+ * packages/lib, which cannot import the apps/web tool registry, so the
+ * cross-check has to happen here.
+ *
+ * This is the guard that will fire when a tool is renamed, which is exactly when
+ * a body silently goes wrong.
+ */
+import { describe, it, expect } from 'vitest';
+import { STARTER_SKILLS } from '@pagespace/lib/commands/starter-skills';
+import { WORKSPACE_TOOL_NAMES } from '@/lib/ai/core/ai-tools';
+
+/**
+ * Backticked lowercase_snake identifiers in a body. Tool names are always
+ * written in backticks in these bodies (house style), so this is where a stale
+ * name would hide.
+ */
+function backtickedIdentifiers(body: string): string[] {
+  return [...new Set(body.match(/`[a-z][a-z0-9_]*`/g) ?? [])].map((m) => m.slice(1, -1));
+}
+
+/**
+ * Identifiers that look like tool names but deliberately are not tools.
+ * `search` is referenced ONLY to tell the agent it does not exist — the body
+ * says so explicitly, because models reach for it by habit.
+ */
+const NOT_TOOLS = new Set([
+  'search',
+  // Tool PARAMETERS and response fields, not tools.
+  'content', 'recursive', 'pageid', 'pageId', 'linestart', 'lineStart',
+  'contentclipped', 'contentClipped', 'contentclippedafterline', 'contentClippedAfterLine',
+  'driveid', 'driveId', 'tool_name',
+]);
+
+const KNOWN_TOOLS = new Set([...WORKSPACE_TOOL_NAMES, 'load_skill']);
+
+describe('starter skill bodies reference only real tools', () => {
+  it.each(STARTER_SKILLS.map((s) => [s.trigger, s.body] as const))(
+    '%s names no tool that does not exist',
+    (_trigger, body) => {
+      const unknown = backtickedIdentifiers(body).filter(
+        (id) => !KNOWN_TOOLS.has(id) && !NOT_TOOLS.has(id),
+      );
+      expect(unknown, `unrecognised identifiers in body: ${unknown.join(', ')}`).toEqual([]);
+    },
+  );
+
+  it('the plan body still steers the agent away from the non-existent `search`', () => {
+    // Deliberate: models reach for a generic `search` tool. If this line is ever
+    // dropped, the body loses the correction that stops that.
+    const plan = STARTER_SKILLS.find((s) => s.trigger === 'plan')!;
+    expect(plan.body).toMatch(/no tool called .?search/i);
+    for (const real of ['regex_search', 'glob_search', 'multi_drive_search']) {
+      expect(plan.body).toContain(real);
+    }
+  });
+
+  it('the plan body does not promise a full subtree without naming `recursive`', () => {
+    // list_pages returns DIRECT CHILDREN by default. An earlier draft claimed it
+    // pulled "a whole subtree in ONE call", which would have had the agent plan
+    // against a silently partial picture.
+    const plan = STARTER_SKILLS.find((s) => s.trigger === 'plan')!;
+    if (/subtree/i.test(plan.body)) {
+      expect(plan.body).toContain('recursive');
+    }
+  });
+});

--- a/apps/web/src/lib/ai/skills/__tests__/starter-skill-tool-references.test.ts
+++ b/apps/web/src/lib/ai/skills/__tests__/starter-skill-tool-references.test.ts
@@ -18,23 +18,27 @@ import { WORKSPACE_TOOL_NAMES } from '@/lib/ai/core/ai-tools';
  * Backticked lowercase_snake identifiers in a body. Tool names are always
  * written in backticks in these bodies (house style), so this is where a stale
  * name would hide.
+ *
+ * Deliberately lowercase-only: every PageSpace tool is snake_case, so this
+ * matches the whole tool namespace while ignoring the camelCase parameter and
+ * response-field names bodies also backtick (`pageId`, `lineStart`,
+ * `contentClipped`). Those need no allowlist because the pattern never sees
+ * them — a camelCase tool name would slip through, but none exists and adding
+ * one would break the repo's own naming convention first.
  */
 function backtickedIdentifiers(body: string): string[] {
   return [...new Set(body.match(/`[a-z][a-z0-9_]*`/g) ?? [])].map((m) => m.slice(1, -1));
 }
 
 /**
- * Identifiers that look like tool names but deliberately are not tools.
- * `search` is referenced ONLY to tell the agent it does not exist — the body
- * says so explicitly, because models reach for it by habit.
+ * Lowercase identifiers that look like tool names but deliberately are not.
+ *
+ * `search` is the load-bearing entry: the body references it ONLY to tell the
+ * agent it does not exist, because models reach for a generic search tool by
+ * habit. The rest are snake_case parameter names a body may legitimately
+ * backtick.
  */
-const NOT_TOOLS = new Set([
-  'search',
-  // Tool PARAMETERS and response fields, not tools.
-  'content', 'recursive', 'pageid', 'pageId', 'linestart', 'lineStart',
-  'contentclipped', 'contentClipped', 'contentclippedafterline', 'contentClippedAfterLine',
-  'driveid', 'driveId', 'tool_name',
-]);
+const NOT_TOOLS = new Set(['search', 'content', 'recursive', 'tool_name']);
 
 const KNOWN_TOOLS = new Set([...WORKSPACE_TOOL_NAMES, 'load_skill']);
 

--- a/apps/web/src/lib/ai/tools/plan-tools.ts
+++ b/apps/web/src/lib/ai/tools/plan-tools.ts
@@ -34,14 +34,26 @@ const planLogger = loggers.ai.child({ module: 'plan-tools' });
  * synthesize an ephemeral id (`workflow-<id>-<ts>`, see workflow-executor) that
  * has no row, so the UPDATE would silently match nothing — say so instead of
  * reporting a success that didn't happen.
+ *
+ * Writability mirrors the chat route's own gate (owner OR `isShared`, see the
+ * `ownsIt || isSharedConversation` check in api/ai/chat/route.ts). Requiring
+ * strict ownership here would mean a collaborator the route explicitly lets
+ * post to a shared conversation could run /plan, watch the agent write the plan
+ * page, and then be told the binding failed — leaving exactly the
+ * lost-after-compaction hole this feature exists to close.
  */
-async function loadOwnedConversation(conversationId: string, userId: string) {
+async function loadWritableConversation(conversationId: string, userId: string) {
   const [row] = await db
-    .select({ id: conversations.id, userId: conversations.userId })
+    .select({
+      id: conversations.id,
+      userId: conversations.userId,
+      isShared: conversations.isShared,
+    })
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .limit(1);
-  return row && row.userId === userId ? row : null;
+  if (!row) return null;
+  return row.userId === userId || row.isShared === true ? row : null;
 }
 
 export const planTools = {
@@ -93,7 +105,7 @@ export const planTools = {
           };
         }
 
-        const conversation = await loadOwnedConversation(conversationId, userId);
+        const conversation = await loadWritableConversation(conversationId, userId);
         if (!conversation) {
           return {
             success: false,
@@ -137,7 +149,7 @@ export const planTools = {
       if (!conversationId) return { success: false, error: 'This context has no conversation.' };
 
       try {
-        const conversation = await loadOwnedConversation(conversationId, userId);
+        const conversation = await loadWritableConversation(conversationId, userId);
         if (!conversation) return { success: false, error: 'This conversation cannot hold a plan binding.' };
 
         // Same single writer as `set_plan` — the clear is just as much a

--- a/apps/web/src/lib/ai/tools/plan-tools.ts
+++ b/apps/web/src/lib/ai/tools/plan-tools.ts
@@ -35,12 +35,25 @@ const planLogger = loggers.ai.child({ module: 'plan-tools' });
  * has no row, so the UPDATE would silently match nothing — say so instead of
  * reporting a success that didn't happen.
  *
- * Writability mirrors the chat route's own gate (owner OR `isShared`, see the
- * `ownsIt || isSharedConversation` check in api/ai/chat/route.ts). Requiring
- * strict ownership here would mean a collaborator the route explicitly lets
- * post to a shared conversation could run /plan, watch the agent write the plan
- * page, and then be told the binding failed — leaving exactly the
- * lost-after-compaction hole this feature exists to close.
+ * Writability mirrors the turn's own gate (owner OR `isShared`, then an explicit
+ * history-delete refusal) — see `authorizePageConversation` in
+ * `lib/ai/core/authorize-page-conversation.ts`. Requiring strict ownership here
+ * would mean a collaborator the pipeline explicitly lets post to a shared
+ * conversation could run /plan, watch the agent write the plan page, and then be
+ * told the binding failed — leaving exactly the lost-after-compaction hole this
+ * feature exists to close.
+ *
+ * Mirrored rather than called: `authorizePageConversation` also demands the
+ * conversation belong to a specific `pageId`, which a global conversation never
+ * does and which this tool has no id for. `isActive === false` (never
+ * `!isActive`) matches that module's rule for the same reason it gives — a row
+ * that simply does not carry the column must read as live, not as deleted.
+ *
+ * The two page/global pipelines already refuse a history-deleted conversation
+ * before any tool runs, so this arm is unreachable from them. It is not dead
+ * code: `set_plan` ships in `pageSpaceTools`, so it is also reachable from
+ * `/api/v1/chat/completions`, the page-agents routes and workflow runs, which do
+ * not all share that pre-check.
  */
 async function loadWritableConversation(conversationId: string, userId: string) {
   const [row] = await db
@@ -48,12 +61,15 @@ async function loadWritableConversation(conversationId: string, userId: string) 
       id: conversations.id,
       userId: conversations.userId,
       isShared: conversations.isShared,
+      isActive: conversations.isActive,
     })
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .limit(1);
   if (!row) return null;
-  return row.userId === userId || row.isShared === true ? row : null;
+  if (row.userId !== userId && row.isShared !== true) return null;
+  if (row.isActive === false) return null;
+  return row;
 }
 
 export const planTools = {

--- a/docs/specs/agent-skills.md
+++ b/docs/specs/agent-skills.md
@@ -175,14 +175,15 @@ same trade Agent Memory makes.
 
 `set_plan`/`clear_plan` are deliberately **not** in `WRITE_TOOLS` — they mutate
 conversation metadata, not user content, and binding an existing plan doc is a
-legitimate read-only-mode action. Writability follows the chat route's own gate
-(owner **or** `isShared`), so a collaborator the route lets post to a shared
-conversation can bind a plan there.
+legitimate read-only-mode action. Writability mirrors the turn's own gate —
+owner **or** `isShared`, then an explicit history-delete refusal, as in
+`authorizePageConversation` — so a collaborator the pipeline lets post to a
+shared conversation can bind a plan there.
 
 Known limits, recorded so they aren't rediscovered as bugs:
 
-- **Surface coverage.** The `ACTIVE PLAN:` section renders on the page-chat and
-  Global Assistant routes only. `set_plan` ships in the shared `pageSpaceTools`
+- **Surface coverage.** The `ACTIVE PLAN:` section renders in the page-chat and
+  Global Assistant turn pipelines only. `set_plan` ships in the shared `pageSpaceTools`
   set, so on `/api/v1/chat/completions`, the page-agents messages route and
   workflow runs the binding persists (and reaches the UI and later chat turns)
   but is not echoed into that surface's own prompt — the same

--- a/docs/specs/agent-skills.md
+++ b/docs/specs/agent-skills.md
@@ -175,7 +175,26 @@ same trade Agent Memory makes.
 
 `set_plan`/`clear_plan` are deliberately **not** in `WRITE_TOOLS` — they mutate
 conversation metadata, not user content, and binding an existing plan doc is a
-legitimate read-only-mode action.
+legitimate read-only-mode action. Writability follows the chat route's own gate
+(owner **or** `isShared`), so a collaborator the route lets post to a shared
+conversation can bind a plan there.
+
+Known limits, recorded so they aren't rediscovered as bugs:
+
+- **Surface coverage.** The `ACTIVE PLAN:` section renders on the page-chat and
+  Global Assistant routes only. `set_plan` ships in the shared `pageSpaceTools`
+  set, so on `/api/v1/chat/completions`, the page-agents messages route and
+  workflow runs the binding persists (and reaches the UI and later chat turns)
+  but is not echoed into that surface's own prompt — the same
+  callable-but-unadvertised position `load_skill` already occupies.
+- **Actor vs principal.** `set_plan` authorizes with `canActorViewPage`
+  (agent-aware); the render-time re-check uses `canPrincipalViewPage`, which does
+  not consider the acting page-agent. An agent removed from a drive after binding
+  keeps seeing the title. Closing this needs one actor abstraction shared by the
+  prompt and tool layers.
+- **Invalidation budget.** The section changes on `set_plan`/`clear_plan`, on a
+  rename of the bound page, and on a visibility change — never on navigation,
+  which is the property the cache-stable placement actually rests on.
 
 ## Surfaces
 

--- a/packages/lib/src/commands/starter-bodies/plan.ts
+++ b/packages/lib/src/commands/starter-bodies/plan.ts
@@ -15,7 +15,7 @@ Turn a vague or multi-step request into a written plan the user can review, edit
 A plan written from assumptions is worse than no plan, because it looks authoritative. Read first:
 
 - \`read_page\` for a specific page you already have an id for.
-- \`list_pages\` with \`include: 'content'\` to pull a whole subtree in ONE call — prefer this over a series of \`read_page\` calls when you are orienting.
+- \`list_pages\` with \`include: 'content'\` batches page content into one call instead of a \`read_page\` per page — much better when you are orienting. Two things to know: it returns **direct children only** unless you pass \`recursive: true\`, and it is capped (50 pages per call, each page's content clipped at ~8,000 chars). A clipped page comes back with \`contentClipped: true\`; if you need the rest, \`read_page\` it with \`lineStart\` set to \`contentClippedAfterLine + 1\`. Don't assume a full subtree came back just because the call succeeded.
 - \`regex_search\` (content or title), \`glob_search\` (page names/types), \`multi_drive_search\` (across workspaces). There is no tool called \`search\` — use one of these.
 
 Stop gathering when you could defend each step you are about to propose. If a genuine fork remains — two reasonable approaches with different consequences — put it in the plan's open questions rather than silently picking one.

--- a/packages/lib/src/commands/starter-skill-installer.ts
+++ b/packages/lib/src/commands/starter-skill-installer.ts
@@ -9,6 +9,21 @@
  * run, and the backfill script must be safely re-runnable after a partial
  * failure. Only the stamp gives both.
  *
+ * KNOWN LIMITATION — read before adding a second starter skill. The stamp is a
+ * ONE-SHOT marker, not a high-water mark: it records "the initial install ran",
+ * and is only ever tested for null-ness. So appending to `STARTER_SKILLS` after
+ * launch reaches NEW users only — every already-stamped user is skipped here,
+ * and `scripts/backfill-starter-skills.ts` cannot even see them, because its
+ * query filters on `starterSkillsInstalledAt IS NULL`.
+ *
+ * This is latent today (there is exactly one starter) but it directly blocks the
+ * planned `orchestrate`/`research`/`execute`/`brainstorm` follow-ups. Fixing it
+ * needs PER-TRIGGER provenance, which a single timestamp cannot express: to add
+ * a starter without resurrecting one the user deleted, you must know which
+ * triggers were ever installed for that user, not merely that some install
+ * happened. That is a schema change (an installed-starters ledger), and it
+ * belongs to whichever PR adds the second starter — not to this one.
+ *
  * SERVER-ONLY — see the note in starter-skills.ts.
  */
 
@@ -87,18 +102,25 @@ async function resolveSkillsFolder(client: DbClient, homeDriveId: string): Promi
  * Safe to call inside an existing transaction (pass the tx as `client`) — the
  * provisioning path does exactly that so a half-installed Home is impossible.
  *
- * Serialization is OWNED BY THIS FUNCTION, not by callers. Provisioning happens
- * to hold a `FOR UPDATE` on the user row already, but the backfill script does
- * not — and without a lock two concurrent runs can both read a NULL stamp,
- * both pass the "already installed?" gate, and both create a Skills folder and
- * a page. Re-locking a row this transaction already holds is a no-op in
- * Postgres, so taking it here is free for the provisioning path and correct for
- * every other caller.
+ * `client` MUST be a transaction, and is deliberately required rather than
+ * defaulted to `db`. The `FOR UPDATE` below only serializes anything while a
+ * transaction is open — on a bare connection each statement autocommits and
+ * releases the lock immediately, so a default of `db` would have silently
+ * offered neither the serialization nor the all-or-nothing install this function
+ * documents. Both callers already pass one (provisioning passes its own tx; the
+ * backfill wraps each user in `db.transaction`).
+ *
+ * Given that, serialization is owned here rather than by callers: provisioning
+ * happens to hold a `FOR UPDATE` on the user row already, but the backfill does
+ * not, and without a lock two concurrent runs can both read a NULL stamp, both
+ * pass the "already installed?" gate, and both create a Skills folder. Re-locking
+ * a row the transaction already holds is a no-op in Postgres, so taking it here
+ * costs provisioning nothing.
  */
 export async function installStarterSkills(
   userId: string,
   homeDriveId: string,
-  client: DbClient = db,
+  client: DbClient,
 ): Promise<InstallStarterSkillsResult> {
   if (STARTER_SKILLS.length === 0) return emptyResult(false);
 

--- a/packages/lib/src/commands/starter-skill-installer.ts
+++ b/packages/lib/src/commands/starter-skill-installer.ts
@@ -39,9 +39,15 @@ import {
   STARTER_SKILL_TRIGGERS,
 } from './starter-skills';
 
-type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];
-type DatabaseType = typeof db;
-export type DbClient = TransactionType | DatabaseType;
+/**
+ * An OPEN transaction. Deliberately not `TransactionType | typeof db`: the
+ * `SELECT … FOR UPDATE` in `installStarterSkills` only serializes anything while
+ * a transaction is held, and the page/command/stamp writes are only atomic
+ * inside one. Admitting the bare connection would let a caller compile fine and
+ * silently get neither — so the requirement the docblock states is enforced by
+ * the type rather than left to a comment.
+ */
+export type DbClient = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 export interface InstallStarterSkillsResult {
   /** Triggers newly installed by this call. */

--- a/scripts/__tests__/backfill-starter-skills.test.ts
+++ b/scripts/__tests__/backfill-starter-skills.test.ts
@@ -25,12 +25,16 @@ vi.mock('@pagespace/db/schema/auth', () => ({
 vi.mock('@pagespace/db/schema/core', () => ({
   drives: { id: 'id', ownerId: 'ownerId', kind: 'kind' },
 }));
+vi.mock('@pagespace/db/schema/commands', () => ({
+  commands: { userId: 'userId', trigger: 'trigger' },
+}));
 vi.mock('@pagespace/db/operators', () => ({
   and: (...a: unknown[]) => ({ and: a }),
   eq: (...a: unknown[]) => ({ eq: a }),
   isNull: (...a: unknown[]) => ({ isNull: a }),
   asc: (...a: unknown[]) => ({ asc: a }),
   gt: (...a: unknown[]) => ({ gt: a }),
+  inArray: (...a: unknown[]) => ({ inArray: a }),
   count: () => ({ count: true }),
 }));
 vi.mock('@pagespace/lib/commands/starter-skill-installer', () => ({ installStarterSkills }));
@@ -45,6 +49,12 @@ let batches: Row[][];
 let remainingCount: number;
 /** Every `gt(users.id, cursor)` the walk issued — the pagination evidence. */
 let cursors: unknown[];
+/**
+ * Commands the scanned users ALREADY own, as the dry run's per-batch collision
+ * probe would find them. Live runs never issue that query — `installStarterSkills`
+ * reports its own skips — so this stays empty for them.
+ */
+let existingCommands: Array<{ userId: string | null; trigger: string }>;
 
 const dbStub = {
   select: vi.fn((projection?: Record<string, unknown>) => {
@@ -53,6 +63,14 @@ const dbStub = {
       const stub: Record<string, unknown> = {};
       stub.from = () => stub;
       stub.where = () => Promise.resolve([{ total: remainingCount }]);
+      return stub;
+    }
+    // The dry run's collision probe: `select({ userId, trigger })` over
+    // `commands`, terminating at `.where()` with no cursor and no limit.
+    if (projection && 'trigger' in projection) {
+      const stub: Record<string, unknown> = {};
+      stub.from = () => stub;
+      stub.where = () => Promise.resolve(existingCommands);
       return stub;
     }
     const stub: Record<string, unknown> = {};
@@ -80,6 +98,7 @@ beforeEach(() => {
   batches = [];
   remainingCount = 0;
   cursors = [];
+  existingCommands = [];
   installStarterSkills.mockResolvedValue(ok());
 });
 
@@ -101,6 +120,39 @@ describe('runBackfill — dry run', () => {
     remainingCount = 999;
 
     expect((await runBackfill({ dryRun: true })).unstampedRemaining).toBe(0);
+  });
+
+  // The whole point of a dry run is to size the rollout. Counting every trigger
+  // as an install ignores the ones the real run will skip because the user
+  // already owns that trigger — so the operator is told "6 installs" and gets 5,
+  // which reads as a partial failure of the real run rather than as the dry run
+  // having been wrong.
+  it('predicts the real run: a trigger the user already owns counts as skipped, not installed', async () => {
+    batches = [[{ userId: 'u1', driveId: 'd1' }], []];
+    existingCommands = [{ userId: 'u1', trigger: '/task' }];
+
+    const summary = await runBackfill({ dryRun: true });
+
+    expect(summary).toMatchObject({ scanned: 1, installed: 1, skippedCollision: 1 });
+    expect(dbStub.transaction).not.toHaveBeenCalled();
+  });
+
+  // A command row with a null userId is a drive-scoped command, not a personal
+  // one. It cannot collide with a personal starter trigger, so folding it into
+  // the collision set would under-predict the installs.
+  it('ignores a driveless command row when predicting collisions', async () => {
+    batches = [[{ userId: 'u1', driveId: 'd1' }], []];
+    existingCommands = [{ userId: null, trigger: '/task' }];
+
+    expect(await runBackfill({ dryRun: true })).toMatchObject({ installed: 2, skippedCollision: 0 });
+  });
+
+  it('does not probe for collisions on a live run — the installer reports its own skips', async () => {
+    batches = [[{ userId: 'u1', driveId: 'd1' }], []];
+
+    await runBackfill();
+
+    expect(dbStub.select.mock.calls.some(([p]) => p && 'trigger' in p)).toBe(false);
   });
 });
 

--- a/scripts/backfill-starter-skills.ts
+++ b/scripts/backfill-starter-skills.ts
@@ -2,7 +2,8 @@ import 'dotenv/config';
 import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { drives } from '@pagespace/db/schema/core';
-import { and, eq, isNull, asc, gt, count } from '@pagespace/db/operators';
+import { commands } from '@pagespace/db/schema/commands';
+import { and, eq, isNull, asc, gt, count, inArray } from '@pagespace/db/operators';
 import { installStarterSkills } from '@pagespace/lib/commands/starter-skill-installer';
 import { STARTER_SKILL_TRIGGERS } from '@pagespace/lib/commands/starter-skills';
 
@@ -71,10 +72,38 @@ export async function runBackfill({ dryRun = false }: { dryRun?: boolean } = {})
     if (batch.length === 0) break;
     cursor = batch[batch.length - 1].userId;
 
+    // A dry run has to account for triggers users ALREADY own, or it reports a
+    // number the real run will not match — an operator sizing the rollout would
+    // be told 6 installs and get 5. One query per batch, dry-run only.
+    const takenByUser = new Map<string, Set<string>>();
+    if (dryRun) {
+      const existing = await db
+        .select({ userId: commands.userId, trigger: commands.trigger })
+        .from(commands)
+        .where(
+          and(
+            inArray(commands.userId, batch.map((r) => r.userId)),
+            inArray(commands.trigger, [...STARTER_SKILL_TRIGGERS]),
+          ),
+        );
+      for (const row of existing) {
+        if (!row.userId) continue;
+        const set = takenByUser.get(row.userId) ?? new Set<string>();
+        set.add(row.trigger);
+        takenByUser.set(row.userId, set);
+      }
+    }
+
     for (const row of batch) {
       summary.scanned++;
       if (dryRun) {
-        summary.installed += STARTER_SKILL_TRIGGERS.length;
+        const taken = takenByUser.get(row.userId);
+        const wouldSkip = STARTER_SKILL_TRIGGERS.filter((t) => taken?.has(t));
+        summary.installed += STARTER_SKILL_TRIGGERS.length - wouldSkip.length;
+        summary.skippedCollision += wouldSkip.length;
+        if (wouldSkip.length > 0) {
+          console.log(`  user ${row.userId}: would keep existing command(s) ${wouldSkip.join(', ')}`);
+        }
         continue;
       }
 


### PR DESCRIPTION
## Why this exists

**PR #2359 merged at `d9b4e26f1`, but review work continued after that commit.** Two pushes — `b831da7a` and `3fc99d8` — landed on the branch after the merge point and were therefore not included. They contain confirmed correctness fixes, so the issues below are currently live in `master`.

This PR is those two commits, cherry-picked onto the post-merge `master`. Clean pick, no conflicts.

They came from a multi-agent adversarial review over the #2359 diff (33 agents: one finder per correctness angle, an independent verifier per finding location). It found six confirmed issues nobody had flagged — including one introduced *while fixing* the CodeRabbit round.

## What's broken in master right now

### `set_plan` fails for collaborators on a shared conversation

`/api/ai/chat` explicitly authorizes non-owners to post to a shared conversation (`ownsIt || isSharedConversation`, route.ts:637-652), but the plan tools required strict ownership. A collaborator running `/plan` watches the agent write the plan page, then gets told the binding failed — leaving exactly the lost-after-compaction hole the feature exists to close. Writability now mirrors the route's own gate.

### PlanChip revalidation is dead code on the Global Assistant

`set_plan` is not in `CORE_TOOL_NAMES`, and the Global Assistant route always splits its toolset, so the agent can only reach it as `execute_tool({tool_name: 'set_plan'})` — producing a `tool-execute_tool` part that the top-level name match never sees. The revalidation shipped in #2359 therefore does nothing on the one surface where the chip is most visible. The detector now unwraps `execute_tool`.

### `resolveHomeDriveHint` leaks past MCP drive scope

The same leak fixed for the plan section in #2359, in the file next door — I missed it in the first pass. A drive-scoped MCP/OAuth token is handed a Home `driveId` it may not reach; and because the `/plan` body sends driveless plans to Home, the agent is then steered into a `create_page` that `driveOutsideMcpScope` rejects every time. Both chat routes now pass their scope ceiling.

### Two installer docblocks were false, not merely unclear

- `starterSkillsInstalledAt` is a **one-shot marker**, not the "high-water mark" it claimed. Appending to `STARTER_SKILLS` after launch reaches new signups only; the backfill cannot even see stamped users because it filters on `starterSkillsInstalledAt IS NULL`. **This silently blocks the `orchestrate`/`research`/`execute`/`brainstorm` follow-ups #2359 promises**, so the limitation and its fix (per-trigger provenance — a schema change) are now spelled out in the docblock and on the epic.
- The `SELECT … FOR UPDATE` said to make serialization "owned by this function" was a **no-op under the default `client = db`** — each statement autocommits and releases the lock. The default is removed so a transaction is required; both real callers already pass one.

### Self-contradictory prompt

"Do NOT assume the Home drive" sat immediately above a line handing the model the Home `driveId`. Resolving that ambiguity the wrong way *is* the bug class the guard was added to prevent. The guard is now scoped to general work and the id labelled off-limits unless explicitly named.

## Refuted — verified, deliberately no change

The claim that removing the `isTaskLinked` branch drops task-linked guidance. Neither producer on the AI location path (`resolvePageContext`, `pageContextToLocationContext`) has ever set that flag; the page-tree APIs that populate it are a different code path. The branch was genuinely dead.

## Documented rather than fixed

Three findings were really "the comment overclaims", so `3fc99d8` makes the claims true instead of leaving a wrong mental model for the next reader:

- The `ACTIVE PLAN` section changes on `set_plan`/`clear_plan`, **on a rename** of the bound page, and on a visibility change. The property that justifies the cache-stable placement is narrower than originally written: none of those track *navigation*.
- The section renders on two routes while `set_plan` ships in the shared tool set, so on three others the binding persists but isn't echoed into that surface's prompt — the same callable-but-unadvertised position `load_skill` already occupies.
- Bind time uses `canActorViewPage` (agent-aware), render time uses `canPrincipalViewPage`. Closing it needs one actor abstraction shared by the prompt and tool layers; recorded with what that would take.

## Found after opening this PR

The three commits above carry the original stranded fixes. Continued verification then found four more issues, none of which any reviewer had flagged:

- **The `/plan` skill body made two false claims about `list_pages`.** It said the call pulls "a whole subtree in ONE call" — it returns **direct children** unless `recursive: true` — and omitted the caps (50 pages, ~8,000 chars per page, `contentClipped: true`). A skill body is instructions the model follows literally, so an agent would have planned against a silently partial picture of the workspace. Fixed, plus a cross-package guard asserting every backticked identifier in every starter body is a real registered tool. Mutation-tested: renaming `read_page` → `read_page_v2` fails it.
- **The backfill dry run lied to operators.** On a seeded population where one user already owned `/plan`, it reported *6 installs* while the real run installed **5**. An operator uses the dry run to size a rollout, so a number the real run will not match is the one output it must not produce. It now predicts exactly — both report 6 scanned / 5 installed / 1 skipped, naming the same colliding user.
- **The two plan readers had no back-reference.** `loadPlan` pointed at `getActivePlan` but not the reverse, so editing the suppression rules on the prompt side gave no signal that the chip's reader mirrors them. Deliberately *not* deduplicated — they differ in ownership semantics (404-not-403) and output shape, so a shared helper would add more branching than the ~15 duplicated lines cost.
- **Six of ten allowlist entries in the new guard were dead**, implying a check that wasn't happening. The pattern is lowercase-only by design; camelCase names are never inspected.

## Verification

Cherry-picked onto post-merge `master` and re-verified from scratch there — not carried over from the #2359 run.

Monorepo typecheck, build and lint clean.

| Suite | Result |
|---|---|
| `@pagespace/lib` | 8,748 passed |
| `web` | 16,184 passed |
| `admin` | 178 passed |

Run against a freshly migrated database. New tests: 8 for `resolveHomeDriveHint` (including the scope-ceiling case), 4 more for `PlanChip` (`execute_tool` unwrapping plus no-double-fetch), 2 for the reworded location guard, 3 for starter-skill tool references.

### Every piece of novel SQL has now executed against a real database

The unit tests drive fakes, so none of the actual SQL had ever run. All of it now has, against a freshly migrated Postgres:

| Area | Result |
|---|---|
| Starter-skill installer | **22/22** — fresh install, re-run no-op, deleted-starter-not-resurrected, collision skip with no orphan page, folder reuse |
| Plan binding | **13/13** — the `conversations ⋈ pages` join, denied-principal suppression, trash/untrash, and `ON DELETE SET NULL` (declared in #2359, never verified until now) |
| Backfill script | end-to-end on a seeded population, which is how the dry-run bug surfaced |

**Guards mutation-tested rather than assumed.** Moving the `FOR UPDATE` below the stamp read fails the ordering test; a two-pool race with the lock removed creates **2 Skills folders** instead of 1 — so CodeRabbit's predicted duplication is real and the lock actually prevents it. Note the command row and page stayed singular even unlocked (the `taken` read plus the unique constraint caught those), so the folder was the *only* thing that duplicated, exactly as that review comment described.

An earlier concurrency attempt reported success and **still passed with the lock deleted** — `getMigrationPool()` is `max: 1`, so the pool serialized both transactions and the race was impossible. Worth flagging as a trap for anyone writing concurrency tests against that helper.

No migration in this PR — schema is unchanged from #2359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KebqPHDM6zHpKV7VPt2Fa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI Home-drive guidance to respect permitted access and avoid unintended defaults.
  * Plan updates now work correctly in shared conversations while protecting private and inactive conversations.
  * Nested plan-tool actions are now recognized reliably in completion tracking.

* **Documentation**
  * Clarified page-listing limits, recursive traversal, and retrieving clipped content.
  * Expanded guidance for plan visibility, authorization, and cache updates.

* **Reliability**
  * Starter skill installation now preserves existing commands during backfills and uses safer transactional handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Rebased onto the chat-pipeline refactor (2026-08-08)

Master moved 202 commits under this branch, including the epic that lifted both
chat route bodies into `lib/ai/chat-pipeline/{page,global}-chat-turn.ts` and
unified the two plan readers into `resolveBoundPlan`.

Six of the seven commits rebased textually clean; only the first conflicted (both
route files). But "applies cleanly" is not "still true" — three of this PR's own
claims had gone stale, which is the exact defect class this PR exists to fix:

- **Re-seated the MCP scope ceiling.** `resolveHomeDriveHint`'s `allowedDriveIds`
  argument was applied at two route call sites that are now thin wrappers. Both
  calls moved with the bodies, so the ceiling is now passed in the pipelines.
- **Fixed a cross-reference that no longer resolved.** The writability docblock
  pointed at an `ownsIt || isSharedConversation` check "in api/ai/chat/route.ts";
  that gate is now `authorizePageConversation`.
- **Mirrored the gate's new third arm.** That extraction added an explicit
  `isActive === false` history-delete refusal which `loadWritableConversation`
  did not have, so its docblock overstated it. Now mirrored (`=== false`, not
  `!isActive`, per that module's own rule).
- **Deleted a note that now argued against its own file.** The "deliberately NOT
  one function" block justified duplication that master's *one plan-read rule*
  refactor removed.

Also re-verified the starter body's `list_pages` claims against the new base:
`recursive` still defaults false, `MAX_CONTENT_INCLUDE_PAGES = 50`,
`MAX_CONTENT_CHARS_PER_PAGE = 8000`, `contentClipped`/`contentClippedAfterLine`
still present.

**Gates on the rebased tree:** typecheck 17/17 and lint 15/15 clean; lib 8,919,
web 16,732, admin 181 passing against a freshly migrated database.
