### PR TITLE
fix(mcp): correct two pasteable configs that could not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **The MCP config you copy out of Settings > MCP now actually starts** — the "No install (npx)"
+  tab handed you a command `npx` cannot run, so the server failed to launch and your AI tool
+  showed no PageSpace tools at all. Copy it again and it works.
+- **The MCP config the CLI prints after minting a key no longer assumes a global install** — it
+  offered only the form that needs `pagespace` on your PATH, which isn't there if you minted the
+  key through `npx`, and which desktop AI apps often can't find even when it is. It now prints the
+  zero-install form that works either way, and mentions the shorter global-install form as an
+  option.
 - **Panes and sidebars no longer sit blank while the messages are right there in the database** —
   every surface used to keep its own private copy of a conversation and its own theory of when to
   refresh, so a message written from one surface could stay invisible in another until you

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -521,8 +521,12 @@ export default function MCPSettingsView() {
 
   const generateConfig = (style: 'global' | 'npx' = setupStyle) => {
     const token = selectedToken || '<YOUR_PAGESPACE_MCP_TOKEN_HERE>';
+    // `-p` is load-bearing: @pagespace/cli publishes two bins (`pagespace` and
+    // `pagespace-mcp`) and neither is named `cli`, so without it npx treats
+    // `@pagespace/cli` as the command, finds no such bin, and exits with
+    // "could not determine executable to run".
     const launch = style === 'npx'
-      ? { command: "npx", args: ["-y", "@pagespace/cli", "pagespace-mcp"] }
+      ? { command: "npx", args: ["-y", "-p", "@pagespace/cli", "pagespace-mcp"] }
       : { command: "pagespace", args: ["mcp"] };
     const config = {
       mcpServers: {

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
@@ -486,7 +486,7 @@ describe('MCPSettingsView — Quick MCP Setup', () => {
     expect(within(setupCard).getByText(/reuse that scoped credential/i)).toBeInTheDocument();
   });
 
-  it('switching to the No install (npx) tab hides the install step and emits an npx config', async () => {
+  it('switching to the No install (npx) tab hides the install step and emits an npx config that names the bin with -p, since @pagespace/cli has two bins and neither is named cli', async () => {
     await renderView();
 
     await userEvent.click(screen.getByRole('tab', { name: /no install \(npx\)/i }));
@@ -496,7 +496,10 @@ describe('MCPSettingsView — Quick MCP Setup', () => {
 
     const config = getConfigJson();
     expect(config.mcpServers.pagespace.command).toBe('npx');
-    expect(config.mcpServers.pagespace.args).toEqual(['-y', '@pagespace/cli', 'pagespace-mcp']);
+    // Dropping `-p` here makes the emitted config unrunnable: npx would take
+    // `@pagespace/cli` as the command name and die with "could not determine
+    // executable to run". Do not "simplify" it away.
+    expect(config.mcpServers.pagespace.args).toEqual(['-y', '-p', '@pagespace/cli', 'pagespace-mcp']);
     expect(config.mcpServers.pagespace.env).toEqual({
       PAGESPACE_API_URL: 'https://pagespace.ai',
       PAGESPACE_TOKEN: '<YOUR_PAGESPACE_MCP_TOKEN_HERE>',

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The MCP config printed after `pagespace keys` / `pagespace keys create` no longer assumes a
+  global install.** It emitted only `{"command": "pagespace", "args": ["mcp"]}`, which needs
+  `pagespace` on the PATH of whatever launches the MCP client — not the case if you minted the key
+  through `npx -y -p @pagespace/cli pagespace keys`, and frequently not the case for GUI clients
+  (Claude Desktop, Cursor) that launch without your shell's PATH. It now prints the zero-install
+  `npx -y -p @pagespace/cli pagespace-mcp` form, matching the README, and offers the global-install
+  shorthand on a following line.
+
 ## [1.6.1] — 2026-07-08
 
 ### Fixed

--- a/packages/cli/src/bin-pagespace-mcp.ts
+++ b/packages/cli/src/bin-pagespace-mcp.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * The `pagespace-mcp` bin — a first-class, zero-install way to run the
- * `pagespace mcp` stdio server via `npx -y @pagespace/cli pagespace-mcp`.
+ * `pagespace mcp` stdio server via `npx -y -p @pagespace/cli pagespace-mcp`
+ * (`-p` required — two bins here, neither named `cli`).
  * Mirrors `bin.ts`'s process wiring exactly, but delegates all argv/route
  * logic to the pure `runPagespaceMcpBin` in `pagespace-mcp-bin.ts` — this
  * file only touches `process.*`.

--- a/packages/cli/src/commands/keys/__tests__/guidance.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/guidance.test.ts
@@ -16,12 +16,23 @@ describe('renderAgentWiringGuidance', () => {
     expect(embeddedJson(lines)).toEqual({
       mcpServers: {
         pagespace: {
-          command: 'pagespace',
-          args: ['mcp'],
+          // `npx`, not `pagespace`: the mint may have run via `npx -p
+          // @pagespace/cli`, and GUI MCP clients don't inherit the shell PATH,
+          // so a bare `pagespace` command is the form most likely to fail.
+          // `-p` is required — two bins here, neither named `cli`.
+          command: 'npx',
+          args: ['-y', '-p', '@pagespace/cli', 'pagespace-mcp'],
           env: { PAGESPACE_KEY: 'ci-bot' },
         },
       },
     });
+  });
+
+  it('offers the global-install shorthand as a follow-up line rather than as the pasted config', () => {
+    const lines = renderAgentWiringGuidance({ keyName: 'ci-bot', host: DEFAULT_HOST });
+    const afterConfig = lines.slice(lines.lastIndexOf('}') + 1).join('\n');
+    expect(afterConfig).toContain('"command": "pagespace", "args": ["mcp"]');
+    expect(afterConfig).toMatch(/globally/i);
   });
 
   it('adds PAGESPACE_API_URL to the env block only for a non-default host', () => {

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -19,11 +19,23 @@ export interface AgentWiringGuidanceParams {
 
 /**
  * Ready-to-paste agent-wiring guidance printed after a successful mint.
- * Mirrors the MCP integration docs
- * (`apps/marketing/src/app/docs/integrations/mcp/page.tsx`): named-key
- * config for this machine, raw-token env var for .env/CI/other machines.
- * `PAGESPACE_API_URL` is included only for a non-default host — against
- * production it would be noise.
+ * Mirrors the zero-install block in the README (`## pagespace mcp`):
+ * named-key config for this machine, raw-token env var for .env/CI/other
+ * machines. `PAGESPACE_API_URL` is included only for a non-default host —
+ * against production it would be noise.
+ *
+ * The `npx` form leads rather than `{command: 'pagespace', args: ['mcp']}`
+ * because nothing here knows how the CLI was invoked: the mint may well have
+ * run through `npx -y -p @pagespace/cli pagespace keys`, leaving no
+ * `pagespace` on PATH at all. Even after a global install, GUI MCP clients
+ * (Claude Desktop, Cursor) launch without the shell's PATH and often can't
+ * find a bare `pagespace`. `npx` works in every one of those cases, so the
+ * global-install shorthand is offered as a follow-up line instead.
+ *
+ * `-p` is load-bearing: this package publishes two bins (`pagespace` and
+ * `pagespace-mcp`) and neither is named `cli`, so without it npx takes
+ * `@pagespace/cli` as the command and exits "could not determine executable
+ * to run".
  */
 export function renderAgentWiringGuidance(params: AgentWiringGuidanceParams): readonly string[] {
   const env: Record<string, string> = { [KEY_ENV_VAR_NAME]: params.keyName };
@@ -33,8 +45,8 @@ export function renderAgentWiringGuidance(params: AgentWiringGuidanceParams): re
   const config = {
     mcpServers: {
       pagespace: {
-        command: 'pagespace',
-        args: ['mcp'],
+        command: 'npx',
+        args: ['-y', '-p', '@pagespace/cli', 'pagespace-mcp'],
         env,
       },
     },
@@ -44,6 +56,8 @@ export function renderAgentWiringGuidance(params: AgentWiringGuidanceParams): re
     '',
     'Add this to your MCP client config (Claude Code, Claude Desktop, Cursor):',
     ...JSON.stringify(config, null, 2).split('\n'),
+    '',
+    'Installed globally and on your MCP client\'s PATH? "command": "pagespace", "args": ["mcp"] does the same thing.',
     '',
     'For .env or CI (or a different machine), use the raw token instead:',
     `${TOKEN_ENV_VAR_NAME}=mcp_...   (shown once, at mint time only)`,

--- a/packages/cli/src/pagespace-mcp-bin.ts
+++ b/packages/cli/src/pagespace-mcp-bin.ts
@@ -1,7 +1,8 @@
 /**
  * `pagespace-mcp` bin — a first-class, zero-install entry point for running
- * the same `pagespace mcp` stdio server via `npx -y @pagespace/cli
- * pagespace-mcp`. `run.ts` already resolves `PAGESPACE_API_URL`/
+ * the same `pagespace mcp` stdio server via `npx -y -p @pagespace/cli
+ * pagespace-mcp` (`-p` required — two bins here, neither named `cli`).
+ * `run.ts` already resolves `PAGESPACE_API_URL`/
  * `PAGESPACE_AUTH_TOKEN` (`auth/legacy-token-env.ts`) for every command, so
  * this alias needs no auth logic of its own — it just has to route to `mcp`.
  * Kept as a pure composition over injected `RunDependencies` (same shape


### PR DESCRIPTION
## Problem

Two pasteable MCP configs handed to users were wrong, in two different ways. Neither is in the docs — every `.md`/docs page in the repo is already correct — but these are the *generated* ones, which is exactly where a user is most likely to copy from.

**Defect 1 — the app emits an npx config that npx cannot run**

Settings → MCP → "No install (npx)" tab emitted:
```json
"args": ["-y", "@pagespace/cli", "pagespace-mcp"]
```

Missing `-p`. `@pagespace/cli` publishes two bins (`pagespace` and `pagespace-mcp`) and **neither is named `cli`**, so npx has no default to pick between them and exits with:
```
npm error could not determine executable to run
```

The CLI's own README documents this exact failure (`packages/cli/README.md:22-23`). Every other example in the repo already has `-p` — the app just didn't get the memo.

**Defect 2 — the CLI prints the fragile form after minting a key**

`packages/cli/src/commands/keys/guidance.ts` unconditionally printed:
```json
{"command": "pagespace", "args": ["mcp"]}
```

This is the global-install-only form. Nothing in the CLI inspects `npm_config_user_agent` or `argv[1]`, so it has no idea whether a global install exists. It breaks two ways:

- The user minted via `npx -y -p @pagespace/cli pagespace keys` — the invocation the CLI's own README teaches — so there is no `pagespace` on PATH. Pasting gives `spawn pagespace ENOENT`.
- Even with a global install, GUI MCP clients (Claude Desktop, Cursor) launch from the Dock without the shell PATH, so a bare `pagespace` frequently isn't found.

## Changes

1. **App:** `apps/web/.../MCPSettingsView.tsx:529` — add `-p` to the npx args. Update the test to assert the `-p` form and reword the test name to state *why* it's required (`@pagespace/cli` has two bins, neither named `cli`).

2. **CLI:** `packages/cli/src/commands/keys/guidance.ts` — lead with the npx form and mention the global shorthand on a following line. Update the test to expect the npx launch shape and assert the global-install alternative is mentioned.

3. Two stale JSDoc comments corrected to include `-p`.

4. Changelog entries added to both `CHANGELOG.md` and `packages/cli/CHANGELOG.md`.

## Verification

- Both fixes mutation-checked: reverting each edit turns its test red.
- `@pagespace/cli`: 1116/1116 pass. Web `MCPSettingsView`: 24/24.
- Verified against real npx from a clean directory:
  - `npx -y @pagespace/cli pagespace-mcp` → `could not determine executable to run`
  - `npx -y -p @pagespace/cli pagespace-mcp` → server starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “No install (npx)” MCP setup so it generates a runnable command.
  * Updated CLI-generated MCP configuration to prioritize zero-install setup and correctly select the MCP executable.
* **Documentation**
  * Clarified MCP setup instructions for both zero-install usage and globally installed CLI users.
  * Updated setup guidance and examples to reflect the corrected commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->