### PR TITLE
fix(agents): one list of a workspace's threads, not two (#2373)

### DIFF
--- a/apps/e2e/tests/18-sidebar-directory-live.spec.ts
+++ b/apps/e2e/tests/18-sidebar-directory-live.spec.ts
@@ -80,9 +80,17 @@ import { authedContext } from '../fixtures/chat.fixture';
  *
  * TWO sessions, and which one is which matters. Session A is opened in the pane
  * grid, only so the console is genuinely live. Session B — the one under test —
- * is NEVER opened, so it has no persisted grid, and the sidebar renders its
- * expansion from the flat `session.conversations` listing (the branch the
- * directory events feed) rather than from pane rows.
+ * is NEVER opened.
+ *
+ * That asymmetry used to be load-bearing for a second reason: the sidebar
+ * rendered PANE rows for a session with a grid and the flat conversation list
+ * for one without, and only the latter carried `sidebar-conversation-row` — so
+ * Session B had to be grid-less for this spec to see anything at all. That fork
+ * was the cause of issue #2373 and is gone: there is one row shape now, every
+ * row carries the testId, and these assertions hold whether or not a session has
+ * a grid. Session B stays unopened only because an unopened session is the
+ * honest test of a DIRECTORY event — nothing about it is being rendered by a
+ * pane surface that might refetch on its own.
  */
 
 // The shared storageState user belongs to a drive this spec does not control;
@@ -441,13 +449,26 @@ test.describe('session directory — a server-created conversation reaches the s
     const { conversationRows: bystanderRows } = await expandSession(page, displayed.sessionId);
     await expect(conversationRows).toHaveCount(1, { timeout: 30_000 });
 
+    // The bystander's own count BEFORE the spawn. Asserting "unchanged" rather
+    // than "zero" is what makes this test about leakage rather than about a
+    // render branch (issue #2373).
+    //
+    // It used to read `toHaveCount(0)`, and the reason was structural: the
+    // displayed session has a persisted grid, so the sidebar rendered PANE rows
+    // for it — and only the conversation branch carried
+    // `sidebar-conversation-row`, so its threads were invisible to this
+    // selector. Both facts are now gone: there is one row shape, every row
+    // carries the testId, and a session's own threads legitimately count. Zero
+    // would now fail for a reason that has nothing to do with leakage.
+    const bystanderBefore = await bystanderRows.count();
+
     await spawnConversationServerSide(request, user, target.sessionId);
     await expect(conversationRows).toHaveCount(2, { timeout: POLL_CONTROL_MS });
 
-    // The displayed session HAS a persisted grid (a window is open on it), so
-    // it renders PANE rows rather than the flat conversation list — which is
-    // precisely why the check is "no conversation row appeared here" rather
-    // than a count of its threads.
-    await expect(bystanderRows).toHaveCount(0);
+    // THE ASSERTION: the spawn moved the target's list and left the bystander's
+    // alone. A listener that inserted into every session — the mistake
+    // `upsertConversationInCache`'s `session.sessionId !== sessionId` guard
+    // exists to prevent — would move this too.
+    await expect(bystanderRows).toHaveCount(bystanderBefore);
   });
 });

--- a/apps/e2e/tests/18-sidebar-directory-live.spec.ts
+++ b/apps/e2e/tests/18-sidebar-directory-live.spec.ts
@@ -283,9 +283,10 @@ async function openConsole(
 }> {
   const user = await seedUser();
   // Session A is opened in the grid; session B is the one under test and is
-  // never opened, so it keeps `workspace: null` in the listing and the sidebar
-  // renders its expansion from the flat conversation list — the branch the
-  // directory events feed.
+  // never opened, so it keeps `workspace: null` in the listing. That used to
+  // decide WHICH row shape the sidebar rendered; since issue #2373 there is
+  // only one, and B stays unopened because an unopened session is the honest
+  // test of a DIRECTORY event — no pane surface of its own to refetch.
   const displayed = await createSession(request, user, 'displayed session');
   const target = await createSession(request, user, 'target session');
 
@@ -460,6 +461,13 @@ test.describe('session directory — a server-created conversation reaches the s
     // selector. Both facts are now gone: there is one row shape, every row
     // carries the testId, and a session's own threads legitimately count. Zero
     // would now fail for a reason that has nothing to do with leakage.
+    //
+    // Settle it FIRST. `count()` takes a snapshot and does not auto-retry, so
+    // reading it mid-render would capture 0, and the auto-retrying assertion
+    // below would then fail the moment the bystander's own row arrived —
+    // flaky, and for the opposite reason to the one under test. One row,
+    // because `createSession` gives each session exactly one conversation.
+    await expect(bystanderRows).toHaveCount(1, { timeout: 30_000 });
     const bystanderBefore = await bystanderRows.count();
 
     await spawnConversationServerSide(request, user, target.sessionId);

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -205,22 +205,16 @@ describe('GET /api/agent-workspaces', () => {
     expect(conversations[1].conversationId).toBe('conv-unplaced');
     expect(conversations[1].pane).toBeNull();
 
-    // `workspace` STILL carries the grid's geometry. This PR narrowed what it
-    // means — it is no longer anyone's answer to "which threads exist" — but
-    // narrowing is not removing, and nothing else asserted it was still served
-    // once a grid existed. It is load-bearing: `AgentsSidebar`'s
-    // `ensureLocalWorkspace` hydrates the store FROM this field for a session
-    // whose grid the pane surface never mounted, and `closePaneConversation`
-    // fails closed without it — so silently dropping it would turn every
-    // sidebar pane-close into a no-op refetch rather than a visible break.
-    expect(body.sessions[0].workspace).toEqual({
-      id: 'ses-1',
-      columns: [
-        { id: 'col-1', panes: [{ id: 'pane-1', scope: { kind: 'chat', targetId: 'conv-1' } }] },
-      ],
-      activePaneId: 'pane-1',
-      pendingPickerPaneId: null,
-    });
+    // The annotation and the geometry AGREE, because both derive from one
+    // grid read (`route.ts` reads `grid` once and passes it to both). Their
+    // disagreeing is the shape of the original bug — two views of placement
+    // that could drift — so it is worth an assertion even though the geometry
+    // itself is already covered by 'should attach the grid as `workspace`'
+    // above, which predates this PR. (An earlier revision of this test claimed
+    // that coverage did not exist. It did; I had searched for it badly.)
+    const placedPaneId = conversations[0].pane.paneId;
+    expect(body.sessions[0].workspace.columns[0].panes[0].id).toBe(placedPaneId);
+    expect(body.sessions[0].workspace.columns[0].id).toBe(conversations[0].pane.columnId);
   });
 
   it('given ?driveId=, should narrow WHERE but never WHOSE (ownerId still rides the filter)', async () => {

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -132,7 +132,17 @@ describe('GET /api/agent-workspaces', () => {
     const response = await GET(new Request('http://localhost/api/agent-workspaces'));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      sessions: [{ ...SESSION_DTO, shells: [SHELL_DTO], conversations: [CONVERSATION_ENTRY], workspace: null }],
+      // Every thread carries its placement (issue #2373). `pane: null` here
+      // because this session has no grid — the point being that the thread is
+      // LISTED regardless, which is what the sidebar renders from now.
+      sessions: [
+        {
+          ...SESSION_DTO,
+          shells: [SHELL_DTO],
+          conversations: [{ ...CONVERSATION_ENTRY, pane: null }],
+          workspace: null,
+        },
+      ],
     });
     expect(mockListSessions).toHaveBeenCalledWith({ ownerId: 'user-1' });
     // ONE bulk call each, however many sessions — the poll must not be 1+3N.
@@ -157,6 +167,43 @@ describe('GET /api/agent-workspaces', () => {
       activePaneId: 'pane-1',
       pendingPickerPaneId: null,
     });
+  });
+
+  /**
+   * ONE LIST, NOT TWO (issue #2373). The route used to hand back the flat
+   * conversations AND the grid and let the client choose; `AgentsSidebar` chose
+   * the grid, so a thread with no pane row was invisible. Placement is
+   * best-effort, so that was the ordinary state of a freshly created thread —
+   * production carried 1 of 3 and 6 of 10 such threads.
+   */
+  it('annotates each thread with its pane, and LISTS a thread that has none', async () => {
+    mockListSessionConversationsBulk.mockResolvedValue(
+      new Map([['ses-1', [CONVERSATION_ENTRY, { ...CONVERSATION_ENTRY, conversationId: 'conv-unplaced' }]]]),
+    );
+    mockReadWorkspaceGridsBulk.mockResolvedValue(
+      new Map([
+        [
+          'ses-1',
+          [
+            {
+              id: 'col-1',
+              panes: [
+                { id: 'pane-1', scope: { kind: 'chat', targetId: CONVERSATION_ENTRY.conversationId } },
+              ],
+            },
+          ],
+        ],
+      ]),
+    );
+
+    const body = await (await GET(new Request('http://localhost/api/agent-workspaces'))).json();
+    const conversations = body.sessions[0].conversations;
+
+    expect(conversations).toHaveLength(2);
+    expect(conversations[0].pane).toEqual({ paneId: 'pane-1', columnId: 'col-1', orderIndex: 0 });
+    // The one the old shape dropped on the floor.
+    expect(conversations[1].conversationId).toBe('conv-unplaced');
+    expect(conversations[1].pane).toBeNull();
   });
 
   it('given ?driveId=, should narrow WHERE but never WHOSE (ownerId still rides the filter)', async () => {

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -204,6 +204,23 @@ describe('GET /api/agent-workspaces', () => {
     // The one the old shape dropped on the floor.
     expect(conversations[1].conversationId).toBe('conv-unplaced');
     expect(conversations[1].pane).toBeNull();
+
+    // `workspace` STILL carries the grid's geometry. This PR narrowed what it
+    // means — it is no longer anyone's answer to "which threads exist" — but
+    // narrowing is not removing, and nothing else asserted it was still served
+    // once a grid existed. It is load-bearing: `AgentsSidebar`'s
+    // `ensureLocalWorkspace` hydrates the store FROM this field for a session
+    // whose grid the pane surface never mounted, and `closePaneConversation`
+    // fails closed without it — so silently dropping it would turn every
+    // sidebar pane-close into a no-op refetch rather than a visible break.
+    expect(body.sessions[0].workspace).toEqual({
+      id: 'ses-1',
+      columns: [
+        { id: 'col-1', panes: [{ id: 'pane-1', scope: { kind: 'chat', targetId: 'conv-1' } }] },
+      ],
+      activePaneId: 'pane-1',
+      pendingPickerPaneId: null,
+    });
   });
 
   it('given ?driveId=, should narrow WHERE but never WHOSE (ownerId still rides the filter)', async () => {

--- a/apps/web/src/app/api/agent-workspaces/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/route.ts
@@ -135,9 +135,9 @@ export async function GET(request: Request) {
         // between, and the choice was wrong in the common case: an open
         // workspace always has a grid, so `AgentsSidebar` always rendered the
         // pane branch, and a thread with no pane row was invisible. Placement
-        // is best-effort — `spawn_session` places only when it has a
-        // `toolCallId` — so "created but not placed" is the ordinary state of a
-        // freshly spawned worker, not an edge case.
+        // is best-effort by design, and a thread created without `placeInGrid`
+        // is never placed at all, so "created but not placed" is a resting
+        // state this list must serve, not a transient to wait out.
         conversations: annotateConversationsWithPanes(
           conversationsBySession.get(session.workspaceId) ?? [],
           grid,

--- a/apps/web/src/app/api/agent-workspaces/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/route.ts
@@ -46,6 +46,7 @@ import {
 } from '@/lib/agent-workspaces/agent-workspaces-runtime';
 import { listShellsBulk, spawnShell } from '@/lib/agent-workspaces/workspace-shells-runtime';
 import { readWorkspaceGridsBulk, workspaceListEntryFromGrid } from '@/lib/agent-workspaces/workspace-layout-runtime';
+import { annotateConversationsWithPanes } from '@/lib/agent-workspaces/annotate-conversation-panes';
 import { sessionQuotaExceeded } from '@/lib/agent-workspaces/quota-response';
 
 /** Bound on the stored display label — rendered everywhere the session appears. */
@@ -121,20 +122,33 @@ export async function GET(request: Request) {
       listSessionConversationsBulk(workspaceIds),
       readWorkspaceGridsBulk(workspaceIds, auth.userId),
     ]);
-    const withChildren = sessions.map((session) => ({
-      ...session,
-      shells: shellsBySession.get(session.workspaceId) ?? [],
-      // The sidebar's expansion list: the threads living in this workspace.
-      conversations: conversationsBySession.get(session.workspaceId) ?? [],
-      // The sidebar's PANE-grouped expansion list, derived from the pane ROWS
-      // (labels joined at read time) — `null` for a session with no grid yet,
-      // which the sidebar reads as "fall back to the flat conversation list
-      // above."
-      workspace: workspaceListEntryFromGrid(
-        session.workspaceId,
-        gridBySession.get(session.workspaceId) ?? null,
-      ),
-    }));
+    const withChildren = sessions.map((session) => {
+      const grid = gridBySession.get(session.workspaceId) ?? null;
+      return {
+        ...session,
+        shells: shellsBySession.get(session.workspaceId) ?? [],
+        // THE list of threads in this workspace — one collection, every thread,
+        // each annotated with where it sits in the grid if it is placed at all
+        // (issue #2373).
+        //
+        // This and `workspace` below used to be two lists the client chose
+        // between, and the choice was wrong in the common case: an open
+        // workspace always has a grid, so `AgentsSidebar` always rendered the
+        // pane branch, and a thread with no pane row was invisible. Placement
+        // is best-effort — `spawn_session` places only when it has a
+        // `toolCallId` — so "created but not placed" is the ordinary state of a
+        // freshly spawned worker, not an edge case.
+        conversations: annotateConversationsWithPanes(
+          conversationsBySession.get(session.workspaceId) ?? [],
+          grid,
+        ),
+        // The grid's GEOMETRY — column widths, pane heights, ordering — for the
+        // pane surface to render. Deliberately no longer the sidebar's source
+        // for "which threads exist": that question has exactly one answer now,
+        // and it is the list above.
+        workspace: workspaceListEntryFromGrid(session.workspaceId, grid),
+      };
+    });
     return NextResponse.json({ sessions: withChildren });
   } catch (error) {
     loggers.api.error(

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1553,7 +1553,7 @@ export default function AgentPanes({
     // With a conversation to seed, the openConversation effect creates the
     // grid on the next tick — the spinner is a single-frame state. A
     // session-only selection has nothing to seed locally; until
-    // `useWorkspaceServerSync`'s hydration seats a saved grid (if one
+    // `useWorkspaceLayoutSync`'s hydration seats a saved grid (if one
     // exists), point at the sidebar rather than spin forever.
     return (
       <div className="flex h-full items-center justify-center">

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -171,6 +171,13 @@ interface SessionConversationEntry {
   conversationId: string;
   title: string | null;
   agentPageId: string | null;
+  /**
+   * Where this thread sits in the workspace's grid, or `null` when it is not
+   * placed. Server-derived (`annotateConversationsWithPanes`) so the sidebar
+   * has ONE list to render rather than choosing between the conversation list
+   * and the grid — see the expansion below.
+   */
+  pane?: { paneId: string; columnId: string; orderIndex: number } | null;
 }
 
 interface SessionListEntry {
@@ -832,22 +839,6 @@ function SessionRow({
     [],
   );
 
-  // Only chat panes address a conversation — a terminal/still-unbound pane
-  // has nothing to show here (shells get their own section below,
-  // unchanged; page panes get their own rows via `pagePanes`). `null` when
-  // this session has no saved grid yet, so the render falls back to the
-  // flat `session.conversations` list.
-  const chatPanes = useMemo(
-    () =>
-      session.workspace
-        ? panesOf(session.workspace).filter(
-            (pane): pane is PaneState & { scope: { kind: 'chat'; targetId: string } } =>
-              pane.scope?.kind === 'chat' && pane.scope.targetId !== null,
-          )
-        : null,
-    [session.workspace],
-  );
-
   // Page panes are server-persisted workspace artifacts exactly like chat
   // panes, so a session's expansion lists them too — a document or task
   // page opened into the grid (by the picker or by an agent's
@@ -969,45 +960,29 @@ function SessionRow({
 
       {expanded && (
         <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">
-          {chatPanes
-            ? chatPanes.map((pane) => (
-                <PaneRow
-                  key={pane.id}
-                  pane={pane}
-                  conversationEntryForTarget={conversationEntryForTarget}
-                  conversationLabel={conversationLabel}
-                  selectedConversationId={selectedConversationId}
-                  onOpenConversation={openConversation}
-                  onClose={closePaneConversation}
-                />
-              ))
-            : session.conversations.map((conversation) => (
-                <RowMenu
-                  key={conversation.conversationId}
-                  items={[
-                    {
-                      label: 'Close',
-                      icon: X,
-                      onSelect: () => void closeConversation(conversation.conversationId),
-                      destructive: true,
-                    },
-                  ]}
-                  menuLabel="Conversation actions"
-                  testId="sidebar-conversation-row"
-                  className={cn(
-                    'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
-                    selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
-                  )}
-                >
-                  <button
-                    type="button"
-                    className="flex min-w-0 flex-1 items-center text-left"
-                    onClick={() => openConversation(conversation)}
-                  >
-                    <span className="truncate">{conversationLabel(conversation)}</span>
-                  </button>
-                </RowMenu>
-              ))}
+          {/* ONE LIST (issue #2373). This used to be
+              `chatPanes ? … : session.conversations`, and an open workspace
+              always has a grid — so the pane branch always won and a thread
+              with no pane row was invisible. Placement is best-effort
+              (`spawn_session` places only when it has a `toolCallId`), so
+              "created but not placed" is the ordinary state of a freshly
+              spawned worker: in production one workspace showed 2 of its 3
+              threads, another 4 of its 10.
+
+              The THREAD is the row. `pane` is an attribute of it, deciding
+              only which close verb applies — unbind the pane, or close the
+              thread outright. */}
+          {session.conversations.map((conversation) => (
+            <ConversationRow
+              key={conversation.conversationId}
+              conversation={conversation}
+              conversationLabel={conversationLabel}
+              selectedConversationId={selectedConversationId}
+              onOpenConversation={openConversation}
+              onClosePane={closePaneConversation}
+              onCloseConversation={closeConversation}
+            />
+          ))}
           {pagePanes.map((pane) => (
             <RowMenu
               key={pane.id}
@@ -1043,7 +1018,7 @@ function SessionRow({
               <span className="truncate">{shell.name}</span>
             </button>
           ))}
-          {(chatPanes ?? session.conversations).length === 0 && pagePanes.length === 0 && (
+          {session.conversations.length === 0 && pagePanes.length === 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">No conversations</div>
           )}
         </div>
@@ -1053,26 +1028,37 @@ function SessionRow({
 }
 
 /**
- * One PANE's row: labeled by its own conversation, updating in place on an
- * agent switch instead of a sibling row appearing — the fix for "changing
- * the agent in a pane spawns a new sidebar item."
+ * ONE THREAD'S ROW — the single shape the workspace expansion renders
+ * (issue #2373).
+ *
+ * There used to be two: a pane-keyed row when the workspace had a grid, and a
+ * conversation-keyed row when it did not. That fork is what made an unplaced
+ * thread invisible, because an open workspace always has a grid. The row is
+ * now keyed by the THREAD, and its pane — when it has one — decides only which
+ * close verb applies.
+ *
+ * Keying by the thread also keeps the property the pane-keyed row was written
+ * for ("changing the agent in a pane spawns a new sidebar item"): the mint
+ * that repoints a pane removes the stale conversation, so it leaves this
+ * listing (`isActive AND closedInWorkspaceAt IS NULL`) rather than lingering
+ * beside its replacement.
  */
-function PaneRow({
-  pane,
-  conversationEntryForTarget,
+function ConversationRow({
+  conversation,
   conversationLabel,
   selectedConversationId,
   onOpenConversation,
-  onClose,
+  onClosePane,
+  onCloseConversation,
 }: {
-  pane: PaneState & { scope: { kind: 'chat'; targetId: string; agentPageId: string | null } };
-  conversationEntryForTarget: (targetId: string, agentPageId: string | null) => SessionConversationEntry;
+  conversation: SessionConversationEntry;
   conversationLabel: (conversation: SessionConversationEntry) => string;
   selectedConversationId: string | null;
   onOpenConversation: (conversation: SessionConversationEntry) => void;
-  onClose: (paneId: string, conversationId: string) => void | Promise<void>;
+  onClosePane: (paneId: string, conversationId: string) => void | Promise<void>;
+  onCloseConversation: (conversationId: string) => void | Promise<void>;
 }) {
-  const activeEntry = conversationEntryForTarget(pane.scope.targetId, pane.scope.agentPageId);
+  const pane = conversation.pane ?? null;
 
   return (
     <RowMenu
@@ -1080,22 +1066,29 @@ function PaneRow({
         {
           label: 'Close',
           icon: X,
-          onSelect: () => void onClose(pane.id, pane.scope.targetId),
+          // A placed thread closes its PANE (which may leave the thread open
+          // elsewhere); an unplaced one has no pane to unbind, so Close means
+          // the thread.
+          onSelect: () =>
+            void (pane
+              ? onClosePane(pane.paneId, conversation.conversationId)
+              : onCloseConversation(conversation.conversationId)),
           destructive: true,
         },
       ]}
       menuLabel="Conversation actions"
+      testId="sidebar-conversation-row"
       className={cn(
         'gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
-        selectedConversationId === pane.scope.targetId && 'bg-accent text-foreground',
+        selectedConversationId === conversation.conversationId && 'bg-accent text-foreground',
       )}
     >
       <button
         type="button"
         className="flex min-w-0 flex-1 items-center text-left"
-        onClick={() => onOpenConversation(activeEntry)}
+        onClick={() => onOpenConversation(conversation)}
       >
-        <span className="truncate">{conversationLabel(activeEntry)}</span>
+        <span className="truncate">{conversationLabel(conversation)}</span>
       </button>
     </RowMenu>
   );

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -978,11 +978,11 @@ function SessionRow({
           {/* ONE LIST (issue #2373). This used to be
               `chatPanes ? … : session.conversations`, and an open workspace
               always has a grid — so the pane branch always won and a thread
-              with no pane row was invisible. Placement is best-effort
-              (`spawn_session` places only when it has a `toolCallId`), so
-              "created but not placed" is the ordinary state of a freshly
-              spawned worker: in production one workspace showed 2 of its 3
-              threads, another 4 of its 10.
+              with no pane row was invisible. Placement is best-effort by
+              design and a thread created without `placeInGrid` is never placed
+              at all, so "created but not placed" is a resting state this list
+              must render, not a transient: in production one workspace showed
+              2 of its 3 threads, another 4 of its 10.
 
               The THREAD is the row. `pane` is an attribute of it, deciding
               only which close verb applies — unbind the pane, or close the

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -758,12 +758,27 @@ function SessionRow({
       // snapshot (polled every 20s), so a second pane opened on this same
       // conversation moments ago could be invisible to it (review finding,
       // carried over from this row's own tab-era close control).
-      const liveWorkspace = useAgentWorkspaceStore.getState().workspaces[session.workspaceId];
-      const shownElsewhere = liveWorkspace
-        ? panesOf(liveWorkspace).some(
-            (p) => p.id !== paneId && p.scope?.kind === 'chat' && p.scope.targetId === conversationId,
-          )
-        : false;
+      //
+      // Through `ensureLocalWorkspace`, NOT a raw store read (review finding —
+      // CodeRabbit). A row can act on a session that is not the displayed one,
+      // and for that session `AgentPanes` — and the layout sync that seats its
+      // grid — was never mounted. A raw read then came back undefined,
+      // `shownElsewhere` defaulted to FALSE, and "close this pane" silently
+      // became "DELETE this conversation" for a thread still open in another
+      // pane. Seating the row's own listing snapshot first is what this helper
+      // is for, and a placed thread always has a `session.workspace` for it to
+      // seat from — the pane it is placed in is in that very grid.
+      const liveWorkspace = ensureLocalWorkspace();
+      if (!liveWorkspace) {
+        // Cannot prove the thread is NOT shown elsewhere, so do not destroy it.
+        // Re-read instead; the row re-renders with a grid and the next click
+        // decides properly.
+        void mutate(isAgentWorkspacesKey);
+        return;
+      }
+      const shownElsewhere = panesOf(liveWorkspace).some(
+        (p) => p.id !== paneId && p.scope?.kind === 'chat' && p.scope.targetId === conversationId,
+      );
       if (shownElsewhere) {
         resetPane(session.workspaceId, paneId);
         return;
@@ -813,7 +828,7 @@ function SessionRow({
         });
       }
     },
-    [mutate, session.workspaceId, session.conversations, resetPane, assignPane],
+    [ensureLocalWorkspace, mutate, session.workspaceId, session.conversations, resetPane, assignPane],
   );
 
   const conversationLabel = useCallback(

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -25,6 +25,7 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
+import { annotateConversationsWithPanes } from '@/lib/agent-workspaces/annotate-conversation-panes';
 
 const mockPush = vi.fn();
 const mockUseAuth = vi.fn();
@@ -158,10 +159,24 @@ const SESSION: SessionFixture = {
   shells: [],
 };
 
+/**
+ * Serve a listing the way the ROUTE serves one (issue #2373): each thread
+ * annotated with its pane placement, using the server's own
+ * `annotateConversationsWithPanes`. Fixtures cannot drift from the shape the
+ * sidebar actually receives — a `workspace` grid and a `conversations` list
+ * that disagreed about placement is precisely the bug this suite now guards.
+ */
 const respondWithSessions = (sessions: SessionFixture[]) => {
+  const annotated = sessions.map((session) => ({
+    ...session,
+    conversations: annotateConversationsWithPanes(
+      session.conversations,
+      (session.workspace as { columns?: unknown } | undefined)?.columns as never,
+    ),
+  }));
   mockFetchWithAuth.mockResolvedValue({
     ok: true,
-    json: async () => ({ sessions }),
+    json: async () => ({ sessions: annotated }),
   });
 };
 
@@ -300,6 +315,65 @@ describe('AgentsSidebar', () => {
       // Two panes, each showing its own conversation — two sibling rows.
       expect(screen.getByText('Researcher — First chat')).toBeDefined();
       expect(screen.getByText('Researcher — Second chat')).toBeDefined();
+    });
+
+    /**
+     * THE BUG (issue #2373). The expansion used to be
+     * `chatPanes ? … : session.conversations`, and an open workspace always
+     * has a grid — so the pane branch always won and a thread with no pane row
+     * simply did not render. Placement is best-effort, so that is the ordinary
+     * state of a freshly spawned worker: production showed one workspace with
+     * 3 threads and 2 panes, another with 10 threads and 4 panes. Six threads
+     * were unreachable from the sidebar entirely.
+     *
+     * Fails on the pre-fix component: only the two placed rows appear.
+     */
+    test('renders a thread that has NO pane, alongside the placed ones', async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          conversations: [
+            ...SESSION.conversations,
+            // Spawned, claimed, never placed — the "hi" conversation from the
+            // production repro.
+            { conversationId: 'conv-unplaced', title: 'hi', agentPageId: 'agent-1' },
+          ],
+          workspace: workspaceFixture,
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+
+      expect(screen.getByText('Researcher — First chat')).toBeDefined();
+      expect(screen.getByText('Researcher — Second chat')).toBeDefined();
+      expect(screen.getByText('Researcher — hi')).toBeDefined();
+      expect(screen.getAllByTestId('sidebar-conversation-row')).toHaveLength(3);
+    });
+
+    test('an unplaced thread closes the THREAD — there is no pane to unbind', async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          conversations: [{ conversationId: 'conv-unplaced', title: 'hi', agentPageId: 'agent-1' }],
+          workspace: workspaceFixture,
+        },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Researcher — hi'));
+      await user.click(await screen.findByText('Close'));
+
+      // The conversation DELETE, not a layout verb: an unplaced thread has no
+      // pane binding to reset.
+      await waitFor(() => {
+        expect(mockDel).toHaveBeenCalledWith(
+          expect.stringContaining('/conversations/conv-unplaced'),
+        );
+      });
     });
 
     test('clicking a pane row selects its conversation', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -745,14 +745,21 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      const [pane1Row] = await screen.findAllByText('Researcher — First chat');
-      fireEvent.contextMenu(pane1Row);
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
-      // The listing survives: the conversation is still shown in pane-2.
+      // Assert the RESET, not merely the absence of a DELETE (review finding —
+      // CodeRabbit): a bare early return on `shownElsewhere` would leave the
+      // clicked pane still bound and pass a no-DELETE-only assertion. The
+      // clicked pane must be emptied and its sibling left alone, which is also
+      // what proves the fix seated the grid — an unseated one cannot see
+      // pane-2, so it would have taken the DELETE branch instead.
       await waitFor(() => {
-        expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+        const panes = useAgentWorkspaceStore.getState().workspaces['ses-1']?.columns[0].panes;
+        expect(panes?.find((p) => p.id === 'pane-1')?.scope).toBeNull();
       });
+      const panes = useAgentWorkspaceStore.getState().workspaces['ses-1'].columns[0].panes;
+      expect(panes.find((p) => p.id === 'pane-2')?.scope?.targetId).toBe('conv-1');
       expect(mockDel).not.toHaveBeenCalled();
     });
 
@@ -779,10 +786,11 @@ describe('AgentsSidebar', () => {
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
-      // Both panes show the identical label (same shared conversation) —
-      // pane-1 renders first, matching `columns[0].panes` order.
-      const [pane1Row] = await screen.findAllByText('Researcher — First chat');
-      fireEvent.contextMenu(pane1Row);
+      // ONE row, though the thread occupies two panes — `findByText` throws on
+      // a second match, so this also pins the property the pane-keyed rows
+      // could not give: the sidebar lists THREADS. The row acts on the thread's
+      // first placement (pane-1), which is what the annotator records.
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
       await user.click(await screen.findByText('Close'));
 
       await waitFor(() => {
@@ -1699,7 +1707,15 @@ describe('AgentsSidebar', () => {
     });
 
     test('typing filters the drive\'s sessions by name, and clearing the query restores the rest', async () => {
-      respondWithSessions([SESSION, { ...SESSION, sessionId: 'ses-2', name: 'design review' }]);
+      // Override BOTH ids. `sessionId` is only the rolling-deploy compat twin;
+      // the sidebar keys rows on the canonical `workspaceId`, so overriding
+      // the twin alone gave two rows keyed `ses-1` — React warned about the
+      // duplicate key and this "two sessions" test was really rendering one
+      // session twice.
+      respondWithSessions([
+        SESSION,
+        { ...SESSION, workspaceId: 'ses-2', sessionId: 'ses-2', name: 'design review' },
+      ]);
       const user = userEvent.setup();
       renderSidebar();
 

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -271,9 +271,13 @@ describe('AgentsSidebar', () => {
     expect(screen.getByLabelText('New session')).toBeDefined();
   });
 
-  test('falls back to a flat conversation list when the session has no saved pane grid', async () => {
-    // SESSION carries no `workspace` — a session never opened under
-    // `useWorkspaceServerSync` (or opened only by an older client).
+  // Named for the deleted fork ("falls back to a flat conversation list") until
+  // issue #2373. There is no fallback now — there is one list, and a session
+  // with no grid is just the case where every thread in it is unplaced. Keeping
+  // the old name would have implied the branch still exists.
+  test('lists a session\'s threads when it has no saved pane grid at all', async () => {
+    // SESSION carries no `workspace` — a session never opened in the grid (or
+    // opened only by a client old enough to predate the layout sync).
     const user = userEvent.setup();
     renderSidebar();
 
@@ -428,7 +432,7 @@ describe('AgentsSidebar', () => {
 
     test('clicking a page pane row focuses the session and that pane, seating the grid from the row\'s own listing', async () => {
       // Deliberately NO local grid: the session isn't the displayed one, so
-      // `AgentPanes`/`useWorkspaceServerSync` never hydrated it. The click
+      // `AgentPanes` and its layout sync never hydrated it. The click
       // must seat the row's own server-listing snapshot before focusing —
       // `selectPane` no-ops on a session the store has never seen (review
       // P1, chatgpt-codex-connector).

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -115,6 +115,7 @@ import {
   __resetWorkspaceQueuesForTests,
 } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import type { WorkspaceState } from '@pagespace/lib/agent-workspaces/workspace-layout-verbs';
+import type { PersistedColumnState } from '@pagespace/lib/agent-workspaces/contract';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
 
@@ -140,7 +141,12 @@ interface SessionFixture {
   sandboxStatus: 'none' | 'starting' | 'running' | 'ended';
   conversations: { conversationId: string; title: string | null; agentPageId: string | null }[];
   shells: { shellId: string; name: string }[];
-  /** Omitted (undefined) in most fixtures — the sidebar reads that as "fall back to the flat conversation list above." */
+  /**
+   * The saved pane grid, omitted in most fixtures. Since issue #2373 the
+   * sidebar no longer picks a row shape from this — it annotates the list
+   * above with it, exactly as the route does. Left `unknown` because the
+   * fixtures are deliberately loose literals; `gridOf` narrows it once.
+   */
   workspace?: unknown;
 }
 
@@ -166,12 +172,15 @@ const SESSION: SessionFixture = {
  * sidebar actually receives — a `workspace` grid and a `conversations` list
  * that disagreed about placement is precisely the bug this suite now guards.
  */
+const gridOf = (workspace: unknown): PersistedColumnState[] | null =>
+  (workspace as { columns?: PersistedColumnState[] } | undefined)?.columns ?? null;
+
 const respondWithSessions = (sessions: SessionFixture[]) => {
   const annotated = sessions.map((session) => ({
     ...session,
     conversations: annotateConversationsWithPanes(
       session.conversations,
-      (session.workspace as { columns?: unknown } | undefined)?.columns as never,
+      gridOf(session.workspace),
     ),
   }));
   mockFetchWithAuth.mockResolvedValue({

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -706,6 +706,56 @@ describe('AgentsSidebar', () => {
       });
     });
 
+    /**
+     * THE SAME CASE, FROM A SESSION THE STORE HAS NEVER SEEN (review finding —
+     * CodeRabbit).
+     *
+     * A sidebar row can act on a session that is not the displayed one, and for
+     * that session `AgentPanes` — and the layout sync that seats its grid — was
+     * never mounted. `closePaneConversation` read the store raw, got undefined,
+     * defaulted `shownElsewhere` to FALSE, and turned "close this pane" into
+     * "DELETE this conversation" for a thread still open in another pane.
+     *
+     * The test above pre-hydrates the store, which is exactly why it could not
+     * see this. Here the store is deliberately left empty: the fix seats the
+     * row's own `session.workspace` snapshot through `ensureLocalWorkspace`
+     * first, so the second pane is visible and only the clicked pane resets.
+     *
+     * Fails on the pre-fix component with a DELETE.
+     */
+    test('closing a shared pane in an UNHYDRATED session still resets locally — never DELETEs', async () => {
+      const sharedWorkspace = {
+        id: 'ses-1',
+        columns: [
+          {
+            id: 'col-1',
+            panes: [
+              { id: 'pane-1', scope: { kind: 'chat', name: 'Conversation', targetId: 'conv-1', agentPageId: 'agent-1' } },
+              { id: 'pane-2', scope: { kind: 'chat', name: 'Conversation', targetId: 'conv-1', agentPageId: 'agent-1' } },
+            ],
+          },
+        ],
+        activePaneId: 'pane-1',
+        pendingPickerPaneId: null,
+      };
+      // NO hydrateWorkspace — this session was never opened in the grid.
+      expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeUndefined();
+      respondWithSessions([{ ...SESSION, workspace: sharedWorkspace }]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      const [pane1Row] = await screen.findAllByText('Researcher — First chat');
+      fireEvent.contextMenu(pane1Row);
+      await user.click(await screen.findByText('Close'));
+
+      // The listing survives: the conversation is still shown in pane-2.
+      await waitFor(() => {
+        expect(useAgentWorkspaceStore.getState().workspaces['ses-1']).toBeDefined();
+      });
+      expect(mockDel).not.toHaveBeenCalled();
+    });
+
     test('closing a pane whose conversation is also open in ANOTHER pane resets it locally only — never DELETEs the shared listing', async () => {
       const sharedWorkspace = {
         id: 'ses-1',

--- a/apps/web/src/lib/agent-workspaces/__tests__/agent-workspaces-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/agent-workspaces-runtime.integration.test.ts
@@ -613,11 +613,19 @@ describe('createConversationInSession — the placeInGrid gate', () => {
     };
 
     await createConversationInSession(input);
-    // A retry of the same creation. The opId derives from the CONVERSATION id
-    // precisely so the verb engine's op memory replays it instead of opening a
-    // second pane — the property the old `toolCallId`-keyed opId could not give
-    // when the SDK supplied no call id.
-    await createConversationInSession(input).catch(() => {});
+    // A retry of the same creation, which must RESOLVE — no `.catch` swallowing
+    // it (review finding — CodeRabbit). Suppressing a rejection here would let
+    // the pane count stay at 1 because the retry never reached placement at
+    // all, which is a pass for the wrong reason. It does resolve; I checked.
+    //
+    // On the mechanism, stated carefully because I got it wrong first: this
+    // does NOT demonstrate the verb engine's op memory. Making the opId unique
+    // per call still leaves the count at 1, because `resolveOpenPlacement`
+    // finds a pane already showing this conversation and FOCUSES it rather
+    // than splitting. Op memory is the guard for a retry that arrives before
+    // the first placement lands; the focus branch covers the case here. What
+    // is asserted is the invariant both exist to protect.
+    await createConversationInSession(input);
 
     expect(await panesTargeting(workspace.id, conversationId)).toHaveLength(1);
   });

--- a/apps/web/src/lib/agent-workspaces/__tests__/agent-workspaces-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/agent-workspaces-runtime.integration.test.ts
@@ -25,6 +25,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and, isNull, count } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
+import { agentWorkspacePanes } from '@pagespace/db/schema/agent-workspace-layout';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { factories } from '@pagespace/db/test/factories';
 import { MAX_SESSION_CONVERSATIONS } from '@pagespace/lib/agent-workspaces/plan-spawn-worker';
@@ -474,5 +475,105 @@ describe('ensureGlobalSandboxSession — auto-provisioning the default Global As
 
     const [stillUnbound] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
     expect(stillUnbound.workspaceId).toBeNull();
+  });
+});
+
+/**
+ * PLACEMENT IS OPT-IN, AND THE OPT-OUT IS THE LOAD-BEARING HALF (issue #2373,
+ * review finding — codex P1).
+ *
+ * `createConversationInSession` places a pane only when the caller asks with
+ * `placeInGrid`. Nothing tested the gate itself: `resolve-open-placement.test.ts`
+ * pins WHY an unconditional placement is wrong (a loading pane is not
+ * `isReplaceable`, so the placement resolves to `split` and the picker's own
+ * bind leaves one conversation in two panes), but deleting
+ * `if (!input.placeInGrid) return;` would leave every one of those assertions
+ * green while the duplicate-pane regression came straight back.
+ *
+ * Asserted against real pane ROWS rather than a mocked collaborator, because
+ * the fact under test is "did a pane get written", not "was a function called".
+ */
+describe('createConversationInSession — the placeInGrid gate', () => {
+  async function panesTargeting(workspaceId: string, conversationId: string) {
+    return db
+      .select({ id: agentWorkspacePanes.id })
+      .from(agentWorkspacePanes)
+      .where(
+        and(
+          eq(agentWorkspacePanes.workspaceId, workspaceId),
+          eq(agentWorkspacePanes.targetId, conversationId),
+        ),
+      );
+  }
+
+  async function seed() {
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const agentPage = await factories.createPage(drive.id, { type: 'AI_CHAT', title: 'Gate Agent' });
+    const [workspace] = await db
+      .insert(agentWorkspaces)
+      .values({ id: createId(), driveId: drive.id, ownerId: owner.id })
+      .returning();
+    return { owner, agentPage, workspace };
+  }
+
+  it('does NOT write a pane when the caller does not ask — the pane-picker routes depend on this', async () => {
+    if (!dbAvailable) return;
+    const { owner, agentPage, workspace } = await seed();
+    const conversationId = createId();
+
+    await createConversationInSession({
+      conversationId,
+      userId: owner.id,
+      agentPageId: agentPage.id,
+      workspaceId: workspace.id,
+    });
+
+    expect(await panesTargeting(workspace.id, conversationId)).toHaveLength(0);
+    // The thread still EXISTS and is listed — that is the whole point of the
+    // read-model fix. Unplaced is a resting state, not an invisible one.
+    const [row] = await db.select().from(conversations).where(eq(conversations.id, conversationId)).limit(1);
+    expect(row.workspaceId).toBe(workspace.id);
+    expect(row.isActive).toBe(true);
+  });
+
+  it('DOES write a pane when the caller asks — spawn_session, which has no browser pane waiting', async () => {
+    if (!dbAvailable) return;
+    const { owner, agentPage, workspace } = await seed();
+    const conversationId = createId();
+
+    await createConversationInSession({
+      conversationId,
+      userId: owner.id,
+      agentPageId: agentPage.id,
+      workspaceId: workspace.id,
+      title: 'Researcher',
+      placeInGrid: true,
+    });
+
+    expect(await panesTargeting(workspace.id, conversationId)).toHaveLength(1);
+  });
+
+  it('places at most ONE pane per thread however often creation is retried', async () => {
+    if (!dbAvailable) return;
+    const { owner, agentPage, workspace } = await seed();
+    const conversationId = createId();
+    const input = {
+      conversationId,
+      userId: owner.id,
+      agentPageId: agentPage.id,
+      workspaceId: workspace.id,
+      title: 'Researcher',
+      placeInGrid: true,
+    };
+
+    await createConversationInSession(input);
+    // A retry of the same creation. The opId derives from the CONVERSATION id
+    // precisely so the verb engine's op memory replays it instead of opening a
+    // second pane — the property the old `toolCallId`-keyed opId could not give
+    // when the SDK supplied no call id.
+    await createConversationInSession(input).catch(() => {});
+
+    expect(await panesTargeting(workspace.id, conversationId)).toHaveLength(1);
   });
 });

--- a/apps/web/src/lib/agent-workspaces/__tests__/agent-workspaces-runtime.integration.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/agent-workspaces-runtime.integration.test.ts
@@ -554,6 +554,51 @@ describe('createConversationInSession — the placeInGrid gate', () => {
     expect(await panesTargeting(workspace.id, conversationId)).toHaveLength(1);
   });
 
+  it('never evicts the conversation that asked for the spawn', async () => {
+    if (!dbAvailable) return;
+    const { owner, agentPage, workspace } = await seed();
+
+    // The spawner: an agent's own thread, already occupying the only pane.
+    const spawnerId = createId();
+    await createConversationInSession({
+      conversationId: spawnerId,
+      userId: owner.id,
+      agentPageId: agentPage.id,
+      workspaceId: workspace.id,
+      title: 'Caller',
+      placeInGrid: true,
+    });
+    expect(await panesTargeting(workspace.id, spawnerId)).toHaveLength(1);
+
+    // Its worker, naming the spawner as off-limits.
+    //
+    // What this pins is the OUTCOME a user cares about — spawning a worker
+    // adds a pane beside your conversation, it never navigates the one you are
+    // reading. Which guard delivers that is deliberately not asserted, and I
+    // checked rather than assumed: removing the `excludeTargetId` pass-through
+    // does NOT flip this test, because `placeWorkerPane` also sets
+    // `preferSplit: true` (`workspace-placement.ts:122`) and that alone is
+    // enough here. `excludeTargetId` is the narrower second guard; its
+    // independent effect belongs to the verb's own tests
+    // (`workspace-placement-worker.test.ts`), which cover the pass-through
+    // directly. Pinning the outcome rather than the mechanism is the point —
+    // it stays true if the guards are ever reshuffled, and it fails if a
+    // future change lets a spawn eat the caller's pane by any route.
+    const workerId = createId();
+    await createConversationInSession({
+      conversationId: workerId,
+      userId: owner.id,
+      agentPageId: agentPage.id,
+      workspaceId: workspace.id,
+      title: 'Researcher',
+      placeInGrid: true,
+      excludeTargetId: spawnerId,
+    });
+
+    expect(await panesTargeting(workspace.id, spawnerId)).toHaveLength(1);
+    expect(await panesTargeting(workspace.id, workerId)).toHaveLength(1);
+  });
+
   it('places at most ONE pane per thread however often creation is retried', async () => {
     if (!dbAvailable) return;
     const { owner, agentPage, workspace } = await seed();

--- a/apps/web/src/lib/agent-workspaces/__tests__/annotate-conversation-panes.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/annotate-conversation-panes.test.ts
@@ -8,9 +8,12 @@
  * however correct its conversation row.
  *
  * The measured production shape at the time of the bug is the first test
- * below: a workspace with more threads than panes. That is the ORDINARY state
- * of a freshly spawned worker, because placement is best-effort —
- * `spawn_session` calls `placeWorkerPane` only when it has a `toolCallId`.
+ * below: a workspace with more threads than panes. Placement is best-effort by
+ * design and a thread created without `placeInGrid` is never placed at all, so
+ * "more threads than panes" is a resting state the sidebar must render, not a
+ * transient to wait out. (This PR also closes the sharpest source of it — the
+ * old `spawn_session` gate skipped placement whenever the SDK supplied no
+ * `toolCallId` — but the list must not depend on that having worked.)
  */
 import { describe, it, expect } from 'vitest';
 import type { PersistedColumnState } from '@pagespace/lib/agent-workspaces/contract';
@@ -111,8 +114,12 @@ describe('annotateConversationsWithPanes', () => {
   });
 
   it('tolerates a pane naming a conversation this workspace does not list', () => {
-    // A cross-workspace target, gated separately by the label resolver. It
-    // annotates nothing here and must not invent a row.
+    // Two ways to reach this: a cross-workspace target (gated separately by the
+    // label resolver), or a thread ranked past MAX_SESSION_CONVERSATIONS, since
+    // the listing is capped at 100 by lastMessageAt. Either way the pane
+    // annotates nothing and must NOT invent a row — synthesising one out of the
+    // grid is the second source of truth this module deletes. Such a pane still
+    // renders in the grid, which reads geometry from the store, not this list.
     const annotated = annotateConversationsWithPanes(
       [thread('mine')],
       grid([{ id: 'col-1', panes: [chatPane('p', 'someone-elses')] }]),

--- a/apps/web/src/lib/agent-workspaces/__tests__/annotate-conversation-panes.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/annotate-conversation-panes.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ONE LIST, NOT TWO (issue #2373).
+ *
+ * `/api/agent-workspaces` returned the flat conversation list AND the pane
+ * grid, and `AgentsSidebar` chose between them with
+ * `chatPanes ?? session.conversations`. An open workspace always has a grid, so
+ * the pane branch always won — and a thread with no pane row was invisible,
+ * however correct its conversation row.
+ *
+ * The measured production shape at the time of the bug is the first test
+ * below: a workspace with more threads than panes. That is the ORDINARY state
+ * of a freshly spawned worker, because placement is best-effort —
+ * `spawn_session` calls `placeWorkerPane` only when it has a `toolCallId`.
+ */
+import { describe, it, expect } from 'vitest';
+import type { PersistedColumnState } from '@pagespace/lib/agent-workspaces/contract';
+import {
+  annotateConversationsWithPanes,
+  paneByConversationId,
+} from '../annotate-conversation-panes';
+
+const thread = (conversationId: string) => ({ conversationId, title: conversationId });
+
+const chatPane = (id: string, targetId: string) => ({
+  id,
+  scope: { kind: 'chat' as const, targetId },
+});
+
+const grid = (columns: { id: string; panes: { id: string; scope: unknown }[] }[]) =>
+  columns as unknown as PersistedColumnState[];
+
+describe('annotateConversationsWithPanes', () => {
+  it('keeps an UNPLACED thread in the list — the whole bug', () => {
+    // Production, workspace tnmj4mu…: 3 threads, 2 panes. The thread titled
+    // "hi" had no pane row and could not be seen or reached from the sidebar.
+    const conversations = [thread('placed-a'), thread('hi'), thread('placed-b')];
+    const annotated = annotateConversationsWithPanes(
+      conversations,
+      grid([
+        { id: 'col-1', panes: [chatPane('pane-1', 'placed-a')] },
+        { id: 'col-2', panes: [chatPane('pane-2', 'placed-b')] },
+      ]),
+    );
+
+    expect(annotated.map((c) => c.conversationId)).toEqual(['placed-a', 'hi', 'placed-b']);
+    expect(annotated.find((c) => c.conversationId === 'hi')?.pane).toBeNull();
+  });
+
+  it('annotates a placed thread with its pane, column and position', () => {
+    const annotated = annotateConversationsWithPanes(
+      [thread('c1'), thread('c2')],
+      grid([{ id: 'col-1', panes: [chatPane('pane-1', 'c1'), chatPane('pane-2', 'c2')] }]),
+    );
+
+    expect(annotated[0].pane).toEqual({ paneId: 'pane-1', columnId: 'col-1', orderIndex: 0 });
+    expect(annotated[1].pane).toEqual({ paneId: 'pane-2', columnId: 'col-1', orderIndex: 1 });
+  });
+
+  it('preserves the listing order rather than re-deriving it from the grid', () => {
+    // The listing arrives newest-activity-first, which is what a sidebar reader
+    // wants. Sorting by grid position would make a thread jump when someone
+    // rearranged panes — geometry is the pane surface's concern, not the list's.
+    const annotated = annotateConversationsWithPanes(
+      [thread('newest'), thread('oldest')],
+      grid([{ id: 'col-1', panes: [chatPane('p1', 'oldest'), chatPane('p2', 'newest')] }]),
+    );
+
+    expect(annotated.map((c) => c.conversationId)).toEqual(['newest', 'oldest']);
+  });
+
+  it('ignores panes that are not chat — a terminal or page pane must not shadow a thread', () => {
+    const annotated = annotateConversationsWithPanes(
+      [thread('c1')],
+      grid([
+        {
+          id: 'col-1',
+          panes: [
+            { id: 'term', scope: { kind: 'terminal', targetId: 'sh_1' } },
+            { id: 'page', scope: { kind: 'page', targetId: 'pg_1' } },
+            { id: 'unbound', scope: null },
+            chatPane('chat', 'c1'),
+          ],
+        },
+      ]),
+    );
+
+    expect(annotated[0].pane).toEqual({ paneId: 'chat', columnId: 'col-1', orderIndex: 3 });
+  });
+
+  it('gives one row for a thread open in two panes — FIRST placement wins', () => {
+    // Legal state: the same conversation in two panes of one grid. The sidebar
+    // lists the THREAD, so it must not double-list.
+    const annotated = annotateConversationsWithPanes(
+      [thread('c1')],
+      grid([
+        { id: 'col-1', panes: [chatPane('first', 'c1')] },
+        { id: 'col-2', panes: [chatPane('second', 'c1')] },
+      ]),
+    );
+
+    expect(annotated).toHaveLength(1);
+    expect(annotated[0].pane?.paneId).toBe('first');
+  });
+
+  it('handles a workspace with no grid at all — every thread unplaced', () => {
+    for (const empty of [null, undefined, [] as PersistedColumnState[]]) {
+      const annotated = annotateConversationsWithPanes([thread('c1'), thread('c2')], empty);
+      expect(annotated).toHaveLength(2);
+      expect(annotated.every((c) => c.pane === null)).toBe(true);
+    }
+  });
+
+  it('tolerates a pane naming a conversation this workspace does not list', () => {
+    // A cross-workspace target, gated separately by the label resolver. It
+    // annotates nothing here and must not invent a row.
+    const annotated = annotateConversationsWithPanes(
+      [thread('mine')],
+      grid([{ id: 'col-1', panes: [chatPane('p', 'someone-elses')] }]),
+    );
+
+    expect(annotated).toHaveLength(1);
+    expect(annotated[0].pane).toBeNull();
+  });
+
+  it('does not mutate the conversations it is given', () => {
+    const conversations = [thread('c1')];
+    annotateConversationsWithPanes(conversations, grid([{ id: 'col', panes: [chatPane('p', 'c1')] }]));
+    expect(conversations[0]).not.toHaveProperty('pane');
+  });
+});
+
+describe('paneByConversationId', () => {
+  it('indexes only chat panes, first wins', () => {
+    const index = paneByConversationId(
+      grid([
+        { id: 'c1', panes: [chatPane('p1', 'conv-a'), { id: 't', scope: { kind: 'terminal', targetId: 'sh' } }] },
+        { id: 'c2', panes: [chatPane('p2', 'conv-a'), chatPane('p3', 'conv-b')] },
+      ]),
+    );
+
+    expect([...index.keys()].sort()).toEqual(['conv-a', 'conv-b']);
+    expect(index.get('conv-a')?.paneId).toBe('p1');
+  });
+});

--- a/apps/web/src/lib/agent-workspaces/__tests__/annotate-conversation-panes.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/annotate-conversation-panes.test.ts
@@ -16,21 +16,18 @@
  * `toolCallId` — but the list must not depend on that having worked.)
  */
 import { describe, it, expect } from 'vitest';
-import type { PersistedColumnState } from '@pagespace/lib/agent-workspaces/contract';
-import {
-  annotateConversationsWithPanes,
-  paneByConversationId,
-} from '../annotate-conversation-panes';
+import type { PersistedColumnState, PersistedPaneState } from '@pagespace/lib/agent-workspaces/contract';
+import { annotateConversationsWithPanes } from '../annotate-conversation-panes';
 
 const thread = (conversationId: string) => ({ conversationId, title: conversationId });
 
-const chatPane = (id: string, targetId: string) => ({
+const chatPane = (id: string, targetId: string): PersistedPaneState => ({
   id,
-  scope: { kind: 'chat' as const, targetId },
+  scope: { kind: 'chat', name: 'Conversation', targetId, agentPageId: null },
 });
 
-const grid = (columns: { id: string; panes: { id: string; scope: unknown }[] }[]) =>
-  columns as unknown as PersistedColumnState[];
+/** Named only so the fixtures read as grids; the literals are already typed. */
+const grid = (columns: PersistedColumnState[]): PersistedColumnState[] => columns;
 
 describe('annotateConversationsWithPanes', () => {
   it('keeps an UNPLACED thread in the list — the whole bug', () => {
@@ -78,8 +75,8 @@ describe('annotateConversationsWithPanes', () => {
         {
           id: 'col-1',
           panes: [
-            { id: 'term', scope: { kind: 'terminal', targetId: 'sh_1' } },
-            { id: 'page', scope: { kind: 'page', targetId: 'pg_1' } },
+            { id: 'term', scope: { kind: 'terminal', name: 'Shell', targetId: 'sh_1', agentPageId: null } },
+            { id: 'page', scope: { kind: 'page', name: 'Doc', targetId: 'pg_1', agentPageId: null } },
             { id: 'unbound', scope: null },
             chatPane('chat', 'c1'),
           ],
@@ -133,19 +130,5 @@ describe('annotateConversationsWithPanes', () => {
     const conversations = [thread('c1')];
     annotateConversationsWithPanes(conversations, grid([{ id: 'col', panes: [chatPane('p', 'c1')] }]));
     expect(conversations[0]).not.toHaveProperty('pane');
-  });
-});
-
-describe('paneByConversationId', () => {
-  it('indexes only chat panes, first wins', () => {
-    const index = paneByConversationId(
-      grid([
-        { id: 'c1', panes: [chatPane('p1', 'conv-a'), { id: 't', scope: { kind: 'terminal', targetId: 'sh' } }] },
-        { id: 'c2', panes: [chatPane('p2', 'conv-a'), chatPane('p3', 'conv-b')] },
-      ]),
-    );
-
-    expect([...index.keys()].sort()).toEqual(['conv-a', 'conv-b']);
-    expect(index.get('conv-a')?.paneId).toBe('p1');
   });
 });

--- a/apps/web/src/lib/agent-workspaces/agent-workspaces-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/agent-workspaces-runtime.ts
@@ -76,6 +76,7 @@ import { conversationRepository } from '@/lib/repositories/conversation-reposito
 import { resolveOrCreateConversation } from '@/lib/repositories/resolve-or-create-conversation';
 import { countOpenConversations } from '@/lib/agent-workspaces/conversation-cap';
 import { createConversationInSessionWith } from '@/lib/agent-workspaces/create-conversation-in-workspace';
+import { placeWorkerPane } from '@/lib/agent-workspaces/workspace-placement';
 import { conversationPageId } from '@pagespace/lib/conversations/conversation-page';
 import {
   closeConversationInSessionWith,
@@ -409,8 +410,13 @@ export async function createConversationInSession(input: {
   workspaceId: string;
   /** Display label written at birth (a spawned worker's name). */
   title?: string | null;
+  /**
+   * The spawning conversation, when it shares this grid — never evicted by its
+   * own spawn. Only `spawn_session` has one.
+   */
+  excludeTargetId?: string;
 }): Promise<void> {
-  return withSessionListingLock(input.workspaceId, () =>
+  await withSessionListingLock(input.workspaceId, () =>
     createConversationInSessionWith(
       {
         ...buildClaimDeps(),
@@ -427,6 +433,42 @@ export async function createConversationInSession(input: {
       input,
     ),
   );
+
+  // PLACEMENT BELONGS TO CREATION, for every caller (issue #2373).
+  //
+  // It used to live in `spawn_session` alone, behind
+  // `if (deps.placeWorkerPane && toolCallId)`. The three ROUTE callers — the
+  // session spawn, the per-workspace conversation POST, and the page-agent
+  // conversation POST — created threads that were never placed at all. Paired
+  // with the sidebar's old `chatPanes ?? conversations` fork, that made every
+  // UI-created thread invisible in any workspace that already had a grid.
+  // Production carried 1 of 3 and 6 of 10 such threads.
+  //
+  // The opId is derived from the conversation id rather than a caller-supplied
+  // `toolCallId`, so it is (a) always available — the old gate silently skipped
+  // placement whenever it was not — and (b) idempotent on the fact that
+  // matters: one placement per thread, however many times creation is retried.
+  //
+  // Best-effort by design, and AFTER the lock: a grid that cannot be written
+  // must not fail a conversation that already exists. The thread is listed
+  // either way now — unplaced instead of invisible — which is exactly what
+  // makes degrading here safe.
+  try {
+    await placeWorkerPane({
+      workspaceId: input.workspaceId,
+      conversationId: input.conversationId,
+      name: input.title ?? 'New conversation',
+      agentPageId: input.agentPageId,
+      opId: `create_conversation:${input.conversationId}`,
+      ...(input.excludeTargetId === undefined ? {} : { excludeTargetId: input.excludeTargetId }),
+    });
+  } catch (error) {
+    loggers.api.warn('conversation created but its pane could not be placed', {
+      workspaceId: input.workspaceId,
+      conversationId: input.conversationId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+  }
 }
 
 /**

--- a/apps/web/src/lib/agent-workspaces/agent-workspaces-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/agent-workspaces-runtime.ts
@@ -415,6 +415,27 @@ export async function createConversationInSession(input: {
    * own spawn. Only `spawn_session` has one.
    */
   excludeTargetId?: string;
+  /**
+   * Put the new thread in the workspace's grid.
+   *
+   * OPT-IN, and the opt-out is the important half. A caller that already has a
+   * pane in mind must NOT ask for this: the pane picker
+   * (`AgentPanes.handlePickAgent`) binds its pane to a LOADING scope
+   * (`{ kind: 'chat', targetId: null }`), POSTs the creation, then binds that
+   * same pane to the new conversation. A loading pane is not `isReplaceable`
+   * (`workspace-layout-verbs.ts:861` — `targetId !== null` fails), so a server
+   * placement resolves to `split` and opens a SECOND pane; the client's own
+   * bind then leaves one conversation displayed twice (review finding — codex
+   * P1).
+   *
+   * So this is for creators with no client pane to fill: `spawn_session`, where
+   * an agent mints a worker and nothing in a browser is waiting to place it.
+   *
+   * Not placing is safe. A thread's VISIBILITY no longer depends on having a
+   * pane — the listing carries unplaced threads and the sidebar renders them
+   * (issue #2373). Placement is about the grid, not about being findable.
+   */
+  placeInGrid?: boolean;
 }): Promise<void> {
   await withSessionListingLock(input.workspaceId, () =>
     createConversationInSessionWith(
@@ -434,25 +455,18 @@ export async function createConversationInSession(input: {
     ),
   );
 
-  // PLACEMENT BELONGS TO CREATION, for every caller (issue #2373).
+  if (!input.placeInGrid) return;
+
+  // The opId derives from the CONVERSATION id, not a caller-supplied
+  // `toolCallId`. The old gate in `spawn_session` was
+  // `if (deps.placeWorkerPane && toolCallId)`, which silently skipped placement
+  // whenever the SDK handed it no call id. A conversation-keyed op is always
+  // available and idempotent on the fact that matters: one pane per thread,
+  // however many times creation is retried.
   //
-  // It used to live in `spawn_session` alone, behind
-  // `if (deps.placeWorkerPane && toolCallId)`. The three ROUTE callers — the
-  // session spawn, the per-workspace conversation POST, and the page-agent
-  // conversation POST — created threads that were never placed at all. Paired
-  // with the sidebar's old `chatPanes ?? conversations` fork, that made every
-  // UI-created thread invisible in any workspace that already had a grid.
-  // Production carried 1 of 3 and 6 of 10 such threads.
-  //
-  // The opId is derived from the conversation id rather than a caller-supplied
-  // `toolCallId`, so it is (a) always available — the old gate silently skipped
-  // placement whenever it was not — and (b) idempotent on the fact that
-  // matters: one placement per thread, however many times creation is retried.
-  //
-  // Best-effort by design, and AFTER the lock: a grid that cannot be written
-  // must not fail a conversation that already exists. The thread is listed
-  // either way now — unplaced instead of invisible — which is exactly what
-  // makes degrading here safe.
+  // Best-effort, and AFTER the listing lock: a grid that cannot be written must
+  // not fail a conversation that already exists. Degrading is safe because the
+  // thread is listed either way now — unplaced rather than invisible.
   try {
     await placeWorkerPane({
       workspaceId: input.workspaceId,

--- a/apps/web/src/lib/agent-workspaces/annotate-conversation-panes.ts
+++ b/apps/web/src/lib/agent-workspaces/annotate-conversation-panes.ts
@@ -1,0 +1,91 @@
+/**
+ * ONE ANSWER TO "WHAT IS IN THIS WORKSPACE" (issue #2373).
+ *
+ * `/api/agent-workspaces` used to return two collections per workspace — the
+ * flat conversation list AND the pane grid — and leave the client to choose.
+ * `AgentsSidebar` chose the grid (`chatPanes ?? session.conversations`), and an
+ * open workspace always HAS a grid, so the pane branch always won. A thread
+ * whose pane row did not exist was therefore invisible, however correct its
+ * conversation row.
+ *
+ * That is not an edge case. Placement is best-effort — `spawn_session` only
+ * calls `placeWorkerPane` when it has a `toolCallId` — so "created but not
+ * placed" is the ordinary state of a freshly spawned worker. Measured in
+ * production at the time of the bug: one workspace had 3 threads and 2 panes,
+ * another had 10 threads and 4 panes. Six of that second workspace's threads
+ * could not be seen or reached from the sidebar at all.
+ *
+ * So the grid stops being a second list and becomes an ANNOTATION on the one
+ * list. Every thread appears; a placed one additionally knows where it sits.
+ *
+ * Pure and total: no IO, no clock, no throw. The grid is untrusted input from
+ * a row read — a pane may name a conversation that is not in this workspace's
+ * listing (a cross-workspace target the label resolver gates separately), and
+ * that pane simply annotates nothing.
+ */
+
+import type { PersistedColumnState } from '@pagespace/lib/agent-workspaces/contract';
+
+/** A thread's placement in its workspace's grid. */
+export interface ConversationPanePlacement {
+  paneId: string;
+  columnId: string;
+  /** Position within the column — grid order without re-reading the grid. */
+  orderIndex: number;
+}
+
+/** The subset of a listing entry this function reads and writes. */
+interface PlaceableConversation {
+  conversationId: string;
+}
+
+/**
+ * Index a grid by the conversation each `chat` pane addresses.
+ *
+ * Only `chat` panes name a conversation — a terminal, a page pane or a
+ * still-unbound pane addresses something else or nothing, and must not shadow
+ * a thread. FIRST placement wins: a conversation open in two panes of one grid
+ * is legal, and the sidebar shows one row for the thread rather than two.
+ */
+export function paneByConversationId(
+  grid: readonly PersistedColumnState[] | null | undefined,
+): Map<string, ConversationPanePlacement> {
+  const byConversation = new Map<string, ConversationPanePlacement>();
+  if (!grid) return byConversation;
+
+  for (const column of grid) {
+    column.panes.forEach((pane, orderIndex) => {
+      const scope = pane.scope;
+      if (!scope || scope.kind !== 'chat' || !scope.targetId) return;
+      if (byConversation.has(scope.targetId)) return;
+      byConversation.set(scope.targetId, {
+        paneId: pane.id,
+        columnId: column.id,
+        orderIndex,
+      });
+    });
+  }
+  return byConversation;
+}
+
+/**
+ * Annotate a workspace's threads with their pane placement, preserving the
+ * caller's ordering.
+ *
+ * Order is deliberately NOT re-derived from the grid. The listing arrives
+ * newest-activity-first (`listSessionConversationsBulk`'s `ROW_NUMBER() OVER
+ * (... ORDER BY lastMessageAt DESC)`), which is the order a sidebar reader
+ * wants; grid position is geometry for the pane surface, and sorting the
+ * sidebar by it would make a thread jump when someone rearranged panes.
+ * Callers that want grid order have `pane.columnId` / `pane.orderIndex`.
+ */
+export function annotateConversationsWithPanes<T extends PlaceableConversation>(
+  conversations: readonly T[],
+  grid: readonly PersistedColumnState[] | null | undefined,
+): (T & { pane: ConversationPanePlacement | null })[] {
+  const byConversation = paneByConversationId(grid);
+  return conversations.map((conversation) => ({
+    ...conversation,
+    pane: byConversation.get(conversation.conversationId) ?? null,
+  }));
+}

--- a/apps/web/src/lib/agent-workspaces/annotate-conversation-panes.ts
+++ b/apps/web/src/lib/agent-workspaces/annotate-conversation-panes.ts
@@ -60,7 +60,7 @@ interface PlaceableConversation {
  * a thread. FIRST placement wins: a conversation open in two panes of one grid
  * is legal, and the sidebar shows one row for the thread rather than two.
  */
-export function paneByConversationId(
+function paneByConversationId(
   grid: readonly PersistedColumnState[] | null | undefined,
 ): Map<string, ConversationPanePlacement> {
   const byConversation = new Map<string, ConversationPanePlacement>();

--- a/apps/web/src/lib/agent-workspaces/annotate-conversation-panes.ts
+++ b/apps/web/src/lib/agent-workspaces/annotate-conversation-panes.ts
@@ -8,9 +8,11 @@
  * whose pane row did not exist was therefore invisible, however correct its
  * conversation row.
  *
- * That is not an edge case. Placement is best-effort — `spawn_session` only
- * calls `placeWorkerPane` when it has a `toolCallId` — so "created but not
- * placed" is the ordinary state of a freshly spawned worker. Measured in
+ * That is not an edge case. This PR closes the worst source of it (placement
+ * used to be skipped entirely whenever the SDK handed `spawn_session` no
+ * `toolCallId`), but "created but not placed" remains a legitimate resting
+ * state, not a failure: placement is best-effort by design, and a thread
+ * created without `placeInGrid` is never placed at all. Measured in
  * production at the time of the bug: one workspace had 3 threads and 2 panes,
  * another had 10 threads and 4 panes. Six of that second workspace's threads
  * could not be seen or reached from the sidebar at all.
@@ -22,6 +24,17 @@
  * a row read — a pane may name a conversation that is not in this workspace's
  * listing (a cross-workspace target the label resolver gates separately), and
  * that pane simply annotates nothing.
+ *
+ * The annotation runs list-to-grid and never the reverse, which is a decision,
+ * not an oversight. The listing is capped at `MAX_SESSION_CONVERSATIONS` (100
+ * by `lastMessageAt`), so a pane whose thread ranks past that cap gets no
+ * sidebar row, where the deleted `PaneRow` path would have synthesised one. We
+ * accept that: the sidebar lists a workspace's THREADS, and inventing a row out
+ * of a pane is precisely the second source of truth this module exists to
+ * remove. The pane itself still renders in the grid, which reads the store's
+ * geometry rather than this listing, so the thread stays visible and closable
+ * where it is actually open. Trading a >100-thread edge for the ordinary
+ * freshly-spawned-worker case measured above is the right side of that bet.
  */
 
 import type { PersistedColumnState } from '@pagespace/lib/agent-workspaces/contract';

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -48,7 +48,7 @@ import {
   getAgentSessionStore,
 } from '@/lib/agent-workspaces/agent-workspaces-runtime';
 import { countOpenConversations } from '@/lib/agent-workspaces/conversation-cap';
-import { applyLayoutVerbForWorkspace, placeWorkerPane } from '@/lib/agent-workspaces/workspace-placement';
+import { applyLayoutVerbForWorkspace } from '@/lib/agent-workspaces/workspace-placement';
 import { readWorkspaceLayoutSnapshot } from '@/lib/agent-workspaces/workspace-layout-runtime';
 import {
   AgentNotInSessionDriveError,
@@ -977,6 +977,9 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           userId: ownerId,
           agentPageId,
           workspaceId,
+          // The spawning conversation shares this grid when the worker lands in
+          // the caller's own workspace — never evicted by its own spawn.
+          excludeTargetId: callerConversationId,
           // The worker's label, written AT BIRTH onto the conversation row —
           // it is what the sidebar and list_sessions display (codex review,
           // P2: the old path reported the name in the tool response and then
@@ -1016,7 +1019,6 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       return { ok: true, workspaceId };
     },
 
-    placeWorkerPane,
 
     // The layout family's two seams (issue #2208). The read is the SAME
     // label-joining snapshot the layout GET serves, so a model and a browser

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -980,6 +980,10 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           // The spawning conversation shares this grid when the worker lands in
           // the caller's own workspace — never evicted by its own spawn.
           excludeTargetId: callerConversationId,
+          // An agent minting a worker has no browser pane waiting to be filled,
+          // so the server places it. The pane-picker routes deliberately do not
+          // ask for this — see `placeInGrid`'s doc.
+          placeInGrid: true,
           // The worker's label, written AT BIRTH onto the conversation row —
           // it is what the sidebar and list_sessions display (codex review,
           // P2: the old path reported the name in the tool response and then

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -1023,7 +1023,6 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       return { ok: true, workspaceId };
     },
 
-
     // The layout family's two seams (issue #2208). The read is the SAME
     // label-joining snapshot the layout GET serves, so a model and a browser
     // never see different names for the same pane; the write is the same

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -428,27 +428,6 @@ export interface SessionToolsDeps {
     | { ok: false; reason: string; detail?: string }
   >;
   /**
-   * Give the freshly spawned worker a PANE in its workspace's grid (epic
-   * Phase 3) — placement the blob era could not express at all, because the
-   * grid's only writer was a browser's debounced PUT. Applied as a real
-   * layout verb, so it lands in the pane rows (visible whenever that grid is
-   * next opened) and broadcasts to any grid already open.
-   *
-   * A courtesy on top of the spawn, never a precondition: the implementation
-   * swallows its own failures, and this dep is OPTIONAL so a test harness (or
-   * any surface with no grid to place into) simply omits it.
-   */
-  placeWorkerPane?: (input: {
-    workspaceId: string;
-    conversationId: string;
-    name: string;
-    agentPageId: string | null;
-    /** Derived from the tool call id — a retried spawn must not place twice. */
-    opId: string;
-    /** The spawning conversation: never evicted by its own spawn. */
-    excludeTargetId?: string;
-  }) => Promise<void>;
-  /**
    * Dispatch one turn into a worker's conversation THROUGH THE STANDARD CHAT
    * PIPELINE (the `ai_stream_sessions` background-run machinery normal
    * conversations use) — never a second engine. `wait` blocks for the reply.
@@ -521,8 +500,8 @@ export interface SessionToolsDeps {
    *
    * `applied: false` is a real, successful answer: the reducer is total, so a
    * stale pane id or a resize that resolves to the size already in force
-   * changes nothing rather than failing. OPTIONAL, like `placeWorkerPane` —
-   * a harness with no grid simply omits it and the tools say so.
+   * changes nothing rather than failing. OPTIONAL — a harness with no grid
+   * simply omits it and the tools say so.
    */
   applyLayoutVerb?: (input: {
     workspaceId: string;
@@ -1040,22 +1019,16 @@ export function createSessionTools(deps: SessionToolsDeps): {
           };
         }
 
-        // Place the worker's pane BEFORE dispatching: the first token of its
-        // reply should stream into a pane the user is already watching, not
-        // arrive before the surface it belongs to exists. `toolCallId` keys
-        // the placement so an SDK retry of this one call replays through the
-        // verb engine's op memory instead of opening a second pane.
-        const toolCallId = (options as { toolCallId?: string } | undefined)?.toolCallId;
-        if (deps.placeWorkerPane && toolCallId) {
-          await deps.placeWorkerPane({
-            workspaceId: created.workspaceId,
-            conversationId,
-            name: plan.name,
-            agentPageId,
-            opId: `spawn_session:${toolCallId}`,
-            excludeTargetId: callerConversationId,
-          });
-        }
+        // Placement happens inside `createWorkerSession` now, for every caller
+        // rather than for this tool alone (issue #2373). It used to sit here,
+        // gated on `deps.placeWorkerPane && toolCallId` — so the three route
+        // callers never placed at all, and even this path silently skipped it
+        // whenever the SDK gave no `toolCallId`. The op key derives from the
+        // conversation id, which is both always available and idempotent on
+        // the fact that matters: one pane per thread.
+        //
+        // It still lands BEFORE the dispatch below, so the worker's first token
+        // streams into a pane the user is already watching.
 
         const dispatched = await deps.dispatch({
           conversationId,

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -1019,15 +1019,20 @@ export function createSessionTools(deps: SessionToolsDeps): {
           };
         }
 
-        // Placement happens inside `createWorkerSession` now, for every caller
-        // rather than for this tool alone (issue #2373). It used to sit here,
-        // gated on `deps.placeWorkerPane && toolCallId` — so the three route
-        // callers never placed at all, and even this path silently skipped it
-        // whenever the SDK gave no `toolCallId`. The op key derives from the
-        // conversation id, which is both always available and idempotent on
-        // the fact that matters: one pane per thread.
+        // Placement moved inside `createWorkerSession`, which this tool asks
+        // for with `placeInGrid` (issue #2373). It used to sit here, gated on
+        // `deps.placeWorkerPane && toolCallId`, and silently skipped placement
+        // whenever the SDK gave no call id. The op key now derives from the
+        // conversation id, which is always available and idempotent on the
+        // fact that matters: one pane per thread.
         //
-        // It still lands BEFORE the dispatch below, so the worker's first token
+        // Still opt-in per caller, not universal — the pane-picker routes
+        // deliberately don't ask, because a browser pane is already waiting to
+        // be bound and a second server placement would race it (codex P1).
+        // Their threads are findable regardless: visibility stopped depending
+        // on placement the moment the read model became one list.
+        //
+        // It lands BEFORE the dispatch below, so the worker's first token
         // streams into a pane the user is already watching.
 
         const dispatched = await deps.dispatch({

--- a/packages/lib/src/agent-workspaces/__tests__/resolve-open-placement.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/resolve-open-placement.test.ts
@@ -191,15 +191,15 @@ describe('resolveOpenPlacement', () => {
  */
 describe('a loading pane is not replaceable — the picker flow depends on it', () => {
   it('does not treat a chat pane awaiting its conversation as fillable', () => {
-    expect(isReplaceable({ id: 'pane-1', scope: { kind: 'chat', name: 'New conversation', targetId: null, agentPageId: null } } as never)).toBe(false);
+    expect(isReplaceable(pane('pane-1', chat(null, 'New conversation')))).toBe(false);
   });
 
   it('does treat an empty pane and a bound chat pane as fillable', () => {
-    expect(isReplaceable({ id: 'p', scope: null } as never)).toBe(true);
-    expect(isReplaceable({ id: 'p', scope: { kind: 'chat', name: 'x', targetId: 'conv-1', agentPageId: null } } as never)).toBe(true);
+    expect(isReplaceable(pane('pane-1', null))).toBe(true);
+    expect(isReplaceable(pane('pane-1', chat('conv-1')))).toBe(true);
   });
 
   it('never treats a terminal as fillable — a shell is not a surface to evict', () => {
-    expect(isReplaceable({ id: 'p', scope: { kind: 'terminal', name: 'sh', targetId: 'sh-1' } } as never)).toBe(false);
+    expect(isReplaceable(pane('pane-1', terminal('sh-1')))).toBe(false);
   });
 });

--- a/packages/lib/src/agent-workspaces/__tests__/resolve-open-placement.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/resolve-open-placement.test.ts
@@ -12,7 +12,7 @@
  * refusals, rather than a merged predicate neither caller can read.
  */
 import { describe, it, expect } from 'vitest';
-import { resolveOpenPlacement, type PaneState, type WorkspaceState } from '../workspace-layout-verbs';
+import { isReplaceable, resolveOpenPlacement, type PaneState, type WorkspaceState } from '../workspace-layout-verbs';
 import type { PaneScope } from '../contract';
 
 const chat = (targetId: string | null, name = 'Conversation'): PaneScope => ({
@@ -170,5 +170,36 @@ describe('resolveOpenPlacement', () => {
         paneId: 'pane-1',
       });
     });
+  });
+});
+
+/**
+ * WHY A SERVER-SIDE PLACEMENT MUST NOT RACE THE PANE PICKER (issue #2373,
+ * review finding — codex P1).
+ *
+ * `AgentPanes.handlePickAgent` binds its pane to a LOADING scope
+ * (`{ kind: 'chat', targetId: null }`), POSTs the creation, then binds that
+ * same pane to the new conversation. If the creation ALSO placed server-side,
+ * the placement would run against a grid whose only candidate pane is that
+ * loading one — and a loading pane is deliberately not replaceable, so the
+ * placement resolves to `split` and opens a SECOND pane. The client's own bind
+ * then leaves one conversation displayed twice.
+ *
+ * The rule below is what makes that true, so it is pinned here: creation places
+ * only for callers with no client pane in flight (`placeInGrid`, see
+ * `agent-workspaces-runtime.ts`).
+ */
+describe('a loading pane is not replaceable — the picker flow depends on it', () => {
+  it('does not treat a chat pane awaiting its conversation as fillable', () => {
+    expect(isReplaceable({ id: 'pane-1', scope: { kind: 'chat', name: 'New conversation', targetId: null, agentPageId: null } } as never)).toBe(false);
+  });
+
+  it('does treat an empty pane and a bound chat pane as fillable', () => {
+    expect(isReplaceable({ id: 'p', scope: null } as never)).toBe(true);
+    expect(isReplaceable({ id: 'p', scope: { kind: 'chat', name: 'x', targetId: 'conv-1', agentPageId: null } } as never)).toBe(true);
+  });
+
+  it('never treats a terminal as fillable — a shell is not a surface to evict', () => {
+    expect(isReplaceable({ id: 'p', scope: { kind: 'terminal', name: 'sh', targetId: 'sh-1' } } as never)).toBe(false);
   });
 });

--- a/packages/lib/src/realtime/rooms.ts
+++ b/packages/lib/src/realtime/rooms.ts
@@ -89,9 +89,11 @@ export const dmRoom = (conversationId: string): string => `dm:${conversationId}`
 /**
  * Agent-session workspace room (`session:<agent_workspaces.id>`) — the layout
  * plane for one workspace: `workspace:updated` (rev-carrying pane-grid
- * events) fan out here (epic Phase 3). Join sites arrive with the client
- * store rewrite PR; the shape is in the grammar now so the server's verb
- * writes are broadcastable from day one.
+ * events) fan out here (epic Phase 3). Clients join from
+ * `useWorkspaceLayoutSync`, which holds this room for the ONE workspace whose
+ * grid is on screen — distinct from `user:<id>:sessions`, the directory plane
+ * carrying every workspace a user owns. Two rooms because the audiences
+ * genuinely differ, not because the concept does.
  */
 export const sessionRoom = (workspaceId: string): string => `session:${workspaceId}`;
 


### PR DESCRIPTION
Part of #2373 — Phase A of collapsing the spawn path to one source of truth.

**In one paragraph:** the sidebar asked two different sources which threads a workspace has — the conversation list and the pane grid — and picked the grid. An open workspace always has a grid, so any thread without a pane row was invisible, which is the ordinary state of a freshly spawned worker. The route now returns **one** list, with each thread carrying its pane placement as an *annotation* rather than the grid being a rival list; the sidebar renders that one list; and placement moved into creation behind an opt-in flag. Measured in production at the time of the bug: one workspace showed 2 of its 3 threads, another 4 of its 10.

The rest of this description is the audit trail — reviewer findings, what self-review turned up, mutation results, and the residuals this PR does not close. Read the sections that matter to you; nothing below changes the paragraph above.


> **Deliberately not `Fixes`.** #2373 names three distinct root causes and this PR closes one of them. Auto-closing the issue on merge would bury the other two.
>
> - **Root cause 1 — the sidebar never shows a newly spawned worker.** Fixed here, though not by the mechanism the issue proposed. The issue read it as a missing realtime push on a 20s poll; the directory events turned out to already exist and route correctly. The actual defect was the read model — the route returned two lists and the client picked the pane one, so an unplaced thread was invisible no matter how promptly its event arrived.
> - **Root cause 2 — `open_page_pane` opens nothing from the global assistant.** Not fixed here. The epic made the tool's `execute` apply a real server-side layout verb, which is the fix the issue itself proposed, but two gaps remain: it places only `if (conversationId && toolCallId && viewerId)` — the same `toolCallId` hole this PR closes for `spawn_session` — and the global assistant still has no pane grid to place into.
> - **Root cause 3 — a `send_session` message doesn't reach a target pane that isn't the active view.** Already fixed, by the epic rather than by this PR — traced rather than assumed. The issue's diagnosis was that `GlobalChatContext` only processes stream events for the *selected* conversation. Panes no longer depend on that: each pane subscribes to its own conversation's room. `PaneChat` → `AssistantSessionChat` → `useAssistantSessionChat:147` → `useConversationSubscription(conversationId)` for assistant threads, and `PaneChat` → `SessionChat` → `useAgentSessionChat:146` → `useAgentChannelMultiplayer` → the same subscription for page-agent threads. A message written to conversation X reaches the pane showing X whatever is selected.
>
> So **root cause 2 is the only one still outstanding**, and it is the reason this PR does not close the issue. It is also narrower than the issue's original framing: the epic already moved `open_page_pane` to a real server-side layout verb, leaving the `toolCallId` gate and the global assistant's missing grid.

## What was wrong

Server-side session tools succeeded, the DB was correct, and the sidebar showed nothing. Two exploration passes confirmed the rooms and event names match exactly on both realtime planes (`rooms.ts:96,120`, `conversation-event-names.ts:44-50`) — **routing was never the bug.**

The bug was that *"which threads are in this workspace"* had **two answers**. `/api/agent-workspaces` returned the flat conversation list AND the pane grid, and `AgentsSidebar` chose:

```ts
chatPanes ?? session.conversations
```

An open workspace always has a grid, so the pane branch always won — and a thread whose pane row didn't exist was invisible, however correct its conversation row. It couldn't be seen, opened, or closed.

Not an edge case. Measured on production while diagnosing:

| workspace | threads | panes | invisible |
|---|---|---|---|
| `tnmj4mu…` Global Assistant | 3 | 2 | 1 |
| `jmn1dan…` Global Assistant 2 | 10 | 4 | **6** |

The conversation titled **"hi"** in the issue is one of them — `pane_rows = 0`.

## Why so many were unplaced

Placement lived in `spawn_session` alone, behind `if (deps.placeWorkerPane && toolCallId)`. Two holes in one line:

- the **three route callers** of `createConversationInSession` — session spawn, per-workspace conversation POST, page-agent conversation POST — never placed a pane at all;
- even the tool's own path silently skipped placement whenever the SDK gave no `toolCallId`.

So every UI-created thread was unplaced, and therefore invisible in any workspace with a grid.

## The fix

**The grid becomes an annotation, not a second list.** `annotateConversationsWithPanes` (pure, total, no IO) joins them server-side: every thread appears, and a placed one carries `{ paneId, columnId, orderIndex }`. Unplaced threads are not filtered — that's the entire point. The route still returns `workspace`, but only for the grid's *geometry*; it is no longer anyone's source for which threads exist.

**This changes the visible row order, deliberately.** A workspace with a grid used to list its rows in grid order (columns, then panes); it now lists them newest-activity-first, because that is the order the listing arrives in and the order a sidebar reader wants. Grid order is not recoverable as a *total* order anyway once unplaced threads are in the list — they have no position, so a grid-ordered list would need an arbitrary fallback for exactly the threads this PR exists to surface. Activity order is the only coherent one, and it has the better property besides: a thread stops jumping when someone rearranges panes. Callers that genuinely want grid order have `pane.columnId` / `pane.orderIndex` on each row. Pinned by `preserves the listing order rather than re-deriving it from the grid`.

**The client stops choosing.** `PaneRow` and the conversation row collapse into one `ConversationRow` keyed by the THREAD. Its pane, when it has one, decides only which close verb applies — unbind the pane, or close the thread.

Keying by the thread preserves what the pane-keyed row was written for (*"changing the agent in a pane spawns a new sidebar item"*): the mint that repoints a pane removes the stale conversation, so it leaves the listing (`isActive AND closedInWorkspaceAt IS NULL`) rather than lingering beside its replacement.

**Placement belongs to creation.** It moves into `createConversationInSession`, which every path already goes through, and is requested there with an opt-in `placeInGrid` flag. (It was unconditional when first written; review round 1 below explains why it must not be — a caller that already has a browser pane in flight would race it.) The op key derives from the *conversation id* rather than a caller-supplied `toolCallId` — always available, and idempotent on the fact that matters: one pane per thread, however many retries. Best-effort and outside the listing lock: a grid that can't be written must not fail a conversation that already exists. Degrading is safe now in a way it wasn't before — the thread is listed either way.

## Tests

Fixtures that can't drift: `AgentsSidebar.test.tsx`'s responder now annotates through the server's own `annotateConversationsWithPanes` rather than hand-writing the shape. A fixture whose grid and conversation list disagreed about placement is exactly the bug this suite is meant to catch.

Three new tests, all observed to fail against the fork:
- an unplaced thread renders alongside placed ones (pre-fix: `Unable to find an element with the text: Researcher — hi`)
- its Close closes the THREAD, since there's no pane to unbind
- the route lists a thread with `pane: null` rather than dropping it

Every sidebar row now carries `testId="sidebar-conversation-row"` — only the conversation branch did before, which is why `18-sidebar-directory-live.spec.ts` had to build a deliberately grid-less workspace to see anything (`:81-85`). That constraint is gone.

## Verification

`typecheck` · `lint` · **16615 web tests pass**, plus `starter-skill-tool-references.test.ts`, which **fails on master too** — verified, unrelated. (This line originally blamed the DB-suite failures on Docker being down. That was wrong; see Validation at the bottom for the actual cause and the re-run with the DB reachable.)

## A residual this PR does not close, stated precisely

The plan for this work asked to move the directory emit off `claimConversation` so that create + claim + place became one unit emitting one terminal event. **I did not do that**, and the ordering race it named is still there:

1. the claim sets `workspaceId` and emits `conversation:updated` (`conversation-repository.ts:414`)
2. the sidebar refetches its listing on that event
3. `placeWorkerPane` writes the pane row and broadcasts `workspace:updated` — which the sidebar does **not** listen for

So a refetch that wins the race stores `pane: null` for a thread that is about to be placed, and nothing corrects it until the next listing event or the SWR poll — `refreshInterval: 120_000`, so up to two minutes.

The visible consequence is a **wrong close verb, not a wrong list**: for that window the row's Close takes the thread-close branch (a soft, reversible `closedInWorkspaceAt` with a `reopen` route) instead of unbinding the pane. The thread is listed correctly throughout, which is the bug this PR set out to fix.

Left alone deliberately, for two reasons. It is strictly better than what it replaces — the same 120s staleness previously made a freshly spawned worker **invisible**, which is issue #2373 itself. And closing it properly belongs to the phases that own it: Phase B (one client cache) and Phase C (one event vocabulary, so a layout event can invalidate a listing). Adding a second server-side emit here would be a behavioural change to a twice-reviewed PR to close a two-minute cosmetic-verb window, and that trade is not worth another review round.

## Scope

Phase A only. Phases B–D of the agreed collapse — one client cache, one event vocabulary, one naming vocabulary — are follow-ons, and PR 17 (dropping the epic's compat shims) stays queued behind them. See `~/.claude/plans/snoopy-cooking-lark.md`.

**Correction to an earlier claim in this description.** It used to say `starter-bodies/plan.ts:53,73` — which tells agents *"never say 'I've opened it for you'"* — was stale guidance about a tool this PR makes reliable. I checked, and that is wrong: `page-pane-tools.ts:105-110` still acks `opened: true` unconditionally and still no-ops outside a session grid, and nothing here changes it. The guidance is accurate and stays.

Found while checking it, and left alone deliberately: `open_page_pane` places only `if (conversationId && toolCallId && viewerId)` — the same `toolCallId` hole this PR closes for `spawn_session`, in a different tool. Page panes are not this PR's subject and the diff is wide enough; filing rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPV7UjjuAzcHmJAhpxL5G8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conversations now appear individually in the agent sidebar, including those not assigned to a pane.
  - Placed conversations display pane, column, and ordering details.
  - Newly created worker conversations are automatically placed in the workspace when applicable.
  - Workspace layout information is provided separately for consistent display.

- **Bug Fixes**
  - Unplaced conversations remain visible and can be deleted safely.
  - Conversation ordering and placement metadata are preserved consistently.
  - Closing panes no longer incorrectly removes conversations still available elsewhere.
  - Repeated worker creation no longer creates duplicate pane placements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 1 — three findings, all fixed (`b09b04d8b`)

**codex P1 — placement raced the pane picker.** Making placement unconditional was too broad. `AgentPanes.handlePickAgent` binds its pane to a LOADING scope (`{ kind: 'chat', targetId: null }`), POSTs the creation, then binds that same pane. `isReplaceable` (`workspace-layout-verbs.ts:861`) fails on `targetId !== null`, so a loading pane is not replaceable, server placement resolved to `split`, and the client's own bind left one conversation in two panes. Verified against the source, not taken on trust.

Placement is now **opt-in** (`placeInGrid`), and only `spawn_session` asks for it. Reverting the routes costs nothing: a thread's *visibility* no longer depends on having a pane — that's what the read model fixed — so placement is about the grid, not about being findable. The rule is pinned in `resolve-open-placement.test.ts`.

**CodeRabbit MAJOR — close could DELETE instead of reset.** `closePaneConversation` read the workspace straight off the store; for a session that isn't the displayed one the grid was never seated, `shownElsewhere` defaulted to false, and "close this pane" became "DELETE this conversation" for a thread still open elsewhere. Now routed through the existing `ensureLocalWorkspace`, with a fail-closed bail-out. Pre-existing, but in code this PR restructures and adjacent to data loss. New test leaves the store empty — the neighbouring test pre-hydrates it, which is why it was blind to this.

**CI — the E2E bystander assertion tested a render branch.** `18-sidebar-directory-live.spec.ts:431` asserted `toHaveCount(0)` on the bystander, and its own comment explained why: only the conversation branch carried `sidebar-conversation-row`. With one row shape and every row tagged, a session's own threads legitimately count. Rewritten to assert the count is **unchanged** by the spawn — what the test was always about, and strictly stronger, since it now catches a stray insert even into a session that legitimately has rows.

Re-validated: `typecheck` web/lib/e2e · `lint` 15/15 · **16617 web tests**. (The 15 DB-dependent suites reported as unreachable here were an invocation problem, not a broken environment — corrected under Validation below, where they run and pass.)


---

## Review round 2 — one finding, plus what self-review turned up (`763732bcd`, `8d3066d92`, `cfd847617`)

**CodeRabbit — the regression test asserted the wrong half.** The unhydrated-session test checked that the store got hydrated and that no DELETE fired, but never that the clicked pane was actually emptied; a bare early return on `shownElsewhere` would have passed it. It now asserts both scopes after the close — `pane-1` is `null`, `pane-2` still targets `conv-1`. The second assertion is what makes the test about the fix at all, since an unseated grid cannot see `pane-2` and would have taken the DELETE branch.

Three things the self-review pass found, none reported by a reviewer:

**The PR documented itself with a bug it had just fixed.** Three comments explained unplaced threads by "`spawn_session` places only when it has a `toolCallId`" — present tense, in the PR that closes exactly that gate. The permanent reason is narrower: placement is best-effort by design, and a thread created without `placeInGrid` is never placed at all. The list must not depend on placement having worked.

**A cap makes one case reachable that a test attributed only to cross-workspace targets.** The annotation runs list-to-grid and never the reverse, and the listing is capped at `MAX_SESSION_CONVERSATIONS` (100, by `lastMessageAt`) — so a pane whose thread ranks past the cap gets no sidebar row, where the deleted `PaneRow` would have synthesised one. Deliberate: inventing a row out of a pane is the second source of truth this PR removes, and such a pane still renders in the grid, which reads geometry from the store rather than from this listing. Documented at the annotator and named in the test.

**Two tests were weaker than they read.** The shared-pane test used `findAllByText(...)[0]` because two panes once rendered the same label — true of the deleted `PaneRow`. One thread now renders one row however many panes hold it, so it uses `findByText`, which throws on a second match: the workaround becomes an assertion of the property the PR establishes. And the session-search fixture built its second session as `{ ...SESSION, sessionId: 'ses-2' }`, overriding only the rolling-deploy compat twin and leaving the canonical `workspaceId` as `ses-1` — React had been warning about the duplicate key and the "two sessions" test was rendering one session twice. Pre-existing on master, fixed here because it is this suite's own coverage.

Plus three comments the epic outlived: a test named for the deleted `chatPanes ? … : conversations` fork, `rooms.ts` still saying layout-room join sites "arrive with the client store rewrite PR" (they arrived — `useWorkspaceLayoutSync.ts:51`), and two present-tense references to `useWorkspaceServerSync`, deleted earlier in this epic.

Re-validated: web `typecheck` clean · web `lint` clean · `AgentsSidebar` 73/73 · `AgentPanes` 81/81 · `annotate-conversation-panes` 9/9 · lib 8826 passed / 0 failed (13 suites fail to load without a local test DB — the known worktree gap, unrelated).


---

## A question a reviewer should ask, answered

**A claim I made and then disproved.** An earlier commit here said nothing asserted that `workspace` still carries the grid's geometry, and added a test for it. That was wrong — `should attach the grid as \`workspace\` in the whole-state shape` has covered exactly that since before this PR; my grep for it was simply bad. The redundant assertion is gone. What replaced it is the part that genuinely was uncovered: the annotation and the geometry **agree**, because `route.ts` reads the grid once and feeds both. Two views of placement drifting apart is the shape of the original bug, so it earns an assertion; the geometry alone did not need a second one.

**"You made a destructive verb newly reachable."** Half true, and worth stating plainly. Before this PR, a workspace with a grid rendered only pane rows, so its Close always meant *unbind the pane*; the thread-closing Close existed only on the flat list, which a workspace with a grid never showed. Now both verbs are reachable in the same expansion, chosen per row by whether the thread is placed — so a stale listing that says `pane: null` for a thread that has since been placed would take the thread verb where it used to take the pane verb.

That is safe, and specifically because of what the thread verb is. `DELETE /api/agent-workspaces/:id/conversations/:id` is a **soft listing close** — it sets `closedInWorkspaceAt`, is explicitly "NOT the history-deleting `ai/page-agents/…` DELETE", never touches a thread's history, has a dedicated `reopen` route, and is refused with a 409 on a session's last open listing (the never-empty invariant), which the row already handles by falling back to the confirmed end-session flow. The worst outcome of the stale-annotation case is a reversible listing close on a thread that could instead have been unbound.

The genuinely destructive direction is the opposite one — pane-close silently becoming thread-close for a thread open in *another* pane — and that is the CodeRabbit MAJOR fixed in round 1, now covered by two tests including one on a session the store has never hydrated.

## Validation

**26,813 tests passing locally, zero failures**, across all three packages — and this number is sound in a way the one it replaces was not.

| package | files | tests | failures |
|---|---|---|---|
| web | 1,123 | 16,748 | 0 |
| `@pagespace/lib` | 409 | 8,922 | 0 |
| `@pagespace/processor` | 65 | 1,143 | 0 |

An earlier revision of this description claimed 26,784 from the same three packages. I withdrew it, because I had produced the lib and processor halves from runs where `ADMIN_DATABASE_URL` pointed at the *shared* `pagespace_test` database. Those admin suites `DROP SCHEMA public`, so that run wiped it — and suites guarded by `requireDb` do not fail on a wiped database, they take an early return and report **passed**. An unknown subset of that figure was therefore vacuous.

Re-run with the databases separated the way CI has them (`pagespace_test` for `DATABASE_URL`, `pagespace_admin_test` for `ADMIN_DATABASE_URL`), the count went **up** by 29 — `gdpr-eraser` in lib, `audit-chainer-worker` and `siem-delivery-worker` in processor, and the three new `placeInGrid` cases. Those are tests that previously reported green while executing nothing. Both databases verified intact afterwards (130 and 15 tables, `drizzle_admin` schema only).

Also clean: web `typecheck`, `@pagespace/lib` `typecheck`, e2e `typecheck`, monorepo `lint` 15/15.

**Mutation-checked, not assumed.** Green tests are evidence only if they would go red for the right reason, so I broke the source deliberately and confirmed each guard fires:

| mutation | result |
|---|---|
| annotator filters out unplaced threads (reintroduces #2373) | **3 layers fail** — annotator 3, route 2, sidebar 15 |
| delete `if (!input.placeInGrid) return;` (reintroduces the codex P1) | gate test fails |
| revert `ensureLocalWorkspace()` to the raw store read (reintroduces the CodeRabbit MAJOR) | unhydrated-session test fails |
| `Close` always deletes the thread instead of unbinding the pane (the data-loss direction) | 5 sidebar tests fail |
| drop `workspace` geometry from the response | 2 route tests fail — one of them already on master |
| delete the `excludeTargetId` pass-through | **does NOT fail** — see below |
| make the placement `opId` unique per call, so retries stop replaying | **does NOT fail** — the focus branch, not op memory, is what holds the count at 1 here |

That last row is why this table exists. I had written a test claiming to guard the `excludeTargetId` pass-through; it does not, because `placeWorkerPane` also sets `preferSplit: true` and that alone suffices in the scenario. The test now states the outcome it actually proves — a spawn never navigates the caller's pane — and the pass-through's own coverage stays where it belongs, in `workspace-placement-worker.test.ts`. Every source file was restored and re-verified green afterwards.

**CI is the authority here, not my shell** — it provisions a clean database per run and supplies `ADMIN_DATABASE_URL` as a separate one.

Not done, and I would rather say so than imply otherwise: the plan's manual step (global assistant → `spawn_session`, watch the sidebar) has not been run against a live app in this session. The E2E spec `18-sidebar-directory-live.spec.ts` exercises the same path in CI and is the closest automated proxy.














