### PR TITLE
The root seed arrives from both ends, and one payload could not hold it twice

### DIFF
--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/conversations/[conversationId]/reopen/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/conversations/[conversationId]/reopen/__tests__/route.test.ts
@@ -3,7 +3,8 @@
  * The session-scoped conversation-reopen route — the undo of the sibling
  * `[conversationId]` route's DELETE. What matters here: the uniform 404 for
  * an unreachable session AND for a conversation this session does not own
- * (or was history-deleted), the 429 + human message on the cap, and that an
+ * (or was history-deleted), the 409 + human message when the workspace is full
+ * — reopening is a re-admission and consumes a cap slot — and that an
  * idempotent re-reopen (already_open) still answers 200 without a fresh
  * audit write — mirrors `[conversationId]/__tests__/route.test.ts`.
  */
@@ -117,19 +118,18 @@ describe('POST /api/agent-workspaces/[workspaceId]/conversations/[conversationId
     expect(response.status).toBe(404);
   });
 
-  it('reopens into a workspace at MAX_SESSION_CONVERSATIONS — a member returning consumes no slot', async () => {
-    // The 429 this replaces existed because reopening restored a listing slot
-    // the close had freed. Under a `move` the node never stopped existing:
-    // closing frees no slot and reopening consumes none, so the cap — which now
-    // bounds MEMBERSHIP, enforced where membership is created — has nothing to
-    // say here and `session_full` is not an outcome this route can receive.
-    mockReopenConversationInSession.mockResolvedValue('reopened');
+  it('409s a workspace at MAX_SESSION_CONVERSATIONS — a return is an ADMISSION and can lose the last slot', async () => {
+    // Closing DESTROYS the node, so a closed thread is a member of nothing and
+    // coming back re-consults the cap like any other admission. 409 rather than
+    // the "nothing here" 404 the other refusals take: the thread exists, it is
+    // the caller's, and closing something else fixes it — the one refusal on
+    // this path a user can act on.
+    mockReopenConversationInSession.mockResolvedValue('session_full');
     const response = await post();
-    expect(response.status).toBe(200);
-    expect(mockAuditRequest).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ eventType: 'security.rate.limited' }),
-    );
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining('full') });
+    // A refusal is not a write.
+    expect(mockAuditRequest).not.toHaveBeenCalled();
   });
 
   it('500s a thrown failure with a human error', async () => {

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/conversations/[conversationId]/reopen/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/conversations/[conversationId]/reopen/route.ts
@@ -1,17 +1,18 @@
 /**
- * Put ONE conversation back on its workspace's grid — the undo of the sibling
+ * Put ONE conversation back into its workspace — the undo of the sibling
  * `[conversationId]` route's DELETE.
  *
- * POST → 200 { ok: true } — a `move` of the thread's node back into the tree.
- * It mints nothing: the node never stopped existing, because a close only
- * changed where it was.
+ * POST → 200 { ok: true } — an ADMISSION, and a re-mint. There is no `readmit`
+ * in the model: that was a `move` back onto the grid, and it existed only
+ * because a closed thread kept a node with no parent. Closing DESTROYS the
+ * node, so a thread that was closed is a member of nothing, and putting it back
+ * is an ordinary admission that mints a fresh node for it.
  *
- * **No `session_full` any more.** The old version was bounded by
- * `MAX_SESSION_CONVERSATIONS`, because reopening restored a listing slot the
- * close had freed. A member that never stopped being a member frees no slot
- * when it is closed and consumes none when it returns, so the ceiling has
- * nothing to say here — it bounds MEMBERSHIP, and is enforced where membership
- * is created.
+ * **Which is why `session_full` is live on this path.** It is bounded by
+ * `MAX_SESSION_CONVERSATIONS` because the cap counts MEMBERSHIP and a close now
+ * genuinely frees a slot — so a return has to re-consult the ceiling like any
+ * other admission, and can lose. It is answered 409 below rather than folded
+ * into the "nothing here" 404: it is the one refusal here a user can resolve.
  *
  * Gated by the same ordinary session access check the close route uses —
  * this is a routine write, not a capability-gated act.

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/conversations/[conversationId]/route.ts
@@ -1,20 +1,25 @@
 /**
- * Close ONE conversation OFF its workspace's grid.
+ * Close ONE conversation OUT of its workspace.
  *
- * DELETE → 200 { ok: true } — a `move` of the thread's node to no parent. The
- * thread stays a MEMBER of the workspace and stays in its listing; only its
- * location changes. This is NOT the history-deleting
+ * DELETE → 200 { ok: true } — a `destroy` of the thread's node. Membership IS
+ * that node, so this removes the thread from the workspace: it leaves the grid
+ * and the listing together, and the table's chat-target uniqueness is freed, so
+ * the thread can afterwards be admitted somewhere else. See
+ * `close-conversation-in-workspace.ts`, which carries the argument for why
+ * "off the grid but still a member" is no longer a state.
+ *
+ * Still NOT the history-deleting
  * `ai/page-agents/[agentId]/conversations/[conversationId]` DELETE — closing
- * never touches a thread's history, and (unlike that route) never removes it
- * from the workspace either.
+ * writes no `conversations` row and never touches a thread's messages. What it
+ * removes is the membership, not the thread.
  *
  * **`last_conversation` is gone from this route.** It refused the close of a
  * workspace's last open listing, because that left a workspace holding nothing
- * — contract invariant 3. A `move` cannot produce that state: every member is
- * still a member afterwards, however few are on screen. Closing the last thread
- * now leaves an EMPTY GRID and a workspace that still holds all its threads,
- * exactly as closing the last PANE already did. Ending a workspace stays an
- * explicit act on a different route.
+ * — contract invariant 3. Holding nothing is now an ordinary resting state: a
+ * root with no children, which `validateTree` accepts. Closing the last thread
+ * leaves an EMPTY workspace, exactly as closing the last PANE already did.
+ * Ending a workspace stays an explicit act on a different route —
+ * `destroy(rootId)`, never inferred from emptiness.
  *
  * Gated by the ordinary session access check (identity + drive membership),
  * NOT the end-access check — closing one thread is a routine write, not the

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -132,10 +132,10 @@ describe('GET /api/agent-workspaces', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       // The listing is handed through UNCHANGED. Every entry already carries
-      // its own `nodeId` and `attached`, read off the node that decided the
-      // thread is in this workspace at all — so there is nothing for the route
-      // to annotate it with, and `annotateConversationsWithPanes` is deleted
-      // rather than ported (issue #2373).
+      // its own `nodeId`, read off the node that decided the thread is in this
+      // workspace at all — so there is nothing for the route to annotate it
+      // with, and `annotateConversationsWithPanes` is deleted rather than
+      // ported (issue #2373).
       sessions: [
         {
           ...SESSION_DTO,
@@ -163,32 +163,27 @@ describe('GET /api/agent-workspaces', () => {
    * `AgentsSidebar` chose the grid, so a thread with no pane row was invisible.
    *
    * The reconciliation that fixed it is gone too, because there is nothing left
-   * to reconcile: membership is the node, so `attached` is read off the same row
-   * that put the thread in the listing. A thread OFF the grid is in the list
-   * with `attached: false` — a resting state, not an absence — and this is the
-   * guard that replaces the deleted annotation's suite.
+   * to reconcile: membership is the node, so a thread is in this listing exactly
+   * when a node of this workspace binds it, and that node's id rides along. This
+   * is the guard that replaces the deleted annotation's suite, so what it has to
+   * pin is the ABSENCE of annotation: whatever the store answers is what the
+   * client gets, key for key.
+   *
+   * It pins that with `toEqual` on the whole array rather than `toMatchObject`
+   * on each entry, because the failure this guards against is the route ADDING a
+   * derived field back — `attached` was one, deleted with the grid it
+   * reconciled against — and a per-key match would not see one arrive.
    */
-  it('LISTS a thread that is off the grid, carrying its node and its state', async () => {
-    mockListSessionConversationsBulk.mockResolvedValue(
-      new Map([
-        [
-          'ses-1',
-          [
-            { ...CONVERSATION_ENTRY, nodeId: 'node-1', attached: true },
-            { ...CONVERSATION_ENTRY, conversationId: 'conv-parked', nodeId: 'node-2', attached: false },
-          ],
-        ],
-      ]),
-    );
+  it('hands the listing back exactly as the store answered it — no annotation, no derived state', async () => {
+    const entries = [
+      { ...CONVERSATION_ENTRY, nodeId: 'node-1' },
+      { ...CONVERSATION_ENTRY, conversationId: 'conv-2', nodeId: 'node-2' },
+    ];
+    mockListSessionConversationsBulk.mockResolvedValue(new Map([['ses-1', entries]]));
 
     const body = await (await GET(new Request('http://localhost/api/agent-workspaces'))).json();
-    const conversations = body.sessions[0].conversations;
 
-    expect(conversations).toHaveLength(2);
-    expect(conversations[0]).toMatchObject({ nodeId: 'node-1', attached: true });
-    // The one the old shape dropped on the floor, and the one a `close` now
-    // produces: still a member, still listed, simply not on screen.
-    expect(conversations[1]).toMatchObject({ conversationId: 'conv-parked', nodeId: 'node-2', attached: false });
+    expect(body.sessions[0].conversations).toEqual(entries);
   });
 
   /**

--- a/apps/web/src/components/agents/AgentPageView.tsx
+++ b/apps/web/src/components/agents/AgentPageView.tsx
@@ -310,11 +310,11 @@ export default function AgentPageView({ page }: AgentPageViewProps) {
             //
             // Addressed as a PLACEMENT, not as a rebind. A binding is for life,
             // so the fresh conversation cannot be pointed at the stale node; it
-            // gets a node of its own in that slot, and the stale one parks —
-            // still a member of the workspace, still one click from the sidebar,
-            // which is strictly better than the pane it used to overwrite in
-            // place. `activeNodeId` is how "here, in this rectangle" is said to
-            // the placement policy.
+            // gets a node of its own in that slot, and the stale one KEEPS ITS
+            // OWN — still in the tree, still a member, still on screen — which
+            // is strictly better than the pane it used to overwrite in place.
+            // `activeNodeId` is how "here, in this rectangle" is said to the
+            // placement policy.
             const workspaceNodes =
               useAgentWorkspaceStore.getState().workspaces[sessionId]?.nodes ?? [];
             const staleNode = workspaceNodes.find(

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -119,11 +119,20 @@ export interface AgentPanesProps {
   /** Fired after the workspace was ended — the host owns what renders next. */
   onSessionEnded?: () => void;
   /**
-   * Fired after a conversation's LISTING closed. `next` is always `null` now:
-   * closing never rebinds a pane to a replacement, because the grid is allowed
-   * to be empty. The shape is kept so a host tracking "current conversation"
-   * independently of the tree can decide for itself what a closed conversation
-   * means for whatever it is showing elsewhere.
+   * Fired after a conversation's LISTING closed. TWO callers, and `next` is what
+   * tells them apart:
+   *
+   *  - A direct close sends `next: null`. Closing never rebinds a pane to a
+   *    replacement, because the grid is allowed to be empty — so there is
+   *    nothing to hand the host but the fact.
+   *  - The cleanup after a mint or a switch sends the REPLACEMENT's id, because
+   *    there the thread that closed was displaced by one the user is now looking
+   *    at. `AgentPageView` branches on exactly that: a non-null `next` whose
+   *    `nextAgentPageId` is its own page navigates to it instead of minting.
+   *
+   * The shape is kept so a host tracking "current conversation" independently of
+   * the tree can decide for itself what a closed conversation means for whatever
+   * it is showing elsewhere.
    */
   onConversationClosed?: (event: { conversationId: string; next: string | null; nextAgentPageId: string | null }) => void;
   /**
@@ -499,18 +508,17 @@ export default function AgentPanes({
   );
 
   /**
-   * Take the node out of the grid and close its conversation's listing — silent
-   * on success, since closing a listing never touches history.
+   * Destroy the node and close its conversation's listing — silent on success,
+   * since closing a listing never touches history.
    *
-   * The node PARKS rather than vanishing, so the thread's row stays in the
-   * sidebar right up until the DELETE confirms it is gone. There is no rebind
-   * branch any more: the grid is allowed to be empty.
+   * There is no rebind branch any more: the grid is allowed to be empty, so
+   * nothing has to be found to put in the gap.
    */
   const closeConversationListing = useCallback(
     async (nodeId: string, conversationId: string) => {
-      // Layout first, and deliberately: parking is reversible and instant, and
-      // the alternative — waiting on the DELETE — is what made a close feel like
-      // the app had ignored it.
+      // Layout first, and deliberately: the local write is instant and the
+      // broadcast reconciles it, where the alternative — waiting on the DELETE —
+      // is what made a close feel like the app had ignored it.
       closePane(sessionId, nodeId);
       try {
         await del(

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -110,10 +110,10 @@ export interface AgentPanesProps {
   driveId: string | null;
   /**
    * The conversation the host wants shown. Selection IS an instruction: this
-   * focuses the node already showing it, un-parks that node when it has one, or
-   * places it. Null for a workspace-only selection (a page/terminal row in the
-   * sidebar, a conversation-less deep link) — there is nothing to show, and the
-   * grid renders whatever the tree holds.
+   * focuses the node already showing it, or places it when nothing does. Null
+   * for a workspace-only selection (a page/terminal row in the sidebar, a
+   * conversation-less deep link) — there is nothing to show, and the grid
+   * renders whatever the tree holds.
    */
   initialConversation: { conversationId: string; agentPageId: string | null; name: string } | null;
   /** Fired after the workspace was ended — the host owns what renders next. */
@@ -450,9 +450,10 @@ export default function AgentPanes({
    * Selection IS an instruction to show the conversation.
    *
    * NOT a grid seed — there is nothing to seed, because the root is minted
-   * server-side by whatever write first needs one. This focuses the node already
-   * showing the thread, un-parks it when it has one, or places it; the store
-   * owns all three (`openConversation`).
+   * server-side by whatever write first needs one. Two outcomes, not the three
+   * the parked model needed: the thread is in the tree, so showing it is FOCUS
+   * and costs no write at all; or it is nowhere, and it is PLACED. The store
+   * owns both (`openConversation`).
    *
    * It still waits for the live conversation set before it can risk an EVICTION.
    * A target already showing never reaches that logic, so that case goes
@@ -557,9 +558,10 @@ export default function AgentPanes({
 
       if (decision.action === 'close-pane') {
         closePane(sessionId, nodeId);
-        // A closed terminal tab is a DELETE, not an orphan. The node parks with
-        // its binding, but the PTY has no surface left and no reattach path
-        // through a parked node's own row, so it goes with the close.
+        // A closed terminal tab is a DELETE, not an orphan. The node and its
+        // binding are gone with the close, so the PTY has no surface left and
+        // nothing that could reattach to it — it goes too, rather than being
+        // left running for a row that no longer exists.
         if (node.target?.kind === 'terminal') closeShell(node.target.id);
         return;
       }
@@ -662,10 +664,11 @@ export default function AgentPanes({
    * After a mint or a switch replaces what a node shows, close the conversation
    * it replaced — the fix for panes silently accumulating stray sidebar rows.
    *
-   * The displaced NODE is parked rather than destroyed, so its thread is still
-   * one click from being shown again right up until this DELETE lands. Runs only
-   * AFTER the replacement is in place; a failed mint never touches the prior
-   * conversation.
+   * Nothing is displaced: a binding is for life, so the replacement is PLACED in
+   * a node of its own rather than repointing this one. The prior thread keeps
+   * its node, stays on screen and stays a member right up until this DELETE
+   * lands and destroys it. Runs only AFTER the replacement is in place; a failed
+   * mint never touches the prior conversation.
    */
   const closeReplacedConversation = useCallback(
     async (oldConversationId: string, newConversationId: string, newAgentPageId: string | null) => {
@@ -963,9 +966,9 @@ export default function AgentPanes({
       }
 
       if (!isCurrent()) return false;
-      // ONE placement call for every branch. The store owns the three cases the
-      // duplicated block here used to hand-roll — already on the grid (focus
-      // it), parked (un-park and focus), nowhere (place it) — and it reads live
+      // ONE placement call for every branch. The store owns the two cases the
+      // duplicated block here used to hand-roll — already in the tree (focus
+      // it), nowhere (place it) — and it reads live
       // state, which is what two panes racing to reopen the same conversation
       // need: a stale pre-request snapshot would let both miss the other's
       // arrival and independently place it, which the chat-target index refuses.

--- a/apps/web/src/components/agents/panes/SessionPanes.tsx
+++ b/apps/web/src/components/agents/panes/SessionPanes.tsx
@@ -199,12 +199,19 @@ function ContainerGroup({
 /**
  * The empty grid — a resting state, not a failure.
  *
- * Closing the last pane parks it and leaves the workspace alive. Under the model
- * this replaces, that state could not be represented (a two-level grid had no
- * spelling for zero columns), so the reducer no-oped on the last close and
- * browser code ended the session instead. The workspace's members are all still
- * there, in the sidebar, one click from being shown again — which is what this
- * says.
+ * A root with no children is a legal tree. Under the model this replaces the
+ * state could not be represented at all — a two-level grid had no spelling for
+ * zero columns — so the reducer no-oped on the last close and browser code
+ * ended the session instead. It is a tree the validator accepts here, and a
+ * workspace that reaches it stays alive: ending one is `destroy(rootId)`, an
+ * explicit act, never inferred from emptiness.
+ *
+ * NOTHING IS PARKED. `closePane` destroys the node, and for a pane bound to a
+ * conversation that is the membership going with it — there is no off-grid
+ * place for a node to wait, which is the whole correction. What the copy points
+ * at is the sidebar's pickers: a page or shell is a drive resource and always
+ * there, and a closed thread's binding is freed by the destroy, so admitting it
+ * again is an ordinary admission.
  */
 function EmptyGrid() {
   return (

--- a/apps/web/src/components/agents/panes/SessionPanes.tsx
+++ b/apps/web/src/components/agents/panes/SessionPanes.tsx
@@ -17,8 +17,8 @@
  * xterm.
  *
  * **An empty grid renders as empty.** A root holding nothing is a legal resting
- * state (closing the last pane parks it and leaves the workspace alive), so this
- * draws the empty frame and says so, instead of treating zero panes as a
+ * state — closing the last pane destroys it and leaves the workspace alive — so
+ * this draws the empty frame and says so, instead of treating zero panes as a
  * workspace that has ended.
  */
 
@@ -39,7 +39,7 @@ import {
 import { gridPanesOf } from '@/stores/agent-workspace/workspace-tree-view';
 
 export interface SessionPanesProps {
-  /** The workspace's whole flat list — attached and detached. Only the grid is drawn here. */
+  /** The workspace's whole flat list. Only what hangs off the root is drawn here. */
   nodes: readonly WorkspaceNode[];
   /** `null` on an empty grid. */
   activeNodeId: string | null;

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -253,7 +253,7 @@ describe('AgentPanes — the grid it renders', () => {
   });
 
   /**
-   * THE EMPTY GRID. Closing the last pane parks it and leaves the workspace
+   * THE EMPTY GRID. Closing the last pane destroys it and leaves the workspace
    * alive — a state the two-level model could not represent, which is why
    * browser code used to end the session instead.
    */

--- a/apps/web/src/components/agents/panes/close-pane.ts
+++ b/apps/web/src/components/agents/panes/close-pane.ts
@@ -22,10 +22,16 @@
  *    before the index has to. One conversation, at most one node.
  *
  * What survives is the fact this module was written for and the model does not
- * answer on its own: whether closing this rectangle should also close the
- * THREAD's listing. Closing a node parks it — it stays a member of the workspace
- * — so that is a genuinely separate question, and it is the one the server route
- * owns the authority on.
+ * answer on its own: whether closing this rectangle should go through the
+ * THREAD's own DELETE instead of the plain node write.
+ *
+ * Both end with the node GONE — membership is the node, so either way the thread
+ * leaves the workspace; nothing parks. What only the route can do is tell the
+ * DIRECTORY PLANE: it emits the conversation's `closed` lifecycle event, and the
+ * node write's `workspace:nodes-updated` does not cover that, because that event
+ * carries the tree while the sidebar's rows come from the LISTING. Close a
+ * chat-bound pane through the node write alone and the grid is right while the
+ * sidebar keeps a row for a thread that is no longer there.
  *
  * A pure decision over PLAIN DATA (the workspace's panes, plus its listing) — no
  * store, no fetch, no IO — so the branch never lives inline in `AgentPanes`.
@@ -39,17 +45,20 @@ export type { SessionConversationSummary };
 export type ClosePaneDecision =
   /** Nothing to act on, or nothing that can be decided yet. */
   | { action: 'noop' }
-  /** A pure layout removal: the node leaves the grid and stays in the workspace. */
+  /**
+   * The plain node write: destroy the node. Nothing else in the workspace has a
+   * listing row to correct, which is what makes this the whole act.
+   */
   | { action: 'close-pane' }
   /**
-   * Take the node out of the grid AND close conversation `conversationId`'s
-   * listing (the workspace-scoped DELETE). The node still only parks — closing
-   * the thread is the extra act, not a different one.
+   * Destroy the node through conversation `conversationId`'s own DELETE (the
+   * workspace-scoped route). The same removal, taken by the one path that also
+   * announces the thread's close to the directory plane.
    */
   | { action: 'close-conversation'; conversationId: string };
 
 export function decideClosePane(params: {
-  /** Every pane in the workspace, attached or parked. */
+  /** Every pane in the workspace — which is every pane in its tree. */
   panes: readonly PaneNode[];
   /** The node being closed. */
   nodeId: string;
@@ -65,7 +74,7 @@ export function decideClosePane(params: {
   if (!node) return { action: 'noop' };
 
   // A picker, a terminal or a page pane addresses no conversation listing, so
-  // this node has nothing of its own to close. Parking it is the whole act.
+  // this node has nothing to announce. Destroying it is the whole act.
   if (node.target === null || node.target.kind !== 'chat') return { action: 'close-pane' };
 
   const conversationId = node.target.id;
@@ -78,7 +87,7 @@ export function decideClosePane(params: {
   if (activeConversations === null) return { action: 'noop' };
 
   // Resolved, and this thread is not in it — somebody else already closed it.
-  // There is nothing left to DELETE; park the node and be done.
+  // There is nothing left to DELETE; destroy the node and be done.
   if (!activeConversations.some((entry) => entry.conversationId === conversationId)) {
     return { action: 'close-pane' };
   }

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -487,11 +487,11 @@ describe('AgentsSidebar', () => {
     });
 
     /**
-     * The agreement itself. A broadcast parks the node between the render and
+     * The agreement itself. A broadcast DESTROYS the node between the render and
      * the click; the menu must have already followed it, because both read the
      * same live tree rather than the snapshot the row arrived on.
      */
-    test('follows a live broadcast: a thread parked under the sidebar switches to closing the THREAD', async () => {
+    test('follows a live broadcast: a thread whose node goes out from under the sidebar switches to closing the THREAD', async () => {
       respondWithSessions([{ ...SESSION, rev: 1, nodes: [treeRoot, chatNode('n1', WS, 0, 'conv-1')] }]);
       mockDel.mockResolvedValue({});
       const user = userEvent.setup();

--- a/apps/web/src/lib/agent-workspaces/__tests__/close-conversation-in-workspace.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/close-conversation-in-workspace.test.ts
@@ -44,7 +44,7 @@ describe('closeConversationInSessionWith', () => {
     deps = makeDeps();
   });
 
-  it('moves the thread off the grid', async () => {
+  it('removes the thread from the workspace', async () => {
     expect(await closeConversationInSessionWith(deps, input)).toBe('closed');
     expect(deps.dismissConversation).toHaveBeenCalledWith({
       conversationId: 'conv-1',
@@ -54,9 +54,10 @@ describe('closeConversationInSessionWith', () => {
 
   it('closes the workspace\'s LAST thread without refusing', async () => {
     // The behaviour change this leaf makes, pinned deliberately. There is no
-    // count to stub because there is no guard: the thread stays a member, so
-    // the workspace it leaves is still not empty. A test that had to arrange
-    // "only one open listing" to reach a 409 has nothing left to arrange.
+    // count to stub because there is no guard: the thread DOES leave, and a
+    // workspace holding nothing is an ordinary resting state — a root with no
+    // children, which `validateTree` accepts. A test that had to arrange "only
+    // one open listing" to reach a 409 has nothing left to arrange.
     expect(await closeConversationInSessionWith(deps, input)).toBe('closed');
   });
 

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PaneTarget, WorkspaceNode } from '@pagespace/lib/agent-workspaces/workspace-node';
 import type { PersistedNodeWrite } from '@pagespace/lib/agent-workspaces/workspace-node-write';
+import { rootSeedFor } from '@pagespace/lib/agent-workspaces/workspace-node-commands';
 import {
   CHAT_TARGET_UNIQUE_INDEX,
   type ChatTargetHolder,
@@ -327,6 +328,57 @@ describe('replay', () => {
     if (replay.status !== 'ok') return;
     expect(replay.changed).toBe(false);
     expect(store.rev).toBe(before);
+  });
+});
+
+/**
+ * THE FIRST WRITE TO AN EMPTY WORKSPACE, which is where the two seeds meet.
+ *
+ * A workspace with no tree is seeded by whichever write first needs a root, and
+ * BOTH ends mint one — the browser so its optimistic tree has somewhere to put
+ * a pane, and this funnel inside the lock so the write is legal whatever the
+ * client sent. `rootSeedFor` makes them the same node, which is what the
+ * deterministic id is for, and they arrive in ONE `put`, where the convergence
+ * has to be a property of the write decision rather than of the upsert. It
+ * wasn't: both copies reached the validator and every first command against an
+ * empty workspace came back `duplicate_id` — a 400 the client's queue treats as
+ * unrecoverable, so it discarded the pending writes and resynced.
+ */
+describe('the root seed the CLIENT also sent', () => {
+  beforeEach(() => {
+    store.rev = 0;
+    store.nodes = [];
+  });
+
+  it('lands as one root, not a refusal', async () => {
+    const seed = rootSeedFor(WORKSPACE);
+    const result = await write({ baseRev: 0, put: [seed, pane('pane-new', WORKSPACE, 0)] });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.snapshot.nodes.filter((node) => node.nodeType === 'root')).toHaveLength(1);
+    expect(store.nodes.filter((node) => node.nodeType === 'root')).toHaveLength(1);
+  });
+
+  it('reaches the store once — one statement cannot carry one key twice', async () => {
+    const seed = rootSeedFor(WORKSPACE);
+    await write({ baseRev: 0, put: [seed, pane('pane-new', WORKSPACE, 0)] });
+    expect(store.writes).toHaveLength(1);
+    const ids = store.writes[0]!.put.map((node) => node.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it('is the same tree the client would have got had it sent no seed at all', async () => {
+    const seeded = await write({ baseRev: 0, put: [rootSeedFor(WORKSPACE), pane('pane-new', WORKSPACE, 0)] });
+    const first = store.nodes;
+
+    store.rev = 0;
+    store.nodes = [];
+    store.writes = [];
+    const bare = await write({ baseRev: 0, put: [pane('pane-new', WORKSPACE, 0)] });
+
+    expect(seeded.status).toBe('ok');
+    expect(bare.status).toBe('ok');
+    expect(first).toEqual(store.nodes);
   });
 });
 

--- a/apps/web/src/lib/agent-workspaces/workspace-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-conversations-runtime.ts
@@ -281,9 +281,11 @@ export async function listAllConversationsPaginated(
       createdAt: conversations.createdAt,
       // MEMBERSHIP, from the tree — the node that binds this thread names the
       // workspace it belongs to, where this used to read the conversation's own
-      // column. Nothing else about this listing changes: a thread OFF the grid
-      // is still a member and still past-conversation history, and a thread in
-      // no workspace at all still has a null here.
+      // column. A thread with no node is in no workspace and gets a null here:
+      // that is the only shape of "not a member" there is now, because the node
+      // IS the membership and there is no off-grid state for one to sit in. The
+      // thread itself is untouched either way — it stays in this listing as
+      // past-conversation history.
       workspaceId: membershipNode.rootId,
       sessionName: agentWorkspaces.name,
       sessionEndedAt: agentWorkspaces.endedAt,

--- a/apps/web/src/stores/agent-workspace/workspace-tree-view.ts
+++ b/apps/web/src/stores/agent-workspace/workspace-tree-view.ts
@@ -4,8 +4,8 @@
  *
  * They live outside React on purpose, and outside the store too. Outside React
  * because every one of them is a decision with edge cases worth testing
- * directly — a detached node, a target with no resolved title, an empty grid —
- * and mounting a component to assert one of those is how a rule ends up
+ * directly — a thread with no node, a target with no resolved title, an empty
+ * grid — and mounting a component to assert one of those is how a rule ends up
  * re-derived slightly differently at the second call site. Outside the store
  * because none of them is state: they are the same list, looked at twice.
  *

--- a/packages/lib/src/agent-workspaces/__tests__/workspace-node-backfill.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/workspace-node-backfill.test.ts
@@ -27,6 +27,7 @@ import {
   type WorkspaceBackfillSource,
   type WorkspaceDerivation,
 } from '../workspace-node-backfill';
+import { rootSeedFor } from '../workspace-node-commands';
 import { nodesFromRows } from '../workspace-node-rows';
 import { validateTree, MAX_NODES } from '../workspace-node-validate';
 import { buildRenderTree } from '../workspace-node-rows';
@@ -105,6 +106,17 @@ describe('deriveWorkspaceNodes — the structure it produces', () => {
     assertWritable(derived);
     expect(derived.rows).toHaveLength(1);
     expect(derived.rows[0]).toMatchObject({ nodeType: 'root', parentId: null, position: 0, axis: 'row' });
+  });
+
+  it('gives it the root the SEED would mint, so the two derivations cannot drift apart', () => {
+    // The migration and the runtime seed must agree on what this workspace's
+    // root is called. If they disagree, a client seeding against an empty local
+    // tree sends a root the backfilled server does not have, and the write is
+    // refused `multiple_roots` instead of converging on the upsert — the exact
+    // property the deterministic id exists to provide.
+    const derived = deriveWorkspaceNodes(source({ workspaceId: 'w1' }));
+    assertWritable(derived);
+    expect(derived.rows[0]?.id).toBe(rootSeedFor('w1').id);
   });
 
   it('turns a multi-pane column into a split of axis column, panes in order', () => {
@@ -677,7 +689,7 @@ describe('deriveWorkspaceNodes — a pane bound to a thread that is not a member
     // the split would be a `degenerate_split` and skip the whole workspace.
     expect(nodeById(derived, 'c1')).toBeUndefined();
     expect(nodeById(derived, 'p1')).toMatchObject({ nodeType: 'pane', position: 0 });
-    expect(nodeById(derived, 'p1')?.parentId).toBe('w1::root');
+    expect(nodeById(derived, 'p1')?.parentId).toBe(rootSeedFor('w1').id);
   });
 
   it('reads a shrunken column’s shares as UNSIZED — they no longer sum to 1', () => {

--- a/packages/lib/src/agent-workspaces/__tests__/workspace-node-backfill.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/workspace-node-backfill.test.ts
@@ -119,6 +119,24 @@ describe('deriveWorkspaceNodes — the structure it produces', () => {
     expect(derived.rows[0]?.id).toBe(rootSeedFor('w1').id);
   });
 
+  it('reports it when a pane already holds the id the root derives from', () => {
+    // The rename keeps the migration correct and silently costs the workspace
+    // the seed-convergence the derived id exists for. Every other rename on this
+    // path emits a note; this one has more to say than those do, so it must not
+    // be the one that goes unreported.
+    const derived = deriveWorkspaceNodes(
+      source({
+        workspaceId: 'w1',
+        columns: [column('c1', 0)],
+        panes: [pane('w1', 'c1', 0, chat('t1'))],
+        conversations: [member('t1')],
+      }),
+    );
+    assertWritable(derived);
+    expect(derived.notes.map((entry) => entry.code)).toContain('root_id_renamed');
+    expect(derived.rows[0]?.id).not.toBe('w1');
+  });
+
   it('turns a multi-pane column into a split of axis column, panes in order', () => {
     const derived = deriveWorkspaceNodes(
       source({

--- a/packages/lib/src/agent-workspaces/__tests__/workspace-node-write.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/workspace-node-write.test.ts
@@ -208,6 +208,33 @@ describe('an id that names two nodes', () => {
     expect(decision.code).toBe('duplicate_id');
   });
 
+  it('refuses a conflicting repeat of an id the workspace ALREADY HOLDS', () => {
+    // The half the tree cannot see, and the reason the check is on the payload.
+    // `upsertNodes` keys `changed` by id and REPLACES a stored node in place, so
+    // the second copy silently wins and the validated tree holds exactly one —
+    // `duplicate_id` never fires. `changedPut` meanwhile keeps both, so
+    // `persist.put` used to carry one conflict key twice and Postgres answered
+    // "cannot affect row a second time": a 500 for a payload the caller should
+    // have been told was a 400.
+    const decision = decide(TWO_PANES, {
+      put: [
+        pane('pane-a', 'root', 0, { target: { kind: 'page', id: 'p1' } }),
+        pane('pane-a', 'root', 0, { target: { kind: 'page', id: 'p2' } }),
+      ],
+    });
+    expect(decision.status).toBe('invalid');
+    if (decision.status !== 'invalid') return;
+    expect(decision.code).toBe('duplicate_id');
+  });
+
+  it('collapses an identical repeat of a STORED id too, which is a retry, not a conflict', () => {
+    const bound = pane('pane-a', 'root', 0, { target: { kind: 'page', id: 'p1' } });
+    const decision = decide(TWO_PANES, { put: [bound, { ...bound }] });
+    expect(decision.status).toBe('ok');
+    if (decision.status !== 'ok') return;
+    expect(decision.persist.put.filter((node) => node.id === 'pane-a')).toHaveLength(1);
+  });
+
   it('collapses the same id said twice IDENTICALLY, because that payload means one thing', () => {
     // Not a relaxation of the check above: the two namings there disagree about
     // `position`, so the tree they describe is ambiguous and stays refused.

--- a/packages/lib/src/agent-workspaces/__tests__/workspace-node-write.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/workspace-node-write.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect } from 'vitest';
 import { decideNodeWrite } from '../workspace-node-write';
 import { applyNodeWrite } from '../workspace-node-algebra';
+import { rootSeedFor } from '../workspace-node-commands';
 import { validateTree } from '../workspace-node-validate';
 import { workspaceNodeWriteRequestSchema } from '../workspace-node-wire';
 import type { WireWorkspaceNode } from '../workspace-node-wire';
@@ -207,6 +208,18 @@ describe('an id that names two nodes', () => {
     expect(decision.code).toBe('duplicate_id');
   });
 
+  it('collapses the same id said twice IDENTICALLY, because that payload means one thing', () => {
+    // Not a relaxation of the check above: the two namings there disagree about
+    // `position`, so the tree they describe is ambiguous and stays refused.
+    // These two describe one node, and a payload that says it twice says it
+    // once.
+    const twice = pane('pane-new', 'root', 2);
+    const decision = decide(TWO_PANES, { put: [twice, { ...twice }] });
+    expect(decision.status).toBe('ok');
+    if (decision.status !== 'ok') return;
+    expect(decision.persist.put.filter((node) => node.id === 'pane-new')).toHaveLength(1);
+  });
+
   it('refuses a put that would give the workspace a second root', () => {
     const decision = decide(TWO_PANES, { put: [{ ...root(), id: 'root-2' }] });
     expect(decision.status).toBe('invalid');
@@ -215,6 +228,59 @@ describe('an id that names two nodes', () => {
     // order settles the dangling/reachability questions first, and a second root
     // descends from nothing.
     expect(['multiple_roots', 'unreachable']).toContain(decision.code);
+  });
+});
+
+/**
+ * THE FIRST WRITE TO AN EMPTY WORKSPACE, which is the shape that actually broke.
+ *
+ * A workspace with no tree is seeded by whichever write first needs a root, and
+ * both ends mint one: the browser prepends `seedRoot`'s node so its optimistic
+ * tree has somewhere to put a pane, and the server prepends its own inside the
+ * lock. `rootSeedFor` makes them the identical node — that is what the
+ * deterministic id is FOR — and they arrive in one `put`, where "identical
+ * writes converge on the upsert" did not hold, because `upsertNodes` collapses
+ * nothing inside `changed`. Every first command against an empty tree came back
+ * `duplicate_id`, a 400 the client's queue treats as unrecoverable: it discards
+ * the pending writes and resyncs.
+ */
+describe('the root seed arriving from BOTH ends of one write', () => {
+  const EMPTY = { rev: 0, baseRev: 0 } as const;
+  const seed = rootSeedFor(WORKSPACE);
+
+  it('is one root, not a refusal', () => {
+    const decision = decide([], {
+      ...EMPTY,
+      put: [seed, { ...seed }, pane('pane-new', WORKSPACE, 0)],
+    });
+    expect(decision.status).toBe('ok');
+    if (decision.status !== 'ok') return;
+    expect(decision.nodes.filter((node) => node.nodeType === 'root')).toHaveLength(1);
+  });
+
+  it('reaches STORAGE once, because one statement cannot carry a key twice', () => {
+    // A collapse that only satisfied the validator would trade the 400 for a
+    // 500: `INSERT … ON CONFLICT DO UPDATE` refuses a payload that names one
+    // conflict key in two rows ("cannot affect row a second time").
+    const decision = decide([], {
+      ...EMPTY,
+      put: [seed, { ...seed }, pane('pane-new', WORKSPACE, 0)],
+    });
+    expect(decision.status).toBe('ok');
+    if (decision.status !== 'ok') return;
+    const ids = decision.persist.put.map((node) => node.id);
+    expect(ids).toEqual([...new Set(ids)]);
+    expect(ids).toContain(WORKSPACE);
+  });
+
+  it('still refuses when the two seeds DISAGREE, which no longer describes one root', () => {
+    const decision = decide([], {
+      ...EMPTY,
+      put: [seed, { ...seed, axis: 'column' as const }, pane('pane-new', WORKSPACE, 0)],
+    });
+    expect(decision.status).toBe('invalid');
+    if (decision.status !== 'invalid') return;
+    expect(decision.code).toBe('duplicate_id');
   });
 });
 

--- a/packages/lib/src/agent-workspaces/workspace-membership.ts
+++ b/packages/lib/src/agent-workspaces/workspace-membership.ts
@@ -53,13 +53,12 @@
  */
 
 import { MAX_SESSION_CONVERSATIONS } from './plan-spawn-worker';
-import { create, destroy, type NodeWrite } from './workspace-node-algebra';
+import { destroy, type NodeWrite } from './workspace-node-algebra';
 import {
   rootOf,
   type NodeAxis,
   type PaneNode,
   type PaneTarget,
-  type RootNode,
   type WorkspaceNode,
 } from './workspace-node';
 import {
@@ -69,7 +68,6 @@ import {
   openShell,
   type CommandCode,
   type CommandResult,
-  type Step,
 } from './workspace-node-commands';
 
 /**
@@ -160,11 +158,6 @@ export interface AdmitInput {
   activeNodeId?: string;
   /** The invoking conversation: never evicted by the thing it spawned. */
   excludeTargetId?: string;
-}
-
-/** A step that writes exactly what it is given — for the one node no operation mints. */
-function staged(write: NodeWrite): Step {
-  return () => ({ ok: true, write });
 }
 
 /**

--- a/packages/lib/src/agent-workspaces/workspace-node-algebra.ts
+++ b/packages/lib/src/agent-workspaces/workspace-node-algebra.ts
@@ -74,9 +74,22 @@ import { validateTree, type TreeViolationCode } from './workspace-node-validate'
  * from memory, both of them consequences of the composite self-FK
  * `(rootId, parentId) → (rootId, id)`:
  *
- *  - **`put` before `drop`.** The FK is `ON DELETE cascade`, and `drop` names
- *    containers whose children are being REPARENTED rather than deleted. See
- *    {@link applyNodeWrite}.
+ *  - **THE CASCADE MUST NOT REACH A REPARENTED CHILD.** The FK is
+ *    `ON DELETE cascade`, and `drop` names containers whose children are being
+ *    REPARENTED rather than deleted — {@link collapseInto} builds precisely that
+ *    shape. IN MEMORY the obligation is discharged by ORDER:
+ *    {@link applyNodeWrite} folds `put` before `drop`, so a survivor already
+ *    hangs off its new parent when its old one goes.
+ *
+ *    **A PERSISTING writer cannot use that order, and must not reach for it.**
+ *    Upserting first leaves one conversation held by two rows for the length of
+ *    the statement, and the table's `UNIQUE (targetId) WHERE targetKind = 'chat'`
+ *    refuses that immediately — closing one hole by opening another. So the
+ *    store deletes FIRST and pays for the cascade a different way: every node
+ *    that survives the write while sitting beneath a removed one is added to the
+ *    upsert, so the delete takes it and the same statement puts it straight
+ *    back. That derivation is `persistedWrite` in `workspace-node-write.ts`, and
+ *    IT — not an ordering — is what a persisting writer owes this type.
  *  - **`put` is ONE statement, not a loop.** Its order is whatever
  *    `upsertNodes` produced — replace in place, then append — and nothing
  *    establishes that a parent precedes its children in it. A multi-row

--- a/packages/lib/src/agent-workspaces/workspace-node-backfill.ts
+++ b/packages/lib/src/agent-workspaces/workspace-node-backfill.ts
@@ -83,6 +83,7 @@ import {
   rowFromNode,
   type WorkspaceNodeRow,
 } from './workspace-node-rows';
+import { rootSeedFor } from './workspace-node-commands';
 import { validateTree, type TreeViolationCode } from './workspace-node-validate';
 import type { PaneNode, PaneTargetKind, SplitNode, WorkspaceNode } from './workspace-node';
 
@@ -758,10 +759,23 @@ export function deriveWorkspaceNodes(
   // ---------------------------------------------------------------------
   // The nodes
   // ---------------------------------------------------------------------
-  const rootId = ids.allocate(`${workspaceId}::root`, 'root').id;
-  const nodes: WorkspaceNode[] = [
-    { nodeType: 'root', id: rootId, parentId: null, position: 0, axis: 'row' },
-  ];
+  // THE SAME ROOT THE SEED WOULD MINT, from the same function, and that is the
+  // point rather than a tidiness. `rootSeedFor` derives its id from the
+  // workspace so that two writers racing to seed an empty tree produce the
+  // IDENTICAL root and converge on the upsert. A backfill that minted its own
+  // shape of id put a second derivation into circulation: a client seeding
+  // against a stale or empty local tree while the server already held a
+  // backfilled root would send a root the server does not have, and the write
+  // would come back `multiple_roots` instead of converging. One derivation,
+  // one root id.
+  //
+  // Still through the allocator, because a pane may already hold this id — the
+  // old schema keys panes per-workspace and nothing stopped one being named
+  // after its workspace. A renamed root loses the convergence above and keeps
+  // the migration correct, which is the right way round.
+  const seed = rootSeedFor(workspaceId);
+  const rootId = ids.allocate(seed.id, 'root').id;
+  const nodes: WorkspaceNode[] = [{ ...seed, id: rootId }];
 
   // ---------------------------------------------------------------------
   // THE MEMBERS THAT HAD NO PANE — resolved BEFORE anything is emitted, because

--- a/packages/lib/src/agent-workspaces/workspace-node-backfill.ts
+++ b/packages/lib/src/agent-workspaces/workspace-node-backfill.ts
@@ -234,8 +234,15 @@ export function resolveChatClaims(params: {
 export type DerivationNoteCode =
   /** A column holding no panes. It renders nothing today and would be a `degenerate_split` tomorrow. */
   | 'empty_column_dropped'
-  /** A column id that collided with a pane id — legal in two tables, impossible in one. */
+  /** A column id that collided with an id already taken — legal in two tables, impossible in one. */
   | 'column_id_renamed'
+  /**
+   * A pane already held the id `rootSeedFor` mints for this workspace, so the
+   * root took a suffixed one. Worth reporting rather than swallowing: the
+   * derived id is what makes a client's seed and the server's the SAME write, so
+   * a renamed root is a workspace that quietly does not have that property.
+   */
+  | 'root_id_renamed'
   /** `kind` without `targetId`, or the reverse. Half a binding is a corrupt pane, not a partial one. */
   | 'pane_target_half_bound'
   /** `kind` outside `'chat' | 'terminal' | 'page'`. The old column had no check constraint. */
@@ -774,7 +781,19 @@ export function deriveWorkspaceNodes(
   // after its workspace. A renamed root loses the convergence above and keeps
   // the migration correct, which is the right way round.
   const seed = rootSeedFor(workspaceId);
-  const rootId = ids.allocate(seed.id, 'root').id;
+  const allocatedRoot = ids.allocate(seed.id, 'root');
+  if (allocatedRoot.renamed) {
+    // REPORTED, not swallowed. Every other rename on this path emits a note, and
+    // this one costs more than a name: the workspace keeps a correct tree but
+    // loses the convergence the derived id exists to provide, and nothing else
+    // in the run would say so.
+    note(
+      'root_id_renamed',
+      workspaceId,
+      `a pane already holds the id this workspace's root derives from; the root is "${allocatedRoot.id}"`,
+    );
+  }
+  const rootId = allocatedRoot.id;
   const nodes: WorkspaceNode[] = [{ ...seed, id: rootId }];
 
   // ---------------------------------------------------------------------
@@ -877,7 +896,10 @@ export function deriveWorkspaceNodes(
       note(
         'column_id_renamed',
         entry.column.id,
-        `column id collides with a pane id in the same workspace; the split is "${allocated.id}"`,
+        // Not "collides with a pane" any more: the ROOT is allocated before the
+        // columns and now prefers the workspace's own id, so it is a second
+        // thing this can collide with.
+        `column id is already taken in this workspace; the split is "${allocated.id}"`,
       );
     }
     const split: SplitNode = {

--- a/packages/lib/src/agent-workspaces/workspace-node-write.ts
+++ b/packages/lib/src/agent-workspaces/workspace-node-write.ts
@@ -106,6 +106,52 @@ function sameNode(left: WorkspaceNode, right: WorkspaceNode): boolean {
 }
 
 /**
+ * ONE NODE SAID TWICE IN ONE PAYLOAD IS ONE NODE — and only when the two
+ * sayings agree.
+ *
+ * The idempotency this model runs on is "the same write applied twice is the
+ * same result", and until this function that held only ACROSS payloads: a
+ * retried POST re-upserts its nodes and lands where the first one did. Within a
+ * single payload the same repetition was fatal, because {@link upsertNodes}
+ * replaces by id against the STORED nodes and appends everything else in order
+ * — it does not collapse a repeat inside `changed` — so both copies reached
+ * {@link validateTree} and came back `duplicate_id`, a 400 the client treats as
+ * unrecoverable.
+ *
+ * That is not a hypothetical shape. It is the ROOT SEED. A workspace with no
+ * tree is seeded by whichever write first needs a root, and BOTH ends mint one:
+ * the browser prepends `seedRoot`'s node so its optimistic tree has somewhere to
+ * put a pane, and the server prepends its own inside the lock so the write is
+ * legal whatever the client sent. Both come from `rootSeedFor(workspaceId)` and
+ * are therefore the identical node — the convergence the deterministic id was
+ * chosen FOR — and they met in one `put`, where the convergence did not apply.
+ * Every first command against an empty tree failed.
+ *
+ * **Identical only, deliberately.** Two DIFFERENT nodes claiming one id is a
+ * real fault with a real code, and collapsing it last-wins would judge a tree on
+ * whichever half survived and then store that half silently. Those repeats are
+ * left in place so the validator still refuses them. What is dropped is
+ * strictly the repetition that says nothing: same id, same everything
+ * {@link sameNode} compares, so the payload means the same with it as without.
+ *
+ * Done HERE rather than at the seed's call site because the duplicate must also
+ * leave `persist.put`: a multi-row `INSERT … ON CONFLICT DO UPDATE` carrying one
+ * key twice is a Postgres error ("cannot affect row a second time"), so a fix
+ * that only satisfied the validator would trade the 400 for a 500.
+ */
+function collapseRepeats(incoming: readonly WorkspaceNode[]): WorkspaceNode[] {
+  const kept: WorkspaceNode[] = [];
+  const byId = new Map<string, WorkspaceNode>();
+  for (const node of incoming) {
+    const seen = byId.get(node.id);
+    if (seen !== undefined && sameNode(seen, node)) continue;
+    byId.set(node.id, node);
+    kept.push(node);
+  }
+  return kept;
+}
+
+/**
  * TRANSLATE THE DECIDED TREE INTO A STORAGE INSTRUCTION, and it is NOT the
  * caller's `put`/`drop`.
  *
@@ -183,7 +229,11 @@ export function decideNodeWrite(request: NodeWriteRequest): NodeWriteDecision {
   // 2. REV.
   if (baseRev !== rev) return { status: 'stale' };
 
-  const incoming = put.map(nodeOfWire);
+  // The payload's nodes, with any node it named twice IDENTICALLY reduced to
+  // one. See {@link collapseRepeats}: the root seed arrives from both ends of a
+  // first write, and everything below — the validated tree, the change
+  // measurement, the storage instruction — must see one of it.
+  const incoming = collapseRepeats(put.map(nodeOfWire));
 
   // 3. VALIDITY OF THE RESULT. Drop then upsert, so an id named in BOTH
   //    resolves as PUT WINS — which is the decision `persistedWrite` below

--- a/packages/lib/src/agent-workspaces/workspace-node-write.ts
+++ b/packages/lib/src/agent-workspaces/workspace-node-write.ts
@@ -128,27 +128,39 @@ function sameNode(left: WorkspaceNode, right: WorkspaceNode): boolean {
  * Every first command against an empty tree failed.
  *
  * **Identical only, deliberately.** Two DIFFERENT nodes claiming one id is a
- * real fault with a real code, and collapsing it last-wins would judge a tree on
- * whichever half survived and then store that half silently. Those repeats are
- * left in place so the validator still refuses them. What is dropped is
- * strictly the repetition that says nothing: same id, same everything
- * {@link sameNode} compares, so the payload means the same with it as without.
+ * real fault: collapsing it last-wins would judge a tree on whichever half
+ * survived and then store that half silently. So this REFUSES that payload
+ * itself, with the validator's own code and wording, rather than collapsing it
+ * and rather than passing it on for {@link validateTree} to catch.
  *
- * Done HERE rather than at the seed's call site because the duplicate must also
- * leave `persist.put`: a multi-row `INSERT … ON CONFLICT DO UPDATE` carrying one
- * key twice is a Postgres error ("cannot affect row a second time"), so a fix
- * that only satisfied the validator would trade the 400 for a 500.
+ * **Refusing here is not belt-and-braces; the validator cannot see it.** A
+ * repeat whose id is ALREADY STORED never reaches the tree as two nodes:
+ * {@link upsertNodes} keys `changed` by id and replaces in place, so the second
+ * copy silently wins and `next` holds exactly one. `duplicate_id` fires only
+ * when the id is NEW and both copies are appended. The two halves then part
+ * ways: `changedPut` is filtered from this list, which still held both, so
+ * `persist.put` carried one conflict key twice and a multi-row
+ * `INSERT … ON CONFLICT DO UPDATE` raised "cannot affect row a second time" — a
+ * 500 where the caller should have been told 400. That is why the check lives
+ * on the payload, where both copies are still visible, instead of on the tree.
  */
-function collapseRepeats(incoming: readonly WorkspaceNode[]): WorkspaceNode[] {
+type CollapsedPut =
+  | { status: 'ok'; nodes: WorkspaceNode[] }
+  | { status: 'conflict'; id: string };
+
+function collapseRepeats(incoming: readonly WorkspaceNode[]): CollapsedPut {
   const kept: WorkspaceNode[] = [];
   const byId = new Map<string, WorkspaceNode>();
   for (const node of incoming) {
     const seen = byId.get(node.id);
-    if (seen !== undefined && sameNode(seen, node)) continue;
+    if (seen !== undefined) {
+      if (!sameNode(seen, node)) return { status: 'conflict', id: node.id };
+      continue;
+    }
     byId.set(node.id, node);
     kept.push(node);
   }
-  return kept;
+  return { status: 'ok', nodes: kept };
 }
 
 /**
@@ -230,10 +242,23 @@ export function decideNodeWrite(request: NodeWriteRequest): NodeWriteDecision {
   if (baseRev !== rev) return { status: 'stale' };
 
   // The payload's nodes, with any node it named twice IDENTICALLY reduced to
-  // one. See {@link collapseRepeats}: the root seed arrives from both ends of a
-  // first write, and everything below — the validated tree, the change
-  // measurement, the storage instruction — must see one of it.
-  const incoming = collapseRepeats(put.map(nodeOfWire));
+  // one — and a payload that named one id twice DIFFERENTLY refused outright.
+  // See {@link collapseRepeats}: the root seed arrives from both ends of a first
+  // write, so everything below (the validated tree, the change measurement, the
+  // storage instruction) must see one of it; and a conflicting repeat has to be
+  // caught here, because a repeat of a STORED id never reaches the tree as two
+  // nodes for `validateTree` to refuse.
+  const collapsed = collapseRepeats(put.map(nodeOfWire));
+  if (collapsed.status === 'conflict') {
+    return {
+      status: 'invalid',
+      code: 'duplicate_id',
+      // The validator's own wording, so one fault reads the same to the caller
+      // whichever of the two places notices it.
+      detail: `id "${collapsed.id}" names more than one node; ids are unique`,
+    };
+  }
+  const incoming = collapsed.nodes;
 
   // 3. VALIDITY OF THE RESULT. Drop then upsert, so an id named in BOTH
   //    resolves as PUT WINS — which is the decision `persistedWrite` below


### PR DESCRIPTION
Follow-up to #2378 and #2380 — the findings from the post-merge review of the node-model cutover, plus the wider sweep those findings pointed at. One real bug, one duplicated derivation, a family of docblocks across ten files describing the model that was replaced, and two tests that asserted retired mechanisms.

## The bug

A workspace with no tree is seeded by whichever write first needs a root, and **both ends mint one**: `runCommand` prepends `seedRoot`'s node so the browser's optimistic tree has somewhere to put a pane, and `commitUnderLock` prepends its own inside the lock so the write is legal whatever the client sent. Both come from `rootSeedFor(workspaceId)`, so they are the identical node — the convergence the deterministic id exists to provide.

They met in one `put`, where that convergence did not apply. `upsertNodes` replaces by id against the **stored** nodes and appends the rest in order; it collapses nothing inside `changed`, so both copies reached `validateTree`:

```
client put ids: [ "ws-1", "pane-1" ]
decision: { "status": "invalid", "code": "duplicate_id" }
```

The route answers 400, and `settle` treats a non-409 4xx as unrecoverable — it discards the queue, raises `refused` and resyncs. Every first command against an empty tree (`openPage`, `openShell`, `openConversation`, `splitPane`) failed that way: a post-cutover workspace with no legacy rows, or the migration window for one with no legacy panes/shells/open conversations.

`decideNodeWrite` now collapses a node the payload named twice **identically**, at the boundary where the payload arrives, so the validated tree, the change measurement and the storage instruction all see one of it.

- **Identical only.** Two *different* nodes claiming one id stay refused — collapsing those last-wins would judge a tree on whichever half survived and then store that half silently.
- **There, not at the seed's call site.** The duplicate has to leave `persist.put` too: one `INSERT … ON CONFLICT DO UPDATE` cannot carry a conflict key twice, so a fix that only satisfied the validator would have traded the 400 for a 500.

## One root id, one derivation

The backfill minted `${workspaceId}::root` while `rootSeedFor` minted `workspaceId`. They do not collide today only because both `seedRoot` call sites guard on "is there a root" rather than on the id — but a client seeding against a stale or empty local tree while the server holds a backfilled root would send a root the server does not have and get `multiple_roots` instead of converging. The backfill now goes through `rootSeedFor`, still via the id allocator (panes reserve their ids first, so a pane named after its workspace would rename the root; a renamed root loses the convergence and keeps the migration correct, which is the right way round).

**Timing.** This wants to land before the backfill runs anywhere real. `0256` (the drop) does not exist yet and the backfill has not been through production, so changing the derivation now means every workspace gets the seed-consistent root. A workspace already backfilled somewhere with the old `::root` id keeps working either way — `seedRoot` guards on "is there a root", not on the id, so the client never seeds over one — it simply does not gain the convergence.

## The parked model, still in the prose

The review found four stale docblocks. Sweeping for the same defect found ten more, and they are one defect: each states as **current** behaviour that a closed node *parks* — keeps its row, loses its parent, stays a member off the grid. `validateTree` calls a non-root node with a null parent `null_parent`, so parking is not merely unused, it is **unspellable**. Every present-tense claim of it is false.

- `NodeWrite` told a persisting writer it owes **`put` before `drop`**. The only persisting writer does the opposite deliberately — the partial chat index makes upsert-first hold one conversation on two rows mid-statement — and pays for the cascade by rescuing survivors into the upsert instead. Following the docblock would reintroduce the violation that ordering exists to avoid.
- The conversation **DELETE** route said closing is "a `move` … the thread stays a MEMBER". It is a `destroy`: membership goes and the chat binding is freed. Its `last_conversation` paragraph justified removing the guard with "a `move` cannot produce that state", which is no longer true — rewritten to the reason that does hold (a root with no children is a tree the validator accepts).
- The **reopen** route said "**No `session_full` any more**" twelve lines above the code that answers `session_full` with a 409 — reopening is a re-admission and consumes a cap slot.
- `close-pane.ts` justified its own existence with "closing a node parks it, so closing the THREAD is a separate question". Both branches destroy the node; what actually separates them is that only the route tells the **directory plane** — it emits the conversation's `closed` lifecycle event, which `workspace:nodes-updated` does not cover, because that event carries the tree while the sidebar's rows come from the listing. Take the node write alone on a chat pane and the grid is right while the sidebar keeps a row for a thread that is gone.
- `SessionPanes.tsx` carried the claim twice (module header and `EmptyGrid`) and documented `nodes` as "attached and detached"; `AgentPanes.tsx` documented selection as three outcomes in two places where `openTarget` has two, reasoned the terminal close from "no reattach path through a parked node's own row", and said a displaced node is "parked rather than destroyed" — nothing is displaced at all, since a binding is for life and the replacement is placed in a node of its own.
- `AgentPageView.tsx`, `workspace-conversations-runtime.ts` and `workspace-tree-view.ts` each carried one more.
- Dead `staged` / `create` / `RootNode` / `Step` removed from `workspace-membership` (`packages/lib` has no ESLint config and no `noUnusedLocals`, so nothing caught them).

## Two tests that asserted retired mechanisms

- The **reopen** route's test asserted "`session_full` is not an outcome this route can receive", leaving the live 409 branch uncovered. It now exercises it.
- `GET /api/agent-workspaces` asserted `attached: true/false` on the listing — a field the route deleted along with the grid it used to reconcile against (#2373). The values came from the test's own fixture and rode through the pass-through, so the assertion proved nothing about the route while documenting a retired field as live contract. It now pins what the route promises — the listing is handed back key for key, nothing annotated onto it — with `toEqual` over the whole array rather than `toMatchObject` per entry, because the regression it guards against is a derived field being **added** back, which a per-key match cannot see.

## Verification

- **Mutation-checked**, both fixes. Disabling `collapseRepeats` turns 3 tests red in `workspace-node-write.test.ts` and 3 in `workspace-node-runtime.test.ts` (the latter only after rebuilding the lib dist that `web` resolves against — worth knowing for anyone repeating this). Making the route re-annotate its listing turns the rewritten `attached` test red, for an `attached` flag and for an unrelated derived key.
- `bun run typecheck`, `bun run lint`, `bun run knip:check` green.
- `@pagespace/lib`: 9256 passed. `web` agent-workspaces + components/agents + sidebar: 859 passed, and the DB-backed integration suites passed against the test Postgres on the first commit.
- Two env-only gaps, untouched by this branch: `gdpr-eraser.integration.test.ts` needs a dedicated `pagespace_admin_test` DB and fails setup on `DROP ROLE admin_app`; and the DB-backed suites do not connect from the scratch worktree the second commit was built in (the repo `.env` points `DATABASE_URL` at the compose hostname `postgres`). The second commit changes comments, one test's assertions and no runtime behaviour reachable from those suites.

No changelog entry: the broken behaviour never reached users — it lands and is fixed inside the same unreleased block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWzqTWbjuQw5d5A3pYfBJ
