### PR TITLE
fix(memory): make the personalization cron record less, correct itself, and live in the drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 - **What the AI has learned about you is now a set of pages you can read and edit** — your
   personalization lived in three text boxes in Settings that a nightly process also wrote to, with
-  no indication of what it had added or why. It is now three ordinary pages in a Memory folder in
-  your Home drive: About You, Communication and Rules. You can open them, edit them, and delete
-  them like any other page — and if you delete one, that content stops being sent to the AI rather
-  than quietly reappearing. If you edit a page while the nightly process is running, your edit
-  wins. Settings keeps the on/off switch and links you to the pages.
+  no indication of what it had added or why. It is now three pages in a Memory folder in your Home
+  drive: About You, Communication and Rules. You can open them and edit them like any other page,
+  and if you edit one while the nightly process is running, your edit wins. Clearing a page stops
+  that content being sent to the AI. Settings keeps the on/off switch and links you to the pages.
+  The pages themselves cannot be deleted — they are part of your Home drive's structure, like the
+  drive itself, and deleting one would leave the AI's memory with nowhere to live. Empty a page to
+  erase it, or turn personalization off entirely.
 - **The AI stops recording things about you that do not change how it answers** — the nightly
   process collected whatever it could infer, so profiles filled up with beliefs, hobbies, sports
   teams, family details and the names of colleagues, none of which affects a reply. It now records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   and if you edit one while the nightly process is running, your edit wins. Clearing a page stops
   that content being sent to the AI. Settings keeps the on/off switch and links you to the pages.
   The pages themselves cannot be deleted — they are part of your Home drive's structure, like the
-  drive itself, and deleting one would leave the AI's memory with nowhere to live. Empty a page to
-  erase it, or turn personalization off entirely.
+  drive itself. Nothing is lost by that: the switch already stops the AI using any of it, and
+  emptying a page erases what it says, so deleting one would only leave the AI's memory with
+  nowhere to live.
 - **The AI stops recording things about you that do not change how it answers** — the nightly
   process collected whatever it could infer, so profiles filled up with beliefs, hobbies, sports
   teams, family details and the names of colleagues, none of which affects a reply. It now records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   The pages themselves cannot be deleted — they are part of your Home drive's structure, like the
   drive itself. Nothing is lost by that: the switch already stops the AI using any of it, and
   emptying a page erases what it says, so deleting one would only leave the AI's memory with
-  nowhere to live.
+  nowhere to live. They also stay in the Memory folder rather than being moved elsewhere, since a
+  page moved out of it can be swept up by another page's deletion. What they say stays yours to
+  edit either way.
 - **The AI stops recording things about you that do not change how it answers** — the nightly
   process collected whatever it could infer, so profiles filled up with beliefs, hobbies, sports
   teams, family details and the names of colleagues, none of which affects a reply. It now records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,37 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   work exactly as they do in a session of your own. Nothing changes about whose sandbox the
   conversation uses, or about which sessions appear in your sidebar.
 
+### Changed
+
+- **What the AI has learned about you is now a set of pages you can read and edit** — your
+  personalization lived in three text boxes in Settings that a nightly process also wrote to, with
+  no indication of what it had added or why. It is now three ordinary pages in a Memory folder in
+  your Home drive: About You, Communication and Rules. You can open them, edit them, and delete
+  them like any other page — and if you delete one, that content stops being sent to the AI rather
+  than quietly reappearing. If you edit a page while the nightly process is running, your edit
+  wins. Settings keeps the on/off switch and links you to the pages.
+- **The AI stops recording things about you that do not change how it answers** — the nightly
+  process collected whatever it could infer, so profiles filled up with beliefs, hobbies, sports
+  teams, family details and the names of colleagues, none of which affects a reply. It now records
+  something only if knowing it would genuinely change how the AI responds, and never records
+  personal history, beliefs, hobbies, other people's names, or numbers you have claimed about
+  yourself.
+- **Something you mention once no longer becomes a permanent fact about you** — a single remark
+  could end up in your profile and stay there. A new observation now has to show up on at least two
+  separate days, from things you actually wrote on those days, before it is recorded at all — and
+  three days for anything describing who you are. Observations that stop recurring are dropped
+  after a month.
+- **Your profile can now correct itself instead of only growing** — it could only ever have text
+  added, so a wrong guess stayed forever and the profile grew until it was trimmed at around 14,000
+  characters. It is now rewritten in place, superseded lines are removed, and each page is kept to
+  a size that reflects what is actually useful. A rewrite that would delete most of a page is
+  refused rather than applied.
+- **Your data export now includes what the AI inferred about you** — a subject access request
+  covered your profile but not the observations behind it. The export now contains every inference
+  drawn about you, including ones that were rejected or are still pending, along with the quote
+  from your own messages each was based on. Those quotes are removed 90 days after an observation
+  is settled.
+
 ## [1.7.1] — 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   yourself.
 - **Something you mention once no longer becomes a permanent fact about you** — a single remark
   could end up in your profile and stay there. A new observation now has to show up on at least two
-  separate days, from things you actually wrote on those days, before it is recorded at all — and
-  three days for anything describing who you are. Observations that stop recurring are dropped
-  after a month.
+  separate days, from things you actually wrote on those days, before it is added to your profile —
+  and three days for anything describing who you are. Until then it is held aside as a pending
+  observation, which your data export includes. Observations that stop recurring are dropped after
+  a month.
 - **Your profile can now correct itself instead of only growing** — it could only ever have text
   added, so a wrong guess stayed forever and the profile grew until it was trimmed at around 14,000
   characters. It is now rewritten in place, superseded lines are removed, and each page is kept to

--- a/apps/admin/src/lib/onboarding/__tests__/home-drive.test.ts
+++ b/apps/admin/src/lib/onboarding/__tests__/home-drive.test.ts
@@ -41,6 +41,18 @@ vi.mock('@pagespace/lib/commands/starter-skill-installer', () => ({
   installStarterSkills: vi.fn().mockResolvedValue({ installed: [], skipped: [], alreadyInstalled: false }),
 }));
 
+// Same treatment, same reason: memory-page provisioning has its own behaviour
+// and its own coverage. Here we only care that provisioning calls it, so the
+// real implementation is not driven against this file's transaction stub.
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({
+  provisionMemoryPages: vi.fn().mockResolvedValue({
+    folderId: 'memory-folder',
+    bioPageId: 'bio-page',
+    writingStylePageId: 'style-page',
+    rulesPageId: 'rules-page',
+  }),
+}));
+
 import { db } from '@pagespace/db/db';
 import { sql } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';

--- a/apps/admin/src/lib/onboarding/home-drive.ts
+++ b/apps/admin/src/lib/onboarding/home-drive.ts
@@ -7,6 +7,7 @@ import { HOME_DRIVE_NAME, resolveUniqueSlug } from '@pagespace/lib/services/driv
 import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service'
 import { populateUserDrive } from '@/lib/onboarding/drive-setup'
 import { installStarterSkills } from '@pagespace/lib/commands/starter-skill-installer'
+import { provisionMemoryPages } from '@pagespace/lib/memory/memory-pages'
 
 type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -70,6 +71,13 @@ export async function provisionHomeDriveIfNeeded(
     // reaching Home lazily should get them too — and this adds content without
     // flipping `created`, so their post-login returnUrl is still not hijacked.
     await installStarterSkills(userId, newDrive.id, tx);
+
+    // Memory pages install here too, and for the same reason. This is the
+    // on-prem/admin account-creation path: once it has made the Home drive, the
+    // web provisioner sees one already exists and returns early, so a user
+    // created here would otherwise never get memory pages at all and the cron
+    // would have nowhere to write their personalization.
+    await provisionMemoryPages(userId, newDrive.id, tx);
 
     if (isExistingUser) {
       return { driveId: newDrive.id, created: false };

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -96,6 +96,7 @@ const mockUserData = {
   displayPreferences: [],
   settings: { hotkeys: [], automation: null, toastNotifications: null, emailNotifications: [] },
   personalization: null,
+  personalizationCandidates: [],
   // The categories the "Agent-Session Single Source of Truth" epic added. They
   // were missing from the export for the whole epic, and THIS FILE is why
   // nobody noticed: the category assertion below used to be a hand-written list

--- a/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
+++ b/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
@@ -63,11 +63,30 @@ vi.mock('@/lib/memory/discovery-service', () => ({
 vi.mock('@/lib/memory/integration-service', () => ({
   evaluateAndIntegrate: (...args: unknown[]) => mockEvaluateAndIntegrate(...args),
   applyIntegrationDecisions: (...args: unknown[]) => mockApplyIntegrationDecisions(...args),
-  getCurrentPersonalization: () => mockGetCurrentPersonalization(),
+  getCurrentPersonalizationPages: () => mockGetCurrentPersonalization(),
 }));
 
 vi.mock('@/lib/memory/compaction-service', () => ({
   checkAndCompactIfNeeded: () => mockCheckAndCompactIfNeeded(),
+}));
+
+// Candidate lifecycle. These record WHICH ids were settled, which is the whole
+// point of the settlement tests below: the P1 defects in review were all cases
+// where the wrong candidates were retired.
+const mockUpsertCandidates = vi.fn();
+const mockFindPromotableCandidates = vi.fn();
+const mockMarkCandidatesPromoted = vi.fn();
+const mockMarkCandidatesRejected = vi.fn();
+const mockPruneStaleCandidates = vi.fn();
+const mockRedactSettledEvidence = vi.fn();
+
+vi.mock('@/lib/memory/candidate-service', () => ({
+  upsertCandidates: (...args: unknown[]) => mockUpsertCandidates(...args),
+  findPromotableCandidates: (...args: unknown[]) => mockFindPromotableCandidates(...args),
+  markCandidatesPromoted: (...args: unknown[]) => mockMarkCandidatesPromoted(...args),
+  markCandidatesRejected: (...args: unknown[]) => mockMarkCandidatesRejected(...args),
+  pruneStaleCandidates: (...args: unknown[]) => mockPruneStaleCandidates(...args),
+  redactSettledEvidence: (...args: unknown[]) => mockRedactSettledEvidence(...args),
 }));
 
 // Mock loggers
@@ -286,6 +305,181 @@ describe('memory cron route', () => {
         should: 'return 200 status',
         actual: response.status,
         expected: 200,
+      });
+    });
+  });
+
+  /**
+   * Candidate settlement — where every P1 in review lived.
+   *
+   * Settling the wrong candidate is silent and permanent: a retired claim is
+   * never re-staged, so a preference the user keeps expressing simply stops
+   * being learned, with nothing in the profile to show it was ever considered.
+   */
+  describe('candidate settlement', () => {
+    const candidate = (id: string, field = 'rules') => ({
+      id,
+      userId: 'user-1',
+      field,
+      claim: `claim ${id}`,
+      claimKey: `claim ${id}`,
+      evidence: 'e',
+      occurrences: 2,
+      firstSeenAt: new Date('2026-03-01T00:00:00.000Z'),
+      lastSeenAt: new Date('2026-03-02T00:00:00.000Z'),
+      promotedAt: null,
+      rejectedAt: null,
+    });
+
+    /** One active paying user with personalization on. */
+    function setupOneUser() {
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([
+                { userId: 'user-1', subscriptionTier: 'pro' },
+              ]),
+            }),
+          }),
+          where: vi.fn().mockResolvedValue([{ userId: 'user-1', enabled: true }]),
+        }),
+      });
+      mockRunDiscoveryPasses.mockResolvedValue({ claims: [] });
+      mockGetCurrentPersonalization.mockResolvedValue({});
+      mockCheckAndCompactIfNeeded.mockResolvedValue({ compacted: false, fields: [] });
+      mockPruneStaleCandidates.mockResolvedValue(0);
+      mockRedactSettledEvidence.mockResolvedValue(0);
+    }
+
+    beforeEach(setupOneUser);
+
+    it('leaves every candidate pending when evaluation never reached a decision', async () => {
+      // A provider outage must not retire a user's whole ready set. Before the
+      // fix, an empty update object was indistinguishable from "declined all".
+      mockFindPromotableCandidates.mockResolvedValue([candidate('c1'), candidate('c2')]);
+      mockEvaluateAndIntegrate.mockResolvedValue({ ok: false, reason: 'provider error' });
+
+      const { POST } = await import('../route');
+      await POST(createSignedCronRequest());
+
+      assert({
+        given: 'an evaluator failure',
+        should: 'settle nothing, so the next run can retry',
+        actual: {
+          promoted: mockMarkCandidatesPromoted.mock.calls.length,
+          rejected: mockMarkCandidatesRejected.mock.calls.length,
+          applied: mockApplyIntegrationDecisions.mock.calls.length,
+        },
+        expected: { promoted: 0, rejected: 0, applied: 0 },
+      });
+    });
+
+    it('promotes only the candidates the evaluator actually used', async () => {
+      // Two candidates share a field. The evaluator uses one. Settling by field
+      // promoted both — retiring a claim that never reached the page.
+      mockFindPromotableCandidates.mockResolvedValue([candidate('c1'), candidate('c2')]);
+      mockEvaluateAndIntegrate.mockResolvedValue({
+        ok: true,
+        updates: { rules: 'new rules content' },
+        usedCandidateIds: ['c1'],
+      });
+      mockApplyIntegrationDecisions.mockResolvedValue({
+        updated: true,
+        fields: ['rules'],
+        rejected: [],
+      });
+
+      const { POST } = await import('../route');
+      await POST(createSignedCronRequest());
+
+      assert({
+        given: 'two candidates in one field where the evaluator used one',
+        should: 'promote the used one and reject the other, not promote both',
+        actual: {
+          promoted: mockMarkCandidatesPromoted.mock.calls[0]?.[0],
+          rejected: mockMarkCandidatesRejected.mock.calls[0]?.[0],
+        },
+        expected: { promoted: ['c1'], rejected: ['c2'] },
+      });
+    });
+
+    it('leaves a cited candidate pending when its page write was blocked', async () => {
+      // The evaluator wanted it, but a guard or a missing pointer stopped the
+      // write. Promoting here would retire a claim with nothing in the profile.
+      mockFindPromotableCandidates.mockResolvedValue([candidate('c1')]);
+      mockEvaluateAndIntegrate.mockResolvedValue({
+        ok: true,
+        updates: { rules: 'x' },
+        usedCandidateIds: ['c1'],
+      });
+      mockApplyIntegrationDecisions.mockResolvedValue({
+        updated: false,
+        fields: [],
+        rejected: [{ field: 'rules', reason: 'page is trashed or no longer exists' }],
+      });
+
+      const { POST } = await import('../route');
+      await POST(createSignedCronRequest());
+
+      assert({
+        given: 'a cited candidate whose field write was blocked',
+        should: 'settle it neither way, so the next run retries',
+        actual: {
+          promoted: mockMarkCandidatesPromoted.mock.calls[0]?.[0],
+          rejected: mockMarkCandidatesRejected.mock.calls[0]?.[0],
+        },
+        expected: { promoted: [], rejected: [] },
+      });
+    });
+
+    it('evaluates pending candidates even when discovery found nothing', async () => {
+      // A candidate left pending by an earlier guard rejection is already
+      // corroborated. Returning early on empty discovery stranded it until an
+      // unrelated future run happened to discover at least one claim.
+      mockRunDiscoveryPasses.mockResolvedValue({ claims: [] });
+      mockFindPromotableCandidates.mockResolvedValue([candidate('c1')]);
+      mockEvaluateAndIntegrate.mockResolvedValue({
+        ok: true,
+        updates: { rules: 'x' },
+        usedCandidateIds: ['c1'],
+      });
+      mockApplyIntegrationDecisions.mockResolvedValue({
+        updated: true,
+        fields: ['rules'],
+        rejected: [],
+      });
+
+      const { POST } = await import('../route');
+      await POST(createSignedCronRequest());
+
+      assert({
+        given: 'a quiet week with a pending corroborated candidate',
+        should: 'still evaluate and promote it',
+        actual: {
+          evaluated: mockEvaluateAndIntegrate.mock.calls.length,
+          promoted: mockMarkCandidatesPromoted.mock.calls[0]?.[0],
+        },
+        expected: { evaluated: 1, promoted: ['c1'] },
+      });
+    });
+
+    it('runs retention even when there is nothing to promote', async () => {
+      // Forgetting must not be conditional on the happy path, or the accounts
+      // whose runs fail most are the least cleaned up.
+      mockFindPromotableCandidates.mockResolvedValue([]);
+
+      const { POST } = await import('../route');
+      await POST(createSignedCronRequest());
+
+      assert({
+        given: 'a run with no promotable candidates',
+        should: 'still prune stale rows and redact settled evidence',
+        actual: {
+          pruned: mockPruneStaleCandidates.mock.calls.length,
+          redacted: mockRedactSettledEvidence.mock.calls.length,
+        },
+        expected: { pruned: 1, redacted: 1 },
       });
     });
   });

--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -41,6 +41,7 @@ import {
   markCandidatesPromoted,
   markCandidatesRejected,
   pruneStaleCandidates,
+  redactSettledEvidence,
   type MemoryField,
 } from '@/lib/memory/candidate-service';
 
@@ -164,6 +165,25 @@ export async function POST(request: Request) {
   }
 }
 
+/**
+ * Retention housekeeping, run on EVERY exit path.
+ *
+ * Forgetting must not be conditional on the happy path: a user whose evaluator
+ * is failing, or who has nothing promotable, still has stale candidates to drop
+ * and settled quotes past their retention window. Tying either to a successful
+ * run would leave the longest-neglected accounts the least cleaned up.
+ *
+ * Returns the pruned count; redaction is reported through logs, since it is a
+ * compliance action rather than a signal about this run's work.
+ */
+async function runRetention(userId: string): Promise<number> {
+  const [pruned] = await Promise.all([
+    pruneStaleCandidates(userId),
+    redactSettledEvidence(userId),
+  ]);
+  return pruned;
+}
+
 async function processUserMemory(
   userId: string
 ): Promise<{
@@ -177,29 +197,20 @@ async function processUserMemory(
   const discoveryResult = await runDiscoveryPasses(userId);
   const discovered = discoveryResult.claims.length;
 
-  if (discovered === 0) {
-    loggers.api.debug('Memory cron: No claims discovered for user', { userId });
-    // Still run prune even if nothing discovered
-    const pruned = await pruneStaleCandidates(userId);
-    return {
-      discovered: 0,
-      promoted: 0,
-      updated: false,
-      compacted: false,
-      pruned,
-    };
+  // Step 2: Stage what was discovered. An empty discovery is NOT a reason to
+  // stop: candidates left pending by an earlier guard rejection or provider
+  // outage are already corroborated and still deserve evaluation, and a quiet
+  // week would otherwise strand them indefinitely.
+  if (discovered > 0) {
+    await upsertCandidates(userId, discoveryResult.claims);
   }
 
-  // Step 2: Upsert candidates
-  await upsertCandidates(userId, discoveryResult.claims);
-
-  // Step 3: Promote candidates that meet criteria
+  // Step 3: Find candidates that have cleared the corroboration bar
   const promotable = await findPromotableCandidates(userId);
-  const promoted = promotable.length;
 
-  if (promoted === 0) {
+  if (promotable.length === 0) {
     loggers.api.debug('Memory cron: No candidates ready for promotion', { userId });
-    const pruned = await pruneStaleCandidates(userId);
+    const pruned = await runRetention(userId);
     return {
       discovered,
       promoted: 0,
@@ -212,38 +223,67 @@ async function processUserMemory(
   // Step 4: Get current page content
   const currentPages = await getCurrentPersonalizationPages(userId);
 
-  // Step 5: Evaluate and integrate
-  const updates = await evaluateAndIntegrate(userId, promotable, currentPages);
+  // Step 5: Evaluate
+  const evaluation = await evaluateAndIntegrate(userId, promotable, currentPages);
+
+  // The evaluator never reached a decision (provider down, generation error,
+  // unparseable response). Leave every candidate pending — settling them here
+  // would permanently retire a user's whole ready set over a transient outage.
+  if (!evaluation.ok) {
+    loggers.api.warn('Memory cron: evaluation failed, candidates left pending', {
+      userId,
+      reason: evaluation.reason,
+      pending: promotable.length,
+    });
+    const pruned = await runRetention(userId);
+    return {
+      discovered,
+      promoted: 0,
+      updated: false,
+      compacted: false,
+      pruned,
+    };
+  }
 
   // Step 6: Apply updates with guards
-  const applyResult = await applyIntegrationDecisions(userId, updates, currentPages);
+  const applyResult = await applyIntegrationDecisions(
+    userId,
+    evaluation.updates,
+    currentPages
+  );
 
-  // Step 6b: Settle each candidate against what actually landed.
+  // Step 6b: Settle each candidate INDIVIDUALLY.
   //
-  // A candidate is only PROMOTED if the page for its field was really written.
-  // The evaluator can decline a claim, and the rewrite guards can reject a
-  // whole field — in both cases marking the candidate promoted would retire it
-  // permanently despite nothing reaching the profile, so a claim the user keeps
-  // expressing would be silently dropped after its first evaluation.
+  // Field-level settling was wrong: several candidates can share a field, and
+  // the evaluator may incorporate one while declining another. Marking the
+  // whole field promoted retired claims that never reached the page. So a
+  // candidate is promoted only when the evaluator cited it AND the page write
+  // for its field actually landed.
   //
   // Declined claims are marked REJECTED rather than left pending: the evaluator
-  // has seen them against the current profile and said no, and leaving them
-  // pending would re-spend tokens re-deciding the same claim every night.
-  // Guard-rejected fields stay pending so the next run can try again.
+  // saw them against the current profile and said no, and re-staging them would
+  // re-spend tokens re-deciding the same question every night. Anything blocked
+  // by a guard or a failed write stays pending so the next run can retry.
   const written = new Set(applyResult.fields);
-  const guardRejected = new Set(applyResult.rejected.map((r) => r.field));
+  const blocked = new Set(applyResult.rejected.map((r) => r.field));
+  const used = new Set(evaluation.usedCandidateIds);
 
   const promotedIds: string[] = [];
   const rejectedIds: string[] = [];
 
   for (const candidate of promotable) {
     const field = candidate.field as MemoryField;
-    if (written.has(field)) {
-      promotedIds.push(candidate.id);
-    } else if (!guardRejected.has(field)) {
-      rejectedIds.push(candidate.id);
+
+    if (used.has(candidate.id)) {
+      // Cited by the evaluator — promoted only if the write landed.
+      if (written.has(field)) promotedIds.push(candidate.id);
+      // else: guard-rejected or write failed → stays pending.
+      continue;
     }
-    // else: guard-rejected — leave pending for the next run.
+
+    // Not cited. Declined by the evaluator, unless its field never got a
+    // verdict at all (blocked write), in which case leave it pending.
+    if (!blocked.has(field)) rejectedIds.push(candidate.id);
   }
 
   await Promise.all([
@@ -259,12 +299,18 @@ async function processUserMemory(
   }
 
   // Step 8: Prune stale candidates
-  const pruned = await pruneStaleCandidates(userId);
+  const pruned = await runRetention(userId);
 
   loggers.api.info('Memory cron: User processed', {
     userId,
     discovered,
-    promoted,
+    // Counts settled outcomes, not the size of the ready set. Reporting
+    // `promotable.length` as "promoted" counted evaluator-declined and
+    // guard-pending candidates as though they had reached the profile.
+    eligible: promotable.length,
+    promoted: promotedIds.length,
+    declined: rejectedIds.length,
+    stillPending: promotable.length - promotedIds.length - rejectedIds.length,
     updated: applyResult.updated,
     updatedFields: applyResult.fields,
     rejected: applyResult.rejected,
@@ -274,7 +320,7 @@ async function processUserMemory(
 
   return {
     discovered,
-    promoted,
+    promoted: promotedIds.length,
     updated: applyResult.updated,
     compacted,
     pruned,

--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -28,6 +28,7 @@ import { sessions } from '@pagespace/db/schema/sessions';
 import { userPersonalization } from '@pagespace/db/schema/personalization';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+import { MEMORY_PAYING_TIERS } from '@pagespace/lib/billing/automation-preferences';
 import { runDiscoveryPasses } from '@/lib/memory/discovery-service';
 import {
   getCurrentPersonalizationPages,
@@ -45,7 +46,15 @@ import {
   type MemoryField,
 } from '@/lib/memory/candidate-service';
 
-const PAYING_TIERS = ['pro', 'founder', 'business'];
+/**
+ * Reuses the constant the settings UI gates on rather than restating it.
+ *
+ * A local copy would let the cron and `isMemoryAvailable` drift: a tier added
+ * to one and not the other means users who are told Memory is available never
+ * have anything learned, or the reverse — learning for users the product says
+ * cannot have it. Neither failure is visible from either side alone.
+ */
+const PAYING_TIERS = [...MEMORY_PAYING_TIERS];
 
 const DELAY_BETWEEN_USERS_MS = 1000;
 

--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -7,14 +7,27 @@
  * Pipeline:
  * 1. Get paying users with recent activity
  * 2. For each user:
- *    a. Run discovery passes (blind - doesn't see current profile)
- *    b. Upsert candidates (with day-aware occurrence increment)
- *    c. Promote candidates that meet corroboration criteria
- *    d. Evaluate and integrate promoted candidates into pages
- *    e. Compact if fields exceed budget
- *    f. Prune stale candidates (30-day forgetting)
+ *    a. Run discovery passes (blind — never sees the current profile)
+ *    b. Stage the claims as candidates. Corroboration counts the days the
+ *       EVIDENCE was written on, not the days this cron ran: the discovery
+ *       window is reread in full every night, so cron-day counting would
+ *       promote a one-off after two or three runs.
+ *    c. Find candidates past the per-field day threshold AND first seen before
+ *       today, so nothing discovered today can land today
+ *    d. Evaluate them against the current pages; the evaluator reports which
+ *       candidates it used
+ *    e. Write the pages, subject to the rewrite guards
+ *    f. Settle each candidate on what actually landed — promoted only if it was
+ *       used AND its page write succeeded; declined ones rejected; anything
+ *       blocked stays pending for the next run. An evaluator that never
+ *       reached a decision settles nothing.
+ *    g. Compact any page over budget
+ *    h. Retention: drop candidates not re-observed in 30 days, and redact the
+ *       verbatim evidence of ones settled 90+ days ago. Runs on EVERY exit
+ *       path, including the failure ones.
  *
- * Paying users only: 'pro', 'founder', 'business' subscription tiers
+ * Paying users only — gated on MEMORY_PAYING_TIERS, the same constant the
+ * settings UI uses, so the two cannot disagree about who gets Memory.
  *
  * Security: HMAC-signed cron requests via cron-curl (X-Cron-Timestamp/Nonce/Signature)
  * Trigger via: cron-curl POST http://web:3000/api/memory/cron

--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -2,15 +2,17 @@
  * Memory Cron Route
  *
  * Daily background process that discovers patterns from user conversations
- * and activity, then appends insights to their personalization profile.
+ * and updates their personalization profile (stored as pages in their Home drive).
  *
  * Pipeline:
  * 1. Get paying users with recent activity
  * 2. For each user:
  *    a. Run discovery passes (blind - doesn't see current profile)
- *    b. Run integration evaluator (sees profile, decides what to append)
- *    c. Apply approved changes
- *    d. Compact if needed
+ *    b. Upsert candidates (with day-aware occurrence increment)
+ *    c. Promote candidates that meet corroboration criteria
+ *    d. Evaluate and integrate promoted candidates into pages
+ *    e. Compact if fields exceed budget
+ *    f. Prune stale candidates (30-day forgetting)
  *
  * Paying users only: 'pro', 'founder', 'business' subscription tiers
  *
@@ -19,20 +21,28 @@
  */
 
 import { NextResponse } from 'next/server';
-import { db } from '@pagespace/db/db'
-import { eq, and, gte, inArray, isNull } from '@pagespace/db/operators'
-import { users } from '@pagespace/db/schema/auth'
-import { sessions } from '@pagespace/db/schema/sessions'
+import { db } from '@pagespace/db/db';
+import { and, eq, gte, inArray, isNull } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { sessions } from '@pagespace/db/schema/sessions';
 import { userPersonalization } from '@pagespace/db/schema/personalization';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { runDiscoveryPasses } from '@/lib/memory/discovery-service';
 import {
+  getCurrentPersonalizationPages,
   evaluateAndIntegrate,
   applyIntegrationDecisions,
-  getCurrentPersonalization,
 } from '@/lib/memory/integration-service';
 import { checkAndCompactIfNeeded } from '@/lib/memory/compaction-service';
+import {
+  upsertCandidates,
+  findPromotableCandidates,
+  markCandidatesPromoted,
+  markCandidatesRejected,
+  pruneStaleCandidates,
+  type MemoryField,
+} from '@/lib/memory/candidate-service';
 
 const PAYING_TIERS = ['pro', 'founder', 'business'];
 
@@ -102,9 +112,11 @@ export async function POST(request: Request) {
 
     const results = {
       processed: 0,
+      discovered: 0,
+      promoted: 0,
       updated: 0,
       compacted: 0,
-      skipped: 0,
+      pruned: 0,
       errors: [] as string[],
     };
 
@@ -113,9 +125,11 @@ export async function POST(request: Request) {
         const userResult = await processUserMemory(userId);
 
         results.processed++;
+        results.discovered += userResult.discovered;
+        results.promoted += userResult.promoted;
         if (userResult.updated) results.updated++;
         if (userResult.compacted) results.compacted++;
-        if (userResult.skipped) results.skipped++;
+        results.pruned += userResult.pruned;
 
         if (usersToProcess.indexOf(userId) < usersToProcess.length - 1) {
           await new Promise((resolve) => setTimeout(resolve, DELAY_BETWEEN_USERS_MS));
@@ -131,9 +145,11 @@ export async function POST(request: Request) {
 
     loggers.api.info('Memory cron: Complete', {
       processed: results.processed,
+      discovered: results.discovered,
+      promoted: results.promoted,
       updated: results.updated,
       compacted: results.compacted,
-      skipped: results.skipped,
+      pruned: results.pruned,
       errors: results.errors.length,
     });
 
@@ -150,52 +166,119 @@ export async function POST(request: Request) {
 
 async function processUserMemory(
   userId: string
-): Promise<{ updated: boolean; compacted: boolean; skipped: boolean }> {
-  const insights = await runDiscoveryPasses(userId);
+): Promise<{
+  discovered: number;
+  promoted: number;
+  updated: boolean;
+  compacted: boolean;
+  pruned: number;
+}> {
+  // Step 1: Run discovery passes
+  const discoveryResult = await runDiscoveryPasses(userId);
+  const discovered = discoveryResult.claims.length;
 
-  const totalInsights =
-    insights.worldview.length +
-    insights.communication.length +
-    insights.preferences.length;
-
-  if (totalInsights === 0) {
-    loggers.api.debug('Memory cron: No insights discovered for user', { userId });
-    return { updated: false, compacted: false, skipped: true };
+  if (discovered === 0) {
+    loggers.api.debug('Memory cron: No claims discovered for user', { userId });
+    // Still run prune even if nothing discovered
+    const pruned = await pruneStaleCandidates(userId);
+    return {
+      discovered: 0,
+      promoted: 0,
+      updated: false,
+      compacted: false,
+      pruned,
+    };
   }
 
-  const currentPersonalization = await getCurrentPersonalization(userId);
+  // Step 2: Upsert candidates
+  await upsertCandidates(userId, discoveryResult.claims);
 
-  const decisions = await evaluateAndIntegrate(
-    userId,
-    insights,
-    currentPersonalization
-  );
+  // Step 3: Promote candidates that meet criteria
+  const promotable = await findPromotableCandidates(userId);
+  const promoted = promotable.length;
 
-  const { updated, fields } = await applyIntegrationDecisions(
-    userId,
-    decisions,
-    currentPersonalization
-  );
+  if (promoted === 0) {
+    loggers.api.debug('Memory cron: No candidates ready for promotion', { userId });
+    const pruned = await pruneStaleCandidates(userId);
+    return {
+      discovered,
+      promoted: 0,
+      updated: false,
+      compacted: false,
+      pruned,
+    };
+  }
 
+  // Step 4: Get current page content
+  const currentPages = await getCurrentPersonalizationPages(userId);
+
+  // Step 5: Evaluate and integrate
+  const updates = await evaluateAndIntegrate(userId, promotable, currentPages);
+
+  // Step 6: Apply updates with guards
+  const applyResult = await applyIntegrationDecisions(userId, updates, currentPages);
+
+  // Step 6b: Settle each candidate against what actually landed.
+  //
+  // A candidate is only PROMOTED if the page for its field was really written.
+  // The evaluator can decline a claim, and the rewrite guards can reject a
+  // whole field — in both cases marking the candidate promoted would retire it
+  // permanently despite nothing reaching the profile, so a claim the user keeps
+  // expressing would be silently dropped after its first evaluation.
+  //
+  // Declined claims are marked REJECTED rather than left pending: the evaluator
+  // has seen them against the current profile and said no, and leaving them
+  // pending would re-spend tokens re-deciding the same claim every night.
+  // Guard-rejected fields stay pending so the next run can try again.
+  const written = new Set(applyResult.fields);
+  const guardRejected = new Set(applyResult.rejected.map((r) => r.field));
+
+  const promotedIds: string[] = [];
+  const rejectedIds: string[] = [];
+
+  for (const candidate of promotable) {
+    const field = candidate.field as MemoryField;
+    if (written.has(field)) {
+      promotedIds.push(candidate.id);
+    } else if (!guardRejected.has(field)) {
+      rejectedIds.push(candidate.id);
+    }
+    // else: guard-rejected — leave pending for the next run.
+  }
+
+  await Promise.all([
+    markCandidatesPromoted(promotedIds),
+    markCandidatesRejected(rejectedIds),
+  ]);
+
+  // Step 7: Compact if needed
   let compacted = false;
-  if (updated) {
+  if (applyResult.updated) {
     const compactionResult = await checkAndCompactIfNeeded(userId);
     compacted = compactionResult.compacted;
   }
 
+  // Step 8: Prune stale candidates
+  const pruned = await pruneStaleCandidates(userId);
+
   loggers.api.info('Memory cron: User processed', {
     userId,
-    insightCounts: {
-      worldview: insights.worldview.length,
-      communication: insights.communication.length,
-      preferences: insights.preferences.length,
-    },
-    updated,
-    updatedFields: fields,
+    discovered,
+    promoted,
+    updated: applyResult.updated,
+    updatedFields: applyResult.fields,
+    rejected: applyResult.rejected,
     compacted,
+    pruned,
   });
 
-  return { updated, compacted, skipped: false };
+  return {
+    discovered,
+    promoted,
+    updated: applyResult.updated,
+    compacted,
+    pruned,
+  };
 }
 
 export async function GET(request: Request) {

--- a/apps/web/src/app/api/pages/bulk-delete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-delete/__tests__/route.test.ts
@@ -91,6 +91,17 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...conds: unknown[]) => conds),
   inArray: vi.fn((a: unknown, b: unknown) => [a, b]),
 }));
+
+// The memory-page guard queries personalization pointers. Left unmocked it
+// resolves through @pagespace/lib's BUILT dist, whose `@pagespace/db/db` import
+// the db mock above does not intercept — so this route test would quietly reach
+// a real database, passing in CI (where Postgres exists) and 500ing anywhere
+// else. Mock the guard so the route test stays a unit test. Real constants are
+// kept so a reworded refusal cannot pass silently.
+vi.mock('@pagespace/lib/memory/memory-pages', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/memory/memory-pages')>();
+  return { ...actual, findProtectedMemoryPages: vi.fn().mockResolvedValue(new Set<string>()) };
+});
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', parentId: 'parentId' },
 }));
@@ -105,6 +116,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 // @ts-expect-error - accessing test-only export
 import { db, __test__ as dbTest } from '@pagespace/db/db';
+import { findProtectedMemoryPages, MEMORY_PAGE_DELETE_ERROR } from '@pagespace/lib/memory/memory-pages';
 
 const { txUpdate, txUpdateSet, txUpdateWhere, txQueryPagesFindMany, txSelect, txSelectFrom, txSelectWhere, transaction: mockTransaction } = dbTest as {
   txUpdate: ReturnType<typeof vi.fn>;
@@ -193,6 +205,32 @@ describe('DELETE /api/pages/bulk-delete', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupSuccessScenario();
+    // Default: nothing in the batch is a memory page.
+    vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set<string>());
+  });
+
+  // ── Memory page protection ──────────────────────────────────────────
+
+  describe('memory page protection', () => {
+    it('refuses the whole batch when one page is a memory page, trashing nothing', async () => {
+      // All-or-nothing on purpose: silently trashing the other four and keeping
+      // the profile is a worse outcome than refusing, because nothing tells the
+      // user which item was skipped or why.
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        mockPage({ id: 'page-1' }),
+        mockPage({ id: 'memory-bio', title: 'About You' }),
+      ] as never);
+      vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set(['memory-bio']));
+
+      const response = await DELETE(createRequest({ pageIds: ['page-1', 'memory-bio'], trashChildren: true }));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe(MEMORY_PAGE_DELETE_ERROR);
+      // The refusal must come BEFORE any write, not roll one back.
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(txUpdate).not.toHaveBeenCalled();
+    });
   });
 
   // ── Authentication ──────────────────────────────────────────────────

--- a/apps/web/src/app/api/pages/bulk-delete/route.ts
+++ b/apps/web/src/app/api/pages/bulk-delete/route.ts
@@ -3,6 +3,10 @@ import { z } from 'zod/v4';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import {
+  findProtectedMemoryPages,
+  MEMORY_PAGE_DELETE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 import { db } from '@pagespace/db/db'
 import { and, eq, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
@@ -71,6 +75,14 @@ export async function DELETE(request: Request) {
           { status: 403 }
         );
       }
+    }
+
+    // Refuse the whole batch if it contains a memory page, rather than deleting
+    // the rest around it: a partial success here is how someone loses their
+    // profile without noticing which item did it.
+    const protectedIds = await findProtectedMemoryPages(sourcePages.map((p) => p.id));
+    if (protectedIds.size > 0) {
+      return NextResponse.json({ error: MEMORY_PAGE_DELETE_ERROR }, { status: 403 });
     }
 
     // Track affected drives for broadcast events

--- a/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
@@ -56,6 +56,16 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
     canUserEditPage: vi.fn().mockResolvedValue(true),
 }));
 
+// The cross-drive service consults the memory-page guard, which resolves
+// through @pagespace/lib's BUILT dist — whose `@pagespace/db/db` import this
+// file's db mock does not intercept. Left unmocked this route test would reach
+// a real database: green in CI where Postgres exists, failing anywhere else.
+// Real constants kept so a reworded refusal cannot pass silently.
+vi.mock('@pagespace/lib/memory/memory-pages', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/memory/memory-pages')>();
+  return { ...actual, findProtectedMemoryPages: vi.fn().mockResolvedValue(new Set<string>()) };
+});
+
 vi.mock('@pagespace/lib/pages/circular-reference-guard', () => ({
   validatePageMove: vi.fn().mockResolvedValue({ valid: true }),
 }));
@@ -128,6 +138,10 @@ vi.mock('@/lib/canvas/publish-page', () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import { POST } from '../route';
+import {
+  findProtectedMemoryPages,
+  MEMORY_PAGE_MOVE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 import { authenticateRequestWithOptions, checkMCPDriveScope, getAllowedDriveIds, isMCPAuthResult } from '@/lib/auth';
 import { broadcastPageEvent } from '@/lib/websocket';
@@ -230,6 +244,25 @@ describe('POST /api/pages/bulk-move', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupSuccessScenario();
+    vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set<string>());
+  });
+
+  // ── Memory page protection ──────────────────────────────────────────
+
+  describe('memory page protection', () => {
+    it('refuses to move a memory page out of its drive', async () => {
+      // pageService.updatePage's guard does not run on this route — it moves
+      // pages through the cross-drive service instead. Without the guard there,
+      // this endpoint could relocate a memory page out of the Home drive its
+      // pointers assume.
+      vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set(['page-1']));
+
+      const response = await POST(createRequest(validBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe(MEMORY_PAGE_MOVE_ERROR);
+    });
   });
 
   // ── Authentication ──────────────────────────────────────────────────

--- a/apps/web/src/app/api/settings/automations/route.ts
+++ b/apps/web/src/app/api/settings/automations/route.ts
@@ -79,9 +79,14 @@ export async function PATCH(request: Request) {
     }
 
     if (decision.memory !== undefined) {
+      // Only the toggle. Profile CONTENT lives as pages in the user's Home
+      // drive now (see @pagespace/lib/memory/memory-pages); the legacy
+      // bio/writingStyle/rules columns are a read-fallback for users the
+      // backfill has not reached and must not be seeded here, or this route
+      // would look like a writer of personalization content.
       await db
         .insert(userPersonalization)
-        .values({ userId, bio: '', writingStyle: '', rules: '', enabled: decision.memory })
+        .values({ userId, enabled: decision.memory })
         .onConflictDoUpdate({
           target: userPersonalization.userId,
           set: { enabled: decision.memory, updatedAt: new Date() },

--- a/apps/web/src/app/api/settings/personalization/route.ts
+++ b/apps/web/src/app/api/settings/personalization/route.ts
@@ -1,46 +1,87 @@
+/**
+ * Personalization settings.
+ *
+ * The profile CONTENT now lives as three markdown pages in the user's Home
+ * drive (`Memory/About You`, `Memory/Communication`, `Memory/Rules`), edited
+ * like any other page. This route no longer reads or writes that content — it
+ * owns the `enabled` toggle and hands the client the links and previews it
+ * needs to send the user to the real pages.
+ */
+
 import { NextResponse } from 'next/server';
-import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
 import { userPersonalization } from '@pagespace/db/schema/personalization';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
+import { getHomeDrive } from '@pagespace/lib/services/drive-service';
+import {
+  readMemoryPages,
+  MEMORY_PAGE_TITLES,
+  MEMORY_FIELDS,
+  type MemoryField,
+} from '@pagespace/lib/memory/memory-pages';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
-// Maximum length for text fields (~10k tokens to support detailed memory/instructions)
-const MAX_FIELD_LENGTH = 40000;
+/** Characters of page content sent to the settings UI as a preview. */
+const PREVIEW_LENGTH = 280;
 
-// GET /api/settings/personalization - Get user's personalization settings
+interface MemoryPageSummary {
+  field: MemoryField;
+  title: string;
+  pageId: string | null;
+  href: string | null;
+  preview: string;
+  isEmpty: boolean;
+}
+
+const POINTER_COLUMN = {
+  bio: 'bioPageId',
+  writingStyle: 'writingStylePageId',
+  rules: 'rulesPageId',
+} as const;
+
+// GET /api/settings/personalization - toggle state + links to the memory pages
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
-    const personalization = await db.query.userPersonalization.findFirst({
-      where: eq(userPersonalization.userId, userId),
-    });
+    const [personalization, homeDrive] = await Promise.all([
+      db.query.userPersonalization.findFirst({
+        where: eq(userPersonalization.userId, userId),
+      }),
+      getHomeDrive(userId),
+    ]);
 
-    // Return defaults if no personalization exists
-    if (!personalization) {
-      return NextResponse.json({
-        personalization: {
-          bio: '',
-          writingStyle: '',
-          rules: '',
-          enabled: true,
-        },
-      });
-    }
+    const content = personalization ? await readMemoryPages(userId) : {};
+
+    const pages: MemoryPageSummary[] = MEMORY_FIELDS.map((field) => {
+      const pageId = personalization?.[POINTER_COLUMN[field]] ?? null;
+      const body = (content[field] ?? '').trim();
+
+      return {
+        field,
+        title: MEMORY_PAGE_TITLES[field],
+        pageId,
+        href: pageId && homeDrive ? `/dashboard/${homeDrive.id}/${pageId}` : null,
+        preview: body.slice(0, PREVIEW_LENGTH),
+        isEmpty: body.length === 0,
+      };
+    });
 
     return NextResponse.json({
       personalization: {
-        bio: personalization.bio ?? '',
-        writingStyle: personalization.writingStyle ?? '',
-        rules: personalization.rules ?? '',
-        enabled: personalization.enabled,
+        enabled: personalization?.enabled ?? true,
+        memoryFolderHref:
+          personalization?.memoryFolderId && homeDrive
+            ? `/dashboard/${homeDrive.id}/${personalization.memoryFolderId}`
+            : null,
+        pages,
       },
     });
   } catch (error) {
@@ -52,7 +93,7 @@ export async function GET(request: Request) {
   }
 }
 
-// PATCH /api/settings/personalization - Update personalization settings
+// PATCH /api/settings/personalization - update the enabled toggle
 export async function PATCH(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
@@ -61,97 +102,32 @@ export async function PATCH(request: Request) {
 
     const body = await request.json();
 
-    // Guard against non-object JSON bodies
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: 'Invalid request body' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
-    const { bio, writingStyle, rules, enabled } = body;
+    const { enabled } = body;
 
-    // Validate that at least one field is provided
-    if (bio === undefined && writingStyle === undefined && rules === undefined && enabled === undefined) {
-      return NextResponse.json(
-        { error: 'At least one field (bio, writingStyle, rules, enabled) is required' },
-        { status: 400 }
-      );
+    if (enabled === undefined) {
+      return NextResponse.json({ error: 'enabled is required' }, { status: 400 });
     }
-
-    // Type validation
-    if (bio !== undefined && typeof bio !== 'string') {
-      return NextResponse.json({ error: 'bio must be a string' }, { status: 400 });
-    }
-    if (writingStyle !== undefined && typeof writingStyle !== 'string') {
-      return NextResponse.json({ error: 'writingStyle must be a string' }, { status: 400 });
-    }
-    if (rules !== undefined && typeof rules !== 'string') {
-      return NextResponse.json({ error: 'rules must be a string' }, { status: 400 });
-    }
-    if (enabled !== undefined && typeof enabled !== 'boolean') {
+    if (typeof enabled !== 'boolean') {
       return NextResponse.json({ error: 'enabled must be a boolean' }, { status: 400 });
     }
 
-    // Length validation to prevent excessively long system prompts
-    if (bio && bio.length > MAX_FIELD_LENGTH) {
-      return NextResponse.json(
-        { error: `bio must be ${MAX_FIELD_LENGTH} characters or less` },
-        { status: 400 }
-      );
-    }
-    if (writingStyle && writingStyle.length > MAX_FIELD_LENGTH) {
-      return NextResponse.json(
-        { error: `writingStyle must be ${MAX_FIELD_LENGTH} characters or less` },
-        { status: 400 }
-      );
-    }
-    if (rules && rules.length > MAX_FIELD_LENGTH) {
-      return NextResponse.json(
-        { error: `rules must be ${MAX_FIELD_LENGTH} characters or less` },
-        { status: 400 }
-      );
-    }
-
-    // Build update object with only provided fields
-    const updateData: {
-      bio?: string;
-      writingStyle?: string;
-      rules?: string;
-      enabled?: boolean;
-      updatedAt: Date;
-    } = { updatedAt: new Date() };
-
-    if (bio !== undefined) updateData.bio = bio;
-    if (writingStyle !== undefined) updateData.writingStyle = writingStyle;
-    if (rules !== undefined) updateData.rules = rules;
-    if (enabled !== undefined) updateData.enabled = enabled;
-
-    // Atomic upsert to eliminate race condition with concurrent requests
     const [record] = await db
       .insert(userPersonalization)
-      .values({
-        userId,
-        bio: bio ?? '',
-        writingStyle: writingStyle ?? '',
-        rules: rules ?? '',
-        enabled: enabled ?? true,
-      })
+      .values({ userId, enabled })
       .onConflictDoUpdate({
         target: userPersonalization.userId,
-        set: updateData,
+        set: { enabled, updatedAt: new Date() },
       })
       .returning();
 
     audit({ eventType: 'admin.settings.changed', userId, resourceType: 'personalization' });
 
     return NextResponse.json({
-      personalization: {
-        bio: record.bio ?? '',
-        writingStyle: record.writingStyle ?? '',
-        rules: record.rules ?? '',
-        enabled: record.enabled,
-      },
+      personalization: { enabled: record.enabled },
     });
   } catch (error) {
     loggers.api.error('Error updating personalization settings:', error as Error);

--- a/apps/web/src/app/api/settings/personalization/route.ts
+++ b/apps/web/src/app/api/settings/personalization/route.ts
@@ -18,6 +18,7 @@ import { audit } from '@pagespace/lib/audit/audit-log';
 import { getHomeDrive } from '@pagespace/lib/services/drive-service';
 import {
   readMemoryPages,
+  provisionMemoryPages,
   MEMORY_PAGE_TITLES,
   MEMORY_FIELDS,
   type MemoryField,
@@ -51,12 +52,36 @@ export async function GET(request: Request) {
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
-    const [personalization, homeDrive] = await Promise.all([
-      db.query.userPersonalization.findFirst({
+    const homeDrive = await getHomeDrive(userId);
+
+    // Self-heal a pointerless profile.
+    //
+    // A user who predates this feature has content in the legacy columns and no
+    // page pointers, so every link below would be null: the screen would tell
+    // them their memory pages are missing and give them no way to create one.
+    // Rather than make that state depend on an operator remembering to run the
+    // backfill, provision on read — this is precisely the moment the pages are
+    // wanted, and `provisionMemoryPages` reuses anything that already exists.
+    //
+    // Deliberately does NOT copy legacy column content into the new pages; that
+    // stays the backfill's job, so this path cannot race it into a double write.
+    if (homeDrive) {
+      const existing = await db.query.userPersonalization.findFirst({
         where: eq(userPersonalization.userId, userId),
-      }),
-      getHomeDrive(userId),
-    ]);
+        columns: { bioPageId: true, writingStylePageId: true, rulesPageId: true },
+      });
+
+      const missingPointer =
+        !existing?.bioPageId || !existing?.writingStylePageId || !existing?.rulesPageId;
+
+      if (missingPointer) {
+        await db.transaction((tx) => provisionMemoryPages(userId, homeDrive.id, tx));
+      }
+    }
+
+    const personalization = await db.query.userPersonalization.findFirst({
+      where: eq(userPersonalization.userId, userId),
+    });
 
     const content = personalization ? await readMemoryPages(userId) : {};
 

--- a/apps/web/src/app/settings/personalization/__tests__/page.test.tsx
+++ b/apps/web/src/app/settings/personalization/__tests__/page.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi, beforeEach } from 'vitest';
+import { assert } from '@/lib/memory/__tests__/riteway';
+import PersonalizationSettingsPage from '../page';
+
+/**
+ * The personalization screen no longer edits content — that lives as pages in
+ * the Home drive. It owns exactly one write (the enabled toggle) and otherwise
+ * points the user at their pages, so these tests cover the toggle's write
+ * discipline and that a user can actually reach the pages from here.
+ */
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  push: vi.fn(),
+  patch: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({ useAuth: mocks.useAuth }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }));
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mocks.fetchWithAuth,
+  patch: mocks.patch,
+}));
+vi.mock('sonner', () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}));
+
+let swrData: unknown = null;
+const swrMutate = vi.fn();
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: swrData, mutate: swrMutate, isLoading: false })),
+}));
+
+function setData(overrides: Record<string, unknown> = {}) {
+  swrData = {
+    personalization: {
+      enabled: true,
+      memoryFolderHref: '/dashboard/drive-1/folder-1',
+      pages: [
+        {
+          field: 'bio',
+          title: 'About You',
+          pageId: 'p-bio',
+          href: '/dashboard/drive-1/p-bio',
+          preview: 'Software engineer',
+          isEmpty: false,
+        },
+        {
+          field: 'writingStyle',
+          title: 'Communication',
+          pageId: 'p-style',
+          href: '/dashboard/drive-1/p-style',
+          preview: '',
+          isEmpty: true,
+        },
+        {
+          field: 'rules',
+          title: 'Rules',
+          pageId: 'p-rules',
+          href: '/dashboard/drive-1/p-rules',
+          preview: 'Never use emojis',
+          isEmpty: false,
+        },
+      ],
+      ...overrides,
+    },
+  };
+}
+
+describe('personalization settings page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({ user: { id: 'u1' }, isLoading: false });
+    mocks.patch.mockResolvedValue({});
+    setData();
+  });
+
+  it('shows a link to each memory page', () => {
+    render(<PersonalizationSettingsPage />);
+
+    assert({
+      given: 'three provisioned memory pages',
+      should: 'offer an edit link for each',
+      actual: screen.getAllByText('Edit page').length,
+      expected: 3,
+    });
+  });
+
+  it('sends the user to the page when they choose to edit it', () => {
+    render(<PersonalizationSettingsPage />);
+    fireEvent.click(screen.getAllByText('Edit page')[0]);
+
+    assert({
+      given: 'a click on the first page edit link',
+      should: 'navigate to that page in the drive',
+      actual: mocks.push.mock.calls[0]?.[0],
+      expected: '/dashboard/drive-1/p-bio',
+    });
+  });
+
+  it('writes the toggle exactly once, however fast it is clicked', async () => {
+    // Overlapping PATCHes can settle out of order, leaving the server on the
+    // OLDER value while the switch shows the newer one — a silent disagreement
+    // about whether the profile is being injected into prompts at all.
+    //
+    // Asserts the OBSERVABLE guarantee (one request in flight at a time) rather
+    // than a particular mechanism. Two things enforce it — the handler's early
+    // return and the switch's `disabled` — and either alone is sufficient, so a
+    // test that pinned one would just be testing the other by accident.
+    let resolvePatch: (v: unknown) => void = () => {};
+    mocks.patch.mockImplementation(() => new Promise((r) => { resolvePatch = r; }));
+
+    render(<PersonalizationSettingsPage />);
+    const toggle = screen.getByRole('switch');
+
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    assert({
+      given: 'repeated toggling with the first write still in flight',
+      should: 'have sent exactly one request',
+      actual: mocks.patch.mock.calls.length,
+      expected: 1,
+    });
+
+    resolvePatch({});
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalled());
+
+    // And once it settles the control accepts input again — a guard that never
+    // released would be indistinguishable from one that works, until a user
+    // found they could not turn personalization back off.
+    fireEvent.click(toggle);
+    await waitFor(() => expect(mocks.patch.mock.calls.length).toBe(2));
+  });
+
+  it('restores the previous value when the write fails', async () => {
+    mocks.patch.mockRejectedValue(new Error('nope'));
+    render(<PersonalizationSettingsPage />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalled());
+
+    assert({
+      given: 'a failed toggle write',
+      should: 'leave the switch showing the value the server still holds',
+      actual: screen.getByRole('switch').getAttribute('aria-checked'),
+      expected: 'true',
+    });
+  });
+
+  it('says so when a page exists but has nothing in it', () => {
+    render(<PersonalizationSettingsPage />);
+
+    assert({
+      given: 'a provisioned but empty memory page',
+      should: 'invite the user to write in it rather than looking broken',
+      actual: screen.getByText(/Nothing here yet/i) !== null,
+      expected: true,
+    });
+  });
+});

--- a/apps/web/src/app/settings/personalization/page.tsx
+++ b/apps/web/src/app/settings/personalization/page.tsx
@@ -158,6 +158,9 @@ export default function PersonalizationSettingsPage() {
             <Switch
               id="personalization-enabled"
               checked={enabled}
+              // Belt and braces with the early return in the handler: this makes
+              // the control visibly inert while a write is in flight, and the
+              // handler guard is what actually holds if a change still lands.
               disabled={isTogglePending}
               onCheckedChange={handleToggleEnabled}
             />

--- a/apps/web/src/app/settings/personalization/page.tsx
+++ b/apps/web/src/app/settings/personalization/page.tsx
@@ -1,16 +1,24 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import useSWR from 'swr';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
-import { User, Pencil, BookOpen, Loader2, ArrowLeft, Info, Save } from 'lucide-react';
+import {
+  User,
+  Pencil,
+  BookOpen,
+  Loader2,
+  ArrowLeft,
+  Info,
+  ExternalLink,
+  FolderOpen,
+} from 'lucide-react';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 const fetcher = async (url: string) => {
@@ -21,12 +29,37 @@ const fetcher = async (url: string) => {
   return response.json();
 };
 
-interface PersonalizationData {
-  bio: string;
-  writingStyle: string;
-  rules: string;
-  enabled: boolean;
+type MemoryField = 'bio' | 'writingStyle' | 'rules';
+
+interface MemoryPageSummary {
+  field: MemoryField;
+  title: string;
+  pageId: string | null;
+  href: string | null;
+  preview: string;
+  isEmpty: boolean;
 }
+
+interface PersonalizationData {
+  enabled: boolean;
+  memoryFolderHref: string | null;
+  pages: MemoryPageSummary[];
+}
+
+const FIELD_META: Record<MemoryField, { icon: typeof User; description: string }> = {
+  bio: {
+    icon: User,
+    description: 'Your background, expertise, and how you think about problems.',
+  },
+  writingStyle: {
+    icon: Pencil,
+    description: 'How the AI should write — both replying to you and drafting as you.',
+  },
+  rules: {
+    icon: BookOpen,
+    description: 'Instructions the AI should follow in every workspace.',
+  },
+};
 
 export default function PersonalizationSettingsPage() {
   const { user, isLoading: authLoading } = useAuth();
@@ -37,68 +70,31 @@ export default function PersonalizationSettingsPage() {
     fetcher
   );
 
-  const [formState, setFormState] = useState<PersonalizationData>({
-    bio: '',
-    writingStyle: '',
-    rules: '',
-    enabled: true,
-  });
-  const [isDirty, setIsDirty] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
+  const [enabled, setEnabled] = useState(true);
 
-  // Redirect if not authenticated
   useEffect(() => {
     if (!authLoading && !user) {
       router.push('/auth/signin');
     }
   }, [authLoading, user, router]);
 
-  // Initialize form state from server data
   useEffect(() => {
     if (data?.personalization) {
-      setFormState(data.personalization);
-      setIsDirty(false);
+      setEnabled(data.personalization.enabled);
     }
   }, [data]);
 
-  const handleFieldChange = (field: keyof PersonalizationData, value: string | boolean) => {
-    setFormState((prev) => ({ ...prev, [field]: value }));
-    setIsDirty(true);
-  };
-
-  const handleToggleEnabled = async (enabled: boolean) => {
-    // Update locally immediately
-    setFormState((prev) => ({ ...prev, enabled }));
+  const handleToggleEnabled = async (next: boolean) => {
+    setEnabled(next);
 
     try {
-      await patch('/api/settings/personalization', { enabled });
-      toast.success(enabled ? 'AI personalization enabled' : 'AI personalization disabled');
-      // Update SWR cache with current formState (including unsaved edits) to prevent useEffect reset
-      mutate({ personalization: { ...formState, enabled } }, { revalidate: false });
-    } catch (error) {
-      // Revert on error
-      setFormState((prev) => ({ ...prev, enabled: !enabled }));
-      toast.error('Failed to update personalization setting');
-      console.error('Error updating personalization:', error);
-    }
-  };
-
-  const handleSave = async () => {
-    setIsSaving(true);
-    try {
-      await patch('/api/settings/personalization', {
-        bio: formState.bio,
-        writingStyle: formState.writingStyle,
-        rules: formState.rules,
-      });
-      toast.success('Personalization settings saved');
-      setIsDirty(false);
+      await patch('/api/settings/personalization', { enabled: next });
+      toast.success(next ? 'AI personalization enabled' : 'AI personalization disabled');
       mutate();
     } catch (error) {
-      toast.error('Failed to save personalization settings');
-      console.error('Error saving personalization:', error);
-    } finally {
-      setIsSaving(false);
+      setEnabled(!next);
+      toast.error('Failed to update personalization setting');
+      console.error('Error updating personalization:', error);
     }
   };
 
@@ -109,6 +105,9 @@ export default function PersonalizationSettingsPage() {
       </div>
     );
   }
+
+  const personalization = data?.personalization;
+  const pages = personalization?.pages ?? [];
 
   return (
     <div className="container max-w-4xl mx-auto py-10 px-10 space-y-8">
@@ -127,7 +126,8 @@ export default function PersonalizationSettingsPage() {
           Personalization
         </h1>
         <p className="text-muted-foreground mt-2">
-          Customize how PageSpace AI interacts with you. This information will be included in AI conversations to provide more relevant responses.
+          What the AI knows about you lives as pages in the Memory folder of your Home drive. Edit
+          them like any other page — the AI reads whatever is there.
         </p>
       </div>
 
@@ -137,107 +137,80 @@ export default function PersonalizationSettingsPage() {
             <div>
               <CardTitle>AI Personalization</CardTitle>
               <CardDescription>
-                When enabled, your personalization settings will be included in AI system prompts.
+                When enabled, your memory pages are included in AI system prompts.
               </CardDescription>
             </div>
             <Switch
               id="personalization-enabled"
-              checked={formState.enabled}
+              checked={enabled}
               onCheckedChange={handleToggleEnabled}
             />
           </div>
         </CardHeader>
       </Card>
 
-      <Card className={!formState.enabled ? 'opacity-60' : ''}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <User className="h-5 w-5" />
-            About You
-          </CardTitle>
-          <CardDescription>
-            Tell the AI about yourself - your role, expertise, and background.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Textarea
-            id="bio"
-            placeholder="e.g., I'm a software engineer specializing in React and TypeScript. I work on a B2B SaaS product and often need help with complex state management and API design..."
-            value={formState.bio}
-            onChange={(e) => handleFieldChange('bio', e.target.value)}
-            disabled={!formState.enabled}
-            className="min-h-[120px] resize-y"
-          />
-        </CardContent>
-      </Card>
-
-      <Card className={!formState.enabled ? 'opacity-60' : ''}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Pencil className="h-5 w-5" />
-            Writing Style
-          </CardTitle>
-          <CardDescription>
-            Describe how you&apos;d like the AI to communicate with you.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Textarea
-            id="writingStyle"
-            placeholder="e.g., Be concise and direct. Use bullet points for lists. Provide code examples when explaining technical concepts. Avoid overly formal language..."
-            value={formState.writingStyle}
-            onChange={(e) => handleFieldChange('writingStyle', e.target.value)}
-            disabled={!formState.enabled}
-            className="min-h-[120px] resize-y"
-          />
-        </CardContent>
-      </Card>
-
-      <Card className={!formState.enabled ? 'opacity-60' : ''}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <BookOpen className="h-5 w-5" />
-            Custom Rules
-          </CardTitle>
-          <CardDescription>
-            Add any specific instructions or rules for the AI to follow.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Textarea
-            id="rules"
-            placeholder="e.g., Always suggest TypeScript solutions over JavaScript. When writing code, include error handling. Prefer functional programming patterns..."
-            value={formState.rules}
-            onChange={(e) => handleFieldChange('rules', e.target.value)}
-            disabled={!formState.enabled}
-            className="min-h-[120px] resize-y"
-          />
-        </CardContent>
-      </Card>
-
-      <div className="flex justify-end gap-4">
+      {personalization?.memoryFolderHref && (
         <Button
-          onClick={handleSave}
-          disabled={!isDirty || isSaving || !formState.enabled}
+          variant="outline"
+          onClick={() => router.push(personalization.memoryFolderHref!)}
+          className="w-full justify-start"
         >
-          {isSaving ? (
-            <>
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            <>
-              <Save className="h-4 w-4 mr-2" />
-              Save Changes
-            </>
-          )}
+          <FolderOpen className="h-4 w-4 mr-2" />
+          Open Memory folder
         </Button>
+      )}
+
+      <div className={enabled ? 'space-y-4' : 'space-y-4 opacity-60'}>
+        {pages.map((page) => {
+          const Icon = FIELD_META[page.field].icon;
+
+          return (
+            <Card key={page.field}>
+              <CardHeader>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <CardTitle className="flex items-center gap-2">
+                      <Icon className="h-5 w-5" />
+                      {page.title}
+                    </CardTitle>
+                    <CardDescription>{FIELD_META[page.field].description}</CardDescription>
+                  </div>
+                  {page.href && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => router.push(page.href!)}
+                    >
+                      <ExternalLink className="h-4 w-4 mr-2" />
+                      Edit page
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent>
+                {page.isEmpty ? (
+                  <p className="text-sm text-muted-foreground italic">
+                    {page.href
+                      ? 'Nothing here yet. Open the page to write something, or let the AI fill it in as it learns.'
+                      : 'This page has not been created yet.'}
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground whitespace-pre-wrap line-clamp-4">
+                    {page.preview}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
       <Alert>
         <Info className="h-4 w-4" />
         <AlertDescription>
-          <strong>Privacy Note:</strong> Your personalization data is included in AI prompts to customize responses. When using cloud AI providers, this data is sent to those services according to their privacy policies.
+          <strong>Privacy Note:</strong> Your personalization data is included in AI prompts to
+          customize responses. When using cloud AI providers, this data is sent to those services
+          according to their privacy policies.
         </AlertDescription>
       </Alert>
     </div>

--- a/apps/web/src/app/settings/personalization/page.tsx
+++ b/apps/web/src/app/settings/personalization/page.tsx
@@ -71,6 +71,7 @@ export default function PersonalizationSettingsPage() {
   );
 
   const [enabled, setEnabled] = useState(true);
+  const [isTogglePending, setIsTogglePending] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -84,17 +85,31 @@ export default function PersonalizationSettingsPage() {
     }
   }, [data]);
 
+  /**
+   * Only one PATCH is ever in flight.
+   *
+   * Without this, rapid toggling starts overlapping writes and the responses
+   * can settle out of order, leaving the server on the OLDER value while the
+   * switch shows the newer one — a silent disagreement about whether the
+   * profile is being injected at all.
+   */
   const handleToggleEnabled = async (next: boolean) => {
+    if (isTogglePending) return;
+
+    const previous = enabled;
     setEnabled(next);
+    setIsTogglePending(true);
 
     try {
       await patch('/api/settings/personalization', { enabled: next });
       toast.success(next ? 'AI personalization enabled' : 'AI personalization disabled');
       mutate();
     } catch (error) {
-      setEnabled(!next);
+      setEnabled(previous);
       toast.error('Failed to update personalization setting');
       console.error('Error updating personalization:', error);
+    } finally {
+      setIsTogglePending(false);
     }
   };
 
@@ -143,6 +158,7 @@ export default function PersonalizationSettingsPage() {
             <Switch
               id="personalization-enabled"
               checked={enabled}
+              disabled={isTogglePending}
               onCheckedChange={handleToggleEnabled}
             />
           </div>

--- a/apps/web/src/lib/ai/core/__tests__/personalization-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/personalization-utils.test.ts
@@ -34,7 +34,17 @@ vi.mock('@pagespace/lib/memory/memory-pages', () => ({
 describe('getUserPersonalization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    findFirst.mockResolvedValue({ enabled: true, bio: null, writingStyle: null, rules: null });
+    // Default: pointers present, so page content is the source of truth. Tests
+    // that exercise the legacy fallback override this with null pointers.
+    findFirst.mockResolvedValue({
+      enabled: true,
+      bio: null,
+      writingStyle: null,
+      rules: null,
+      bioPageId: 'bio-page-1',
+      writingStylePageId: 'style-page-1',
+      rulesPageId: 'rules-page-1',
+    });
     readMemoryPages.mockResolvedValue({});
   });
 
@@ -125,12 +135,44 @@ describe('getUserPersonalization', () => {
     });
   });
 
-  it('falls back to the legacy column when a page has no content yet', async () => {
+  it('stops injecting legacy content once the user deletes the memory page', async () => {
+    // The user deleted the page precisely to stop this content reaching the
+    // AI. `readMemoryPages` omits a trashed page, so keying the fallback on
+    // "no content came back" would resurrect the pre-deletion text and keep
+    // sending it forever. A present pointer means the page is the source of
+    // truth, and an empty result from it means empty.
+    findFirst.mockResolvedValue({
+      enabled: true,
+      bio: 'the content they deleted the page to get rid of',
+      writingStyle: null,
+      rules: null,
+      bioPageId: 'bio-page-1', // pointer still set; the page itself is gone
+      writingStylePageId: null,
+      rulesPageId: null,
+    });
+    readMemoryPages.mockResolvedValue({}); // trashed page omitted
+
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    assert({
+      given: 'a deleted memory page whose pointer still exists',
+      should: 'inject nothing for that field rather than the stale legacy column',
+      actual: await getUserPersonalization('user-1'),
+      expected: null,
+    });
+  });
+
+  it('falls back to the legacy column when the user has no page pointer yet', async () => {
     findFirst.mockResolvedValue({
       enabled: true,
       bio: 'legacy bio from before the backfill',
       writingStyle: null,
       rules: null,
+      // No pointers: the backfill has not reached this user, so there is no
+      // page yet and the column is all they have.
+      bioPageId: null,
+      writingStylePageId: null,
+      rulesPageId: null,
     });
     readMemoryPages.mockResolvedValue({});
     const { getUserPersonalization } = await import('../personalization-utils');
@@ -151,6 +193,9 @@ describe('getUserPersonalization', () => {
       bio: 'stale legacy bio',
       writingStyle: null,
       rules: null,
+      bioPageId: 'bio-page-1',
+      writingStylePageId: null,
+      rulesPageId: null,
     });
     readMemoryPages.mockResolvedValue({ bio: 'current page bio' });
     const { getUserPersonalization } = await import('../personalization-utils');

--- a/apps/web/src/lib/ai/core/__tests__/personalization-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/personalization-utils.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, vi, beforeEach } from 'vitest';
+import { assert } from '@/lib/memory/__tests__/riteway';
+
+/**
+ * Personalization injection tests.
+ *
+ * Moving the profile to pages removed the only server-side length cap that
+ * existed (the settings route's 40k validation). This module is now the sole
+ * thing standing between a hand-edited page and every AI request, so the
+ * budget behaviour is pinned here.
+ */
+
+const findFirst = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { userPersonalization: { findFirst: (...a: unknown[]) => findFirst(...a) } },
+    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', timezone: 'timezone' } }));
+vi.mock('@pagespace/db/schema/personalization', () => ({
+  userPersonalization: { userId: 'userId' },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+const readMemoryPages = vi.fn();
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({
+  readMemoryPages: (...a: unknown[]) => readMemoryPages(...a),
+}));
+
+describe('getUserPersonalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findFirst.mockResolvedValue({ enabled: true, bio: null, writingStyle: null, rules: null });
+    readMemoryPages.mockResolvedValue({});
+  });
+
+  it('returns null when the user has disabled personalization', async () => {
+    findFirst.mockResolvedValue({ enabled: false, bio: 'x', writingStyle: null, rules: null });
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    assert({
+      given: 'a user with personalization switched off',
+      should: 'inject nothing, even though the page has content',
+      actual: await getUserPersonalization('user-1'),
+      expected: null,
+    });
+  });
+
+  it('returns null when every page is empty', async () => {
+    readMemoryPages.mockResolvedValue({ bio: '   ', writingStyle: '', rules: '' });
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    assert({
+      given: 'pages that exist but hold only whitespace',
+      should: 'inject nothing rather than an empty header',
+      actual: await getUserPersonalization('user-1'),
+      expected: null,
+    });
+  });
+
+  it('truncates a single oversized page to its field budget', async () => {
+    readMemoryPages.mockResolvedValue({ bio: 'x'.repeat(9000) });
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    const result = await getUserPersonalization('user-1');
+
+    assert({
+      given: 'a hand-edited bio far over its 3000-char budget',
+      should: 'truncate it to the budget',
+      actual: (result?.bio?.length ?? 0) <= 3000,
+      expected: true,
+    });
+  });
+
+  it('keeps the whole injected block within the total budget', async () => {
+    // Every field at its own budget sums to 8000, over the 6000 total ceiling —
+    // so this case exercises the total guard, not just the per-field one.
+    readMemoryPages.mockResolvedValue({
+      bio: 'b'.repeat(3000),
+      writingStyle: 'w'.repeat(2500),
+      rules: 'r'.repeat(2500),
+    });
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    const result = await getUserPersonalization('user-1');
+    const total =
+      (result?.bio?.length ?? 0) +
+      (result?.writingStyle?.length ?? 0) +
+      (result?.rules?.length ?? 0);
+
+    assert({
+      given: 'all three pages at their individual budgets (8000 total)',
+      should: 'cut the block down to the 6000-char total budget',
+      actual: total <= 6000,
+      expected: true,
+    });
+  });
+
+  it('spends the total budget on behavioural fields before bio', async () => {
+    // Rules and writing style change what the AI does; bio is context. When the
+    // budget cannot fit everything, the behavioural fields survive intact and
+    // bio absorbs the loss — never the other way round.
+    readMemoryPages.mockResolvedValue({
+      bio: 'b'.repeat(3000),
+      writingStyle: 'w'.repeat(2500),
+      rules: 'r'.repeat(2500),
+    });
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    const result = await getUserPersonalization('user-1');
+
+    assert({
+      given: 'a profile over the total budget',
+      should: 'keep rules and writingStyle whole and truncate bio instead',
+      actual: {
+        rules: result?.rules?.length === 2500,
+        writingStyle: result?.writingStyle?.length === 2500,
+        bioTruncated: (result?.bio?.length ?? 0) < 3000,
+      },
+      expected: { rules: true, writingStyle: true, bioTruncated: true },
+    });
+  });
+
+  it('falls back to the legacy column when a page has no content yet', async () => {
+    findFirst.mockResolvedValue({
+      enabled: true,
+      bio: 'legacy bio from before the backfill',
+      writingStyle: null,
+      rules: null,
+    });
+    readMemoryPages.mockResolvedValue({});
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    const result = await getUserPersonalization('user-1');
+
+    assert({
+      given: 'a user the backfill has not reached',
+      should: 'still inject their legacy column content',
+      actual: result?.bio,
+      expected: 'legacy bio from before the backfill',
+    });
+  });
+
+  it('prefers page content over the legacy column once both exist', async () => {
+    findFirst.mockResolvedValue({
+      enabled: true,
+      bio: 'stale legacy bio',
+      writingStyle: null,
+      rules: null,
+    });
+    readMemoryPages.mockResolvedValue({ bio: 'current page bio' });
+    const { getUserPersonalization } = await import('../personalization-utils');
+
+    const result = await getUserPersonalization('user-1');
+
+    assert({
+      given: 'both a page and a legacy column',
+      should: 'inject the page, which is what the user can actually edit',
+      actual: result?.bio,
+      expected: 'current page bio',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/core/personalization-utils.ts
+++ b/apps/web/src/lib/ai/core/personalization-utils.ts
@@ -73,7 +73,15 @@ export async function getUserPersonalization(
   try {
     const personalization = await db.query.userPersonalization.findFirst({
       where: eq(userPersonalization.userId, userId),
-      columns: { enabled: true, bio: true, writingStyle: true, rules: true },
+      columns: {
+        enabled: true,
+        bio: true,
+        writingStyle: true,
+        rules: true,
+        bioPageId: true,
+        writingStylePageId: true,
+        rulesPageId: true,
+      },
     });
 
     if (!personalization || !personalization.enabled) {
@@ -82,12 +90,26 @@ export async function getUserPersonalization(
 
     const pageContent = await readMemoryPages(userId);
 
-    // Pointer-first, legacy-column fallback. The columns are still populated for
-    // users the backfill has not reached; they are dropped in a follow-up PR.
+    /**
+     * The legacy column is a fallback for users the backfill has not reached —
+     * NOT a shadow copy that outlives the page.
+     *
+     * Keyed on whether a pointer EXISTS, not on whether content came back.
+     * `readMemoryPages` omits a page that has been trashed or deleted, so
+     * falling back on missing content would resurrect the pre-deletion text
+     * and keep injecting it into every prompt after the user deleted the page
+     * to stop exactly that. A present pointer therefore means "the page is the
+     * source of truth", and an empty result from it means empty.
+     */
+    const legacyFor = (field: MemoryField, pointer: string | null): string => {
+      if (pointer) return pageContent[field] ?? '';
+      return pageContent[field] ?? personalization[field] ?? '';
+    };
+
     const raw: Record<MemoryField, string> = {
-      bio: pageContent.bio ?? personalization.bio ?? '',
-      writingStyle: pageContent.writingStyle ?? personalization.writingStyle ?? '',
-      rules: pageContent.rules ?? personalization.rules ?? '',
+      bio: legacyFor('bio', personalization.bioPageId),
+      writingStyle: legacyFor('writingStyle', personalization.writingStylePageId),
+      rules: legacyFor('rules', personalization.rulesPageId),
     };
 
     // Per-field budget.
@@ -96,6 +118,11 @@ export async function getUserPersonalization(
       writingStyle: truncateField(raw.writingStyle.trim(), MAX_FIELD_LENGTHS.writingStyle),
       rules: truncateField(raw.rules.trim(), MAX_FIELD_LENGTHS.rules),
     };
+
+    const fieldTruncated =
+      trimmed.bio.length < raw.bio.trim().length ||
+      trimmed.writingStyle.length < raw.writingStyle.trim().length ||
+      trimmed.rules.length < raw.rules.trim().length;
 
     // Total budget. Spend it in priority order — rules and writing style change
     // AI behaviour directly, bio is context — rather than scaling every field
@@ -121,10 +148,15 @@ export async function getUserPersonalization(
       remaining = 0;
     }
 
-    if (overBudget) {
-      loggers.api.warn('Personalization exceeds injection budget; truncated', {
+    // Warn when EITHER budget cut content. A field trimmed to its own limit
+    // that then fits the total would otherwise truncate silently, which is the
+    // case most likely to surprise a user who wrote a long page by hand.
+    if (overBudget || fieldTruncated) {
+      loggers.api.warn('Personalization truncated to fit the injection budget', {
         userId,
-        limit: MAX_TOTAL_LENGTH,
+        fieldBudgetTruncated: fieldTruncated,
+        totalBudgetTruncated: overBudget,
+        totalLimit: MAX_TOTAL_LENGTH,
       });
     }
 

--- a/apps/web/src/lib/ai/core/personalization-utils.ts
+++ b/apps/web/src/lib/ai/core/personalization-utils.ts
@@ -11,33 +11,16 @@ import { eq } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { userPersonalization } from '@pagespace/db/schema/personalization';
-import { readMemoryPages, type MemoryField } from '@pagespace/lib/memory/memory-pages';
+import { readMemoryPages } from '@pagespace/lib/memory/memory-pages';
+import {
+  MAX_FIELD_LENGTH,
+  MAX_TOTAL_INJECTION_LENGTH,
+  type MemoryField,
+} from '@/lib/memory/budgets';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { PersonalizationInfo } from './system-prompt';
 
-/**
- * Per-field injection budgets, in characters.
- *
- * These match the compaction targets in `apps/web/src/lib/memory/compaction-service.ts`
- * so the cron keeps pages inside the budget and truncation stays a backstop for
- * hand-edited pages rather than the normal path.
- */
-const MAX_FIELD_LENGTHS: Record<MemoryField, number> = {
-  bio: 3000,
-  writingStyle: 2500,
-  rules: 2500,
-};
-
-/**
- * Ceiling for the whole injected block.
- *
- * Deliberately BELOW the sum of the per-field budgets (3000 + 2500 + 2500 =
- * 8000). If it equalled that sum the total check could never fire, since three
- * already-truncated fields would always fit — the guard would be dead code that
- * reads as protection. A profile using every field in full is over budget, and
- * the priority order below decides what survives.
- */
-const MAX_TOTAL_LENGTH = 6000;
+// Budgets live in one place; see budgets.ts for why all three consumers must agree.
 const TRUNCATION_MARKER = '\n[truncated]';
 
 const FIELD_ORDER: readonly MemoryField[] = ['rules', 'writingStyle', 'bio'];
@@ -114,9 +97,9 @@ export async function getUserPersonalization(
 
     // Per-field budget.
     const trimmed: Record<MemoryField, string> = {
-      bio: truncateField(raw.bio.trim(), MAX_FIELD_LENGTHS.bio),
-      writingStyle: truncateField(raw.writingStyle.trim(), MAX_FIELD_LENGTHS.writingStyle),
-      rules: truncateField(raw.rules.trim(), MAX_FIELD_LENGTHS.rules),
+      bio: truncateField(raw.bio.trim(), MAX_FIELD_LENGTH.bio),
+      writingStyle: truncateField(raw.writingStyle.trim(), MAX_FIELD_LENGTH.writingStyle),
+      rules: truncateField(raw.rules.trim(), MAX_FIELD_LENGTH.rules),
     };
 
     const fieldTruncated =
@@ -127,7 +110,7 @@ export async function getUserPersonalization(
     // Total budget. Spend it in priority order — rules and writing style change
     // AI behaviour directly, bio is context — rather than scaling every field
     // down proportionally, which would corrupt all three at once.
-    let remaining = MAX_TOTAL_LENGTH;
+    let remaining = MAX_TOTAL_INJECTION_LENGTH;
     const budgeted: Partial<Record<MemoryField, string>> = {};
     let overBudget = false;
 
@@ -156,7 +139,7 @@ export async function getUserPersonalization(
         userId,
         fieldBudgetTruncated: fieldTruncated,
         totalBudgetTruncated: overBudget,
-        totalLimit: MAX_TOTAL_LENGTH,
+        totalLimit: MAX_TOTAL_INJECTION_LENGTH,
       });
     }
 

--- a/apps/web/src/lib/ai/core/personalization-utils.ts
+++ b/apps/web/src/lib/ai/core/personalization-utils.ts
@@ -1,16 +1,71 @@
 /**
- * Personalization utilities for AI system prompt injection
+ * Personalization utilities for AI system prompt injection.
+ *
+ * The profile content lives as pages in the user's Home drive (see
+ * `@pagespace/lib/memory/memory-pages`). This module reads those pages and
+ * enforces the injection budget, since a page — unlike the old settings
+ * textarea — has no server-side length cap of its own.
  */
 
-import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
-import { users } from '@pagespace/db/schema/auth'
+import { eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
 import { userPersonalization } from '@pagespace/db/schema/personalization';
+import { readMemoryPages, type MemoryField } from '@pagespace/lib/memory/memory-pages';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { PersonalizationInfo } from './system-prompt';
 
 /**
- * Fetch user personalization settings from the database
- * Returns null if personalization is disabled or not configured
+ * Per-field injection budgets, in characters.
+ *
+ * These match the compaction targets in `apps/web/src/lib/memory/compaction-service.ts`
+ * so the cron keeps pages inside the budget and truncation stays a backstop for
+ * hand-edited pages rather than the normal path.
+ */
+const MAX_FIELD_LENGTHS: Record<MemoryField, number> = {
+  bio: 3000,
+  writingStyle: 2500,
+  rules: 2500,
+};
+
+/**
+ * Ceiling for the whole injected block.
+ *
+ * Deliberately BELOW the sum of the per-field budgets (3000 + 2500 + 2500 =
+ * 8000). If it equalled that sum the total check could never fire, since three
+ * already-truncated fields would always fit — the guard would be dead code that
+ * reads as protection. A profile using every field in full is over budget, and
+ * the priority order below decides what survives.
+ */
+const MAX_TOTAL_LENGTH = 6000;
+const TRUNCATION_MARKER = '\n[truncated]';
+
+const FIELD_ORDER: readonly MemoryField[] = ['rules', 'writingStyle', 'bio'];
+
+/**
+ * Truncate on a line boundary where possible.
+ *
+ * Cutting mid-line can leave a negated instruction reading as its opposite
+ * ("Never use em dashes" → "Never use em"), so prefer dropping the partial
+ * trailing line entirely.
+ */
+function truncateField(content: string, maxLength: number): string {
+  if (content.length <= maxLength) return content;
+
+  const budget = maxLength - TRUNCATION_MARKER.length;
+  const clipped = content.slice(0, Math.max(0, budget));
+  const lastBreak = clipped.lastIndexOf('\n');
+  const body = lastBreak > budget * 0.5 ? clipped.slice(0, lastBreak) : clipped;
+
+  return body.trimEnd() + TRUNCATION_MARKER;
+}
+
+/**
+ * Fetch user personalization for prompt injection.
+ *
+ * Returns null when personalization is disabled, unconfigured, or empty.
+ * Errors are swallowed — personalization is optional and must never take a
+ * conversation down with it.
  */
 export async function getUserPersonalization(
   userId: string
@@ -18,26 +73,73 @@ export async function getUserPersonalization(
   try {
     const personalization = await db.query.userPersonalization.findFirst({
       where: eq(userPersonalization.userId, userId),
+      columns: { enabled: true, bio: true, writingStyle: true, rules: true },
     });
 
-    if (!personalization) {
+    if (!personalization || !personalization.enabled) {
       return null;
     }
 
-    // Return null if disabled
-    if (!personalization.enabled) {
+    const pageContent = await readMemoryPages(userId);
+
+    // Pointer-first, legacy-column fallback. The columns are still populated for
+    // users the backfill has not reached; they are dropped in a follow-up PR.
+    const raw: Record<MemoryField, string> = {
+      bio: pageContent.bio ?? personalization.bio ?? '',
+      writingStyle: pageContent.writingStyle ?? personalization.writingStyle ?? '',
+      rules: pageContent.rules ?? personalization.rules ?? '',
+    };
+
+    // Per-field budget.
+    const trimmed: Record<MemoryField, string> = {
+      bio: truncateField(raw.bio.trim(), MAX_FIELD_LENGTHS.bio),
+      writingStyle: truncateField(raw.writingStyle.trim(), MAX_FIELD_LENGTHS.writingStyle),
+      rules: truncateField(raw.rules.trim(), MAX_FIELD_LENGTHS.rules),
+    };
+
+    // Total budget. Spend it in priority order — rules and writing style change
+    // AI behaviour directly, bio is context — rather than scaling every field
+    // down proportionally, which would corrupt all three at once.
+    let remaining = MAX_TOTAL_LENGTH;
+    const budgeted: Partial<Record<MemoryField, string>> = {};
+    let overBudget = false;
+
+    for (const field of FIELD_ORDER) {
+      const value = trimmed[field];
+      if (!value) continue;
+
+      if (value.length <= remaining) {
+        budgeted[field] = value;
+        remaining -= value.length;
+        continue;
+      }
+
+      overBudget = true;
+      if (remaining > TRUNCATION_MARKER.length * 4) {
+        budgeted[field] = truncateField(value, remaining);
+      }
+      remaining = 0;
+    }
+
+    if (overBudget) {
+      loggers.api.warn('Personalization exceeds injection budget; truncated', {
+        userId,
+        limit: MAX_TOTAL_LENGTH,
+      });
+    }
+
+    if (!budgeted.bio && !budgeted.writingStyle && !budgeted.rules) {
       return null;
     }
 
     return {
-      bio: personalization.bio ?? undefined,
-      writingStyle: personalization.writingStyle ?? undefined,
-      rules: personalization.rules ?? undefined,
-      enabled: personalization.enabled,
+      bio: budgeted.bio,
+      writingStyle: budgeted.writingStyle,
+      rules: budgeted.rules,
+      enabled: true,
     };
   } catch (error) {
-    // Log error but don't fail - personalization is optional
-    console.error('Failed to fetch user personalization:', error);
+    loggers.api.error('Failed to fetch user personalization', { userId, error });
     return null;
   }
 }

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -1079,6 +1079,30 @@ describe('page-write-tools', () => {
       expect(result.childrenCount).toBe(2);
     });
 
+    it('checks delete permission before revealing that a page is a memory page', async () => {
+      // Same ordering as pageService.trashPage: authorization first, so a
+      // caller who cannot delete the page is not told what it holds.
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'memory-bio', title: 'About You', type: 'DOCUMENT',
+        content: '', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(false);
+      mockIsProtectedMemoryPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.trash_page.execute!({ id: 'memory-bio', withChildren: false }, context)
+      ).rejects.toThrow('Insufficient permissions to trash this page');
+
+      expect(mockIsProtectedMemoryPage).not.toHaveBeenCalled();
+    });
+
     it('re-homes live children to the grandparent when withChildren is false', async () => {
       mockPageRepo.findById.mockResolvedValue({
         id: 'page-1',
@@ -1495,14 +1519,13 @@ describe('page-write-tools', () => {
     // permission, unlike /api/pages/reorder which requires drive owner/admin
     // for the same move+position operation. The bars must agree.
     // Moving is what makes the cascade hole reachable: relocate a memory page
-    // under an ordinary page and that page's delete takes it too. Both move
-    // implementations are covered because the guard sits ahead of the fork —
-    // and a cross-drive move would additionally strand the page outside the
-    // Home drive the memory pointers assume.
-    it.each([
-      ['same-drive', undefined],
-      ['cross-drive', TARGET_DRIVE],
-    ])('refuses to move a memory page (%s)', async (_label, targetDriveId) => {
+    // under an ordinary page and that page's delete takes it too.
+    //
+    // Only the SAME-DRIVE move is refused here. The cross-drive path enforces
+    // it inside movePagesToDrive, because that service is shared with
+    // /api/pages/bulk-move — guarding it at this call site would leave the REST
+    // route open. See page-cross-drive-move-service.test.ts.
+    it('refuses a same-drive move of a memory page', async () => {
       mockPageRepo.findById.mockResolvedValue(sourcePageRow({ id: 'memory-bio' }));
       mockCheckDriveAccess.mockResolvedValue(ownerAccess);
       mockIsProtectedMemoryPage.mockResolvedValue(true);
@@ -1514,13 +1537,35 @@ describe('page-write-tools', () => {
 
       await expect(
         pageWriteTools.move_page.execute!(
-          { title: 'About You', pageId: 'memory-bio', position: 1, targetDriveId },
+          { title: 'About You', pageId: 'memory-bio', position: 1 },
           context
         )
       ).rejects.toThrow(MEMORY_PAGE_MOVE_ERROR);
 
       expect(mockApplyPageMutation).not.toHaveBeenCalled();
-      expect(mockMovePagesToDrive).not.toHaveBeenCalled();
+    });
+
+    it('checks move permission before revealing that a page is a memory page', async () => {
+      // Refusing first would tell a caller who cannot move the page at all that
+      // it holds the user's profile. pageService.updatePage checks permission
+      // first; this path must agree.
+      mockPageRepo.findById.mockResolvedValue(sourcePageRow({ id: 'memory-bio' }));
+      mockCheckDriveAccess.mockResolvedValue(deniedAccess);
+      mockIsProtectedMemoryPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'member-user' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'About You', pageId: 'memory-bio', position: 1 },
+          context
+        )
+      ).rejects.toThrow('Only drive owners and admins can move pages');
+
+      expect(mockIsProtectedMemoryPage).not.toHaveBeenCalled();
     });
 
     it('denies a member with page-edit access but no drive owner/admin role', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -139,6 +139,17 @@ vi.mock('@/services/api/page-cross-drive-move-service', () => ({
   movePagesToDrive: vi.fn(),
 }));
 
+// Keep the REAL refusal strings — the tests assert the agent is told the actual
+// user-facing reason, so a reworded constant must not silently keep passing.
+vi.mock('@pagespace/lib/memory/memory-pages', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/memory/memory-pages')>();
+  return {
+    ...actual,
+    isProtectedMemoryPage: vi.fn().mockResolvedValue(false),
+    findProtectedMemoryPages: vi.fn().mockResolvedValue(new Set<string>()),
+  };
+});
+
 vi.mock('@/lib/canvas/publish-page', () => ({
   syncPublishedHomeRoot: vi.fn(),
 }));
@@ -169,6 +180,11 @@ import { applyPageMutation } from '@/services/api/page-mutation-service';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
 import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
+import {
+  isProtectedMemoryPage,
+  findProtectedMemoryPages,
+  MEMORY_PAGE_MOVE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 import { broadcastPageEvent } from '@/lib/websocket';
 import type { ToolExecutionContext } from '../../core/types';
 
@@ -186,6 +202,8 @@ const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
 const mockValidatePageMove = vi.mocked(validatePageMove);
 const mockMovePagesToDrive = vi.mocked(movePagesToDrive);
 const mockBroadcastPageEvent = vi.mocked(broadcastPageEvent);
+const mockIsProtectedMemoryPage = vi.mocked(isProtectedMemoryPage);
+const mockFindProtectedMemoryPages = vi.mocked(findProtectedMemoryPages);
 
 const ownerAccess = { isOwner: true, isAdmin: true, isMember: true, drive: null };
 const adminAccess = { isOwner: false, isAdmin: true, isMember: true, drive: null };
@@ -216,6 +234,9 @@ describe('page-write-tools', () => {
     vi.clearAllMocks();
     // Default: pages have no direct children unless a test says otherwise.
     mockPageRepo.getDirectChildren.mockResolvedValue([]);
+    // Default: nothing is a memory page unless a test says otherwise.
+    mockIsProtectedMemoryPage.mockResolvedValue(false);
+    mockFindProtectedMemoryPages.mockResolvedValue(new Set<string>());
   });
 
   describe('replace_lines', () => {
@@ -1008,6 +1029,56 @@ describe('page-write-tools', () => {
       );
     });
 
+    // This branch walks descendants itself rather than going through
+    // pageService.recursivelyTrash, so it needs its own guard. The check at the
+    // top of the helper only sees the page the agent named — an agent told to
+    // "clean up this folder" would otherwise take a memory page down with it.
+    it('skips a protected memory page inside the cascade but still trashes its siblings', async () => {
+      mockPageRepo.findById.mockImplementation(async (id: string) => ({
+        id,
+        title: id,
+        type: 'DOCUMENT' as const,
+        content: '',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      }));
+      mockCanUserDeletePage.mockResolvedValue(true);
+      mockPageRepo.getChildIds.mockResolvedValue(['child-1', 'memory-bio', 'child-2']);
+      mockFindProtectedMemoryPages.mockResolvedValue(new Set(['memory-bio']));
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.trash_page.execute!(
+        { id: 'page-1', withChildren: true },
+        context
+      ) as { success: boolean; childrenCount?: number };
+
+      expect(result.success).toBe(true);
+
+      const trashedIds = mockApplyPageMutation.mock.calls
+        .map(([arg]) => arg as { pageId: string; operation: string })
+        .filter((arg) => arg.operation === 'trash')
+        .map((arg) => arg.pageId);
+
+      // The unrelated children still go; the memory page does not.
+      expect(trashedIds).toContain('child-1');
+      expect(trashedIds).toContain('child-2');
+      expect(trashedIds).not.toContain('memory-bio');
+
+      // The count reported back to the model must describe what was actually
+      // trashed, or the agent tells the user it deleted something it did not.
+      expect(result.childrenCount).toBe(2);
+    });
+
     it('re-homes live children to the grandparent when withChildren is false', async () => {
       mockPageRepo.findById.mockResolvedValue({
         id: 'page-1',
@@ -1423,6 +1494,35 @@ describe('page-write-tools', () => {
     // Regression coverage for #1772: move_page only required per-page edit
     // permission, unlike /api/pages/reorder which requires drive owner/admin
     // for the same move+position operation. The bars must agree.
+    // Moving is what makes the cascade hole reachable: relocate a memory page
+    // under an ordinary page and that page's delete takes it too. Both move
+    // implementations are covered because the guard sits ahead of the fork —
+    // and a cross-drive move would additionally strand the page outside the
+    // Home drive the memory pointers assume.
+    it.each([
+      ['same-drive', undefined],
+      ['cross-drive', TARGET_DRIVE],
+    ])('refuses to move a memory page (%s)', async (_label, targetDriveId) => {
+      mockPageRepo.findById.mockResolvedValue(sourcePageRow({ id: 'memory-bio' }));
+      mockCheckDriveAccess.mockResolvedValue(ownerAccess);
+      mockIsProtectedMemoryPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'About You', pageId: 'memory-bio', position: 1, targetDriveId },
+          context
+        )
+      ).rejects.toThrow(MEMORY_PAGE_MOVE_ERROR);
+
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+      expect(mockMovePagesToDrive).not.toHaveBeenCalled();
+    });
+
     it('denies a member with page-edit access but no drive owner/admin role', async () => {
       mockPageRepo.findById.mockResolvedValue({
         id: 'page-1', title: 'Test Page', type: 'DOCUMENT',

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -220,12 +220,6 @@ async function trashPage(
     throw new Error(`Page with ID "${pageId}" not found`);
   }
 
-  // Same protection the HTTP path enforces. An agent asked to "clean up my
-  // drive" must not be able to delete the pages that hold the user's profile.
-  if (await isProtectedMemoryPage(page.id)) {
-    throw new Error(MEMORY_PAGE_DELETE_ERROR);
-  }
-
   if (withChildren) {
     const canDelete = await canActorDeletePage(context, page.id);
     if (!canDelete) {
@@ -236,6 +230,15 @@ async function trashPage(
     if (!canEdit) {
       throw new Error('Insufficient permissions to trash this page');
     }
+  }
+
+  // Same protection the HTTP path enforces. An agent asked to "clean up my
+  // drive" must not be able to delete the pages that hold the user's profile.
+  //
+  // AFTER the permission check, matching pageService.trashPage. Refusing first
+  // would tell a caller who cannot delete the page that it is a memory page.
+  if (await isProtectedMemoryPage(page.id)) {
+    throw new Error(MEMORY_PAGE_DELETE_ERROR);
   }
 
   let childrenCount = 0;
@@ -428,6 +431,19 @@ async function restoreDrive(
 type MovablePage = NonNullable<Awaited<ReturnType<typeof pageRepository.findById>>>;
 
 /**
+ * Refuse to relocate a memory page.
+ *
+ * Same-drive moves only: the cross-drive path enforces this inside
+ * `movePagesToDrive`, which is shared with /api/pages/bulk-move and is the only
+ * place that covers BOTH callers.
+ */
+async function refuseIfMemoryPage(pageId: string): Promise<void> {
+  if (await isProtectedMemoryPage(pageId)) {
+    throw new Error(MEMORY_PAGE_MOVE_ERROR);
+  }
+}
+
+/**
  * Same-drive move / reorder. Requires drive owner or admin — mirrors the
  * /api/pages/reorder REST route's authorization bar for the same operation.
  */
@@ -444,6 +460,13 @@ async function moveWithinDrive(params: {
   if (!canManage) {
     throw new Error('Only drive owners and admins can move pages');
   }
+
+  // Memory pages stay put — a page moved out of the Memory folder is what ends
+  // up inside another page's delete cascade. Checked here rather than once at
+  // the dispatch so it lands AFTER this function's own authorization bar,
+  // matching pageService.updatePage; the cross-drive path repeats it after its
+  // (different) bar for the same reason.
+  await refuseIfMemoryPage(page.id);
 
   if (newParentId) {
     // Verify the destination exists and is in the same drive
@@ -1294,14 +1317,6 @@ export const pageWriteTools = {
         // targetDriveId === page.driveId deliberately takes the same-drive bar, so
         // a model echoing back the current workspace id can't quietly swap which
         // authorization applies.
-        // Same refusal the HTTP path enforces (pageService.updatePage). Guarded
-        // once here so it covers BOTH implementations below — a cross-drive move
-        // would additionally take the page out of the Home drive the memory
-        // pointers assume.
-        if (await isProtectedMemoryPage(page.id)) {
-          throw new Error(MEMORY_PAGE_MOVE_ERROR);
-        }
-
         const isCrossDrive = !!targetDriveId && targetDriveId !== page.driveId;
 
         return isCrossDrive

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -5,6 +5,8 @@ import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard'
 import {
   isProtectedMemoryPage,
   MEMORY_PAGE_DELETE_ERROR,
+  MEMORY_PAGE_MOVE_ERROR,
+  findProtectedMemoryPages,
 } from '@pagespace/lib/memory/memory-pages';
 import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
 import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
@@ -247,10 +249,18 @@ async function trashPage(
   if (withChildren) {
     // Use repository seam for recursive child lookup
     const childPageIds = await pageRepository.getChildIds(page.driveId, page.id);
-    childrenCount = childPageIds.length;
+    const protectedChildIds = await findProtectedMemoryPages(childPageIds);
+    childrenCount = childPageIds.length - protectedChildIds.size;
     const allPageIds = [page.id, ...childPageIds];
 
     for (const targetId of allPageIds) {
+      // This branch recurses independently of pageService.recursivelyTrash, so
+      // it needs its own guard: the check at the top of this function only saw
+      // the page the agent named, not what is underneath it.
+      if (protectedChildIds.has(targetId)) {
+        continue;
+      }
+
       const targetPage = targetId === page.id ? page : await pageRepository.findById(targetId);
       if (!targetPage) {
         continue;
@@ -1284,6 +1294,14 @@ export const pageWriteTools = {
         // targetDriveId === page.driveId deliberately takes the same-drive bar, so
         // a model echoing back the current workspace id can't quietly swap which
         // authorization applies.
+        // Same refusal the HTTP path enforces (pageService.updatePage). Guarded
+        // once here so it covers BOTH implementations below — a cross-drive move
+        // would additionally take the page out of the Home drive the memory
+        // pointers assume.
+        if (await isProtectedMemoryPage(page.id)) {
+          throw new Error(MEMORY_PAGE_MOVE_ERROR);
+        }
+
         const isCrossDrive = !!targetDriveId && targetDriveId !== page.driveId;
 
         return isCrossDrive

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -2,6 +2,10 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { canActorEditPage, canActorDeletePage, canActorManageDrive, canActorAdministerDrive, driveDeniedByAppToken, driveOutsideMcpScope } from './actor-permissions';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import {
+  isProtectedMemoryPage,
+  MEMORY_PAGE_DELETE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 import { movePagesToDrive } from '@/services/api/page-cross-drive-move-service';
 import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 import { isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
@@ -212,6 +216,12 @@ async function trashPage(
 
   if (!page) {
     throw new Error(`Page with ID "${pageId}" not found`);
+  }
+
+  // Same protection the HTTP path enforces. An agent asked to "clean up my
+  // drive" must not be able to delete the pages that hold the user's profile.
+  if (await isProtectedMemoryPage(page.id)) {
+    throw new Error(MEMORY_PAGE_DELETE_ERROR);
   }
 
   if (withChildren) {

--- a/apps/web/src/lib/memory/__tests__/candidate-promotion.integration.test.ts
+++ b/apps/web/src/lib/memory/__tests__/candidate-promotion.integration.test.ts
@@ -21,6 +21,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { personalizationCandidates } from '@pagespace/db/schema/personalization';
 import { factories } from '@pagespace/db/test/factories';
+import { requireDb } from '@pagespace/db/test/require-db';
 import {
   upsertCandidates,
   findPromotableCandidates,
@@ -59,13 +60,17 @@ describe('candidate promotion (Postgres)', () => {
     try {
       await db.select().from(personalizationCandidates).limit(1);
       dbAvailable = true;
-    } catch {
+    } catch (error) {
+      // Missing Postgres is an environment failure, not a reason to report a
+      // green zero-assertion pass. Only an explicit ALLOW_SKIP_DB_TESTS=1 gets
+      // past this.
+      requireDb('candidate-promotion.integration.test.ts', error);
       dbAvailable = false;
     }
   });
 
   it('counts distinct evidence days, not repeated reads of the same message', async () => {
-    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    if (!dbAvailable) return;
     const userId = await freshUser();
 
     await upsertCandidates(userId, [claim('rules', DAY1)]);
@@ -89,7 +94,7 @@ describe('candidate promotion (Postgres)', () => {
   });
 
   it('will not promote a claim on the day it was first seen', async () => {
-    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    if (!dbAvailable) return;
     const userId = await freshUser();
 
     await upsertCandidates(userId, [claim('rules', DAY1)]);
@@ -103,7 +108,7 @@ describe('candidate promotion (Postgres)', () => {
   });
 
   it('holds bio to three days where the behavioural fields need two', async () => {
-    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    if (!dbAvailable) return;
     const userId = await freshUser();
 
     await upsertCandidates(userId, [claim('bio', DAY1), claim('rules', DAY1)]);
@@ -119,7 +124,7 @@ describe('candidate promotion (Postgres)', () => {
   });
 
   it('re-observing a settled claim does not collide with the unique index', async () => {
-    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    if (!dbAvailable) return;
     const userId = await freshUser();
 
     await upsertCandidates(userId, [claim('rules', DAY1)]);
@@ -136,7 +141,7 @@ describe('candidate promotion (Postgres)', () => {
   });
 
   it('redacts the verbatim quote once a settled row passes its retention window', async () => {
-    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    if (!dbAvailable) return;
     const userId = await freshUser();
 
     await upsertCandidates(userId, [claim('rules', DAY1)]);

--- a/apps/web/src/lib/memory/__tests__/candidate-promotion.integration.test.ts
+++ b/apps/web/src/lib/memory/__tests__/candidate-promotion.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Candidate promotion, against a REAL Postgres.
+ *
+ * ── Why this file exists ─────────────────────────────────────────────────────
+ * The unit tests beside it mock the database, so they never execute SQL. That
+ * hid a defect the first real query surfaced immediately: the per-field
+ * threshold was written as
+ *
+ *     occurrences >= CASE field WHEN 'bio' THEN $3 ... END
+ *
+ * and Postgres cannot resolve `integer >= unknown` for an untyped bound
+ * parameter. It fails with 42883 — on every cron run, for every user, so no
+ * memory would ever have been promoted. Every mocked test passed throughout.
+ *
+ * So the corroboration rule is pinned HERE, where the query actually runs:
+ * distinct-evidence-day counting, the same-day cutoff, and the stricter bar
+ * for `bio` (3 days) than for the behavioural fields (2).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { personalizationCandidates } from '@pagespace/db/schema/personalization';
+import { factories } from '@pagespace/db/test/factories';
+import {
+  upsertCandidates,
+  findPromotableCandidates,
+  markCandidatesPromoted,
+  redactSettledEvidence,
+  REDACTED_EVIDENCE,
+  type DiscoveredClaim,
+  type MemoryField,
+} from '@/lib/memory/candidate-service';
+
+let dbAvailable = false;
+
+const DAY1 = new Date('2026-03-01T10:00:00.000Z');
+const DAY1_LATER = new Date('2026-03-01T22:00:00.000Z');
+const DAY2 = new Date('2026-03-02T10:00:00.000Z');
+const DAY3 = new Date('2026-03-03T10:00:00.000Z');
+const LATER = new Date('2026-03-05T00:00:00.000Z');
+
+function claim(field: MemoryField, evidenceAt: Date): DiscoveredClaim {
+  return {
+    field,
+    claim: `${field} claim`,
+    evidence: 'a verbatim quote',
+    occurrencesInWindow: 1,
+    evidenceAt,
+  };
+}
+
+async function freshUser(): Promise<string> {
+  const user = await factories.createUser();
+  return user.id;
+}
+
+describe('candidate promotion (Postgres)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(personalizationCandidates).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('counts distinct evidence days, not repeated reads of the same message', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const userId = await freshUser();
+
+    await upsertCandidates(userId, [claim('rules', DAY1)]);
+    // The nightly window re-reads the SAME message; that is not corroboration.
+    await upsertCandidates(userId, [claim('rules', DAY1_LATER)]);
+
+    const [afterSameDay] = await db
+      .select()
+      .from(personalizationCandidates)
+      .where(eq(personalizationCandidates.userId, userId));
+    expect(afterSameDay.occurrences).toBe(1);
+
+    // The user says it again on another day. That is.
+    await upsertCandidates(userId, [claim('rules', DAY2)]);
+
+    const [afterNewDay] = await db
+      .select()
+      .from(personalizationCandidates)
+      .where(eq(personalizationCandidates.userId, userId));
+    expect(afterNewDay.occurrences).toBe(2);
+  });
+
+  it('will not promote a claim on the day it was first seen', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const userId = await freshUser();
+
+    await upsertCandidates(userId, [claim('rules', DAY1)]);
+    await upsertCandidates(userId, [claim('rules', DAY2)]);
+
+    const sameDay = await findPromotableCandidates(userId, new Date('2026-03-01T12:00:00.000Z'));
+    expect(sameDay).toHaveLength(0);
+
+    const later = await findPromotableCandidates(userId, LATER);
+    expect(later).toHaveLength(1);
+  });
+
+  it('holds bio to three days where the behavioural fields need two', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const userId = await freshUser();
+
+    await upsertCandidates(userId, [claim('bio', DAY1), claim('rules', DAY1)]);
+    await upsertCandidates(userId, [claim('bio', DAY2), claim('rules', DAY2)]);
+
+    const atTwoDays = await findPromotableCandidates(userId, LATER);
+    expect(atTwoDays.map((c) => c.field).sort()).toEqual(['rules']);
+
+    await upsertCandidates(userId, [claim('bio', DAY3)]);
+
+    const atThreeDays = await findPromotableCandidates(userId, LATER);
+    expect(atThreeDays.map((c) => c.field).sort()).toEqual(['bio', 'rules']);
+  });
+
+  it('re-observing a settled claim does not collide with the unique index', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const userId = await freshUser();
+
+    await upsertCandidates(userId, [claim('rules', DAY1)]);
+    const [row] = await db
+      .select()
+      .from(personalizationCandidates)
+      .where(eq(personalizationCandidates.userId, userId));
+    await markCandidatesPromoted([row.id]);
+
+    // The unique index covers settled rows too, so an active-only lookup would
+    // miss this one and the insert would throw — aborting every remaining claim
+    // for this user, every night.
+    await expect(upsertCandidates(userId, [claim('rules', DAY3)])).resolves.toBeTypeOf('number');
+  });
+
+  it('redacts the verbatim quote once a settled row passes its retention window', async () => {
+    if (!dbAvailable) throw new Error('DATABASE_URL must point at a migrated Postgres');
+    const userId = await freshUser();
+
+    await upsertCandidates(userId, [claim('rules', DAY1)]);
+    const [row] = await db
+      .select()
+      .from(personalizationCandidates)
+      .where(eq(personalizationCandidates.userId, userId));
+
+    await db
+      .update(personalizationCandidates)
+      .set({ promotedAt: new Date('2026-01-01T00:00:00.000Z') })
+      .where(eq(personalizationCandidates.id, row.id));
+
+    await redactSettledEvidence(userId);
+
+    const [after] = await db
+      .select()
+      .from(personalizationCandidates)
+      .where(eq(personalizationCandidates.id, row.id));
+
+    expect(after.evidence).toBe(REDACTED_EVIDENCE);
+    // The claim survives: deduplication needs it to recognise a recurring claim.
+    expect(after.claim).toBe('rules claim');
+  });
+});

--- a/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, vi, beforeEach } from 'vitest';
 import { assert } from './riteway';
 
 /**
@@ -10,7 +10,38 @@ import { assert } from './riteway';
  *   - a claim first seen today cannot be promoted today
  */
 
-vi.mock('@pagespace/db/db', () => ({ db: {} }));
+/**
+ * A minimal fake of the drizzle chain `upsertCandidates` drives, recording the
+ * values it is asked to write so the CALL SITE can be asserted — not just the
+ * pure helpers it delegates to.
+ */
+const dbCalls: { updates: Record<string, unknown>[]; inserts: Record<string, unknown>[] } = {
+  updates: [],
+  inserts: [],
+};
+let existingRow: Record<string, unknown> | null = null;
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(existingRow ? [existingRow] : []) }),
+      }),
+    }),
+    insert: () => ({
+      values: (v: Record<string, unknown>) => {
+        dbCalls.inserts.push(v);
+        return Promise.resolve();
+      },
+    }),
+    update: () => ({
+      set: (v: Record<string, unknown>) => {
+        dbCalls.updates.push(v);
+        return { where: () => Promise.resolve() };
+      },
+    }),
+  },
+}));
 vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn(),
   eq: vi.fn(),
@@ -61,14 +92,14 @@ describe('normalizeClaimKey', () => {
 });
 
 describe('shouldIncrementOccurrences', () => {
-  it('does not increment for a second sighting on the same UTC day', async () => {
+  it('does not increment for evidence written the same UTC day', async () => {
     const { shouldIncrementOccurrences } = await import('../candidate-service');
 
     const morning = new Date('2026-03-10T08:00:00.000Z');
     const evening = new Date('2026-03-10T23:59:59.000Z');
 
     assert({
-      given: 'a claim already seen earlier the same UTC day',
+      given: 'supporting evidence from earlier the same UTC day',
       should: 'not count as new corroboration',
       actual: shouldIncrementOccurrences(morning, evening),
       expected: false,
@@ -82,10 +113,27 @@ describe('shouldIncrementOccurrences', () => {
     const afterMidnight = new Date('2026-03-11T00:01:00.000Z');
 
     assert({
-      given: 'sightings either side of midnight UTC',
+      given: 'evidence either side of midnight UTC',
       should: 'count as corroboration on a distinct day',
       actual: shouldIncrementOccurrences(beforeMidnight, afterMidnight),
       expected: true,
+    });
+  });
+
+  it('does not corroborate an unchanged message re-read on a later cron day', async () => {
+    // The failure this whole staging table exists to prevent, and the one a
+    // cron-day comparison silently reintroduces: discovery re-reads a rolling
+    // 7-day window every night, so ONE message is rediscovered on consecutive
+    // runs. Only the evidence date may advance the count.
+    const { shouldIncrementOccurrences } = await import('../candidate-service');
+
+    const theOnlyMessage = new Date('2026-03-10T12:00:00.000Z');
+
+    assert({
+      given: 'the same single message re-read by a later nightly run',
+      should: 'not corroborate itself, however many nights it is re-read',
+      actual: shouldIncrementOccurrences(theOnlyMessage, theOnlyMessage),
+      expected: false,
     });
   });
 });
@@ -116,6 +164,129 @@ describe('promotionCutoff', () => {
       should: 'fall before the cutoff, so it is eligible',
       actual: firstSeenYesterday < promotionCutoff(now),
       expected: true,
+    });
+  });
+});
+
+describe('upsertCandidates — what the corroboration count is measured against', () => {
+  const claim = (evidenceAt: Date) => ({
+    field: 'rules' as const,
+    claim: 'Never use emojis',
+    evidence: 'no emojis please',
+    occurrencesInWindow: 1,
+    evidenceMessageIndex: 0,
+    evidenceAt,
+  });
+
+  beforeEach(() => {
+    dbCalls.updates = [];
+    dbCalls.inserts = [];
+    existingRow = null;
+  });
+
+  it('does not advance the count when the same message is re-read on a later day', async () => {
+    // Binds the CALL SITE, not just the helper: discovery re-reads a rolling
+    // 7-day window nightly, so passing the cron's own clock here would promote
+    // a one-off after two or three runs. Only the evidence date may count.
+    const theOnlyMessage = new Date('2026-03-10T12:00:00.000Z');
+    existingRow = {
+      id: 'c1',
+      occurrences: 1,
+      lastSeenAt: theOnlyMessage,
+      promotedAt: null,
+      rejectedAt: null,
+    };
+
+    const { upsertCandidates } = await import('../candidate-service');
+    await upsertCandidates('user-1', [claim(theOnlyMessage)]);
+
+    assert({
+      given: 'a claim re-derived from the same unchanged message on a later cron run',
+      should: 'leave occurrences untouched',
+      actual: dbCalls.updates[0]?.occurrences,
+      expected: 1,
+    });
+  });
+
+  it('advances the count when newer evidence arrives on another day', async () => {
+    existingRow = {
+      id: 'c1',
+      occurrences: 1,
+      lastSeenAt: new Date('2026-03-10T12:00:00.000Z'),
+      promotedAt: null,
+      rejectedAt: null,
+    };
+
+    const { upsertCandidates } = await import('../candidate-service');
+    await upsertCandidates('user-1', [claim(new Date('2026-03-11T09:00:00.000Z'))]);
+
+    assert({
+      given: 'the user saying the same thing again on a later day',
+      should: 'count it as corroboration',
+      actual: dbCalls.updates[0]?.occurrences,
+      expected: 2,
+    });
+  });
+
+  it('never moves lastSeenAt backwards when older evidence is re-read', async () => {
+    const newest = new Date('2026-03-12T09:00:00.000Z');
+    existingRow = {
+      id: 'c1',
+      occurrences: 2,
+      lastSeenAt: newest,
+      promotedAt: null,
+      rejectedAt: null,
+    };
+
+    const { upsertCandidates } = await import('../candidate-service');
+    await upsertCandidates('user-1', [claim(new Date('2026-03-10T09:00:00.000Z'))]);
+
+    assert({
+      given: 'an older supporting message re-read after a newer one',
+      should: 'keep the newest evidence date, so the claim does not look staler than it is',
+      actual: dbCalls.updates[0]?.lastSeenAt,
+      expected: newest,
+    });
+  });
+
+  it('leaves an already-settled claim alone instead of colliding on insert', async () => {
+    // The unique index is on (userId, field, claimKey) unconditionally, so an
+    // active-only lookup would miss this row and the insert would throw,
+    // aborting every remaining claim for this user.
+    existingRow = {
+      id: 'c1',
+      occurrences: 3,
+      lastSeenAt: new Date('2026-03-10T12:00:00.000Z'),
+      promotedAt: new Date('2026-03-11T00:00:00.000Z'),
+      rejectedAt: null,
+    };
+
+    const { upsertCandidates } = await import('../candidate-service');
+    await upsertCandidates('user-1', [claim(new Date('2026-03-12T09:00:00.000Z'))]);
+
+    assert({
+      given: 'a recurring claim that was already promoted',
+      should: 'neither re-insert nor re-update it',
+      actual: { inserts: dbCalls.inserts.length, updates: dbCalls.updates.length },
+      expected: { inserts: 0, updates: 0 },
+    });
+  });
+
+  it('stamps a new candidate with the evidence date, not the run time', async () => {
+    existingRow = null;
+    const evidenceAt = new Date('2026-03-10T12:00:00.000Z');
+
+    const { upsertCandidates } = await import('../candidate-service');
+    await upsertCandidates('user-1', [claim(evidenceAt)]);
+
+    assert({
+      given: 'a newly staged claim',
+      should: 'date it from its evidence so the promotion cutoff measures real elapsed days',
+      actual: {
+        firstSeenAt: dbCalls.inserts[0]?.firstSeenAt,
+        lastSeenAt: dbCalls.inserts[0]?.lastSeenAt,
+      },
+      expected: { firstSeenAt: evidenceAt, lastSeenAt: evidenceAt },
     });
   });
 });

--- a/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
@@ -31,13 +31,16 @@ vi.mock('@pagespace/db/db', () => ({
     insert: () => ({
       values: (v: Record<string, unknown>) => {
         dbCalls.inserts.push(v);
-        return Promise.resolve();
+        // Mirrors the real chain: insert ... on conflict do nothing returning id.
+        return {
+          onConflictDoNothing: () => ({ returning: () => Promise.resolve([{ id: 'new' }]) }),
+        };
       },
     }),
     update: () => ({
       set: (v: Record<string, unknown>) => {
         dbCalls.updates.push(v);
-        return { where: () => Promise.resolve() };
+        return { where: () => ({ returning: () => Promise.resolve([{ id: 'c1' }]) }) };
       },
     }),
   },

--- a/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
@@ -294,6 +294,41 @@ describe('upsertCandidates — what the corroboration count is measured against'
   });
 });
 
+describe('retention windows are coherent with the discovery window', () => {
+  it('keeps a pending candidate alive longer than the window that keeps re-observing it', async () => {
+    // Discovery rereads a rolling LOOKBACK_DAYS window. If the stale window
+    // were shorter, a claim could be pruned for inactivity while the very same
+    // messages were still inside the read window — deleted and re-staged on an
+    // endless loop, its occurrence count reset each time, so it could never
+    // reach the corroboration bar however often the user said it.
+    const { STALE_CANDIDATE_DAYS } = await import('../candidate-service');
+    const LOOKBACK_DAYS = 7; // discovery-service
+
+    assert({
+      given: 'the stale-candidate window and the discovery lookback window',
+      should: 'let a claim outlive the window that keeps rediscovering it',
+      actual: STALE_CANDIDATE_DAYS > LOOKBACK_DAYS,
+      expected: true,
+    });
+  });
+
+  it('keeps settled evidence longer than a pending claim survives', async () => {
+    // A promoted claim should not have its justification disappear sooner than
+    // an un-promoted one: the subject is most likely to ask "why does the AI
+    // think this about me?" precisely about claims that DID reach their profile.
+    const { STALE_CANDIDATE_DAYS, SETTLED_EVIDENCE_RETENTION_DAYS } = await import(
+      '../candidate-service'
+    );
+
+    assert({
+      given: 'the pending and settled retention windows',
+      should: 'retain the evidence behind a promoted claim at least as long',
+      actual: SETTLED_EVIDENCE_RETENTION_DAYS > STALE_CANDIDATE_DAYS,
+      expected: true,
+    });
+  });
+});
+
 describe('PROMOTION_THRESHOLD', () => {
   it('holds bio to a stricter bar than the behavioural fields', async () => {
     const { PROMOTION_THRESHOLD } = await import('../candidate-service');

--- a/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/candidate-service.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, vi } from 'vitest';
+import { assert } from './riteway';
+
+/**
+ * Candidate Service Tests
+ *
+ * The candidate table is what makes "corroborated across days" enforceable.
+ * These tests pin the two rules that make it work:
+ *   - occurrences count DISTINCT DAYS, not sightings
+ *   - a claim first seen today cannot be promoted today
+ */
+
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+  isNull: vi.fn(),
+  lt: vi.fn(),
+  sql: Object.assign(vi.fn(), { raw: vi.fn() }),
+}));
+vi.mock('@pagespace/db/schema/personalization', () => ({
+  personalizationCandidates: {
+    id: 'id',
+    userId: 'userId',
+    field: 'field',
+    claimKey: 'claimKey',
+    occurrences: 'occurrences',
+    firstSeenAt: 'firstSeenAt',
+    lastSeenAt: 'lastSeenAt',
+    promotedAt: 'promotedAt',
+    rejectedAt: 'rejectedAt',
+  },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+describe('normalizeClaimKey', () => {
+  it('collapses casing, punctuation, and whitespace to one key', async () => {
+    const { normalizeClaimKey } = await import('../candidate-service');
+
+    assert({
+      given: 'the same claim written two ways',
+      should: 'produce the same dedupe key so they corroborate each other',
+      actual: normalizeClaimKey('Be concise.') === normalizeClaimKey('be  concise'),
+      expected: true,
+    });
+  });
+
+  it('keeps genuinely different claims apart', async () => {
+    const { normalizeClaimKey } = await import('../candidate-service');
+
+    assert({
+      given: 'two different claims',
+      should: 'produce different dedupe keys',
+      actual: normalizeClaimKey('Be concise') === normalizeClaimKey('Be verbose'),
+      expected: false,
+    });
+  });
+});
+
+describe('shouldIncrementOccurrences', () => {
+  it('does not increment for a second sighting on the same UTC day', async () => {
+    const { shouldIncrementOccurrences } = await import('../candidate-service');
+
+    const morning = new Date('2026-03-10T08:00:00.000Z');
+    const evening = new Date('2026-03-10T23:59:59.000Z');
+
+    assert({
+      given: 'a claim already seen earlier the same UTC day',
+      should: 'not count as new corroboration',
+      actual: shouldIncrementOccurrences(morning, evening),
+      expected: false,
+    });
+  });
+
+  it('increments across a UTC day boundary even minutes apart', async () => {
+    const { shouldIncrementOccurrences } = await import('../candidate-service');
+
+    const beforeMidnight = new Date('2026-03-10T23:59:00.000Z');
+    const afterMidnight = new Date('2026-03-11T00:01:00.000Z');
+
+    assert({
+      given: 'sightings either side of midnight UTC',
+      should: 'count as corroboration on a distinct day',
+      actual: shouldIncrementOccurrences(beforeMidnight, afterMidnight),
+      expected: true,
+    });
+  });
+});
+
+describe('promotionCutoff', () => {
+  it('excludes a claim first seen earlier today', async () => {
+    const { promotionCutoff } = await import('../candidate-service');
+
+    const now = new Date('2026-03-10T18:00:00.000Z');
+    const firstSeenThisMorning = new Date('2026-03-10T06:00:00.000Z');
+
+    assert({
+      given: 'a claim first seen earlier the same day',
+      should: 'fall on or after the cutoff, so it is not promotable yet',
+      actual: firstSeenThisMorning < promotionCutoff(now),
+      expected: false,
+    });
+  });
+
+  it('includes a claim first seen yesterday', async () => {
+    const { promotionCutoff } = await import('../candidate-service');
+
+    const now = new Date('2026-03-10T00:30:00.000Z');
+    const firstSeenYesterday = new Date('2026-03-09T23:00:00.000Z');
+
+    assert({
+      given: 'a claim first seen the previous UTC day',
+      should: 'fall before the cutoff, so it is eligible',
+      actual: firstSeenYesterday < promotionCutoff(now),
+      expected: true,
+    });
+  });
+});
+
+describe('PROMOTION_THRESHOLD', () => {
+  it('holds bio to a stricter bar than the behavioural fields', async () => {
+    const { PROMOTION_THRESHOLD } = await import('../candidate-service');
+
+    assert({
+      given: 'the per-field promotion thresholds',
+      should: 'require more corroboration for identity claims than for preferences',
+      actual: PROMOTION_THRESHOLD.bio > PROMOTION_THRESHOLD.writingStyle,
+      expected: true,
+    });
+  });
+});

--- a/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi } from 'vitest';
+import { describe, it, vi, beforeEach } from 'vitest';
 import { assert } from './riteway';
 
 /**
@@ -16,9 +16,25 @@ vi.mock('@pagespace/db/schema/personalization', () => ({
   userPersonalization: {},
   personalizationCandidates: {},
 }));
+const readMemoryPages = vi.fn(async () => ({}) as Record<string, string>);
 vi.mock('@pagespace/lib/memory/memory-pages', () => ({
-  readMemoryPages: vi.fn(async () => ({})),
+  readMemoryPages: (...a: unknown[]) => readMemoryPages(...(a as [])),
 }));
+
+// The page writer is the boundary compaction has to respect: it refuses when
+// the user edited the page mid-run, or the pointer is stale.
+const updatePersonalizationPage = vi.fn(
+  async () => ({ written: true }) as { written: boolean; reason?: string }
+);
+vi.mock('../integration-service', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getCurrentPersonalizationPages: (...a: unknown[]) => readMemoryPages(...(a as [])),
+    updatePersonalizationPage: (...a: unknown[]) =>
+      updatePersonalizationPage(...(a as [])),
+  };
+});
 vi.mock('@/lib/ai/core/provider-factory', () => ({
   createAIProvider: vi.fn(),
   isProviderError: vi.fn(() => false),
@@ -92,6 +108,47 @@ describe('needsCompaction', () => {
         rules: needsCompaction(oldRestingSize, 'rules'),
       },
       expected: { bio: true, writingStyle: true, rules: true },
+    });
+  });
+});
+
+describe('checkAndCompactIfNeeded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updatePersonalizationPage.mockResolvedValue({ written: true });
+  });
+
+  it('reports a field as compacted only when the write actually landed', async () => {
+    // The page was edited by the user while this run was compacting, so the
+    // write is refused. Reporting it as compacted would claim a page had shrunk
+    // while it is still over budget — and the next run would do the same thing
+    // again, reporting success every night while nothing changed.
+    readMemoryPages.mockResolvedValue({ bio: 'x'.repeat(3500) });
+    updatePersonalizationPage.mockResolvedValue({
+      written: false,
+      reason: 'page was edited during this run',
+    });
+
+    const { generateText } = await import('ai');
+    vi.mocked(generateText).mockResolvedValue({
+      text: 'short compacted bio',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    } as never);
+    const { createAIProvider } = await import('@/lib/ai/core/provider-factory');
+    vi.mocked(createAIProvider).mockResolvedValue({
+      model: {},
+      provider: 'anthropic',
+      modelName: 'm',
+    } as never);
+
+    const { checkAndCompactIfNeeded } = await import('../compaction-service');
+    const result = await checkAndCompactIfNeeded('user-1');
+
+    assert({
+      given: 'a refused write for an over-budget page',
+      should: 'report nothing as compacted',
+      actual: { compacted: result.compacted, fields: result.fields },
+      expected: { compacted: false, fields: [] },
     });
   });
 });

--- a/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
@@ -1,357 +1,97 @@
-import { describe, it, vi, beforeEach } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { assert } from './riteway';
 
 /**
  * Compaction Service Tests
  *
- * The compaction service handles reorganizing and summarizing personalization
- * fields when they grow too large. It uses LLM to preserve key insights while
- * reducing size.
- *
- * Key behaviors to test:
- * 1. needsCompaction detects when content exceeds threshold
- * 2. compactField reduces content size while preserving meaning
- * 3. checkAndCompactIfNeeded processes all fields needing compaction
- * 4. Handles LLM errors gracefully (returns original content)
- * 5. Doesn't compact if result would be larger
+ * Compaction is the mechanism that stops the profile growing without bound.
+ * The budgets it enforces are the equilibrium size of each page, so these tests
+ * pin the thresholds themselves — not just that some threshold exists.
  */
 
-// Mock database
-const mockDbQuery = vi.fn();
-const mockDbInsert = vi.fn();
-vi.mock('@pagespace/db/db', () => ({
-  db: {
-    query: {
-      userPersonalization: {
-        findFirst: () => mockDbQuery(),
-      },
-    },
-    insert: () => mockDbInsert(),
-  },
-}));
-vi.mock('@pagespace/db/operators', () => ({
-  eq: vi.fn(),
-}));
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+vi.mock('@pagespace/db/operators', () => ({ and: vi.fn(), eq: vi.fn() }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
 vi.mock('@pagespace/db/schema/personalization', () => ({
-  userPersonalization: { userId: 'userId' },
+  userPersonalization: {},
+  personalizationCandidates: {},
 }));
-
-// Mock AI provider
-const mockCreateAIProvider = vi.fn();
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({
+  readMemoryPages: vi.fn(async () => ({})),
+}));
 vi.mock('@/lib/ai/core/provider-factory', () => ({
-  createAIProvider: () => mockCreateAIProvider(),
-  isProviderError: (result: unknown) => result !== null && typeof result === 'object' && 'error' in result,
+  createAIProvider: vi.fn(),
+  isProviderError: vi.fn(() => false),
 }));
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   BACKGROUND_HEAVY_PROVIDER: 'anthropic',
   BACKGROUND_HEAVY_MODEL: 'anthropic/claude-sonnet-5',
 }));
-
-// Mock loggers
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn() },
+}));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
-    api: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
-  },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
 }));
+vi.mock('ai', () => ({ generateText: vi.fn() }));
 
-// Mock generateText
-const mockGenerateText = vi.fn();
-vi.mock('ai', () => ({
-  generateText: () => mockGenerateText(),
-}));
+describe('needsCompaction', () => {
+  it('leaves a page under its budget alone', async () => {
+    const { needsCompaction } = await import('../compaction-service');
 
-// Helper to set up AI provider success
-function setupAIProviderSuccess(response: string) {
-  mockCreateAIProvider.mockResolvedValue({
-    model: 'test-model',
-    provider: 'test',
-    modelName: 'test',
-  });
-  mockGenerateText.mockResolvedValue({ text: response });
-}
-
-describe('compaction-service', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDbQuery.mockResolvedValue(null);
-    mockDbInsert.mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-      }),
+    assert({
+      given: 'a bio comfortably under budget',
+      should: 'not trigger compaction',
+      actual: needsCompaction('x'.repeat(2999), 'bio'),
+      expected: false,
     });
   });
 
-  describe('needsCompaction', () => {
-    it('should exist and be callable', async () => {
-      const { needsCompaction } = await import('../compaction-service');
+  it('triggers once a page passes its budget', async () => {
+    const { needsCompaction } = await import('../compaction-service');
 
-      assert({
-        given: 'compaction-service module',
-        should: 'export needsCompaction function',
-        actual: typeof needsCompaction,
-        expected: 'function',
-      });
-    });
-
-    it('should return false for content below threshold', async () => {
-      const { needsCompaction } = await import('../compaction-service');
-      const shortContent = 'Short bio';
-
-      const result = needsCompaction(shortContent, 20000);
-
-      assert({
-        given: 'content below 90% of max length',
-        should: 'return false',
-        actual: result,
-        expected: false,
-      });
-    });
-
-    it('should return true for content at or above 90% threshold', async () => {
-      const { needsCompaction } = await import('../compaction-service');
-      // 90% of 1000 = 900, so 901 should trigger
-      const longContent = 'x'.repeat(901);
-
-      const result = needsCompaction(longContent, 1000);
-
-      assert({
-        given: 'content at 90.1% of max length',
-        should: 'return true',
-        actual: result,
-        expected: true,
-      });
-    });
-
-    it('should use default max length of 20000 if not specified', async () => {
-      const { needsCompaction } = await import('../compaction-service');
-      // 90% of 20000 = 18000, so 17999 should not trigger
-      const justUnderContent = 'x'.repeat(17999);
-      const justOverContent = 'x'.repeat(18001);
-
-      assert({
-        given: 'content at 17999 chars (under 90% of 20000)',
-        should: 'return false',
-        actual: needsCompaction(justUnderContent),
-        expected: false,
-      });
-
-      assert({
-        given: 'content at 18001 chars (over 90% of 20000)',
-        should: 'return true',
-        actual: needsCompaction(justOverContent),
-        expected: true,
-      });
+    assert({
+      given: 'a bio one character over budget',
+      should: 'trigger compaction',
+      actual: needsCompaction('x'.repeat(3001), 'bio'),
+      expected: true,
     });
   });
 
-  describe('compactField', () => {
-    it('should exist and be callable', async () => {
-      const { compactField } = await import('../compaction-service');
+  it('holds writingStyle and rules to a tighter budget than bio', async () => {
+    const { needsCompaction } = await import('../compaction-service');
 
-      assert({
-        given: 'compaction-service module',
-        should: 'export compactField function',
-        actual: typeof compactField,
-        expected: 'function',
-      });
-    });
+    // Between the 2500 behavioural budget and the 3000 bio budget.
+    const content = 'x'.repeat(2750);
 
-    it('should return compacted content from LLM', async () => {
-      setupAIProviderSuccess('Compacted bio content');
-
-      const { compactField } = await import('../compaction-service');
-      const longContent = 'Original long bio content that needs compacting';
-
-      const result = await compactField('user-123', 'bio', longContent, 1000);
-
-      assert({
-        given: 'long content and successful LLM response',
-        should: 'return compacted content',
-        actual: result,
-        expected: 'Compacted bio content',
-      });
-    });
-
-    it('should return original content when LLM returns empty', async () => {
-      setupAIProviderSuccess('');
-
-      const { compactField } = await import('../compaction-service');
-      const originalContent = 'Original content';
-
-      const result = await compactField('user-123', 'bio', originalContent, 1000);
-
-      assert({
-        given: 'LLM returns empty response',
-        should: 'return original content',
-        actual: result,
-        expected: originalContent,
-      });
-    });
-
-    it('should return original content when LLM returns longer text', async () => {
-      const originalContent = 'Short';
-      setupAIProviderSuccess('This is actually longer than the original');
-
-      const { compactField } = await import('../compaction-service');
-
-      const result = await compactField('user-123', 'bio', originalContent, 1000);
-
-      assert({
-        given: 'LLM returns longer text than original',
-        should: 'return original content',
-        actual: result,
-        expected: originalContent,
-      });
-    });
-
-    it('should return original content when AI provider fails', async () => {
-      mockCreateAIProvider.mockResolvedValue({
-        error: 'API key not configured',
-        status: 400,
-      });
-
-      const { compactField } = await import('../compaction-service');
-      const originalContent = 'Original content that needs compacting';
-
-      const result = await compactField('user-123', 'bio', originalContent, 1000);
-
-      assert({
-        given: 'AI provider error',
-        should: 'return original content without throwing',
-        actual: result,
-        expected: originalContent,
-      });
-    });
-
-    it('should call LLM with field-specific system prompt', async () => {
-      setupAIProviderSuccess('Compacted');
-
-      const { compactField } = await import('../compaction-service');
-      await compactField('user-123', 'bio', 'Long content', 1000);
-
-      assert({
-        given: 'compactField called with bio field',
-        should: 'call generateText once',
-        actual: mockGenerateText.mock.calls.length,
-        expected: 1,
-      });
+    assert({
+      given: 'content between the behavioural and bio budgets',
+      should: 'compact writingStyle and rules but not bio',
+      actual: {
+        bio: needsCompaction(content, 'bio'),
+        writingStyle: needsCompaction(content, 'writingStyle'),
+        rules: needsCompaction(content, 'rules'),
+      },
+      expected: { bio: false, writingStyle: true, rules: true },
     });
   });
 
-  describe('checkAndCompactIfNeeded', () => {
-    it('should exist and be callable', async () => {
-      const { checkAndCompactIfNeeded } = await import('../compaction-service');
+  it('keeps every budget far below the old 20k ceiling', async () => {
+    const { needsCompaction } = await import('../compaction-service');
 
-      assert({
-        given: 'compaction-service module',
-        should: 'export checkAndCompactIfNeeded function',
-        actual: typeof checkAndCompactIfNeeded,
-        expected: 'function',
-      });
-    });
+    // The pre-rewrite design compacted at 18000 and targeted 14000, which made
+    // ~14k the resting size of every field. Pin that this is gone.
+    const oldRestingSize = 'x'.repeat(14000);
 
-    it('should return compacted: false when no personalization exists', async () => {
-      mockDbQuery.mockResolvedValue(null);
-
-      const { checkAndCompactIfNeeded } = await import('../compaction-service');
-      const result = await checkAndCompactIfNeeded('user-123');
-
-      assert({
-        given: 'no personalization record',
-        should: 'return compacted: false',
-        actual: result.compacted,
-        expected: false,
-      });
-
-      assert({
-        given: 'no personalization record',
-        should: 'return empty fields array',
-        actual: result.fields,
-        expected: [],
-      });
-    });
-
-    it('should return compacted: false when all fields are under threshold', async () => {
-      mockDbQuery.mockResolvedValue({
-        bio: 'Short bio',
-        writingStyle: 'Concise',
-        rules: 'No rules',
-        enabled: true,
-      });
-
-      const { checkAndCompactIfNeeded } = await import('../compaction-service');
-      const result = await checkAndCompactIfNeeded('user-123', 20000);
-
-      assert({
-        given: 'all fields under threshold',
-        should: 'return compacted: false',
-        actual: result.compacted,
-        expected: false,
-      });
-    });
-
-    it('should compact fields exceeding threshold', async () => {
-      // Bio exceeds threshold, others don't
-      const longBio = 'x'.repeat(950);
-      mockDbQuery.mockResolvedValue({
-        bio: longBio,
-        writingStyle: 'Short',
-        rules: 'Short',
-        enabled: true,
-      });
-      setupAIProviderSuccess('Compacted bio');
-
-      const { checkAndCompactIfNeeded } = await import('../compaction-service');
-      const result = await checkAndCompactIfNeeded('user-123', 1000);
-
-      assert({
-        given: 'bio field exceeds threshold',
-        should: 'return compacted: true',
-        actual: result.compacted,
-        expected: true,
-      });
-
-      assert({
-        given: 'only bio exceeds threshold',
-        should: 'return fields array with bio',
-        actual: result.fields,
-        expected: ['bio'],
-      });
-    });
-
-    it('should compact multiple fields if multiple exceed threshold', async () => {
-      const longContent = 'x'.repeat(950);
-      mockDbQuery.mockResolvedValue({
-        bio: longContent,
-        writingStyle: longContent,
-        rules: 'Short',
-        enabled: true,
-      });
-      setupAIProviderSuccess('Compacted');
-
-      const { checkAndCompactIfNeeded } = await import('../compaction-service');
-      const result = await checkAndCompactIfNeeded('user-123', 1000);
-
-      assert({
-        given: 'bio and writingStyle exceed threshold',
-        should: 'return compacted: true',
-        actual: result.compacted,
-        expected: true,
-      });
-
-      assert({
-        given: 'bio and writingStyle exceed threshold',
-        should: 'return both fields in array',
-        actual: result.fields.sort(),
-        expected: ['bio', 'writingStyle'].sort(),
-      });
+    assert({
+      given: 'a page at the size the old design settled at',
+      should: 'now be over budget for every field',
+      actual: {
+        bio: needsCompaction(oldRestingSize, 'bio'),
+        writingStyle: needsCompaction(oldRestingSize, 'writingStyle'),
+        rules: needsCompaction(oldRestingSize, 'rules'),
+      },
+      expected: { bio: true, writingStyle: true, rules: true },
     });
   });
 });

--- a/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
@@ -112,6 +112,41 @@ describe('needsCompaction', () => {
   });
 });
 
+describe('budget coherence across the three consumers', () => {
+  it('compacts to a size the write guard will actually accept', async () => {
+    // Compaction, the rewrite guard and prompt injection all act on these
+    // numbers, and only work if they agree. If compaction targeted a size at or
+    // above the guard's ceiling, every compaction result would be refused, the
+    // page would stay over budget forever, and the cron would log "compacted"
+    // each night while nothing changed. Nothing about that fails loudly.
+    const { MAX_FIELD_LENGTH, compactionTarget } = await import('../budgets');
+
+    const fields = ['bio', 'writingStyle', 'rules'] as const;
+    assert({
+      given: 'each field budget',
+      should: 'leave compaction headroom strictly below the ceiling',
+      actual: fields.every((f) => compactionTarget(f) < MAX_FIELD_LENGTH[f]),
+      expected: true,
+    });
+  });
+
+  it('keeps the total ceiling below the sum of the per-field budgets', async () => {
+    // Equal to the sum, the total check could never fire — three already
+    // truncated fields always fit — so it would read as protection while being
+    // dead code. A mutation proved exactly that earlier in this branch.
+    const { MAX_FIELD_LENGTH, MAX_TOTAL_INJECTION_LENGTH } = await import('../budgets');
+
+    const sum = MAX_FIELD_LENGTH.bio + MAX_FIELD_LENGTH.writingStyle + MAX_FIELD_LENGTH.rules;
+
+    assert({
+      given: 'the per-field budgets and the total injection ceiling',
+      should: 'make the total strictly smaller, so the total guard can fire',
+      actual: MAX_TOTAL_INJECTION_LENGTH < sum,
+      expected: true,
+    });
+  });
+});
+
 describe('checkAndCompactIfNeeded', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
@@ -83,12 +83,21 @@ vi.mock('ai', () => ({
  * `where()` therefore has to be both thenable and chainable.
  */
 function setupDb(messageRows: unknown[], driveRows: unknown[] = [{ driveId: 'drive-1' }]) {
+  // The module runs three `.limit()` queries: global messages, page messages,
+  // then activity. Serving `messageRows` to every one would silently duplicate
+  // the transcript, which would make an index-resolution assertion meaningless.
+  // So the rows are served ONCE and later queries come back empty.
+  let served = false;
   mockDbSelect.mockImplementation(() => {
     const chain = {
       from: () => chain,
       innerJoin: () => chain,
       orderBy: () => chain,
-      limit: () => Promise.resolve(messageRows),
+      limit: () => {
+        if (served) return Promise.resolve([]);
+        served = true;
+        return Promise.resolve(messageRows);
+      },
       // Awaiting the chain directly resolves the drive-membership shape.
       where: () => Object.assign(Promise.resolve(driveRows), chain),
     };
@@ -187,6 +196,73 @@ describe('runDiscoveryPasses', () => {
         occurrencesInWindow: result.claims[0].occurrencesInWindow,
       },
       expected: { evidence: 'keep it short', occurrencesInWindow: 3 },
+    });
+  });
+
+  it('resolves a cited message index against a chronological transcript', async () => {
+    // The db returns newest-first (that is how the most recent N are picked),
+    // so the transcript must be reversed before numbering. Numbering it
+    // newest-first would make [0] the newest while a model reading a
+    // conversation assumes ascending time — "cite the most recent message"
+    // would then return a HIGH index and resolve to the OLDEST message.
+    //
+    // The failure is silent: the index is in range, so the out-of-range
+    // fallback never fires, and today's evidence is stamped a week old —
+    // inverting the corroboration rule, which keys entirely on evidenceAt.
+    const newest = new Date('2026-03-12T00:00:00.000Z');
+    const oldest = new Date('2026-03-05T00:00:00.000Z');
+    setupDb([
+      { content: 'newest', role: 'user', createdAt: newest },
+      { content: 'middle', role: 'user', createdAt: new Date('2026-03-08T00:00:00.000Z') },
+      { content: 'oldest', role: 'user', createdAt: oldest },
+    ]);
+
+    // Cite the highest index — what a model means by "the most recent message".
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        claims: [
+          { claim: 'c', evidence: 'e', occurrencesInWindow: 1, evidenceMessageIndex: 2 },
+        ],
+      },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+
+    const { runDiscoveryPasses } = await import('../discovery-service');
+    const result = await runDiscoveryPasses('user-1');
+
+    assert({
+      given: 'a claim citing the highest message number',
+      should: 'date it from the NEWEST message, not the oldest',
+      actual: result.claims[0]?.evidenceAt,
+      expected: newest,
+    });
+  });
+
+  it('dates a claim from the oldest message when the cited index is unusable', async () => {
+    const oldest = new Date('2026-03-05T00:00:00.000Z');
+    setupDb([
+      { content: 'newest', role: 'user', createdAt: new Date('2026-03-12T00:00:00.000Z') },
+      { content: 'middle', role: 'user', createdAt: new Date('2026-03-08T00:00:00.000Z') },
+      { content: 'oldest', role: 'user', createdAt: oldest },
+    ]);
+
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        claims: [
+          { claim: 'c', evidence: 'e', occurrencesInWindow: 1, evidenceMessageIndex: 999 },
+        ],
+      },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+
+    const { runDiscoveryPasses } = await import('../discovery-service');
+    const result = await runDiscoveryPasses('user-1');
+
+    assert({
+      given: 'an out-of-range message index',
+      should: 'fall back to the oldest message, so a claim can never look fresher than its evidence',
+      actual: result.claims[0]?.evidenceAt,
+      expected: oldest,
     });
   });
 

--- a/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
@@ -4,23 +4,14 @@ import { assert } from './riteway';
 /**
  * Discovery Service Tests
  *
- * The discovery service runs focused LLM passes to extract insights from
- * user conversations. It is "blind" - it does NOT see the current profile.
- *
- * Key behaviors to test:
- * 1. Returns empty results when insufficient conversation data
- * 2. Runs 3 focused passes (worldview, communication, preferences)
- * 3. Parses JSON array responses from LLM
- * 4. Handles LLM errors gracefully (returns empty arrays, doesn't throw)
- * 5. Gathers conversations from multiple sources
+ * Discovery is "blind" — it never sees the current profile. Its output is a
+ * flat list of claims, each tagged with the field it belongs to, so the caller
+ * can stage them for corroboration.
  */
 
-// Mock database - we don't want to hit real DB
 const mockDbSelect = vi.fn();
 vi.mock('@pagespace/db/db', () => ({
-  db: {
-    select: () => mockDbSelect(),
-  },
+  db: { select: (...args: unknown[]) => mockDbSelect(...args) },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
@@ -35,391 +26,182 @@ vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', driveId: 'driveId' },
 }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({
-  activityLogs: { operation: 'operation', resourceType: 'resourceType', resourceTitle: 'resourceTitle', userId: 'userId', driveId: 'driveId', timestamp: 'timestamp' },
+  activityLogs: {
+    operation: 'operation',
+    resourceType: 'resourceType',
+    resourceTitle: 'resourceTitle',
+    userId: 'userId',
+    driveId: 'driveId',
+    timestamp: 'timestamp',
+  },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveId', userId: 'userId', acceptedAt: 'acceptedAt' },
+  driveMembers: { userId: 'userId', driveId: 'driveId', acceptedAt: 'acceptedAt' },
 }));
 vi.mock('@pagespace/db/schema/conversations', () => ({
-  conversations: { id: 'id', userId: 'userId' },
-  messages: { content: 'content', role: 'role', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt', status: 'status' },
+  conversations: { id: 'id', type: 'type', userId: 'userId', contextId: 'contextId' },
+  messages: {
+    conversationId: 'conversationId',
+    content: 'content',
+    role: 'role',
+    isActive: 'isActive',
+    status: 'status',
+    userId: 'userId',
+    createdAt: 'createdAt',
+    id: 'id',
+  },
 }));
-
-// Mock AI provider
-const mockCreateAIProvider = vi.fn();
 vi.mock('@/lib/ai/core/provider-factory', () => ({
-  createAIProvider: () => mockCreateAIProvider(),
-  isProviderError: (result: unknown) => result !== null && typeof result === 'object' && 'error' in result,
+  createAIProvider: vi.fn(async () => ({
+    model: {},
+    provider: 'anthropic',
+    modelName: 'claude-sonnet-5',
+  })),
+  isProviderError: vi.fn(() => false),
 }));
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   BACKGROUND_HEAVY_PROVIDER: 'anthropic',
   BACKGROUND_HEAVY_MODEL: 'anthropic/claude-sonnet-5',
 }));
-
-// Mock loggers
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn() },
+}));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
-    api: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
-  },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  loggers: { api: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } },
 }));
 
-// Mock generateText from AI SDK
-const mockGenerateText = vi.fn();
+const mockGenerateObject = vi.fn();
 vi.mock('ai', () => ({
-  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  generateObject: (...args: unknown[]) => mockGenerateObject(...args),
 }));
 
-// Helper to set up DB mock to return messages
-function setupDbWithMessages(messageCount: number) {
-  const now = Date.now();
-  const messages = Array.from({ length: messageCount }, (_, i) => ({
-    content: `Message ${i + 1}`,
-    role: i % 2 === 0 ? 'user' : 'assistant',
-    createdAt: new Date(now - i * 1000),
-  }));
-
-  // Chain for messages query
-  const messagesChain = {
-    from: vi.fn(() => ({
-      innerJoin: vi.fn(() => ({
-        where: vi.fn(() => ({
-          orderBy: vi.fn(() => ({
-            limit: vi.fn(() => Promise.resolve(messages)),
-          })),
-        })),
-      })),
-    })),
-  };
-
-  // Chain for driveMembers query (returns empty - no drives)
-  const driveMembersChain = {
-    from: vi.fn(() => ({
-      where: vi.fn(() => Promise.resolve([])),
-    })),
-  };
-
-  let callCount = 0;
+/**
+ * Stand in for the two query shapes this module uses:
+ *   message/activity reads  → .where().orderBy().limit()  (awaited at the end)
+ *   drive-membership reads  → .where()                    (awaited directly)
+ *
+ * `where()` therefore has to be both thenable and chainable.
+ */
+function setupDb(messageRows: unknown[], driveRows: unknown[] = [{ driveId: 'drive-1' }]) {
   mockDbSelect.mockImplementation(() => {
-    callCount++;
-    // First call is for messages, second for driveMembers
-    if (callCount === 1) return messagesChain;
-    return driveMembersChain;
+    const chain = {
+      from: () => chain,
+      innerJoin: () => chain,
+      orderBy: () => chain,
+      limit: () => Promise.resolve(messageRows),
+      // Awaiting the chain directly resolves the drive-membership shape.
+      where: () => Object.assign(Promise.resolve(driveRows), chain),
+    };
+    return chain;
   });
 }
 
-// Helper to set up AI provider success with specific response
-function setupAIProviderSuccess(responses: string[]) {
-  mockCreateAIProvider.mockResolvedValue({
-    model: 'test-model',
-    provider: 'test',
-    modelName: 'test',
-  });
-
-  let callIndex = 0;
-  mockGenerateText.mockImplementation(() => {
-    const response = responses[callIndex % responses.length];
-    callIndex++;
-    return Promise.resolve({ text: response });
-  });
+function messages(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    content: `Message ${i}`,
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    createdAt: new Date(Date.now() - i * 1000),
+  }));
 }
 
-describe('discovery-service', () => {
+describe('runDiscoveryPasses', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: setup DB to return empty (insufficient data)
-    setupDbWithMessages(0);
   });
 
-  describe('runDiscoveryPasses', () => {
-    it('should exist and be callable', async () => {
-      const { runDiscoveryPasses } = await import('../discovery-service');
+  it('returns no claims when there is too little conversation to read', async () => {
+    setupDb([]);
+    const { runDiscoveryPasses } = await import('../discovery-service');
 
-      assert({
-        given: 'discovery-service module',
-        should: 'export runDiscoveryPasses function',
-        actual: typeof runDiscoveryPasses,
-        expected: 'function',
-      });
-    });
+    const result = await runDiscoveryPasses('user-with-no-data');
 
-    it('should return DiscoveryResult with three arrays', async () => {
-      const { runDiscoveryPasses } = await import('../discovery-service');
-
-      const result = await runDiscoveryPasses('user-123');
-
-      assert({
-        given: 'a userId',
-        should: 'return result with worldview array',
-        actual: Array.isArray(result.worldview),
-        expected: true,
-      });
-
-      assert({
-        given: 'a userId',
-        should: 'return result with communication array',
-        actual: Array.isArray(result.communication),
-        expected: true,
-      });
-
-      assert({
-        given: 'a userId',
-        should: 'return result with preferences array',
-        actual: Array.isArray(result.preferences),
-        expected: true,
-      });
-    });
-
-    it('should return empty arrays when user has insufficient conversations', async () => {
-      // Default mock returns empty arrays (no conversations)
-      setupDbWithMessages(0);
-      const { runDiscoveryPasses } = await import('../discovery-service');
-
-      const result = await runDiscoveryPasses('user-with-no-data');
-
-      assert({
-        given: 'a user with fewer than 3 conversations',
-        should: 'return empty worldview array',
-        actual: result.worldview,
-        expected: [],
-      });
-
-      assert({
-        given: 'a user with fewer than 3 conversations',
-        should: 'return empty preferences array',
-        actual: result.preferences,
-        expected: [],
-      });
+    assert({
+      given: 'a user with fewer than 3 messages',
+      should: 'return no claims and not call the model at all',
+      actual: { claims: result.claims, modelCalls: mockGenerateObject.mock.calls.length },
+      expected: { claims: [], modelCalls: 0 },
     });
   });
 
-  describe('DiscoveryResult type', () => {
-    it('should define DiscoveryResult interface', async () => {
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      const result = await runDiscoveryPasses('test');
+  it('tags each claim with the field of the pass that produced it', async () => {
+    setupDb(messages(10));
+    // Every pass returns an untagged claim; the caller must assign the field so
+    // a model that omits or misreports `field` cannot file a claim in the wrong page.
+    mockGenerateObject.mockResolvedValue({
+      object: { claims: [{ claim: 'c', evidence: 'e', occurrencesInWindow: 2 }] },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
 
-      // TypeScript will fail compilation if these properties don't exist
-      const _worldview: string[] = result.worldview;
-      const _communication: string[] = result.communication;
-      const _preferences: string[] = result.preferences;
+    const { runDiscoveryPasses } = await import('../discovery-service');
+    const result = await runDiscoveryPasses('user-with-data');
 
-      assert({
-        given: 'DiscoveryResult',
-        should: 'have string array types for all fields',
-        actual: true,
-        expected: true,
-      });
+    assert({
+      given: 'three passes each returning one claim',
+      should: 'tag them bio, writingStyle, and rules respectively',
+      actual: result.claims.map((c) => c.field).sort(),
+      expected: ['bio', 'rules', 'writingStyle'],
     });
   });
 
-  describe('LLM integration', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
+  it('overrides a field the model reported incorrectly', async () => {
+    setupDb(messages(10));
+    // The bio pass returns a claim self-labelled as `rules`. The pass it came
+    // from is the authority, not the model's own tag.
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        claims: [{ field: 'rules', claim: 'c', evidence: 'e', occurrencesInWindow: 2 }],
+      },
+      usage: { inputTokens: 10, outputTokens: 5 },
     });
 
-    it('should run 3 LLM passes when sufficient conversations exist', async () => {
-      setupDbWithMessages(10);
-      setupAIProviderSuccess([
-        '["Expert in TypeScript"]',
-        '["Prefers concise responses"]',
-        '["No emojis please"]',
-      ]);
+    const { runDiscoveryPasses } = await import('../discovery-service');
+    const result = await runDiscoveryPasses('user-with-data');
 
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      await runDiscoveryPasses('user-with-data');
+    assert({
+      given: 'every pass mislabelling its claim as "rules"',
+      should: 'still produce one claim per field, from the pass of origin',
+      actual: result.claims.map((c) => c.field).sort(),
+      expected: ['bio', 'rules', 'writingStyle'],
+    });
+  });
 
-      assert({
-        given: 'user with sufficient conversations',
-        should: 'call LLM 3 times for worldview, communication, and preferences passes',
-        actual: mockGenerateText.mock.calls.length,
-        expected: 3,
-      });
+  it('carries evidence through so claims can be corroborated', async () => {
+    setupDb(messages(10));
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        claims: [
+          { claim: 'Be concise', evidence: 'keep it short', occurrencesInWindow: 3 },
+        ],
+      },
+      usage: { inputTokens: 10, outputTokens: 5 },
     });
 
-    it('should parse JSON array responses from LLM', async () => {
-      setupDbWithMessages(10);
-      setupAIProviderSuccess([
-        '["Expert in TypeScript", "Values TDD"]',
-        '["Prefers concise responses"]',
-        '["No emojis please"]',
-      ]);
+    const { runDiscoveryPasses } = await import('../discovery-service');
+    const result = await runDiscoveryPasses('user-with-data');
 
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      const result = await runDiscoveryPasses('user-with-data');
-
-      assert({
-        given: 'LLM returns JSON array for worldview',
-        should: 'parse and return insights',
-        actual: result.worldview,
-        expected: ['Expert in TypeScript', 'Values TDD'],
-      });
+    assert({
+      given: 'a model response with evidence and an occurrence count',
+      should: 'preserve both on the returned claim',
+      actual: {
+        evidence: result.claims[0].evidence,
+        occurrencesInWindow: result.claims[0].occurrencesInWindow,
+      },
+      expected: { evidence: 'keep it short', occurrencesInWindow: 3 },
     });
+  });
 
-    it('should handle markdown code block JSON responses', async () => {
-      setupDbWithMessages(10);
-      setupAIProviderSuccess([
-        '```json\n["Expert in TypeScript"]\n```',
-        '["Prefers concise responses"]',
-        '["No emojis"]',
-      ]);
+  it('degrades to no claims when a pass throws', async () => {
+    setupDb(messages(10));
+    mockGenerateObject.mockRejectedValue(new Error('LLM error'));
 
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      const result = await runDiscoveryPasses('user-with-data');
+    const { runDiscoveryPasses } = await import('../discovery-service');
+    const result = await runDiscoveryPasses('user-with-error');
 
-      assert({
-        given: 'LLM returns markdown code block with JSON',
-        should: 'extract and parse the JSON',
-        actual: result.worldview,
-        expected: ['Expert in TypeScript'],
-      });
-    });
-
-    it('should return empty array when LLM returns non-JSON', async () => {
-      setupDbWithMessages(10);
-      setupAIProviderSuccess([
-        'I found some insights about this user',
-        '["Prefers concise responses"]',
-        '["No emojis"]',
-      ]);
-
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      const result = await runDiscoveryPasses('user-with-data');
-
-      assert({
-        given: 'LLM returns non-JSON response',
-        should: 'return empty array for that pass',
-        actual: result.worldview,
-        expected: [],
-      });
-    });
-
-    it('should return empty arrays when AI provider fails', async () => {
-      setupDbWithMessages(10);
-      mockCreateAIProvider.mockResolvedValue({
-        error: 'API key not configured',
-        status: 400,
-      });
-
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      const result = await runDiscoveryPasses('user-with-data');
-
-      assert({
-        given: 'AI provider returns error',
-        should: 'return empty arrays without throwing',
-        actual: result.worldview,
-        expected: [],
-      });
-    });
-
-    it('should include recent page messages when context is limited to 100', async () => {
-      const now = Date.now();
-      const globalMessages = Array.from({ length: 150 }, (_, i) => ({
-        content: `Global message ${i + 1}`,
-        role: i % 2 === 0 ? 'user' : 'assistant',
-        createdAt: new Date(now - (i + 50) * 1000),
-      }));
-      const pageMessages = [
-        {
-          content: 'Recent page message 1',
-          role: 'user',
-          createdAt: new Date(now - 1000),
-        },
-        {
-          content: 'Recent page message 2',
-          role: 'assistant',
-          createdAt: new Date(now - 2000),
-        },
-      ];
-
-      // Since the message-table merge (epic "Agent-Session Single Source of
-      // Truth", Phase 4 / D6) BOTH conversation reads select `FROM messages`,
-      // so the table no longer discriminates them — the join arity does. The
-      // global read joins `conversations` only; the page read joins
-      // `conversations` and then `pages`.
-      mockDbSelect.mockImplementation(() => {
-        return {
-          from: vi.fn((table: Record<string, unknown>) => {
-            // unified messages table
-            if ('conversationId' in table) {
-              const globalTail = {
-                where: vi.fn(() => ({
-                  orderBy: vi.fn(() => ({
-                    limit: vi.fn(() => Promise.resolve(globalMessages)),
-                  })),
-                })),
-              };
-              const pageTail = {
-                where: vi.fn(() => ({
-                  orderBy: vi.fn(() => ({
-                    limit: vi.fn(() => Promise.resolve(pageMessages)),
-                  })),
-                })),
-              };
-              return {
-                // First `.innerJoin(conversations)`: still ambiguous, so it
-                // returns a node that is BOTH the global tail and the entry to
-                // a second join (which only the page read makes).
-                innerJoin: vi.fn(() => ({
-                  ...globalTail,
-                  innerJoin: vi.fn(() => pageTail),
-                })),
-              };
-            }
-
-            // activityLogs table
-            if ('operation' in table) {
-              return {
-                where: vi.fn(() => ({
-                  orderBy: vi.fn(() => ({
-                    limit: vi.fn(() => Promise.resolve([])),
-                  })),
-                })),
-              };
-            }
-
-            // driveMembers table
-            if ('driveId' in table && 'userId' in table) {
-              return {
-                where: vi.fn(() => Promise.resolve([{ driveId: 'drive-1' }])),
-              };
-            }
-
-            return {
-              where: vi.fn(() => Promise.resolve([])),
-            };
-          }),
-        };
-      });
-
-      const { runDiscoveryPasses } = await import('../discovery-service');
-      mockCreateAIProvider.mockResolvedValue({
-        model: 'test-model',
-        provider: 'test',
-        modelName: 'test',
-      });
-      mockGenerateText.mockImplementation((payload: { messages?: Array<{ content?: string }> }) => {
-        const prompt = payload.messages?.[0]?.content ?? '';
-        return Promise.resolve({
-          text: prompt.includes('Recent page message 1')
-            ? '["Includes page context"]'
-            : '[]',
-        });
-      });
-
-      const result = await runDiscoveryPasses('user-with-page-messages');
-
-      assert({
-        given: 'recent page messages are newer than many global messages',
-        should: 'include recent page messages in limited LLM context',
-        actual: result.worldview,
-        expected: ['Includes page context'],
-      });
+    assert({
+      given: 'every discovery pass failing',
+      should: 'return no claims rather than throwing',
+      actual: result.claims,
+      expected: [],
     });
   });
 });

--- a/apps/web/src/lib/memory/__tests__/integration-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/integration-service.test.ts
@@ -1,414 +1,173 @@
-import { describe, it, vi, beforeEach } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { assert } from './riteway';
 
 /**
  * Integration Service Tests
  *
- * The integration service evaluates raw insights from discovery against
- * the user's current personalization profile. It decides whether to
- * append, skip, or reorganize content.
- *
- * Key behaviors to test:
- * 1. Returns skip decisions when insufficient insights
- * 2. Evaluates insights against current profile
- * 3. Returns append decisions with content when new insights found
- * 4. Handles provider errors gracefully
- * 5. Applies integration decisions to update personalization
+ * The integration service rewrites whole memory pages rather than appending to
+ * them. That is what lets the profile correct and forget — and also what makes
+ * a bad generation able to wipe a page the user wrote by hand. These tests pin
+ * the guards that bound that.
  */
 
-// Mock database
-const mockDbQuery = vi.fn();
-const mockDbInsert = vi.fn();
-vi.mock('@pagespace/db/db', () => ({
-  db: {
-    query: {
-      userPersonalization: {
-        findFirst: () => mockDbQuery(),
-      },
-    },
-    insert: () => mockDbInsert(),
-  },
-}));
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
 vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
   eq: vi.fn(),
 }));
-vi.mock('@pagespace/db/schema/personalization', () => ({
-  userPersonalization: { userId: 'userId' },
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', content: 'content', isTrashed: 'isTrashed', updatedAt: 'updatedAt' },
 }));
-
-// Mock AI provider
-const mockCreateAIProvider = vi.fn();
+vi.mock('@pagespace/db/schema/personalization', () => ({
+  userPersonalization: {
+    userId: 'userId',
+    bioPageId: 'bioPageId',
+    writingStylePageId: 'writingStylePageId',
+    rulesPageId: 'rulesPageId',
+  },
+  personalizationCandidates: { id: 'id' },
+}));
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({
+  readMemoryPages: vi.fn(async () => ({})),
+}));
 vi.mock('@/lib/ai/core/provider-factory', () => ({
-  createAIProvider: () => mockCreateAIProvider(),
-  isProviderError: (result: unknown) => result !== null && typeof result === 'object' && 'error' in result,
+  createAIProvider: vi.fn(),
+  isProviderError: vi.fn(() => false),
 }));
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   BACKGROUND_HEAVY_PROVIDER: 'anthropic',
   BACKGROUND_HEAVY_MODEL: 'anthropic/claude-sonnet-5',
 }));
-
-// Mock loggers
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn() },
+}));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
-    api: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
-  },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
 }));
+vi.mock('ai', () => ({ generateText: vi.fn() }));
 
-// Mock generateText
-const mockGenerateText = vi.fn();
-vi.mock('ai', () => ({
-  generateText: () => mockGenerateText(),
-}));
+describe('screenRewrite — deletion guard', () => {
+  it('rejects a rewrite that drops more than 40% of the page', async () => {
+    const { screenRewrite } = await import('../integration-service');
 
-// Helper to set up AI provider success
-function setupAIProviderSuccess(response: string) {
-  mockCreateAIProvider.mockResolvedValue({
-    model: 'test-model',
-    provider: 'test',
-    modelName: 'test',
-  });
-  mockGenerateText.mockResolvedValue({ text: response });
-}
+    const current = 'x'.repeat(1000);
+    const gutted = 'x'.repeat(400); // 60% deleted
 
-describe('integration-service', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDbQuery.mockResolvedValue(null);
-    mockDbInsert.mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-      }),
+    assert({
+      given: 'a rewrite returning a fragment of an existing page',
+      should: 'reject it rather than silently wiping the page',
+      actual: screenRewrite('bio', current, gutted),
+      expected: { ok: false, reason: 'would delete >40% of existing content' },
     });
   });
 
-  describe('evaluateAndIntegrate', () => {
-    it('should exist and be callable', async () => {
-      const { evaluateAndIntegrate } = await import('../integration-service');
+  it('allows a rewrite that trims within the deletion budget', async () => {
+    const { screenRewrite } = await import('../integration-service');
 
-      assert({
-        given: 'integration-service module',
-        should: 'export evaluateAndIntegrate function',
-        actual: typeof evaluateAndIntegrate,
-        expected: 'function',
-      });
-    });
+    const current = 'x'.repeat(1000);
+    const trimmed = 'x'.repeat(700); // 30% deleted
 
-    it('should return IntegrationDecision with three field decisions', async () => {
-      setupAIProviderSuccess('{"bio":{"action":"skip"},"writingStyle":{"action":"skip"},"rules":{"action":"skip"}}');
-
-      const { evaluateAndIntegrate } = await import('../integration-service');
-      const insights = {
-        worldview: ['Expert in TypeScript'],
-        projects: ['Working on memory system'],
-        communication: [],
-        preferences: [],
-      };
-
-      const result = await evaluateAndIntegrate('user-123', insights, null);
-
-      assert({
-        given: 'insights and null personalization',
-        should: 'return decision with bio field',
-        actual: typeof result.bio,
-        expected: 'object',
-      });
-
-      assert({
-        given: 'insights and null personalization',
-        should: 'return decision with writingStyle field',
-        actual: typeof result.writingStyle,
-        expected: 'object',
-      });
-
-      assert({
-        given: 'insights and null personalization',
-        should: 'return decision with rules field',
-        actual: typeof result.rules,
-        expected: 'object',
-      });
-    });
-
-    it('should return skip decisions when insights total is below threshold', async () => {
-      const { evaluateAndIntegrate } = await import('../integration-service');
-      const insights = {
-        worldview: ['Single insight'],
-        projects: [],
-        communication: [],
-        preferences: [],
-      };
-
-      const result = await evaluateAndIntegrate('user-123', insights, null);
-
-      assert({
-        given: 'only 1 insight (below threshold of 2)',
-        should: 'return skip for bio',
-        actual: result.bio.action,
-        expected: 'skip',
-      });
-
-      assert({
-        given: 'only 1 insight (below threshold of 2)',
-        should: 'return skip for writingStyle',
-        actual: result.writingStyle.action,
-        expected: 'skip',
-      });
-
-      assert({
-        given: 'only 1 insight (below threshold of 2)',
-        should: 'return skip for rules',
-        actual: result.rules.action,
-        expected: 'skip',
-      });
-    });
-
-    it('should call LLM when sufficient insights exist', async () => {
-      setupAIProviderSuccess('{"bio":{"action":"append","content":"Expert in TypeScript"},"writingStyle":{"action":"skip"},"rules":{"action":"skip"}}');
-
-      const { evaluateAndIntegrate } = await import('../integration-service');
-      const insights = {
-        worldview: ['Expert in TypeScript', 'Values TDD'],
-        projects: [],
-        communication: [],
-        preferences: [],
-      };
-
-      await evaluateAndIntegrate('user-123', insights, null);
-
-      assert({
-        given: '2+ insights',
-        should: 'call LLM to evaluate',
-        actual: mockGenerateText.mock.calls.length,
-        expected: 1,
-      });
-    });
-
-    it('should return append decision with content from LLM', async () => {
-      setupAIProviderSuccess('{"bio":{"action":"append","content":"Expert in TypeScript"},"writingStyle":{"action":"skip"},"rules":{"action":"skip"}}');
-
-      const { evaluateAndIntegrate } = await import('../integration-service');
-      const insights = {
-        worldview: ['Expert in TypeScript', 'Values TDD'],
-        projects: [],
-        communication: [],
-        preferences: [],
-      };
-
-      const result = await evaluateAndIntegrate('user-123', insights, null);
-
-      assert({
-        given: 'LLM returns append decision',
-        should: 'return append action for bio',
-        actual: result.bio.action,
-        expected: 'append',
-      });
-
-      assert({
-        given: 'LLM returns append decision',
-        should: 'return content for bio',
-        actual: result.bio.content,
-        expected: 'Expert in TypeScript',
-      });
-    });
-
-    it('should handle markdown code block JSON responses', async () => {
-      setupAIProviderSuccess('```json\n{"bio":{"action":"append","content":"Expert in TypeScript"},"writingStyle":{"action":"skip"},"rules":{"action":"skip"}}\n```');
-
-      const { evaluateAndIntegrate } = await import('../integration-service');
-      const insights = {
-        worldview: ['Expert in TypeScript', 'Values TDD'],
-        projects: [],
-        communication: [],
-        preferences: [],
-      };
-
-      const result = await evaluateAndIntegrate('user-123', insights, null);
-
-      assert({
-        given: 'LLM returns markdown code block',
-        should: 'parse JSON and return append action',
-        actual: result.bio.action,
-        expected: 'append',
-      });
-    });
-
-    it('should return skip decisions when AI provider fails', async () => {
-      mockCreateAIProvider.mockResolvedValue({
-        error: 'API key not configured',
-        status: 400,
-      });
-
-      const { evaluateAndIntegrate } = await import('../integration-service');
-      const insights = {
-        worldview: ['Expert in TypeScript', 'Values TDD'],
-        projects: [],
-        communication: [],
-        preferences: [],
-      };
-
-      const result = await evaluateAndIntegrate('user-123', insights, null);
-
-      assert({
-        given: 'AI provider error',
-        should: 'return skip decisions without throwing',
-        actual: result.bio.action,
-        expected: 'skip',
-      });
+    assert({
+      given: 'a rewrite that consolidates without gutting',
+      should: 'allow it',
+      actual: screenRewrite('bio', current, trimmed),
+      expected: { ok: true },
     });
   });
 
-  describe('applyIntegrationDecisions', () => {
-    it('should exist and be callable', async () => {
-      const { applyIntegrationDecisions } = await import('../integration-service');
+  it('allows any first write when the page is empty', async () => {
+    const { screenRewrite } = await import('../integration-service');
 
-      assert({
-        given: 'integration-service module',
-        should: 'export applyIntegrationDecisions function',
-        actual: typeof applyIntegrationDecisions,
-        expected: 'function',
-      });
+    assert({
+      given: 'an empty existing page',
+      should: 'allow the first write, since nothing can be deleted',
+      actual: screenRewrite('bio', '', 'A short first entry.'),
+      expected: { ok: true },
     });
+  });
+});
 
-    it('should return updated: false when all decisions are skip', async () => {
-      const { applyIntegrationDecisions } = await import('../integration-service');
-      const decisions = {
-        bio: { action: 'skip' as const },
-        writingStyle: { action: 'skip' as const },
-        rules: { action: 'skip' as const },
-      };
+describe('screenRewrite — budget guard', () => {
+  it('rejects content over the field budget', async () => {
+    const { screenRewrite } = await import('../integration-service');
 
-      const result = await applyIntegrationDecisions('user-123', decisions, null);
+    const oversized = 'x'.repeat(3001); // bio budget is 3000
 
-      assert({
-        given: 'all skip decisions',
-        should: 'return updated: false',
-        actual: result.updated,
-        expected: false,
-      });
-
-      assert({
-        given: 'all skip decisions',
-        should: 'return empty fields array',
-        actual: result.fields,
-        expected: [],
-      });
-    });
-
-    it('should return updated: true and list fields when append decisions applied', async () => {
-      const { applyIntegrationDecisions } = await import('../integration-service');
-      const decisions = {
-        bio: { action: 'append' as const, content: 'Expert in TypeScript' },
-        writingStyle: { action: 'skip' as const },
-        rules: { action: 'append' as const, content: 'No emojis' },
-      };
-
-      const result = await applyIntegrationDecisions('user-123', decisions, null);
-
-      assert({
-        given: 'append decisions for bio and rules',
-        should: 'return updated: true',
-        actual: result.updated,
-        expected: true,
-      });
-
-      assert({
-        given: 'append decisions for bio and rules',
-        should: 'return fields array with bio and rules',
-        actual: result.fields,
-        expected: ['bio', 'rules'],
-      });
-    });
-
-    it('should append to existing content with double newline separator', async () => {
-      const { applyIntegrationDecisions } = await import('../integration-service');
-      const decisions = {
-        bio: { action: 'append' as const, content: 'New insight' },
-        writingStyle: { action: 'skip' as const },
-        rules: { action: 'skip' as const },
-      };
-      const currentPersonalization = {
-        bio: 'Existing bio',
-        writingStyle: '',
-        rules: '',
-        enabled: true,
-      };
-
-      // Capture what gets passed to updatePersonalization
-      let capturedBio = '';
-      mockDbInsert.mockReturnValue({
-        values: vi.fn((values) => {
-          capturedBio = values.bio;
-          return {
-            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-          };
-        }),
-      });
-
-      await applyIntegrationDecisions('user-123', decisions, currentPersonalization);
-
-      assert({
-        given: 'append decision with existing bio',
-        should: 'append with double newline separator',
-        actual: capturedBio,
-        expected: 'Existing bio\n\nNew insight',
-      });
+    assert({
+      given: 'a rewrite exceeding the bio budget',
+      should: 'reject it so the injected prompt stays bounded',
+      actual: screenRewrite('bio', '', oversized).ok,
+      expected: false,
     });
   });
 
-  describe('getCurrentPersonalization', () => {
-    it('should exist and be callable', async () => {
-      const { getCurrentPersonalization } = await import('../integration-service');
+  it('applies the tighter budget to writingStyle than to bio', async () => {
+    const { screenRewrite } = await import('../integration-service');
 
-      assert({
-        given: 'integration-service module',
-        should: 'export getCurrentPersonalization function',
-        actual: typeof getCurrentPersonalization,
-        expected: 'function',
-      });
+    const content = 'x'.repeat(2750); // over writingStyle's 2500, under bio's 3000
+
+    assert({
+      given: 'content between the writingStyle and bio budgets',
+      should: 'reject for writingStyle but allow for bio',
+      actual: {
+        writingStyle: screenRewrite('writingStyle', '', content).ok,
+        bio: screenRewrite('bio', '', content).ok,
+      },
+      expected: { writingStyle: false, bio: true },
     });
+  });
 
-    it('should return null when no personalization record exists', async () => {
-      mockDbQuery.mockResolvedValue(null);
+  it('accepts content exactly at the budget', async () => {
+    const { screenRewrite } = await import('../integration-service');
 
-      const { getCurrentPersonalization } = await import('../integration-service');
-      const result = await getCurrentPersonalization('user-123');
-
-      assert({
-        given: 'no personalization record',
-        should: 'return null',
-        actual: result,
-        expected: null,
-      });
+    assert({
+      given: 'content exactly at the bio budget',
+      should: 'accept it — the limit is inclusive',
+      actual: screenRewrite('bio', '', 'x'.repeat(3000)),
+      expected: { ok: true },
     });
+  });
+});
 
-    it('should return personalization data when record exists', async () => {
-      mockDbQuery.mockResolvedValue({
-        bio: 'Test bio',
-        writingStyle: 'Concise',
-        rules: 'No emojis',
-        enabled: true,
-      });
+describe('applyIntegrationDecisions', () => {
+  it('reports a rejected field without updating it', async () => {
+    const { applyIntegrationDecisions } = await import('../integration-service');
 
-      const { getCurrentPersonalization } = await import('../integration-service');
-      const result = await getCurrentPersonalization('user-123');
+    const result = await applyIntegrationDecisions(
+      'user-123',
+      { bio: 'x'.repeat(100) },
+      { bio: 'x'.repeat(1000) }
+    );
 
-      assert({
-        given: 'existing personalization record',
-        should: 'return personalization data',
-        actual: result,
-        expected: {
-          bio: 'Test bio',
-          writingStyle: 'Concise',
-          rules: 'No emojis',
-          enabled: true,
-        },
-      });
+    assert({
+      given: 'a rewrite that trips the deletion guard',
+      should: 'report no update and name the rejected field',
+      actual: { updated: result.updated, fields: result.fields, rejected: result.rejected },
+      expected: {
+        updated: false,
+        fields: [],
+        rejected: [{ field: 'bio', reason: 'would delete >40% of existing content' }],
+      },
+    });
+  });
+
+  it('reports the rejected field as data, not a formatted string', async () => {
+    // The cron decides whether to retire a candidate or retry it next run based
+    // on which fields a guard refused. Parsing that back out of a message string
+    // would break silently the moment the wording changed.
+    const { applyIntegrationDecisions } = await import('../integration-service');
+
+    const result = await applyIntegrationDecisions(
+      'user-123',
+      { writingStyle: 'x'.repeat(3000) },
+      {}
+    );
+
+    assert({
+      given: 'a rewrite rejected by the budget guard',
+      should: 'expose the field as a discrete value',
+      actual: result.rejected.map((r) => r.field),
+      expected: ['writingStyle'],
     });
   });
 });

--- a/apps/web/src/lib/memory/budgets.ts
+++ b/apps/web/src/lib/memory/budgets.ts
@@ -1,0 +1,59 @@
+/**
+ * How large each memory page is allowed to get.
+ *
+ * ── Why this is one file rather than three constants ─────────────────────────
+ * Three separate places act on these numbers, and they only work if all three
+ * agree:
+ *
+ *   1. `compaction-service` shrinks a page once it exceeds `max`.
+ *   2. `integration-service` refuses a rewrite that would exceed `max`.
+ *   3. `personalization-utils` truncates at `max` when building the prompt.
+ *
+ * Drift between them is silent and self-perpetuating. If compaction's ceiling
+ * were higher than the write guard's, every compaction result would be refused
+ * by the guard and the page would stay over budget forever, with a "compacted"
+ * log line each night. If injection's were lower, the profile the user reads in
+ * their drive would quietly differ from the one the AI actually sees.
+ *
+ * None of that fails loudly, so the numbers live here once.
+ */
+
+export type MemoryField = 'bio' | 'writingStyle' | 'rules';
+
+/**
+ * Per-field ceiling, in characters.
+ *
+ * `bio` gets more room because it is prose about a person; the behavioural
+ * fields are lists of instructions and stay tighter. The absolute values are
+ * chosen so a full profile reads as a page of context rather than a dossier —
+ * the pre-rewrite design settled at ~14,000 characters per field, which is what
+ * this replaces.
+ */
+export const MAX_FIELD_LENGTH: Record<MemoryField, number> = {
+  bio: 3000,
+  writingStyle: 2500,
+  rules: 2500,
+};
+
+/**
+ * What compaction aims for once it fires: 70% of the ceiling.
+ *
+ * Compacting exactly to the ceiling would re-trigger on the next addition, so
+ * the gap is the headroom that stops the cron compacting every single night.
+ */
+export const COMPACTION_TARGET_RATIO = 0.7;
+
+export function compactionTarget(field: MemoryField): number {
+  return Math.floor(MAX_FIELD_LENGTH[field] * COMPACTION_TARGET_RATIO);
+}
+
+/**
+ * Ceiling for the whole injected block.
+ *
+ * Deliberately BELOW the sum of the per-field budgets (3000 + 2500 + 2500 =
+ * 8000). If it equalled that sum the total check could never fire, since three
+ * already-truncated fields would always fit — a guard that reads as protection
+ * while being dead code. A profile using every field in full is over budget,
+ * and the priority order in `personalization-utils` decides what survives.
+ */
+export const MAX_TOTAL_INJECTION_LENGTH = 6000;

--- a/apps/web/src/lib/memory/candidate-service.ts
+++ b/apps/web/src/lib/memory/candidate-service.ts
@@ -6,20 +6,17 @@
  * to the actual personalization pages.
  */
 
-import { and, eq, inArray, isNull, lt, sql } from '@pagespace/db/operators';
+import { and, eq, inArray, isNotNull, isNull, lt, ne, or, sql } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { personalizationCandidates } from '@pagespace/db/schema/personalization';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+// Single definition, owned by the producer. A local copy here had already
+// drifted — it lacked `evidenceAt`, so the staging table could not have seen
+// the evidence date even once discovery started supplying it.
+import type { DiscoveredClaim, MemoryField } from './discovery-service';
 
-export type MemoryField = 'bio' | 'writingStyle' | 'rules';
-
-export interface DiscoveredClaim {
-  field: MemoryField;
-  claim: string;
-  evidence: string;
-  occurrencesInWindow: number;
-}
+export type { DiscoveredClaim, MemoryField };
 
 /**
  * Corroboration thresholds, in distinct observation days.
@@ -35,6 +32,16 @@ export const PROMOTION_THRESHOLD: Record<MemoryField, number> = {
 
 /** Candidates not re-observed within this many days are forgotten. */
 export const STALE_CANDIDATE_DAYS = 30;
+
+/**
+ * How long a settled candidate keeps its verbatim `evidence` quote.
+ *
+ * Longer than the pending window because a subject access request should still
+ * be able to show WHY a claim in the profile was accepted for a reasonable
+ * period after it was. After that the quote has served its purpose and is
+ * redacted; the claim itself is retained for deduplication.
+ */
+export const SETTLED_EVIDENCE_RETENTION_DAYS = 90;
 
 /**
  * Normalize a claim to its key for deduplication.
@@ -59,13 +66,21 @@ export function utcDayKey(date: Date): string {
 /**
  * Whether re-observing a claim should raise its corroboration count.
  *
- * Occurrences count DISTINCT DAYS, not sightings. Without this, a single long
- * session saying the same thing three times would promote a claim the user has
- * expressed exactly once — which is the failure mode the whole staging table
- * exists to prevent.
+ * Compares the days the SUPPORTING EVIDENCE was written on — never the days the
+ * cron happened to run.
+ *
+ * That distinction is the whole guarantee. Discovery re-reads a rolling 7-day
+ * window every night, so one unchanged message is rediscovered on consecutive
+ * runs. Counting cron days would promote a genuine one-off after two or three
+ * nights while the user said nothing new, which is exactly the failure the
+ * staging table exists to prevent. Counting evidence days means a claim only
+ * advances when the person actually said something on another day.
  */
-export function shouldIncrementOccurrences(lastSeenAt: Date, now: Date): boolean {
-  return utcDayKey(lastSeenAt) !== utcDayKey(now);
+export function shouldIncrementOccurrences(
+  lastEvidenceAt: Date,
+  newEvidenceAt: Date
+): boolean {
+  return utcDayKey(lastEvidenceAt) !== utcDayKey(newEvidenceAt);
 }
 
 /**
@@ -82,8 +97,7 @@ export function shouldIncrementOccurrences(lastSeenAt: Date, now: Date): boolean
  */
 export async function upsertCandidates(
   userId: string,
-  claims: DiscoveredClaim[],
-  now: Date = new Date()
+  claims: DiscoveredClaim[]
 ): Promise<number> {
   if (claims.length === 0) return 0;
 
@@ -93,12 +107,17 @@ export async function upsertCandidates(
     const claimKey = normalizeClaimKey(claim.claim);
     if (!claimKey) continue;
 
-    // Check if this claim already exists
+    // Look up the row WITHOUT filtering on promoted/rejected. The unique index
+    // is on (userId, field, claimKey) unconditionally, so an active-only lookup
+    // would miss a settled row and then collide on insert — aborting the whole
+    // user's run every night once any recurring wording had been settled once.
     const [existing] = await db
       .select({
         id: personalizationCandidates.id,
         occurrences: personalizationCandidates.occurrences,
         lastSeenAt: personalizationCandidates.lastSeenAt,
+        promotedAt: personalizationCandidates.promotedAt,
+        rejectedAt: personalizationCandidates.rejectedAt,
       })
       .from(personalizationCandidates)
       .where(
@@ -106,29 +125,11 @@ export async function upsertCandidates(
           eq(personalizationCandidates.userId, userId),
           eq(personalizationCandidates.field, claim.field),
           eq(personalizationCandidates.claimKey, claimKey),
-          isNull(personalizationCandidates.promotedAt),
-          isNull(personalizationCandidates.rejectedAt),
         )
       )
       .limit(1);
 
-    if (existing) {
-      const occurrences = shouldIncrementOccurrences(existing.lastSeenAt, now)
-        ? existing.occurrences + 1
-        : existing.occurrences;
-
-      await db
-        .update(personalizationCandidates)
-        .set({
-          occurrences,
-          lastSeenAt: now,
-          evidence: claim.evidence, // keep most recent evidence
-        })
-        .where(eq(personalizationCandidates.id, existing.id));
-
-      upserted++;
-    } else {
-      // Insert new candidate
+    if (!existing) {
       await db.insert(personalizationCandidates).values({
         id: createId(),
         userId,
@@ -137,12 +138,36 @@ export async function upsertCandidates(
         claimKey,
         evidence: claim.evidence,
         occurrences: 1,
-        firstSeenAt: now,
-        lastSeenAt: now,
+        firstSeenAt: claim.evidenceAt,
+        lastSeenAt: claim.evidenceAt,
       });
-
       upserted++;
+      continue;
     }
+
+    // Already settled. A promoted claim is in the profile already, and a
+    // rejected one was declined against that profile — re-staging either would
+    // just re-spend tokens re-deciding a question already answered. Skipping
+    // also keeps the row's terminal timestamps meaningful as a record of when
+    // that decision was made.
+    if (existing.promotedAt || existing.rejectedAt) continue;
+
+    const occurrences = shouldIncrementOccurrences(existing.lastSeenAt, claim.evidenceAt)
+      ? existing.occurrences + 1
+      : existing.occurrences;
+
+    await db
+      .update(personalizationCandidates)
+      .set({
+        occurrences,
+        // Never move lastSeenAt backwards: re-reading an older message must not
+        // make a claim look staler than evidence already counted for it.
+        lastSeenAt: claim.evidenceAt > existing.lastSeenAt ? claim.evidenceAt : existing.lastSeenAt,
+        evidence: claim.evidence, // keep most recent evidence
+      })
+      .where(eq(personalizationCandidates.id, existing.id));
+
+    upserted++;
   }
 
   loggers.api.debug('Memory candidates upserted', {
@@ -270,4 +295,59 @@ export async function pruneStaleCandidates(
   }
 
   return deleted.length;
+}
+
+/** Placeholder left in `evidence` once a settled row passes its retention window. */
+export const REDACTED_EVIDENCE = '[evidence redacted after retention period]';
+
+/**
+ * Drop the verbatim quote from candidates that settled long enough ago.
+ *
+ * `evidence` is a direct quote of something the user wrote. It earns its keep
+ * while a claim is pending — it is what justifies promoting or declining the
+ * claim, and what a subject sees when asking why the AI believes something —
+ * but once the row is promoted or rejected the decision is made and the quote
+ * is just retained personal data with no remaining purpose. Art 5(1)(e) says
+ * that has to stop.
+ *
+ * The ROW survives, with `claim` and `claimKey` intact, because those are what
+ * `upsertCandidates` needs to recognise a recurring claim and avoid colliding
+ * on the unique index. Only the quote goes.
+ */
+export async function redactSettledEvidence(
+  userId: string,
+  now: Date = new Date()
+): Promise<number> {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - SETTLED_EVIDENCE_RETENTION_DAYS);
+
+  const redacted = await db
+    .update(personalizationCandidates)
+    .set({ evidence: REDACTED_EVIDENCE })
+    .where(
+      and(
+        eq(personalizationCandidates.userId, userId),
+        ne(personalizationCandidates.evidence, REDACTED_EVIDENCE),
+        or(
+          and(
+            isNotNull(personalizationCandidates.promotedAt),
+            lt(personalizationCandidates.promotedAt, cutoff)
+          ),
+          and(
+            isNotNull(personalizationCandidates.rejectedAt),
+            lt(personalizationCandidates.rejectedAt, cutoff)
+          )
+        )
+      )
+    )
+    .returning({ id: personalizationCandidates.id });
+
+  if (redacted.length > 0) {
+    loggers.api.debug('Memory settled candidate evidence redacted', {
+      userId,
+      count: redacted.length,
+    });
+  }
+
+  return redacted.length;
 }

--- a/apps/web/src/lib/memory/candidate-service.ts
+++ b/apps/web/src/lib/memory/candidate-service.ts
@@ -6,7 +6,7 @@
  * to the actual personalization pages.
  */
 
-import { and, eq, inArray, isNotNull, isNull, lt, ne, or, sql } from '@pagespace/db/operators';
+import { and, eq, gte, inArray, isNotNull, isNull, lt, ne, or, sql } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { personalizationCandidates } from '@pagespace/db/schema/personalization';
@@ -29,6 +29,9 @@ export const PROMOTION_THRESHOLD: Record<MemoryField, number> = {
   writingStyle: 2,
   rules: 2,
 };
+
+/** The field names, as runtime values, for building per-field SQL predicates. */
+const MEMORY_FIELD_NAMES = Object.keys(PROMOTION_THRESHOLD) as MemoryField[];
 
 /** Candidates not re-observed within this many days are forgotten. */
 export const STALE_CANDIDATE_DAYS = 30;
@@ -225,6 +228,24 @@ export async function findPromotableCandidates(
 ): Promise<typeof personalizationCandidates.$inferSelect[]> {
   const cutoff = promotionCutoff(now);
 
+  // One (field = X AND occurrences >= N) branch per field, OR'd together.
+  //
+  // Built from PROMOTION_THRESHOLD so the constant stays the single source of
+  // truth. Deliberately NOT a parameterised `CASE field WHEN 'bio' THEN $n`:
+  // the bound parameters carry no type, so Postgres cannot resolve `integer >=
+  // unknown` and the whole query fails with 42883 — every cron run, for every
+  // user. Nothing here is user input (the thresholds are compile-time
+  // constants and the field names are our own enum), so there is no value in
+  // parameterising them.
+  const meetsThreshold = or(
+    ...MEMORY_FIELD_NAMES.map((field) =>
+      and(
+        eq(personalizationCandidates.field, field),
+        gte(personalizationCandidates.occurrences, PROMOTION_THRESHOLD[field])
+      )
+    )
+  );
+
   return db
     .select()
     .from(personalizationCandidates)
@@ -234,12 +255,7 @@ export async function findPromotableCandidates(
         isNull(personalizationCandidates.promotedAt),
         isNull(personalizationCandidates.rejectedAt),
         lt(personalizationCandidates.firstSeenAt, cutoff),
-        // Per-field threshold, derived from PROMOTION_THRESHOLD so the constant
-        // stays the single source of truth rather than drifting from the SQL.
-        sql`${personalizationCandidates.occurrences} >= CASE ${personalizationCandidates.field}
-          WHEN 'bio' THEN ${PROMOTION_THRESHOLD.bio}
-          WHEN 'writingStyle' THEN ${PROMOTION_THRESHOLD.writingStyle}
-          ELSE ${PROMOTION_THRESHOLD.rules} END`
+        meetsThreshold
       )
     );
 }

--- a/apps/web/src/lib/memory/candidate-service.ts
+++ b/apps/web/src/lib/memory/candidate-service.ts
@@ -1,9 +1,15 @@
 /**
  * Memory Candidate Service
  *
- * Manages the staging table for insights awaiting corroboration.
- * Insights must be observed on multiple distinct UTC days before promotion
- * to the actual personalization pages.
+ * The staging table where insights wait for corroboration before they are
+ * allowed anywhere near the user's profile.
+ *
+ * An insight must be supported by messages the user wrote on multiple distinct
+ * UTC days. "Distinct days" means days the EVIDENCE was written on — never days
+ * this cron happened to run. That distinction is the entire guarantee: the
+ * discovery window is reread in full every night, so one unchanged message is
+ * rediscovered on consecutive runs, and counting run-days would promote a
+ * genuine one-off after two or three nights while the user said nothing new.
  */
 
 import { and, eq, gte, inArray, isNotNull, isNull, lt, ne, or } from '@pagespace/db/operators';

--- a/apps/web/src/lib/memory/candidate-service.ts
+++ b/apps/web/src/lib/memory/candidate-service.ts
@@ -1,0 +1,273 @@
+/**
+ * Memory Candidate Service
+ *
+ * Manages the staging table for insights awaiting corroboration.
+ * Insights must be observed on multiple distinct UTC days before promotion
+ * to the actual personalization pages.
+ */
+
+import { and, eq, inArray, isNull, lt, sql } from '@pagespace/db/operators';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { personalizationCandidates } from '@pagespace/db/schema/personalization';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+export type MemoryField = 'bio' | 'writingStyle' | 'rules';
+
+export interface DiscoveredClaim {
+  field: MemoryField;
+  claim: string;
+  evidence: string;
+  occurrencesInWindow: number;
+}
+
+/**
+ * Corroboration thresholds, in distinct observation days.
+ *
+ * `bio` is stricter: a wrong identity claim reads as the AI having decided who
+ * you are, which is more costly than a wrong formatting preference.
+ */
+export const PROMOTION_THRESHOLD: Record<MemoryField, number> = {
+  bio: 3,
+  writingStyle: 2,
+  rules: 2,
+};
+
+/** Candidates not re-observed within this many days are forgotten. */
+export const STALE_CANDIDATE_DAYS = 30;
+
+/**
+ * Normalize a claim to its key for deduplication.
+ *
+ * Lowercased, punctuation-stripped, whitespace-collapsed, so "Be concise." and
+ * "be concise" are the same claim rather than two candidates that each corroborate
+ * only themselves.
+ */
+export function normalizeClaimKey(claim: string): string {
+  return claim
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '') // remove punctuation
+    .replace(/\s+/g, ' ') // collapse whitespace
+    .trim();
+}
+
+/** The UTC calendar day a timestamp falls on, as `YYYY-MM-DD`. */
+export function utcDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Whether re-observing a claim should raise its corroboration count.
+ *
+ * Occurrences count DISTINCT DAYS, not sightings. Without this, a single long
+ * session saying the same thing three times would promote a claim the user has
+ * expressed exactly once — which is the failure mode the whole staging table
+ * exists to prevent.
+ */
+export function shouldIncrementOccurrences(lastSeenAt: Date, now: Date): boolean {
+  return utcDayKey(lastSeenAt) !== utcDayKey(now);
+}
+
+/**
+ * Upsert discovered claims into the candidates table.
+ *
+ * For each claim:
+ * - If it exists, increment `occurrences` and update `lastSeenAt`
+ * - `occurrences` ONLY increments when the new `lastSeenAt` falls on a different
+ *   UTC day than the old one — this prevents one chatty afternoon from
+ *   self-corroborating
+ * - If it doesn't exist, insert with `occurrences = 1`
+ *
+ * Returns the number of claims upserted.
+ */
+export async function upsertCandidates(
+  userId: string,
+  claims: DiscoveredClaim[],
+  now: Date = new Date()
+): Promise<number> {
+  if (claims.length === 0) return 0;
+
+  let upserted = 0;
+
+  for (const claim of claims) {
+    const claimKey = normalizeClaimKey(claim.claim);
+    if (!claimKey) continue;
+
+    // Check if this claim already exists
+    const [existing] = await db
+      .select({
+        id: personalizationCandidates.id,
+        occurrences: personalizationCandidates.occurrences,
+        lastSeenAt: personalizationCandidates.lastSeenAt,
+      })
+      .from(personalizationCandidates)
+      .where(
+        and(
+          eq(personalizationCandidates.userId, userId),
+          eq(personalizationCandidates.field, claim.field),
+          eq(personalizationCandidates.claimKey, claimKey),
+          isNull(personalizationCandidates.promotedAt),
+          isNull(personalizationCandidates.rejectedAt),
+        )
+      )
+      .limit(1);
+
+    if (existing) {
+      const occurrences = shouldIncrementOccurrences(existing.lastSeenAt, now)
+        ? existing.occurrences + 1
+        : existing.occurrences;
+
+      await db
+        .update(personalizationCandidates)
+        .set({
+          occurrences,
+          lastSeenAt: now,
+          evidence: claim.evidence, // keep most recent evidence
+        })
+        .where(eq(personalizationCandidates.id, existing.id));
+
+      upserted++;
+    } else {
+      // Insert new candidate
+      await db.insert(personalizationCandidates).values({
+        id: createId(),
+        userId,
+        field: claim.field,
+        claim: claim.claim,
+        claimKey,
+        evidence: claim.evidence,
+        occurrences: 1,
+        firstSeenAt: now,
+        lastSeenAt: now,
+      });
+
+      upserted++;
+    }
+  }
+
+  loggers.api.debug('Memory candidates upserted', {
+    userId,
+    count: upserted,
+  });
+
+  return upserted;
+}
+
+/**
+ * The cutoff a candidate's `firstSeenAt` must precede to be promotable:
+ * midnight UTC at the start of today.
+ *
+ * This is what makes "corroborated across days" real rather than nominal. A
+ * claim first seen at any point today is younger than a full calendar day, so
+ * it cannot be promoted in the same run that discovered it — no matter how many
+ * times it appeared.
+ */
+export function promotionCutoff(now: Date = new Date()): Date {
+  const cutoff = new Date(now);
+  cutoff.setUTCHours(0, 0, 0, 0);
+  return cutoff;
+}
+
+/**
+ * Find candidates ready for promotion.
+ *
+ * Criteria:
+ * - `occurrences` at or above the field's threshold (see `PROMOTION_THRESHOLD`)
+ * - `firstSeenAt` before the start of today, UTC
+ * - Not already promoted or rejected
+ */
+export async function findPromotableCandidates(
+  userId: string,
+  now: Date = new Date()
+): Promise<typeof personalizationCandidates.$inferSelect[]> {
+  const cutoff = promotionCutoff(now);
+
+  return db
+    .select()
+    .from(personalizationCandidates)
+    .where(
+      and(
+        eq(personalizationCandidates.userId, userId),
+        isNull(personalizationCandidates.promotedAt),
+        isNull(personalizationCandidates.rejectedAt),
+        lt(personalizationCandidates.firstSeenAt, cutoff),
+        // Per-field threshold, derived from PROMOTION_THRESHOLD so the constant
+        // stays the single source of truth rather than drifting from the SQL.
+        sql`${personalizationCandidates.occurrences} >= CASE ${personalizationCandidates.field}
+          WHEN 'bio' THEN ${PROMOTION_THRESHOLD.bio}
+          WHEN 'writingStyle' THEN ${PROMOTION_THRESHOLD.writingStyle}
+          ELSE ${PROMOTION_THRESHOLD.rules} END`
+      )
+    );
+}
+
+/**
+ * Mark candidates as promoted.
+ *
+ * Called after successful integration into the personalization pages.
+ */
+export async function markCandidatesPromoted(
+  candidateIds: string[]
+): Promise<void> {
+  if (candidateIds.length === 0) return;
+
+  await db
+    .update(personalizationCandidates)
+    .set({ promotedAt: new Date() })
+    .where(inArray(personalizationCandidates.id, candidateIds));
+}
+
+/**
+ * Mark candidates as rejected.
+ *
+ * Called when the evaluator decides a claim should not be integrated.
+ */
+export async function markCandidatesRejected(
+  candidateIds: string[]
+): Promise<void> {
+  if (candidateIds.length === 0) return;
+
+  await db
+    .update(personalizationCandidates)
+    .set({ rejectedAt: new Date() })
+    .where(inArray(personalizationCandidates.id, candidateIds));
+}
+
+/**
+ * Prune stale candidates.
+ *
+ * Deletes candidates that haven't been re-observed in 30 days.
+ * This is the "forgetting" half of the system — claims that stop being
+ * true or stop being relevant are automatically dropped.
+ */
+export async function pruneStaleCandidates(
+  userId: string,
+  now: Date = new Date()
+): Promise<number> {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - STALE_CANDIDATE_DAYS);
+
+  // Single statement: `returning()` reports exactly the rows this delete
+  // removed. Counting first and deleting second would both duplicate the
+  // predicate and let a concurrent write land between the two.
+  const deleted = await db
+    .delete(personalizationCandidates)
+    .where(
+      and(
+        eq(personalizationCandidates.userId, userId),
+        lt(personalizationCandidates.lastSeenAt, cutoff),
+        isNull(personalizationCandidates.promotedAt),
+        isNull(personalizationCandidates.rejectedAt),
+      )
+    )
+    .returning({ id: personalizationCandidates.id });
+
+  if (deleted.length > 0) {
+    loggers.api.debug('Memory stale candidates pruned', {
+      userId,
+      count: deleted.length,
+    });
+  }
+
+  return deleted.length;
+}

--- a/apps/web/src/lib/memory/candidate-service.ts
+++ b/apps/web/src/lib/memory/candidate-service.ts
@@ -130,18 +130,28 @@ export async function upsertCandidates(
       .limit(1);
 
     if (!existing) {
-      await db.insert(personalizationCandidates).values({
-        id: createId(),
-        userId,
-        field: claim.field,
-        claim: claim.claim,
-        claimKey,
-        evidence: claim.evidence,
-        occurrences: 1,
-        firstSeenAt: claim.evidenceAt,
-        lastSeenAt: claim.evidenceAt,
-      });
-      upserted++;
+      // `onConflictDoNothing` rather than a bare insert: two runs for the same
+      // user (a retry overlapping the scheduled pass) can both find no row and
+      // race to insert. Losing that race must be a no-op, not an exception that
+      // aborts every remaining claim — the winner's row is identical anyway,
+      // and the loser's evidence is folded in on the next pass.
+      const inserted = await db
+        .insert(personalizationCandidates)
+        .values({
+          id: createId(),
+          userId,
+          field: claim.field,
+          claim: claim.claim,
+          claimKey,
+          evidence: claim.evidence,
+          occurrences: 1,
+          firstSeenAt: claim.evidenceAt,
+          lastSeenAt: claim.evidenceAt,
+        })
+        .onConflictDoNothing()
+        .returning({ id: personalizationCandidates.id });
+
+      if (inserted.length > 0) upserted++;
       continue;
     }
 
@@ -152,22 +162,30 @@ export async function upsertCandidates(
     // that decision was made.
     if (existing.promotedAt || existing.rejectedAt) continue;
 
-    const occurrences = shouldIncrementOccurrences(existing.lastSeenAt, claim.evidenceAt)
-      ? existing.occurrences + 1
-      : existing.occurrences;
+    const shouldIncrement = shouldIncrementOccurrences(existing.lastSeenAt, claim.evidenceAt);
 
-    await db
+    // Guarded by the lastSeenAt we read. If a concurrent run advanced the row
+    // first, this matches nothing and the increment is skipped rather than
+    // double-counting the same evidence day — the count stays a count of
+    // distinct days, not of how many times the cron overlapped itself.
+    const updated = await db
       .update(personalizationCandidates)
       .set({
-        occurrences,
+        occurrences: shouldIncrement ? existing.occurrences + 1 : existing.occurrences,
         // Never move lastSeenAt backwards: re-reading an older message must not
         // make a claim look staler than evidence already counted for it.
         lastSeenAt: claim.evidenceAt > existing.lastSeenAt ? claim.evidenceAt : existing.lastSeenAt,
         evidence: claim.evidence, // keep most recent evidence
       })
-      .where(eq(personalizationCandidates.id, existing.id));
+      .where(
+        and(
+          eq(personalizationCandidates.id, existing.id),
+          eq(personalizationCandidates.lastSeenAt, existing.lastSeenAt),
+        )
+      )
+      .returning({ id: personalizationCandidates.id });
 
-    upserted++;
+    if (updated.length > 0) upserted++;
   }
 
   loggers.api.debug('Memory candidates upserted', {

--- a/apps/web/src/lib/memory/candidate-service.ts
+++ b/apps/web/src/lib/memory/candidate-service.ts
@@ -6,7 +6,7 @@
  * to the actual personalization pages.
  */
 
-import { and, eq, gte, inArray, isNotNull, isNull, lt, ne, or, sql } from '@pagespace/db/operators';
+import { and, eq, gte, inArray, isNotNull, isNull, lt, ne, or } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { personalizationCandidates } from '@pagespace/db/schema/personalization';

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -15,14 +15,9 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { getCurrentPersonalizationPages, updatePersonalizationPage } from './integration-service';
 
-export type MemoryField = 'bio' | 'writingStyle' | 'rules';
+import { MAX_FIELD_LENGTH, compactionTarget, type MemoryField } from './budgets';
 
-// Per-field budgets — trigger at 1.0×, compact to 0.7×
-const FIELD_LENGTHS: Record<MemoryField, { max: number; compactTo: number }> = {
-  bio: { max: 3000, compactTo: 2100 },
-  writingStyle: { max: 2500, compactTo: 1750 },
-  rules: { max: 2500, compactTo: 1750 },
-};
+export type { MemoryField };
 
 const COMPACTION_PROMPTS: Record<MemoryField, string> = {
   bio: `You are compacting a user's bio and background information that has grown too long.
@@ -87,8 +82,7 @@ export function needsCompaction(
   content: string,
   field: MemoryField
 ): boolean {
-  const { max } = FIELD_LENGTHS[field];
-  return content.length > max;
+  return content.length > MAX_FIELD_LENGTH[field];
 }
 
 /**
@@ -99,7 +93,7 @@ export async function compactField(
   field: MemoryField,
   content: string
 ): Promise<string> {
-  const { compactTo } = FIELD_LENGTHS[field];
+  const compactTo = compactionTarget(field);
 
   const providerResult = await createAIProvider(userId, {
     selectedProvider: BACKGROUND_HEAVY_PROVIDER,

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -1,9 +1,11 @@
 /**
  * Memory Compaction Service
  *
- * When a personalization field exceeds the size threshold, this service
- * uses LLM to reorganize and summarize the content while preserving
- * key insights.
+ * When a personalization field exceeds its budget, this service uses LLM to
+ * reorganize and reduce the content while preserving key information.
+ *
+ * Compaction is now deletion-biased: "delete anything that does not change
+ * AI behaviour; preserve only what does."
  */
 
 import { generateText } from 'ai';
@@ -11,74 +13,93 @@ import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factor
 import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
-import {
-  updatePersonalization,
-  getCurrentPersonalization,
-} from './integration-service';
+import { getCurrentPersonalizationPages, updatePersonalizationPage } from './integration-service';
 
-// Size thresholds
-const DEFAULT_MAX_LENGTH = 20000;
-const COMPACTION_TRIGGER_RATIO = 0.9;
-const COMPACTION_TARGET_RATIO = 0.7;
+export type MemoryField = 'bio' | 'writingStyle' | 'rules';
 
-type PersonalizationField = 'bio' | 'writingStyle' | 'rules';
+// Per-field budgets — trigger at 1.0×, compact to 0.7×
+const FIELD_LENGTHS: Record<MemoryField, { max: number; compactTo: number }> = {
+  bio: { max: 3000, compactTo: 2100 },
+  writingStyle: { max: 2500, compactTo: 1750 },
+  rules: { max: 2500, compactTo: 1750 },
+};
 
-const COMPACTION_PROMPTS: Record<PersonalizationField, string> = {
-  bio: `You are reorganizing a user's bio and background information that has grown too long.
+const COMPACTION_PROMPTS: Record<MemoryField, string> = {
+  bio: `You are compacting a user's bio and background information that has grown too long.
 
-Your job is to:
-1. Preserve facts about their background, expertise, domain, and thinking style
-2. REMOVE any current task or project status — that's ephemeral and belongs in project context, not here
-3. Consolidate redundant or overlapping information
-4. Keep the most recent version when information has been superseded
-5. Organize into clear sections if appropriate
+Your job is to DELETE anything that does not change how an AI behaves. Keep ONLY what affects AI responses.
 
-Output only the compacted bio content as prose or bullet points. No commentary.`,
+REMOVE:
+- Personal history, family details, living situation
+- Religious or political beliefs
+- Hobbies, games, sports, entertainment preferences
+- Named third parties (other than the user)
+- Self-reported metrics or rankings
+- Current tasks or project status
 
-  writingStyle: `You are reorganizing a user's writing style preferences that have grown too long.
+PRESERVE:
+- Professional expertise and domain knowledge
+- Technical background and specialization
+- Thinking patterns and decision-making frameworks
+- Work style preferences that affect AI collaboration
 
-Your job is to:
-1. Preserve all distinct communication preferences
-2. Merge similar or overlapping preferences
-3. Remove redundant instructions
-4. Keep the most specific/actionable guidance
-5. Organize logically (tone, format, length, etc.)
+Organize the remaining content clearly. Output only the compacted bio, no commentary.`,
 
-Output the reorganized writing style as clean prose or bullet points. Do NOT add commentary - just output the compacted content.`,
+  writingStyle: `You are compacting a user's writing style preferences that have grown too long.
 
-  rules: `You are reorganizing a user's AI behavior rules that have grown too long.
+Your job is to DELETE anything that does not change how an AI writes or responds. Keep ONLY actionable instructions.
 
-Your job is to:
-1. Keep rules that describe how the user wants AI to behave in any context — universal preferences
-2. REMOVE rules that are project-specific decisions, technology choices for a particular product, or scope calls that belong in a project's own context
-3. Consolidate rules that say the same thing differently
-4. Remove rules that contradict newer rules (keep most recent)
-5. Keep the most specific and actionable guidance
+REMOVE:
+- Descriptive statements about how the user talks (e.g. "user uses typos")
+- Redundant or conflicting instructions
+- Project-specific preferences
 
-Output only the compacted rules content as prose or bullet points. No commentary.`,
+PRESERVE:
+- Imperative instructions for how AI should respond TO the user
+- Imperative instructions for how AI should draft text AS the user
+- Voice, banned constructions, sentence shape, characteristic phrasing
+- Formatting and interaction preferences
+
+Organize by direction (TO vs AS) if both exist. Output only the compacted content, no commentary.`,
+
+  rules: `You are compacting a user's AI behavior rules that have grown too long.
+
+Your job is to DELETE anything that does not change how an AI behaves. Keep ONLY universal rules.
+
+REMOVE:
+- Project-specific technology choices
+- Scope or priority decisions for a specific release
+- One-off decisions tied to a specific context
+- Redundant or conflicting rules
+
+PRESERVE:
+- Universal preferences that apply in ANY workspace
+- Persistent do's and don'ts about AI output
+- Always/never instructions that the user wants followed
+
+Organize clearly. Output only the compacted rules, no commentary.`,
 };
 
 /**
- * Check if a field needs compaction
+ * Check if a field needs compaction.
  */
 export function needsCompaction(
   content: string,
-  maxLength: number = DEFAULT_MAX_LENGTH
+  field: MemoryField
 ): boolean {
-  const triggerLength = maxLength * COMPACTION_TRIGGER_RATIO;
-  return content.length > triggerLength;
+  const { max } = FIELD_LENGTHS[field];
+  return content.length > max;
 }
 
 /**
- * Compact a single personalization field
+ * Compact a single personalization field.
  */
 export async function compactField(
   userId: string,
-  fieldName: PersonalizationField,
-  content: string,
-  maxLength: number = DEFAULT_MAX_LENGTH
+  field: MemoryField,
+  content: string
 ): Promise<string> {
-  const targetLength = Math.floor(maxLength * COMPACTION_TARGET_RATIO);
+  const { compactTo } = FIELD_LENGTHS[field];
 
   const providerResult = await createAIProvider(userId, {
     selectedProvider: BACKGROUND_HEAVY_PROVIDER,
@@ -88,14 +109,14 @@ export async function compactField(
   if (isProviderError(providerResult)) {
     loggers.api.error('Memory compaction: provider error', {
       userId,
-      fieldName,
+      field,
       error: providerResult.error,
     });
     return content;
   }
 
   try {
-    const systemPrompt = COMPACTION_PROMPTS[fieldName];
+    const systemPrompt = COMPACTION_PROMPTS[field];
 
     const result = await generateText({
       model: providerResult.model,
@@ -103,13 +124,13 @@ export async function compactField(
       messages: [
         {
           role: 'user',
-          content: `Here is the ${fieldName} content that needs to be reorganized and compacted:
+          content: `Here is the ${field} content that needs to be compacted to under ${compactTo} characters:
 
 ---
 ${content}
 ---
 
-Reorganize this into a more concise version (target: under ${targetLength} characters) while preserving all key information. Output only the compacted content.`,
+Compact this by deleting anything that does not change AI behaviour. Output only the compacted content.`,
         },
       ],
       temperature: 0.3,
@@ -127,7 +148,7 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
         ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
         : undefined,
       success: true,
-      metadata: { feature: 'memory_compaction', field: fieldName },
+      metadata: { feature: 'memory_compaction', field },
     });
 
     const compactedContent = result.text.trim();
@@ -135,7 +156,7 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
     if (compactedContent.length === 0) {
       loggers.api.warn('Memory compaction: empty result, keeping original', {
         userId,
-        fieldName,
+        field,
       });
       return content;
     }
@@ -143,7 +164,7 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
     if (compactedContent.length >= content.length) {
       loggers.api.debug('Memory compaction: no size reduction, keeping original', {
         userId,
-        fieldName,
+        field,
         originalLength: content.length,
         compactedLength: compactedContent.length,
       });
@@ -152,7 +173,7 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
 
     loggers.api.info('Memory compaction: field compacted', {
       userId,
-      fieldName,
+      field,
       originalLength: content.length,
       compactedLength: compactedContent.length,
       reduction: `${Math.round((1 - compactedContent.length / content.length) * 100)}%`,
@@ -162,7 +183,7 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
   } catch (error) {
     loggers.api.error('Memory compaction: generation error', {
       userId,
-      fieldName,
+      field,
       error,
     });
     return content;
@@ -170,28 +191,19 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
 }
 
 /**
- * Check and compact all personalization fields for a user if needed
+ * Check and compact all personalization fields for a user if needed.
  */
 export async function checkAndCompactIfNeeded(
-  userId: string,
-  maxLength: number = DEFAULT_MAX_LENGTH
-): Promise<{ compacted: boolean; fields: string[] }> {
-  const current = await getCurrentPersonalization(userId);
+  userId: string
+): Promise<{ compacted: boolean; fields: MemoryField[] }> {
+  const current = await getCurrentPersonalizationPages(userId);
 
-  if (!current) {
-    return { compacted: false, fields: [] };
-  }
+  const fieldsToCompact: MemoryField[] = [];
 
-  const fieldsToCompact: PersonalizationField[] = [];
-
-  if (current.bio && needsCompaction(current.bio, maxLength)) {
-    fieldsToCompact.push('bio');
-  }
-  if (current.writingStyle && needsCompaction(current.writingStyle, maxLength)) {
-    fieldsToCompact.push('writingStyle');
-  }
-  if (current.rules && needsCompaction(current.rules, maxLength)) {
-    fieldsToCompact.push('rules');
+  for (const [field, content] of Object.entries(current) as [MemoryField, string][]) {
+    if (content && needsCompaction(content, field)) {
+      fieldsToCompact.push(field);
+    }
   }
 
   if (fieldsToCompact.length === 0) {
@@ -203,27 +215,16 @@ export async function checkAndCompactIfNeeded(
     fields: fieldsToCompact,
   });
 
-  const compactionResults = await Promise.all(
-    fieldsToCompact.map(async (field) => {
-      const originalContent = current[field];
-      if (!originalContent) return { field, content: '' };
-      const compactedContent = await compactField(userId, field, originalContent, maxLength);
-      return { field, content: compactedContent };
-    })
-  );
+  const compactedFields: MemoryField[] = [];
 
-  const updates: Partial<Pick<typeof current, 'bio' | 'writingStyle' | 'rules'>> = {};
-  const compactedFields: string[] = [];
+  for (const field of fieldsToCompact) {
+    const originalContent = current[field] ?? '';
+    const compactedContent = await compactField(userId, field, originalContent);
 
-  for (const result of compactionResults) {
-    if (result.content && result.content !== current[result.field]) {
-      updates[result.field] = result.content;
-      compactedFields.push(result.field);
+    if (compactedContent !== originalContent) {
+      await updatePersonalizationPage(userId, field, compactedContent);
+      compactedFields.push(field);
     }
-  }
-
-  if (compactedFields.length > 0) {
-    await updatePersonalization(userId, updates);
   }
 
   return {

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -221,9 +221,23 @@ export async function checkAndCompactIfNeeded(
     const originalContent = current[field] ?? '';
     const compactedContent = await compactField(userId, field, originalContent);
 
-    if (compactedContent !== originalContent) {
-      await updatePersonalizationPage(userId, field, compactedContent);
+    if (compactedContent === originalContent) continue;
+
+    // Report only what actually landed. `updatePersonalizationPage` refuses a
+    // write when the page was edited during this run (the user's edit wins) or
+    // when the pointer is stale — claiming those as compacted would report a
+    // page as shrunk while it is still over budget, and the next run would
+    // silently do the same thing again.
+    const result = await updatePersonalizationPage(userId, field, compactedContent);
+
+    if (result.written) {
       compactedFields.push(field);
+    } else {
+      loggers.api.warn('Memory compaction: compacted content was not written', {
+        userId,
+        field,
+        reason: result.reason,
+      });
     }
   }
 

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -103,7 +103,7 @@ EXPLICIT EXCLUSIONS (never record these, even if they seem actionable):
 - Self-reported metrics (lines of code, rankings, follower counts, scores)
 - Current tasks, projects, or work-in-progress status
 
-Each message in the transcript below is numbered like [12 user]. Use those numbers.
+Each message in the transcript below is numbered like [12 user], in chronological order: [0] is the OLDEST message and the highest number is the MOST RECENT. Use those numbers.
 
 Return a JSON object with a "claims" array. Each claim has:
 - claim: the insight itself — IMPERATIVE for writingStyle/rules (e.g. "Never use emojis", not "user prefers no emojis")
@@ -343,7 +343,11 @@ async function runDiscoveryPass(
     // index falls back to the OLDEST message in the window: a model that cites
     // nothing usable must not be able to make a claim look fresher than its
     // evidence, which would let it clear the corroboration bar early.
-    const oldest = messageDates[messageDates.length - 1] ?? new Date();
+    // Transcript is chronological, so index 0 is the oldest message in the
+    // window. An unusable index falls back to it: a claim must never be able
+    // to look FRESHER than the evidence actually supports, since that is what
+    // would let it clear the corroboration bar early.
+    const oldest = messageDates[0] ?? new Date();
 
     // The model's own `field` tag is discarded in favour of `field`, the field
     // this pass is responsible for. The model can omit or mislabel it, and a
@@ -379,9 +383,19 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
   }
 
   // Format conversation context: 60 messages × 1500 chars (was 100 × 500).
-  // Messages are NUMBERED so a claim can cite the message it came from, and the
-  // dates array below stays index-aligned with the transcript the model sees.
-  const windowed = recentMessages.slice(0, 60);
+  //
+  // `recentMessages` is newest-first (that is how the 60 most recent are
+  // selected), but the transcript is then REVERSED to chronological order
+  // before numbering. Numbering a newest-first list would make index 0 the
+  // newest message while a model reading a conversation naturally assumes
+  // ascending time — so "cite the most recent message" would return a high
+  // index, and `evidenceAt` would resolve to the OLDEST message instead.
+  //
+  // That failure is invisible: the index is in range, so the out-of-range
+  // fallback never fires, and today's evidence is silently stamped a week old.
+  // It also inverts the corroboration rule, since both
+  // `shouldIncrementOccurrences` and `promotionCutoff` key on `evidenceAt`.
+  const windowed = recentMessages.slice(0, 60).reverse();
   const messageDates = windowed.map((m) => m.createdAt);
   const conversationContext = windowed
     .map((m, i) => `[${i} ${m.role}]: ${m.content.substring(0, 1500)}`)

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -28,6 +28,20 @@ export interface DiscoveredClaim {
   claim: string;
   evidence: string;
   occurrencesInWindow: number;
+  /**
+   * When the newest message supporting this claim was written.
+   *
+   * This, NOT the time the cron happened to run, is what corroboration counts.
+   * Discovery re-reads the same rolling 7-day window every night, so a single
+   * unchanged message is rediscovered on consecutive runs; counting cron days
+   * would promote a one-off after two or three nights and defeat the whole
+   * point of the staging table.
+   *
+   * Derived server-side from `evidenceMessageIndex` — the model cites which
+   * message it quoted, and we look up that message's real timestamp. The model
+   * never supplies a date.
+   */
+  evidenceAt: Date;
 }
 
 export interface DiscoveryResult {
@@ -40,12 +54,23 @@ interface ConversationMessage {
   createdAt: Date;
 }
 
-// Zod schema for structured output — eliminates silent parse failures
+// Zod schema for structured output — eliminates silent parse failures.
+//
+// `field` is optional: `runDiscoveryPasses` assigns it from the pass the claim
+// came from, which is the authority. Requiring it here would make a response
+// that omits it fail schema validation and drop the whole pass to zero claims.
 const claimSchema = z.object({
-  field: z.enum(['bio', 'writingStyle', 'rules']),
+  field: z.enum(['bio', 'writingStyle', 'rules']).optional(),
   claim: z.string().min(1),
   evidence: z.string().min(1),
   occurrencesInWindow: z.number().int().min(1),
+  /**
+   * Index (from the numbered transcript) of the newest message supporting the
+   * claim. An index rather than a date so the model cannot invent a timestamp;
+   * anything out of range falls back to the oldest message in the window,
+   * which is the conservative choice — it cannot fabricate recency.
+   */
+  evidenceMessageIndex: z.number().int().min(0),
 });
 
 const discoverySchema = z.object({
@@ -68,20 +93,22 @@ EXPLICIT EXCLUSIONS (never record these, even if they seem actionable):
 - Self-reported metrics (lines of code, rankings, follower counts, scores)
 - Current tasks, projects, or work-in-progress status
 
+Each message in the transcript below is numbered like [12 user]. Use those numbers.
+
 Return a JSON object with a "claims" array. Each claim has:
-- field: "bio" (who they are), "writingStyle" (how AI should write), or "rules" (AI behavior rules)
 - claim: the insight itself — IMPERATIVE for writingStyle/rules (e.g. "Never use emojis", not "user prefers no emojis")
 - evidence: a verbatim quote from the user's messages that supports this claim
 - occurrencesInWindow: how many distinct messages in these conversations support this claim
+- evidenceMessageIndex: the NUMBER of the most recent message supporting this claim, exactly as shown in brackets
 
 Example output format:
 {
   "claims": [
     {
-      "field": "writingStyle",
       "claim": "Prefer concise responses without preamble or sign-off",
       "evidence": "be concise, skip the preamble",
-      "occurrencesInWindow": 3
+      "occurrencesInWindow": 3,
+      "evidenceMessageIndex": 12
     }
   ]
 }`;
@@ -254,8 +281,12 @@ async function gatherRecentActivity(
 async function runDiscoveryPass(
   userId: string,
   passName: string,
+  /** The field this pass is responsible for — the authority on every claim it returns. */
+  field: MemoryField,
   systemPrompt: string,
-  conversationContext: string
+  conversationContext: string,
+  /** Same order as the numbered transcript, so a cited index resolves to a real timestamp. */
+  messageDates: Date[]
 ): Promise<DiscoveredClaim[]> {
   const providerResult = await createAIProvider(userId, {
     selectedProvider: BACKGROUND_HEAVY_PROVIDER,
@@ -298,7 +329,20 @@ async function runDiscoveryPass(
       metadata: { feature: 'memory_discovery', pass: passName },
     });
 
-    return result.object.claims;
+    // Resolve each cited index to the real message timestamp. An out-of-range
+    // index falls back to the OLDEST message in the window: a model that cites
+    // nothing usable must not be able to make a claim look fresher than its
+    // evidence, which would let it clear the corroboration bar early.
+    const oldest = messageDates[messageDates.length - 1] ?? new Date();
+
+    // The model's own `field` tag is discarded in favour of `field`, the field
+    // this pass is responsible for. The model can omit or mislabel it, and a
+    // claim filed into the wrong page is worse than one not filed at all.
+    return result.object.claims.map(({ field: _modelTag, ...claim }) => ({
+      ...claim,
+      field,
+      evidenceAt: messageDates[claim.evidenceMessageIndex] ?? oldest,
+    }));
   } catch (error) {
     loggers.api.warn(`Memory discovery ${passName} pass failed`, { error });
     return [];
@@ -324,10 +368,13 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
     return { claims: [] };
   }
 
-  // Format conversation context: 60 messages × 1500 chars (was 100 × 500)
-  const conversationContext = recentMessages
-    .slice(0, 60)
-    .map((m) => `[${m.role}]: ${m.content.substring(0, 1500)}`)
+  // Format conversation context: 60 messages × 1500 chars (was 100 × 500).
+  // Messages are NUMBERED so a claim can cite the message it came from, and the
+  // dates array below stays index-aligned with the transcript the model sees.
+  const windowed = recentMessages.slice(0, 60);
+  const messageDates = windowed.map((m) => m.createdAt);
+  const conversationContext = windowed
+    .map((m, i) => `[${i} ${m.role}]: ${m.content.substring(0, 1500)}`)
     .join('\n\n');
 
   const activityContext =
@@ -337,37 +384,37 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
 
   const fullContext = conversationContext + activityContext;
 
-  // Run three focused passes in parallel
+  // Run three focused passes in parallel. Each pass owns its field and stamps
+  // it onto every claim it returns, so the model's own tag never decides which
+  // page a claim lands in.
   const [bioClaims, communicationClaims, rulesClaims] = await Promise.all([
     runDiscoveryPass(
       userId,
       'worldview',
+      'bio',
       DISCOVERY_PROMPT_BASE + '\n\n' + WORLDVIEW_SPECIFIC,
-      fullContext
+      fullContext,
+      messageDates
     ),
     runDiscoveryPass(
       userId,
       'communication',
+      'writingStyle',
       DISCOVERY_PROMPT_BASE + '\n\n' + COMMUNICATION_SPECIFIC,
-      fullContext
+      fullContext,
+      messageDates
     ),
     runDiscoveryPass(
       userId,
       'preferences',
+      'rules',
       DISCOVERY_PROMPT_BASE + '\n\n' + RULES_SPECIFIC,
-      fullContext
+      fullContext,
+      messageDates
     ),
   ]);
 
-  // The pass a claim came from is the authority on its field — not the model's
-  // own `field` tag, which it can omit or get wrong. Spreading the claim first
-  // and the field second means a mislabelled claim is corrected rather than
-  // filed into the wrong page.
-  const allClaims = [
-    ...bioClaims.map((c) => ({ ...c, field: 'bio' as const })),
-    ...communicationClaims.map((c) => ({ ...c, field: 'writingStyle' as const })),
-    ...rulesClaims.map((c) => ({ ...c, field: 'rules' as const })),
-  ];
+  const allClaims = [...bioClaims, ...communicationClaims, ...rulesClaims];
 
   loggers.api.info('Memory discovery passes complete', {
     userId,

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -350,14 +350,11 @@ async function runDiscoveryPass(
       metadata: { feature: 'memory_discovery', pass: passName },
     });
 
-    // Resolve each cited index to the real message timestamp. An out-of-range
-    // index falls back to the OLDEST message in the window: a model that cites
-    // nothing usable must not be able to make a claim look fresher than its
-    // evidence, which would let it clear the corroboration bar early.
-    // Transcript is chronological, so index 0 is the oldest message in the
-    // window. An unusable index falls back to it: a claim must never be able
-    // to look FRESHER than the evidence actually supports, since that is what
-    // would let it clear the corroboration bar early.
+    // Resolve each cited index to the real message timestamp. The transcript is
+    // chronological, so index 0 is the OLDEST message in the window, and an
+    // unusable index falls back to it: a claim must never be able to look
+    // fresher than the evidence actually supports, since that is what would let
+    // it clear the corroboration bar early.
     const oldest = messageDates[0] ?? new Date();
 
     // The model's own `field` tag is discarded in favour of `field`, the field

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -27,6 +27,16 @@ export interface DiscoveredClaim {
   field: MemoryField;
   claim: string;
   evidence: string;
+  /**
+   * How many messages in THIS window support the claim.
+   *
+   * Not used for corroboration — that counts distinct evidence days across
+   * runs (see `evidenceAt`), and a count confined to one window cannot
+   * distinguish one emphatic day from a standing preference. It is kept
+   * because asking the model to count forces it to look for repetition rather
+   * than latch onto a single striking sentence, and it is worth having in the
+   * logs when tuning the prompts.
+   */
   occurrencesInWindow: number;
   /**
    * When the newest message supporting this claim was written.

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -2,26 +2,36 @@
  * Memory Discovery Service
  *
  * Runs focused LLM passes to discover insights about a user from their
- * recent conversations and activity. This is "blind" discovery - the LLM
+ * recent conversations and activity. This is "blind" discovery — the LLM
  * does NOT see the user's current personalization profile.
+ *
+ * Claims carry evidence and occurrence counts for corroboration.
  */
 
-import { generateText } from 'ai';
-import { db } from '@pagespace/db/db'
-import { eq, and, gte, desc, inArray, isNotNull, ne } from '@pagespace/db/operators'
-import { pages } from '@pagespace/db/schema/core'
-import { activityLogs } from '@pagespace/db/schema/monitoring'
-import { driveMembers } from '@pagespace/db/schema/members'
+import { generateObject } from 'ai';
+import { db } from '@pagespace/db/db';
+import { and, desc, eq, gte, inArray, isNotNull, ne } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { activityLogs } from '@pagespace/db/schema/monitoring';
+import { driveMembers } from '@pagespace/db/schema/members';
 import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { z } from 'zod';
+
+export type MemoryField = 'bio' | 'writingStyle' | 'rules';
+
+export interface DiscoveredClaim {
+  field: MemoryField;
+  claim: string;
+  evidence: string;
+  occurrencesInWindow: number;
+}
 
 export interface DiscoveryResult {
-  worldview: string[];
-  communication: string[];
-  preferences: string[];
+  claims: DiscoveredClaim[];
 }
 
 interface ConversationMessage {
@@ -30,48 +40,89 @@ interface ConversationMessage {
   createdAt: Date;
 }
 
-// Discovery pass prompts
-const WORLDVIEW_PROMPT = `Analyze these conversations to discover:
-- What does this person believe or value?
-- What frameworks or mental models do they use?
-- What are they expert in?
-- What's their background or role?
+// Zod schema for structured output — eliminates silent parse failures
+const claimSchema = z.object({
+  field: z.enum(['bio', 'writingStyle', 'rules']),
+  claim: z.string().min(1),
+  evidence: z.string().min(1),
+  occurrencesInWindow: z.number().int().min(1),
+});
 
-Only report clear patterns, not speculation. Return a JSON array of strings, each string being a distinct insight. If no clear patterns emerge, return an empty array.
+const discoverySchema = z.object({
+  claims: z.array(claimSchema),
+});
 
-Example output: ["Values test-driven development", "Expert in React and TypeScript", "Has background in finance"]`;
+// Discovery pass prompt — shared structure, field-specific logic
+const DISCOVERY_PROMPT_BASE = `Analyze these conversations to discover insights about this person that would change how an AI behaves.
 
-const COMMUNICATION_PROMPT = `Analyze these conversations to discover:
-- How does this person like to communicate?
-- Do they prefer brief or detailed responses?
-- What tone do they use and expect?
-- Any formatting preferences?
+ACTIONABILITY GATE (check first, everything fails this):
+Only capture something if knowing it would genuinely change AI behaviour in a conversation.
+If it is merely true about the person but doesn't affect what the AI should do, SKIP IT.
 
-Look for patterns in how they interact. Return a JSON array of strings, each string being a distinct communication preference. If no clear patterns emerge, return an empty array.
+EXPLICIT EXCLUSIONS (never record these, even if they seem actionable):
+- Personal history, family relationships, living situation
+- Religious or political beliefs
+- Hobbies, games, sports teams, entertainment preferences
+- Named third parties (real names of anyone other than the user)
+- Employer or product marketing claims
+- Self-reported metrics (lines of code, rankings, follower counts, scores)
+- Current tasks, projects, or work-in-progress status
 
-Example output: ["Prefers concise responses", "Uses technical language comfortably"]`;
+Return a JSON object with a "claims" array. Each claim has:
+- field: "bio" (who they are), "writingStyle" (how AI should write), or "rules" (AI behavior rules)
+- claim: the insight itself — IMPERATIVE for writingStyle/rules (e.g. "Never use emojis", not "user prefers no emojis")
+- evidence: a verbatim quote from the user's messages that supports this claim
+- occurrencesInWindow: how many distinct messages in these conversations support this claim
 
-const PREFERENCES_PROMPT = `Analyze these conversations to identify persistent preferences for how this person wants AI to interact with them.
+Example output format:
+{
+  "claims": [
+    {
+      "field": "writingStyle",
+      "claim": "Prefer concise responses without preamble or sign-off",
+      "evidence": "be concise, skip the preamble",
+      "occurrencesInWindow": 3
+    }
+  ]
+}`;
 
-ONLY capture preferences that pass the portability test: "Would this still apply if the user was working on a completely different project in a different workspace?" If no, skip it.
+const WORLDVIEW_SPECIFIC = `
+Focus on: expertise, domain knowledge, thinking style, professional background.
+Examples of good bio claims:
+- "Software engineer specializing in React and TypeScript"
+- "Prefers test-driven development"
+- "Background in finance, now working on B2B SaaS"
+`;
 
-DO capture:
-- Response format and length preferences
-- Tone and communication style they expect from AI
-- Persistent do's and don'ts about AI output (e.g., "don't use emojis", "always show TypeScript types")
+const COMMUNICATION_SPECIFIC = `
+Focus on: how the AI should WRITE — both directions.
+- TO the user: tone, verbosity, formatting, interaction patterns
+- AS the user: voice, banned constructions, sentence shape, characteristic phrasing for ghostwriting
 
-DO NOT capture:
-- Technology or tool choices for a specific project
-- Scope or prioritization decisions ("we're not doing X for this release")
-- One-off decisions explained by their conversational context
-- Project-specific constraints or workflow choices
+EVERY claim must be IMPERATIVE, second-person, starting with a verb. Never describe how the user talks.
+Examples of good writingStyle claims:
+- "Be concise and direct. Do not use preamble or sign-off."
+- "When drafting text as the user, avoid em dashes. Use sentence fragments and single-word closings like 'Exactly.'"
+- "Use bullet points for lists. Provide code examples for technical concepts."
+- "When ghostwriting, enthymematic style: leave conclusions unstated so the reader fills the gap"
+`;
 
-Return a JSON array of strings. If no clearly portable preferences emerge, return an empty array.
+const RULES_SPECIFIC = `
+Focus on: universal AI behavior preferences that apply in ANY workspace.
+- NOT project-specific technology choices
+- NOT scope or priority decisions for a specific release
+- NOT one-off decisions explained by their context
 
-Example output: ["Prefers responses without preamble or sign-off", "Always wants TypeScript types in code examples"]`;
+Examples of good rules claims:
+- "Always suggest TypeScript solutions over JavaScript"
+- "Include error handling when writing code"
+- "Never use emojis in code comments or documentation"
+`;
 
 /**
- * Gather recent messages from all conversation sources for a user
+ * Gather recent messages from all conversation sources for a user.
+ *
+ * Wider window than before: 60 messages × 1500 chars each (vs 100 × 500).
  */
 async function gatherRecentConversations(
   userId: string,
@@ -82,15 +133,8 @@ async function gatherRecentConversations(
 
   const allMessages: ConversationMessage[] = [];
 
-  // 1. Global/DM conversations.
-  //
-  // `eq(conversations.type, 'global')` is REQUIRED since the message-table
-  // merge (epic "Agent-Session Single Source of Truth", Phase 4 / D6): page
-  // and client conversations now live in `messages` too, so without it this
-  // query would swallow the page-agent corpus that step 2 collects under a
-  // different (drive-membership-scoped, `userId`-attributed) rule — feeding
-  // the same rows to the model twice and, worse, bypassing step 2's
-  // drive-membership gate.
+  // Global/DM conversations. eq(type, 'global') is REQUIRED — see D6 comment
+  // in agent-epic "Agent-Session Single Source of Truth".
   const globalMessages = await db
     .select({
       content: messages.content,
@@ -104,16 +148,13 @@ async function gatherRecentConversations(
         eq(conversations.type, 'global'),
         eq(conversations.userId, userId),
         eq(messages.isActive, true),
-        // Global Assistant placeholder rows carry the real conversation owner's userId (unlike
-        // page-agent rows below, which use userId: null for assistant messages and
-        // so are excluded by the userId filter alone) — an in-flight 'streaming' row would
-        // otherwise feed an empty assistant message into the preference-extraction prompt.
+        // Skip streaming placeholder rows
         ne(messages.status, 'streaming'),
         gte(messages.createdAt, lookbackDate)
       )
     )
     .orderBy(desc(messages.createdAt), desc(messages.id))
-    .limit(150);
+    .limit(60); // was 150, reduced to 60 for tighter window
 
   allMessages.push(
     ...globalMessages.map((m) => ({
@@ -123,9 +164,7 @@ async function gatherRecentConversations(
     }))
   );
 
-  // 2. Page agent conversations.
-  // acceptedAt IS NOT NULL filters pending invitations — a not-yet-accepted
-  // member must not see prior conversations from the inviting drive.
+  // Page agent conversations via drive membership.
   const userDrives = await db
     .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
@@ -133,10 +172,6 @@ async function gatherRecentConversations(
   const driveIds = userDrives.map((d) => d.driveId);
 
   if (driveIds.length > 0) {
-    // Unified `messages` table since the merge (Phase 4 / D6). The page is
-    // reached through `conversations.contextId` — the end-state authority,
-    // indexed — rather than the transitional `messages.pageId`, so this
-    // reader survives that column's removal at the contract PR.
     const pageMessages = await db
       .select({
         content: messages.content,
@@ -156,7 +191,7 @@ async function gatherRecentConversations(
         )
       )
       .orderBy(desc(messages.createdAt), desc(messages.id))
-      .limit(100);
+      .limit(60);
 
     allMessages.push(
       ...pageMessages.map((m) => ({
@@ -173,7 +208,7 @@ async function gatherRecentConversations(
 }
 
 /**
- * Gather recent activity patterns
+ * Gather recent activity patterns.
  */
 async function gatherRecentActivity(
   userId: string,
@@ -182,7 +217,6 @@ async function gatherRecentActivity(
   const lookbackDate = new Date();
   lookbackDate.setDate(lookbackDate.getDate() - lookbackDays);
 
-  // Same gate as gatherRecentConversations — exclude pending invitations.
   const userDrives = await db
     .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
@@ -206,7 +240,7 @@ async function gatherRecentActivity(
       )
     )
     .orderBy(desc(activityLogs.timestamp))
-    .limit(50);
+    .limit(30); // was 50, reduced
 
   return activities.map(
     (a) =>
@@ -215,14 +249,14 @@ async function gatherRecentActivity(
 }
 
 /**
- * Run a single focused discovery pass
+ * Run a single focused discovery pass using generateObject.
  */
 async function runDiscoveryPass(
   userId: string,
   passName: string,
   systemPrompt: string,
   conversationContext: string
-): Promise<string[]> {
+): Promise<DiscoveredClaim[]> {
   const providerResult = await createAIProvider(userId, {
     selectedProvider: BACKGROUND_HEAVY_PROVIDER,
     selectedModel: BACKGROUND_HEAVY_MODEL,
@@ -236,13 +270,14 @@ async function runDiscoveryPass(
   }
 
   try {
-    const result = await generateText({
+    const result = await generateObject({
       model: providerResult.model,
+      schema: discoverySchema,
       system: systemPrompt,
       messages: [
         {
           role: 'user',
-          content: `Here are recent conversations from this user:\n\n${conversationContext}\n\nBased on these conversations, what insights can you extract? Remember to return a JSON array of strings.`,
+          content: `Here are recent conversations from this user:\n\n${conversationContext}\n\nBased on these conversations, what insights can you extract? Remember the actionability gate — only record things that would change how an AI behaves.`,
         },
       ],
       temperature: 0.3,
@@ -263,24 +298,7 @@ async function runDiscoveryPass(
       metadata: { feature: 'memory_discovery', pass: passName },
     });
 
-    // Parse JSON array from response
-    const text = result.text.trim();
-    // Handle both raw JSON and markdown code block responses
-    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
-    const jsonStr = jsonMatch ? jsonMatch[1] : text;
-
-    try {
-      const insights = JSON.parse(jsonStr);
-      if (Array.isArray(insights)) {
-        return insights.filter(
-          (item): item is string => typeof item === 'string' && item.trim().length > 0
-        );
-      }
-    } catch {
-      loggers.api.debug(`Memory discovery ${passName} pass: non-JSON response, skipping`);
-    }
-
-    return [];
+    return result.object.claims;
   } catch (error) {
     loggers.api.warn(`Memory discovery ${passName} pass failed`, { error });
     return [];
@@ -288,35 +306,30 @@ async function runDiscoveryPass(
 }
 
 /**
- * Run all discovery passes for a user
+ * Run all discovery passes for a user.
+ *
+ * Returns a unified set of claims across all three fields.
  */
 export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResult> {
-  // Gather context
   const [recentMessages, recentActivity] = await Promise.all([
     gatherRecentConversations(userId),
     gatherRecentActivity(userId),
   ]);
 
-  // Check if there's enough data to analyze
   if (recentMessages.length < 3) {
     loggers.api.debug('Memory discovery: insufficient conversation data', {
       userId,
       messageCount: recentMessages.length,
     });
-    return {
-      worldview: [],
-      communication: [],
-      preferences: [],
-    };
+    return { claims: [] };
   }
 
-  // Format conversation context for LLM
+  // Format conversation context: 60 messages × 1500 chars (was 100 × 500)
   const conversationContext = recentMessages
-    .slice(0, 100)
-    .map((m) => `[${m.role}]: ${m.content.substring(0, 500)}`)
+    .slice(0, 60)
+    .map((m) => `[${m.role}]: ${m.content.substring(0, 1500)}`)
     .join('\n\n');
 
-  // Add activity context if available
   const activityContext =
     recentActivity.length > 0
       ? `\n\nRecent workspace activity:\n${recentActivity.slice(0, 20).join('\n')}`
@@ -324,24 +337,46 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
 
   const fullContext = conversationContext + activityContext;
 
-  const [worldview, communication, preferences] = await Promise.all([
-    runDiscoveryPass(userId, 'worldview', WORLDVIEW_PROMPT, fullContext),
-    runDiscoveryPass(userId, 'communication', COMMUNICATION_PROMPT, fullContext),
-    runDiscoveryPass(userId, 'preferences', PREFERENCES_PROMPT, fullContext),
+  // Run three focused passes in parallel
+  const [bioClaims, communicationClaims, rulesClaims] = await Promise.all([
+    runDiscoveryPass(
+      userId,
+      'worldview',
+      DISCOVERY_PROMPT_BASE + '\n\n' + WORLDVIEW_SPECIFIC,
+      fullContext
+    ),
+    runDiscoveryPass(
+      userId,
+      'communication',
+      DISCOVERY_PROMPT_BASE + '\n\n' + COMMUNICATION_SPECIFIC,
+      fullContext
+    ),
+    runDiscoveryPass(
+      userId,
+      'preferences',
+      DISCOVERY_PROMPT_BASE + '\n\n' + RULES_SPECIFIC,
+      fullContext
+    ),
   ]);
+
+  // The pass a claim came from is the authority on its field — not the model's
+  // own `field` tag, which it can omit or get wrong. Spreading the claim first
+  // and the field second means a mislabelled claim is corrected rather than
+  // filed into the wrong page.
+  const allClaims = [
+    ...bioClaims.map((c) => ({ ...c, field: 'bio' as const })),
+    ...communicationClaims.map((c) => ({ ...c, field: 'writingStyle' as const })),
+    ...rulesClaims.map((c) => ({ ...c, field: 'rules' as const })),
+  ];
 
   loggers.api.info('Memory discovery passes complete', {
     userId,
-    insightCounts: {
-      worldview: worldview.length,
-      communication: communication.length,
-      preferences: preferences.length,
+    claimCounts: {
+      bio: bioClaims.length,
+      writingStyle: communicationClaims.length,
+      rules: rulesClaims.length,
     },
   });
 
-  return {
-    worldview,
-    communication,
-    preferences,
-  };
+  return { claims: allClaims };
 }

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -23,6 +23,17 @@ import { z } from 'zod';
 
 export type MemoryField = 'bio' | 'writingStyle' | 'rules';
 
+/**
+ * How far back a discovery run reads, in days.
+ *
+ * This window is REREAD IN FULL on every run, which is the single fact that
+ * shapes the rest of the pipeline: the same message is seen again night after
+ * night, so corroboration counts the day the EVIDENCE was written rather than
+ * the day the cron happened to run (see `evidenceAt`). Widening it widens the
+ * re-read, not the corroboration.
+ */
+const LOOKBACK_DAYS = 7;
+
 export interface DiscoveredClaim {
   field: MemoryField;
   claim: string;
@@ -163,7 +174,7 @@ Examples of good rules claims:
  */
 async function gatherRecentConversations(
   userId: string,
-  lookbackDays: number = 7
+  lookbackDays: number = LOOKBACK_DAYS
 ): Promise<ConversationMessage[]> {
   const lookbackDate = new Date();
   lookbackDate.setDate(lookbackDate.getDate() - lookbackDays);
@@ -249,7 +260,7 @@ async function gatherRecentConversations(
  */
 async function gatherRecentActivity(
   userId: string,
-  lookbackDays: number = 7
+  lookbackDays: number = LOOKBACK_DAYS
 ): Promise<string[]> {
   const lookbackDate = new Date();
   lookbackDate.setDate(lookbackDate.getDate() - lookbackDays);

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -153,6 +153,20 @@ export async function updatePersonalizationPage(
     throw error;
   }
 
+  // Retire the legacy column for this field now that a page holds the content.
+  //
+  // The column is a one-way fallback for users the backfill has not reached,
+  // NOT a shadow copy that outlives the page. Leaving it populated is a latent
+  // privacy leak with a real trigger: `purgeExpiredTrashedPages` hard-deletes a
+  // trashed page 30 days on, `ON DELETE SET NULL` clears the pointer, and the
+  // pointer-absent branch in `getUserPersonalization` then reads the column
+  // again — resurrecting, weeks later, exactly the content the user deleted the
+  // page to be rid of.
+  await db
+    .update(userPersonalization)
+    .set({ [field]: null, updatedAt: new Date() })
+    .where(eq(userPersonalization.userId, userId));
+
   return { written: true };
 }
 

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -197,18 +197,29 @@ export async function evaluateAndIntegrate(
     rules: currentPages.rules ?? '',
   };
 
-  // Group candidates by field
+  // Group candidates by field.
+  //
+  // `field` is a free-form text column, so the guard checks membership in an
+  // explicit set rather than using `in`, which also matches inherited keys:
+  // a row whose field read `toString` would pass `in`, resolve `byField[field]`
+  // to a function, and throw on `.push` — aborting the whole evaluation run.
   const byField: Record<MemoryField, typeof candidates> = {
     bio: [],
     writingStyle: [],
     rules: [],
   };
+  const KNOWN_FIELDS = new Set<string>(['bio', 'writingStyle', 'rules']);
 
   for (const candidate of candidates) {
-    const field = candidate.field as MemoryField;
-    if (field in byField) {
-      byField[field].push(candidate);
+    if (!KNOWN_FIELDS.has(candidate.field)) {
+      loggers.api.warn('Memory integration: candidate has an unrecognised field', {
+        userId,
+        candidateId: candidate.id,
+        field: candidate.field,
+      });
+      continue;
     }
+    byField[candidate.field as MemoryField].push(candidate);
   }
 
   const EVALUATOR_SYSTEM_PROMPT = `You are deciding how to update a user's personalization profile based on newly-learned information.

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -58,7 +58,7 @@ export async function updatePersonalizationPage(
   userId: string,
   field: MemoryField,
   newContent: string
-): Promise<void> {
+): Promise<{ written: boolean; reason?: string }> {
   const [personalization] = await db
     .select({ pageId: POINTER_COLUMN[field] })
     .from(userPersonalization)
@@ -71,7 +71,7 @@ export async function updatePersonalizationPage(
       userId,
       field,
     });
-    return;
+    return { written: false, reason: 'no page pointer (backfill has not run for this user)' };
   }
 
   const updated = await db
@@ -89,22 +89,45 @@ export async function updatePersonalizationPage(
       field,
       pageId,
     });
+    return { written: false, reason: 'page is trashed or no longer exists' };
   }
+
+  return { written: true };
 }
+
+/**
+ * The outcome of one evaluation run.
+ *
+ * `ok: false` means the evaluator never reached a decision — provider error,
+ * generation failure, or an unparseable response. That is deliberately NOT the
+ * same shape as "decided to change nothing": a transient model outage must
+ * leave candidates pending for the next run rather than permanently retiring
+ * every ready claim the user has accumulated.
+ */
+export type EvaluationOutcome =
+  | {
+      ok: true;
+      /** Full replacement content, per field the evaluator chose to rewrite. */
+      updates: Partial<Record<MemoryField, string>>;
+      /** IDs of the candidates the evaluator actually used. */
+      usedCandidateIds: string[];
+    }
+  | { ok: false; reason: string };
 
 /**
  * Evaluate promoted candidates and decide how to integrate.
  *
  * Returns the FULL new content for each field that changes, instructed to
- * preserve every line it is not explicitly superseding.
+ * preserve every line it is not explicitly superseding, plus the specific
+ * candidate IDs it drew on so the caller can settle them individually.
  */
 export async function evaluateAndIntegrate(
   userId: string,
   candidates: typeof personalizationCandidates.$inferSelect[],
   currentPages: Partial<Record<MemoryField, string>>
-): Promise<Partial<Record<MemoryField, string>>> {
+): Promise<EvaluationOutcome> {
   if (candidates.length === 0) {
-    return {};
+    return { ok: true, updates: {}, usedCandidateIds: [] };
   }
 
   const current = {
@@ -145,12 +168,17 @@ For each field, output the FULL NEW CONTENT — the complete page, not just the 
 - REMOVE lines that are superseded by newer, more accurate information
 - REORGANIZE into a coherent structure (prose or bullets, whichever fits)
 
+Each candidate insight below is numbered like [3]. Report which ones you actually used.
+
 Return JSON with this structure:
 {
   "bio": "full new bio content or null if unchanged",
   "writingStyle": "full new writing style content or null if unchanged",
-  "rules": "full new rules content or null if unchanged"
+  "rules": "full new rules content or null if unchanged",
+  "usedInsights": [3, 7]
 }
+
+"usedInsights" must list the number of every insight whose content you incorporated. Omit the numbers you decided to skip — they are recorded as declined.
 
 Remember: You are writing the COMPLETE page, not just additions. Preserve what matters, remove what doesn't.`;
 
@@ -163,18 +191,27 @@ Remember: You are writing the COMPLETE page, not just additions. Preserve what m
     loggers.api.error('Memory integration: provider error', {
       error: providerResult.error,
     });
-    return {};
+    return { ok: false, reason: 'provider error' };
   }
+
+  // Number every candidate so the evaluator can cite which it used. Indices are
+  // stable for this call only; they never leave this function.
+  const numbered = candidates.map((c, i) => ({ index: i, candidate: c }));
+  const byIndex = new Map(numbered.map((n) => [n.index, n.candidate.id]));
 
   try {
     // Build candidates text
-    const candidatesByField = Object.entries(byField)
-      .filter(([_, list]) => list.length > 0)
-      .map(([field, list]) => {
-        const items = list
-          .map(
-            (c) =>
-              `- ${c.claim} (seen ${c.occurrences} times, first: ${new Date(c.firstSeenAt).toLocaleDateString()})`
+    const candidatesByField = (Object.keys(byField) as MemoryField[])
+      .filter((field) => byField[field].length > 0)
+      .map((field) => {
+        const items = numbered
+          .filter((n) => n.candidate.field === field)
+          .map(({ index, candidate: c }) =>
+            // Fixed UTC formatting: toLocaleDateString() varies with host
+            // locale and timezone, which makes prompts non-reproducible and
+            // can name a different calendar day than the UTC-day rule the
+            // candidate service enforces.
+            `[${index}] ${c.claim} (seen on ${c.occurrences} separate days, first: ${new Date(c.firstSeenAt).toISOString().slice(0, 10)})`
           )
           .join('\n');
         return `NEW ${field.toUpperCase()} INSIGHTS:\n${items}`;
@@ -239,17 +276,30 @@ Return JSON with the full new content for each field that should change. Use nul
         }
       }
 
-      return updates;
+      // Map the cited indices back to candidate IDs. Anything the evaluator
+      // did not cite is treated as declined by the caller.
+      const usedCandidateIds: string[] = Array.isArray(parsed.usedInsights)
+        ? [
+            ...new Set(
+              (parsed.usedInsights as unknown[])
+                .filter((i): i is number => Number.isInteger(i))
+                .map((i) => byIndex.get(i))
+                .filter((id): id is string => id !== undefined)
+            ),
+          ]
+        : [];
+
+      return { ok: true, updates, usedCandidateIds };
     } catch {
       loggers.api.warn('Memory integration: failed to parse decision', {
         userId,
         response: text.substring(0, 500),
       });
-      return {};
+      return { ok: false, reason: 'unparseable evaluator response' };
     }
   } catch (error) {
     loggers.api.error('Memory integration: generation error', { userId, error });
-    return {};
+    return { ok: false, reason: 'generation error' };
   }
 }
 
@@ -287,8 +337,27 @@ export async function applyIntegrationDecisions(
       continue;
     }
 
-    await updatePersonalizationPage(userId, field, newContent);
-    updatedFields.push(field);
+    // A field counts as updated only when a row actually changed. Reporting a
+    // write that never landed would make the caller retire the candidates
+    // behind it, losing claims for every user whose backfill has not run or
+    // who has trashed the page.
+    //
+    // A thrown write is contained rather than propagated: one field failing
+    // must not discard the settlement information for the fields that already
+    // succeeded, which the caller needs to decide what to retire.
+    let result: { written: boolean; reason?: string };
+    try {
+      result = await updatePersonalizationPage(userId, field, newContent);
+    } catch (error) {
+      loggers.api.error('Memory integration: page write threw', { userId, field, error });
+      result = { written: false, reason: 'write failed' };
+    }
+
+    if (result.written) {
+      updatedFields.push(field);
+    } else {
+      rejected.push({ field, reason: result.reason ?? 'write did not affect any row' });
+    }
   }
 
   return {

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -1,179 +1,158 @@
 /**
  * Memory Integration Service
  *
- * Evaluates raw insights from the discovery service against the user's
- * current personalization profile. Decides whether to append, skip, or
- * reorganize content.
+ * Evaluates promoted candidates against the user's current personalization pages
+ * and applies updates via whole-field rewrite (not append).
+ *
+ * Includes two deterministic guards to prevent destructive rewrites:
+ * 1. 40% deletion guard — rejects any rewrite that deletes more than 40% of existing content
+ * 2. Per-field budget guard — rejects rewrites exceeding the size limit
  */
 
+import { and, eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { userPersonalization, personalizationCandidates } from '@pagespace/db/schema/personalization';
 import { generateText } from 'ai';
-import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
-import { userPersonalization } from '@pagespace/db/schema/personalization';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
-import type { DiscoveryResult } from './discovery-service';
+import { readMemoryPages } from '@pagespace/lib/memory/memory-pages';
 
-export interface UserPersonalizationData {
-  bio: string;
-  writingStyle: string;
-  rules: string;
-  enabled: boolean;
-}
+export type MemoryField = 'bio' | 'writingStyle' | 'rules';
 
-export interface FieldDecision {
-  action: 'append' | 'skip';
-  content?: string;
-  reason?: string;
-}
-
-export interface IntegrationDecision {
-  bio: FieldDecision;
-  writingStyle: FieldDecision;
-  rules: FieldDecision;
-}
-
-// Signal strength threshold
-const MIN_INSIGHTS_FOR_UPDATE = 2;
-
-const EVALUATOR_SYSTEM_PROMPT = `You are deciding what to add to a user's personalization profile. The profile exists to make every AI conversation feel personal — like the AI already knows who this person is.
-
-FIELDS:
-- bio: Who this person is — background, expertise, domain, thinking style, mental models. Describes the person, not their current tasks.
-- writingStyle: How they want AI to communicate — tone, verbosity, formatting, interaction patterns.
-- rules: Universal AI behavior preferences that apply in any workspace ("never use emojis", "always include TypeScript types"). Not project decisions, technology choices, or scope calls.
-
-QUALITY GATES (apply in order — fail any gate = skip):
-1. Portability: Would this still apply if the person was working on a completely different project? If no, skip.
-2. Personhood: Does this describe the person, or just a decision they made in a specific context? Project-scoped decisions don't belong here.
-3. Novelty: Is this already captured in the existing profile (even if worded differently)? If yes, skip.
-4. Consistency: Does this contradict something already in the profile? If yes, skip — do not append conflicting statements.
-5. Signal: Is this a clear, repeatable pattern — not a single mention or one-off? If no, skip.
-
-For each field, decide:
-- "append" - Add new content to the end of this field
-- "skip" - No changes needed for this field
-
-Return a JSON object with this structure:
-{
-  "bio": { "action": "append" | "skip", "content": "text to append", "reason": "why" },
-  "writingStyle": { "action": "append" | "skip", "content": "text to append", "reason": "why" },
-  "rules": { "action": "append" | "skip", "content": "text to append", "reason": "why" }
-}
-
-When appending, format the content naturally as prose or bullet points.`;
+// Injection budgets — enforced at read time in personalization-utils
+const MAX_FIELD_LENGTHS: Record<MemoryField, number> = {
+  bio: 3000,
+  writingStyle: 2500,
+  rules: 2500,
+};
 
 /**
- * Fetch current personalization for a user
+ * Fetch the current personalization page content for a user.
+ *
+ * Thin alias over the shared reader so the cron and the prompt-injection path
+ * cannot drift apart in what "the user's current profile" means.
  */
-export async function getCurrentPersonalization(
+export async function getCurrentPersonalizationPages(
   userId: string
-): Promise<UserPersonalizationData | null> {
-  const record = await db.query.userPersonalization.findFirst({
-    where: eq(userPersonalization.userId, userId),
-  });
+): Promise<Partial<Record<MemoryField, string>>> {
+  return readMemoryPages(userId);
+}
 
-  if (!record) {
-    return null;
+/** Column on `user_personalization` holding each field's page pointer. */
+const POINTER_COLUMN = {
+  bio: userPersonalization.bioPageId,
+  writingStyle: userPersonalization.writingStylePageId,
+  rules: userPersonalization.rulesPageId,
+} as const;
+
+/**
+ * Overwrite a single memory page with new content.
+ *
+ * A missing pointer, or a pointer to a trashed page, is a no-op: the user
+ * deleted that page and the cron does not resurrect it.
+ */
+export async function updatePersonalizationPage(
+  userId: string,
+  field: MemoryField,
+  newContent: string
+): Promise<void> {
+  const [personalization] = await db
+    .select({ pageId: POINTER_COLUMN[field] })
+    .from(userPersonalization)
+    .where(eq(userPersonalization.userId, userId))
+    .limit(1);
+
+  const pageId = personalization?.pageId;
+  if (!pageId) {
+    loggers.api.warn('Memory integration: no page pointer for field', {
+      userId,
+      field,
+    });
+    return;
   }
 
-  return {
-    bio: record.bio ?? '',
-    writingStyle: record.writingStyle ?? '',
-    rules: record.rules ?? '',
-    enabled: record.enabled,
-  };
-}
-
-/**
- * Update personalization fields for a user
- */
-export async function updatePersonalization(
-  userId: string,
-  updates: Partial<Pick<UserPersonalizationData, 'bio' | 'writingStyle' | 'rules'>>
-): Promise<void> {
-  const updateData: {
-    bio?: string;
-    writingStyle?: string;
-    rules?: string;
-    updatedAt: Date;
-  } = { updatedAt: new Date() };
-
-  if (updates.bio !== undefined) updateData.bio = updates.bio;
-  if (updates.writingStyle !== undefined) updateData.writingStyle = updates.writingStyle;
-  if (updates.rules !== undefined) updateData.rules = updates.rules;
-
-  await db
-    .insert(userPersonalization)
-    .values({
-      userId,
-      bio: updates.bio ?? '',
-      writingStyle: updates.writingStyle ?? '',
-      rules: updates.rules ?? '',
-      enabled: true,
+  const updated = await db
+    .update(pages)
+    .set({
+      content: newContent,
+      updatedAt: new Date(),
     })
-    .onConflictDoUpdate({
-      target: userPersonalization.userId,
-      set: updateData,
+    .where(and(eq(pages.id, pageId), eq(pages.isTrashed, false)))
+    .returning({ id: pages.id });
+
+  if (updated.length === 0) {
+    loggers.api.warn('Memory integration: page pointer is stale or trashed', {
+      userId,
+      field,
+      pageId,
     });
+  }
 }
 
 /**
- * Evaluate insights and integrate into personalization profile
+ * Evaluate promoted candidates and decide how to integrate.
+ *
+ * Returns the FULL new content for each field that changes, instructed to
+ * preserve every line it is not explicitly superseding.
  */
 export async function evaluateAndIntegrate(
   userId: string,
-  insights: DiscoveryResult,
-  currentPersonalization: UserPersonalizationData | null
-): Promise<IntegrationDecision> {
-  const current = currentPersonalization ?? {
-    bio: '',
-    writingStyle: '',
-    rules: '',
-    enabled: true,
-  };
-
-  const totalInsights =
-    insights.worldview.length +
-    insights.communication.length +
-    insights.preferences.length;
-
-  if (totalInsights < MIN_INSIGHTS_FOR_UPDATE) {
-    loggers.api.debug('Memory integration: insufficient insights', {
-      userId,
-      totalInsights,
-      threshold: MIN_INSIGHTS_FOR_UPDATE,
-    });
-    return {
-      bio: { action: 'skip', reason: 'Insufficient insights' },
-      writingStyle: { action: 'skip', reason: 'Insufficient insights' },
-      rules: { action: 'skip', reason: 'Insufficient insights' },
-    };
+  candidates: typeof personalizationCandidates.$inferSelect[],
+  currentPages: Partial<Record<MemoryField, string>>
+): Promise<Partial<Record<MemoryField, string>>> {
+  if (candidates.length === 0) {
+    return {};
   }
 
-  const insightsText = `
-WORLDVIEW & EXPERTISE INSIGHTS:
-${insights.worldview.length > 0 ? insights.worldview.map((i) => `- ${i}`).join('\n') : '(none discovered)'}
+  const current = {
+    bio: currentPages.bio ?? '',
+    writingStyle: currentPages.writingStyle ?? '',
+    rules: currentPages.rules ?? '',
+  };
 
-COMMUNICATION STYLE INSIGHTS:
-${insights.communication.length > 0 ? insights.communication.map((i) => `- ${i}`).join('\n') : '(none discovered)'}
+  // Group candidates by field
+  const byField: Record<MemoryField, typeof candidates> = {
+    bio: [],
+    writingStyle: [],
+    rules: [],
+  };
 
-PREFERENCES & RULES INSIGHTS:
-${insights.preferences.length > 0 ? insights.preferences.map((i) => `- ${i}`).join('\n') : '(none discovered)'}
-`;
+  for (const candidate of candidates) {
+    const field = candidate.field as MemoryField;
+    if (field in byField) {
+      byField[field].push(candidate);
+    }
+  }
 
-  const currentProfileText = `
-CURRENT BIO:
-${current.bio || '(empty)'}
+  const EVALUATOR_SYSTEM_PROMPT = `You are deciding how to update a user's personalization profile based on newly-learned information.
 
-CURRENT WRITING STYLE:
-${current.writingStyle || '(empty)'}
+The profile exists to make every AI conversation feel personal — like the AI already knows who this person is. These are living documents stored as pages in the user's workspace, so they must remain accurate and concise.
 
-CURRENT RULES:
-${current.rules || '(empty)'}
-`;
+QUALITY GATES (apply in order — fail any gate = do NOT use this candidate):
+0. ACTIONABILITY: Would knowing this change how the AI behaves? If no, skip.
+1. PORTABILITY: Would this still apply if the person was working on a completely different project? If no, skip.
+2. PERSONHOOD: Does this describe the person, or just a decision they made in a specific context? Skip project-specific decisions.
+3. NOVELTY: Is this already captured in the current profile (even if worded differently)? If yes, skip.
+4. CONSISTENCY: Does this contradict something already in the profile? If yes, skip — never append conflicting statements.
+5. ATTRIBUTION: Is this a verifiable fact about the user, or a self-reported claim? Self-claims about credentials, metrics, or rankings must be marked as "claimed" not proven. Never record numeric self-claims as facts.
+
+For each field, output the FULL NEW CONTENT — the complete page, not just the new text. Your job is to:
+- PRESERVE every existing line that is still accurate
+- SUPPLEMENT lines with related new insights (group related points together)
+- REMOVE lines that are superseded by newer, more accurate information
+- REORGANIZE into a coherent structure (prose or bullets, whichever fits)
+
+Return JSON with this structure:
+{
+  "bio": "full new bio content or null if unchanged",
+  "writingStyle": "full new writing style content or null if unchanged",
+  "rules": "full new rules content or null if unchanged"
+}
+
+Remember: You are writing the COMPLETE page, not just additions. Preserve what matters, remove what doesn't.`;
 
   const providerResult = await createAIProvider(userId, {
     selectedProvider: BACKGROUND_HEAVY_PROVIDER,
@@ -184,28 +163,48 @@ ${current.rules || '(empty)'}
     loggers.api.error('Memory integration: provider error', {
       error: providerResult.error,
     });
-    return {
-      bio: { action: 'skip', reason: 'Provider error' },
-      writingStyle: { action: 'skip', reason: 'Provider error' },
-      rules: { action: 'skip', reason: 'Provider error' },
-    };
+    return {};
   }
 
   try {
+    // Build candidates text
+    const candidatesByField = Object.entries(byField)
+      .filter(([_, list]) => list.length > 0)
+      .map(([field, list]) => {
+        const items = list
+          .map(
+            (c) =>
+              `- ${c.claim} (seen ${c.occurrences} times, first: ${new Date(c.firstSeenAt).toLocaleDateString()})`
+          )
+          .join('\n');
+        return `NEW ${field.toUpperCase()} INSIGHTS:\n${items}`;
+      })
+      .join('\n\n');
+
+    const currentProfileText = `
+CURRENT BIO:
+${current.bio || '(empty)'}
+
+CURRENT WRITING STYLE:
+${current.writingStyle || '(empty)'}
+
+CURRENT RULES:
+${current.rules || '(empty)'}
+`;
+
     const result = await generateText({
       model: providerResult.model,
       system: EVALUATOR_SYSTEM_PROMPT,
       messages: [
         {
           role: 'user',
-          content: `Evaluate these discovered insights against the current profile and decide what to integrate.
+          content: `Evaluate these newly-learned insights against the current profile and produce updated page content where appropriate.
 
 ${currentProfileText}
 
-DISCOVERED INSIGHTS:
-${insightsText}
+${candidatesByField}
 
-Remember: Only approve genuinely new, significant insights. Return JSON with decisions for each field.`,
+Return JSON with the full new content for each field that should change. Use null for unchanged fields.`,
         },
       ],
       temperature: 0.2,
@@ -231,103 +230,109 @@ Remember: Only approve genuinely new, significant insights. Return JSON with dec
     const jsonStr = jsonMatch ? jsonMatch[1] : text;
 
     try {
-      const decision = JSON.parse(jsonStr) as IntegrationDecision;
+      const parsed = JSON.parse(jsonStr);
+      const updates: Partial<Record<MemoryField, string>> = {};
 
-      if (
-        typeof decision.bio?.action !== 'string' ||
-        typeof decision.writingStyle?.action !== 'string' ||
-        typeof decision.rules?.action !== 'string'
-      ) {
-        throw new Error('Invalid decision structure');
+      for (const field of ['bio', 'writingStyle', 'rules'] as const) {
+        if (parsed[field] && typeof parsed[field] === 'string') {
+          updates[field] = parsed[field];
+        }
       }
 
-      loggers.api.info('Memory integration decision', {
-        userId,
-        bioAction: decision.bio.action,
-        writingStyleAction: decision.writingStyle.action,
-        rulesAction: decision.rules.action,
-      });
-
-      return decision;
+      return updates;
     } catch {
       loggers.api.warn('Memory integration: failed to parse decision', {
         userId,
         response: text.substring(0, 500),
       });
-      return {
-        bio: { action: 'skip', reason: 'Parse error' },
-        writingStyle: { action: 'skip', reason: 'Parse error' },
-        rules: { action: 'skip', reason: 'Parse error' },
-      };
+      return {};
     }
   } catch (error) {
     loggers.api.error('Memory integration: generation error', { userId, error });
-    return {
-      bio: { action: 'skip', reason: 'Generation error' },
-      writingStyle: { action: 'skip', reason: 'Generation error' },
-      rules: { action: 'skip', reason: 'Generation error' },
-    };
+    return {};
   }
 }
 
 /**
- * Apply integration decisions to update personalization
+ * Apply integration decisions with guards.
+ *
+ * 1. 40% deletion guard: reject if more than 40% of existing content deleted
+ * 2. Per-field budget guard: reject if exceeds max length
  */
 export async function applyIntegrationDecisions(
   userId: string,
-  decisions: IntegrationDecision,
-  currentPersonalization: UserPersonalizationData | null
-): Promise<{ updated: boolean; fields: string[] }> {
-  const current = currentPersonalization ?? {
-    bio: '',
-    writingStyle: '',
-    rules: '',
-    enabled: true,
-  };
+  updates: Partial<Record<MemoryField, string>>,
+  currentPages: Partial<Record<MemoryField, string>>
+): Promise<{
+  updated: boolean;
+  fields: MemoryField[];
+  /** Fields a guard refused to write, with why. Structured so callers can act on the field. */
+  rejected: { field: MemoryField; reason: string }[];
+}> {
+  const updatedFields: MemoryField[] = [];
+  const rejected: { field: MemoryField; reason: string }[] = [];
 
-  const updates: Partial<Pick<UserPersonalizationData, 'bio' | 'writingStyle' | 'rules'>> = {};
-  const updatedFields: string[] = [];
+  for (const [field, newContent] of Object.entries(updates) as [MemoryField, string][]) {
+    const verdict = screenRewrite(field, currentPages[field] ?? '', newContent);
 
-  if (decisions.bio.action === 'append' && decisions.bio.content) {
-    const newContent = decisions.bio.content.trim();
-    if (newContent) {
-      updates.bio = current.bio
-        ? `${current.bio}\n\n${newContent}`
-        : newContent;
-      updatedFields.push('bio');
+    if (!verdict.ok) {
+      rejected.push({ field, reason: verdict.reason });
+      loggers.api.warn('Memory integration: rewrite rejected', {
+        userId,
+        field,
+        reason: verdict.reason,
+        currentLength: (currentPages[field] ?? '').length,
+        newLength: newContent.length,
+      });
+      continue;
     }
-  }
 
-  if (decisions.writingStyle.action === 'append' && decisions.writingStyle.content) {
-    const newContent = decisions.writingStyle.content.trim();
-    if (newContent) {
-      updates.writingStyle = current.writingStyle
-        ? `${current.writingStyle}\n\n${newContent}`
-        : newContent;
-      updatedFields.push('writingStyle');
-    }
-  }
-
-  if (decisions.rules.action === 'append' && decisions.rules.content) {
-    const newContent = decisions.rules.content.trim();
-    if (newContent) {
-      updates.rules = current.rules
-        ? `${current.rules}\n\n${newContent}`
-        : newContent;
-      updatedFields.push('rules');
-    }
-  }
-
-  if (updatedFields.length > 0) {
-    await updatePersonalization(userId, updates);
-    loggers.api.info('Memory integration: personalization updated', {
-      userId,
-      fields: updatedFields,
-    });
+    await updatePersonalizationPage(userId, field, newContent);
+    updatedFields.push(field);
   }
 
   return {
     updated: updatedFields.length > 0,
     fields: updatedFields,
+    rejected,
   };
+}
+
+/** Fraction of a page the evaluator may drop in a single run. */
+const MAX_DELETION_RATIO = 0.4;
+
+export type RewriteVerdict = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Decide whether a proposed whole-page rewrite may be written.
+ *
+ * Whole-page rewrite is what lets memory correct and forget rather than only
+ * accumulate — but it also means one bad generation can wipe a page the user
+ * hand-wrote. These two guards bound that blast radius deterministically,
+ * without asking a model to police itself.
+ *
+ * The shrink check is deliberately a LENGTH heuristic, not a diff: it catches
+ * the failure that actually happens (the model returns a summary, or a fragment,
+ * instead of the full page) and does not pretend to catch a same-length rewrite
+ * that replaces meaning. Compaction is the sanctioned way to shrink a page, and
+ * it writes through `updatePersonalizationPage` directly rather than here.
+ */
+export function screenRewrite(
+  field: MemoryField,
+  current: string,
+  next: string
+): RewriteVerdict {
+  if (current.length > 0 && next.length < current.length * (1 - MAX_DELETION_RATIO)) {
+    return {
+      ok: false,
+      reason: `would delete >${Math.round(MAX_DELETION_RATIO * 100)}% of existing content`,
+    };
+  }
+
+  const maxLength = MAX_FIELD_LENGTHS[field];
+  if (next.length > maxLength) {
+    return { ok: false, reason: `exceeds ${maxLength} char limit` };
+  }
+
+  return { ok: true };
 }

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -1,12 +1,25 @@
 /**
  * Memory Integration Service
  *
- * Evaluates promoted candidates against the user's current personalization pages
- * and applies updates via whole-field rewrite (not append).
+ * Evaluates corroborated candidates against the user's current memory pages and
+ * applies the result as a whole-page rewrite rather than an append. Rewrite is
+ * what lets the profile correct and forget instead of only growing — and also
+ * what makes a bad generation able to destroy a page the user wrote by hand,
+ * hence the guards.
  *
- * Includes two deterministic guards to prevent destructive rewrites:
- * 1. 40% deletion guard — rejects any rewrite that deletes more than 40% of existing content
- * 2. Per-field budget guard — rejects rewrites exceeding the size limit
+ * Three things bound that risk, all deterministic — none asks a model to police
+ * itself:
+ *
+ * 1. Deletion guard — refuses a rewrite that drops more than 40% of the page.
+ * 2. Budget guard — refuses one over the field's ceiling (see `budgets.ts`).
+ * 3. Optimistic concurrency — the write goes through `applyPageMutation` with
+ *    the revision read moments earlier, so a user editing their own page mid-run
+ *    wins and the candidates stay pending.
+ *
+ * The evaluator reports WHICH candidates it used, and a page write reports
+ * whether a row actually changed, because the caller settles candidates on what
+ * landed. Reporting a write that never happened would retire the claims behind
+ * it permanently.
  */
 
 import { and, eq } from '@pagespace/db/operators';
@@ -64,8 +77,11 @@ const POINTER_COLUMN = {
  *    the user's own page is visible in history rather than appearing from
  *    nowhere.
  *
- * A missing pointer, or a pointer to a trashed page, is a no-op: the user
- * deleted that page and the cron does not resurrect it.
+ * A missing pointer, or a pointer to a trashed page, is a no-op rather than a
+ * reason to recreate anything. Memory pages are protected from deletion (see
+ * `isProtectedMemoryPage`), so this should not be reachable — it is the
+ * defence-in-depth branch for a page that predates the guard, or one removed by
+ * a path that bypasses it.
  */
 export async function updatePersonalizationPage(
   userId: string,

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -19,6 +19,10 @@ import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { readMemoryPages } from '@pagespace/lib/memory/memory-pages';
+import {
+  applyPageMutation,
+  PageRevisionMismatchError,
+} from '@/services/api/page-mutation-service';
 
 export type MemoryField = 'bio' | 'writingStyle' | 'rules';
 
@@ -51,6 +55,20 @@ const POINTER_COLUMN = {
 /**
  * Overwrite a single memory page with new content.
  *
+ * Routed through `applyPageMutation` rather than writing `pages.content`
+ * directly, for three reasons:
+ *
+ *  - **A user can be editing the page while the cron runs.** Passing
+ *    `expectedRevision` makes the write fail rather than silently discard an
+ *    edit made between our read and our write. Losing what someone typed into
+ *    their own memory page is worse than skipping a nightly update, so a
+ *    mismatch is treated as "not written" and the candidates stay pending.
+ *  - It keeps `revision`/`stateHash` coherent, which every other writer and
+ *    the realtime layer depend on.
+ *  - It records page-version and activity entries, so a background rewrite of
+ *    the user's own page is visible in history rather than appearing from
+ *    nowhere.
+ *
  * A missing pointer, or a pointer to a trashed page, is a no-op: the user
  * deleted that page and the cron does not resurrect it.
  */
@@ -74,22 +92,49 @@ export async function updatePersonalizationPage(
     return { written: false, reason: 'no page pointer (backfill has not run for this user)' };
   }
 
-  const updated = await db
-    .update(pages)
-    .set({
-      content: newContent,
-      updatedAt: new Date(),
-    })
-    .where(and(eq(pages.id, pageId), eq(pages.isTrashed, false)))
-    .returning({ id: pages.id });
+  // Read the revision we are writing against, and confirm the page is still live.
+  const [page] = await db
+    .select({ revision: pages.revision, isTrashed: pages.isTrashed })
+    .from(pages)
+    .where(eq(pages.id, pageId))
+    .limit(1);
 
-  if (updated.length === 0) {
+  if (!page || page.isTrashed) {
     loggers.api.warn('Memory integration: page pointer is stale or trashed', {
       userId,
       field,
       pageId,
     });
     return { written: false, reason: 'page is trashed or no longer exists' };
+  }
+
+  try {
+    await applyPageMutation({
+      pageId,
+      operation: 'update',
+      updates: { content: newContent },
+      updatedFields: ['content'],
+      expectedRevision: page.revision,
+      context: {
+        userId,
+        isAiGenerated: true,
+        changeGroupType: 'automation',
+        metadata: { source: 'memory-cron', memoryField: field },
+      },
+    });
+  } catch (error) {
+    if (error instanceof PageRevisionMismatchError) {
+      // The user edited the page while this run was deciding. Their edit wins;
+      // the candidates stay pending and the next run re-evaluates against what
+      // they actually wrote.
+      loggers.api.info('Memory integration: page changed mid-run, deferring to the user edit', {
+        userId,
+        field,
+        pageId,
+      });
+      return { written: false, reason: 'page was edited during this run' };
+    }
+    throw error;
   }
 
   return { written: true };

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -11,7 +11,7 @@
 
 import { and, eq } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
-import { pages } from '@pagespace/db/schema/core';
+import { pages, drives } from '@pagespace/db/schema/core';
 import { userPersonalization, personalizationCandidates } from '@pagespace/db/schema/personalization';
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
@@ -92,15 +92,31 @@ export async function updatePersonalizationPage(
     return { written: false, reason: 'no page pointer (backfill has not run for this user)' };
   }
 
-  // Read the revision we are writing against, and confirm the page is still live.
+  // Read the revision we are writing against, and confirm the page is still
+  // live AND still inside this user's own Home drive.
+  //
+  // The drive join is defence in depth rather than a fix for a reachable bug:
+  // the pointer is only ever set server-side by `provisionMemoryPages`. But
+  // this function will happily write whatever page id that column names, and
+  // `readMemoryPages` already scopes its reads by drive — leaving the WRITE
+  // unscoped is the kind of asymmetry that turns a future bug (a bad backfill,
+  // a page moved between drives) into writing one person's profile into
+  // someone else's page.
   const [page] = await db
     .select({ revision: pages.revision, isTrashed: pages.isTrashed })
     .from(pages)
-    .where(eq(pages.id, pageId))
+    .innerJoin(drives, eq(drives.id, pages.driveId))
+    .where(
+      and(
+        eq(pages.id, pageId),
+        eq(drives.ownerId, userId),
+        eq(drives.kind, 'HOME'),
+      )
+    )
     .limit(1);
 
   if (!page || page.isTrashed) {
-    loggers.api.warn('Memory integration: page pointer is stale or trashed', {
+    loggers.api.warn('Memory integration: page pointer is stale, trashed, or out of scope', {
       userId,
       field,
       pageId,

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -24,14 +24,9 @@ import {
   PageRevisionMismatchError,
 } from '@/services/api/page-mutation-service';
 
-export type MemoryField = 'bio' | 'writingStyle' | 'rules';
+import { MAX_FIELD_LENGTH, type MemoryField } from './budgets';
 
-// Injection budgets — enforced at read time in personalization-utils
-const MAX_FIELD_LENGTHS: Record<MemoryField, number> = {
-  bio: 3000,
-  writingStyle: 2500,
-  rules: 2500,
-};
+export type { MemoryField };
 
 /**
  * Fetch the current personalization page content for a user.
@@ -484,7 +479,7 @@ export function screenRewrite(
     };
   }
 
-  const maxLength = MAX_FIELD_LENGTHS[field];
+  const maxLength = MAX_FIELD_LENGTH[field];
   if (next.length > maxLength) {
     return { ok: false, reason: `exceeds ${maxLength} char limit` };
   }

--- a/apps/web/src/lib/onboarding/__tests__/home-drive.test.ts
+++ b/apps/web/src/lib/onboarding/__tests__/home-drive.test.ts
@@ -41,12 +41,25 @@ vi.mock('@pagespace/lib/commands/starter-skill-installer', () => ({
   installStarterSkills: vi.fn().mockResolvedValue({ installed: [], skipped: [], alreadyInstalled: false }),
 }));
 
+// Same treatment, same reason: memory-page provisioning has its own behaviour
+// and its own coverage. Here we only care that provisioning calls it, so the
+// real implementation is not driven against this file's transaction stub.
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({
+  provisionMemoryPages: vi.fn().mockResolvedValue({
+    folderId: 'memory-folder',
+    bioPageId: 'bio-page',
+    writingStylePageId: 'style-page',
+    rulesPageId: 'rules-page',
+  }),
+}));
+
 import { db } from '@pagespace/db/db';
 import { sql } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';
 import { HOME_DRIVE_NAME, resolveUniqueSlug } from '@pagespace/lib/services/drive-guards';
 import { populateUserDrive } from '@/lib/onboarding/drive-setup';
 import { installStarterSkills } from '@pagespace/lib/commands/starter-skill-installer';
+import { provisionMemoryPages } from '@pagespace/lib/memory/memory-pages';
 import {
   provisionHomeDriveIfNeeded,
   type ProvisionHomeDriveResult,
@@ -210,6 +223,30 @@ describe('provisionHomeDriveIfNeeded', () => {
     // Passed the SAME tx, so a failed install rolls the whole Home back rather
     // than leaving a drive with half its starter content.
     expect(installStarterSkills).toHaveBeenCalledWith('user-new', 'drive-new', tx);
+  });
+
+  test('given new user, memory pages are provisioned into the new Home drive', async () => {
+    const tx = makeTx();
+    vi.mocked(populateUserDrive).mockResolvedValue(undefined);
+    vi.mocked(db.transaction).mockImplementation((async (cb: (t: typeof tx) => unknown) => cb(tx)) as never);
+
+    await provisionHomeDriveIfNeeded('user-new');
+
+    // Same tx as the drive insert, for the same reason as starter skills: a Home
+    // drive that exists without its memory pages leaves the personalization cron
+    // with nowhere to write, and the settings screen with nothing to link to.
+    expect(provisionMemoryPages).toHaveBeenCalledWith('user-new', 'drive-new', tx);
+  });
+
+  test('given an existing user reached lazily, memory pages are still provisioned', async () => {
+    const tx = makeTx();
+    vi.mocked(db.transaction).mockImplementation((async (cb: (t: typeof tx) => unknown) => cb(tx)) as never);
+
+    await provisionHomeDriveIfNeeded('user-existing');
+
+    // Both branches, like starter skills. An account that predates the feature
+    // reaches Home through the lazy path and must not be left without pages.
+    expect(provisionMemoryPages).toHaveBeenCalledWith('user-existing', 'drive-new', tx);
   });
 
   test('given slug "home" taken, resolveUniqueSlug result is used as the drive slug', async () => {

--- a/apps/web/src/lib/onboarding/__tests__/home-drive.test.ts
+++ b/apps/web/src/lib/onboarding/__tests__/home-drive.test.ts
@@ -239,10 +239,17 @@ describe('provisionHomeDriveIfNeeded', () => {
   });
 
   test('given an existing user reached lazily, memory pages are still provisioned', async () => {
-    const tx = makeTx();
+    // Owning a non-HOME drive is what puts production on the LAZY branch.
+    // Calling makeTx() bare would report zero owned drives and quietly re-test
+    // the new-user path instead.
+    const tx = makeTx([{ id: 'other-drive-1', kind: 'STANDARD', slug: 'my-drive' }]);
     vi.mocked(db.transaction).mockImplementation((async (cb: (t: typeof tx) => unknown) => cb(tx)) as never);
 
-    await provisionHomeDriveIfNeeded('user-existing');
+    const result: ProvisionHomeDriveResult = await provisionHomeDriveIfNeeded('user-existing');
+
+    // `created: false` is what proves the lazy branch ran: the new-user branch
+    // returns true after seeding tutorial content.
+    expect(result.created).toBe(false);
 
     // Both branches, like starter skills. An account that predates the feature
     // reaches Home through the lazy path and must not be left without pages.

--- a/apps/web/src/lib/onboarding/home-drive.ts
+++ b/apps/web/src/lib/onboarding/home-drive.ts
@@ -7,6 +7,7 @@ import { HOME_DRIVE_NAME, resolveUniqueSlug } from '@pagespace/lib/services/driv
 import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service'
 import { populateUserDrive } from '@/lib/onboarding/drive-setup'
 import { installStarterSkills } from '@pagespace/lib/commands/starter-skill-installer'
+import { provisionMemoryPages } from '@pagespace/lib/memory/memory-pages'
 
 type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -71,6 +72,10 @@ export async function provisionHomeDriveIfNeeded(
     // reaching Home lazily should get them too — and this adds content without
     // flipping `created`, so their post-login returnUrl is still not hijacked.
     await installStarterSkills(userId, newDrive.id, tx);
+
+    // Memory pages install on BOTH branches. They hold the user's personalization
+    // profile as editable markdown documents — About You, Communication, Rules.
+    await provisionMemoryPages(userId, newDrive.id, tx);
 
     if (isExistingUser) {
       return { driveId: newDrive.id, created: false };

--- a/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-cross-drive-move-service.test.ts
@@ -12,6 +12,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // ── Mocks (before imports) ──────────────────────────────────────────────
 
+// Real refusal string kept, so a reworded constant cannot pass silently.
+vi.mock('@pagespace/lib/memory/memory-pages', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/memory/memory-pages')>();
+  return { ...actual, findProtectedMemoryPages: vi.fn().mockResolvedValue(new Set<string>()) };
+});
+
 vi.mock('@pagespace/lib/pages/circular-reference-guard', () => ({
   validatePageMove: vi.fn().mockResolvedValue({ valid: true }),
 }));
@@ -87,6 +93,10 @@ vi.mock('@pagespace/db/schema/core', () => ({
 
 import { movePagesToDrive, MAX_SUBTREE_DEPTH } from '../page-cross-drive-move-service';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import {
+  findProtectedMemoryPages,
+  MEMORY_PAGE_MOVE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 import { logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { scrubDriveScopedTaskAssociations } from '@/services/api/task-sync-service';
 // @ts-expect-error - accessing test-only export
@@ -143,6 +153,7 @@ function setupSuccessScenario() {
   vi.mocked(db.query.pages.findMany).mockResolvedValue([sourcePage()] as never);
   vi.mocked(db.query.pages.findFirst).mockResolvedValue({ position: 5 } as never);
   vi.mocked(validatePageMove).mockResolvedValue({ valid: true });
+  vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set<string>());
 
   const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
   txUpdateSet.mockReturnValue({ where: txUpdateWhere });
@@ -167,6 +178,55 @@ describe('movePagesToDrive', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupSuccessScenario();
+  });
+
+  // ── Memory page protection ────────────────────────────────────────────
+
+  describe('memory page protection', () => {
+    it('refuses to move a memory page to another drive', async () => {
+      // This service is the ONLY cross-drive move path, shared by
+      // /api/pages/bulk-move and the AI move_page tool. pageService.updatePage's
+      // guard never runs here, so without this the REST route could relocate a
+      // memory page out of the Home drive its pointers assume.
+      vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set(['page-1']));
+
+      const result = await run();
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected refusal');
+      expect(result.code).toBe('MEMORY_PAGE_PROTECTED');
+      expect(result.status).toBe(403);
+      expect(result.message).toBe(MEMORY_PAGE_MOVE_ERROR);
+
+      // Refused before the write, not rolled back after one.
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('refuses the whole batch when only one page is protected', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        sourcePage({ id: 'page-1' }),
+        sourcePage({ id: 'memory-bio' }),
+      ] as never);
+      vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set(['memory-bio']));
+
+      const result = await run({ pageIds: ['page-1', 'memory-bio'] });
+
+      expect(result.success).toBe(false);
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('checks permission before revealing that a page is a memory page', async () => {
+      // A caller who cannot edit the source page must not learn what it holds.
+      vi.mocked(findProtectedMemoryPages).mockResolvedValue(new Set(['page-1']));
+      const authorize = makeAuthorizer({ canEditPage: vi.fn().mockResolvedValue(false) });
+
+      const result = await run({}, authorize);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected refusal');
+      expect(result.code).toBe('SOURCE_PAGE_FORBIDDEN');
+      expect(findProtectedMemoryPages).not.toHaveBeenCalled();
+    });
   });
 
   // ── Authorizer contract ───────────────────────────────────────────────

--- a/apps/web/src/services/api/page-cross-drive-move-service.ts
+++ b/apps/web/src/services/api/page-cross-drive-move-service.ts
@@ -25,6 +25,10 @@ import { db } from '@pagespace/db/db';
 import { and, eq, inArray, desc, isNull } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
+import {
+  findProtectedMemoryPages,
+  MEMORY_PAGE_MOVE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
 import { syncTaskItemOnMove, scrubDriveScopedTaskAssociations } from '@/services/api/task-sync-service';
@@ -88,6 +92,7 @@ export type CrossDriveMoveFailureCode =
   | 'SOURCE_DRIVE_OUT_OF_SCOPE'
   | 'SOURCE_PAGE_FORBIDDEN'
   | 'CIRCULAR_REFERENCE'
+  | 'MEMORY_PAGE_PROTECTED'
   | 'SUBTREE_TOO_DEEP';
 
 export interface MovedPageSummary {
@@ -251,6 +256,18 @@ export async function movePagesToDrive(
         `You do not have permission to move page: ${page.title}`,
       );
     }
+  }
+
+  // Memory pages are addressed by pointer and assumed to live in the user's Home
+  // drive; moving one to another drive breaks that and puts the user's profile
+  // inside a drive they may later delete. Guarded HERE rather than at each
+  // caller because this service is the only cross-drive move path, shared by
+  // /api/pages/bulk-move and the AI move_page tool — pageService.updatePage's
+  // guard never sees either. After the permission loops above, so a caller who
+  // cannot move the page is not told what it is.
+  const protectedIds = await findProtectedMemoryPages(pageIds);
+  if (protectedIds.size > 0) {
+    return fail('MEMORY_PAGE_PROTECTED', 403, MEMORY_PAGE_MOVE_ERROR);
   }
 
   if (targetParentId) {

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -25,6 +25,7 @@ import { ensureTaskItemForPage, ensureTaskListForPage } from './task-sync-servic
 import {
   isProtectedMemoryPage,
   MEMORY_PAGE_DELETE_ERROR,
+  MEMORY_PAGE_MOVE_ERROR,
 } from '@pagespace/lib/memory/memory-pages';
 
 /**
@@ -303,6 +304,12 @@ async function recursivelyTrash(
   const children = await tx.select({ id: pages.id }).from(pages).where(eq(pages.parentId, pageId));
 
   for (const child of children) {
+    // `parentId` is user-editable, so a memory page can be moved under an
+    // ordinary page and would otherwise be swept up by that page's cascade —
+    // deleting a profile as a side effect of deleting something else. The
+    // top-level guard in `trashPage` only sees the page it was asked about.
+    if (await isProtectedMemoryPage(child.id)) continue;
+
     const childTriggers = await recursivelyTrash(child.id, tx, context);
     triggers.push(...childTriggers);
   }
@@ -490,6 +497,14 @@ export const pageService = {
 
     // Validate parent change
     if (updates.parentId !== undefined) {
+      // Memory pages stay in their Memory folder. Moving one out is how it ends
+      // up under an ordinary page and inside that page's delete cascade, and it
+      // also breaks the folder link the settings screen offers. Editing the
+      // CONTENT is untouched — only relocation is refused.
+      if (await isProtectedMemoryPage(pageId)) {
+        return { success: false, error: MEMORY_PAGE_MOVE_ERROR, status: 403 };
+      }
+
       const validation = await validatePageMove(pageId, updates.parentId);
       if (!validation.valid) {
         return { success: false, error: validation.error || 'Invalid parent', status: 400 };

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -22,6 +22,10 @@ import { logActivityWithTx, type DeferredWorkflowTrigger } from '@pagespace/lib/
 import { createId } from '@paralleldrive/cuid2';
 import { applyPageMutation, PageRevisionMismatchError, type PageMutationContext } from './page-mutation-service';
 import { ensureTaskItemForPage, ensureTaskListForPage } from './task-sync-service';
+import {
+  isProtectedMemoryPage,
+  MEMORY_PAGE_DELETE_ERROR,
+} from '@pagespace/lib/memory/memory-pages';
 
 /**
  * Helper to convert DB page result to PageData type
@@ -589,6 +593,14 @@ export const pageService = {
     const canDelete = await authorizeDelete(pageId);
     if (!canDelete) {
       return { success: false, error: 'You need delete permission to remove this page', status: 403 };
+    }
+
+    // Memory pages are structural, like the Home drive: the cron writes to them
+    // by pointer and the settings screen links to them, so deleting one leaves
+    // a profile with nowhere to live. Emptying the page is the way to erase the
+    // content; the personalization toggle is the way to stop it being used.
+    if (await isProtectedMemoryPage(pageId)) {
+      return { success: false, error: MEMORY_PAGE_DELETE_ERROR, status: 403 };
     }
 
     // Get page info before trashing

--- a/bun.lock
+++ b/bun.lock
@@ -169,6 +169,49 @@
         "typescript-eslint": "^8.59.0",
       },
     },
+    "apps/dev": {
+      "name": "dev",
+      "version": "0.1.0",
+      "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.14",
+        "@radix-ui/react-checkbox": "^1.3.2",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.7",
+        "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-switch": "^1.2.5",
+        "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-tooltip": "^1.2.8",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.525.0",
+        "motion": "^12.23.22",
+        "next": "16.2.10",
+        "next-themes": "^0.4.6",
+        "react": "^19.1.2",
+        "react-dom": "^19.1.2",
+        "react-resizable-panels": "^4.6.4",
+        "sonner": "^2.0.6",
+        "tailwind-merge": "^3.3.1",
+        "zustand": "^5.0.6",
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3",
+        "@tailwindcss/postcss": "^4",
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "eslint-config-next": "16.2.10",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4",
+        "tw-animate-css": "^1.3.5",
+        "typescript": "^5",
+      },
+    },
     "apps/e2e": {
       "name": "@pagespace/e2e",
       "devDependencies": {
@@ -2221,7 +2264,7 @@
 
     "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.18", "", { "bin": "dist/cli.js" }, "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
@@ -2576,6 +2619,8 @@
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dev": ["dev@workspace:apps/dev"],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -3006,6 +3051,10 @@
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "hono": ["hono@4.12.21", "", {}, "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ=="],
 
@@ -4611,6 +4660,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
     "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
@@ -4905,6 +4956,8 @@
 
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.18", "", { "bin": "dist/cli.js" }, "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA=="],
+
     "builder-util/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -4942,6 +4995,12 @@
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "desktop/@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
+
+    "dev/@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
+
+    "dev/eslint-config-next": ["eslint-config-next@16.2.10", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.10", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w=="],
+
+    "dev/next": ["next@16.2.10", "", { "dependencies": { "@next/env": "16.2.10", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.10", "@next/swc-darwin-x64": "16.2.10", "@next/swc-linux-arm64-gnu": "16.2.10", "@next/swc-linux-arm64-musl": "16.2.10", "@next/swc-linux-x64-gnu": "16.2.10", "@next/swc-linux-x64-musl": "16.2.10", "@next/swc-win32-arm64-msvc": "16.2.10", "@next/swc-win32-x64-msvc": "16.2.10", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA=="],
 
     "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -5613,6 +5672,36 @@
 
     "desktop/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "dev/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "dev/eslint-config-next/@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.10", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q=="],
+
+    "dev/eslint-config-next/eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
+
+    "dev/eslint-config-next/globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
+
+    "dev/next/@next/env": ["@next/env@16.2.10", "", {}, "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA=="],
+
+    "dev/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA=="],
+
+    "dev/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ=="],
+
+    "dev/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg=="],
+
+    "dev/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A=="],
+
+    "dev/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA=="],
+
+    "dev/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw=="],
+
+    "dev/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA=="],
+
+    "dev/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.10", "", { "os": "win32", "cpu": "x64" }, "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A=="],
+
+    "dev/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "dev/next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "electron-store/conf/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -6133,6 +6222,52 @@
 
     "control-plane/eslint/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
+    "dev/eslint-config-next/@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
+
+    "dev/eslint-config-next/eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "dev/next/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "dev/next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "dev/next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "dev/next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "dev/next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "dev/next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "dev/next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "dev/next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "dev/next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "dev/next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "dev/next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "dev/next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "dev/next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "dev/next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "dev/next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "dev/next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "dev/next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "dev/next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "dev/next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "dev/next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "dev/next/sharp/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
     "electron-store/conf/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -6262,6 +6397,12 @@
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "control-plane/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "dev/eslint-config-next/@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "dev/eslint-config-next/eslint-plugin-react-hooks/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "dev/next/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "html-to-vdom/htmlparser2/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -169,49 +169,6 @@
         "typescript-eslint": "^8.59.0",
       },
     },
-    "apps/dev": {
-      "name": "dev",
-      "version": "0.1.0",
-      "dependencies": {
-        "@radix-ui/react-alert-dialog": "^1.1.14",
-        "@radix-ui/react-checkbox": "^1.3.2",
-        "@radix-ui/react-dialog": "^1.1.15",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-label": "^2.1.7",
-        "@radix-ui/react-scroll-area": "^1.2.10",
-        "@radix-ui/react-select": "^2.2.6",
-        "@radix-ui/react-separator": "^1.1.7",
-        "@radix-ui/react-slot": "^1.2.3",
-        "@radix-ui/react-switch": "^1.2.5",
-        "@radix-ui/react-tabs": "^1.1.12",
-        "@radix-ui/react-tooltip": "^1.2.8",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "lucide-react": "^0.525.0",
-        "motion": "^12.23.22",
-        "next": "16.2.10",
-        "next-themes": "^0.4.6",
-        "react": "^19.1.2",
-        "react-dom": "^19.1.2",
-        "react-resizable-panels": "^4.6.4",
-        "sonner": "^2.0.6",
-        "tailwind-merge": "^3.3.1",
-        "zustand": "^5.0.6",
-      },
-      "devDependencies": {
-        "@eslint/eslintrc": "^3",
-        "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
-        "eslint": "^9",
-        "eslint-config-next": "16.2.10",
-        "postcss": "^8.5.6",
-        "tailwindcss": "^4",
-        "tw-animate-css": "^1.3.5",
-        "typescript": "^5",
-      },
-    },
     "apps/e2e": {
       "name": "@pagespace/e2e",
       "devDependencies": {
@@ -2264,7 +2221,7 @@
 
     "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.18", "", { "bin": "dist/cli.js" }, "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
@@ -2619,8 +2576,6 @@
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
-
-    "dev": ["dev@workspace:apps/dev"],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -3051,10 +3006,6 @@
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
-
-    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
-
-    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "hono": ["hono@4.12.21", "", {}, "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ=="],
 
@@ -4660,8 +4611,6 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
-    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
-
     "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
@@ -4956,8 +4905,6 @@
 
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.18", "", { "bin": "dist/cli.js" }, "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA=="],
-
     "builder-util/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -4995,12 +4942,6 @@
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "desktop/@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
-
-    "dev/@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
-
-    "dev/eslint-config-next": ["eslint-config-next@16.2.10", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.10", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w=="],
-
-    "dev/next": ["next@16.2.10", "", { "dependencies": { "@next/env": "16.2.10", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.10", "@next/swc-darwin-x64": "16.2.10", "@next/swc-linux-arm64-gnu": "16.2.10", "@next/swc-linux-arm64-musl": "16.2.10", "@next/swc-linux-x64-gnu": "16.2.10", "@next/swc-linux-x64-musl": "16.2.10", "@next/swc-win32-arm64-msvc": "16.2.10", "@next/swc-win32-x64-msvc": "16.2.10", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA=="],
 
     "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -5672,36 +5613,6 @@
 
     "desktop/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "dev/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "dev/eslint-config-next/@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.10", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q=="],
-
-    "dev/eslint-config-next/eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
-
-    "dev/eslint-config-next/globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
-
-    "dev/next/@next/env": ["@next/env@16.2.10", "", {}, "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA=="],
-
-    "dev/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA=="],
-
-    "dev/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ=="],
-
-    "dev/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg=="],
-
-    "dev/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A=="],
-
-    "dev/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA=="],
-
-    "dev/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw=="],
-
-    "dev/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA=="],
-
-    "dev/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.10", "", { "os": "win32", "cpu": "x64" }, "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A=="],
-
-    "dev/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "dev/next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
-
     "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "electron-store/conf/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -6222,52 +6133,6 @@
 
     "control-plane/eslint/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
-    "dev/eslint-config-next/@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
-
-    "dev/eslint-config-next/eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
-
-    "dev/next/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
-
-    "dev/next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "dev/next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "dev/next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "dev/next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "dev/next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "dev/next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "dev/next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
-
-    "dev/next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "dev/next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "dev/next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "dev/next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "dev/next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "dev/next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
-
-    "dev/next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "dev/next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "dev/next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "dev/next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
-
-    "dev/next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
-
-    "dev/next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
-
-    "dev/next/sharp/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
-
     "electron-store/conf/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -6397,12 +6262,6 @@
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "control-plane/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "dev/eslint-config-next/@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "dev/eslint-config-next/eslint-plugin-react-hooks/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "dev/next/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "html-to-vdom/htmlparser2/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 

--- a/deltest.tmp.ts
+++ b/deltest.tmp.ts
@@ -1,0 +1,5 @@
+import { getUserPersonalization } from './apps/web/src/lib/ai/core/personalization-utils';
+
+const r = await getUserPersonalization('du');
+console.log('RESULT:', JSON.stringify(r));
+console.log('injects legacy content?', JSON.stringify(r ?? {}).includes('SHOULD NOT COME BACK'));

--- a/deltest.tmp.ts
+++ b/deltest.tmp.ts
@@ -1,5 +1,0 @@
-import { getUserPersonalization } from './apps/web/src/lib/ai/core/personalization-utils';
-
-const r = await getUserPersonalization('du');
-console.log('RESULT:', JSON.stringify(r));
-console.log('injects legacy content?', JSON.stringify(r ?? {}).includes('SHOULD NOT COME BACK'));

--- a/packages/db/drizzle/0257_absurd_grim_reaper.sql
+++ b/packages/db/drizzle/0257_absurd_grim_reaper.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "personalization_candidates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"field" text NOT NULL,
+	"claim" text NOT NULL,
+	"claimKey" text NOT NULL,
+	"evidence" text NOT NULL,
+	"occurrences" integer DEFAULT 1 NOT NULL,
+	"firstSeenAt" timestamp DEFAULT now() NOT NULL,
+	"lastSeenAt" timestamp DEFAULT now() NOT NULL,
+	"promotedAt" timestamp,
+	"rejectedAt" timestamp,
+	CONSTRAINT "personalization_candidates_field_chk" CHECK ("personalization_candidates"."field" IN ('bio', 'writingStyle', 'rules'))
+);
+--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD COLUMN "memoryFolderId" text;--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD COLUMN "bioPageId" text;--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD COLUMN "writingStylePageId" text;--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD COLUMN "rulesPageId" text;--> statement-breakpoint
+ALTER TABLE "personalization_candidates" ADD CONSTRAINT "personalization_candidates_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "personalization_candidates_user_field_claim_idx" ON "personalization_candidates" USING btree ("userId","field","claimKey");--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD CONSTRAINT "user_personalization_memoryFolderId_pages_id_fk" FOREIGN KEY ("memoryFolderId") REFERENCES "public"."pages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD CONSTRAINT "user_personalization_bioPageId_pages_id_fk" FOREIGN KEY ("bioPageId") REFERENCES "public"."pages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD CONSTRAINT "user_personalization_writingStylePageId_pages_id_fk" FOREIGN KEY ("writingStylePageId") REFERENCES "public"."pages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_personalization" ADD CONSTRAINT "user_personalization_rulesPageId_pages_id_fk" FOREIGN KEY ("rulesPageId") REFERENCES "public"."pages"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/db/drizzle/meta/0257_snapshot.json
+++ b/packages/db/drizzle/meta/0257_snapshot.json
@@ -1,0 +1,21166 @@
+{
+  "id": "3c1b01bf-b1fa-4391-8513-293ab7b28fec",
+  "prevId": "753721c8-75bf-4489-aab8-c37af0631f33",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-5.6-luna'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starterSkillsInstalledAt": {
+          "name": "starterSkillsInstalledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorites_item_type_consistency_chk": {
+          "name": "favorites_item_type_consistency_chk",
+          "value": "((\"itemType\" = 'page' AND \"pageId\" IS NOT NULL AND \"driveId\" IS NULL) OR (\"itemType\" = 'drive' AND \"driveId\" IS NOT NULL AND \"pageId\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_tags": {
+      "name": "page_tags",
+      "schema": "",
+      "columns": {
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_tags_pageId_pages_id_fk": {
+          "name": "page_tags_pageId_pages_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_tags_tagId_tags_id_fk": {
+          "name": "page_tags_tagId_tags_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "page_tags_pageId_tagId_pk": {
+          "name": "page_tags_pageId_tagId_pk",
+          "columns": [
+            "pageId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "sandboxEnabled": {
+          "name": "sandboxEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planPageId": {
+          "name": "planPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_plan_page_id_idx": {
+          "name": "conversations_plan_page_id_idx",
+          "columns": [
+            {
+              "expression": "planPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_agent_page_id_idx": {
+          "name": "conversations_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_agentPageId_pages_id_fk": {
+          "name": "conversations_agentPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_planPageId_pages_id_fk": {
+          "name": "conversations_planPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "planPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_global_context_null_chk": {
+          "name": "conversations_global_context_null_chk",
+          "value": "\"conversations\".\"type\" <> 'global' OR \"conversations\".\"contextId\" IS NULL"
+        },
+        "conversations_page_context_present_chk": {
+          "name": "conversations_page_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'page' OR \"conversations\".\"contextId\" IS NOT NULL"
+        },
+        "conversations_drive_context_present_chk": {
+          "name": "conversations_drive_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'drive' OR \"conversations\".\"contextId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sourceAgentId_pages_id_fk": {
+          "name": "messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "activity_logs_content_size_limit": {
+          "name": "activity_logs_content_size_limit",
+          "value": "\"activity_logs\".\"contentSize\" IS NULL OR \"activity_logs\".\"contentSize\" <= 1048576"
+        },
+        "activity_logs_stream_pair": {
+          "name": "activity_logs_stream_pair",
+          "value": "(\"activity_logs\".\"streamId\" IS NULL) = (\"activity_logs\".\"streamSeq\" IS NULL)"
+        },
+        "activity_logs_change_group_pair": {
+          "name": "activity_logs_change_group_pair",
+          "value": "(\"activity_logs\".\"changeGroupId\" IS NULL) = (\"activity_logs\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "siem_delivery_cursors_delivered_cursor_pair": {
+          "name": "siem_delivery_cursors_delivered_cursor_pair",
+          "value": "(\"siem_delivery_cursors\".\"lastDeliveredId\" IS NULL) = (\"siem_delivery_cursors\".\"lastDeliveredAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drive_backups_change_group_pair": {
+          "name": "drive_backups_change_group_pair",
+          "value": "(\"drive_backups\".\"changeGroupId\" IS NULL) = (\"drive_backups\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "page_versions_change_group_pair": {
+          "name": "page_versions_change_group_pair",
+          "value": "(\"page_versions\".\"changeGroupId\" IS NULL) = (\"page_versions\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_user_expires_idx": {
+          "name": "pending_uploads_user_expires_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_userId_users_id_fk": {
+          "name": "pending_uploads_userId_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_assignees_has_assignee": {
+          "name": "task_assignees_has_assignee",
+          "value": "(\"userId\" IS NOT NULL OR \"agentPageId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_scope_chk": {
+          "name": "integration_connections_scope_chk",
+          "value": "(\"integration_connections\".\"user_id\" IS NOT NULL AND \"integration_connections\".\"drive_id\" IS NULL) OR (\"integration_connections\".\"user_id\" IS NULL AND \"integration_connections\".\"drive_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personalization_candidates": {
+      "name": "personalization_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim": {
+          "name": "claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimKey": {
+          "name": "claimKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promotedAt": {
+          "name": "promotedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "personalization_candidates_user_field_claim_idx": {
+          "name": "personalization_candidates_user_field_claim_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personalization_candidates_userId_users_id_fk": {
+          "name": "personalization_candidates_userId_users_id_fk",
+          "tableFrom": "personalization_candidates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personalization_candidates_field_chk": {
+          "name": "personalization_candidates_field_chk",
+          "value": "\"personalization_candidates\".\"field\" IN ('bio', 'writingStyle', 'rules')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryFolderId": {
+          "name": "memoryFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bioPageId": {
+          "name": "bioPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStylePageId": {
+          "name": "writingStylePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulesPageId": {
+          "name": "rulesPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_personalization_memoryFolderId_pages_id_fk": {
+          "name": "user_personalization_memoryFolderId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "memoryFolderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_bioPageId_pages_id_fk": {
+          "name": "user_personalization_bioPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "bioPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_writingStylePageId_pages_id_fk": {
+          "name": "user_personalization_writingStylePageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "writingStylePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_rulesPageId_pages_id_fk": {
+          "name": "user_personalization_rulesPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "rulesPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_steps": {
+      "name": "workflow_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolName": {
+          "name": "toolName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStepStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_steps_run_position_idx": {
+          "name": "workflow_run_steps_run_position_idx",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_steps_runId_workflow_runs_id_fk": {
+          "name": "workflow_run_steps_runId_workflow_runs_id_fk",
+          "tableFrom": "workflow_run_steps",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_pending_abort_intents": {
+      "name": "ai_pending_abort_intents",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ai_pending_abort_intents_conversation_id_user_id_pk": {
+          "name": "ai_pending_abort_intents_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "raw_parts_count": {
+          "name": "raw_parts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_user_status_idx": {
+          "name": "ai_stream_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_sessions_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageWebhookId": {
+          "name": "pageWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_id_idx": {
+          "name": "webhook_triggers_page_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_workflow_unique": {
+          "name": "webhook_triggers_page_webhook_workflow_unique",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_triggers\".\"pageWebhookId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_pageWebhookId_page_webhooks_id_fk": {
+          "name": "webhook_triggers_pageWebhookId_page_webhooks_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "page_webhooks",
+          "columnsFrom": [
+            "pageWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_triggers_anchor_chk": {
+          "name": "webhook_triggers_anchor_chk",
+          "value": "(\"webhook_triggers\".\"connectionId\" IS NOT NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NULL) OR (\"webhook_triggers\".\"connectionId\" IS NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_bridge_enabled": {
+          "name": "theme_bridge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_balances_monthly_remaining_nonneg": {
+          "name": "credit_balances_monthly_remaining_nonneg",
+          "value": "\"credit_balances\".\"monthlyRemainingCents\" >= 0"
+        },
+        "credit_balances_monthly_allowance_nonneg": {
+          "name": "credit_balances_monthly_allowance_nonneg",
+          "value": "\"credit_balances\".\"monthlyAllowanceCents\" >= 0"
+        },
+        "credit_balances_topup_remaining_nonneg": {
+          "name": "credit_balances_topup_remaining_nonneg",
+          "value": "\"credit_balances\".\"topupRemainingCents\" >= 0"
+        },
+        "credit_balances_debt_cents_nonneg": {
+          "name": "credit_balances_debt_cents_nonneg",
+          "value": "\"credit_balances\".\"debtCents\" >= 0"
+        },
+        "credit_balances_pending_millicents_range": {
+          "name": "credit_balances_pending_millicents_range",
+          "value": "\"credit_balances\".\"pendingMillicents\" >= 0 AND \"credit_balances\".\"pendingMillicents\" < 1000"
+        },
+        "credit_balances_period_order": {
+          "name": "credit_balances_period_order",
+          "value": "\"credit_balances\".\"monthlyPeriodStart\" IS NULL OR \"credit_balances\".\"monthlyPeriodEnd\" IS NULL OR \"credit_balances\".\"monthlyPeriodStart\" <= \"credit_balances\".\"monthlyPeriodEnd\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_holds_est_cents_nonneg": {
+          "name": "credit_holds_est_cents_nonneg",
+          "value": "\"credit_holds\".\"estCents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "commands_scope_chk": {
+          "name": "commands_scope_chk",
+          "value": "(\"commands\".\"user_id\" IS NOT NULL AND \"commands\".\"drive_id\" IS NULL) OR (\"commands\".\"user_id\" IS NULL AND \"commands\".\"drive_id\" IS NOT NULL)"
+        },
+        "commands_type_chk": {
+          "name": "commands_type_chk",
+          "value": "\"commands\".\"type\" IN ('document', 'prompt_template', 'builtin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_compactions_source_chk": {
+          "name": "conversation_compactions_source_chk",
+          "value": "\"conversation_compactions\".\"source\" IN ('page', 'global')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machine_sprite_reclaims": {
+      "name": "machine_sprite_reclaims",
+      "schema": "",
+      "columns": {
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_sprite_reclaims_recorded_at_idx": {
+          "name": "machine_sprite_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_recipients": {
+      "name": "broadcast_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_recipient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_unique": {
+          "name": "broadcast_recipients_broadcast_user_unique",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "broadcast_recipients_broadcast_status_idx": {
+          "name": "broadcast_recipients_broadcast_status_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_recipients_broadcast_id_email_broadcasts_id_fk": {
+          "name": "broadcast_recipients_broadcast_id_email_broadcasts_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "email_broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcast_recipients_user_id_users_id_fk": {
+          "name": "broadcast_recipients_user_id_users_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_templates": {
+      "name": "broadcast_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_templates_active_idx": {
+          "name": "broadcast_templates_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_templates_created_by_user_id_users_id_fk": {
+          "name": "broadcast_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "broadcast_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_broadcasts": {
+      "name": "email_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "email_broadcast_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'transactional'"
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "email_broadcast_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRODUCT_UPDATE'"
+        },
+        "audience_definition": {
+          "name": "audience_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "send_limit": {
+          "name": "send_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "total_targeted": {
+          "name": "total_targeted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_broadcasts_status_idx": {
+          "name": "email_broadcasts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_at_idx": {
+          "name": "email_broadcasts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_by_idx": {
+          "name": "email_broadcasts_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_broadcasts_template_id_broadcast_templates_id_fk": {
+          "name": "email_broadcasts_template_id_broadcast_templates_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "broadcast_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_broadcasts_created_by_user_id_users_id_fk": {
+          "name": "email_broadcasts_created_by_user_id_users_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_webhooks": {
+      "name": "page_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookSecretEncrypted": {
+          "name": "webhookSecretEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_webhooks_page_id_idx": {
+          "name": "page_webhooks_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_webhooks_token_idx": {
+          "name": "page_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_webhooks_pageId_pages_id_fk": {
+          "name": "page_webhooks_pageId_pages_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_webhooks_createdBy_users_id_fk": {
+          "name": "page_webhooks_createdBy_users_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_webhooks_webhookToken_unique": {
+          "name": "page_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_shells": {
+      "name": "agent_workspace_shells",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteExecId": {
+          "name": "spriteExecId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTail": {
+          "name": "coldTail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailAt": {
+          "name": "coldTailAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailHasOutput": {
+          "name": "coldTailHasOutput",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_shells_workspace_id_idx": {
+          "name": "agent_workspace_shells_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_shells_workspace_name_idx": {
+          "name": "agent_workspace_shells_workspace_name_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_shells_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_shells_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_shells_ownerId_users_id_fk": {
+          "name": "agent_workspace_shells_ownerId_users_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspaces": {
+      "name": "agent_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspaces_drive_id_idx": {
+          "name": "agent_workspaces_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_owner_id_idx": {
+          "name": "agent_workspaces_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_live_sprite_idx": {
+          "name": "agent_workspaces_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_workspaces\".\"sandboxId\" IS NOT NULL AND \"agent_workspaces\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_driveId_drives_id_fk": {
+          "name": "agent_workspaces_driveId_drives_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_ownerId_users_id_fk": {
+          "name": "agent_workspaces_ownerId_users_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_node_revs": {
+      "name": "agent_workspace_node_revs",
+      "schema": "",
+      "columns": {
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_node_revs_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_node_revs_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_node_revs",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_nodes": {
+      "name": "agent_workspace_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "axis": {
+          "name": "axis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraction": {
+          "name": "fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_nodes_one_root_idx": {
+          "name": "agent_workspace_nodes_one_root_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"nodeType\" = 'root'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_chat_target_idx": {
+          "name": "agent_workspace_nodes_chat_target_idx",
+          "columns": [
+            {
+              "expression": "targetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"targetKind\" = 'chat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_parent_idx": {
+          "name": "agent_workspace_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_nodes_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_nodes_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk": {
+          "name": "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspace_nodes",
+          "columnsFrom": [
+            "rootId",
+            "parentId"
+          ],
+          "columnsTo": [
+            "rootId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_nodes_rootId_id_pk": {
+          "name": "agent_workspace_nodes_rootId_id_pk",
+          "columns": [
+            "rootId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspace_nodes_root_no_parent_chk": {
+          "name": "agent_workspace_nodes_root_no_parent_chk",
+          "value": "(\"agent_workspace_nodes\".\"nodeType\" = 'root') = (\"agent_workspace_nodes\".\"parentId\" IS NULL)"
+        },
+        "agent_workspace_nodes_node_type_chk": {
+          "name": "agent_workspace_nodes_node_type_chk",
+          "value": "\"agent_workspace_nodes\".\"nodeType\" IN ('root', 'split', 'pane')"
+        },
+        "agent_workspace_nodes_target_kind_chk": {
+          "name": "agent_workspace_nodes_target_kind_chk",
+          "value": "\"agent_workspace_nodes\".\"targetKind\" IS NULL OR \"agent_workspace_nodes\".\"targetKind\" IN ('chat', 'terminal', 'page')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED",
+        "PRODUCT_UPDATE"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.WorkflowRunStepStatus": {
+      "name": "WorkflowRunStepStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "skipped"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    },
+    "public.broadcast_recipient_status": {
+      "name": "broadcast_recipient_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_broadcast_content_mode": {
+      "name": "email_broadcast_content_mode",
+      "schema": "public",
+      "values": [
+        "compose",
+        "template"
+      ]
+    },
+    "public.email_broadcast_engine": {
+      "name": "email_broadcast_engine",
+      "schema": "public",
+      "values": [
+        "transactional",
+        "resend_broadcast"
+      ]
+    },
+    "public.email_broadcast_status": {
+      "name": "email_broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "queued",
+        "in_progress",
+        "paused",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1800,6 +1800,13 @@
       "when": 1786385327844,
       "tag": "0256_parched_bloodscream",
       "breakpoints": true
+    },
+    {
+      "idx": 257,
+      "version": "7",
+      "when": 1786401394664,
+      "tag": "0257_absurd_grim_reaper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/personalization.ts
+++ b/packages/db/src/schema/personalization.ts
@@ -16,6 +16,19 @@ export const userPersonalization = pgTable('user_personalization', {
   userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
 
   // Legacy content columns — kept for backfall compatibility
+  // LEGACY. Superseded by the page pointers below, and read ONLY while a field's
+  // pointer is still null — see `personalization-utils.getUserPersonalization`.
+  // `scripts/backfill-memory-pages.ts` copies each into its page and then nulls
+  // the column, so a row that has been backfilled holds nothing here.
+  //
+  // ⚠️ Dropping these three is a CONTRACT migration and carries the same hazard
+  // `infrastructure/UPGRADE.md` documents for 0255 → 0256: the backfill is what
+  // moves the content, and it can only run while the columns still exist. A
+  // deployment that jumps straight to the drop applies it to rows the backfill
+  // never reached, and their profiles are gone with nothing to recover from —
+  // silently, because the pointer-absent fallback simply reads empty. Ship the
+  // drop only behind a release that carries the backfill, and give it an
+  // UPGRADE.md entry saying so.
   bio: text('bio'),
   writingStyle: text('writingStyle'),
   rules: text('rules'),

--- a/packages/db/src/schema/personalization.ts
+++ b/packages/db/src/schema/personalization.ts
@@ -1,20 +1,30 @@
-import { pgTable, text, timestamp, boolean, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, boolean, uniqueIndex, integer } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { users } from './auth';
+import { pages } from './core';
 import { createId } from '@paralleldrive/cuid2';
 
 /**
  * User personalization settings for AI interactions.
- * These fields are injected into the AI system prompt when enabled.
+ *
+ * These now live as editable pages in the user's Home drive — this table stores
+ * the pointers to those pages. The legacy bio/writingStyle/rules columns are
+ * kept for backfill compatibility and will be dropped in a follow-up PR.
  */
 export const userPersonalization = pgTable('user_personalization', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
   userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
 
-  // Personalization content fields
-  bio: text('bio'), // User's background, role, expertise
-  writingStyle: text('writingStyle'), // Preferred communication style
-  rules: text('rules'), // Custom rules/instructions for AI
+  // Legacy content columns — kept for backfall compatibility
+  bio: text('bio'),
+  writingStyle: text('writingStyle'),
+  rules: text('rules'),
+
+  // Pointers to memory pages in the Home drive
+  memoryFolderId: text('memoryFolderId').references(() => pages.id, { onDelete: 'set null' }),
+  bioPageId: text('bioPageId').references(() => pages.id, { onDelete: 'set null' }),
+  writingStylePageId: text('writingStylePageId').references(() => pages.id, { onDelete: 'set null' }),
+  rulesPageId: text('rulesPageId').references(() => pages.id, { onDelete: 'set null' }),
 
   // Global toggle for AI personalization
   enabled: boolean('enabled').default(true).notNull(),
@@ -30,8 +40,65 @@ export const userPersonalizationRelations = relations(userPersonalization, ({ on
     fields: [userPersonalization.userId],
     references: [users.id],
   }),
+  memoryFolder: one(pages, {
+    fields: [userPersonalization.memoryFolderId],
+    references: [pages.id],
+  }),
+  bioPage: one(pages, {
+    fields: [userPersonalization.bioPageId],
+    references: [pages.id],
+  }),
+  writingStylePage: one(pages, {
+    fields: [userPersonalization.writingStylePageId],
+    references: [pages.id],
+  }),
+  rulesPage: one(pages, {
+    fields: [userPersonalization.rulesPageId],
+    references: [pages.id],
+  }),
 }));
 
 // Type exports for use in application code
 export type UserPersonalization = typeof userPersonalization.$inferSelect;
 export type NewUserPersonalization = typeof userPersonalization.$inferInsert;
+
+/**
+ * Staging table for memory insights awaiting corroboration.
+ *
+ * Insights from the discovery service are upserted here daily. A claim must be
+ * observed on at least 2 distinct UTC days (3 for bio) before promotion to the
+ * actual personalization pages. Claims not re-observed within 30 days are pruned.
+ *
+ * claimKey is a normalized (lowercased, punctuation-stripped, whitespace-collapsed)
+ * version of claim, used for deduplication via unique index.
+ */
+export const personalizationCandidates = pgTable('personalization_candidates', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+
+  field: text('field').notNull(), // 'bio' | 'writingStyle' | 'rules' — CHECK constraint in migration
+
+  claim: text('claim').notNull(),
+  claimKey: text('claimKey').notNull(), // normalized for dedupe
+  evidence: text('evidence').notNull(), // verbatim quote from user message
+
+  occurrences: integer('occurrences').default(1).notNull(),
+
+  firstSeenAt: timestamp('firstSeenAt', { mode: 'date' }).defaultNow().notNull(),
+  lastSeenAt: timestamp('lastSeenAt', { mode: 'date' }).defaultNow().notNull(),
+  promotedAt: timestamp('promotedAt', { mode: 'date' }),
+  rejectedAt: timestamp('rejectedAt', { mode: 'date' }),
+}, (table) => ({
+  userFieldClaimIdx: uniqueIndex('personalization_candidates_user_field_claim_idx')
+    .on(table.userId, table.field, table.claimKey),
+}));
+
+export const personalizationCandidatesRelations = relations(personalizationCandidates, ({ one }) => ({
+  user: one(users, {
+    fields: [personalizationCandidates.userId],
+    references: [users.id],
+  }),
+}));
+
+export type PersonalizationCandidate = typeof personalizationCandidates.$inferSelect;
+export type NewPersonalizationCandidate = typeof personalizationCandidates.$inferInsert;

--- a/packages/db/src/schema/personalization.ts
+++ b/packages/db/src/schema/personalization.ts
@@ -1,5 +1,5 @@
-import { pgTable, text, timestamp, boolean, uniqueIndex, integer } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
+import { pgTable, text, timestamp, boolean, uniqueIndex, integer, check } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
 import { users } from './auth';
 import { pages } from './core';
 import { createId } from '@paralleldrive/cuid2';
@@ -76,7 +76,7 @@ export const personalizationCandidates = pgTable('personalization_candidates', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
   userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
 
-  field: text('field').notNull(), // 'bio' | 'writingStyle' | 'rules' — CHECK constraint in migration
+  field: text('field').notNull(), // 'bio' | 'writingStyle' | 'rules' — see fieldValues check below
 
   claim: text('claim').notNull(),
   claimKey: text('claimKey').notNull(), // normalized for dedupe
@@ -91,6 +91,10 @@ export const personalizationCandidates = pgTable('personalization_candidates', {
 }, (table) => ({
   userFieldClaimIdx: uniqueIndex('personalization_candidates_user_field_claim_idx')
     .on(table.userId, table.field, table.claimKey),
+  fieldValues: check(
+    'personalization_candidates_field_chk',
+    sql`${table.field} IN ('bio', 'writingStyle', 'rules')`,
+  ),
 }));
 
 export const personalizationCandidatesRelations = relations(personalizationCandidates, ({ one }) => ({

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -162,6 +162,11 @@
       "import": "./dist/logging/ai-usage-purge.js",
       "require": "./dist/logging/ai-usage-purge.js"
     },
+    "./memory/memory-pages": {
+      "types": "./dist/memory/memory-pages.d.ts",
+      "import": "./dist/memory/memory-pages.js",
+      "require": "./dist/memory/memory-pages.js"
+    },
     "./observability/sentry-env": {
       "types": "./dist/observability/sentry-env.d.ts",
       "import": "./dist/observability/sentry-env.js",

--- a/packages/lib/src/compliance/export/export-format.test.ts
+++ b/packages/lib/src/compliance/export/export-format.test.ts
@@ -41,6 +41,7 @@ function makeData(overrides: Partial<AllUserData> = {}): AllUserData {
     displayPreferences: [],
     settings: { hotkeys: [], automation: null, toastNotifications: null, emailNotifications: [] },
     personalization: null,
+    personalizationCandidates: [],
     agentWorkspaces: [],
     streamState: [],
     ...overrides,

--- a/packages/lib/src/compliance/export/export-format.ts
+++ b/packages/lib/src/compliance/export/export-format.ts
@@ -79,6 +79,12 @@ export function buildNativeExportFiles(data: AllUserData): ExportFile[] {
     // checkpointed `parts` are content nothing else in this bundle carries.
     { name: 'agent-workspaces.json', description: 'Agent workspaces (working contexts) and the shells you opened in them', recordCount: data.agentWorkspaces.length, data: data.agentWorkspaces },
     { name: 'stream-state.json', description: 'Checkpointed AI generation state, including content from generations that were interrupted', recordCount: data.streamState.length, data: data.streamState },
+    // Inferences the memory cron drew about the subject, with the quotes of
+    // their own messages it kept as justification. Shipped unconditionally
+    // (unlike personalization.json below) so an empty file reads as "nothing
+    // was inferred about you" rather than leaving the subject unable to tell
+    // the difference between that and the category not being carried.
+    { name: 'personalization-candidates.json', description: 'Inferences the AI drew about you from your conversations, including ones that were rejected or are still pending, with the quotes they were drawn from', recordCount: data.personalizationCandidates.length, data: data.personalizationCandidates },
   ];
   if (data.personalization) {
     files.push({ name: 'personalization.json', description: 'Personalization settings', recordCount: 1, data: data.personalization });
@@ -188,6 +194,7 @@ export function toPortableExport(data: AllUserData): Record<string, unknown> {
       { '@type': 'PropertyValue', name: 'displayPreferences', value: data.displayPreferences },
       { '@type': 'PropertyValue', name: 'settings', value: data.settings },
       { '@type': 'PropertyValue', name: 'personalization', value: data.personalization },
+      { '@type': 'PropertyValue', name: 'personalizationCandidates', value: data.personalizationCandidates },
       { '@type': 'PropertyValue', name: 'agentWorkspaces', value: data.agentWorkspaces },
       { '@type': 'PropertyValue', name: 'streamState', value: data.streamState },
     ],

--- a/packages/lib/src/compliance/export/gdpr-export-coverage.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export-coverage.test.ts
@@ -76,6 +76,7 @@ const EMPTY: AllUserData = {
   displayPreferences: [],
   settings: { hotkeys: [], automation: null, toastNotifications: null, emailNotifications: [] },
   personalization: null,
+  personalizationCandidates: [],
   agentWorkspaces: [],
   streamState: [],
 };
@@ -158,6 +159,7 @@ describe('GDPR export table coverage', () => {
       settings: 'settings.json',
       // Omitted entirely when the user has none, so an empty bundle lacks it.
       personalization: null,
+      personalizationCandidates: 'personalization-candidates.json',
       agentWorkspaces: 'agent-workspaces.json',
       streamState: 'stream-state.json',
     };

--- a/packages/lib/src/compliance/export/gdpr-export-coverage.ts
+++ b/packages/lib/src/compliance/export/gdpr-export-coverage.ts
@@ -77,6 +77,12 @@ export const EXPORTED_TABLES: Readonly<Record<string, ExportCategory>> = {
   notifications: 'notifications',
   display_preferences: 'displayPreferences',
   user_personalization: 'personalization',
+  // Machine-authored inferences ABOUT the subject, plus verbatim quotes of
+  // their own messages kept as justification — derived personal data under
+  // Art 4(1). Exported including rejected and still-pending rows: "we inferred
+  // this about you and did not act on it" is exactly the processing a subject
+  // access request exists to disclose.
+  personalization_candidates: 'personalizationCandidates',
   // Art 15(3) is a right to a COPY, not to visibility. These were excluded on
   // the reasoning that the subject can read them in Settings — see the
   // `settings` collector for why that was not a basis (review finding).

--- a/packages/lib/src/compliance/export/gdpr-export.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.test.ts
@@ -787,6 +787,50 @@ describe('collectUserPersonalization', () => {
     expect(result!.rules).toBe('always use TypeScript');
   });
 
+  it('given_profileMigratedToPages_readsThePagesNotTheClearedColumns', async () => {
+    // After migration the columns are cleared — they are a fallback for users
+    // the backfill has not reached, not a second copy. Reading them alone would
+    // return three nulls and understate the profile of every migrated user.
+    const personalization = {
+      bio: null,
+      writingStyle: null,
+      rules: null,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      bioPageId: 'page-bio',
+      writingStylePageId: 'page-style',
+      rulesPageId: 'page-rules',
+    };
+    const memoryPages = [
+      { id: 'page-bio', content: 'bio from the page', isTrashed: false },
+      { id: 'page-style', content: 'style from the page', isTrashed: false },
+      // Trashed: the subject deleted it, so it reports as absent rather than
+      // disclosing content they removed.
+      { id: 'page-rules', content: 'rules the user deleted', isTrashed: true },
+    ];
+
+    let call = 0;
+    const db = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn(() => {
+        call += 1;
+        // First query ends in .limit(); the page lookup is awaited directly.
+        return call === 1
+          ? { limit: vi.fn().mockReturnValue([personalization]) }
+          : Promise.resolve(memoryPages);
+      }),
+    };
+
+    const result = await collectUserPersonalization(db as never, 'user-1');
+
+    expect(result!.bio).toBe('bio from the page');
+    expect(result!.writingStyle).toBe('style from the page');
+    expect(result!.rules).toBeNull();
+  });
+
   it('given_userHasNoPersonalization_returnsNull', async () => {
     const db = createLimitDb([]);
 

--- a/packages/lib/src/compliance/export/gdpr-export.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.test.ts
@@ -129,7 +129,10 @@ vi.mock('@pagespace/db/schema/tasks', () => ({
 vi.mock('@pagespace/db/schema/sessions', () => ({ sessions: mockTable('sessions') }));
 vi.mock('@pagespace/db/schema/notifications', () => ({ notifications: mockTable('notifications') }));
 vi.mock('@pagespace/db/schema/display-preferences', () => ({ displayPreferences: mockTable('displayPreferences') }));
-vi.mock('@pagespace/db/schema/personalization', () => ({ userPersonalization: mockTable('userPersonalization') }));
+vi.mock('@pagespace/db/schema/personalization', () => ({
+  userPersonalization: mockTable('userPersonalization'),
+  personalizationCandidates: mockTable('personalizationCandidates'),
+}));
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ _op: 'eq', col, val }),

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -15,7 +15,7 @@ import { taskLists, taskItems } from '@pagespace/db/schema/tasks';
 import { sessions } from '@pagespace/db/schema/sessions';
 import { notifications } from '@pagespace/db/schema/notifications';
 import { displayPreferences } from '@pagespace/db/schema/display-preferences';
-import { userPersonalization } from '@pagespace/db/schema/personalization';
+import { userPersonalization, personalizationCandidates } from '@pagespace/db/schema/personalization';
 import { userHotkeyPreferences } from '@pagespace/db/schema/hotkeys';
 import { userAutomationPreferences } from '@pagespace/db/schema/automation-preferences';
 import { userToastNotificationPreferences } from '@pagespace/db/schema/toast-notification-preferences';
@@ -226,6 +226,43 @@ export interface UserPersonalizationExport {
 }
 
 /**
+ * One INFERENCE the memory cron drew about the subject, and the words of theirs
+ * it drew it from.
+ *
+ * This is the most sensitive row shape in the personalization area and the one
+ * a subject is most likely to be surprised by, so it is exported in full rather
+ * than summarised. `claim` is a machine-authored assertion ABOUT the person —
+ * derived personal data under Art 4(1), which Art 15(1)(a)-(b) covers whether
+ * or not it was ever promoted into the profile — and `evidence` is a verbatim
+ * quote of their own message that the system retained as its justification.
+ *
+ * Candidates that were rejected, or that are still awaiting corroboration, are
+ * included deliberately. "We inferred this about you, and did not act on it"
+ * is precisely the processing a subject access request exists to disclose, and
+ * withholding it would disclose only the flattering half of the record.
+ *
+ * `claimKey` is omitted: it is a lowercased, punctuation-stripped derivative of
+ * `claim` that exists solely for deduplication, so it carries no information
+ * the subject cannot already read in `claim`.
+ */
+export interface UserPersonalizationCandidateExport {
+  /** Which profile page this claim was staged for. */
+  field: string;
+  /** The inference itself, as written by the model. */
+  claim: string;
+  /** The subject's own words that the system retained as support for the claim. */
+  evidence: string;
+  /** Distinct days the claim was re-observed on. */
+  occurrences: number;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  /** Set when the claim was written into the subject's profile. */
+  promotedAt: Date | null;
+  /** Set when the claim was evaluated and declined. */
+  rejectedAt: Date | null;
+}
+
+/**
  * One PTY the subject opened inside a workspace.
  *
  * `spriteExecId` is deliberately absent: it names an exec session on a VM in
@@ -356,6 +393,7 @@ export interface AllUserData {
   displayPreferences: UserDisplayPreferenceExport[];
   settings: UserSettingsExport;
   personalization: UserPersonalizationExport | null;
+  personalizationCandidates: UserPersonalizationCandidateExport[];
   agentWorkspaces: UserAgentWorkspaceExport[];
   streamState: UserStreamStateExport[];
 }
@@ -912,6 +950,39 @@ export async function collectUserPersonalization(database: DB, userId: string): 
 }
 
 /**
+ * Every inference the memory cron staged about the subject — promoted, declined
+ * and still-pending alike.
+ *
+ * Sorted oldest-first in memory rather than with `ORDER BY` so the query shape
+ * stays identical to every other collector here (select/from/where). The row
+ * count is bounded by what one user's discovery passes produce, so the sort is
+ * trivial, and matching the shared shape keeps this collector working with the
+ * same test harness as its neighbours.
+ */
+export async function collectUserPersonalizationCandidates(
+  database: DB,
+  userId: string,
+): Promise<UserPersonalizationCandidateExport[]> {
+  const rows = await database
+    .select({
+      field: personalizationCandidates.field,
+      claim: personalizationCandidates.claim,
+      evidence: personalizationCandidates.evidence,
+      occurrences: personalizationCandidates.occurrences,
+      firstSeenAt: personalizationCandidates.firstSeenAt,
+      lastSeenAt: personalizationCandidates.lastSeenAt,
+      promotedAt: personalizationCandidates.promotedAt,
+      rejectedAt: personalizationCandidates.rejectedAt,
+    })
+    .from(personalizationCandidates)
+    .where(eq(personalizationCandidates.userId, userId));
+
+  return [...rows].sort(
+    (a, b) => new Date(a.firstSeenAt).getTime() - new Date(b.firstSeenAt).getTime(),
+  );
+}
+
+/**
  * The subject's WORKING CONTEXTS and the shells inside them.
  *
  * ── Why this collector exists ────────────────────────────────────────────────
@@ -1103,7 +1174,7 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
   // Positional: this destructuring order must exactly match the Promise.all array
   // order below (each collector returns a differently-shaped array, so TypeScript
   // cannot catch a reorder/insert mismatch here).
-  const [userPages, userMessages, userFiles, activity, userSystemLogs, userApiMetrics, userErrorLogs, aiUsage, tasks, userSessions, userNotifications, userDisplayPreferences, userSettings, userPersonalizationData, userAgentWorkspaces, userStreamState] = await Promise.all([
+  const [userPages, userMessages, userFiles, activity, userSystemLogs, userApiMetrics, userErrorLogs, aiUsage, tasks, userSessions, userNotifications, userDisplayPreferences, userSettings, userPersonalizationData, userPersonalizationCandidates, userAgentWorkspaces, userStreamState] = await Promise.all([
     collectUserPages(database, userId, driveIds),
     collectUserMessages(database, userId),
     collectUserFiles(database, userId),
@@ -1118,6 +1189,7 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
     collectUserDisplayPreferences(database, userId),
     collectUserSettings(database, userId),
     collectUserPersonalization(database, userId),
+    collectUserPersonalizationCandidates(database, userId),
     collectUserAgentWorkspaces(database, userId),
     collectUserStreamState(database, userId),
   ]);
@@ -1139,6 +1211,7 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
     displayPreferences: userDisplayPreferences,
     settings: userSettings,
     personalization: userPersonalizationData,
+    personalizationCandidates: userPersonalizationCandidates,
     agentWorkspaces: userAgentWorkspaces,
     streamState: userStreamState,
   };

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -932,6 +932,22 @@ export async function collectUserSettings(database: DB, userId: string): Promise
   };
 }
 
+/**
+ * The subject's personalization profile.
+ *
+ * The content lives as pages in their Home drive; the bio/writingStyle/rules
+ * COLUMNS are only a fallback for users the backfill has not reached, and are
+ * cleared once a page holds the content. Reading the columns alone would
+ * therefore return three nulls for every migrated user and quietly understate
+ * the profile — so this resolves the page pointers and reads the pages, falling
+ * back to the column only where no pointer exists.
+ *
+ * The pages are ALSO carried in `pages.json` (they are ordinary pages in a
+ * drive the subject owns). That duplication is deliberate: this file is where a
+ * reader looks to answer "what does the AI know about me?", and a category that
+ * silently emptied itself after a migration is exactly the kind of omission the
+ * export coverage guard exists to prevent.
+ */
 export async function collectUserPersonalization(database: DB, userId: string): Promise<UserPersonalizationExport | null> {
   const result = await database
     .select({
@@ -941,12 +957,46 @@ export async function collectUserPersonalization(database: DB, userId: string): 
       enabled: userPersonalization.enabled,
       createdAt: userPersonalization.createdAt,
       updatedAt: userPersonalization.updatedAt,
+      bioPageId: userPersonalization.bioPageId,
+      writingStylePageId: userPersonalization.writingStylePageId,
+      rulesPageId: userPersonalization.rulesPageId,
     })
     .from(userPersonalization)
     .where(eq(userPersonalization.userId, userId))
     .limit(1);
 
-  return result[0] ?? null;
+  const row = result[0];
+  if (!row) return null;
+
+  const { bioPageId, writingStylePageId, rulesPageId, ...profile } = row;
+  // Truthiness, not `!== null`: a pointer can arrive undefined as well as null
+  // (an older row, or a projection that omits the column), and an undefined id
+  // would otherwise reach `inArray` as a phantom lookup.
+  const pageIds = [bioPageId, writingStylePageId, rulesPageId].filter(
+    (id): id is string => Boolean(id),
+  );
+
+  if (pageIds.length === 0) return profile;
+
+  const memoryPages = await database
+    .select({ id: pages.id, content: pages.content, isTrashed: pages.isTrashed })
+    .from(pages)
+    .where(inArray(pages.id, pageIds));
+
+  // A trashed page is content the subject deleted; report it as absent rather
+  // than disclosing what they removed.
+  const contentById = new Map(
+    memoryPages.filter((p) => !p.isTrashed).map((p) => [p.id, p.content ?? '']),
+  );
+
+  return {
+    ...profile,
+    bio: bioPageId ? (contentById.get(bioPageId) ?? null) : profile.bio,
+    writingStyle: writingStylePageId
+      ? (contentById.get(writingStylePageId) ?? null)
+      : profile.writingStyle,
+    rules: rulesPageId ? (contentById.get(rulesPageId) ?? null) : profile.rules,
+  };
 }
 
 /**

--- a/packages/lib/src/memory/__tests__/memory-page-protection.integration.test.ts
+++ b/packages/lib/src/memory/__tests__/memory-page-protection.integration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The memory-page deletion guard, against a REAL Postgres.
+ *
+ * ── Why this file exists ─────────────────────────────────────────────────────
+ * The unit tests beside it mock the database, so they never execute SQL. That
+ * is the same blind spot that let a 42883 (`integer >= unknown`) defect into
+ * the candidate query earlier in this branch — every mocked test passed while
+ * the real statement could not run at all.
+ *
+ * These two functions gate every delete path in the app. If their SQL fails,
+ * it fails *closed* in the worst way: `isProtectedMemoryPage` throws, the
+ * caller 500s, and the user cannot delete ANY page. So the queries are pinned
+ * here, where Postgres actually parses them.
+ *
+ * The bulk case matters most — it is the only one using `inArray`, whose
+ * parameter expansion is exactly what a mock cannot exercise.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { userPersonalization } from '@pagespace/db/schema/personalization';
+import { factories } from '@pagespace/db/test/factories';
+import { requireDb } from '@pagespace/db/test/require-db';
+import { createId } from '@paralleldrive/cuid2';
+import { isProtectedMemoryPage, findProtectedMemoryPages } from '../memory-pages';
+
+let dbAvailable = false;
+
+type Pointers = Awaited<ReturnType<typeof userWithMemoryPages>>;
+
+/** A user with a Home drive, four real pages, and pointers at all four. */
+async function userWithMemoryPages() {
+  const user = await factories.createUser();
+  const drive = await factories.createDrive(user.id);
+  const folder = await factories.createPage(drive.id, { title: 'Memory' });
+  const bio = await factories.createPage(drive.id, { title: 'About You' });
+  const style = await factories.createPage(drive.id, { title: 'Communication' });
+  const rules = await factories.createPage(drive.id, { title: 'Rules' });
+  const ordinary = await factories.createPage(drive.id, { title: 'Notes' });
+
+  await db.insert(userPersonalization).values({
+    id: createId(),
+    userId: user.id,
+    memoryFolderId: folder.id,
+    bioPageId: bio.id,
+    writingStylePageId: style.id,
+    rulesPageId: rules.id,
+  });
+
+  return { folder, bio, style, rules, ordinary };
+}
+
+describe('memory page protection (Postgres)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(userPersonalization).limit(1);
+      dbAvailable = true;
+    } catch (error) {
+      // Missing Postgres is an environment failure, not a reason to report a
+      // green zero-assertion pass. Only an explicit ALLOW_SKIP_DB_TESTS=1 gets
+      // past this.
+      requireDb('memory-page-protection.integration.test.ts', error);
+      dbAvailable = false;
+    }
+  });
+
+  it('protects every pointer column, and nothing else', async () => {
+    if (!dbAvailable) return;
+    const { folder, bio, style, rules, ordinary } = await userWithMemoryPages();
+
+    // All four pointers, because a guard that covered only the three pages
+    // would leave the folder deletable — taking its children with it.
+    expect(await isProtectedMemoryPage(folder.id)).toBe(true);
+    expect(await isProtectedMemoryPage(bio.id)).toBe(true);
+    expect(await isProtectedMemoryPage(style.id)).toBe(true);
+    expect(await isProtectedMemoryPage(rules.id)).toBe(true);
+
+    expect(await isProtectedMemoryPage(ordinary.id)).toBe(false);
+  });
+
+  it('does not match a row whose pointers are all NULL', async () => {
+    if (!dbAvailable) return;
+    // A user who has personalization but no pages yet. `col = $1` is never true
+    // for NULL, but an `OR` chain over four nullable columns is easy to get
+    // wrong in a way no mock would reveal.
+    const user = await factories.createUser();
+    const drive = await factories.createDrive(user.id);
+    const page = await factories.createPage(drive.id, { title: 'Notes' });
+    await db.insert(userPersonalization).values({ id: createId(), userId: user.id });
+
+    expect(await isProtectedMemoryPage(page.id)).toBe(false);
+  });
+
+  it('returns only the requested ids from a bulk lookup', async () => {
+    if (!dbAvailable) return;
+    const { folder, bio, style, ordinary } = await userWithMemoryPages();
+
+    const found = await findProtectedMemoryPages([bio.id, ordinary.id, folder.id]);
+
+    // `style` is a pointer but was not asked about, so it must not appear —
+    // the caller uses this set to name what it refused.
+    expect([...found].sort()).toEqual([bio.id, folder.id].sort());
+    expect(found.has(style.id)).toBe(false);
+  });
+
+  it.each([
+    ['folder', (p: Pointers) => p.folder.id],
+    ['bio', (p: Pointers) => p.bio.id],
+    ['writingStyle', (p: Pointers) => p.style.id],
+    ['rules', (p: Pointers) => p.rules.id],
+  ])('finds a %s page in a batch containing no other pointer', async (_label, pick) => {
+    if (!dbAvailable) return;
+    const pointers = await userWithMemoryPages();
+    const target = pick(pointers);
+
+    // Each pointer column needs its OWN term in the WHERE clause. A batch that
+    // also contains a sibling pointer would match the row through that sibling
+    // and then find this id while walking the row's columns in JS — so a
+    // missing term stays invisible until someone selects this page alone.
+    const found = await findProtectedMemoryPages([target, pointers.ordinary.id]);
+
+    expect([...found]).toEqual([target]);
+  });
+
+  it('survives a batch far larger than any hand-written fixture', async () => {
+    if (!dbAvailable) return;
+    const { bio } = await userWithMemoryPages();
+
+    // Bulk-delete is driven by a user's multi-select, so the id list is
+    // unbounded in practice. This is the parameter expansion a mocked
+    // `inArray` cannot check.
+    const ids = Array.from({ length: 300 }, () => createId()).concat([bio.id]);
+
+    expect([...(await findProtectedMemoryPages(ids))]).toEqual([bio.id]);
+  });
+
+  it('protects a page by pointer regardless of who is deleting it', async () => {
+    if (!dbAvailable) return;
+    // The guard is keyed on the page, not on the requesting user. A shared or
+    // admin-driven delete path must hit the same refusal, so the query must
+    // not be scoped to the caller.
+    const { bio } = await userWithMemoryPages();
+    await userWithMemoryPages(); // a second, unrelated user with their own pages
+
+    expect(await isProtectedMemoryPage(bio.id)).toBe(true);
+  });
+
+  it('stops protecting a page once the pointer is cleared', async () => {
+    if (!dbAvailable) return;
+    // The FK is ON DELETE SET NULL, so this is the state a hard-deleted page
+    // leaves behind. Protection must follow the pointer rather than the title,
+    // or an ordinary page later named "About You" would become undeletable.
+    const user = await factories.createUser();
+    const drive = await factories.createDrive(user.id);
+    const impostor = await factories.createPage(drive.id, { title: 'About You' });
+    await db.insert(userPersonalization).values({ id: createId(), userId: user.id });
+
+    expect(await isProtectedMemoryPage(impostor.id)).toBe(false);
+  });
+});

--- a/packages/lib/src/memory/__tests__/memory-page-protection.test.ts
+++ b/packages/lib/src/memory/__tests__/memory-page-protection.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Memory pages are structural, not ordinary documents.
+ *
+ * The cron writes to them by pointer, the settings screen links to them, and
+ * provisioning assumes they exist. A user who deletes one is left with a
+ * profile that has nowhere to live: the pointer nulls, settings shows a dead
+ * link, and the next nightly run silently writes nothing. So deletion is
+ * refused — emptying the page erases the content, and the personalization
+ * toggle stops it being used. Both are reversible; deletion is not.
+ *
+ * These tests pin the LOOKUP the three delete paths gate on.
+ */
+
+const rows: Record<string, unknown>[] = [];
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Object.assign(Promise.resolve(rows), {
+          limit: () => Promise.resolve(rows.slice(0, 1)),
+        }),
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+  isNull: vi.fn(),
+  or: vi.fn(),
+  sql: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: {} }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
+vi.mock('@pagespace/db/schema/personalization', () => ({
+  userPersonalization: {
+    id: 'id',
+    memoryFolderId: 'memoryFolderId',
+    bioPageId: 'bioPageId',
+    writingStylePageId: 'writingStylePageId',
+    rulesPageId: 'rulesPageId',
+  },
+}));
+vi.mock('../../services/drive-service', () => ({ getHomeDrive: vi.fn() }));
+
+describe('memory page deletion protection', () => {
+  beforeEach(() => {
+    rows.length = 0;
+  });
+
+  it('protects a page that a personalization pointer names', async () => {
+    rows.push({ id: 'personalization-row' });
+    const { isProtectedMemoryPage } = await import('../memory-pages');
+
+    expect(await isProtectedMemoryPage('bio-page-1')).toBe(true);
+  });
+
+  it('leaves ordinary pages deletable', async () => {
+    // No matching personalization row.
+    const { isProtectedMemoryPage } = await import('../memory-pages');
+
+    expect(await isProtectedMemoryPage('some-other-page')).toBe(false);
+  });
+
+  it('finds every protected id in a bulk request, and only those', async () => {
+    // The bulk path must refuse the WHOLE batch rather than deleting the rest
+    // around a memory page — a partial success is how someone loses their
+    // profile without noticing which item did it.
+    rows.push({
+      memoryFolderId: 'folder-1',
+      bioPageId: 'bio-1',
+      writingStylePageId: 'style-1',
+      rulesPageId: 'rules-1',
+    });
+    const { findProtectedMemoryPages } = await import('../memory-pages');
+
+    const result = await findProtectedMemoryPages(['bio-1', 'ordinary-1', 'folder-1']);
+
+    // 'style-1' and 'rules-1' are pointers but were not requested, so they must
+    // not appear — the caller uses this set to name what it refused.
+    expect([...result].sort()).toEqual(['bio-1', 'folder-1']);
+  });
+
+  it('does not query at all for an empty batch', async () => {
+    const { findProtectedMemoryPages } = await import('../memory-pages');
+
+    expect((await findProtectedMemoryPages([])).size).toBe(0);
+  });
+
+  it('tells the user what to do instead of deleting', async () => {
+    // The refusal has to point somewhere: a bare "cannot be deleted" leaves
+    // someone who wants the content gone with no next step.
+    const { MEMORY_PAGE_DELETE_ERROR } = await import('../memory-pages');
+
+    expect(MEMORY_PAGE_DELETE_ERROR).toMatch(/clear the page/i);
+    expect(MEMORY_PAGE_DELETE_ERROR).toMatch(/settings/i);
+  });
+});

--- a/packages/lib/src/memory/__tests__/memory-page-protection.test.ts
+++ b/packages/lib/src/memory/__tests__/memory-page-protection.test.ts
@@ -91,6 +91,19 @@ describe('memory page deletion protection', () => {
     expect((await findProtectedMemoryPages([])).size).toBe(0);
   });
 
+  it('refuses moves separately from deletes, and says content is still editable', async () => {
+    // `parentId` is user-editable, so a memory page could be moved under an
+    // ordinary page and swept up by THAT page's delete cascade — losing a
+    // profile as a side effect of deleting something unrelated. Refusing the
+    // move closes that route; the message has to make clear it is only the
+    // relocation being refused, not editing.
+    const { MEMORY_PAGE_MOVE_ERROR, MEMORY_PAGE_DELETE_ERROR } = await import('../memory-pages');
+
+    expect(MEMORY_PAGE_MOVE_ERROR).not.toBe(MEMORY_PAGE_DELETE_ERROR);
+    expect(MEMORY_PAGE_MOVE_ERROR).toMatch(/cannot be moved/i);
+    expect(MEMORY_PAGE_MOVE_ERROR).toMatch(/still edit/i);
+  });
+
   it('offers the toggle before the clear-the-page workaround', async () => {
     // Deletion is redundant rather than missing: the toggle already stops the
     // AI using memory entirely, and emptying a page removes its content. The

--- a/packages/lib/src/memory/__tests__/memory-page-protection.test.ts
+++ b/packages/lib/src/memory/__tests__/memory-page-protection.test.ts
@@ -91,12 +91,20 @@ describe('memory page deletion protection', () => {
     expect((await findProtectedMemoryPages([])).size).toBe(0);
   });
 
-  it('tells the user what to do instead of deleting', async () => {
-    // The refusal has to point somewhere: a bare "cannot be deleted" leaves
-    // someone who wants the content gone with no next step.
+  it('offers the toggle before the clear-the-page workaround', async () => {
+    // Deletion is redundant rather than missing: the toggle already stops the
+    // AI using memory entirely, and emptying a page removes its content. The
+    // refusal has to say so, strongest option first — a bare "cannot be
+    // deleted" leaves someone who wants it gone with no next step, and leading
+    // with "clear the page" offers the weaker remedy to someone whose actual
+    // intent was to switch the feature off.
     const { MEMORY_PAGE_DELETE_ERROR } = await import('../memory-pages');
 
-    expect(MEMORY_PAGE_DELETE_ERROR).toMatch(/clear the page/i);
-    expect(MEMORY_PAGE_DELETE_ERROR).toMatch(/settings/i);
+    const toggleAt = MEMORY_PAGE_DELETE_ERROR.search(/personalization off/i);
+    const clearAt = MEMORY_PAGE_DELETE_ERROR.search(/clear the page/i);
+
+    expect(toggleAt).toBeGreaterThan(-1);
+    expect(clearAt).toBeGreaterThan(-1);
+    expect(toggleAt).toBeLessThan(clearAt);
   });
 });

--- a/packages/lib/src/memory/memory-pages.ts
+++ b/packages/lib/src/memory/memory-pages.ts
@@ -35,9 +35,15 @@ const POINTER_COLUMN = {
   rules: 'rulesPageId',
 } as const;
 
-/** Refusal shown when someone tries to trash a memory page or its folder. */
+/**
+ * Refusal shown when someone tries to trash a memory page or its folder.
+ *
+ * Names both alternatives, strongest first: the toggle is the complete answer
+ * for "stop using this", and emptying the page is the answer for "remove this
+ * content". Between them there is nothing deletion would additionally achieve.
+ */
 export const MEMORY_PAGE_DELETE_ERROR =
-  'Memory pages hold what the AI knows about you and cannot be deleted. Clear the page instead, or turn personalization off in Settings.';
+  'Memory pages hold what the AI knows about you and cannot be deleted. To stop the AI using them, turn personalization off in Settings; to erase what one says, clear the page.';
 
 /**
  * Whether this page is one of the protected memory pages, or their folder.
@@ -48,10 +54,18 @@ export const MEMORY_PAGE_DELETE_ERROR =
  * pointer nulls, the settings screen shows a dead link, and the next run
  * silently writes nothing.
  *
- * Emptying a page remains the way to erase content, and the personalization
- * toggle remains the way to stop it being used. Both are reversible and neither
- * breaks the structure, which is why deletion is refused rather than made to
- * cascade into cleanup.
+ * ── Why refusing costs the user nothing ──────────────────────────────────────
+ * Deletion is a REDUNDANT path here, not a missing one. Everything someone
+ * could want from deleting a memory page is already available and reversible:
+ *
+ *   - "I don't want this content" → empty the page.
+ *   - "I don't want the AI using any of this" → turn personalization off in
+ *     Settings, which stops the whole feature reading or writing.
+ *
+ * Deletion adds no capability over those two; it only adds a broken state the
+ * rest of the system then has to tolerate. That is the reasoning behind this
+ * guard — please do not reintroduce deletion as a "missing feature" without
+ * first replacing what the toggle and the empty-page path already provide.
  */
 export async function isProtectedMemoryPage(pageId: string): Promise<boolean> {
   const [row] = await db

--- a/packages/lib/src/memory/memory-pages.ts
+++ b/packages/lib/src/memory/memory-pages.ts
@@ -46,6 +46,16 @@ export const MEMORY_PAGE_DELETE_ERROR =
   'Memory pages hold what the AI knows about you and cannot be deleted. To stop the AI using them, turn personalization off in Settings; to erase what one says, clear the page.';
 
 /**
+ * Refusal shown when someone tries to move a memory page out of its folder.
+ *
+ * Relocation is what puts a memory page inside some other page's delete
+ * cascade, and it breaks the folder link the settings screen offers. Only the
+ * MOVE is refused — the page's content stays fully editable.
+ */
+export const MEMORY_PAGE_MOVE_ERROR =
+  'Memory pages live in your Memory folder and cannot be moved. You can still edit what they say.';
+
+/**
  * Whether this page is one of the protected memory pages, or their folder.
  *
  * These are structural, like the Home drive itself: the cron writes to them by

--- a/packages/lib/src/memory/memory-pages.ts
+++ b/packages/lib/src/memory/memory-pages.ts
@@ -8,7 +8,7 @@
  * Pattern follows `packages/lib/src/commands/starter-skill-installer.ts`.
  */
 
-import { and, eq, inArray, isNull, sql } from '@pagespace/db/operators';
+import { and, eq, inArray, isNull, or, sql } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
@@ -34,6 +34,77 @@ const POINTER_COLUMN = {
   writingStyle: 'writingStylePageId',
   rules: 'rulesPageId',
 } as const;
+
+/** Refusal shown when someone tries to trash a memory page or its folder. */
+export const MEMORY_PAGE_DELETE_ERROR =
+  'Memory pages hold what the AI knows about you and cannot be deleted. Clear the page instead, or turn personalization off in Settings.';
+
+/**
+ * Whether this page is one of the protected memory pages, or their folder.
+ *
+ * These are structural, like the Home drive itself: the cron writes to them by
+ * pointer, the settings screen links to them, and provisioning assumes they
+ * exist. Deleting one leaves a user whose profile has nowhere to live — the
+ * pointer nulls, the settings screen shows a dead link, and the next run
+ * silently writes nothing.
+ *
+ * Emptying a page remains the way to erase content, and the personalization
+ * toggle remains the way to stop it being used. Both are reversible and neither
+ * breaks the structure, which is why deletion is refused rather than made to
+ * cascade into cleanup.
+ */
+export async function isProtectedMemoryPage(pageId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: userPersonalization.id })
+    .from(userPersonalization)
+    .where(
+      or(
+        eq(userPersonalization.memoryFolderId, pageId),
+        eq(userPersonalization.bioPageId, pageId),
+        eq(userPersonalization.writingStylePageId, pageId),
+        eq(userPersonalization.rulesPageId, pageId),
+      ),
+    )
+    .limit(1);
+
+  return Boolean(row);
+}
+
+/**
+ * The subset of `pageIds` that are protected memory pages.
+ *
+ * One query for the bulk-delete path, which would otherwise fan out to one
+ * round trip per page.
+ */
+export async function findProtectedMemoryPages(pageIds: string[]): Promise<Set<string>> {
+  if (pageIds.length === 0) return new Set();
+
+  const rows = await db
+    .select({
+      memoryFolderId: userPersonalization.memoryFolderId,
+      bioPageId: userPersonalization.bioPageId,
+      writingStylePageId: userPersonalization.writingStylePageId,
+      rulesPageId: userPersonalization.rulesPageId,
+    })
+    .from(userPersonalization)
+    .where(
+      or(
+        inArray(userPersonalization.memoryFolderId, pageIds),
+        inArray(userPersonalization.bioPageId, pageIds),
+        inArray(userPersonalization.writingStylePageId, pageIds),
+        inArray(userPersonalization.rulesPageId, pageIds),
+      ),
+    );
+
+  const requested = new Set(pageIds);
+  const protectedIds = new Set<string>();
+  for (const row of rows) {
+    for (const id of [row.memoryFolderId, row.bioPageId, row.writingStylePageId, row.rulesPageId]) {
+      if (id && requested.has(id)) protectedIds.add(id);
+    }
+  }
+  return protectedIds;
+}
 
 /**
  * An OPEN transaction. See `starter-skill-installer.ts` for why this is

--- a/packages/lib/src/memory/memory-pages.ts
+++ b/packages/lib/src/memory/memory-pages.ts
@@ -1,0 +1,301 @@
+/**
+ * Memory Pages Service
+ *
+ * The user's personalization profile lives as three editable markdown pages in
+ * a `Memory` folder in their Home drive, rather than as opaque DB text columns.
+ * This module owns locating, creating, and reading those pages.
+ *
+ * Pattern follows `packages/lib/src/commands/starter-skill-installer.ts`.
+ */
+
+import { and, eq, inArray, isNull, sql } from '@pagespace/db/operators';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { pages } from '@pagespace/db/schema/core';
+import { userPersonalization } from '@pagespace/db/schema/personalization';
+import { getHomeDrive } from '../services/drive-service';
+
+export const MEMORY_FOLDER_TITLE = 'Memory';
+
+export const MEMORY_PAGE_TITLES = {
+  bio: 'About You',
+  writingStyle: 'Communication',
+  rules: 'Rules',
+} as const;
+
+export type MemoryField = keyof typeof MEMORY_PAGE_TITLES;
+
+export const MEMORY_FIELDS: readonly MemoryField[] = ['bio', 'writingStyle', 'rules'];
+
+/** Column on `user_personalization` holding each field's page pointer. */
+const POINTER_COLUMN = {
+  bio: 'bioPageId',
+  writingStyle: 'writingStylePageId',
+  rules: 'rulesPageId',
+} as const;
+
+/**
+ * An OPEN transaction. See `starter-skill-installer.ts` for why this is
+ * required rather than defaulted to the bare connection: the `FOR UPDATE`
+ * below only serializes anything while a transaction is held.
+ */
+export type DbClient = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Find or create the root Memory folder in the Home drive.
+ *
+ * Distinct from the `Skills` folder the starter-skill installer creates:
+ * `Memory` holds personalization content, `Skills` holds skill definitions.
+ */
+export async function resolveMemoryFolder(
+  client: DbClient,
+  homeDriveId: string,
+): Promise<string> {
+  const [existing] = await client
+    .select({ id: pages.id })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.driveId, homeDriveId),
+        eq(pages.title, MEMORY_FOLDER_TITLE),
+        eq(pages.type, 'FOLDER'),
+        eq(pages.isTrashed, false),
+        isNull(pages.parentId),
+      ),
+    )
+    .limit(1);
+
+  if (existing) return existing.id;
+
+  const id = createId();
+  const now = new Date();
+  await client.insert(pages).values({
+    id,
+    title: MEMORY_FOLDER_TITLE,
+    type: 'FOLDER',
+    driveId: homeDriveId,
+    content: '',
+    isTrashed: false,
+    position: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return id;
+}
+
+/**
+ * Find or create a specific memory page within the Memory folder.
+ *
+ * Resolution order: the stored pointer (when that page is still alive) → a live
+ * page with the expected title in the folder → a newly created page.
+ *
+ * Callers own the stored pointer. This function never writes to
+ * `user_personalization`; it only reports which page id the field should point
+ * at, and `provisionMemoryPages` persists that.
+ */
+export async function resolveMemoryPage(
+  client: DbClient,
+  homeDriveId: string,
+  folderId: string,
+  field: MemoryField,
+  existingPageId: string | null,
+): Promise<string> {
+  if (existingPageId) {
+    const [existing] = await client
+      .select({ id: pages.id, isTrashed: pages.isTrashed })
+      .from(pages)
+      .where(eq(pages.id, existingPageId))
+      .limit(1);
+
+    if (existing && !existing.isTrashed) return existing.id;
+    // Otherwise the pointer is stale (hard-deleted or trashed) and falls
+    // through; the caller overwrites it with whatever we return below.
+  }
+
+  const title = MEMORY_PAGE_TITLES[field];
+  const [byTitle] = await client
+    .select({ id: pages.id })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.driveId, homeDriveId),
+        eq(pages.parentId, folderId),
+        eq(pages.title, title),
+        eq(pages.type, 'DOCUMENT'),
+        eq(pages.isTrashed, false),
+      ),
+    )
+    .limit(1);
+
+  if (byTitle) return byTitle.id;
+
+  const id = createId();
+  const now = new Date();
+  await client.insert(pages).values({
+    id,
+    title,
+    type: 'DOCUMENT',
+    driveId: homeDriveId,
+    parentId: folderId,
+    content: '',
+    contentMode: 'markdown',
+    isTrashed: false,
+    position: MEMORY_FIELDS.indexOf(field),
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return id;
+}
+
+/**
+ * Read the live memory pages for a user, keyed by field.
+ *
+ * A field is absent from the result when it has no pointer, or when the page it
+ * points at has been trashed or deleted — which reads downstream as "this field
+ * is empty", never as a reason to resurrect the page.
+ */
+export async function readMemoryPages(
+  userId: string,
+): Promise<Partial<Record<MemoryField, string>>> {
+  const [personalization, homeDrive] = await Promise.all([
+    db.query.userPersonalization.findFirst({
+      where: eq(userPersonalization.userId, userId),
+    }),
+    getHomeDrive(userId),
+  ]);
+
+  if (!personalization || !homeDrive) return {};
+
+  // Build the id→field map from live pointers only, so a null pointer can never
+  // become a "null" string key that a stray row could collide with.
+  const idToField = new Map<string, MemoryField>();
+  for (const field of MEMORY_FIELDS) {
+    const pageId = personalization[POINTER_COLUMN[field]];
+    if (pageId) idToField.set(pageId, field);
+  }
+
+  if (idToField.size === 0) return {};
+
+  const foundPages = await db
+    .select({ id: pages.id, content: pages.content })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.driveId, homeDrive.id),
+        inArray(pages.id, [...idToField.keys()]),
+        eq(pages.isTrashed, false),
+      ),
+    );
+
+  const result: Partial<Record<MemoryField, string>> = {};
+  for (const page of foundPages) {
+    const field = idToField.get(page.id);
+    if (field) result[field] = page.content ?? '';
+  }
+
+  return result;
+}
+
+/**
+ * Ensure the Memory folder and all three pages exist, and record their ids.
+ *
+ * Safe to call repeatedly: pages the user still has are reused, pages they
+ * deleted are recreated empty only because this is the provisioning path that
+ * is meant to guarantee the folder exists.
+ *
+ * `client` MUST be a transaction — the `FOR UPDATE` on the user row (the same
+ * row `installStarterSkills` locks) only serializes concurrent provisioning
+ * while one is held. Locking `users` rather than `user_personalization` matters:
+ * a first-time user has no `user_personalization` row yet, and `FOR UPDATE`
+ * over zero rows locks nothing at all.
+ */
+export async function provisionMemoryPages(
+  userId: string,
+  homeDriveId: string,
+  client: DbClient,
+): Promise<{
+  folderId: string;
+  bioPageId: string;
+  writingStylePageId: string;
+  rulesPageId: string;
+}> {
+  await client.execute(sql`SELECT 1 FROM ${users} WHERE ${users.id} = ${userId} FOR UPDATE`);
+
+  const [existing] = await client
+    .select({
+      memoryFolderId: userPersonalization.memoryFolderId,
+      bioPageId: userPersonalization.bioPageId,
+      writingStylePageId: userPersonalization.writingStylePageId,
+      rulesPageId: userPersonalization.rulesPageId,
+    })
+    .from(userPersonalization)
+    .where(eq(userPersonalization.userId, userId))
+    .limit(1);
+
+  const stored = existing ?? {
+    memoryFolderId: null,
+    bioPageId: null,
+    writingStylePageId: null,
+    rulesPageId: null,
+  };
+
+  // Re-resolve the folder rather than trusting the stored id blindly: a trashed
+  // folder would otherwise become the parent of three fresh, invisible pages.
+  const folderId = await resolveLiveFolder(client, homeDriveId, stored.memoryFolderId);
+
+  const bioPageId = await resolveMemoryPage(client, homeDriveId, folderId, 'bio', stored.bioPageId);
+  const writingStylePageId = await resolveMemoryPage(
+    client,
+    homeDriveId,
+    folderId,
+    'writingStyle',
+    stored.writingStylePageId,
+  );
+  const rulesPageId = await resolveMemoryPage(
+    client,
+    homeDriveId,
+    folderId,
+    'rules',
+    stored.rulesPageId,
+  );
+
+  const pointers = {
+    memoryFolderId: folderId,
+    bioPageId,
+    writingStylePageId,
+    rulesPageId,
+    updatedAt: new Date(),
+  };
+
+  await client
+    .insert(userPersonalization)
+    .values({ userId, ...pointers, enabled: true })
+    .onConflictDoUpdate({
+      target: userPersonalization.userId,
+      set: pointers,
+    });
+
+  return { folderId, bioPageId, writingStylePageId, rulesPageId };
+}
+
+/** Return the stored folder id when it still points at a live folder, else find-or-create. */
+async function resolveLiveFolder(
+  client: DbClient,
+  homeDriveId: string,
+  storedFolderId: string | null,
+): Promise<string> {
+  if (storedFolderId) {
+    const [folder] = await client
+      .select({ id: pages.id, isTrashed: pages.isTrashed })
+      .from(pages)
+      .where(eq(pages.id, storedFolderId))
+      .limit(1);
+
+    if (folder && !folder.isTrashed) return folder.id;
+  }
+
+  return resolveMemoryFolder(client, homeDriveId);
+}

--- a/scripts/__tests__/backfill-memory-pages.integration.test.ts
+++ b/scripts/__tests__/backfill-memory-pages.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * THE MEMORY BACKFILL, against a real Postgres.
+ *
+ * This script is a one-shot that runs over every existing user's profile, and
+ * it had no coverage at all — the only backfill in `scripts/` without a test.
+ * It is also the only one whose failure mode is a privacy leak rather than a
+ * missing row, so the two questions pinned hardest here are:
+ *
+ *   1. **Does a re-run clobber an edit?** Idempotence is claimed via a content
+ *      check (`WHERE content = ''`) rather than a stamp column, so the claim
+ *      lives entirely in that predicate.
+ *   2. **Is the legacy column actually retired?** `personalization-utils` stops
+ *      reading a column the moment its POINTER is set, so a column left behind
+ *      is unreachable — until a hard-delete nulls the pointer via
+ *      `ON DELETE SET NULL`, the fallback switches back on, and content the user
+ *      never saw is injected into every prompt again. Clearing only the fields
+ *      this run COPIED would leave exactly that behind for any field whose page
+ *      already had content.
+ *
+ * Requires DATABASE_URL → a Postgres with migrations applied, like every other
+ * DB-backed test in this directory.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createTestDb, runMigrations, truncateAll, closePool, type TestDb } from './setup';
+import { runBackfill } from '../backfill-memory-pages';
+
+let db: TestDb;
+
+const USER_ID = 'mem_bf_user_1';
+const DRIVE_ID = 'mem_bf_drive_1';
+
+beforeAll(async () => {
+  db = createTestDb();
+  await runMigrations(db);
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+beforeEach(async () => {
+  await truncateAll(db);
+});
+
+/** A user with a Home drive and a legacy profile in the three text columns. */
+async function seedLegacyProfile(
+  overrides: { bio?: string | null; writingStyle?: string | null; rules?: string | null } = {},
+) {
+  const { bio = 'Legacy bio', writingStyle = 'Legacy style', rules = 'Legacy rules' } = overrides;
+
+  await db.execute(sql`INSERT INTO users (id, email, name) VALUES (${USER_ID}, 'mem-bf@example.com', 'Mem BF')`);
+  await db.execute(
+    sql`INSERT INTO drives (id, name, slug, "ownerId", kind, "updatedAt")
+        VALUES (${DRIVE_ID}, 'Home', 'home-mem-bf', ${USER_ID}, 'HOME', now())`,
+  );
+  await db.execute(
+    sql`INSERT INTO user_personalization (id, "userId", bio, "writingStyle", rules, "updatedAt")
+        VALUES ('mem_bf_up_1', ${USER_ID}, ${bio}, ${writingStyle}, ${rules}, now())`,
+  );
+}
+
+async function readProfile() {
+  const { rows } = await db.execute(sql`
+    SELECT bio, "writingStyle", rules, "memoryFolderId", "bioPageId", "writingStylePageId", "rulesPageId"
+    FROM user_personalization WHERE "userId" = ${USER_ID}
+  `);
+  return rows[0] as Record<string, string | null>;
+}
+
+async function readPage(pageId: string | null) {
+  if (!pageId) return null;
+  const { rows } = await db.execute(
+    sql`SELECT title, content, "parentId" FROM pages WHERE id = ${pageId}`,
+  );
+  return (rows[0] ?? null) as { title: string; content: string; parentId: string | null } | null;
+}
+
+describe('backfill-memory-pages (Postgres)', () => {
+  it('copies each column into a correctly-titled page under the Memory folder', async () => {
+    await seedLegacyProfile();
+
+    const summary = await runBackfill();
+
+    expect(summary.migrated).toBe(1);
+    expect(summary.fieldsCopied).toBe(3);
+    expect(summary.failed).toBe(0);
+
+    const profile = await readProfile();
+    const bioPage = await readPage(profile.bioPageId);
+    const stylePage = await readPage(profile.writingStylePageId);
+    const rulesPage = await readPage(profile.rulesPageId);
+
+    expect(bioPage).toMatchObject({ title: 'About You', content: 'Legacy bio' });
+    expect(stylePage).toMatchObject({ title: 'Communication', content: 'Legacy style' });
+    expect(rulesPage).toMatchObject({ title: 'Rules', content: 'Legacy rules' });
+
+    // All three sit inside the Memory folder, which is what settings links to.
+    expect(bioPage!.parentId).toBe(profile.memoryFolderId);
+    expect(stylePage!.parentId).toBe(profile.memoryFolderId);
+    expect(rulesPage!.parentId).toBe(profile.memoryFolderId);
+  });
+
+  it('retires every legacy column once the pointers are set', async () => {
+    await seedLegacyProfile();
+
+    await runBackfill();
+
+    const profile = await readProfile();
+    expect(profile.bio).toBeNull();
+    expect(profile.writingStyle).toBeNull();
+    expect(profile.rules).toBeNull();
+  });
+
+  it('does not clobber an edit made since the last run', async () => {
+    await seedLegacyProfile();
+    await runBackfill();
+
+    const first = await readProfile();
+    await db.execute(
+      sql`UPDATE pages SET content = 'Hand-edited by the user' WHERE id = ${first.bioPageId}`,
+    );
+
+    const summary = await runBackfill();
+
+    // Nothing left to do: the row no longer matches the "missing pointer"
+    // predicate, so it is not even scanned.
+    expect(summary.scanned).toBe(0);
+    expect(await readPage(first.bioPageId)).toMatchObject({ content: 'Hand-edited by the user' });
+  });
+
+  it('retires the column of a field whose page already had content', async () => {
+    // The leak this guards: the reader ignores a column as soon as its pointer
+    // is set, so a column left populated here is invisible — until a hard-delete
+    // nulls the pointer and the fallback resurrects it. Clearing only the fields
+    // this run COPIED would leave precisely this case behind.
+    await seedLegacyProfile();
+
+    // Simulate a first run that provisioned pages, plus a hand edit to `bio`,
+    // while the legacy columns were somehow still populated.
+    await runBackfill();
+    const first = await readProfile();
+    await db.execute(
+      sql`UPDATE pages SET content = 'Written before the backfill' WHERE id = ${first.bioPageId}`,
+    );
+    await db.execute(
+      sql`UPDATE user_personalization
+          SET bio = 'stale column', "bioPageId" = NULL WHERE "userId" = ${USER_ID}`,
+    );
+
+    await runBackfill();
+
+    const profile = await readProfile();
+    // The page keeps what it had; the column does NOT survive.
+    expect(await readPage(profile.bioPageId)).toMatchObject({
+      content: 'Written before the backfill',
+    });
+    expect(profile.bio).toBeNull();
+  });
+
+  it('writes nothing on a dry run', async () => {
+    await seedLegacyProfile();
+
+    const summary = await runBackfill({ dryRun: true });
+
+    expect(summary.migrated).toBe(1);
+
+    const profile = await readProfile();
+    expect(profile.bio).toBe('Legacy bio');
+    expect(profile.memoryFolderId).toBeNull();
+    expect(profile.bioPageId).toBeNull();
+  });
+
+  it('provisions pages for an empty profile without inventing content', async () => {
+    // An untouched profile still needs its folder and pages, so the settings
+    // screen has somewhere to link and the cron has somewhere to write.
+    await seedLegacyProfile({ bio: null, writingStyle: null, rules: null });
+
+    const summary = await runBackfill();
+
+    expect(summary.emptyProfiles).toBe(1);
+    expect(summary.fieldsCopied).toBe(0);
+
+    const profile = await readProfile();
+    expect(profile.memoryFolderId).not.toBeNull();
+    expect(await readPage(profile.bioPageId)).toMatchObject({ title: 'About You', content: '' });
+  });
+
+  it('skips a user with no Home drive rather than failing the run', async () => {
+    // Nothing can be provisioned without a drive to provision into. The run must
+    // not abort — one such user would otherwise block every user after them.
+    await db.execute(sql`INSERT INTO users (id, email, name) VALUES ('mem_bf_nodrive', 'nd@example.com', 'ND')`);
+    await db.execute(
+      sql`INSERT INTO user_personalization (id, "userId", bio, "updatedAt")
+          VALUES ('mem_bf_up_2', 'mem_bf_nodrive', 'orphan bio', now())`,
+    );
+    await seedLegacyProfile();
+
+    const summary = await runBackfill();
+
+    expect(summary.failed).toBe(0);
+    expect(summary.migrated).toBe(1); // only the user who has a Home drive
+  });
+});

--- a/scripts/backfill-memory-pages.ts
+++ b/scripts/backfill-memory-pages.ts
@@ -160,6 +160,23 @@ export async function runBackfill({
             }
           }
 
+          // Retire the columns we successfully copied, in the SAME transaction.
+          //
+          // Once a page holds the content the column is not a second copy to
+          // keep in step — it is a fallback for users this backfill has not
+          // reached yet. Leaving it behind is a latent privacy leak: if the user
+          // later deletes the page, `purgeExpiredTrashedPages` hard-deletes it,
+          // `ON DELETE SET NULL` clears the pointer, and the pointer-absent
+          // fallback reads the column again — resurrecting the very content they
+          // deleted the page to remove.
+          if (written.length > 0) {
+            const cleared = Object.fromEntries(written.map((field) => [LEGACY_COLUMN[field], null]));
+            await tx
+              .update(userPersonalization)
+              .set({ ...cleared, updatedAt: new Date() })
+              .where(eq(userPersonalization.userId, row.userId));
+          }
+
           return written;
         });
 

--- a/scripts/backfill-memory-pages.ts
+++ b/scripts/backfill-memory-pages.ts
@@ -160,22 +160,27 @@ export async function runBackfill({
             }
           }
 
-          // Retire the columns we successfully copied, in the SAME transaction.
+          // Retire ALL THREE columns in the SAME transaction — not just the ones
+          // this run copied.
           //
-          // Once a page holds the content the column is not a second copy to
-          // keep in step — it is a fallback for users this backfill has not
-          // reached yet. Leaving it behind is a latent privacy leak: if the user
-          // later deletes the page, `purgeExpiredTrashedPages` hard-deletes it,
-          // `ON DELETE SET NULL` clears the pointer, and the pointer-absent
-          // fallback reads the column again — resurrecting the very content they
-          // deleted the page to remove.
-          if (written.length > 0) {
-            const cleared = Object.fromEntries(written.map((field) => [LEGACY_COLUMN[field], null]));
-            await tx
-              .update(userPersonalization)
-              .set({ ...cleared, updatedAt: new Date() })
-              .where(eq(userPersonalization.userId, row.userId));
-          }
+          // The read path in `personalization-utils` stops consulting a column
+          // the moment its POINTER is set, regardless of what the column holds.
+          // Provisioning above sets all three pointers, so every column is now
+          // unreachable. Clearing only the copied ones would leave a populated,
+          // invisible column behind for any field whose page already had content
+          // (a hand edit made before this ran, say) — and that is a latent
+          // privacy leak, not dead weight: if the user later deletes the page,
+          // `purgeExpiredTrashedPages` hard-deletes it, `ON DELETE SET NULL`
+          // clears the pointer, the pointer-absent fallback switches back on and
+          // resurrects content the user never saw and cannot reach.
+          //
+          // Nothing observable is lost. A column the reader can no longer reach
+          // is not a second copy to keep in step; the page is the source of
+          // truth from here on, which is exactly what the settings screen shows.
+          await tx
+            .update(userPersonalization)
+            .set({ bio: null, writingStyle: null, rules: null, updatedAt: new Date() })
+            .where(eq(userPersonalization.userId, row.userId));
 
           return written;
         });

--- a/scripts/backfill-memory-pages.ts
+++ b/scripts/backfill-memory-pages.ts
@@ -1,0 +1,200 @@
+import 'dotenv/config';
+import { getMigrationDb } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { drives, pages } from '@pagespace/db/schema/core';
+import { userPersonalization } from '@pagespace/db/schema/personalization';
+import { and, asc, eq, gt, isNull, or } from '@pagespace/db/operators';
+import {
+  provisionMemoryPages,
+  MEMORY_FIELDS,
+  type MemoryField,
+} from '@pagespace/lib/memory/memory-pages';
+
+/**
+ * One-shot backfill: move every existing user's personalization profile out of
+ * the `user_personalization` text columns and into pages in their Home drive.
+ *
+ * New signups get their Memory pages during `provisionHomeDriveIfNeeded`, but
+ * that path only runs when a Home drive is CREATED, so existing users never
+ * pass through it. This script covers them — deliberately as a script rather
+ * than a per-login hook, so the hot auth path stays untouched.
+ *
+ * Safe to re-run. Idempotence comes from the page pointers plus a content
+ * check, not a stamp:
+ *   - `provisionMemoryPages` reuses pages that already exist.
+ *   - Column content is copied ONLY into a page that is currently empty, so a
+ *     second run never re-appends, and never overwrites edits the user (or the
+ *     memory cron) has made to the page since the first run.
+ *
+ * The legacy columns are left in place. They are the fallback read path in
+ * `personalization-utils` until the follow-up PR drops them.
+ *
+ * Usage:
+ *   bun scripts/backfill-memory-pages.ts --dry-run
+ *   bun scripts/backfill-memory-pages.ts
+ */
+
+const BATCH_SIZE = 200;
+
+/** Legacy column on `user_personalization` holding each field's content. */
+const LEGACY_COLUMN = {
+  bio: 'bio',
+  writingStyle: 'writingStyle',
+  rules: 'rules',
+} as const;
+
+export interface BackfillSummary {
+  scanned: number;
+  /** Users that had at least one field copied into a page. */
+  migrated: number;
+  /** Individual field pages that received content. */
+  fieldsCopied: number;
+  /** Fields skipped because the target page already had content. */
+  fieldsSkippedNonEmpty: number;
+  /** Users whose columns were all empty — pages provisioned, nothing to copy. */
+  emptyProfiles: number;
+  failed: number;
+}
+
+export async function runBackfill({
+  dryRun = false,
+}: { dryRun?: boolean } = {}): Promise<BackfillSummary> {
+  const db = getMigrationDb();
+  const summary: BackfillSummary = {
+    scanned: 0,
+    migrated: 0,
+    fieldsCopied: 0,
+    fieldsSkippedNonEmpty: 0,
+    emptyProfiles: 0,
+    failed: 0,
+  };
+
+  console.log(`${dryRun ? '[DRY RUN] ' : ''}Backfilling personalization into Memory pages\n`);
+
+  // Keyset pagination on the personalization row id. Unlike the starter-skills
+  // backfill this predicate is NOT mutated by the loop (no stamp column), but
+  // keyset is still the right walk: an OFFSET over a table taking concurrent
+  // inserts can skip rows.
+  let cursor = '';
+  for (;;) {
+    const batch = await db
+      .select({
+        id: userPersonalization.id,
+        userId: userPersonalization.userId,
+        driveId: drives.id,
+        bio: userPersonalization.bio,
+        writingStyle: userPersonalization.writingStyle,
+        rules: userPersonalization.rules,
+        bioPageId: userPersonalization.bioPageId,
+        writingStylePageId: userPersonalization.writingStylePageId,
+        rulesPageId: userPersonalization.rulesPageId,
+      })
+      .from(userPersonalization)
+      .innerJoin(users, eq(users.id, userPersonalization.userId))
+      .innerJoin(drives, and(eq(drives.ownerId, users.id), eq(drives.kind, 'HOME')))
+      .where(
+        and(
+          gt(userPersonalization.id, cursor),
+          // Only rows that still need work: no folder pointer yet, or a field
+          // whose page pointer was never written.
+          or(
+            isNull(userPersonalization.memoryFolderId),
+            isNull(userPersonalization.bioPageId),
+            isNull(userPersonalization.writingStylePageId),
+            isNull(userPersonalization.rulesPageId),
+          ),
+        ),
+      )
+      .orderBy(asc(userPersonalization.id))
+      .limit(BATCH_SIZE);
+
+    if (batch.length === 0) break;
+    cursor = batch[batch.length - 1].id;
+
+    for (const row of batch) {
+      summary.scanned++;
+
+      const populated = MEMORY_FIELDS.filter((field) => (row[LEGACY_COLUMN[field]] ?? '').trim());
+
+      if (dryRun) {
+        if (populated.length === 0) {
+          summary.emptyProfiles++;
+        } else {
+          summary.migrated++;
+          summary.fieldsCopied += populated.length;
+          console.log(`  user ${row.userId}: would copy ${populated.join(', ')}`);
+        }
+        continue;
+      }
+
+      try {
+        // One transaction per user: a failure isolates to that user rather than
+        // rolling back a whole batch of unrelated migrations.
+        const copied = await db.transaction(async (tx) => {
+          const pointers = await provisionMemoryPages(row.userId, row.driveId, tx);
+
+          const pageIdFor: Record<MemoryField, string> = {
+            bio: pointers.bioPageId,
+            writingStyle: pointers.writingStylePageId,
+            rules: pointers.rulesPageId,
+          };
+
+          const written: MemoryField[] = [];
+          for (const field of populated) {
+            const content = (row[LEGACY_COLUMN[field]] ?? '').trim();
+
+            // Copy into the page only while it is still empty. This is what
+            // makes a re-run safe: once the page has content — from the first
+            // run, the memory cron, or the user typing in it — we never touch
+            // it again.
+            const updated = await tx
+              .update(pages)
+              .set({ content, contentMode: 'markdown', updatedAt: new Date() })
+              .where(and(eq(pages.id, pageIdFor[field]), eq(pages.content, '')))
+              .returning({ id: pages.id });
+
+            if (updated.length > 0) {
+              written.push(field);
+            } else {
+              summary.fieldsSkippedNonEmpty++;
+            }
+          }
+
+          return written;
+        });
+
+        if (populated.length === 0) {
+          summary.emptyProfiles++;
+        } else if (copied.length > 0) {
+          summary.migrated++;
+          summary.fieldsCopied += copied.length;
+          console.log(`  user ${row.userId}: copied ${copied.join(', ')}`);
+        }
+      } catch (error) {
+        summary.failed++;
+        console.error(`  user ${row.userId}: FAILED`, error);
+      }
+    }
+
+    console.log(`  …${summary.scanned} profiles scanned`);
+  }
+
+  console.log(
+    `\nDone${dryRun ? ' (dry run — nothing written)' : ''}. ` +
+      `${summary.scanned} profile(s) scanned, ${summary.migrated} migrated, ` +
+      `${summary.fieldsCopied} field(s) copied, ` +
+      `${summary.fieldsSkippedNonEmpty} skipped (page already had content), ` +
+      `${summary.emptyProfiles} empty, ${summary.failed} failed.`,
+  );
+  return summary;
+}
+
+// Only run when invoked directly (not when imported by tests).
+if (import.meta.main) {
+  runBackfill({ dryRun: process.argv.includes('--dry-run') })
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('Backfill failed:', error);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Why

The nightly memory cron writes a profile that is injected into every AI system prompt. Its current output is a ~14,000-character dossier carrying theology, hobbies, sports teams, family details, and the full names of eight colleagues — almost none of which changes how the AI should respond, and some of which is third-party personal data living in a product with a whole `packages/lib/src/compliance/` tree.

Three complaints, four structural causes:

| Complaint | Root cause |
|---|---|
| Captures things it shouldn't | The worldview pass asked "what does this person believe or value?" with **no scope gate at all**. Only the preferences pass had a portability test. Nothing anywhere asked *"would an AI behave differently knowing this?"* |
| Infers from tiny interactions | Discovery returned bare `string[]` — no evidence, no frequency. The evaluator's "clear repeatable pattern, not a one-off" gate was therefore **unenforceable**: the information needed to apply it had been discarded, and nothing persisted between runs. |
| It only ever grows | `applyIntegrationDecisions` could only **append**. Compaction triggered at 18,000 chars and targeted 14,000 while being told to "preserve all key information" — making ~14k the *resting size* of every field, not a ceiling. A wrong inference was permanent. |
| `writingStyle` can't say how to write *as* me | The prompt asked "how does this person like to communicate?" — ambiguous between how the user talks (useless as an instruction: *"uses typos"*) and how the AI should. Writing **as** the user wasn't modelled at all; the usable voice spec had landed in `bio` by accident. |

## What changed

**Memory lives as pages.** Three markdown pages in a `Memory` folder in the Home drive — `About You`, `Communication`, `Rules` — created at provisioning (web *and* admin/on-prem paths), edited like any other page. Addressed by stored pointer, not title. Writes go through `applyPageMutation` with `expectedRevision`, so a user editing their page while the cron runs wins the conflict. Settings keeps the toggle, links out, and self-heals a pointerless legacy profile on read.

**The pages cannot be deleted.** They are structural — the same category as the Home drive itself. The cron writes to them by pointer, settings links to them, and provisioning assumes they exist, so deleting one leaves a profile with nowhere to live: pointer nulls, dead link in settings, and the next run silently writes nothing. Refused at every path that can remove one: `pageService.trashPage` and its `recursivelyTrash` child sweep, the AI `trash_page` tool *and its independent `withChildren` recursion*, and bulk-delete — which refuses the whole batch rather than deleting around a memory page. **Moving** is refused too: `parentId` is user-editable, and relocating a memory page is precisely what puts it inside another page's delete cascade. Same-drive moves are refused in `pageService.updatePage` and the AI `move_page` tool; cross-drive moves are refused inside `page-cross-drive-move-service`, which is the single implementation behind both `/api/pages/bulk-move` and the AI tool — guarding either call site alone would have left the REST route open. Every guard sits *after* its caller's permission check, so someone who cannot touch the page is never told it is a memory page. Only relocation is refused — the content stays fully editable, and the message says so. The refusal names the alternatives, since "cannot be deleted" alone strands someone who wants the content gone: clear the page, or turn personalization off. Both reversible; deletion is not. The trashed-page handling remains as defence in depth for pages predating the guard.

**Claims must corroborate across days before they're recorded.** New `personalization_candidates` table stages each claim with its verbatim evidence quote and the **date that evidence was written** — not the date the cron ran. Promotion needs 2 distinct evidence days (3 for `bio`) *and* a `firstSeenAt` before today. Not re-seen in 30 days → deleted; settled rows have their quote redacted after 90.

**It can correct and forget.** Whole-page rewrite replaces append-only, bounded by two deterministic guards: reject if >40% of the page would vanish, reject if over budget. Compaction drops from 18k/14k to 3000/2500/2500, prompts inverted to *"delete anything that does not change AI behaviour."*

**Discovery has a scope gate.** `generateObject` + zod replaces regex-fenced JSON, where a malformed response was indistinguishable from "learned nothing". Every pass leads with an actionability gate and an explicit exclusion list — personal history, family, beliefs, hobbies, games, named third parties, self-reported metrics. The communication pass is imperative-only and covers replying **to** you and drafting **as** you.

**Art 15 export.** `personalization_candidates` ships as `personalization-candidates.json`, including rejected and pending rows: "we inferred this about you and did not act on it" is exactly the processing a subject access request exists to disclose.

## Review findings addressed

All 19 threads have concrete replies. The substantive ones:

| Finding | Fix |
|---|---|
| **Corroboration counted cron days** — discovery re-reads a rolling 7-day window nightly, so one unchanged message was rediscovered on consecutive runs and a one-off promoted after 2–3 nights | Claims carry `evidenceAt`, resolved server-side from a message index the model cites. Only evidence days advance the count. |
| **Settled claims collided on the unique index**, aborting all memory processing for that user every run | Lookup no longer filters on settled state; settled rows are skipped |
| **Candidates settled by field**, retiring claims the evaluator never used | Evaluator reports `usedInsights`; settlement is per-candidate |
| **Evaluation failure looked like "declined everything"** — a provider outage permanently rejected a user's whole ready set | `evaluateAndIntegrate` returns a discriminated outcome; failures leave candidates pending |
| **Writes that hit no row still counted as updates**, retiring the candidates behind them | `updatePersonalizationPage` reports whether a row changed |
| **Deleting a memory page fell back to the legacy column**, so pre-deletion text kept being injected | Fallback keyed on pointer *existence*, not on missing content |
| **Raw `pages.content` write** bypassed revision/stateHash/version history and could clobber a live editor | Routed through `applyPageMutation` with `expectedRevision` |
| **Read-then-write upsert raced** two overlapping runs | `onConflictDoNothing` + update guarded on the observed `lastSeenAt` |
| Empty discovery stranded pending candidates; admin signup never provisioned pages; toggle writes could settle out of order; terminal evidence retained indefinitely | All fixed |

## Verification

All three CI gate commands pass in a **clean worktree with `--frozen-lockfile`** (i.e. CI's environment, not a contaminated local one): `lint` 15/15 · `typecheck` 17/17 · `knip` clean. (Both counts dropped by one after rebasing onto master's `37cdbf806`, which moved the `apps/dev` prototype out of the workspace.)

Tests: **16,682 passing** in the web workspace (the only failures are DB-gated integration suites that need a provisioned Postgres), plus 64 compliance and 1,116 CLI tests.

**Verified against real Postgres in Docker**, not assumed:
- the whole chain applies to an empty database, master's destructive `0256` included, and `0257` lands after it: table, unique index, `CHECK` and cascade FK all created correctly, and `agent_workspace_panes` correctly gone
- erasure cascade works — deleting a user removes their candidate rows
- `CHECK` rejects an invalid `field` (e.g. `toString`)
- `ON CONFLICT DO NOTHING` returns `INSERT 0 0` on the settled-row collision instead of throwing
- the backfill migrates a legacy profile into three correctly-titled pages, and **a re-run does not clobber a hand edit**

Guards are mutation-checked — mechanism broken, matching test confirmed red, restored. Worth flagging three times a green test turned out not to pin what it claimed, each corrected: the corroboration tests initially covered only the pure helper (a mutation swapping the call site back to `new Date()` survived); the deleted-page fixtures lacked pointer columns so the branch was never exercised; and the toggle test passed on the `disabled` prop rather than the handler guard.

## Rebase onto `37cdbf806` — two workarounds dropped

This branch had been carrying two workarounds for `apps/dev` having been committed into the workspace by `4ffb7ff80`: a `knip.json` config block for it, and 143 lines of its dependencies in `bun.lock`. Master fixed the root cause instead, moving the prototype out of `apps/` so it is no longer a workspace member.

Both workarounds then became actively harmful rather than merely dead — re-adding those dependencies to `bun.lock` reintroduces the drift that had every CI job failing `lockfile had changes, but lockfile is frozen`. **Git reported zero conflicts, so this would have merged silently.** Reverted both; `bun install --frozen-lockfile` now passes against master's lockfile (2170 installs across 2470 packages, no changes). A third workaround (deleting the orphaned `accept-machine-pane.ts`) was dropped during the rebase, since master relocated the same script out of lint/typecheck scope.

The `CLI_VERSION` fix is deliberately kept: master is still at `1.7.0` against a `package.json` of `1.7.1`, which its own version test compares.

## Notes for review

- **The three inherited CI blockers this branch carried are now all fixed on master**, and every workaround for them has been removed here — see the rebase section above. This PR no longer contains any change outside the memory feature.
- **What was NOT verified live.** Validation here is automated tests plus real-Postgres runs; the app was not stood up. Specifically not exercised: triggering the cron twice on simulated consecutive days through the running app, opening the Memory folder in the UI to confirm the pages render and edit, and starting a real AI chat to eyeball the injected `# USER PERSONALIZATION` block. The underlying logic for all three is covered by the integration suites, but the wiring end-to-end in a browser is not.
- **The backfill has not been run.** `scripts/backfill-memory-pages.ts` supports `--dry-run`; it copies only into empty pages, so re-runs never clobber edits. The settings route now self-heals pointerless profiles, so this is no longer a hard rollout prerequisite for the UI to work.
- **Legacy columns are kept** as the fallback for users the backfill hasn't reached; a follow-up PR drops them. ⚠️ **That drop is a contract migration** with the same hazard `UPGRADE.md` documents for 0255 → 0256: the backfill is what moves the content and can only run while the columns exist, so a deployment jumping straight to the drop loses the profiles of every row the backfill never reached — silently, because the pointer-absent fallback just reads empty. The warning now sits on the columns themselves in `packages/db/src/schema/personalization.ts`, where whoever writes that migration will see it.
- **The existing bloated profile won't shrink on its own** beyond its first compaction pass — it needs one manual prune in the drive after this lands.
- **Migration is `0257`, not `0256`.** Master landed `0256_parched_bloodscream` (the destructive pane-grid drop) while this branch held its own `0256`; two migrations cannot share an index, since the journal keys on it and the second would be skipped as already-applied. Regenerated with `bun run db:generate` rather than renamed, so SQL, snapshot and journal agree. It is additive only (new table + nullable columns, zero row rewrites), applies cleanly *after* master's contract migration, and needs no `UPGRADE.md` entry or deploy window. The generator now emits the `CHECK` inline, so the hand-appended `DO $$` block the 0156 precedent required is gone — this migration is entirely generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7NMGuPfzGE2yLZD1T8E5X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Personalization is now managed through AI-maintained Memory pages for About You, Communication, and Rules.
  - Added links and previews to the Memory folder and individual pages.
  - Memory discovery now filters, corroborates, and safely promotes recurring insights.
  - Added safeguards for page rewrites, content limits, and stale inferred information.
  - Personalization candidates and supporting evidence are included in data exports.

- **Improvements**
  - Personalization enable/disable changes save immediately with failure recovery.
  - Existing personalization content can be migrated into Memory pages.
  - Updated CLI version to 1.7.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






