### PR TITLE
fix(ci): scripts/ is a build input for the migrate image but was not a trigger

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -12,20 +12,24 @@ on:
       # A BUILD INPUT THAT WAS NOT A TRIGGER, and the asymmetry was silent.
       # `apps/web/Dockerfile.migrate` does `COPY scripts ./scripts` — one-off
       # scripts are meant to run on the migrate image, and its own comments say
-      # so — but a script-only change matched none of the paths above, so the
-      # image was never rebuilt and the published tag never gained the file.
+      # so — but a script-only change matched none of the paths above, so this
+      # workflow never ran for it, the image was never rebuilt, and the
+      # published tag never gained the file.
       #
       # Proved on 2026-08-10: `registry.fly.io/pagespace-web:migrate` did not
       # contain `scripts/backfill-agent-workspace-nodes.ts` at all. An absolute
-      # path failed identically, ruling out a working-directory explanation, and
-      # a GREEN `Docker Images` run left the Fly tag on the same digest, because
-      # this workflow does not build the migrate image inline — it pulls
-      # `ghcr.io/2witstudios/pagespace-migrate:latest` and retags, so a stale
-      # GHCR `:latest` propagates and a green run proves nothing about contents.
+      # path failed identically, which rules out a working-directory
+      # explanation — the file was simply absent.
       #
-      # The rollout step "run it as a one-off machine on the migrate image" was
-      # therefore impossible to perform, which is how the epic's own backfill
-      # gate came to be unrunnable.
+      # The consequence was not theoretical. The node-tree epic's rollout says
+      # to run its backfill "as a one-off machine on the migrate image", and the
+      # drop that follows (`0256`) is gated on that run exiting 0. With the
+      # script absent, that gate could not be executed at all — the one check
+      # between the drop and a workspace whose membership lives only in the
+      # columns being dropped.
+      #
+      # This is a class of bug rather than one missing file: every future
+      # script-only change would go the same way, invisibly, with CI green.
       - 'scripts/**'
       - 'bun.lock'
       - '.github/workflows/docker-images.yml'

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,6 +9,24 @@ on:
       - 'apps/**'
       - 'packages/**'
       - 'docker/**'
+      # A BUILD INPUT THAT WAS NOT A TRIGGER, and the asymmetry was silent.
+      # `apps/web/Dockerfile.migrate` does `COPY scripts ./scripts` — one-off
+      # scripts are meant to run on the migrate image, and its own comments say
+      # so — but a script-only change matched none of the paths above, so the
+      # image was never rebuilt and the published tag never gained the file.
+      #
+      # Proved on 2026-08-10: `registry.fly.io/pagespace-web:migrate` did not
+      # contain `scripts/backfill-agent-workspace-nodes.ts` at all. An absolute
+      # path failed identically, ruling out a working-directory explanation, and
+      # a GREEN `Docker Images` run left the Fly tag on the same digest, because
+      # this workflow does not build the migrate image inline — it pulls
+      # `ghcr.io/2witstudios/pagespace-migrate:latest` and retags, so a stale
+      # GHCR `:latest` propagates and a green run proves nothing about contents.
+      #
+      # The rollout step "run it as a one-off machine on the migrate image" was
+      # therefore impossible to perform, which is how the epic's own backfill
+      # gate came to be unrunnable.
+      - 'scripts/**'
       - 'bun.lock'
       - '.github/workflows/docker-images.yml'
 


### PR DESCRIPTION
One line of YAML. It unblocks the `0256` gate, which currently **cannot be executed at all**.

## The bug

`apps/web/Dockerfile.migrate` does `COPY scripts ./scripts`, and its own comments say one-off scripts are meant to run on that image. But `docker-images.yml` fired only on `apps/**`, `packages/**`, `docker/**`, `bun.lock` and itself.

So **`scripts/` was a build input that was not a trigger.** A script-only change never rebuilt the image, and the published tag never gained the file.

## Proof (production, 2026-08-10 — three one-shot machines, all destroyed)

```
bun scripts/backfill-agent-workspace-nodes.ts
  → error: Module not found "scripts/backfill-agent-workspace-nodes.ts"

bun /app/scripts/backfill-agent-workspace-nodes.ts
  → error: Module not found "/app/scripts/backfill-agent-workspace-nodes.ts"
```

The **absolute path failing identically rules out a working-directory explanation** — the file is simply absent.

And a **green `Docker Images` run in between** left `registry.fly.io/pagespace-web:migrate` resolving to the *same digest* (`sha256:3d2512…`). That workflow doesn't build the migrate image inline — it pulls `ghcr.io/2witstudios/pagespace-migrate:latest` and retags. A stale GHCR `:latest` propagates to Fly silently, so **a green run proves nothing about the tag's contents.**

## Why it matters

The node-tree epic's rollout says to run the backfill "as a one-off machine on the migrate image", and migration `0256` — which drops `conversations.workspaceId` and the old pane tables — is gated on that run exiting 0.

With the script absent from the image, that gate could not be run. It is the only check standing between the drop and a workspace whose membership lives *only* in the columns being dropped.

This is a class of bug, not one missing file: every future script-only change — backfills, one-off repairs, migration helpers — would have gone the same way, invisibly, with CI green.

## Validation

YAML re-parsed after the edit; trigger list now `apps/** · packages/** · docker/** · scripts/** · bun.lock · .github/workflows/docker-images.yml`.

Merging this rebuilds the image, since the workflow file is itself a trigger path. **Afterwards:** re-run the backfill DRY on a one-off machine and require exit 0 before generating `0256`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images are now automatically rebuilt and published when files under the scripts directory change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->