### PR TITLE
test(agent-workspaces): pin chat containment on a write that actually changes something

### DIFF
--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
@@ -544,6 +544,34 @@ describe('a chat target whose thread has been DELETED', () => {
     expect(chatBindings.livenessAsked).toEqual([]);
   });
 
+  it('lets a workspace holding a DEAD thread still open a new pane — containment, on a write that actually changes something', async () => {
+    // THE PROBE THE TEST ABOVE CANNOT BE. Its write re-sends an identical node,
+    // so `decision.persist.put` is EMPTY and nothing is asked about anything —
+    // it passes whether liveness is scoped to INTRODUCED targets or widened to
+    // the whole payload. That mutation survived a review of this file (`M4`);
+    // the assertion that claims to pin containment could not see it.
+    //
+    // This write CHANGES the tree, so the payload is non-empty and carries the
+    // dead thread's node alongside the live newcomer. Scoped to introduced, only
+    // `conv-live` is asked about and the write lands. Widened to the payload,
+    // the long-dead `conv-1` refuses it — which is the user-visible shape of the
+    // bug: one thread dies under a pane and the workspace can never open another
+    // chat pane again.
+    store.nodes = [root, pane('pane-a', 'root', 0, { kind: 'chat', id: 'conv-1' })];
+    chatBindings.deleted = ['conv-1'];
+
+    const result = await write({
+      put: [
+        pane('pane-a', 'root', 0, { kind: 'chat', id: 'conv-1' }),
+        pane('pane-new', 'root', 1, { kind: 'chat', id: 'conv-live' }),
+      ],
+    });
+
+    expect(result.status).toBe('ok');
+    // Only the newcomer was ever the subject of the question.
+    expect(chatBindings.livenessAsked).toEqual([['conv-live']]);
+  });
+
   it('runs AFTER the ACL gate, so a refusal never confirms a conversation the caller may not touch', async () => {
     // Same oracle argument as the holder check above: "that thread is deleted"
     // is a fact about a conversation, and a caller with no authority over it


### PR DESCRIPTION
Follow-up to #2378 (merged). One test, no production code.

## What it fixes

`is asked ONLY about targets the write INTRODUCES` re-sends an identical node, so `decision.persist.put` comes out **empty** and the liveness check is never reached. It passes whether liveness is scoped to introduced targets or widened to the whole wire payload — the assertion that names containment cannot see the thing it names. An adversarial review of that file flagged it as a surviving mutation (`M4` in `.pu-reports/pu-rev-races.md`, since removed from the repo).

## The case that discriminates

A workspace already holding a pane whose thread has died, plus a write that opens a **new** chat pane beside it. The payload carries both the dead binding and the live newcomer, and the tree genuinely changes — so the check runs and has something to be wrong about.

- Scoped to introduced: only `conv-live` is asked about, the write lands.
- Widened to the raw payload: the long-dead `conv-1` refuses it.

That refusal is the user-visible shape of the bug, and why this deserves a test rather than a comment: **one thread dies under a pane and the workspace can never open another chat pane again.**

## Mutation-verified, and the aiming matters

- Widening over `decision.persist.put` is behaviourally **inert** here — `persist.put` already holds only the changed nodes, which for this input is exactly the introduced set. Nothing to catch.
- Widening over the raw `wanted.put` is the real mutation, and this test dies under it.

Worth recording: I could not reproduce `M4` as a *surviving* mutation once aimed correctly — the raw-payload widening is caught by three existing tests as well as this one. So M4 is not the coverage hole it was reported as. This test still earns its place, because nothing else asserts the property on a write that changes the tree.

## Validation

`bun run --filter web test -- src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts` → 40 passed. Typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace updates involving deleted chat threads.
  * New live chat targets can now be added successfully even when existing panes reference deleted threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->