### PR TITLE
One writer for a pane close, and the last pane ends the session again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Closing a chat pane no longer shows "Could not close this conversation"** — closing sent two
+  requests that removed the same thing, and the second one arrived to find the first had already
+  done it. The pane closed correctly either way, so the error was pure noise; there is one request
+  now.
+- **Closing the last pane asks whether to end the session again** — it had started leaving you in an
+  empty grid with nothing to do, which was not what anyone wanted. You get the same confirm the
+  sidebar's "End session" uses, and Cancel leaves everything exactly as it was. Closing the last
+  conversation row in the sidebar now asks the same question, instead of quietly emptying the
+  session.
+- **A conversation removed from a session leaves the sidebar however it was removed** — closing a
+  pane, closing a sidebar row, an agent closing one on your behalf, or ending the session. Only one
+  of those used to tell the sidebar, so a thread you had just closed could sit in the list for up to
+  two minutes.
+- **A thread whose history was deleted can no longer get stuck in a session** — if the cleanup that
+  removes it from your session failed, every later attempt to close it reported success and did
+  nothing, leaving a pane that could not be closed. The close is attempted properly now.
 - **A pane appears in the sidebar the moment it exists** — the sidebar and the pane layout used to
   be two separate records of what a session contained, kept in step by convention, so a pane you or
   an agent opened could take up to two minutes to show up in the list. They are now two views of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **A pane appears in the sidebar the moment it exists** — the sidebar and the pane layout used to
+  be two separate records of what a session contained, kept in step by convention, so a pane you or
+  an agent opened could take up to two minutes to show up in the list. They are now two views of
+  one thing, so there is nothing to fall out of step.
+- **A thread can no longer go missing from its own session** — a session's membership and its
+  layout were stored separately, and a thread that had no pane was simply absent from the list.
+  Sessions existed with more threads than the sidebar would show. Membership is now the same record
+  as placement, so a thread that is in a session is always visible in it, open or not.
+- **Opening a conversation that is already open in another session says so, instead of leaving a
+  dead pane behind** — a conversation lives in exactly one pane, and trying to show one that
+  another session already holds used to fail as a server error. The pane you had just opened stayed
+  on screen, showing nothing, until something else happened to refresh the layout. The attempt is
+  now refused properly and the layout corrects itself straight away.
 - **Closing a chat pane no longer shows "Could not close this conversation"** — closing sent two
   requests that removed the same thing, and the second one arrived to find the first had already
   done it. The pane closed correctly either way, so the error was pure noise; there is one request
@@ -23,19 +36,6 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 - **A thread whose history was deleted can no longer get stuck in a session** — if the cleanup that
   removes it from your session failed, every later attempt to close it reported success and did
   nothing, leaving a pane that could not be closed. The close is attempted properly now.
-- **A pane appears in the sidebar the moment it exists** — the sidebar and the pane layout used to
-  be two separate records of what a session contained, kept in step by convention, so a pane you or
-  an agent opened could take up to two minutes to show up in the list. They are now two views of
-  one thing, so there is nothing to fall out of step.
-- **A thread can no longer go missing from its own session** — a session's membership and its
-  layout were stored separately, and a thread that had no pane was simply absent from the list.
-  Sessions existed with more threads than the sidebar would show. Membership is now the same record
-  as placement, so a thread that is in a session is always visible in it, open or not.
-- **Opening a conversation that is already open in another session says so, instead of leaving a
-  dead pane behind** — a conversation lives in exactly one pane, and trying to show one that
-  another session already holds used to fail as a server error. The pane you had just opened stayed
-  on screen, showing nothing, until something else happened to refresh the layout. The attempt is
-  now refused properly and the layout corrects itself straight away.
 - **The MCP config you copy out of Settings > MCP now actually starts** — the "No install (npx)"
   tab handed you a command `npx` cannot run, so the server failed to launch and your AI tool
   showed no PageSpace tools at all. Copy it again and it works.

--- a/apps/e2e/tests/18-sidebar-directory-live.spec.ts
+++ b/apps/e2e/tests/18-sidebar-directory-live.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type APIRequestContext, type BrowserContext, type Page } from '@playwright/test';
 import { seedUser, type SeededUser } from '../support/db';
-import { sessionPost, sessionDelete } from '../support/http';
+import { sessionPost, sessionDelete, sessionGet } from '../support/http';
 import { authedContext } from '../fixtures/chat.fixture';
 
 /**
@@ -188,6 +188,48 @@ async function spawnConversationServerSide(
     );
   }
   return ((await response.json()) as { conversationId: string }).conversationId;
+}
+
+/**
+ * Close a conversation the way a USER does: one `drop` at the node write.
+ *
+ * This is the path the browser actually takes — `closePane` queues a drop and
+ * the pump POSTs it — and until the announcement moved into the write funnel it
+ * was the path that announced NOTHING. The route-based close below is still
+ * exercised beside it, but a spec that only drove the route would keep passing
+ * while the real close left the row on screen, which is exactly what happened.
+ */
+async function dropChatNodeServerSide(
+  request: APIRequestContext,
+  user: SeededUser,
+  sessionId: string,
+  conversationId: string,
+): Promise<void> {
+  const read = await sessionGet(request, `/api/agent-workspaces/${encodeURIComponent(sessionId)}/nodes`, user);
+  if (!read.ok()) {
+    throw new Error(`dropChatNodeServerSide: read answered ${read.status()}: ${(await read.text()).slice(0, 500)}`);
+  }
+  const tree = (await read.json()) as {
+    rev: number;
+    nodes: Array<{ id: string; nodeType: string; target: { kind: string; id: string } | null }>;
+  };
+  const node = tree.nodes.find(
+    (candidate) =>
+      candidate.nodeType === 'pane' && candidate.target?.kind === 'chat' && candidate.target.id === conversationId,
+  );
+  if (!node) throw new Error(`dropChatNodeServerSide: no chat node holds ${conversationId}`);
+
+  const response = await sessionPost(
+    request,
+    `/api/agent-workspaces/${encodeURIComponent(sessionId)}/nodes`,
+    user,
+    { baseRev: tree.rev, put: [], drop: [node.id] },
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `dropChatNodeServerSide: write answered ${response.status()}: ${(await response.text()).slice(0, 500)}`,
+    );
+  }
 }
 
 /** Close a conversation out of its session, again from outside the browser. */
@@ -408,8 +450,9 @@ test.describe('session directory — a server-created conversation reaches the s
     await expect(conversationRows).toHaveCount(1, { timeout: 30_000 });
 
     // A SECOND conversation, so the close below is an ordinary close rather
-    // than a collision with the never-empty invariant (the server refuses to
-    // close a session's last open listing with a 409).
+    // than one that empties the workspace. (The never-empty 409 this used to
+    // cite is gone: the server stopped refusing the last close in the node-tree
+    // cutover, and ending a session is now the CLIENT's decision, confirmed.)
     const spawned = await spawnConversationServerSide(request, user, target.sessionId);
     await expect(conversationRows).toHaveCount(2, { timeout: POLL_CONTROL_MS });
 
@@ -428,6 +471,45 @@ test.describe('session directory — a server-created conversation reaches the s
     // backstop is finally deleted.
     // eslint-disable-next-line no-console -- surfaced in the Playwright report, not app code
     console.log(`listing fetches blocked during the close window: ${blockedFetches()}`);
+  });
+
+  /**
+   * THE SAME SEAM, DRIVEN THE WAY A USER DRIVES IT.
+   *
+   * The test above closes through `DELETE …/conversations/{id}`, which no client
+   * sends any more: closing a pane is one `drop` at `POST …/nodes`. That made it
+   * a spec that kept passing while covering a path nothing takes — and the
+   * announcement it proves reaches the sidebar was, on the real path, never
+   * emitted at all. The drop is the close now, on the tree and in the listing
+   * alike, so the announcement has to ride on the drop.
+   */
+  test('a node DROP removes the row with the listing fetch cut off at the network', async ({
+    browser,
+    baseURL,
+    request,
+  }) => {
+    const { user, page, target } = await openConsole(browser, baseURL!, request);
+
+    const { conversationRows } = await expandSession(page, target.sessionId);
+    await expect(conversationRows).toHaveCount(1, { timeout: 30_000 });
+
+    // A second conversation, so this is an ordinary close rather than one that
+    // empties the workspace.
+    const spawned = await spawnConversationServerSide(request, user, target.sessionId);
+    await expect(conversationRows).toHaveCount(2, { timeout: POLL_CONTROL_MS });
+
+    const blockedFetches = await blockSessionListingFetches(page);
+
+    await dropChatNodeServerSide(request, user, target.sessionId, spawned);
+
+    // The row can only have left because the WRITE FUNNEL emitted
+    // `conversation:closed` — the browser never asked and cannot ask, and the
+    // structural `workspace:nodes-updated` beside it carries the tree, which
+    // this cache is not keyed by.
+    await expect(conversationRows).toHaveCount(1, { timeout: POLL_CONTROL_MS });
+
+    // eslint-disable-next-line no-console -- surfaced in the Playwright report, not app code
+    console.log(`listing fetches blocked during the drop window: ${blockedFetches()}`);
   });
 
   /**

--- a/apps/e2e/tests/18-sidebar-directory-live.spec.ts
+++ b/apps/e2e/tests/18-sidebar-directory-live.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect, type APIRequestContext, type BrowserContext, type Page } from '@playwright/test';
 import { seedUser, type SeededUser } from '../support/db';
 import { sessionPost, sessionDelete, sessionGet } from '../support/http';
+import { closePane as closePaneCommand } from '@pagespace/lib/agent-workspaces/workspace-node-commands';
+import type { WorkspaceNode } from '@pagespace/lib/agent-workspaces/workspace-node';
 import { authedContext } from '../fixtures/chat.fixture';
 
 /**
@@ -209,21 +211,28 @@ async function dropChatNodeServerSide(
   if (!read.ok()) {
     throw new Error(`dropChatNodeServerSide: read answered ${read.status()}: ${(await read.text()).slice(0, 500)}`);
   }
-  const tree = (await read.json()) as {
-    rev: number;
-    nodes: Array<{ id: string; nodeType: string; target: { kind: string; id: string } | null }>;
-  };
+  const tree = (await read.json()) as { rev: number; nodes: WorkspaceNode[] };
   const node = tree.nodes.find(
     (candidate) =>
       candidate.nodeType === 'pane' && candidate.target?.kind === 'chat' && candidate.target.id === conversationId,
   );
   if (!node) throw new Error(`dropChatNodeServerSide: no chat node holds ${conversationId}`);
 
+  // COMPILED THROUGH THE SAME COMMAND THE BROWSER RUNS, not hand-rolled as
+  // `{put: [], drop: [nodeId]}`. A bare drop is not what closing a pane is: the
+  // node's parent split may be left holding one child, which `validateTree`
+  // refuses as `degenerate_split` — so the hand-rolled version 400s on exactly
+  // the grid this spec builds. `closePane` composes the destroy with the
+  // collapse, and driving it here is what keeps this test on the real path
+  // rather than on a second, simpler one that only looks like it.
+  const command = closePaneCommand(tree.nodes, { nodeId: node.id });
+  if (!command.ok) throw new Error(`dropChatNodeServerSide: closePane refused: ${command.code}`);
+
   const response = await sessionPost(
     request,
     `/api/agent-workspaces/${encodeURIComponent(sessionId)}/nodes`,
     user,
-    { baseRev: tree.rev, put: [], drop: [node.id] },
+    { baseRev: tree.rev, put: command.write.put, drop: command.write.drop },
   );
   if (!response.ok()) {
     throw new Error(

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/__tests__/route.test.ts
@@ -76,6 +76,7 @@ describe('GET /api/agent-workspaces/[workspaceId]', () => {
     expect(await response.json()).toEqual({
       session: { workspaceId: SESSION_ID, dto: true },
       sandboxEligible: true,
+      canEndSession: true,
     });
     // The full centralized canRunCode verdict for THIS requester against the
     // session's own coordinates (review #2326): payer tier alone enabled
@@ -94,7 +95,33 @@ describe('GET /api/agent-workspaces/[workspaceId]', () => {
     expect(await response.json()).toEqual({
       session: { workspaceId: SESSION_ID, dto: true },
       sandboxEligible: false,
+      canEndSession: true,
     });
+  });
+
+  /**
+   * `canEndSession` — the second capability the client cannot compute.
+   *
+   * Ending is gated by `checkSessionEndAccess`, which is STRICTER than the
+   * `checkSessionAccess` that let the caller reach this row at all (owner
+   * always; otherwise drive owner/admin AND real code-execution capability).
+   * The pane grid asks for it so closing the last pane does not offer an
+   * end-session confirm to someone the DELETE below would refuse.
+   */
+  it('reports canEndSession: false for a member who may reach the session but not end it', async () => {
+    mockCheckSessionEndAccess.mockResolvedValue({ allowed: false, reason: 'delete_authority_required' });
+
+    const response = await get();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      session: { workspaceId: SESSION_ID, dto: true },
+      sandboxEligible: true,
+      canEndSession: false,
+    });
+    // The SAME check the DELETE is gated by, asked about the same session — not
+    // a second rule that could drift from it.
+    expect(mockCheckSessionEndAccess).toHaveBeenCalledWith(AUTH_USER.userId, SESSION_ID);
   });
 
   it('given a never-provisioned session (no row), should answer { session: null } with 200 — NOT 404', async () => {

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/route.ts
@@ -1,11 +1,13 @@
 /**
  * One agent session — status / ensure+provision / end.
  *
- * GET    → 200 { session: AgentSessionDTO | null }
+ * GET    → 200 { session: AgentSessionDTO | null, sandboxEligible, canEndSession }
  *   `{ session: null }` whether the session never existed OR is someone
  *   else's — never a 404 or a 403: the same answer either way, so a probe
  *   learns nothing from it. (Post-unconflation every spawned session has a
  *   row from birth; null here means the id resolves to nothing you may see.)
+ *   The two booleans are capabilities the client cannot compute for itself —
+ *   both are resolved server-side and both are absent when `session` is null.
  *
  * POST   → 200 { session } — provision the EXISTING session's sandbox,
  *   idempotent by the session id (a re-POST resumes). No body: sessions are
@@ -112,7 +114,20 @@ export async function GET(request: Request, context: RouteContext) {
     driveId: row.driveId,
     ownerId: row.ownerId,
   });
-  return NextResponse.json({ session: toAgentSessionDTO(row), sandboxEligible });
+  // Whether THIS REQUESTER may end this workspace — the same `checkSessionEndAccess`
+  // the DELETE below is gated by, resolved here for the same reason
+  // `sandboxEligible` is: the client cannot compute it. Ending is STRICTER than
+  // reaching the session (owner always; otherwise drive owner/admin AND real
+  // code-execution capability), so a member who may use but not end one would
+  // otherwise be offered the last-pane end confirm and handed a 404 for obeying
+  // it. Read-only and already behind the same access gate as the row itself, so
+  // it discloses nothing the caller could not learn by pressing the button.
+  const endAccess = await checkSessionEndAccess(auth.userId, workspaceId);
+  return NextResponse.json({
+    session: toAgentSessionDTO(row),
+    sandboxEligible,
+    canEndSession: endAccess.allowed,
+  });
 }
 
 const PROVISION_FAILURE_STATUS: Record<string, number> = {

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -50,7 +50,7 @@ import { Check, History, Loader2, MessageSquare, Plus, Save, Settings } from 'lu
 import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
-import { fetchWithAuth, post, del, ApiRequestError } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useWorkspaceLayoutSync } from '@/stores/agent-workspace/useWorkspaceLayoutSync';
@@ -213,6 +213,13 @@ export default function AgentPanes({
   // picker's Shell/reattach buttons mustn't flash disabled on every mount.
   const { data: sessionRecordData } = useSessionRecord(sessionId);
   const canRunSandbox = sessionRecordData?.sandboxEligible ?? true;
+  // Defaults to FALSE, unlike `canRunSandbox` above — and the asymmetry is
+  // deliberate. An optimistic sandbox flag costs a button that flashes
+  // enabled; an optimistic END flag costs a confirm dialog raised for someone
+  // the server will refuse, and the user has already agreed to destroy their
+  // session by the time they learn that. Until the record resolves, closing
+  // the last pane just closes it.
+  const canEndSession = sessionRecordData?.canEndSession ?? false;
 
   // The tree is SERVER-AUTHORITATIVE: the store posts each edit as its own
   // write-set, and this hook supplies the other direction — the mount-time
@@ -508,41 +515,49 @@ export default function AgentPanes({
   );
 
   /**
-   * Destroy the node and close its conversation's listing — silent on success,
-   * since closing a listing never touches history.
+   * Close a chat pane: ONE write, and it is the node drop.
    *
-   * There is no rebind branch any more: the grid is allowed to be empty, so
-   * nothing has to be found to put in the gap.
+   * **This used to send two, and they destroyed the same thing.** The store's
+   * `closePane` queues a `drop` that the pump POSTs to `/nodes`, and this
+   * function then awaited `DELETE …/conversations/{id}` — whose `expel` is a
+   * destroy of that same node. Both take the workspace's advisory lock, the
+   * drop normally wins, and the DELETE's expel then finds no node:
+   * `not_a_member` → `not_in_session` → 404 → "Could not close this
+   * conversation". The pane closed anyway (nothing rolls the drop back), so the
+   * toast was pure noise; under lock contention the same race produced the 500
+   * variant instead.
+   *
+   * Making the route idempotent would have silenced it in four lines and left
+   * the double-write permanent in a model whose premise is one fact, one
+   * writer. The listing is derived from the nodes now
+   * (`workspace-conversations-runtime.ts` builds it from
+   * `agentWorkspaceNodes WHERE targetKind = 'chat'`; there is no
+   * `closedInWorkspaceAt` column left), so the node drop IS the close for the
+   * sidebar exactly as it is for the tree, and the DELETE was a second writer
+   * for a fact the node write already owns.
+   *
+   * The directory `conversation:closed` the route used to emit is not lost — it
+   * moved INTO the write funnel (`commitUnderLock`), which every producer
+   * passes through. It was already not firing for most of them: the drop
+   * usually beat the DELETE, so `announceClosed` ran on a branch that was
+   * seldom taken, and the sidebar's own row-close never went through the route
+   * at all.
+   *
+   * Synchronous now, and nothing awaits it — so no rebind branch, no catch, no
+   * toast on the success path.
    */
-  const closeConversationListing = useCallback(
-    async (nodeId: string, conversationId: string) => {
-      // Layout first, and deliberately: the local write is instant and the
-      // broadcast reconciles it, where the alternative — waiting on the DELETE —
-      // is what made a close feel like the app had ignored it.
+  const closeChatPane = useCallback(
+    (nodeId: string, conversationId: string) => {
       closePane(sessionId, nodeId);
-      try {
-        await del(
-          `/api/agent-workspaces/${encodeURIComponent(sessionId)}/conversations/${encodeURIComponent(conversationId)}`,
-        );
-      } catch (error) {
-        if (error instanceof ApiRequestError && error.status === 409) {
-          // The workspace's LAST open listing — the server is the authority on
-          // the never-empty invariant, so fall back to the confirmed
-          // end-workspace flow.
-          setPendingEnd({ nodeId });
-          return;
-        }
-        console.error('Failed to close this conversation:', error);
-        toast.error('Could not close this conversation', {
-          description: error instanceof Error ? error.message : 'Please try again.',
-        });
-        return;
-      }
       onConversationClosed?.({ conversationId, next: null, nextAgentPageId: null });
+      // Instant LOCAL freshness for the switch decision's own cache. The
+      // broader `void mutate(isAgentWorkspacesKey)` that used to follow is gone
+      // with the DELETE it depended on: it was only safe because it ran AFTER
+      // an awaited round trip, and firing it beside a merely-QUEUED drop races
+      // the pump's POST — the revalidation can answer from before the drop
+      // landed and put the row back. Other clients are settled by the funnel's
+      // `conversation:closed` instead (`session-directory-listener.ts`).
       recordClosedConversation(conversationId);
-      // Instant sidebar freshness — the closed listing's row leaves every open
-      // `/api/agent-workspaces**` poll without waiting on its interval.
-      void mutate(isAgentWorkspacesKey);
     },
     [sessionId, closePane, onConversationClosed, recordClosedConversation],
   );
@@ -555,9 +570,21 @@ export default function AgentPanes({
         panes: paneNodesOf(nodes),
         nodeId,
         activeConversations: closeDecisionListing,
+        canEndSession,
       });
 
       if (decision.action === 'noop') return;
+
+      // ABOVE `beginPaneAssign`, and that placement is the point of putting it
+      // here rather than below with the others. That call's own comment says to
+      // fire it "only once a decision ACTUALLY commits to altering this node";
+      // an end-session raises a confirm and writes nothing, and the user may
+      // cancel — which then costs nothing, because nothing was invalidated and
+      // nothing was mutated (`onOpenChange(false)` just clears `pendingEnd`).
+      if (decision.action === 'end-session') {
+        setPendingEnd({ nodeId });
+        return;
+      }
 
       // Only once a decision ACTUALLY commits to altering this node: a stale
       // close attempt that changed nothing must not invalidate a genuinely
@@ -574,9 +601,9 @@ export default function AgentPanes({
         return;
       }
 
-      void closeConversationListing(nodeId, decision.conversationId);
+      closeChatPane(nodeId, decision.conversationId);
     },
-    [nodes, closePane, sessionId, closeShell, closeDecisionListing, closeConversationListing, beginPaneAssign],
+    [nodes, closePane, sessionId, closeShell, closeDecisionListing, closeChatPane, beginPaneAssign, canEndSession],
   );
 
   const confirmEndSession = useCallback(async () => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -262,6 +262,15 @@ beforeEach(() => {
     isLoading: false,
   });
   mockFetchWithAuth.mockImplementation(async (url: string) => jsonOk(defaultFetchRoute(url)));
+  // A RESOLVED PROMISE BY DEFAULT, so no test depends on another having set one.
+  // `vi.clearAllMocks()` clears calls but NOT implementations, so `del` used to
+  // arrive here carrying whatever `mockResolvedValue` the previous test left on
+  // it — and the terminal-close test relied on that leak without saying so.
+  // When the chat close stopped issuing a DELETE, the leak stopped too:
+  // `closeShell`'s `void del(...).catch(...)` got `undefined` back and threw
+  // inside a React event handler. Every test still passed and the RUN exited 1
+  // on the unhandled error.
+  mockDel.mockResolvedValue(undefined);
 });
 
 

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -39,6 +39,12 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   ApiRequestError,
 }));
 
+// Unmocked until now, which is why the reported symptom was invisible here: a
+// spurious "Could not close this conversation" toast is not observable unless
+// something records the call.
+const mockToast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() }));
+vi.mock('sonner', () => ({ toast: mockToast }));
+
 let cuidCounter = 0;
 vi.mock('@paralleldrive/cuid2', () => ({
   createId: () => `new-id-${++cuidCounter}`,
@@ -138,14 +144,33 @@ import type { WorkspaceNodeTarget } from '@pagespace/lib/agent-workspaces/worksp
 const jsonOk = (body: unknown) => ({ ok: true, json: async () => body });
 
 /**
- * The default routing every test starts from: empty shells, an empty
- * session-conversations list (both `selectPaneAgent`'s switch-decision data
- * AND `decideClosePane`'s close-decision data), and `useResolvedAgent`'s two
- * lookups per fixture agent (id/title come from `mockUsePageAgents` above). A
- * test that cares about a specific route layers its own `mockImplementation`
- * on top, falling back to this for every other URL.
+ * This session's own RECORD — `useSessionRecord`'s read, and the source of
+ * `canEndSession`, which `decideClosePane` needs to know whether the last-pane
+ * close may offer to end the workspace.
+ *
+ * Matched EXACTLY, and ahead of every `includes('/api/agent-workspaces')`
+ * branch below: the listing key is a prefix of this one, so a substring test
+ * would answer a record read with a `{sessions: []}` body and the flag would
+ * read as absent — which is a silent false, not an error.
+ */
+const SESSION_RECORD_URL = '/api/agent-workspaces/ses-1';
+let mockCanEndSession = true;
+const sessionRecord = () => ({
+  session: { driveId: 'drive-1', name: 'Session' },
+  sandboxEligible: true,
+  canEndSession: mockCanEndSession,
+});
+
+/**
+ * The default routing every test starts from: this session's record, empty
+ * shells, an empty session-conversations list (both `selectPaneAgent`'s
+ * switch-decision data AND `decideClosePane`'s close-decision data), and
+ * `useResolvedAgent`'s two lookups per fixture agent (id/title come from
+ * `mockUsePageAgents` above). A test that cares about a specific route layers
+ * its own `mockImplementation` on top, falling back to this for every other URL.
  */
 function defaultFetchRoute(url: string): unknown {
+  if (url === SESSION_RECORD_URL) return sessionRecord();
   if (url.includes('/shells')) return { shells: [] };
   if (url.includes('/api/agent-workspaces')) return { sessions: [] };
   if (url === '/api/pages/agent-1') return { id: 'agent-1', title: 'Researcher', driveId: 'drive-1' };
@@ -164,13 +189,46 @@ function mockSessionConversations(
   conversations: Array<{ conversationId: string; agentPageId: string | null; lastMessageAt?: string | null }>,
 ) {
   mockFetchWithAuth.mockImplementation(async (url: string) => {
-    if (url.includes('/api/agent-workspaces')) {
+    if (url !== SESSION_RECORD_URL && url.includes('/api/agent-workspaces')) {
       return jsonOk({
         sessions: [{ workspaceId: 'ses-1', sessionId: 'ses-1', conversations: conversations.map((c) => ({ lastMessageAt: null, ...c })) }],
       });
     }
     return jsonOk(defaultFetchRoute(url));
   });
+}
+
+/**
+ * Every node write this test issued, as `{put, drop}` — the ONE channel a pane
+ * close is allowed to use.
+ *
+ * The double-send this suite failed to catch survived precisely because
+ * `fetchWithAuth` (the `/nodes` POST) and `del` (the conversations DELETE) are
+ * separate spies, so no assertion ever looked at both. Anything asserting that a
+ * close is one write has to look across the two, which is what this and
+ * {@link conversationDeletes} are for.
+ */
+function nodeWrites(): Array<{ put: unknown[]; drop: string[] }> {
+  return mockFetchWithAuth.mock.calls
+    .filter(([url, init]) => typeof url === 'string' && url.endsWith('/nodes') && init?.method === 'POST')
+    .map(([, init]) => JSON.parse(init.body as string) as { put: unknown[]; drop: string[] });
+}
+
+/** Every conversation-scoped DELETE this test issued. */
+function conversationDeletes(): string[] {
+  return mockDel.mock.calls
+    .map(([url]) => url as string)
+    .filter((url) => typeof url === 'string' && url.includes('/conversations/'));
+}
+
+/**
+ * THE CROSS-CHANNEL ASSERTION: closing a chat pane is exactly one node drop and
+ * no conversation DELETE.
+ */
+async function expectSingleDropClose(nodeId: string) {
+  await waitFor(() => expect(nodeWrites().some((write) => write.drop.includes(nodeId))).toBe(true));
+  expect(nodeWrites().filter((write) => write.drop.includes(nodeId))).toHaveLength(1);
+  expect(conversationDeletes()).toEqual([]);
 }
 
 function renderPanes(props: Partial<React.ComponentProps<typeof AgentPanes>> = {}) {
@@ -189,6 +247,7 @@ function renderPanes(props: Partial<React.ComponentProps<typeof AgentPanes>> = {
 beforeEach(() => {
   vi.clearAllMocks();
   cuidCounter = 0;
+  mockCanEndSession = true;
   useAgentWorkspaceStore.setState({ workspaces: {}, sync: {}, focus: {}, queueErrors: {} });
   usePendingStreamsStore.setState({ streams: new Map() });
   // The write queue's generation counters and retry timers are module-level
@@ -315,9 +374,14 @@ describe('AgentPanes — selection is an instruction', () => {
 });
 
 describe('AgentPanes — closing a pane', () => {
-  it('destroys the node and closes the thread when the listing has it open', async () => {
+  it('closes a chat pane with ONE node drop and no conversation DELETE', async () => {
+    // THE DOUBLE-SEND REGRESSION. Both requests destroyed the same node: the
+    // store's drop, POSTed to /nodes, and a DELETE whose `expel` is the same
+    // destroy. The drop normally won, so the DELETE's expel found nothing,
+    // answered 404, and raised a toast for a close that had already succeeded.
+    // Asserted across BOTH channels, because the two are separate spies and
+    // that is exactly why nothing caught it.
     mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
-    mockDel.mockResolvedValue({});
     seat([rootNode, chatNode('n1', WS, 0, 'conv-1'), chatNode('n2', WS, 1, 'conv-2')]);
     const user = userEvent.setup();
     renderPanes();
@@ -325,39 +389,42 @@ describe('AgentPanes — closing a pane', () => {
     await screen.findAllByTestId('pane-chat');
     await user.click(within(screen.getAllByTestId('pane-bar')[0]).getByLabelText('Close pane'));
 
-    await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-workspaces/ses-1/conversations/conv-1'));
+    await expectSingleDropClose('n1');
     // DESTROYED, not parked. It used to survive with a null parent, still a
     // member holding its binding — the state that made a closed pane and a
     // broken one the same row.
     expect(nodeById('n1')).toBeUndefined();
   });
 
-  it('leaves an EMPTY GRID when the last pane closes, and does not end the workspace', async () => {
+  it('shows no error toast on a successful close', async () => {
+    // The reported symptom, stated directly. Unobservable before this suite
+    // mocked `sonner` at all.
     mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
-    mockDel.mockResolvedValue({});
-    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1'), chatNode('n2', WS, 1, 'conv-2')]);
     const user = userEvent.setup();
     renderPanes();
 
-    await screen.findByTestId('pane-chat');
-    await user.click(screen.getByLabelText('Close pane'));
+    await screen.findAllByTestId('pane-chat');
+    await user.click(within(screen.getAllByTestId('pane-bar')[0]).getByLabelText('Close pane'));
 
     await waitFor(() => expect(nodeById('n1')).toBeUndefined());
-    // No confirm dialog, and the SESSION itself is untouched — closing the last
-    // pane leaves an empty tree, it does not end the workspace.
-    expect(screen.queryByRole('alertdialog')).toBeNull();
-    expect(mockDel).not.toHaveBeenCalledWith('/api/agent-workspaces/ses-1');
-    expect(useAgentWorkspaceStore.getState().workspaces[WS]).toBeDefined();
-    expect(await screen.findByTestId('empty-grid')).toBeDefined();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 
   it('closing a terminal pane kills its shell — a closed tab is a DELETE, not an orphan', async () => {
-    seat([rootNode, paneNode('n1', WS, 0, { kind: 'terminal', id: 'shell-1' })], []);
+    seat(
+      [
+        rootNode,
+        paneNode('n1', WS, 0, { kind: 'terminal', id: 'shell-1' }),
+        chatNode('n2', WS, 1, 'conv-2'),
+      ],
+      [],
+    );
     const user = userEvent.setup();
     renderPanes({ initialConversation: null });
 
     await screen.findByTestId('pane-shell');
-    await user.click(screen.getByLabelText('Close pane'));
+    await user.click(within(screen.getAllByTestId('pane-bar')[0]).getByLabelText('Close pane'));
 
     await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-workspaces/ses-1/shells/shell-1'));
     expect(nodeById('n1')).toBeUndefined();
@@ -365,13 +432,14 @@ describe('AgentPanes — closing a pane', () => {
 
   it('does nothing while the listing has not resolved — a close never acts on an unverified fact', async () => {
     // The default route answers `sessions: []`, so THIS workspace's own entry
-    // never appears: "not loaded" is not "loaded and empty".
-    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    // never appears: "not loaded" is not "loaded and empty". Two panes, so the
+    // last-pane branch (which is decided ABOVE this guard) is not what answers.
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1'), chatNode('n2', WS, 1, 'conv-2')]);
     const user = userEvent.setup();
     renderPanes();
 
-    await screen.findByTestId('pane-chat');
-    await user.click(screen.getByLabelText('Close pane'));
+    await screen.findAllByTestId('pane-chat');
+    await user.click(within(screen.getAllByTestId('pane-bar')[0]).getByLabelText('Close pane'));
 
     expect(mockDel).not.toHaveBeenCalled();
     expect(nodeById('n1')?.parentId).toBe(WS);
@@ -379,21 +447,31 @@ describe('AgentPanes — closing a pane', () => {
 
   it('is a pure layout close when the listing resolved WITHOUT this thread', async () => {
     mockSessionConversations([{ conversationId: 'conv-other', agentPageId: 'agent-1' }]);
-    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1'), chatNode('n2', WS, 1, 'conv-2')]);
     const user = userEvent.setup();
     renderPanes();
 
-    await screen.findByTestId('pane-chat');
+    await screen.findAllByTestId('pane-chat');
     await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
-    await user.click(screen.getByLabelText('Close pane'));
+    await user.click(within(screen.getAllByTestId('pane-bar')[0]).getByLabelText('Close pane'));
 
     await waitFor(() => expect(nodeById('n1')).toBeUndefined());
     expect(mockDel).not.toHaveBeenCalled();
   });
+});
 
-  it("falls back to the end-workspace confirm when the server says this was the last open listing (409)", async () => {
+/**
+ * CLOSING THE LAST PANE ENDS THE SESSION — restored, and decided on the client.
+ *
+ * It used to be the server's `last_conversation` 409 caught by the close
+ * DELETE's error branch; the node-tree cutover removed that refusal, which left
+ * the branch unreachable and the user stranded in an empty grid. The whole
+ * decision is `decideClosePane`'s now, so the confirm is raised without any
+ * request having to fail first — `mockDel` never rejects in any of these.
+ */
+describe('AgentPanes — closing the LAST pane', () => {
+  it('raises the end-session confirm instead of emptying the grid', async () => {
     mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
-    mockDel.mockRejectedValue(new ApiRequestError('last listing', 409));
     seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
     const user = userEvent.setup();
     renderPanes();
@@ -402,6 +480,93 @@ describe('AgentPanes — closing a pane', () => {
     await user.click(screen.getByLabelText('Close pane'));
 
     expect(await screen.findByRole('alertdialog')).toBeDefined();
+    // NOTHING has been written yet — the confirm is the whole act so far.
+    expect(nodeById('n1')).toBeDefined();
+    expect(nodeWrites()).toEqual([]);
+    expect(mockDel).not.toHaveBeenCalled();
+  });
+
+  it('raises it for a lone TERMINAL pane too — the count is of panes, not of chats', async () => {
+    seat([rootNode, paneNode('n1', WS, 0, { kind: 'terminal', id: 'shell-1' })], []);
+    const user = userEvent.setup();
+    renderPanes({ initialConversation: null });
+
+    await screen.findByTestId('pane-shell');
+    await user.click(screen.getByLabelText('Close pane'));
+
+    expect(await screen.findByRole('alertdialog')).toBeDefined();
+    expect(mockDel).not.toHaveBeenCalledWith('/api/agent-workspaces/ses-1/shells/shell-1');
+  });
+
+  it('raises it while the listing has NOT resolved', async () => {
+    // The default route never lists this workspace, so `activeConversations` is
+    // null. Behind that guard the click would silently no-op; the decision is
+    // taken above it.
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const user = userEvent.setup();
+    renderPanes();
+
+    await screen.findByTestId('pane-chat');
+    await user.click(screen.getByLabelText('Close pane'));
+
+    expect(await screen.findByRole('alertdialog')).toBeDefined();
+  });
+
+  it('Cancel leaves the pane exactly where it was, having written nothing', async () => {
+    mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const user = userEvent.setup();
+    renderPanes();
+
+    await screen.findByTestId('pane-chat');
+    await user.click(screen.getByLabelText('Close pane'));
+    await user.click(await screen.findByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+    expect(nodeById('n1')).toBeDefined();
+    expect(nodeWrites()).toEqual([]);
+    expect(mockDel).not.toHaveBeenCalled();
+    expect(useAgentWorkspaceStore.getState().workspaces[WS]).toBeDefined();
+  });
+
+  it('Confirm ends the session', async () => {
+    mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+    mockDel.mockResolvedValue({});
+    const onSessionEnded = vi.fn();
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const user = userEvent.setup();
+    renderPanes({ onSessionEnded });
+
+    await screen.findByTestId('pane-chat');
+    await user.click(screen.getByLabelText('Close pane'));
+    await user.click(await screen.findByRole('button', { name: /end session/i }));
+
+    await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/agent-workspaces/ses-1'));
+    await waitFor(() => expect(useAgentWorkspaceStore.getState().workspaces[WS]).toBeUndefined());
+    expect(onSessionEnded).toHaveBeenCalled();
+  });
+
+  it('a member who may NOT end the workspace keeps the ordinary close', async () => {
+    // `DELETE /api/agent-workspaces/{id}` is gated by `checkSessionEndAccess`,
+    // which is stricter than the access that let them reach the pane. Offering
+    // a confirm they would obey and then be refused for is worse than the empty
+    // grid they had before.
+    mockCanEndSession = false;
+    mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const user = userEvent.setup();
+    renderPanes();
+
+    await screen.findByTestId('pane-chat');
+    // Wait for the session record to land, or the flag reads as its (false)
+    // default for a reason that has nothing to do with permission.
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledWith(SESSION_RECORD_URL));
+    await user.click(screen.getByLabelText('Close pane'));
+
+    await waitFor(() => expect(nodeById('n1')).toBeUndefined());
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(mockDel).not.toHaveBeenCalledWith('/api/agent-workspaces/ses-1');
+    expect(await screen.findByTestId('empty-grid')).toBeDefined();
   });
 });
 

--- a/apps/web/src/components/agents/panes/__tests__/close-pane.test.ts
+++ b/apps/web/src/components/agents/panes/__tests__/close-pane.test.ts
@@ -1,7 +1,15 @@
 /**
- * What closing a pane MEANS. Two branches where there were five — the model
- * removed three of them, and each removal is pinned here by its absence being
- * asserted rather than merely no longer written.
+ * What closing a pane MEANS.
+ *
+ * Three branches. Two of them — the layout close and the thread close — turn on
+ * what the pane HOLDS; the third turns on how many panes are left, and it is
+ * decided first.
+ *
+ * Nearly every fixture below used to be a SINGLE-pane workspace, because the
+ * pane count was not part of the decision. It is now, so each of them gained a
+ * second pane and exercises the branch it was written for again. The ones that
+ * were about the last pane specifically are the `end-session` pins, inverted
+ * from the "we no longer do that" assertions they were.
  */
 import { describe, it, expect } from 'vitest';
 import type { PaneNode } from '@pagespace/lib/agent-workspaces/workspace-node';
@@ -18,31 +26,41 @@ function terminal(id: string, shellId: string): PaneNode {
 function picker(id: string): PaneNode {
   return { nodeType: 'pane', id, parentId: WS, position: 0, target: null };
 }
+/**
+ * A second pane, so a fixture exercises the branch it was written for rather
+ * than the last-pane branch above it. Deliberately a chat with its own thread —
+ * a kind the decision has to look past, not a picker it would skip anyway.
+ */
+const OTHER = chat('n-other', 'c-other');
 
 const listing = (...ids: string[]): SessionConversationSummary[] =>
   ids.map((conversationId) => ({ conversationId, agentPageId: null, lastMessageAt: null }));
 
+/** Every case below is a member who MAY end the workspace unless it says otherwise. */
+const decide = (params: Omit<Parameters<typeof decideClosePane>[0], 'canEndSession'> & { canEndSession?: boolean }) =>
+  decideClosePane({ canEndSession: true, ...params });
+
 describe('decideClosePane', () => {
   it('should do nothing for a node the workspace does not hold', () => {
-    expect(decideClosePane({ panes: [chat('n1', 'c1')], nodeId: 'ghost', activeConversations: listing('c1') })).toEqual({
+    expect(decide({ panes: [chat('n1', 'c1'), OTHER], nodeId: 'ghost', activeConversations: listing('c1') })).toEqual({
       action: 'noop',
     });
   });
 
   it('should be a pure layout close for a picker pane', () => {
-    expect(decideClosePane({ panes: [picker('n1')], nodeId: 'n1', activeConversations: listing() })).toEqual({
+    expect(decide({ panes: [picker('n1'), OTHER], nodeId: 'n1', activeConversations: listing() })).toEqual({
       action: 'close-pane',
     });
   });
 
   it('should be a pure layout close for a terminal pane', () => {
     expect(
-      decideClosePane({ panes: [terminal('n1', 'shell-1')], nodeId: 'n1', activeConversations: listing() }),
+      decide({ panes: [terminal('n1', 'shell-1'), OTHER], nodeId: 'n1', activeConversations: listing() }),
     ).toEqual({ action: 'close-pane' });
   });
 
   it('should close the THREAD for a chat pane whose listing is open', () => {
-    expect(decideClosePane({ panes: [chat('n1', 'c1')], nodeId: 'n1', activeConversations: listing('c1') })).toEqual({
+    expect(decide({ panes: [chat('n1', 'c1'), OTHER], nodeId: 'n1', activeConversations: listing('c1') })).toEqual({
       action: 'close-conversation',
       conversationId: 'c1',
     });
@@ -55,57 +73,113 @@ describe('decideClosePane', () => {
    * left to retry the close from.
    */
   it('should do nothing while the listing has not resolved', () => {
-    expect(decideClosePane({ panes: [chat('n1', 'c1')], nodeId: 'n1', activeConversations: null })).toEqual({
+    expect(decide({ panes: [chat('n1', 'c1'), OTHER], nodeId: 'n1', activeConversations: null })).toEqual({
       action: 'noop',
     });
   });
 
   it('should be a pure layout close when the listing resolved WITHOUT this thread', () => {
-    // Somebody else already closed it: there is nothing left to DELETE.
-    expect(decideClosePane({ panes: [chat('n1', 'c1')], nodeId: 'n1', activeConversations: listing('c2') })).toEqual({
+    // Somebody else already closed it: there is no listing left to follow.
+    expect(decide({ panes: [chat('n1', 'c1'), OTHER], nodeId: 'n1', activeConversations: listing('c2') })).toEqual({
       action: 'close-pane',
     });
   });
 
+  it('should close the thread for a node nested below a split, like any other', () => {
+    // Where a pane SITS was never part of this decision — what it reads is the
+    // listing — and depth is what "somewhere other than the root's own
+    // children" means now.
+    expect(
+      decide({ panes: [chat('n1', 'c1', 's1'), OTHER], nodeId: 'n1', activeConversations: listing('c1') }),
+    ).toEqual({ action: 'close-conversation', conversationId: 'c1' });
+  });
+
   /**
-   * THE THREE BRANCHES THE MODEL RETIRED. Each is asserted as a NON-outcome,
-   * because "we stopped writing that code" and "that outcome can no longer
-   * happen" are different claims and only the second one is a guarantee.
+   * THE LAST PANE. These three used to assert the opposite — that the decision
+   * would NOT offer to end the workspace — which was the node-tree cutover's
+   * behaviour and the one the product asked to have back. Inverted deliberately:
+   * closing the last pane would leave a session holding nothing, and a user
+   * stranded in an empty grid with no visible way forward is what shipped.
    */
-  describe('what the model retired', () => {
-    it('should NOT offer to end the workspace when the last pane closes', () => {
-      // An empty grid is a resting state. Ending is a lifecycle act elsewhere.
-      const decision = decideClosePane({
+  describe('the last pane', () => {
+    it('should offer to end the workspace when the last CHAT pane closes', () => {
+      const decision = decide({
         panes: [chat('only', 'c1')],
         nodeId: 'only',
         activeConversations: listing('c1'),
       });
-      expect(decision.action).toBe('close-conversation');
-      expect(decision).not.toHaveProperty('rebindTo');
+      expect(decision).toEqual({ action: 'end-session' });
     });
 
-    it('should NOT offer to end the workspace when the last pane is a picker either', () => {
-      expect(decideClosePane({ panes: [picker('only')], nodeId: 'only', activeConversations: listing() })).toEqual({
-        action: 'close-pane',
+    it('should offer to end the workspace when the last pane is a PICKER', () => {
+      // `panes` is every pane of every kind, so "last pane of any kind" needs
+      // no per-kind branch — decided above the target-kind test for exactly
+      // this reason.
+      expect(decide({ panes: [picker('only')], nodeId: 'only', activeConversations: listing() })).toEqual({
+        action: 'end-session',
       });
     });
 
-    it('should NOT rebind the last pane to some other open thread', () => {
-      const decision = decideClosePane({
+    it('should offer to end the workspace when the last pane is a TERMINAL', () => {
+      expect(decide({ panes: [terminal('only', 'shell-1')], nodeId: 'only', activeConversations: listing() })).toEqual(
+        { action: 'end-session' },
+      );
+    });
+
+    it('should offer to end the workspace even while the listing has NOT resolved', () => {
+      // Decided ABOVE the `activeConversations === null` guard. Ending destroys
+      // the tree and the sandbox and never consults the listing, so behind that
+      // guard this would silently no-op while the listing loaded — which reads
+      // to the user as the click being ignored.
+      expect(decide({ panes: [chat('only', 'c1')], nodeId: 'only', activeConversations: null })).toEqual({
+        action: 'end-session',
+      });
+    });
+
+    it('should still NOT rebind the last pane to some other open thread', () => {
+      // The retired branch stays retired: ending is what the user asked for and
+      // is confirmed first, where a rebind was a guess nobody asked for.
+      const decision = decide({
         panes: [picker('only')],
         nodeId: 'only',
         activeConversations: listing('c-other'),
       });
-      expect(decision).toEqual({ action: 'close-pane' });
+      expect(decision).toEqual({ action: 'end-session' });
+      expect(decision).not.toHaveProperty('rebindTo');
     });
 
-    it('should close the thread for a node nested below a split, like any other', () => {
-      // Was stated with a PARKED node. Where a pane sits was never part of this
-      // decision — what it reads is the LISTING — and depth is what "somewhere
-      // other than the root's own children" means now.
+    it('should do nothing for a node the workspace does not hold, even as its only pane', () => {
+      // The lookup still comes first: a stale close for a node that is gone is
+      // not a reason to offer to end the workspace.
+      expect(decide({ panes: [chat('only', 'c1')], nodeId: 'ghost', activeConversations: listing('c1') })).toEqual({
+        action: 'noop',
+      });
+    });
+
+    it('should fall back to the ordinary close for a member who may NOT end the workspace', () => {
+      // `DELETE /api/agent-workspaces/{id}` is gated by `checkSessionEndAccess`,
+      // stricter than the access that let them reach the pane. Offering a
+      // confirm they would obey and then be refused for is worse than leaving
+      // them the previous behaviour: an empty grid someone else can end.
       expect(
-        decideClosePane({ panes: [chat('n1', 'c1', 's1')], nodeId: 'n1', activeConversations: listing('c1') }),
+        decideClosePane({
+          panes: [chat('only', 'c1')],
+          nodeId: 'only',
+          activeConversations: listing('c1'),
+          canEndSession: false,
+        }),
       ).toEqual({ action: 'close-conversation', conversationId: 'c1' });
+    });
+
+    it('should fall back to a pure layout close for a picker, for that same member', () => {
+      expect(
+        decideClosePane({
+          panes: [picker('only')],
+          nodeId: 'only',
+          activeConversations: listing(),
+          canEndSession: false,
+        }),
+      ).toEqual({ action: 'close-pane' });
     });
   });
 });

--- a/apps/web/src/components/agents/panes/close-pane.ts
+++ b/apps/web/src/components/agents/panes/close-pane.ts
@@ -4,37 +4,43 @@
  * one conversation closes THAT conversation's listing; closing a node bound to
  * anything else is pure layout.
  *
- * **Two branches left of five, and the model is what removed the other three.**
+ * **Three branches, and each one is here because the model does not answer it.**
  *
- *  - `end-session` is GONE. Closing the last pane leaves an empty grid and does
- *    not end the workspace. That decision used to live half in the reducer
+ *  - `end-session` — closing the LAST pane. This was removed in the node-tree
+ *    cutover on the grounds that the decision "used to live half in the reducer
  *    (which no-oped on the last pane, because a two-level grid could not
- *    represent zero) and half in browser code that ended the session — the exact
- *    half-in-each-place coupling the flat model exists to delete. `validateTree`
- *    is explicit that a root holding nothing is an ordinary state, and ending a
- *    workspace is an explicit lifecycle act elsewhere, behind its own confirm.
- *  - `rebind-pane` is GONE with it. It existed to keep the grid non-empty by
+ *    represent zero) and half in browser code that ended the session — the
+ *    exact half-in-each-place coupling the flat model exists to delete". That
+ *    objection is right about the OLD SHAPE and says nothing against the
+ *    decision existing: it is answered by putting the WHOLE decision here,
+ *    where it is one branch over the same plain data as its neighbours, with no
+ *    half anywhere else. What is left in browser code is raising the confirm,
+ *    which is rendering. Restored because the product wants it: `validateTree`
+ *    permits a root holding nothing, but permitting a state is not the same as
+ *    leaving a user in it, and the previous release stranded people in an empty
+ *    grid with no visible way forward.
+ *  - `rebind-pane` is GONE, and stays gone. It kept the grid non-empty by
  *    repointing the last pane at some other open thread — a guess the user did
- *    not ask for, needed only because zero was unspellable.
+ *    not ask for, needed only because zero was unspellable. Ending is not that:
+ *    it is what the user asked for, confirmed first, and cancellable.
  *  - The "shown in another pane" branch is GONE because the state is now
  *    UNSPELLABLE: `agent_workspace_nodes` carries `UNIQUE (targetId) WHERE
  *    targetKind = 'chat'`, and the algebra's `shownElsewhere` refuses the bind
  *    before the index has to. One conversation, at most one node.
  *
- * What survives is the fact this module was written for and the model does not
- * answer on its own: whether closing this rectangle should go through the
- * THREAD's own DELETE instead of the plain node write.
+ * The other fact this module was written for is whether closing a chat pane
+ * needs the THREAD's own DELETE on top of the node write. **It no longer does.**
+ * The listing is derived from the nodes (`workspace-conversations-runtime.ts`
+ * reads `agentWorkspaceNodes WHERE targetKind = 'chat'`), and the directory
+ * `conversation:closed` is emitted by the write funnel itself, for every
+ * producer — so `close-conversation` names the CALLER's follow-up (tell the
+ * console, patch the local switch-decision cache) rather than a second request.
+ * Both branches destroy the node and nothing parks: membership IS the node, so
+ * either way the thread leaves the workspace.
  *
- * Both end with the node GONE — membership is the node, so either way the thread
- * leaves the workspace; nothing parks. What only the route can do is tell the
- * DIRECTORY PLANE: it emits the conversation's `closed` lifecycle event, and the
- * node write's `workspace:nodes-updated` does not cover that, because that event
- * carries the tree while the sidebar's rows come from the LISTING. Close a
- * chat-bound pane through the node write alone and the grid is right while the
- * sidebar keeps a row for a thread that is no longer there.
- *
- * A pure decision over PLAIN DATA (the workspace's panes, plus its listing) — no
- * store, no fetch, no IO — so the branch never lives inline in `AgentPanes`.
+ * A pure decision over PLAIN DATA (the workspace's panes, its listing, and
+ * whether this viewer may end the workspace at all) — no store, no fetch, no IO
+ * — so the branch never lives inline in `AgentPanes`.
  */
 
 import type { PaneNode } from '@pagespace/lib/agent-workspaces/workspace-node';
@@ -51,11 +57,18 @@ export type ClosePaneDecision =
    */
   | { action: 'close-pane' }
   /**
-   * Destroy the node through conversation `conversationId`'s own DELETE (the
-   * workspace-scoped route). The same removal, taken by the one path that also
-   * announces the thread's close to the directory plane.
+   * Destroy the node AND tell the caller which thread went with it, so it can
+   * follow its own selection and patch the switch-decision cache. Not a second
+   * request: the node write is the close, on the tree and in the listing alike.
    */
-  | { action: 'close-conversation'; conversationId: string };
+  | { action: 'close-conversation'; conversationId: string }
+  /**
+   * This was the workspace's last pane. Closing it would leave a session
+   * holding nothing, so raise the end-session confirm instead — the same
+   * confirmed, cancellable act the sidebar's own "End session" uses. NOT the
+   * close: nothing is written unless the user confirms.
+   */
+  | { action: 'end-session' };
 
 export function decideClosePane(params: {
   /** Every pane in the workspace — which is every pane in its tree. */
@@ -66,12 +79,45 @@ export function decideClosePane(params: {
    * This workspace's open conversation listings — the SWR fetch backing the pane
    * bar. `null` while it has not resolved yet: a close must never act on an
    * unverified fact.
+   *
+   * Typed to the ONE field this reads rather than to the whole
+   * {@link SessionConversationSummary}. The two callers hold different rows
+   * (the grid's carries `lastMessageAt` for the switch decision; the sidebar's
+   * carries `title` for its label) and neither difference is any of this
+   * function's business — asking for the union would force one of them to
+   * fabricate a column to answer a question about membership.
    */
-  activeConversations: readonly SessionConversationSummary[] | null;
+  activeConversations: readonly Pick<SessionConversationSummary, 'conversationId'>[] | null;
+  /**
+   * Whether this viewer may end the workspace — `DELETE /api/agent-workspaces/
+   * {id}` is gated by `checkSessionEndAccess`, which is STRICTER than the
+   * `checkSessionAccess` that let them reach the pane in the first place.
+   *
+   * Without this, a member who may use but not end a workspace would be offered
+   * a confirm and then handed a failure toast for obeying it. They keep the
+   * previous behaviour instead: the last pane closes and the grid is empty,
+   * which is a state they can live in and someone else can end.
+   */
+  canEndSession: boolean;
 }): ClosePaneDecision {
-  const { panes, nodeId, activeConversations } = params;
+  const { panes, nodeId, activeConversations, canEndSession } = params;
   const node = panes.find((pane) => pane.id === nodeId);
   if (!node) return { action: 'noop' };
+
+  // THE LAST PANE, decided before anything about what it holds.
+  //
+  // Before the target-kind branch, because "last pane of ANY kind" is the
+  // question — `panes` is every pane in the tree, so a lone terminal or a lone
+  // picker empties the workspace exactly as a lone chat does, and there is
+  // nothing kind-specific to weigh.
+  //
+  // Before the `activeConversations === null` guard, because ending does not
+  // consult the listing: it destroys the tree and the sandbox, and it is the
+  // one act here that is confirmed before anything is written. Behind that
+  // guard, closing the last pane while the listing was still loading would
+  // silently no-op — the worst of the three outcomes, since it looks like the
+  // click was ignored.
+  if (panes.length === 1 && canEndSession) return { action: 'end-session' };
 
   // A picker, a terminal or a page pane addresses no conversation listing, so
   // this node has nothing to announce. Destroying it is the whole act.
@@ -86,8 +132,9 @@ export function decideClosePane(params: {
   // left to retry the close from.
   if (activeConversations === null) return { action: 'noop' };
 
-  // Resolved, and this thread is not in it — somebody else already closed it.
-  // There is nothing left to DELETE; destroy the node and be done.
+  // Resolved, and this thread is not in it — somebody else already closed it,
+  // so there is no listing left for the caller to follow. Destroy the node and
+  // be done.
   if (!activeConversations.some((entry) => entry.conversationId === conversationId)) {
     return { action: 'close-pane' };
   }

--- a/apps/web/src/components/agents/useSessionRecord.ts
+++ b/apps/web/src/components/agents/useSessionRecord.ts
@@ -36,6 +36,17 @@ export interface SessionRecordResponse {
    * resolve a payer against).
    */
   sandboxEligible?: boolean;
+  /**
+   * Whether this VIEWER may end this workspace. Server-resolved for the same
+   * reason as `sandboxEligible`: ending is gated by `checkSessionEndAccess`,
+   * which is stricter than the access that let them reach the session at all
+   * (owner always; otherwise drive owner/admin AND real code-execution
+   * capability), and none of those inputs are on the client.
+   *
+   * `undefined` when `session` is null, and read as FALSE by callers — offering
+   * an act that 404s is worse than not offering it.
+   */
+  canEndSession?: boolean;
 }
 
 async function sessionFetcher(url: string): Promise<SessionRecordResponse> {

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -30,11 +30,12 @@ import {
   gridPanesOf,
   indexTargets,
   lookupTarget,
+  paneNodesOf,
   type MemberPlacement,
 } from '@/stores/agent-workspace/workspace-tree-view';
 import type { WorkspaceNode } from '@pagespace/lib/agent-workspaces/workspace-node';
 import type { WorkspaceNodeTarget } from '@pagespace/lib/agent-workspaces/workspace-node-wire';
-import { fetchWithAuth, del, ApiRequestError } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth, del } from '@/lib/auth/auth-fetch';
 import {
   isAgentWorkspacesKey,
   isWorkspaceListingKey,
@@ -42,6 +43,7 @@ import {
   forgetConversationInCache,
   restoreWorkspaceInCache,
 } from '@/components/agents/panes/workspace-conversations';
+import { decideClosePane } from '@/components/agents/panes/close-pane';
 import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
 
@@ -756,13 +758,11 @@ function SessionRow({
           `/api/agent-workspaces/${encodeURIComponent(session.workspaceId)}/conversations/${encodeURIComponent(conversationId)}`,
         );
       } catch (error) {
-        if (error instanceof ApiRequestError && error.status === 409) {
-          // The workspace's LAST open listing — the server is the authority on
-          // the never-empty invariant; fall back to the same confirmed
-          // end-session flow the row's own "End session" already uses.
-          setConfirmingEnd(true);
-          return;
-        }
+        // No 409 branch: the server stopped refusing the last close in the
+        // node-tree cutover, so the `last_conversation` fallback that used to
+        // live here was dead code. The last-pane end-session it reached for is
+        // decided on the client now, by `decideClosePane` — see
+        // `closeConversationRow` below.
         console.error('Failed to close this conversation:', error);
         toast.error('Could not close this conversation', {
           description: error instanceof Error ? error.message : 'Please try again.',
@@ -793,15 +793,51 @@ function SessionRow({
    * revalidation, so there is no such gap; and if `tree` is somehow absent the
    * placement reads `unplaced`, which closes the LISTING rather than guessing.
    */
+  /**
+   * Destroy one of this workspace's nodes from a sidebar row — through the SAME
+   * decision the pane's own close button takes.
+   *
+   * It used to call `closePane` directly, which meant the sidebar could empty a
+   * workspace's tree in a way the grid refuses to: two affordances for one act,
+   * disagreeing about the last one. `decideClosePane` is that act, so both go
+   * through it and the last row raises the confirm this row already owns.
+   *
+   * `canEndSession: true` is a fact about THIS listing, not an assumption. It
+   * is filtered `{ownerId: auth.userId}` (`GET /api/agent-workspaces`), so every
+   * session here is the viewer's own, and `decideAgentSessionEndAccess` allows
+   * the owner unconditionally — release-of-compute needs no capability. The
+   * pane grid, which can be mounted on someone else's workspace, resolves the
+   * real answer from the session record instead.
+   */
+  const closeNodeRow = useCallback(
+    (nodeId: string) => {
+      const decision = decideClosePane({
+        panes: tree ? paneNodesOf(tree.nodes) : [],
+        nodeId,
+        // This row's own listing — the same fact the grid feeds the decision,
+        // from the poll that produced the row.
+        activeConversations: session.conversations,
+        canEndSession: true,
+      });
+      if (decision.action === 'end-session') {
+        setConfirmingEnd(true);
+        return;
+      }
+      if (decision.action === 'noop') return;
+      closePane(session.workspaceId, nodeId);
+    },
+    [closePane, session.workspaceId, session.conversations, tree],
+  );
+
   const closeConversationRow = useCallback(
     (conversationId: string, placement: MemberPlacement, nodeId: string | null) => {
       if (placement === 'grid' && nodeId !== null) {
-        closePane(session.workspaceId, nodeId);
+        closeNodeRow(nodeId);
         return;
       }
       void closeConversation(conversationId);
     },
-    [closePane, closeConversation, session.workspaceId],
+    [closeNodeRow, closeConversation],
   );
 
   const conversationLabel = useCallback(
@@ -911,8 +947,7 @@ function SessionRow({
                   // affordance for a member that was not on screen.
                   label: 'Close',
                   icon: X,
-                  onSelect: () =>
-                    row.nodeId === null ? undefined : closePane(session.workspaceId, row.nodeId),
+                  onSelect: () => (row.nodeId === null ? undefined : closeNodeRow(row.nodeId)),
                   destructive: true,
                 },
               ]}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1140,16 +1140,69 @@ describe('AgentsSidebar', () => {
       );
     });
 
-    test('a 409 (the session\'s last open listing) falls back to the end-session confirm dialog, mirroring the pane grid', async () => {
-      mockDel.mockRejectedValue(new ApiRequestError('last open listing', 409));
+    /**
+     * REPLACES the 409 fallback. The server stopped refusing the last close in
+     * the node-tree cutover, so the `last_conversation` branch this used to
+     * exercise was unreachable code — the DELETE simply succeeded and left the
+     * workspace holding nothing. The decision is `decideClosePane`'s now, taken
+     * BEFORE anything is sent, which is also what stops these two affordances
+     * disagreeing: the sidebar row used to call `closePane` directly and could
+     * empty a tree the pane's own close button refuses to.
+     */
+    test("closing the last PLACED row raises the end-session confirm, and sends nothing", async () => {
+      respondWithSessions([
+        {
+          ...SESSION,
+          rev: 1,
+          nodes: [treeRoot, chatNode('n1', WS, 0, 'conv-1')],
+          conversations: [{ conversationId: 'conv-1', title: 'First chat', agentPageId: 'agent-1' }],
+        },
+      ]);
       const user = userEvent.setup();
       renderSidebar();
 
       await user.click(await screen.findByLabelText(/expand api refactor/i));
       fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
-      await user.click(await screen.findByText('Close conversation'));
+      // "Close pane", not "Close conversation": the row is PLACED, so its menu
+      // names the node it holds.
+      await user.click(await screen.findByText('Close pane'));
 
       expect(await screen.findByRole('alertdialog')).toBeDefined();
+      // Nothing written and nothing requested — the confirm is the whole act,
+      // and `mockDel` never rejected to produce it.
+      expect(mockDel).not.toHaveBeenCalled();
+      expect(
+        mockFetchWithAuth.mock.calls.some(
+          ([url, init]) => typeof url === 'string' && url.includes('/nodes') && init?.method === 'POST',
+        ),
+      ).toBe(false);
+    });
+
+    test('closing a NON-last placed row drops its node and raises no dialog', async () => {
+      respondWithSessions([
+        { ...SESSION, rev: 1, nodes: [treeRoot, chatNode('n1', WS, 0, 'conv-1'), chatNode('n2', WS, 1, 'conv-2')] },
+      ]);
+      const user = userEvent.setup();
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText(/expand api refactor/i));
+      fireEvent.contextMenu(await screen.findByText('Researcher — First chat'));
+      await user.click(await screen.findByText('Close pane'));
+
+      await waitFor(() =>
+        expect(
+          mockFetchWithAuth.mock.calls.some(
+            ([url, init]) =>
+              typeof url === 'string' &&
+              url.includes('/nodes') &&
+              init?.method === 'POST' &&
+              JSON.parse(init.body as string).drop.includes('n1'),
+          ),
+        ).toBe(true),
+      );
+      expect(screen.queryByRole('alertdialog')).toBeNull();
+      // And no second writer for the same removal — the DELETE is gone.
+      expect(mockDel).not.toHaveBeenCalled();
     });
 
     test('a non-409 failure shows an error toast, not the end-session dialog', async () => {

--- a/apps/web/src/lib/agent-workspaces/__tests__/close-conversation-in-workspace.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/close-conversation-in-workspace.test.ts
@@ -1,14 +1,23 @@
 /**
- * CLOSING IS A `move`, SO CLOSING KEEPS MEMBERSHIP.
+ * CLOSING A THREAD OUT OF ITS WORKSPACE — the route's decision, and now ONLY the
+ * route's decision.
  *
- * Two things this suite holds down that the previous shape could not even
- * state:
+ * Three things this suite holds down:
  *
  *  - **There is no never-empty guard, and there is no `countOpenConversations`
  *    dep to mock.** `last_conversation` refused the close of a workspace's last
- *    open listing because that emptied the workspace. A `move` cannot empty
- *    anything, so the guard has nothing to guard — its ABSENCE from these deps
- *    is the assertion.
+ *    open listing because that emptied the workspace. Emptying it is an
+ *    ordinary resting state, so the guard has nothing to guard — its ABSENCE
+ *    from these deps is the assertion.
+ *  - **There is no `announceClosed` dep either, and that absence is the second
+ *    assertion.** The directory `conversation:closed` moved into the write
+ *    funnel (`commitUnderLock`), because THIS function is only one of four
+ *    producers that remove a chat node — the pane drop, the sidebar's row drop
+ *    and an agent tool's close never came through here, so an announcement
+ *    owned by this branch fired for a quarter of the closes. Its coverage lives
+ *    in `workspace-node-runtime.test.ts` now, on the funnel that every producer
+ *    passes through; the other side of the seam is still
+ *    `session-directory-listener.test.ts`.
  *  - **The ownership gate is unchanged and still first.** Workspace access is
  *    drive-membership-wide; it is not ownership of a thread, and only this line
  *    stands between a member's private thread and anyone who can reach the
@@ -17,13 +26,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   closeConversationInSessionWith,
+  dismissOutcomeOf,
   type CloseConversationInSessionDeps,
 } from '../close-conversation-in-workspace';
 
 interface MockDeps extends CloseConversationInSessionDeps {
   findConversation: ReturnType<typeof vi.fn>;
   dismissConversation: ReturnType<typeof vi.fn>;
-  announceClosed: ReturnType<typeof vi.fn>;
 }
 
 const OWNER = 'user-1';
@@ -33,7 +42,6 @@ function makeDeps(overrides: Partial<Record<keyof MockDeps, unknown>> = {}): Moc
   return {
     findConversation: vi.fn(async () => ({ userId: OWNER, isActive: true })),
     dismissConversation: vi.fn(async () => 'dismissed' as const),
-    announceClosed: vi.fn(),
     ...overrides,
   } as MockDeps;
 }
@@ -75,11 +83,32 @@ describe('closeConversationInSessionWith', () => {
     expect(deps.dismissConversation).not.toHaveBeenCalled();
   });
 
-  it('treats a history-deleted thread as already closed, and writes nothing', async () => {
+  /**
+   * INVERTED, and the inversion is the fix.
+   *
+   * `already_closed` used to be answered from `isActive` alone, BEFORE the
+   * membership write — and the route answers 200 `{ok: true}` for it. That is
+   * only sound if a dead thread never has a node, and a FAILED expel leaves
+   * exactly that: `expelConversationFromSession` logs and returns `refused`, the
+   * soft-delete proceeds regardless, and the node survives bound to a dead
+   * thread. Every later close then reported success having written nothing, so
+   * the pane was unclosable and said so silently.
+   */
+  it('still ATTEMPTS the removal for a history-deleted thread, so a stranded node is repaired', async () => {
     deps.findConversation.mockResolvedValue({ userId: OWNER, isActive: false });
 
+    expect(await closeConversationInSessionWith(deps, input)).toBe('closed');
+    expect(deps.dismissConversation).toHaveBeenCalledWith({ conversationId: 'conv-1', workspaceId: 'ws-1' });
+  });
+
+  it('answers already_closed for a history-deleted thread once the write confirms there is no node', async () => {
+    // The ordinary dead-thread case, reached THROUGH the write rather than
+    // ahead of it: no listing, no node, nothing to do. It discloses nothing a
+    // guesser could use — the ownership gate above has already passed.
+    deps.findConversation.mockResolvedValue({ userId: OWNER, isActive: false });
+    deps.dismissConversation.mockResolvedValue('not_a_member');
+
     expect(await closeConversationInSessionWith(deps, input)).toBe('already_closed');
-    expect(deps.dismissConversation).not.toHaveBeenCalled();
   });
 
   it('reports a thread this workspace does not hold as "not there" — which a RE-SENT close also is', async () => {
@@ -99,73 +128,70 @@ describe('closeConversationInSessionWith', () => {
   });
 
   /**
-   * THE DIRECTORY ANNOUNCEMENT — the half that broke, and the half no unit test
-   * spanned.
+   * THE DIRECTORY ANNOUNCEMENT IS NOT THIS FUNCTION'S ANY MORE.
    *
-   * When closing stopped being a `conversations` column write, the repository
-   * writers that stamped it were deleted and their `conversation:closed` emit
-   * went with them, on a comment's claim that the membership write's
-   * `workspace:nodes-updated` broadcast now covered it. It does not: that event
-   * carries the TREE, and the sidebar's conversation rows are keyed by the
-   * LISTING, in an SWR cache no tree event touches. Nothing emitted
-   * `conversation:closed` at all, so a server-side close left the row on screen
-   * until the 120s backstop poll.
+   * When closing stopped being a `conversations` column write, its
+   * `conversation:closed` emit was deleted on a comment's claim that the
+   * membership write's `workspace:nodes-updated` covered it. It does not — that
+   * event carries the TREE, and the sidebar's conversation rows are keyed by
+   * the LISTING, in an SWR cache no tree event touches — so an `announceClosed`
+   * dep was added HERE to put it back.
    *
-   * Only `apps/e2e/tests/18-sidebar-directory-live.spec.ts` caught it, because
-   * the seam ran between a server module and a browser listener and no unit
-   * test crossed it. These do — from this side, "a close says so"; from the
-   * other, `session-directory-listener.test.ts`'s "and the listener answers it
-   * without a request".
+   * That put it in the wrong place. Membership is the node, so a chat node
+   * leaving the tree is the thread leaving the workspace however it left; this
+   * route is one producer of that out of four, and in practice the least likely
+   * to win — the pane's own drop normally committed first, leaving this branch
+   * un-taken. The emit lives in the write funnel now, and these two assertions
+   * are what is left of the dep here: that there ISN'T one.
    */
   describe('the directory announcement', () => {
-    it('announces a close that actually happened, with the row it gated on', async () => {
-      const row = { userId: OWNER, isActive: true, id: 'conv-1', rev: 7 };
-      deps.findConversation.mockResolvedValue(row);
-
-      expect(await closeConversationInSessionWith(deps, input)).toBe('closed');
-
-      expect(deps.announceClosed).toHaveBeenCalledTimes(1);
-      // The SAME row the ownership gate read — the close writes no
-      // `conversations` column, so this read is the only place the emit context
-      // comes from and re-reading it would be a second query.
-      expect(deps.announceClosed).toHaveBeenCalledWith(row);
+    it('is not a dep of this decision — nothing here can emit', () => {
+      expect(deps).not.toHaveProperty('announceClosed');
     });
 
-    it('announces AFTER the membership write, never before it', async () => {
-      const order: string[] = [];
-      deps.dismissConversation.mockImplementation(async () => {
-        order.push('write');
-        return 'dismissed' as const;
-      });
-      deps.announceClosed.mockImplementation(() => order.push('announce'));
-
-      await closeConversationInSessionWith(deps, input);
-
-      // Announcing a close the write then refuses is the failure mode that
-      // reads as "the row vanished and came back".
-      expect(order).toEqual(['write', 'announce']);
+    it('is not owed on a repeat close either — this function answers, and announces nothing', async () => {
+      // Every outcome, and none of them reaches an emitter, because there is
+      // none to reach. `workspace-node-runtime.test.ts` owns the positive case.
+      for (const outcome of ['dismissed', 'not_a_member', 'refused'] as const) {
+        deps = makeDeps({ dismissConversation: vi.fn(async () => outcome) });
+        await closeConversationInSessionWith(deps, input);
+        expect(Object.keys(deps)).toEqual(['findConversation', 'dismissConversation']);
+      }
     });
+  });
+});
 
-    it.each([
-      ['a thread the workspace does not hold', 'not_a_member' as const],
-      ['a tree that refused the removal', 'refused' as const],
-    ])('stays silent for %s', async (_label, outcome) => {
-      deps.dismissConversation.mockResolvedValue(outcome);
+/**
+ * READING THE MEMBERSHIP WRITE'S ANSWER.
+ *
+ * Extracted from the production wiring, where it was an inline narrowing that
+ * removed `refused` and `stale` and let everything else mean "dismissed" — so
+ * `conflict`, which is a ROLLED-BACK write, reported a successful close.
+ */
+describe('dismissOutcomeOf', () => {
+  it('reads `ok` as the dismissal', () => {
+    expect(dismissOutcomeOf({ status: 'ok' })).toBe('dismissed');
+  });
 
-      expect(await closeConversationInSessionWith(deps, input)).toBe('not_in_session');
-      expect(deps.announceClosed).not.toHaveBeenCalled();
-    });
+  it('reads `conflict` as a REFUSAL, not a dismissal', () => {
+    // THE FIX. A conflict is raised from inside the write's transaction and
+    // unwinds it, so nothing was removed — answering `dismissed` made the route
+    // reply 200 "closed" and write a `data.write` audit event for a close that
+    // never happened.
+    expect(dismissOutcomeOf({ status: 'conflict', code: 'target_already_shown' })).toBe('refused');
+  });
 
-    it.each([
-      ['a conversation this user does not own', { userId: 'user-2', isActive: true }],
-      ['a history-deleted thread', { userId: OWNER, isActive: false }],
-      ['a conversation that does not exist', null],
-    ])('stays silent for %s — nothing was written to announce', async (_label, row) => {
-      deps.findConversation.mockResolvedValue(row);
+  it('reads `stale` as a refusal', () => {
+    expect(dismissOutcomeOf({ status: 'stale' })).toBe('refused');
+  });
 
-      await closeConversationInSessionWith(deps, input);
+  it('keeps `not_a_member` distinct — it is the only refusal a caller can act on', () => {
+    expect(dismissOutcomeOf({ status: 'refused', code: 'not_a_member' })).toBe('not_a_member');
+  });
 
-      expect(deps.announceClosed).not.toHaveBeenCalled();
-    });
+  it('collapses every other refusal code', () => {
+    for (const code of ['forbidden_target', 'awaiting_backfill', 'target_deleted', 'session_full']) {
+      expect(dismissOutcomeOf({ status: 'refused', code })).toBe('refused');
+    }
   });
 });

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
@@ -22,7 +22,7 @@ import {
 const WORKSPACE = 'ws-1';
 const VIEWER = 'user-1';
 
-const { store, mockBroadcast, authorize, labelRows, chatBindings } = vi.hoisted(() => ({
+const { store, mockBroadcast, mockConversationClosed, authorize, labelRows, chatBindings, directoryRows } = vi.hoisted(() => ({
   /**
    * A workspace's nodes and rev, mutated by the write exactly as the DB would
    * be — plus `rows`, which stands for whatever `within` writes on the same
@@ -30,8 +30,41 @@ const { store, mockBroadcast, authorize, labelRows, chatBindings } = vi.hoisted(
    * back on a throw, so "the membership write unwound" and "it returned a
    * refusal" are distinguishable states rather than the same empty `writes`.
    */
-  store: { rev: 0, nodes: [] as WorkspaceNode[], writes: [] as PersistedNodeWrite[], rows: [] as string[] },
+  store: {
+    rev: 0,
+    nodes: [] as WorkspaceNode[],
+    writes: [] as PersistedNodeWrite[],
+    rows: [] as string[],
+    /**
+     * A transaction that fails AT COMMIT, after the body has run to completion.
+     *
+     * The only way to reach the far side of every in-body refusal and still not
+     * have the write land — which is the one seam that can tell "read inside
+     * the transaction, emit after it commits" from "emit inside it". Every
+     * other rollback in this suite is a throw from the body, which happens
+     * before the directory read is even reached.
+     */
+    throwOnCommit: null as Error | null,
+  },
   mockBroadcast: vi.fn(),
+  /**
+   * The DIRECTORY plane's `conversation:closed`. Async like the real one, and
+   * typed with its argument so `mock.calls` is a tuple the assertions can index.
+   */
+  mockConversationClosed: vi.fn(async (_ctx: { conversationId: string }) => {}),
+  /**
+   * What `readConversationDirectoryRows` answers — the display facts a
+   * `conversation:closed` is addressed with. Seeded per test for whichever
+   * threads that test's tree holds.
+   */
+  directoryRows: [] as Array<{
+    id: string;
+    rev: number;
+    userId: string;
+    isShared: boolean;
+    type: string;
+    contextId: string | null;
+  }>,
   authorize: { allow: true, seen: [] as unknown[] },
   labelRows: {
     conversations: [] as unknown[],
@@ -83,11 +116,13 @@ vi.mock('@pagespace/lib/services/agent-workspaces/workspace-node-store', async (
         rows: [...store.rows],
       };
       try {
-        return await fn({
+        const answer = await fn({
           select: () => ({
             from: () => ({ where: () => ({ limit: async () => labelRows.workspaces }) }),
           }),
         });
+        if (store.throwOnCommit !== null) throw store.throwOnCommit;
+        return answer;
       } catch (error) {
         Object.assign(store, snapshot);
         throw error;
@@ -104,6 +139,8 @@ vi.mock('@pagespace/lib/services/agent-workspaces/workspace-node-store', async (
       chatBindings.livenessAsked.push([...targetIds]);
       return targetIds.filter((id) => chatBindings.deleted.includes(id));
     },
+    readConversationDirectoryRows: async (_tx: unknown, ids: readonly string[]) =>
+      directoryRows.filter((row) => ids.includes(row.id)),
     writeWorkspaceNodes: async (_tx: unknown, input: { write: PersistedNodeWrite }) => {
       if (chatBindings.throwOnWrite !== null) throw chatBindings.throwOnWrite;
       store.writes.push(input.write);
@@ -120,6 +157,18 @@ vi.mock('@pagespace/lib/services/agent-workspaces/workspace-node-store', async (
 
 vi.mock('@/lib/websocket/agent-workspace-events', () => ({
   broadcastWorkspaceNodesUpdated: (...args: unknown[]) => mockBroadcast(...args),
+}));
+
+// `SERVER_TRIGGERED_BROWSER_SESSION` is not decoration: `emitContextFromRow`
+// reads it for the default `triggeredBy`, and vitest raises on a missing named
+// export from a mocked module. That throw is SYNCHRONOUS and lands inside
+// `announceWithoutUnsucceeding`, which swallows it by contract — so an
+// incomplete mock here reads as "the funnel does not announce" rather than as
+// an error. (It also demonstrated the contract works: the write still
+// succeeded.)
+vi.mock('@/lib/websocket/conversation-events', () => ({
+  conversationEvents: { closed: (ctx: { conversationId: string }) => mockConversationClosed(ctx) },
+  SERVER_TRIGGERED_BROWSER_SESSION: 'server',
 }));
 
 vi.mock('../authorize-pane-scope', async () => {
@@ -148,7 +197,12 @@ vi.mock('@pagespace/db/schema/agent-workspaces', () => ({
   agentWorkspaces: { __name: 'workspaces' },
 }));
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { __name: 'pages' } }));
-vi.mock('@pagespace/db/operators', () => ({ inArray: () => ({}), eq: () => ({}) }));
+vi.mock('@pagespace/db/operators', () => ({
+  inArray: () => ({}),
+  eq: () => ({}),
+  and: () => ({}),
+  sql: Object.assign(() => ({}), { raw: () => ({}) }),
+}));
 vi.mock('@pagespace/lib/permissions/permissions', () => ({ getUserAccessLevel: async () => 'VIEW' }));
 vi.mock('@pagespace/lib/permissions/conversation-access', () => ({ canAccessConversation: async () => true }));
 
@@ -173,6 +227,7 @@ beforeEach(() => {
   store.nodes = [root, pane('pane-a', 'root', 0), pane('pane-b', 'root', 1)];
   store.writes = [];
   store.rows = [];
+  store.throwOnCommit = null;
   authorize.allow = true;
   authorize.seen = [];
   labelRows.conversations = [];
@@ -184,6 +239,7 @@ beforeEach(() => {
   chatBindings.throwOnWrite = null;
   chatBindings.deleted = [];
   chatBindings.livenessAsked = [];
+  directoryRows.length = 0;
 });
 
 function write(over: { baseRev?: number; put?: WorkspaceNode[]; drop?: string[] } = {}) {
@@ -328,6 +384,125 @@ describe('replay', () => {
     if (replay.status !== 'ok') return;
     expect(replay.changed).toBe(false);
     expect(store.rev).toBe(before);
+  });
+});
+
+/**
+ * THE DIRECTORY PLANE'S HALF OF A MEMBERSHIP CHANGE.
+ *
+ * `conversation:closed` used to be emitted by the close ROUTE's own decision,
+ * which is one of four producers that remove a chat node — and, in practice,
+ * the one that usually lost: the pane's optimistic `drop` reached this funnel
+ * first, so the route's `expel` found no node and its announcement branch was
+ * never taken. It is emitted from HERE now, so it is a property of the write
+ * rather than of which endpoint a client happened to call.
+ *
+ * The sidebar's rows come from the LISTING, not the tree, so the structural
+ * `workspace:nodes-updated` beside it cannot take a row out of that cache — the
+ * other side of the seam is `session-directory-listener.test.ts`.
+ */
+describe('the conversation:closed announcement', () => {
+  const chatPane = (id: string, conversationId: string, position: number) =>
+    pane(id, 'root', position, { kind: 'chat', id: conversationId });
+  const directoryRow = (id: string) => ({
+    id,
+    rev: 7,
+    userId: VIEWER,
+    isShared: false,
+    type: 'global',
+    contextId: null,
+  });
+
+  beforeEach(() => {
+    store.nodes = [root, chatPane('pane-a', 'conv-1', 0), chatPane('pane-b', 'conv-2', 1)];
+    directoryRows.push(directoryRow('conv-1'), directoryRow('conv-2'));
+  });
+
+  it('announces once for the thread a drop removed, and for no other', async () => {
+    const result = await write({ drop: ['pane-b'] });
+    expect(result.status).toBe('ok');
+
+    expect(mockConversationClosed).toHaveBeenCalledTimes(1);
+    expect(mockConversationClosed).toHaveBeenCalledWith(expect.objectContaining({ conversationId: 'conv-2', rev: 7 }));
+  });
+
+  it('announces NOTHING for a hand-off — the same thread on a different node', async () => {
+    // THE CASE A `drop`-shaped implementation gets wrong. The write drops
+    // `pane-a` and puts `pane-c` holding the same conversation; the thread
+    // never left the workspace, so telling every subscriber it closed would be
+    // a lie the sidebar acts on.
+    const result = await write({
+      drop: ['pane-b'],
+      put: [chatPane('pane-c', 'conv-2', 1)],
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.changed).toBe(true);
+    expect(mockConversationClosed).not.toHaveBeenCalled();
+  });
+
+  it('announces nothing on a REPLAY — no rev, no broadcast, no announcement', async () => {
+    await write({ drop: ['pane-b'] });
+    expect(mockConversationClosed).toHaveBeenCalledTimes(1);
+
+    const replay = await write({ drop: ['pane-b'] });
+    expect(replay.status).toBe('ok');
+    if (replay.status !== 'ok') return;
+    expect(replay.changed).toBe(false);
+    // Still one: the second POST produced the tree already stored, so it minted
+    // no rev, broadcast nothing, and owes the directory plane nothing either.
+    expect(mockConversationClosed).toHaveBeenCalledTimes(1);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces nothing for a write that ROLLED BACK', async () => {
+    // A refusal raised after the decision — the write unwinds, so there is no
+    // membership change to announce. Announcing from inside the transaction
+    // would have shipped this one.
+    authorize.allow = false;
+    const result = await write({
+      drop: ['pane-b'],
+      put: [chatPane('pane-c', 'conv-new', 1)],
+    });
+    expect(result.status).toBe('refused');
+    expect(store.writes).toEqual([]);
+    expect(mockConversationClosed).not.toHaveBeenCalled();
+  });
+
+  it('announces for every thread an end-session destroyed', async () => {
+    // The producer that never announced AT ALL under the old shape: ending a
+    // session goes nowhere near the close route.
+    const result = await destroyWorkspaceTree({ workspaceId: WORKSPACE, actingUserId: VIEWER });
+    expect(result.status).toBe('ok');
+
+    expect(mockConversationClosed).toHaveBeenCalledTimes(2);
+    expect(
+      mockConversationClosed.mock.calls.map(([ctx]) => ctx.conversationId).sort(),
+    ).toEqual(['conv-1', 'conv-2']);
+  });
+
+  it('announces nothing when the transaction fails AT COMMIT', async () => {
+    // The seam between reading inside the transaction and emitting after it.
+    // Every other refusal in this funnel throws before the directory read is
+    // reached; this one lets the whole body run and then fails, so an emit
+    // placed beside the read would ship a `conversation:closed` for a removal
+    // that rolled back — telling every subscriber a thread had left a workspace
+    // it is still in, with nothing to correct it but the 120s poll.
+    store.throwOnCommit = new Error('commit failed');
+
+    await expect(write({ drop: ['pane-b'] })).rejects.toThrow('commit failed');
+
+    expect(store.nodes.map((node) => node.id)).toEqual(['root', 'pane-a', 'pane-b']);
+    expect(mockConversationClosed).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('announces nothing for a pure layout write that removed no thread', async () => {
+    const result = await write({ put: [chatPane('pane-a', 'conv-1', 1), chatPane('pane-b', 'conv-2', 0)] });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.changed).toBe(true);
+    expect(mockConversationClosed).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/workspace-node-runtime.test.ts
@@ -428,7 +428,7 @@ describe('the conversation:closed announcement', () => {
 
   it('announces NOTHING for a hand-off — the same thread on a different node', async () => {
     // THE CASE A `drop`-shaped implementation gets wrong. The write drops
-    // `pane-a` and puts `pane-c` holding the same conversation; the thread
+    // `pane-b` and puts `pane-c` holding the same conversation; the thread
     // never left the workspace, so telling every subscriber it closed would be
     // a lie the sidebar acts on.
     const result = await write({

--- a/apps/web/src/lib/agent-workspaces/agent-workspaces-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/agent-workspaces-runtime.ts
@@ -88,6 +88,7 @@ import {
 } from '@/lib/agent-workspaces/workspace-node-runtime';
 import {
   closeConversationInSessionWith,
+  dismissOutcomeOf,
   type CloseConversationOutcome,
 } from '@/lib/agent-workspaces/close-conversation-in-workspace';
 import {
@@ -565,16 +566,14 @@ export async function closeConversationInSession(input: {
           actingUserId: input.userId,
           run: (nodes) => expel(nodes, { target: { kind: 'chat', id: conversationId } }),
         });
-        if (result.status === 'refused') {
-          return result.code === 'not_a_member' ? 'not_a_member' : 'refused';
-        }
-        if (result.status === 'stale') return 'refused';
-        return 'dismissed';
+        // POSITIVELY narrowed, in a pure function beside the type it produces
+        // — see `dismissOutcomeOf` for the `conflict` fallthrough this replaces.
+        return dismissOutcomeOf(result);
       },
-      // The directory plane. See `announceClosed`'s own doc for why the node
-      // write's `workspace:nodes-updated` does not cover this: that event
-      // carries the TREE, and the sidebar's rows come from the LISTING.
-      announceClosed: (row) => emitConversationLifecycle('closed', row),
+      // No `announceClosed`: the write funnel emits `conversation:closed` for
+      // every chat node a committed write removes, whichever producer removed
+      // it. See `dismissConversation`'s doc in
+      // `close-conversation-in-workspace.ts`.
     },
     input,
   );

--- a/apps/web/src/lib/agent-workspaces/close-conversation-in-workspace.ts
+++ b/apps/web/src/lib/agent-workspaces/close-conversation-in-workspace.ts
@@ -41,10 +41,36 @@ export type CloseConversationOutcome = 'closed' | 'already_closed' | 'not_in_ses
 export type DismissConversationOutcome = 'dismissed' | 'not_a_member' | 'refused';
 
 /**
- * The row facts this decision gates on. Deliberately the MINIMUM: the deps are
- * generic over whatever richer row the caller's read actually returns (see
- * `announceClosed`), so the production wiring can hand its emit context
- * straight through without this module having to name it.
+ * Read a membership write's answer as a dismissal or a refusal — POSITIVELY
+ * narrowed, which is the whole point of it existing as a function.
+ *
+ * The wiring used to narrow away `refused` and `stale` inline and let
+ * everything else fall through to `dismissed`. That fallthrough covered `ok`
+ * **and** `conflict`, and a conflict is a ROLLED-BACK write: the route answered
+ * 200 "closed" and wrote a `data.write` audit event for a close that never
+ * happened. Latent rather than live — a pure destroy introduces no binding, so
+ * it cannot currently raise the chat-target conflict — but it is exactly the
+ * class `commitUnderLock` documents at length, and both neighbouring call sites
+ * already guard it (`admitConversationNode` handles `conflict` explicitly,
+ * `expelConversationFromSession` is exhaustive-safe via `if (status === 'ok')`).
+ *
+ * Lives here, beside the type it produces, so it is testable without the
+ * database the wiring is bolted to.
+ */
+export function dismissOutcomeOf(result: { status: string; code?: string }): DismissConversationOutcome {
+  if (result.status === 'ok') return 'dismissed';
+  if (result.status === 'refused' && result.code === 'not_a_member') return 'not_a_member';
+  return 'refused';
+}
+
+/**
+ * The row facts this decision gates on, and now the WHOLE row it reads.
+ *
+ * The deps used to be generic over whatever richer row the caller's read
+ * returned, so `announceClosed` could be handed its emit context without this
+ * module naming it. That dep is gone — the write funnel announces — so these
+ * two columns are the entire input, and a generic that abstracts over nothing
+ * would only make a reader look for the part that uses it.
  */
 export interface ConversationCloseSubject {
   /**
@@ -54,14 +80,15 @@ export interface ConversationCloseSubject {
    */
   userId: string;
   /**
-   * History soft-delete. A history-deleted thread has no listing left to
-   * close; its node is removed by the delete itself, so closing one is
-   * `already_closed` rather than an act with anything to do.
+   * History soft-delete. A history-deleted thread has no listing left to close,
+   * so once the membership write confirms there is no node either, the answer
+   * is `already_closed`. It is read AFTER that write, never instead of it — see
+   * the comment on the `dismissConversation` call.
    */
   isActive: boolean;
 }
 
-export interface CloseConversationInSessionDeps<TRow extends ConversationCloseSubject = ConversationCloseSubject> {
+export interface CloseConversationInSessionDeps {
   /**
    * Row facts for the ownership gate.
    *
@@ -70,43 +97,44 @@ export interface CloseConversationInSessionDeps<TRow extends ConversationCloseSu
    * lock, which is the only place the answer cannot go stale between the check
    * and the act.
    */
-  findConversation: (conversationId: string) => Promise<TRow | null>;
-  /** THE MEMBERSHIP WRITE — `destroy` the thread's node. */
+  findConversation: (conversationId: string) => Promise<ConversationCloseSubject | null>;
+  /**
+   * THE MEMBERSHIP WRITE — `destroy` the thread's node.
+   *
+   * **It announces, too, and that is why there is no `announceClosed` dep.**
+   * The directory plane still has to hear about a close: closing is a node
+   * `destroy`, whose `workspace:nodes-updated` carries the TREE, while the
+   * sidebar's rows come from the LISTING (`AgentsSidebar`'s `conversationRows`
+   * is "keyed by the listing and never by the tree", and the store the tree
+   * event feeds deliberately ignores workspaces it is not already tracking), so
+   * the structural broadcast cannot take a row out of the listing cache.
+   * Regression caught by `apps/e2e/tests/18-sidebar-directory-live.spec.ts`,
+   * which blocks the listing fetch at the network so that only the event can
+   * move the row.
+   *
+   * What changed is WHERE that announcement is made. It used to be a dep here,
+   * on the theory that this function is the only place that knows a close
+   * happened — true of this ROUTE, and false of the workspace. Membership is
+   * the node, so a chat node leaving the tree is the thread leaving the
+   * workspace however it left: a pane drop, the sidebar's row drop, an agent
+   * tool's close, an end-session. Only one of those ever came through here, so
+   * the announcement fired for one producer out of four. It is emitted from the
+   * write funnel now (`commitUnderLock` → `announceClosedConversations`), which
+   * every one of them passes through, and keeping a dep here as well would
+   * double-emit for this one.
+   */
   dismissConversation: (input: {
     conversationId: string;
     workspaceId: string;
   }) => Promise<DismissConversationOutcome>;
-  /**
-   * ANNOUNCE THE CLOSE ON THE DIRECTORY PLANE — `conversation:closed`.
-   *
-   * A dep rather than a caller-side follow-up because THIS function is the only
-   * place that knows a close actually happened: every other answer below is a
-   * refusal wearing the same shape, and a caller re-deriving "did it close" from
-   * the returned string is a second copy of this switch.
-   *
-   * **Why it exists at all, since the membership write already broadcasts.**
-   * Closing is a node `destroy`, and that write emits `workspace:nodes-updated`
-   * — the TREE plane. The sidebar's rows are not the tree: `AgentsSidebar`'s
-   * `conversationRows` is "keyed by the listing and never by the tree", and the
-   * store the tree event feeds deliberately ignores workspaces it is not
-   * already tracking. So the structural broadcast cannot, even in principle,
-   * take a row out of the listing cache — only the directory event can, and
-   * for the window in which nothing emitted one, a closed thread stayed in the
-   * sidebar until the 120s backstop poll. Regression caught by
-   * `apps/e2e/tests/18-sidebar-directory-live.spec.ts`, which blocks the
-   * listing fetch at the network so that only the event can move the row.
-   *
-   * Fire-and-forget by contract: a broadcast that fails must not un-succeed a
-   * committed close.
-   */
-  announceClosed: (row: TRow) => void;
 }
 
 /**
  * Make an announcement keep the promise its type already makes.
  *
- * `announceClosed` and `announceReopened` are declared fire-and-forget: a
- * broadcast that fails must not un-succeed a committed write. Both return
+ * The directory announcements — `announceReopened` here, and the write funnel's
+ * own `announceClosedConversations` — are declared fire-and-forget: a broadcast
+ * that fails must not un-succeed a committed write. Both return
  * `void`, so a rejected promise is already nobody's problem — but a SYNCHRONOUS
  * throw from the injected callback is not. It propagates out of the caller and
  * turns a committed membership change into a reported failure, and the retry
@@ -126,8 +154,8 @@ export function announceWithoutUnsucceeding(announce: () => void): void {
   }
 }
 
-export async function closeConversationInSessionWith<TRow extends ConversationCloseSubject>(
-  deps: CloseConversationInSessionDeps<TRow>,
+export async function closeConversationInSessionWith(
+  deps: CloseConversationInSessionDeps,
   { conversationId, userId, workspaceId }: { conversationId: string; userId: string; workspaceId: string },
 ): Promise<CloseConversationOutcome> {
   const row = await deps.findConversation(conversationId);
@@ -146,15 +174,25 @@ export async function closeConversationInSessionWith<TRow extends ConversationCl
   // Refuses as `not_in_session` — the same shape a nonexistent id gets, so an
   // id-guessing caller cannot tell "not yours" from "not there".
   if (row.userId !== userId) return 'not_in_session';
-  if (!row.isActive) return 'already_closed';
 
+  // ATTEMPTED REGARDLESS OF `isActive`, and the order is the fix.
+  //
+  // A history-deleted thread has no listing left to close, so this used to
+  // return `already_closed` right here, BEFORE the write — and the route
+  // answers 200 `{ok: true}` for it. That is only sound if a dead thread never
+  // has a node, which is exactly the state a FAILED expel leaves behind:
+  // `expelConversationFromSession` logs and returns `refused` when the
+  // membership write does not land, the soft-delete proceeds anyway, and the
+  // node survives bound to a dead thread. Every later close then answered
+  // "already closed, nothing to do" having written nothing, so the pane was
+  // unclosable and said so in the only way a success can — silently.
+  //
+  // Attempting the write costs a dead thread one indexed lookup that answers
+  // `not_a_member`, and repairs the one case where it does not. Nothing is owed
+  // to the directory plane either way: the `deleted` event already fired.
   const outcome = await deps.dismissConversation({ conversationId, workspaceId });
   switch (outcome) {
     case 'dismissed':
-      // AFTER the write, and only on the branch that wrote. Announcing beside
-      // the call would announce the refusals too, which is the failure mode
-      // that reads as "the row vanished and came back".
-      announceWithoutUnsucceeding(() => deps.announceClosed(row));
       return 'closed';
     // "This workspace does not hold that thread" and "the tree would not take
     // the removal" collapse to one answer, the same shape a nonexistent id gets.
@@ -165,7 +203,16 @@ export async function closeConversationInSessionWith<TRow extends ConversationCl
     // the first one removed the node, so the second genuinely finds no member.
     // The distinction the old `already_parked` drew — "it is already where you
     // asked" — needed a node that survived the close, and none does.
+    //
+    // The ONE exception is the history-deleted thread, and it is where
+    // `already_closed` now lives: no listing, no node, nothing to do, and the
+    // caller already passed the ownership gate above so this discloses nothing
+    // a guesser could use. Reaching it through the write rather than ahead of
+    // it is the whole point — a dead thread that DOES still have a node gets
+    // that node removed and answers `closed`, where the old ordering answered
+    // "already closed" and wrote nothing, forever.
     case 'not_a_member':
+      return row.isActive ? 'not_in_session' : 'already_closed';
     case 'refused':
       return 'not_in_session';
   }

--- a/apps/web/src/lib/agent-workspaces/workspace-node-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-node-runtime.ts
@@ -62,18 +62,25 @@ import {
   conflictingChatTargets,
   isChatTargetUniqueViolation,
 } from '@pagespace/lib/agent-workspaces/workspace-node-chat-binding';
+import { removedChatTargets } from '@pagespace/lib/agent-workspaces/workspace-node-membership-diff';
 import {
   awaitsBackfill,
   readChatTargetHolders,
+  readConversationDirectoryRows,
   readDeletedChatTargets,
   readWorkspaceNodeSnapshot,
   readWorkspaceNodeSnapshots,
   withWorkspaceLock,
   writeWorkspaceNodes,
+  type ConversationDirectoryRow,
   type DbExecutor,
   type WorkspaceNodeSnapshot,
 } from '@pagespace/lib/services/agent-workspaces/workspace-node-store';
 import { broadcastWorkspaceNodesUpdated } from '@/lib/websocket/agent-workspace-events';
+import { conversationEvents } from '@/lib/websocket/conversation-events';
+import { emitContextFromRow } from '@/lib/repositories/conversation-rev';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { announceWithoutUnsucceeding } from './close-conversation-in-workspace';
 import { authorizePaneTargets, introducedPaneTargets, paneScopeDeps } from './authorize-pane-scope';
 
 /**
@@ -159,6 +166,32 @@ async function readWorkspaceOwnerId(executor: DbExecutor, workspaceId: string): 
     .where(eq(agentWorkspaces.id, workspaceId))
     .limit(1);
   return rows[0]?.ownerId ?? null;
+}
+
+/**
+ * Announce `conversation:closed` for every thread a committed write removed
+ * from its workspace — the directory plane's half of a membership change.
+ *
+ * Fire-and-forget in both directions a broadcast can fail. A rejected promise
+ * is swallowed with a log, matching `emitConversationLifecycle`'s own policy;
+ * a SYNCHRONOUS throw is caught by {@link announceWithoutUnsucceeding}, which
+ * is the one that would otherwise matter — the write is already committed, so
+ * letting it propagate would report a failure for something that happened, and
+ * the retry would find the node gone and report "not there" a second time.
+ * The sidebar's 120s backstop poll covers the announcement that never lands.
+ */
+function announceClosedConversations(rows: readonly ConversationDirectoryRow[]): void {
+  for (const row of rows) {
+    announceWithoutUnsucceeding(() => {
+      void conversationEvents.closed(emitContextFromRow(row)).catch((error: unknown) => {
+        loggers.api.warn('conversation lifecycle event emission failed', {
+          conversationId: row.id,
+          kind: 'closed',
+          error: error instanceof Error ? error.message : 'unknown',
+        });
+      });
+    });
+  }
 }
 
 /**
@@ -559,11 +592,13 @@ async function commitUnderLock(input: {
       }
     }
 
-    // A write that produces the tree already stored mints no rev and broadcasts
-    // nothing — which is what makes a retried POST observably, and not merely
-    // structurally, a no-op.
+    // A write that produces the tree already stored mints no rev, broadcasts
+    // nothing, and announces nothing — which is what makes a retried POST
+    // observably, and not merely structurally, a no-op. The empty `closed` here
+    // is not a shortcut: a tree identical to the one stored removed nothing, so
+    // the diff below would answer `[]` for it anyway.
     if (!decision.changed) {
-      return { kind: 'ok' as const, snapshot: before, changed: false, ownerId: null };
+      return { kind: 'ok' as const, snapshot: before, changed: false, ownerId: null, closed: [] };
     }
 
     const rev = await writeWorkspaceNodes(tx, { workspaceId, write: decision.persist });
@@ -573,7 +608,26 @@ async function commitUnderLock(input: {
     // needs it to reach the owner's own sessions room; see
     // `broadcastWorkspaceNodesUpdated` for why that room and no other.
     const ownerId = await readWorkspaceOwnerId(tx, workspaceId);
-    return { kind: 'ok' as const, snapshot: { rev, nodes: decision.nodes }, changed: true, ownerId };
+    // THE DIRECTORY PLANE'S HALF OF THIS WRITE, read here and emitted after the
+    // commit (see the `outcome.changed` block below).
+    //
+    // Membership IS the node, so a chat node leaving the tree is the thread
+    // leaving the workspace — and the sidebar's rows come from the LISTING, not
+    // the tree, so `workspace:nodes-updated` cannot take one out of the listing
+    // cache. Announcing from HERE rather than from the close route is what makes
+    // the announcement a property of the write instead of a property of which
+    // client happened to call which endpoint: a pane drop, the sidebar's row
+    // drop, an agent tool's close and an end-session all pass through this
+    // funnel, and only one of them ever went through the route that announced.
+    //
+    // `decision.nodes` is the FINAL tree, never `decision.persist.drop` — a
+    // hand-off drops a target from one node and puts it on another in the same
+    // write, and that must announce nothing. See `removedChatTargets`.
+    const closed = await readConversationDirectoryRows(
+      tx,
+      removedChatTargets(before.nodes, decision.nodes),
+    );
+    return { kind: 'ok' as const, snapshot: { rev, nodes: decision.nodes }, changed: true, ownerId, closed };
   }).catch((error: unknown) => {
     // OUTSIDE the transaction body on purpose — this runs once the rollback has
     // ALREADY unwound. A refusal raised after `within` wrote cannot RETURN,
@@ -646,6 +700,13 @@ async function commitUnderLock(input: {
       nodes: outcome.snapshot.nodes,
       ownerId: outcome.ownerId,
     });
+    // The DIRECTORY plane's `conversation:closed`, one per thread this write
+    // took out of the workspace. Read inside the transaction (see above),
+    // emitted only AFTER it committed and only when something changed — so a
+    // replayed POST, which mints no rev and produces the tree already stored,
+    // announces nothing, exactly as it broadcasts nothing. A rolled-back write
+    // never reaches here at all: `outcome` is `refused` or `conflict`.
+    announceClosedConversations(outcome.closed);
   }
   return { status: 'ok', snapshot, changed: outcome.changed };
 }

--- a/apps/web/src/lib/repositories/conversation-rev.ts
+++ b/apps/web/src/lib/repositories/conversation-rev.ts
@@ -131,9 +131,23 @@ export function emitConversationLifecycle(
   });
 }
 
-/** Build the emitter context from a bumped row + the acting principal. */
+/**
+ * Build the emitter context from a bumped row + the acting principal.
+ *
+ * Takes a `Pick` rather than a whole {@link BumpedConversationRow}, matching
+ * {@link scopeFromRow} beside it: these five columns are the entire input, and
+ * declaring the whole row would force a caller that reads only what an
+ * announcement is addressed with (`readConversationDirectoryRows`) to read
+ * title, timestamps and liveness it will never send. Every existing caller
+ * passes a full row and still type-checks — this only widens what is accepted.
+ */
+export type ConversationEmitSubject = Pick<
+  BumpedConversationRow,
+  'id' | 'rev' | 'userId' | 'isShared' | 'type' | 'contextId'
+>;
+
 export function emitContextFromRow(
-  row: BumpedConversationRow,
+  row: ConversationEmitSubject,
   triggeredBy?: ConversationEventTriggeredBy,
 ): ConversationEmitContext {
   return {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1832,6 +1832,11 @@
       "import": "./dist/agent-workspaces/workspace-node-write.js",
       "require": "./dist/agent-workspaces/workspace-node-write.js"
     },
+    "./agent-workspaces/workspace-node-membership-diff": {
+      "types": "./dist/agent-workspaces/workspace-node-membership-diff.d.ts",
+      "import": "./dist/agent-workspaces/workspace-node-membership-diff.js",
+      "require": "./dist/agent-workspaces/workspace-node-membership-diff.js"
+    },
     "./agent-workspaces/workspace-node-chat-binding": {
       "types": "./dist/agent-workspaces/workspace-node-chat-binding.d.ts",
       "import": "./dist/agent-workspaces/workspace-node-chat-binding.js",

--- a/packages/lib/src/agent-workspaces/__tests__/workspace-node-membership-diff.test.ts
+++ b/packages/lib/src/agent-workspaces/__tests__/workspace-node-membership-diff.test.ts
@@ -1,0 +1,102 @@
+/**
+ * WHAT A WRITE TOOK OUT OF A WORKSPACE.
+ *
+ * The one property worth stating twice: this is a set difference against the
+ * FINAL tree, not a reading of the write's `drop`. A hand-off drops a target
+ * from one node and puts it on another in the same write, and announcing a
+ * close for that would tell every subscriber a thread had left a workspace it
+ * never left. Every case below is really that one distinction from a different
+ * angle.
+ */
+import { describe, it, expect } from 'vitest';
+import type { WorkspaceNode } from '../workspace-node';
+import { removedChatTargets } from '../workspace-node-membership-diff';
+
+const WS = 'ws-1';
+const root: WorkspaceNode = { nodeType: 'root', id: WS, parentId: null, position: 0, axis: 'row' };
+const split = (id: string, parentId: string): WorkspaceNode => ({
+  nodeType: 'split',
+  id,
+  parentId,
+  position: 0,
+  axis: 'row',
+});
+const chat = (id: string, conversationId: string, parentId: string = WS): WorkspaceNode => ({
+  nodeType: 'pane',
+  id,
+  parentId,
+  position: 0,
+  target: { kind: 'chat', id: conversationId },
+});
+const terminal = (id: string, shellId: string): WorkspaceNode => ({
+  nodeType: 'pane',
+  id,
+  parentId: WS,
+  position: 0,
+  target: { kind: 'terminal', id: shellId },
+});
+const page = (id: string, pageId: string): WorkspaceNode => ({
+  nodeType: 'pane',
+  id,
+  parentId: WS,
+  position: 0,
+  target: { kind: 'page', id: pageId },
+});
+const picker = (id: string): WorkspaceNode => ({ nodeType: 'pane', id, parentId: WS, position: 0, target: null });
+
+describe('removedChatTargets', () => {
+  it('reports a chat pane that was destroyed', () => {
+    const before = [root, chat('n1', 'c1'), chat('n2', 'c2')];
+    expect(removedChatTargets(before, [root, chat('n2', 'c2')])).toEqual(['c1']);
+  });
+
+  it('reports NOTHING for a hand-off — dropped from one node, put on another', () => {
+    // THE CASE THAT MAKES THIS A DIFF AND NOT A READING OF `drop`. The write's
+    // `drop` names `n1`; the thread never left.
+    const before = [root, chat('n1', 'c1')];
+    const after = [root, chat('n2', 'c1')];
+    expect(removedChatTargets(before, after)).toEqual([]);
+  });
+
+  it('reports nothing for a pure move — same node, new parent', () => {
+    const before = [root, chat('n1', 'c1')];
+    const after = [root, split('s1', WS), chat('n1', 'c1', 's1')];
+    expect(removedChatTargets(before, after)).toEqual([]);
+  });
+
+  it('reports nothing for a resize or any other write that touches no binding', () => {
+    const before = [root, chat('n1', 'c1'), chat('n2', 'c2')];
+    expect(removedChatTargets(before, before)).toEqual([]);
+  });
+
+  it('reports every chat in the tree when the root is destroyed', () => {
+    // An end-session. This is the producer that never announced at all under
+    // the old shape, because it never went near the close route.
+    const before = [root, chat('n1', 'c1'), split('s1', WS), chat('n2', 'c2', 's1')];
+    expect(removedChatTargets(before, []).sort()).toEqual(['c1', 'c2']);
+  });
+
+  it('reports the thread a REBIND displaced, and not the one that replaced it', () => {
+    // `unbindPane` destroys the node and seats a fresh unbound one, so the old
+    // thread genuinely left; the new binding is an introduction, which is
+    // `introducedPaneTargets`' half of the question.
+    const before = [root, chat('n1', 'c1')];
+    const after = [root, chat('n2', 'c2')];
+    expect(removedChatTargets(before, after)).toEqual(['c1']);
+  });
+
+  it('ignores every non-chat target', () => {
+    // A page shown in two panes is ordinary and a terminal's lifecycle is the
+    // shell route's; only a chat target's presence in a tree means membership.
+    const before = [root, terminal('n1', 'shell-1'), page('n2', 'page-1'), picker('n3')];
+    expect(removedChatTargets(before, [root])).toEqual([]);
+  });
+
+  it('ignores a chat introduced by the write', () => {
+    expect(removedChatTargets([root], [root, chat('n1', 'c1')])).toEqual([]);
+  });
+
+  it('answers nothing for an empty before-tree', () => {
+    expect(removedChatTargets([], [root, chat('n1', 'c1')])).toEqual([]);
+  });
+});

--- a/packages/lib/src/agent-workspaces/workspace-node-membership-diff.ts
+++ b/packages/lib/src/agent-workspaces/workspace-node-membership-diff.ts
@@ -1,0 +1,58 @@
+/**
+ * WHICH CHAT THREADS A WRITE TOOK OUT OF A WORKSPACE — the mirror of
+ * `introducedPaneTargets`, and the other half of the same question.
+ *
+ * That function asks what a write BRINGS IN, because bringing a target in is
+ * what needs authorizing. This asks what a write TAKES OUT, because taking a
+ * chat target out is the one structural change the directory plane has to hear
+ * about: membership IS the node, so a chat node leaving the tree is the thread
+ * leaving the workspace, and the sidebar's rows come from the LISTING rather
+ * than from the tree (`AgentsSidebar`'s `conversationRows` is "keyed by the
+ * listing and never by the tree"). The node write's own
+ * `workspace:nodes-updated` carries the tree and therefore cannot, even in
+ * principle, take a row out of the listing cache.
+ *
+ * **Set difference against the FINAL tree, never against the write's `drop`.**
+ * A `drop` is not a removal — a hand-off moves a target from one node to
+ * another by dropping the first and putting the second in the same write, and
+ * announcing a close for that would tell every subscriber the thread had left a
+ * workspace it never left. The only honest question is whether the target is
+ * still held by SOME pane once the write has landed, which is a property of the
+ * two trees and of nothing else.
+ *
+ * Chat only, and for the same reason the binding index is: a page shown in two
+ * panes is ordinary, and a terminal's lifecycle is the shell route's. Only a
+ * chat target's presence in a tree means membership.
+ *
+ * Pure, over plain node lists — so the funnel that calls it can be tested
+ * without a database and this rule cannot acquire a second copy inside one.
+ */
+
+import type { WorkspaceNode } from './workspace-node';
+
+/** Every chat target held by a pane in `nodes`. */
+function chatTargetsHeldBy(nodes: readonly WorkspaceNode[]): Set<string> {
+  const held = new Set<string>();
+  for (const node of nodes) {
+    if (node.nodeType !== 'pane') continue;
+    if (node.target === null || node.target.kind !== 'chat') continue;
+    held.add(node.target.id);
+  }
+  return held;
+}
+
+/**
+ * The chat targets held by a pane in `before` and by NO pane in `after`.
+ *
+ * Order follows `before`, and duplicates cannot occur — the source is a set.
+ * The table's `UNIQUE (targetId) WHERE targetKind = 'chat'` makes "held by a
+ * pane" and "held by exactly one pane" the same fact, so nothing here has to
+ * count.
+ */
+export function removedChatTargets(
+  before: readonly WorkspaceNode[],
+  after: readonly WorkspaceNode[],
+): string[] {
+  const held = chatTargetsHeldBy(after);
+  return [...chatTargetsHeldBy(before)].filter((targetId) => !held.has(targetId));
+}

--- a/packages/lib/src/services/agent-workspaces/workspace-node-store.ts
+++ b/packages/lib/src/services/agent-workspaces/workspace-node-store.ts
@@ -349,6 +349,68 @@ export async function readDeletedChatTargets(
 }
 
 /**
+ * One conversation directory row per id — exactly the facts a
+ * `conversation:closed` announcement is addressed with.
+ *
+ * The projection is not a judgement call: it is what `emitContextFromRow`
+ * consumes (`conversationId`, `rev`, `scope` — derived from `type`/`contextId`/
+ * `userId` — `ownerId`, `isShared`). Nothing more is read because nothing more
+ * is sent, and a wider projection would invite a caller to make a decision out
+ * of a display fact.
+ *
+ * **A plain read: no `FOR SHARE`, unlike {@link readDeletedChatTargets}.** That
+ * lock exists because liveness is a PRECONDITION there — the write is only
+ * sound if the thread is still alive when it commits, so the read and the write
+ * have to serialize on the conversation row. Nothing here is a precondition.
+ * The membership change has already been decided; these are the display facts
+ * an announcement is addressed with, and a row that changes underneath them
+ * costs an announcement carrying a title from a moment ago. Taking a row lock
+ * for that would make every close wait behind every rename of the same thread,
+ * to buy nothing.
+ *
+ * `rev` is passed through UNBUMPED, matching every other membership
+ * announcement: it is the MESSAGE plane's watermark and a membership change
+ * writes no message, so bumping it would make every subscribed pane detect a
+ * gap and refetch a transcript that did not change.
+ *
+ * A missing id yields no row rather than an error — an announcement has nothing
+ * to address without one, and the caller drops it.
+ */
+export interface ConversationDirectoryRow {
+  id: string;
+  rev: number;
+  userId: string;
+  isShared: boolean;
+  type: string;
+  contextId: string | null;
+}
+
+export async function readConversationDirectoryRows(
+  executor: DbExecutor,
+  conversationIds: readonly string[],
+): Promise<ConversationDirectoryRow[]> {
+  if (conversationIds.length === 0) return [];
+  const { conversations } = await import('@pagespace/db/schema/conversations');
+
+  const rows = await executor
+    .select({
+      id: conversations.id,
+      rev: conversations.rev,
+      userId: conversations.userId,
+      isShared: conversations.isShared,
+      type: conversations.type,
+      contextId: conversations.contextId,
+    })
+    .from(conversations)
+    .where(inArray(conversations.id, [...conversationIds]));
+
+  // `rev` is a bigint; node-postgres hands int8 back as text rather than risk a
+  // silent precision loss. Coerced here for the same reason the join read above
+  // coerces its own — so nothing downstream has to remember.
+  return rows.map((row) => ({ ...row, rev: Number(row.rev) }));
+}
+
+/**
  * Persist a decided write and mint the workspace's next rev.
  *
  * Takes {@link PersistedNodeWrite} — the storage instruction `decideNodeWrite`


### PR DESCRIPTION
Two defects in the same components, sharing one cause: after #2378 made the node the single record of membership, two client paths kept sending a **second write for a fact the node write already owns**, and a server refusal the client still branched on stopped existing.

Stacked conceptually on #2383 (the Agents nav / conversation-list fix) but touching disjoint files — this branches off `master` and does not need it.

---

## 1. The spurious close toast

Closing a chat pane issued **two requests that destroyed the same node**:

| | |
|---|---|
| `POST …/nodes` with `drop:[nodeId]` | the store's optimistic write, dispatched first |
| `DELETE …/conversations/{id}` | whose `expel` is a `destroy` of that same node |

Both take the workspace's advisory lock. The drop normally commits first, so the DELETE's expel finds no node — `not_a_member` → `not_in_session` → **404** → *"Could not close this conversation"*. Nothing rolls the drop back, so the pane closed correctly and the error was pure noise. Lock contention produces the 500 variant of the same race.

### Why not just make the route idempotent

`not_a_member → 200` is about four lines and silences the toast. It also makes the double-write permanent in a model whose stated premise is *one fact, one writer* — and leaves the directory announcement firing only when the DELETE happens to win, which is nondeterministic and worse than never.

The listing is derived from the nodes now (`workspace-conversations-runtime.ts` builds it from `agentWorkspaceNodes WHERE targetKind = 'chat'`; there is no `closedInWorkspaceAt` column left). **The node drop IS the close** — for the sidebar exactly as for the tree. So the DELETE goes, from both producers: the pane's close button and the sidebar's placed row.

### The announcement moves rather than disappears

`conversation:closed` is what takes a row out of the sidebar's listing cache; the structural `workspace:nodes-updated` carries the tree and cannot. But it was **already firing for roughly one close in four**: `announceClosed` ran only on the branch the *losing* DELETE reached, and the sidebar's own row-close never went through the route at all. That is an argument for moving it into the funnel every producer passes, not for keeping the DELETE.

- **`removedChatTargets(before, after)`** — new pure module in `packages/lib`, the mirror of `introducedPaneTargets`. A set difference against the **final tree**, never against `drop`: a hand-off drops a target from one node and puts it on another in the same write, and announcing a close for that would tell every subscriber a thread left a workspace it never left.
- **`readConversationDirectoryRows`** in the node store, beside `readChatTargetHolders` / `readDeletedChatTargets`. A plain read, **no `FOR SHARE`** — that lock exists because liveness is a *precondition* there; these are display facts, and locking them would make every close queue behind every rename of the same thread. In the store rather than inline because `workspace-node-runtime.test.ts` mocks the store wholesale and hand-rolls a `select()` stub that answers one query.
- **Emitted from `commitUnderLock`**: read inside the transaction, emitted after it commits, only when something changed. So a pane drop, a sidebar drop, an agent tool's close and an end-session now announce identically, and a replay announces nothing.
- **`void mutate(isAgentWorkspacesKey)` goes with the DELETE it depended on.** It was only safe because it followed an *awaited* round trip; beside a merely-queued drop it races the pump's POST and can revalidate the row back. `recordClosedConversation` gives local freshness; the new server event settles other clients.

## 2. Closing the last pane ends the session again

#2378 removed the server's `last_conversation` 409, so the client's catch branch became unreachable and users were left in an empty grid with nothing to do.

`close-pane.ts` argues `end-session` was removed because it *"used to live half in the reducer and half in browser code — the exact half-in-each-place coupling the flat model exists to delete."* **That objection is right about the old shape and says nothing against the decision existing.** The answer is to put the *whole* decision in `decideClosePane`, where it is one branch over the same plain data as its two neighbours — the pane list it already receives. What remains in browser code is raising a dialog, which is rendering, not deciding.

Two placement details that are the substance of the branch:

- **Above the target-kind test.** `panes` is every pane of every kind, so "last pane of any kind" comes for free — a lone terminal or a lone picker empties the workspace exactly as a lone chat does.
- **Above the `activeConversations === null` guard.** Ending destroys the tree and the sandbox and never consults the listing. Behind that guard, closing the last pane while the listing loads silently no-ops, which reads as the click being ignored — the worst of the three outcomes.

`handleClosePane` raises it **above `beginPaneAssign`**, whose own comment says to fire only once a decision commits to altering the node. An end-session may be cancelled, and cancel is then genuinely free: nothing invalidated, nothing mutated. `confirmEndSession` and `EndSessionDialog` are untouched.

The **sidebar's row-close and artifact-row Close route through the same decision.** They called `closePane` directly, so the sidebar could empty a tree the grid refuses to — two affordances for one act, disagreeing about the last one.

**`canEndSession` is a real gate, not a formality.** `DELETE /api/agent-workspaces/{id}` is behind `checkSessionEndAccess`, stricter than the `checkSessionAccess` that lets someone reach the pane, so a member who may *use* but not *end* a workspace would have been offered a confirm and handed a 404 for obeying it. The session record answers it — server-resolved for the same reason `sandboxEligible` beside it is, and defaulting to **false** while unresolved (an optimistic sandbox flag costs a button that flashes enabled; an optimistic end flag costs a confirm the user has already agreed to by the time it fails). Those members keep today's behaviour. The sidebar passes `true` as a *fact*, not an assumption: its listing is filtered `{ownerId: auth.userId}`, and `decideAgentSessionEndAccess` allows the owner unconditionally.

## 3. Two adjacent defects, both verified

**`conflict` read as a successful close.** The close wiring narrowed away `refused` and `stale` and let everything else mean `dismissed` — covering `ok` **and** `conflict`. A conflict is a rolled-back write, so a close that wrote nothing answered 200 "closed" plus a `data.write` audit event. Latent rather than live (a pure destroy introduces no binding, so it cannot currently raise the chat-target conflict), but exactly the class documented at `workspace-node-runtime.ts`, and both neighbouring call sites already guard it. Extracted as `dismissOutcomeOf` beside the type it produces, so the narrowing is testable without the database the wiring is bolted to.

**`already_closed` returned before the write.** A history-deleted thread answered `already_closed` from `isActive` alone, and the route answers 200 for it — sound only if a dead thread never has a node, which a *failed* expel is precisely not: `expelConversationFromSession` logs and returns `refused`, the soft-delete proceeds anyway, and the node survives bound to a dead thread. Every later close then reported success having written nothing — unclosable, silently. The write is attempted regardless of `isActive`; `already_closed` is reached *through* its `not_a_member`. No announcement is owed either way (the `deleted` event already fired).

---

## Tests

**The test that would have caught the double-send.** It survived because `fetchWithAuth` (the `/nodes` POST) and `del` (the DELETE) are mocked as separate spies, so nothing ever asserted across both. There is a cross-channel helper now — `expectSingleDropClose` asserts one node write carrying `drop:['n1']` *and* zero conversation-scoped DELETEs. The suite also mocks `sonner` for the first time; without that the reported symptom is literally unobservable.

**Fixture surgery, done first so the new semantics are visible in the diff.** Nearly every `close-pane.test.ts` fixture was a single-pane workspace and would now answer `end-session`; each gained a second pane so it exercises the branch it was written for. Same for the `AgentPanes` close tests. The three *"should NOT offer to end the workspace"* assertions are inverted deliberately and re-purposed as the any-kind pins.

**Mutation-checked, each fix broken and the named test watched go red:**

| mutation | red |
|---|---|
| `removedChatTargets` ignores the after-tree | hand-off, move, resize, destroy (4) |
| emit moved inside the transaction | *announces nothing when the transaction fails at commit* |
| `await del(…/conversations/…)` restored | *closes a chat pane with ONE node drop and no conversation DELETE* |
| `end-session` branch deleted | 5 last-pane tests |
| `canEndSession` ignored | the permission fallbacks, in both suites |
| decision moved below the listing guard | picker, terminal, listing-unresolved, no-rebind |
| decision moved below the target-kind branch | picker, terminal, no-rebind |
| sidebar row bypasses `decideClosePane` | *closing the last PLACED row raises the end-session confirm* |
| `already_closed` answered before the write | *still ATTEMPTS the removal for a history-deleted thread* |
| `conflict` falls through to `dismissed` | *reads `conflict` as a REFUSAL* |
| `canEndSession: true` hardcoded in the route | *reports canEndSession: false for a member who may not end it* |

**Two mutations initially survived, and both led to real coverage rather than a claim.**

- Moving the emit *outside* the `outcome.changed` guard changed nothing, because the `!decision.changed` early return already carries `closed: []`. The guard is belt-and-braces; the code comment now says so instead of claiming the guard is what silences a replay.
- Emitting *inside* the transaction also survived, because every existing rollback in that suite throws **before** the directory read is reached. The test lock stub now models a transaction that fails **at commit** — the one seam that can tell "read inside, emit after commit" from "emit inside" — and the mutation goes red.

**E2E.** `18-sidebar-directory-live.spec.ts` drove the close by calling the DELETE route directly, so it kept passing while covering a path no client takes. A sibling test drives a `POST /nodes` drop with the listing GET blocked at the network — the only test proving the funnel's announcement reaches the sidebar without a request. (Its stale "the server refuses the last close with a 409" comment is corrected too.)

## Gates

```
bun run typecheck    Tasks: 17 successful, 17 total
bun run lint         Tasks: 15 successful, 15 total
bun run knip:check   [ok] knip: 4 issue(s), all within baseline (4).
bun run --filter web test
                     Test Files  1127 passed | 1 skipped (1128)
                          Tests  16810 passed | 6 skipped (16816)
bun run --filter @pagespace/lib test
                     Test Files  420 passed | 2 skipped (422)
                          Tests  9271 passed | 6 skipped (9277)
```

Both suites need a **migrated** database and `ADMIN_DATABASE_URL`; without them ~25 integration suites fail on `42P01 relation does not exist` and `gdpr-eraser` on the missing admin URL. Those are the worktree environment, not this branch. (Note for the next person: `bun run db:migrate` from the repo root silently migrates whatever the root `.env` points at, not the `DATABASE_URL` you passed — run it from `packages/db`.)

## Manual verification

Production build (`next start` — `bun run dev` can't serve this app, the CSP has no dev exemption for Next's `unsafe-eval`), real Postgres, seeded user and drive, 1440×900, driven with Playwright with every request recorded:

1. New session → split → fill the second pane. **2 panes, 2 conversation rows in the expanded sidebar.**
2. **Close the non-last pane** → 1 pane, 1 sidebar row. Requests during the close: exactly `POST /api/agent-workspaces/{id}/nodes`. Conversation-scoped DELETEs: **none**. Toasts: **none**. *(This step is the reported bug, fixed.)*
3. **Close the last pane** → the *"End this session?"* dialog appears, the pane is still there, and **zero requests** were sent.
4. **Cancel** → dialog gone, pane still there, session still in the sidebar.
5. **Close again → End session** → the session ends, the URL drops its selection, the sidebar reads *"No sessions in this drive yet"*, and no toast fires.

One honesty note on step 2: the sidebar row leaving does not by itself prove the *announcement* path, since `recordClosedConversation` patches the same SWR key locally. Isolating the announcement is what the e2e sibling (listing GET blocked) and the funnel unit tests are for.

## Two CI failures after the first push, both mine, both in test code

Recording these because the second one is a lesson about how I checked, not just about the code.

**E2E.** `dropChatNodeServerSide` hand-rolled `{put: [], drop: [nodeId]}`, which is not what closing a pane is — dropping a pane whose parent split then holds one child leaves a tree `validateTree` refuses (`degenerate_split`), so it 400'd on exactly the two-pane grid the spec builds. It compiles through `closePane` now, the same command the browser runs. Verified against a running server rather than reasoned about: bare drop → `400 degenerate_split`, compiled write (`put=1 drop=2`) → `200`.

**Unit.** `mockDel` had no default implementation, so `closeShell`'s `void del(...).catch(...)` got `undefined` back and threw inside a React event handler. It had been masked by a leak: `vi.clearAllMocks()` clears calls but **not** implementations, so `del` arrived carrying whatever `mockResolvedValue` an earlier test left on it — and the terminal-close test depended on that without saying so. Removing the chat close's DELETE removed the leak with it.

Every test still passed; the **run** exited 1 on the unhandled error. My local check grepped for failures and never looked at the exit code, which is why I reported it green. `beforeEach` now gives `del` a resolved default so no test depends on another's leftovers, and the full suite is re-verified by exit status (`EXIT=0`, `Errors` absent) rather than by grep.

## Found, not fixed

- **Close-success effects run before the node write is acknowledged** (`AgentPanes.tsx`, `closeChatPane`; `AgentPageView.tsx:394`). Raised in review (P2) and correct on the consequence: if the queued `/nodes` POST is refused with a non-retryable 4xx, the store rolls the drop back, but `onConversationClosed` has already fired — and in `AgentPageView` that mints a replacement conversation. Narrow in practice (a destroy introduces no target, so the introduction-only refusals cannot fire; the client compiles the same write the server validates, so the validator cannot; `stale` rebases) and strictly better than the previous shape, where the DELETE could succeed while the node write rolled back — closing the listing server-side while the pane came back. The fix is a per-write acknowledgement from the queue pump, which the store has no notion of today; that is its own design, not a footnote here.
- **`AgentPanes.tsx`'s module docblock** still says ending is "reachable from the server's own `last_conversation` 409" (`apps/web/src/components/agents/panes/AgentPanes.tsx:41-44`). The 409 is gone and the decision is the client's; the prose is stale in the same way #2381 found the parked-model prose stale. Left alone here only because it is prose in a file this PR already changes heavily — happy to fold it in.
- **The sidebar's row menu offers "End session" unconditionally** (`AgentsSidebar.tsx`, `menuItems`), with no `canEndSession` equivalent. Correct today — the listing is owner-filtered so every listed session is endable by the viewer — but it is an invariant held by a query filter somewhere else, not by the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMesaDDBUUcxXYS29uDUp7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate requests when closing panes or conversations.
  - Sidebar and workspace views now stay synchronized after conversations are closed.
  - Improved cleanup for conversations whose history has been deleted.
  - Prevented incorrect closure notifications after failed or rolled-back updates.
  - Final-pane closure now consistently prompts for confirmation when permitted.

- **Improvements**
  - Added reliable indicators for session-ending and sandbox capabilities.
  - Non-final panes close directly without unnecessary confirmation.
  - Improved closure behavior across sidebar and workspace views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
