### PR TITLE
fix(agents): opening a conversation from the Agents history lands as a pane, always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Opening a past conversation keeps you in Agents** — every row in the Agents conversation list
+  sent you out to the dashboard when you clicked it, including conversations that were already open
+  in a session. The session was right there and you were simply not taken to it. A conversation you
+  pick from that list now opens as a pane in Agents, whichever kind it is: one already in a session
+  opens in place, and a global-assistant or page-agent conversation that has never had a session
+  gets one and opens there. The dashboard is still where you land when a conversation genuinely
+  cannot be opened in Agents — you have run out of sandboxes, or it is an API-created conversation
+  with no in-app view.
 - **Agents takes you to your conversations again** — clicking Agents in the sidebar reopened
   whichever session you last had open, and once you were inside a session there was no way back to
   the list except ending the session. Your history was unreachable without destroying the work you

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -21,6 +21,7 @@ const {
   mockFindSessionRecord,
   mockClaimConversationInSession,
   mockFindWorkspaceOfConversation,
+  mockCheckSessionAccess,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAuditRequest: vi.fn(),
@@ -41,6 +42,7 @@ const {
   mockFindSessionRecord: vi.fn(),
   mockClaimConversationInSession: vi.fn(),
   mockFindWorkspaceOfConversation: vi.fn(),
+  mockCheckSessionAccess: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -74,6 +76,7 @@ vi.mock('@/lib/agent-workspaces/agent-workspaces-runtime', () => ({
   findSessionRecord: (...args: unknown[]) => mockFindSessionRecord(...args),
   claimConversationInSession: (...args: unknown[]) => mockClaimConversationInSession(...args),
   findWorkspaceOfConversation: (...args: unknown[]) => mockFindWorkspaceOfConversation(...args),
+  checkSessionAccess: (...args: unknown[]) => mockCheckSessionAccess(...args),
 }));
 vi.mock('@/lib/agent-workspaces/workspace-shells-runtime', () => ({
   listShellsBulk: (...args: unknown[]) => mockListShellsBulk(...args),
@@ -124,6 +127,9 @@ beforeEach(() => {
   mockListSessionConversationsBulk.mockResolvedValue(new Map([['ses-1', [CONVERSATION_ENTRY]]]));
   mockReadWorkspaceNodesBulk.mockResolvedValue(new Map());
   mockCountActiveSessionsForOwner.mockResolvedValue(0);
+  // Default: the caller CAN open whatever workspace a claim conflict names.
+  // The tests that care about the denial path say so explicitly.
+  mockCheckSessionAccess.mockResolvedValue({ allowed: true });
 });
 
 describe('GET /api/agent-workspaces', () => {
@@ -604,6 +610,24 @@ describe("POST /api/agent-workspaces — firstThing: 'claim'", () => {
     const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({ workspaceId: 'ses-other' });
+    expect(mockCheckSessionAccess).toHaveBeenCalledWith('user-1', 'ses-other');
+    expect(mockSpawnSession).not.toHaveBeenCalled();
+  });
+
+  it('409s WITHOUT naming a workspace the caller cannot open — owning the conversation is not access to the session holding it', async () => {
+    // Any accepted drive member may create their own conversation inside
+    // another member's drive session, and that membership can lapse while
+    // conversation ownership never does. The 404 above proves only "this
+    // conversation is yours", so the id goes through the same centralized gate
+    // every other workspace route uses. The listing route already masks
+    // `workspaceId` in this exact situation; without this the 409 would
+    // disclose what the listing deliberately hides, and the client would
+    // select a workspace it cannot open.
+    mockFindWorkspaceOfConversation.mockResolvedValue('ses-someone-elses');
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'not_a_member' });
+    const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.not.toHaveProperty('workspaceId');
     expect(mockSpawnSession).not.toHaveBeenCalled();
   });
 
@@ -635,6 +659,15 @@ describe("POST /api/agent-workspaces — firstThing: 'claim'", () => {
     const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({ workspaceId: 'ses-winner' });
+  });
+
+  it('given the race was lost to a workspace the caller cannot open, the 409 still names nothing', async () => {
+    mockFindWorkspaceOfConversation.mockResolvedValueOnce(null).mockResolvedValue('ses-someone-elses');
+    mockCheckSessionAccess.mockResolvedValue({ allowed: false, reason: 'not_a_member' });
+    mockClaimConversationInSession.mockResolvedValue('not_found');
+    const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.not.toHaveProperty('workspaceId');
   });
 
   it('given the race was lost for some other reason, the 409 names no workspace rather than inventing one', async () => {

--- a/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/__tests__/route.test.ts
@@ -593,10 +593,17 @@ describe("POST /api/agent-workspaces — firstThing: 'claim'", () => {
     expect(mockSpawnSession).not.toHaveBeenCalled();
   });
 
-  it('409s a conversation that some workspace\'s tree already holds', async () => {
+  it('409s a conversation that some workspace\'s tree already holds, NAMING that workspace so the caller can open it', async () => {
+    // The refusal carries its own remedy. Without the id the client has
+    // nothing to act on and treats "already belongs to a session" as a dead
+    // end — which is how a normal history click ended up on /dashboard.
+    // Disclosure is safe: the ownership check above already 404s anything the
+    // caller does not own, so this can only ever name the caller's own
+    // workspace.
     mockFindWorkspaceOfConversation.mockResolvedValue('ses-other');
     const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
     expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ workspaceId: 'ses-other' });
     expect(mockSpawnSession).not.toHaveBeenCalled();
   });
 
@@ -615,6 +622,26 @@ describe("POST /api/agent-workspaces — firstThing: 'claim'", () => {
     const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
     expect(response.status).toBe(409);
     expect(mockEndSession).toHaveBeenCalledWith('ses-new');
+  });
+
+  it('given the race was lost to another claim, the 409 NAMES the workspace that won it', async () => {
+    // The preflight saw no workspace (first call), then the atomic claim came
+    // back `not_found` because someone else got there first — so by the time
+    // we look again (second call) the winner exists. Same reasoning as the
+    // preflight's 409: the caller wanted this conversation in a workspace, one
+    // now exists, and it is theirs.
+    mockFindWorkspaceOfConversation.mockResolvedValueOnce(null).mockResolvedValue('ses-winner');
+    mockClaimConversationInSession.mockResolvedValue('not_found');
+    const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ workspaceId: 'ses-winner' });
+  });
+
+  it('given the race was lost for some other reason, the 409 names no workspace rather than inventing one', async () => {
+    mockClaimConversationInSession.mockResolvedValue('not_found');
+    const response = await spawn({ firstThing: 'claim', conversationId: 'conv-1' });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.not.toHaveProperty('workspaceId');
   });
 
   it('given claim fails for a truly unexpected outcome, ENDS the session and responds 502', async () => {

--- a/apps/web/src/app/api/agent-workspaces/conversations/__tests__/wire-contract.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/conversations/__tests__/wire-contract.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+/**
+ * THE REGRESSION THIS FILE EXISTS FOR.
+ *
+ * The client used to hand-declare its own copy of this endpoint's row shape
+ * saying `sessionId`, while the server had been renamed to `workspaceId`.
+ * Every test on both sides passed, because each side's fixtures were written
+ * against its OWN hand-declaration — consistent with each other, and wrong
+ * about the wire. In production `row.sessionId` was `undefined` on every row,
+ * so an already-bound conversation never resolved to `pane`, its claim 409'd,
+ * and clicking history ejected the user to `/dashboard`.
+ *
+ * So this test refuses to hand-declare anything. It drives the REAL route
+ * handler, takes the REAL JSON off its response, and hands that to the REAL
+ * `resolveNavigationTarget` the click path uses. The only thing it fixes by
+ * hand is what the DB layer returns — and that value is typed
+ * `PastConversationServerRow`, so it cannot drift from the server either.
+ *
+ * Reintroduce the mismatch in any single place and this goes red at runtime,
+ * where the type system could not see it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockAuthenticateRequest,
+  mockListAllConversationsPaginated,
+  mockGetBatchPagePermissions,
+  mockResolveDriveMembership,
+} = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockListAllConversationsPaginated: vi.fn(),
+  mockGetBatchPagePermissions: vi.fn(),
+  mockResolveDriveMembership: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => result != null && typeof result === 'object' && 'error' in result,
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
+}));
+vi.mock('@pagespace/lib/services/agent-workspaces/agent-workspace-tenant', () => ({
+  resolveDriveMembership: (...args: unknown[]) => mockResolveDriveMembership(...args),
+}));
+// Only the DB read is mocked. Everything from the route's serialization
+// outward — including `NextResponse.json`'s `Date` → ISO-string handling — is
+// the real thing, which is exactly the boundary that broke.
+vi.mock('@/lib/agent-workspaces/workspace-conversations-runtime', () => ({
+  listAllConversationsPaginated: (...args: unknown[]) => mockListAllConversationsPaginated(...args),
+  encodeCursor: (sortKey: Date | string, id: string) =>
+    Buffer.from(JSON.stringify({ sortKey: new Date(sortKey).toISOString(), id })).toString('base64url'),
+}));
+
+import { GET } from '../route';
+import { resolveNavigationTarget } from '@/components/agents/resolveNavigationTarget';
+import type {
+  PastConversationDTO,
+  PastConversationServerRow,
+  PastConversationsResponseDTO,
+} from '@/lib/agent-workspaces/past-conversation-dto';
+
+/* ------------------------------------------------------------------ *
+ * Type-level half: the serialized server row IS the client's DTO.
+ * Checked by `bun run typecheck` (apps/web's tsconfig includes tests).
+ * ------------------------------------------------------------------ */
+
+/** What `NextResponse.json` does to a row: every `Date` becomes an ISO string. */
+type Serialized<T> = {
+  [K in keyof T]: T[K] extends Date ? string : T[K] extends Date | null ? string | null : T[K];
+};
+/** Collapses an intersection into a plain object type so the two sides compare structurally. */
+type Flatten<T> = { [K in keyof T]: T[K] };
+/** Declaring one of these is the assertion: a violated `extends` is a compile error. */
+type Assignable<_A extends _B, _B> = true;
+
+/**
+ * The client narrows `type` to `ConversationKind`; the server leaves it the
+ * plain `string` the `conversations.type` text column hands back. That one
+ * widening is the ONLY licensed difference — everything else, field names
+ * above all, must agree in both directions (assignability one way catches a
+ * missing field, the other way catches an extra one).
+ */
+type WireDTOWithRawType = Flatten<Omit<PastConversationDTO, 'type'> & { type: string }>;
+type SerializedServerRow = Flatten<Serialized<PastConversationServerRow>>;
+
+type _ServerRowFitsTheWireDTO = Assignable<SerializedServerRow, WireDTOWithRawType>;
+type _WireDTOFitsTheServerRow = Assignable<WireDTOWithRawType, SerializedServerRow>;
+
+/* ------------------------------------------------------------------ *
+ * Runtime half: real route → real JSON → real navigation decision.
+ * ------------------------------------------------------------------ */
+
+const AUTH = { userId: 'user-1', role: 'user' };
+
+/** Typed as the SERVER's row, so a rename there breaks this fixture too. */
+const BOUND_PAGE_ROW: PastConversationServerRow = {
+  conversationId: 'conv-bound',
+  title: 'Live chat',
+  type: 'page',
+  agentPageId: 'agent-1',
+  pageTitle: 'Researcher',
+  lastMessageAt: new Date('2026-07-28T00:00:00.000Z'),
+  createdAt: new Date('2026-07-27T00:00:00.000Z'),
+  workspaceId: 'workspace-1',
+  sessionName: 'Worker',
+  sessionEndedAt: null,
+  driveId: 'drive-1',
+};
+
+const UNBOUND_GLOBAL_ROW: PastConversationServerRow = {
+  conversationId: 'conv-global',
+  title: null,
+  type: 'global',
+  agentPageId: null,
+  pageTitle: null,
+  lastMessageAt: new Date('2026-07-26T00:00:00.000Z'),
+  createdAt: new Date('2026-07-26T00:00:00.000Z'),
+  workspaceId: null,
+  sessionName: null,
+  sessionEndedAt: null,
+  driveId: null,
+};
+
+async function fetchRows(): Promise<PastConversationDTO[]> {
+  const response = await GET(new Request('http://localhost/api/agent-workspaces/conversations'));
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as PastConversationsResponseDTO;
+  return body.conversations;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH);
+  mockGetBatchPagePermissions.mockResolvedValue(new Map([['agent-1', { canView: true }]]));
+  mockResolveDriveMembership.mockResolvedValue('member');
+  mockListAllConversationsPaginated.mockResolvedValue({
+    conversations: [BOUND_PAGE_ROW, UNBOUND_GLOBAL_ROW],
+    pagination: { hasMore: false, nextCursor: null, limit: 20 },
+  });
+});
+
+describe('past-conversations wire contract', () => {
+  it('puts the workspace binding on the wire under the name the client reads', async () => {
+    const [bound, unbound] = await fetchRows();
+
+    // The assertion the old code could not have passed: the property the
+    // client's navigation actually reads is present and carries the id.
+    expect(bound.workspaceId).toBe('workspace-1');
+    expect(unbound.workspaceId).toBeNull();
+    // ...and nothing on the wire is called `sessionId`. A server that renamed
+    // it back would satisfy the line above only by ALSO sending the old name.
+    expect(Object.keys(bound)).not.toContain('sessionId');
+  });
+
+  it('a real wire row for a workspace-bound conversation resolves to a pane, not a claim', async () => {
+    const [bound] = await fetchRows();
+
+    // No re-typing, no fixture: the object the browser would receive, handed
+    // to the function the click handler calls.
+    expect(resolveNavigationTarget(bound, undefined)).toEqual({
+      kind: 'pane',
+      sessionId: 'workspace-1',
+      conversationId: 'conv-bound',
+      agentId: 'agent-1',
+    });
+  });
+
+  it('a real wire row for an unbound conversation still resolves to a claim', async () => {
+    const [, unbound] = await fetchRows();
+
+    expect(resolveNavigationTarget(unbound, 'drive-current')).toEqual({
+      kind: 'claimable',
+      conversationId: 'conv-global',
+      agentPageId: null,
+      driveId: 'drive-current',
+      fallback: { kind: 'global', conversationId: 'conv-global', driveId: 'drive-current' },
+    });
+  });
+
+  it('serializes timestamps as strings, as the client DTO declares them', async () => {
+    const [bound] = await fetchRows();
+
+    expect(bound.lastMessageAt).toBe('2026-07-28T00:00:00.000Z');
+    expect(bound.createdAt).toBe('2026-07-27T00:00:00.000Z');
+  });
+});

--- a/apps/web/src/app/api/agent-workspaces/conversations/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/conversations/route.ts
@@ -1,6 +1,7 @@
 /**
  * GET ?driveId=<id> | (none = every drive) & limit & cursor
- *   → { conversations: PastConversationRow[], pagination: { hasMore, nextCursor, limit } }
+ *   → `PastConversationsResponseDTO` — see `past-conversation-dto.ts`, the
+ *     single declaration of this wire shape that the client imports too.
  *
  * The Agents surface's default middle-panel view: every conversation the
  * requester owns — session-bound or not, page-agent or global-assistant —
@@ -24,8 +25,8 @@ import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import {
   listAllConversationsPaginated,
   encodeCursor,
-  type PastConversationRow,
 } from '@/lib/agent-workspaces/workspace-conversations-runtime';
+import type { PastConversationServerRow } from '@/lib/agent-workspaces/past-conversation-dto';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 
@@ -46,11 +47,11 @@ const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const MAX_INTERNAL_FETCHES = 5;
 
 function maskOrDrop(
-  row: PastConversationRow,
+  row: PastConversationServerRow,
   canViewPage: (agentPageId: string) => boolean,
   canAccessSessionDrive: (driveId: string) => boolean,
   scopedDriveId: string | undefined,
-): PastConversationRow[] {
+): PastConversationServerRow[] {
   if (row.type === 'page' && row.agentPageId !== null && !canViewPage(row.agentPageId)) {
     // Drive-scoped requests must DROP the row entirely, not just mask its
     // fields: the drive filter itself runs against the page's CURRENT
@@ -110,8 +111,8 @@ async function fetchVisiblePage(
   scopedDriveId: string | undefined,
   limit: number,
   initialCursor: string | undefined,
-): Promise<{ conversations: PastConversationRow[]; hasMore: boolean; nextCursor: string | null }> {
-  const visible: PastConversationRow[] = [];
+): Promise<{ conversations: PastConversationServerRow[]; hasMore: boolean; nextCursor: string | null }> {
+  const visible: PastConversationServerRow[] = [];
   let cursor = initialCursor;
   let hasMore = true;
 

--- a/apps/web/src/app/api/agent-workspaces/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/route.ts
@@ -45,7 +45,7 @@ import {
   type AgentSessionListFilter,
 } from '@/lib/agent-workspaces/agent-workspaces-runtime';
 import { listShellsBulk, spawnShell } from '@/lib/agent-workspaces/workspace-shells-runtime';
-import { findWorkspaceOfConversation } from '@/lib/agent-workspaces/agent-workspaces-runtime';
+import { findWorkspaceOfConversation, checkSessionAccess } from '@/lib/agent-workspaces/agent-workspaces-runtime';
 import { readWorkspaceNodesBulk } from '@/lib/agent-workspaces/workspace-node-runtime';
 import { sessionQuotaExceeded } from '@/lib/agent-workspaces/quota-response';
 
@@ -304,17 +304,29 @@ export async function POST(request: Request) {
     // exists to answer the ordinary one before a workspace row is minted.
     const existingWorkspaceId = await findWorkspaceOfConversation(conversationId);
     if (existingWorkspaceId !== null) {
-      // NAME the owning workspace. This refusal carries its own remedy: the
-      // caller wanted this conversation opened in a workspace and one already
-      // exists, so the client can select straight into it rather than
-      // treating the conflict as a dead end and ejecting to /dashboard.
+      // NAME the owning workspace — but only one the caller can actually open.
+      // This refusal carries its own remedy: the caller wanted this
+      // conversation opened in a workspace and one already exists, so the
+      // client selects straight into it rather than treating the conflict as a
+      // dead end and ejecting to /dashboard.
       //
-      // Safe to disclose: the ownership check immediately above already
-      // refused, with a uniform 404, any conversation not owned by
-      // `auth.userId`. So the only id this can ever reveal is the workspace
-      // holding the caller's OWN conversation — nothing about anyone else's.
+      // Owning the CONVERSATION is not access to the WORKSPACE holding it.
+      // Any accepted drive member may create their own conversation inside
+      // another member's drive session (`decideAgentSessionAccess` grants by
+      // drive membership, not session ownership), and that membership can
+      // lapse while conversation ownership never does. The 404 above proves
+      // only "this conversation is yours" — so the id goes through the same
+      // centralized gate every other workspace route uses, and is simply
+      // omitted when it does not pass. The listing route already masks
+      // `workspaceId` in exactly this situation (see `maskOrDrop`); this keeps
+      // the two consistent instead of letting the 409 disclose what the
+      // listing deliberately hides. Reported by review on #2386.
+      const access = await checkSessionAccess(auth.userId, existingWorkspaceId);
       return NextResponse.json(
-        { error: 'That conversation already belongs to a session', workspaceId: existingWorkspaceId },
+        {
+          error: 'That conversation already belongs to a session',
+          ...(access.allowed ? { workspaceId: existingWorkspaceId } : {}),
+        },
         { status: 409 },
       );
     }
@@ -569,17 +581,24 @@ export async function POST(request: Request) {
         // Same conflict, same status the preflight gives it — not a server
         // fault, so not 502.
         //
-        // If the cause WAS the likely one, the winning workspace exists now
-        // and is the caller's own (ownership was proven in the preflight
-        // above, and never lapses), so name it for the same reason the
-        // preflight does — the client opens it instead of dead-ending. Best
-        // effort: any other cause of `not_found` simply finds nothing here
-        // and the refusal degrades to the plain message it always was.
+        // If the cause WAS the likely one, the winning workspace exists now,
+        // so name it for the same reason the preflight does — the client opens
+        // it instead of dead-ending — behind the same access gate, since
+        // owning the conversation is not access to whatever workspace won the
+        // race. Best effort throughout: any other cause of `not_found` finds
+        // nothing here, and a workspace the caller cannot open is simply not
+        // named, degrading to the plain refusal this always was.
         const raceWinnerWorkspaceId = await findWorkspaceOfConversation(conversationId).catch(() => null);
+        const raceWinnerOpenable =
+          raceWinnerWorkspaceId !== null &&
+          (await checkSessionAccess(auth.userId, raceWinnerWorkspaceId).then(
+            (a) => a.allowed,
+            () => false,
+          ));
         return NextResponse.json(
           {
             error: 'That conversation is no longer available to claim',
-            ...(raceWinnerWorkspaceId ? { workspaceId: raceWinnerWorkspaceId } : {}),
+            ...(raceWinnerOpenable ? { workspaceId: raceWinnerWorkspaceId } : {}),
           },
           { status: 409 },
         );

--- a/apps/web/src/app/api/agent-workspaces/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/route.ts
@@ -302,9 +302,19 @@ export async function POST(request: Request) {
     // chat-target index. An ADVISORY preflight: the claim's own decision asks
     // the same question, and the unique index settles the racing case, so this
     // exists to answer the ordinary one before a workspace row is minted.
-    if ((await findWorkspaceOfConversation(conversationId)) !== null) {
+    const existingWorkspaceId = await findWorkspaceOfConversation(conversationId);
+    if (existingWorkspaceId !== null) {
+      // NAME the owning workspace. This refusal carries its own remedy: the
+      // caller wanted this conversation opened in a workspace and one already
+      // exists, so the client can select straight into it rather than
+      // treating the conflict as a dead end and ejecting to /dashboard.
+      //
+      // Safe to disclose: the ownership check immediately above already
+      // refused, with a uniform 404, any conversation not owned by
+      // `auth.userId`. So the only id this can ever reveal is the workspace
+      // holding the caller's OWN conversation — nothing about anyone else's.
       return NextResponse.json(
-        { error: 'That conversation already belongs to a session' },
+        { error: 'That conversation already belongs to a session', workspaceId: existingWorkspaceId },
         { status: 409 },
       );
     }
@@ -558,8 +568,19 @@ export async function POST(request: Request) {
         // this atomic claim (most likely: another request claimed it first).
         // Same conflict, same status the preflight gives it — not a server
         // fault, so not 502.
+        //
+        // If the cause WAS the likely one, the winning workspace exists now
+        // and is the caller's own (ownership was proven in the preflight
+        // above, and never lapses), so name it for the same reason the
+        // preflight does — the client opens it instead of dead-ending. Best
+        // effort: any other cause of `not_found` simply finds nothing here
+        // and the refusal degrades to the plain message it always was.
+        const raceWinnerWorkspaceId = await findWorkspaceOfConversation(conversationId).catch(() => null);
         return NextResponse.json(
-          { error: 'That conversation is no longer available to claim' },
+          {
+            error: 'That conversation is no longer available to claim',
+            ...(raceWinnerWorkspaceId ? { workspaceId: raceWinnerWorkspaceId } : {}),
+          },
           { status: 409 },
         );
       }

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -160,6 +160,12 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
             error instanceof ApiRequestError ? error.body : undefined,
           );
           if (ownerWorkspaceId) {
+            // Same reason the success path above invalidates: the panes render
+            // off this shared listing, and a workspace that won the race was
+            // created by ANOTHER tab — so this tab's cache has never seen it
+            // and would not until its own 20s poll fired. More necessary here
+            // than on the success path, not less (review finding).
+            void mutate(isAgentWorkspacesKey);
             selectConversation({
               sessionId: ownerWorkspaceId,
               conversationId: target.conversationId,

--- a/apps/web/src/components/agents/AgentsPastConversationsList.tsx
+++ b/apps/web/src/components/agents/AgentsPastConversationsList.tsx
@@ -13,32 +13,21 @@ import { useGlobalChatConversation } from '@/contexts/GlobalChatContext';
 import { useDriveStore } from '@/hooks/useDrive';
 import { cn } from '@/lib/utils';
 import EmptyState from './EmptyState';
-import { resolveNavigationTarget, type ConversationKind, type ClaimableFallback } from './resolveNavigationTarget';
-import { classifySpawnRefusal } from './spawn-refusal';
+import { resolveNavigationTarget, type ClaimableFallback } from './resolveNavigationTarget';
+import { classifySpawnRefusal, claimConflictWorkspaceId } from './spawn-refusal';
 import { isAgentWorkspacesKey } from './panes/workspace-conversations';
+// The row/response shapes come from the ONE shared declaration of this
+// endpoint's wire contract. This file used to keep its own `PastConversationDTO`
+// copy, which said `sessionId` where the server says `workspaceId` — see
+// `past-conversation-dto.ts` for why that compiled and what it broke.
+import type {
+  PastConversationDTO,
+  PastConversationsResponseDTO,
+} from '@/lib/agent-workspaces/past-conversation-dto';
 
 const PAGE_SIZE = 20;
 
-interface ConversationRowDTO {
-  conversationId: string;
-  title: string | null;
-  type: ConversationKind;
-  agentPageId: string | null;
-  pageTitle: string | null;
-  lastMessageAt: string | null;
-  createdAt: string;
-  sessionId: string | null;
-  sessionName: string | null;
-  sessionEndedAt: string | null;
-  driveId: string | null;
-}
-
-interface ConversationsResponse {
-  conversations: ConversationRowDTO[];
-  pagination: { hasMore: boolean; nextCursor: string | null; limit: number };
-}
-
-async function conversationsFetcher(url: string): Promise<ConversationsResponse> {
+async function conversationsFetcher(url: string): Promise<PastConversationsResponseDTO> {
   const response = await fetchWithAuth(url);
   if (!response.ok) throw new Error(`Failed to list conversations (${response.status})`);
   return response.json();
@@ -52,7 +41,7 @@ function buildKey(driveId: string | undefined, cursor: string | null): string {
   return `/api/agent-workspaces/conversations?${params.toString()}`;
 }
 
-function rowLabel(row: ConversationRowDTO): string {
+function rowLabel(row: PastConversationDTO): string {
   if (row.title) return row.title;
   if (row.type === 'page') return row.pageTitle ?? 'Untitled conversation';
   if (row.type === 'global') return 'Global assistant chat';
@@ -60,9 +49,9 @@ function rowLabel(row: ConversationRowDTO): string {
   return 'Untitled conversation';
 }
 
-function rowSubtitle(row: ConversationRowDTO, showDrive: boolean, driveName: string | undefined): string {
+function rowSubtitle(row: PastConversationDTO, showDrive: boolean, driveName: string | undefined): string {
   const parts: string[] = [];
-  if (row.sessionId) {
+  if (row.workspaceId) {
     parts.push(row.sessionName ? row.sessionName : 'Session');
   } else if (row.type === 'page' && row.pageTitle) {
     parts.push(row.pageTitle);
@@ -96,7 +85,7 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
   // back server-side. Also drives the row's disabled/spinner state.
   const [claimingId, setClaimingId] = useState<string | null>(null);
 
-  const { data, error, isLoading, isValidating } = useSWR<ConversationsResponse>(
+  const { data, error, isLoading, isValidating } = useSWR<PastConversationsResponseDTO>(
     buildKey(driveId, cursor),
     conversationsFetcher,
     {
@@ -134,7 +123,7 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
     }
   };
 
-  const handleRowClick = async (row: ConversationRowDTO) => {
+  const handleRowClick = async (row: PastConversationDTO) => {
     const target = resolveNavigationTarget(row, driveId);
     switch (target.kind) {
       case 'pane':
@@ -158,12 +147,32 @@ export default function AgentsPastConversationsList({ driveId }: { driveId?: str
             agentId: target.agentPageId,
           });
         } catch (error) {
+          const status = error instanceof ApiRequestError ? error.status : undefined;
+
+          // "That conversation already belongs to a session" is not a reason
+          // to leave the Agents surface — it CARRIES the answer. The claim
+          // lost a race (another tab, or a claim that landed between this
+          // listing's fetch and this click), so the workspace the user wanted
+          // already exists and the 409 names it. Open it, exactly as the
+          // `pane` branch above would have.
+          const ownerWorkspaceId = claimConflictWorkspaceId(
+            status,
+            error instanceof ApiRequestError ? error.body : undefined,
+          );
+          if (ownerWorkspaceId) {
+            selectConversation({
+              sessionId: ownerWorkspaceId,
+              conversationId: target.conversationId,
+              agentId: target.agentPageId,
+            });
+            return;
+          }
+
           // Same split `useResolvedConversation.ts` uses for an opportunistic
           // session spawn: QUOTA is worth interrupting the user for (they
           // have the capability and simply ran out of allowance); every
           // other refusal degrades silently into the exact behavior this
           // row had before claiming existed.
-          const status = error instanceof ApiRequestError ? error.status : undefined;
           const refusal = classifySpawnRefusal(status, error instanceof Error ? error.message : null);
           console.warn('Session claim refused; falling back:', error);
           if (refusal.kind === 'quota') {

--- a/apps/web/src/components/agents/__tests__/AgentsPastConversationsList.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsPastConversationsList.test.tsx
@@ -62,6 +62,9 @@ import type { PastConversationDTO } from '@/lib/agent-workspaces/past-conversati
  */
 type Row = PastConversationDTO;
 
+/** A real cuid2 — `claimConflictWorkspaceId` refuses anything that is not one. */
+const OWNER_WORKSPACE_ID = 'nshgif165q8ehrnjgx9jvqxc';
+
 const PAGE_ROW: Row = {
   conversationId: 'conv-page',
   title: 'Page chat',
@@ -156,7 +159,9 @@ describe('AgentsPastConversationsList', () => {
     mockPost.mockRejectedValue(
       new ApiRequestError('That conversation already belongs to a session', 409, {
         error: 'That conversation already belongs to a session',
-        workspaceId: 'ses-owner',
+        // A real cuid2 — the client validates the shape, so `ses-owner` would
+        // be refused as an id no `agentWorkspaces.id` could hold.
+        workspaceId: OWNER_WORKSPACE_ID,
       }),
     );
     renderList();
@@ -164,11 +169,39 @@ describe('AgentsPastConversationsList', () => {
 
     await user.click(await screen.findByText('Page chat'));
 
-    await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-owner'));
+    await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe(OWNER_WORKSPACE_ID));
     expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-page');
     expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
     expect(mockPush).not.toHaveBeenCalled();
     expect(mockToastError).not.toHaveBeenCalled();
+    // The winning workspace was minted by another tab, so this tab's shared
+    // listing has never seen it — the panes render off that listing, so it
+    // must be revalidated or the selection points at nothing until the 20s
+    // poll happens to fire.
+    expect(mockMutate).toHaveBeenCalledWith(isAgentWorkspacesKey);
+  });
+
+  test('a 409 naming an UNOPENABLE workspace falls back — the server withheld the id', async () => {
+    // The server omits `workspaceId` when the caller cannot open that
+    // workspace (it can hold a conversation you own inside a drive session you
+    // have since lost membership of). Nothing to select into, so the
+    // pre-existing degrade is right — and the client must not invent one.
+    mockFetchWithAuth.mockResolvedValue(conversationsResponse([PAGE_ROW]));
+    mockPost.mockRejectedValue(
+      new ApiRequestError('That conversation already belongs to a session', 409, {
+        error: 'That conversation already belongs to a session',
+      }),
+    );
+    renderList();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('Page chat'));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/agent-1?conversationId=conv-page'),
+    );
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBeNull();
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
   test('a 409 that names no workspace still falls back — nothing to open', async () => {

--- a/apps/web/src/components/agents/__tests__/AgentsPastConversationsList.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsPastConversationsList.test.tsx
@@ -1,6 +1,6 @@
 /**
  * The Agents console's default middle-panel view — every past conversation
- * the requester owns. The behavior worth pinning: clicking a session-less
+ * the requester owns. The behavior worth pinning: clicking an unbound
  * row now tries to CLAIM it into a freshly spawned session (landing it in
  * the pane grid with a real sandbox) before falling back to the pre-claim
  * page/global navigation, and a capability-kind failure degrades silently
@@ -50,20 +50,17 @@ import AgentsPastConversationsList from '../AgentsPastConversationsList';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { ApiRequestError } from '@/lib/auth/auth-fetch';
 import { isAgentWorkspacesKey } from '../panes/workspace-conversations';
+import type { PastConversationDTO } from '@/lib/agent-workspaces/past-conversation-dto';
 
-interface Row {
-  conversationId: string;
-  title: string | null;
-  type: 'page' | 'global';
-  agentPageId: string | null;
-  pageTitle: string | null;
-  lastMessageAt: string | null;
-  createdAt: string;
-  sessionId: string | null;
-  sessionName: string | null;
-  sessionEndedAt: string | null;
-  driveId: string | null;
-}
+/**
+ * The wire shape, imported — NOT re-declared here. A private `interface Row`
+ * used to live in this file saying `sessionId`, and that is precisely how the
+ * bug stayed invisible: these tests fed the component rows shaped like the
+ * client's wrong belief, so they agreed with it. Fixtures now come from the
+ * one declaration the server is derived from as well
+ * (`past-conversation-dto.ts`), so a rename breaks this file too.
+ */
+type Row = PastConversationDTO;
 
 const PAGE_ROW: Row = {
   conversationId: 'conv-page',
@@ -73,7 +70,7 @@ const PAGE_ROW: Row = {
   pageTitle: 'Researcher',
   lastMessageAt: '2026-07-28T00:00:00.000Z',
   createdAt: '2026-07-28T00:00:00.000Z',
-  sessionId: null,
+  workspaceId: null,
   sessionName: null,
   sessionEndedAt: null,
   driveId: 'drive-1',
@@ -87,7 +84,7 @@ const GLOBAL_ROW: Row = {
   pageTitle: null,
   lastMessageAt: '2026-07-28T00:00:00.000Z',
   createdAt: '2026-07-28T00:00:00.000Z',
-  sessionId: null,
+  workspaceId: null,
   sessionName: null,
   sessionEndedAt: null,
   driveId: null,
@@ -101,7 +98,7 @@ const BOUND_ROW: Row = {
   pageTitle: 'Researcher',
   lastMessageAt: '2026-07-28T00:00:00.000Z',
   createdAt: '2026-07-28T00:00:00.000Z',
-  sessionId: 'ses-1',
+  workspaceId: 'ses-1',
   sessionName: 'Worker',
   sessionEndedAt: null,
   driveId: 'drive-1',
@@ -134,7 +131,7 @@ beforeEach(() => {
 });
 
 describe('AgentsPastConversationsList', () => {
-  test('a session-bound row selects it directly — no claim, no navigation', async () => {
+  test('a workspace-bound row selects it directly — no claim, no navigation', async () => {
     mockFetchWithAuth.mockResolvedValue(conversationsResponse([BOUND_ROW]));
     renderList();
     const user = userEvent.setup();
@@ -142,11 +139,58 @@ describe('AgentsPastConversationsList', () => {
     await user.click(await screen.findByText('Live chat'));
 
     expect(mockPost).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
     expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-1');
     expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-bound');
+    expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
   });
 
-  test('a session-less page row claims into a freshly spawned session and selects it', async () => {
+  test('a 409 naming the owning workspace opens THAT workspace — it never leaves the surface', async () => {
+    // The race this exists for: another tab (or a claim that landed between
+    // this listing's fetch and the click) already claimed the conversation,
+    // so the row is stale and the claim is refused. The refusal names the
+    // winner, and "already belongs to a session" is the answer, not a dead
+    // end — before this, it fell through to `navigateFallback` and pushed the
+    // user to /dashboard.
+    mockFetchWithAuth.mockResolvedValue(conversationsResponse([PAGE_ROW]));
+    mockPost.mockRejectedValue(
+      new ApiRequestError('That conversation already belongs to a session', 409, {
+        error: 'That conversation already belongs to a session',
+        workspaceId: 'ses-owner',
+      }),
+    );
+    renderList();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('Page chat'));
+
+    await waitFor(() => expect(useAgentSurfaceStore.getState().selectedSessionId).toBe('ses-owner'));
+    expect(useAgentSurfaceStore.getState().selectedConversationId).toBe('conv-page');
+    expect(useAgentSurfaceStore.getState().selectedAgentId).toBe('agent-1');
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  test('a 409 that names no workspace still falls back — nothing to open', async () => {
+    // The route's other 409: a `type: 'client'` conversation, refused because
+    // no in-app viewer can host it. There is no workspace to select into, so
+    // the pre-existing degrade is still the right answer.
+    mockFetchWithAuth.mockResolvedValue(conversationsResponse([PAGE_ROW]));
+    mockPost.mockRejectedValue(
+      new ApiRequestError('That conversation is not available', 409, { error: 'That conversation is not available' }),
+    );
+    renderList();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('Page chat'));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/agent-1?conversationId=conv-page'),
+    );
+    expect(useAgentSurfaceStore.getState().selectedSessionId).toBeNull();
+  });
+
+  test('an unbound page row claims into a freshly spawned session and selects it', async () => {
     mockFetchWithAuth.mockResolvedValue(conversationsResponse([PAGE_ROW]));
     mockPost.mockResolvedValue({ session: { workspaceId: 'ses-new', sessionId: 'ses-new' }, conversationId: 'conv-page' });
     renderList();
@@ -190,7 +234,7 @@ describe('AgentsPastConversationsList', () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  test('a session-less global row claims with the surface\'s own (absent) drive scope', async () => {
+  test('an unbound global row claims with the surface\'s own (absent) drive scope', async () => {
     mockFetchWithAuth.mockResolvedValue(conversationsResponse([GLOBAL_ROW]));
     mockPost.mockResolvedValue({ session: { workspaceId: 'ses-new', sessionId: 'ses-new' }, conversationId: 'conv-global' });
     renderList();

--- a/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
+++ b/apps/web/src/components/agents/__tests__/AgentsSurface.test.tsx
@@ -108,9 +108,34 @@ import {
 } from '@/stores/agent-workspace/useAgentWorkspaceStore';
 import type { WorkspaceNode } from '@pagespace/lib/agent-workspaces/workspace-node';
 import type { WorkspaceNodeTarget } from '@pagespace/lib/agent-workspaces/workspace-node-wire';
+import type { PastConversationDTO } from '@/lib/agent-workspaces/past-conversation-dto';
 
 /** Empty by default — the "no history yet" case is the common one across these tests; individual tests override with `mockFetchWithAuth.mockImplementation`. */
 const EMPTY_CONVERSATIONS = { conversations: [], pagination: { hasMore: false, nextCursor: null, limit: 20 } };
+
+/**
+ * Every past-conversation fixture in this file goes through here, TYPED as
+ * the shared wire row — never an inline object literal, which is exactly how
+ * these tests came to describe a row the server has never sent (`sessionId`,
+ * renamed to `workspaceId` and never followed on the client). A literal in a
+ * `json: async () => ({...})` mock is checked by nothing at all; this is.
+ */
+function pastConversationRow(overrides: Partial<PastConversationDTO> = {}): PastConversationDTO {
+  return {
+    conversationId: 'conv-1',
+    title: null,
+    type: 'global',
+    agentPageId: null,
+    pageTitle: null,
+    lastMessageAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    workspaceId: null,
+    sessionName: null,
+    sessionEndedAt: null,
+    driveId: null,
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
   // Two different endpoints share this mock — route by URL rather than one
@@ -472,19 +497,10 @@ describe('past conversations (default view, replacing the old static prompt)', (
           ok: true,
           json: async () => ({
             conversations: [
-              {
+              pastConversationRow({
                 conversationId: 'conv-hist-1',
                 title: 'A past chat',
-                type: 'global',
-                agentPageId: null,
-                pageTitle: null,
-                lastMessageAt: new Date().toISOString(),
-                createdAt: new Date().toISOString(),
-                sessionId: null,
-                sessionName: null,
-                sessionEndedAt: null,
-                driveId: null,
-              },
+              }),
             ],
             pagination: { hasMore: false, nextCursor: null, limit: 20 },
           }),
@@ -499,7 +515,7 @@ describe('past conversations (default view, replacing the old static prompt)', (
     expect(screen.queryByText('Select a session')).toBeNull();
   });
 
-  it('clicking a session-bound row opens it in the pane grid, same as picking it from the sidebar', async () => {
+  it('clicking a workspace-bound row opens it in the pane grid, same as picking it from the sidebar', async () => {
     // A drive scope no earlier test fetched — see the cache note above.
     mockFetchWithAuth.mockImplementation(async (url: string) => {
       if (url.includes('/api/agent-workspaces/conversations')) {
@@ -507,19 +523,16 @@ describe('past conversations (default view, replacing the old static prompt)', (
           ok: true,
           json: async () => ({
             conversations: [
-              {
+              pastConversationRow({
                 conversationId: 'conv-1',
                 title: 'Session chat',
                 type: 'page',
                 agentPageId: 'agent-1',
                 pageTitle: 'My Agent',
-                lastMessageAt: new Date().toISOString(),
-                createdAt: new Date().toISOString(),
-                sessionId: 'ses-1',
+                workspaceId: 'ses-1',
                 sessionName: 'My Session',
-                sessionEndedAt: null,
                 driveId: 'drive-1',
-              },
+              }),
             ],
             pagination: { hasMore: false, nextCursor: null, limit: 20 },
           }),
@@ -543,19 +556,10 @@ describe('past conversations (default view, replacing the old static prompt)', (
       ok: true,
       json: async () => ({
         conversations: [
-          {
+          pastConversationRow({
             conversationId: cursor ? `conv-${driveLabel}-page2` : `conv-${driveLabel}-page1`,
             title: cursor ? `${driveLabel} page 2` : `${driveLabel} page 1`,
-            type: 'global',
-            agentPageId: null,
-            pageTitle: null,
-            lastMessageAt: new Date().toISOString(),
-            createdAt: new Date().toISOString(),
-            sessionId: null,
-            sessionName: null,
-            sessionEndedAt: null,
-            driveId: null,
-          },
+          }),
         ],
         // Page 1 always advertises more, so the Next button is enabled —
         // page 2 (any `cursor` present) is the end of the list.
@@ -605,19 +609,10 @@ describe('past conversations (default view, replacing the old static prompt)', (
           ok: true,
           json: async () => ({
             conversations: [
-              {
+              pastConversationRow({
                 conversationId: cursor ? 'conv-page2' : 'conv-page1',
                 title: cursor ? 'Page 2 chat' : 'Page 1 chat',
-                type: 'global',
-                agentPageId: null,
-                pageTitle: null,
-                lastMessageAt: new Date().toISOString(),
-                createdAt: new Date().toISOString(),
-                sessionId: null,
-                sessionName: null,
-                sessionEndedAt: null,
-                driveId: null,
-              },
+              }),
             ],
             pagination: { hasMore: !cursor, nextCursor: cursor ? null : 'conv-page1', limit: 20 },
           }),
@@ -659,19 +654,10 @@ describe('past conversations (default view, replacing the old static prompt)', (
       ok: true as const,
       json: async () => ({
         conversations: [
-          {
+          pastConversationRow({
             conversationId: `conv-${label}`,
             title: label,
-            type: 'global',
-            agentPageId: null,
-            pageTitle: null,
-            lastMessageAt: new Date().toISOString(),
-            createdAt: new Date().toISOString(),
-            sessionId: null,
-            sessionName: null,
-            sessionEndedAt: null,
-            driveId: null,
-          },
+          }),
         ],
         pagination: { hasMore: nextCursor !== null, nextCursor, limit: 20 },
       }),
@@ -713,19 +699,12 @@ describe('past conversations (default view, replacing the old static prompt)', (
           ok: true,
           json: async () => ({
             conversations: [
-              {
+              pastConversationRow({
                 conversationId: 'conv-client-1',
                 title: 'My API thread',
                 type: 'client',
-                agentPageId: null,
-                pageTitle: null,
-                lastMessageAt: new Date().toISOString(),
-                createdAt: new Date().toISOString(),
-                sessionId: null,
-                sessionName: null,
-                sessionEndedAt: null,
                 driveId: 'drive-1',
-              },
+              }),
             ],
             pagination: { hasMore: false, nextCursor: null, limit: 20 },
           }),

--- a/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
+++ b/apps/web/src/components/agents/__tests__/resolveNavigationTarget.test.ts
@@ -1,10 +1,17 @@
 /**
  * Pure function, no I/O — a click on a past-conversation row must land in
- * exactly the right place for that row's kind. A session-bound conversation
+ * exactly the right place for that row's kind. A WORKSPACE-BOUND conversation
  * always wins the pane grid, whatever its `type`; everything else branches on
  * `type` with an exhaustive switch (compile-time guarded — see the `never`
  * check in the source) so a future `ConversationKind` value can't silently
  * misroute here.
+ *
+ * These cases all existed before and all passed, including the pane ones —
+ * against a row shape that said `sessionId`, a field the server has never
+ * sent. Every `workspaceId` below is now `Pick`ed from the shared wire
+ * contract, so the fixtures can no longer describe a row that cannot arrive.
+ * The end-to-end proof that the wire agrees lives in
+ * `api/agent-workspaces/conversations/__tests__/wire-contract.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
 import { resolveNavigationTarget, type PastConversationRow } from '../resolveNavigationTarget';
@@ -14,35 +21,35 @@ function row(overrides: Partial<PastConversationRow> = {}): PastConversationRow 
     conversationId: 'conv-1',
     type: 'global',
     agentPageId: null,
-    sessionId: null,
+    workspaceId: null,
     driveId: null,
     ...overrides,
   };
 }
 
 describe('resolveNavigationTarget', () => {
-  it('a session-bound conversation opens the pane grid, whatever its type', () => {
+  it('a workspace-bound conversation opens the pane grid, whatever its type', () => {
     const target = resolveNavigationTarget(
-      row({ type: 'page', sessionId: 'ses-1', agentPageId: 'agent-1', driveId: 'drive-1' }),
+      row({ type: 'page', workspaceId: 'ses-1', agentPageId: 'agent-1', driveId: 'drive-1' }),
       undefined,
     );
     expect(target).toEqual({ kind: 'pane', sessionId: 'ses-1', conversationId: 'conv-1', agentId: 'agent-1' });
   });
 
-  it('a session-bound page conversation whose page is currently inaccessible is unavailable, not a pane', () => {
+  it('a workspace-bound page conversation whose page is currently inaccessible is unavailable, not a pane', () => {
     // The API masks `driveId` to null (never a real value for a live page)
     // specifically when it already checked and the requester can no longer
     // view that page. Opening the pane anyway would hit a 403 on the message
     // fetch and silently show nothing (review finding) — this must be caught
-    // before the unconditional sessionId branch below, not after it.
+    // before the unconditional workspaceId branch below, not after it.
     const target = resolveNavigationTarget(
-      row({ type: 'page', sessionId: 'ses-1', agentPageId: 'agent-1', driveId: null }),
+      row({ type: 'page', workspaceId: 'ses-1', agentPageId: 'agent-1', driveId: null }),
       undefined,
     );
     expect(target).toEqual({ kind: 'unavailable' });
   });
 
-  it('a session-less page conversation is claimable — spawning a session is tried before falling back to its agent page', () => {
+  it('an unbound page conversation is claimable — spawning a session is tried before falling back to its agent page', () => {
     const target = resolveNavigationTarget(
       row({ type: 'page', agentPageId: 'agent-1', driveId: 'drive-1' }),
       undefined,
@@ -57,7 +64,6 @@ describe('resolveNavigationTarget', () => {
         driveId: 'drive-1',
         pageId: 'agent-1',
         conversationId: 'conv-1',
-        sessionId: null,
       },
     });
   });
@@ -76,7 +82,7 @@ describe('resolveNavigationTarget', () => {
     expect(target).toEqual({ kind: 'unavailable' });
   });
 
-  it('a session-less global conversation is claimable — its fallback is wherever the global assistant currently lives', () => {
+  it('an unbound global conversation is claimable — its fallback is wherever the global assistant currently lives', () => {
     const target = resolveNavigationTarget(row({ type: 'global' }), 'drive-current');
     expect(target).toEqual({
       kind: 'claimable',
@@ -87,7 +93,7 @@ describe('resolveNavigationTarget', () => {
     });
   });
 
-  it('a session-less global conversation with no current drive scope falls back to the dashboard home', () => {
+  it('an unbound global conversation with no current drive scope falls back to the dashboard home', () => {
     const target = resolveNavigationTarget(row({ type: 'global' }), undefined);
     expect(target).toEqual({
       kind: 'claimable',
@@ -98,9 +104,9 @@ describe('resolveNavigationTarget', () => {
     });
   });
 
-  it('a session-bound row still wins the pane grid even for a claimable-shaped type (branch-ordering regression guard)', () => {
+  it('a workspace-bound row still wins the pane grid even for a claimable-shaped type (branch-ordering regression guard)', () => {
     const target = resolveNavigationTarget(
-      row({ type: 'global', sessionId: 'ses-1' }),
+      row({ type: 'global', workspaceId: 'ses-1' }),
       'drive-current',
     );
     expect(target).toEqual({ kind: 'pane', sessionId: 'ses-1', conversationId: 'conv-1', agentId: null });

--- a/apps/web/src/components/agents/__tests__/spawn-refusal.test.ts
+++ b/apps/web/src/components/agents/__tests__/spawn-refusal.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { classifySpawnRefusal } from '../spawn-refusal';
+import { classifySpawnRefusal, claimConflictWorkspaceId } from '../spawn-refusal';
 
 describe('classifySpawnRefusal', () => {
   it("a 429 is a QUOTA refusal, carrying the server's own message", () => {
@@ -34,5 +34,44 @@ describe('classifySpawnRefusal', () => {
     // same way; only the allowance case earns the interruption.
     expect(classifySpawnRefusal(502, null).kind).toBe('capability');
     expect(classifySpawnRefusal(500, 'Could not start a session').kind).toBe('capability');
+  });
+});
+
+/**
+ * The other half of a claim refusal: a 409 that names the workspace already
+ * holding the conversation is not a degrade at all — it is the answer, and the
+ * caller opens that workspace instead of leaving the Agents surface.
+ */
+describe('claimConflictWorkspaceId', () => {
+  it("names the workspace a 409 body carries", () => {
+    expect(
+      claimConflictWorkspaceId(409, {
+        error: 'That conversation already belongs to a session',
+        workspaceId: 'ses-owner',
+      }),
+    ).toBe('ses-owner');
+  });
+
+  it('ignores a 409 that names no workspace — the type:\'client\' refusal has none to give', () => {
+    expect(claimConflictWorkspaceId(409, { error: 'That conversation is not available' })).toBeNull();
+  });
+
+  it('never reads a workspace out of any other status, however the body looks', () => {
+    // A 403/429/500 body is a refusal to degrade from, not a redirect. Reading
+    // an id out of one would silently select into a workspace the server never
+    // said was there.
+    expect(claimConflictWorkspaceId(403, { workspaceId: 'ses-owner' })).toBeNull();
+    expect(claimConflictWorkspaceId(429, { workspaceId: 'ses-owner' })).toBeNull();
+    expect(claimConflictWorkspaceId(undefined, { workspaceId: 'ses-owner' })).toBeNull();
+  });
+
+  it('treats a body of any unexpected shape as naming nothing', () => {
+    // Straight off the wire and therefore unknown until proven — the same
+    // discipline whose absence caused the `sessionId`/`workspaceId` mismatch.
+    expect(claimConflictWorkspaceId(409, undefined)).toBeNull();
+    expect(claimConflictWorkspaceId(409, null)).toBeNull();
+    expect(claimConflictWorkspaceId(409, 'That conversation already belongs to a session')).toBeNull();
+    expect(claimConflictWorkspaceId(409, { workspaceId: 42 })).toBeNull();
+    expect(claimConflictWorkspaceId(409, { workspaceId: '' })).toBeNull();
   });
 });

--- a/apps/web/src/components/agents/__tests__/spawn-refusal.test.ts
+++ b/apps/web/src/components/agents/__tests__/spawn-refusal.test.ts
@@ -42,14 +42,19 @@ describe('classifySpawnRefusal', () => {
  * holding the conversation is not a degrade at all — it is the answer, and the
  * caller opens that workspace instead of leaving the Agents surface.
  */
+// A REAL cuid2, because `claimConflictWorkspaceId` validates the shape —
+// `agentWorkspaces.id` is `$defaultFn(createId)` everywhere, so a fixture that
+// is not one would be testing a value the server cannot send.
+const WORKSPACE_ID = 'qbiohdrz7895nz87fpw8w0h5';
+
 describe('claimConflictWorkspaceId', () => {
   it("names the workspace a 409 body carries", () => {
     expect(
       claimConflictWorkspaceId(409, {
         error: 'That conversation already belongs to a session',
-        workspaceId: 'ses-owner',
+        workspaceId: WORKSPACE_ID,
       }),
-    ).toBe('ses-owner');
+    ).toBe(WORKSPACE_ID);
   });
 
   it('ignores a 409 that names no workspace — the type:\'client\' refusal has none to give', () => {
@@ -60,9 +65,9 @@ describe('claimConflictWorkspaceId', () => {
     // A 403/429/500 body is a refusal to degrade from, not a redirect. Reading
     // an id out of one would silently select into a workspace the server never
     // said was there.
-    expect(claimConflictWorkspaceId(403, { workspaceId: 'ses-owner' })).toBeNull();
-    expect(claimConflictWorkspaceId(429, { workspaceId: 'ses-owner' })).toBeNull();
-    expect(claimConflictWorkspaceId(undefined, { workspaceId: 'ses-owner' })).toBeNull();
+    expect(claimConflictWorkspaceId(403, { workspaceId: WORKSPACE_ID })).toBeNull();
+    expect(claimConflictWorkspaceId(429, { workspaceId: WORKSPACE_ID })).toBeNull();
+    expect(claimConflictWorkspaceId(undefined, { workspaceId: WORKSPACE_ID })).toBeNull();
   });
 
   it('treats a body of any unexpected shape as naming nothing', () => {
@@ -73,5 +78,14 @@ describe('claimConflictWorkspaceId', () => {
     expect(claimConflictWorkspaceId(409, 'That conversation already belongs to a session')).toBeNull();
     expect(claimConflictWorkspaceId(409, { workspaceId: 42 })).toBeNull();
     expect(claimConflictWorkspaceId(409, { workspaceId: '' })).toBeNull();
+  });
+
+  it('refuses a nonempty id that is not a real workspace id', () => {
+    // Nonempty is not enough: this id would be selected into the surface store
+    // and written to the URL, so a value no `agentWorkspaces.id` could ever
+    // hold is worth refusing outright rather than opening a junk workspace.
+    expect(claimConflictWorkspaceId(409, { workspaceId: 'not-a-workspace-id' })).toBeNull();
+    expect(claimConflictWorkspaceId(409, { workspaceId: `  ${WORKSPACE_ID}  ` })).toBeNull();
+    expect(claimConflictWorkspaceId(409, { workspaceId: `${WORKSPACE_ID}/../other` })).toBeNull();
   });
 });

--- a/apps/web/src/components/agents/resolveNavigationTarget.ts
+++ b/apps/web/src/components/agents/resolveNavigationTarget.ts
@@ -7,40 +7,53 @@
  * branch, which is what a bare `if/else if/else` chain would do.
  */
 
-/**
- * Mirrors `conversations.type` (`packages/db/src/schema/conversations.ts`) —
- * the only values any production code path writes. `'client'` is the rare
- * API-managed conversation created via `POST /api/v1/conversations` (never
- * `'drive'` — that value was never actually written by any code path; it was
- * a documentation mistake corrected once this got fixed).
- */
-export type ConversationKind = 'global' | 'page' | 'client';
+import type { PastConversationDTO } from '@/lib/agent-workspaces/past-conversation-dto';
 
-export interface PastConversationRow {
-  conversationId: string;
-  type: ConversationKind;
-  agentPageId: string | null;
-  sessionId: string | null;
-  driveId: string | null;
-}
+/**
+ * Exactly the fields of a wire row this decision reads — PICKED from the
+ * shared DTO, never re-declared. The predecessor of this type was a private,
+ * hand-written interface saying `sessionId` where the server has always said
+ * `workspaceId`; it compiled forever and made `row.sessionId` `undefined` on
+ * every real row, so the `pane` branch below could never fire (see
+ * `past-conversation-dto.ts` for the full account). `Pick` is what stops that
+ * happening again: rename a field on the DTO and this line is a compile
+ * error, not a silent `undefined`.
+ */
+export type PastConversationRow = Pick<
+  PastConversationDTO,
+  'conversationId' | 'type' | 'agentPageId' | 'workspaceId' | 'driveId'
+>;
 
 /** Where a `claimable` row's click routes if the claim-into-a-session attempt fails. */
 export type ClaimableFallback =
-  | { kind: 'page'; driveId: string; pageId: string; conversationId: string; sessionId: string | null }
+  // No session/workspace id here on purpose: a fallback is only ever reached
+  // for a row that HAS no workspace. The field this used to carry was
+  // unconditionally null and read by nothing — dead weight that, after the
+  // `workspaceId` rename, read as though a fallback could name a workspace.
+  | { kind: 'page'; driveId: string; pageId: string; conversationId: string }
   | { kind: 'global'; conversationId: string; driveId: string | null }
   | { kind: 'unavailable' };
 
 export type NavigationTarget =
+  /**
+   * `sessionId` here is the CLIENT's vocabulary — the field
+   * `useAgentSurfaceStore.selectConversation` takes and the name the URL uses
+   * — for the id the wire calls `workspaceId`. This is the one place the two
+   * names meet, and it is a deliberate translation rather than a shape the
+   * server ever sends.
+   */
   | { kind: 'pane'; sessionId: string; conversationId: string; agentId: string | null }
   /**
-   * A session-less `type: 'page'` or `type: 'global'` row — clicking it
+   * A workspace-less `type: 'page'` or `type: 'global'` row — clicking it
    * should spawn a session and claim this SAME conversation into it (see
    * `claim-conversation-in-workspace.ts`), landing it in the pane grid with a
    * real sandbox, rather than opening it read-only outside any session.
    * `fallback` carries exactly what this row would have resolved to before
    * claiming existed — the old `page`/`global` target — so a failed claim
-   * (quota, a race, a permission edge) degrades to today's exact behavior
-   * instead of a dead end.
+   * (quota, a permission edge) degrades to today's exact behavior instead of
+   * a dead end. A claim refused because the conversation ALREADY has a
+   * workspace is NOT one of those cases — that refusal names the workspace
+   * and the caller opens it (`claimConflictWorkspaceId`).
    */
   | { kind: 'claimable'; conversationId: string; agentPageId: string | null; driveId: string | null; fallback: ClaimableFallback }
   /**
@@ -58,14 +71,16 @@ export type NavigationTarget =
   | { kind: 'unavailable' };
 
 /**
- * A session-bound conversation always wins, whatever its `type` — it opens in
- * the pane grid in-place, the one case that never leaves the Agents surface.
+ * A workspace-bound conversation always wins, whatever its `type` — it opens
+ * in the pane grid in-place, the one case that never leaves the Agents
+ * surface. That is also the rule the past-conversations list exists to serve:
+ * a history row clicked ON the Agents surface belongs on the Agents surface.
  *
  * EXCEPT a `type: 'page'` row whose `driveId` came back null: the API masks
  * `driveId` to null (route.ts) ONLY when it already checked and the
  * requester can no longer view that page — a real, live page always belongs
  * to a drive, so this can never be a legitimate "no drive" value. Checking
- * it before the `sessionId` branch matters because a session-bound page
+ * it before the `workspaceId` branch matters because a bound page
  * conversation would otherwise open `AgentPanes` unconditionally; the pane's
  * message fetch enforces the same permission server-side and 403s, so the
  * click would silently fail to show anything (review finding).
@@ -78,8 +93,8 @@ export function resolveNavigationTarget(
     return { kind: 'unavailable' };
   }
 
-  if (row.sessionId) {
-    return { kind: 'pane', sessionId: row.sessionId, conversationId: row.conversationId, agentId: row.agentPageId };
+  if (row.workspaceId) {
+    return { kind: 'pane', sessionId: row.workspaceId, conversationId: row.conversationId, agentId: row.agentPageId };
   }
 
   switch (row.type) {
@@ -95,13 +110,12 @@ export function resolveNavigationTarget(
           driveId: row.driveId,
           pageId: row.agentPageId,
           conversationId: row.conversationId,
-          sessionId: null,
         },
       };
     }
-    // API-managed (POST /api/v1/conversations) — always session-less (confirmed:
-    // nothing ever binds a `client` row to a session) and has no in-app chat
-    // surface to open into, and no session claim can grant it one either
+    // API-managed (POST /api/v1/conversations) — never bound to a workspace
+    // (confirmed: nothing ever binds a `client` row to one) and has no in-app
+    // chat surface to open into, and no session claim can grant it one either
     // (claim refuses `type: 'client'` — see `claim-conversation-in-workspace.ts`).
     case 'client':
       return { kind: 'unavailable' };

--- a/apps/web/src/components/agents/spawn-refusal.ts
+++ b/apps/web/src/components/agents/spawn-refusal.ts
@@ -32,3 +32,29 @@ export function classifySpawnRefusal(status: number | undefined, message: string
   }
   return { kind: 'capability', message: trimmed && trimmed.length > 0 ? trimmed : DEFAULT_CAPABILITY_MESSAGE };
 }
+
+/**
+ * The workspace a claim's 409 names as the conversation's CURRENT owner, if
+ * it named one — the id `POST /api/agent-workspaces` puts in the body of its
+ * "that conversation already belongs to a session" refusal.
+ *
+ * Not every 409 on that route carries one (a `type: 'client'` conversation is
+ * refused 409 too, and owns no workspace by construction), hence the null
+ * return rather than a throw: absent means "no workspace to open, fall back
+ * as before".
+ *
+ * Disclosure is safe by the time the server writes this id: the route
+ * already refused any conversation the caller does not own with a uniform
+ * 404, so the only workspace id it can ever name is one holding the caller's
+ * own conversation.
+ *
+ * Deliberately defensive about the body's shape — it comes off the wire, so
+ * it is `unknown` until proven otherwise, the exact lesson of the field
+ * mismatch this whole change fixes.
+ */
+export function claimConflictWorkspaceId(status: number | undefined, body: unknown): string | null {
+  if (status !== 409) return null;
+  if (typeof body !== 'object' || body === null) return null;
+  const workspaceId = (body as { workspaceId?: unknown }).workspaceId;
+  return typeof workspaceId === 'string' && workspaceId.length > 0 ? workspaceId : null;
+}

--- a/apps/web/src/components/agents/spawn-refusal.ts
+++ b/apps/web/src/components/agents/spawn-refusal.ts
@@ -14,6 +14,8 @@
  * fetch or toast.
  */
 
+import { isCuid } from '@paralleldrive/cuid2';
+
 export type SpawnRefusalKind = 'quota' | 'capability';
 
 export interface SpawnRefusal {
@@ -50,11 +52,17 @@ export function classifySpawnRefusal(status: number | undefined, message: string
  *
  * Deliberately defensive about the body's shape — it comes off the wire, so
  * it is `unknown` until proven otherwise, the exact lesson of the field
- * mismatch this whole change fixes.
+ * mismatch this whole change fixes. That extends to the VALUE, not just the
+ * type: `agentWorkspaces.id` is a cuid2 by construction (`$defaultFn(createId)`,
+ * and nothing anywhere inserts a hand-made id), so anything else is not an id
+ * this app could open — selecting it would put a junk workspace in the store
+ * and the URL. `isCuid` is the same validator `IdSchema` applies to every
+ * other id in the codebase (review finding).
  */
 export function claimConflictWorkspaceId(status: number | undefined, body: unknown): string | null {
   if (status !== 409) return null;
   if (typeof body !== 'object' || body === null) return null;
   const workspaceId = (body as { workspaceId?: unknown }).workspaceId;
-  return typeof workspaceId === 'string' && workspaceId.length > 0 ? workspaceId : null;
+  if (typeof workspaceId !== 'string' || !isCuid(workspaceId)) return null;
+  return workspaceId;
 }

--- a/apps/web/src/lib/agent-workspaces/past-conversation-dto.ts
+++ b/apps/web/src/lib/agent-workspaces/past-conversation-dto.ts
@@ -1,0 +1,92 @@
+/**
+ * THE WIRE CONTRACT for `GET /api/agent-workspaces/conversations` — ONE
+ * declaration of the row shape, imported by both ends.
+ *
+ * This file exists because both ends used to hand-declare it separately and
+ * silently drifted. The `agent_sessions` → `agent_workspaces` rename renamed
+ * the server's field to `workspaceId`; the client's two private copies
+ * (`PastConversationRow` in `resolveNavigationTarget.ts` and
+ * `ConversationRowDTO` in `AgentsPastConversationsList.tsx`) kept saying
+ * `sessionId`. Nothing failed to compile, because a hand-written interface
+ * handed to `useSWR<T>` / `fetchWithAuth`'s generic is an ASSERTION about
+ * data crossing an untyped boundary, not a check of it. So at runtime every
+ * row's `sessionId` was `undefined`, every already-bound conversation
+ * resolved to `claimable`, its claim 409'd ("already belongs to a session" —
+ * because it did), and the click ejected the user to `/dashboard`.
+ *
+ * Types only, no runtime imports, so a client component can import from it
+ * without dragging `@pagespace/db` into the browser bundle.
+ *
+ * Both ends are now DERIVED from the declarations below — the server row via
+ * `PastConversationServerRow`, the client's navigation input via a `Pick` in
+ * `resolveNavigationTarget.ts` — and `conversations/__tests__/wire-contract`
+ * pins the real route's serialized output against `PastConversationDTO`
+ * field-for-field. A rename on either side now fails to COMPILE.
+ */
+
+/** `Omit`, but a key that isn't on `T` is a compile error rather than a silent no-op. */
+type OmitStrict<T, K extends keyof T> = Omit<T, K>;
+
+/**
+ * Mirrors `conversations.type` (`packages/db/src/schema/conversations.ts`) —
+ * the only values any production code path writes. `'client'` is the rare
+ * API-managed conversation created via `POST /api/v1/conversations` (never
+ * `'drive'` — that value was never actually written by any code path; it was
+ * a documentation mistake corrected once this got fixed).
+ */
+export type ConversationKind = 'global' | 'page' | 'client';
+
+/** One past-conversation row, exactly as it arrives in the browser. */
+export interface PastConversationDTO {
+  conversationId: string;
+  title: string | null;
+  type: ConversationKind;
+  /** The page id when `type === 'page'`, else null. */
+  agentPageId: string | null;
+  /** The agent page's own title (distinct from the conversation's own title), when `type === 'page'`. */
+  pageTitle: string | null;
+  /** Real recency — see `recencyExpr` in the runtime. Never simply `conversations.lastMessageAt`, which stays null forever for `type: 'page'`. */
+  lastMessageAt: string | null;
+  createdAt: string;
+  /**
+   * THE WORKSPACE (agent session) THIS THREAD BELONGS TO, read from its tree
+   * node — null when it belongs to none. Named `workspaceId`, not
+   * `sessionId`: the node model calls the root a workspace, and this name is
+   * the one the server actually puts on the wire. The client's own
+   * vocabulary for the same id is still `sessionId` (the store field, the
+   * URL param) — that translation happens once, deliberately, in
+   * `resolveNavigationTarget`.
+   */
+  workspaceId: string | null;
+  /** '' when the workspace has no display name, mirroring `toAgentSessionDTO`'s `name ?? ''`. */
+  sessionName: string | null;
+  sessionEndedAt: string | null;
+  /** Resolved from the page's drive, the workspace's drive, or (for `type: 'client'`) the conversation's own contextId. Null only for a driveless global-assistant conversation. */
+  driveId: string | null;
+}
+
+export interface PastConversationsResponseDTO {
+  conversations: PastConversationDTO[];
+  pagination: { hasMore: boolean; nextCursor: string | null; limit: number };
+}
+
+/**
+ * The same rows as the server holds them, one step before `NextResponse.json`
+ * serializes them into `PastConversationDTO`.
+ *
+ * Only two differences, and both are the serializer's doing rather than a
+ * second opinion about the shape: timestamps are still real `Date`s, and
+ * `type` is still the plain `string` the `conversations.type` text column
+ * hands back (the DB, unlike the app, is not constrained to
+ * `ConversationKind`). Every other field — crucially every field NAME — comes
+ * from the DTO above, so the two cannot drift.
+ */
+export type PastConversationServerRow = OmitStrict<
+  PastConversationDTO,
+  'type' | 'lastMessageAt' | 'createdAt' | 'sessionEndedAt'
+> & {
+  type: string;
+  lastMessageAt: Date | null;
+  createdAt: Date;
+  sessionEndedAt: Date | null;
+};

--- a/apps/web/src/lib/agent-workspaces/workspace-conversations-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-conversations-runtime.ts
@@ -23,25 +23,10 @@ import { agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
 import { agentWorkspaceNodes } from '@pagespace/db/schema/agent-workspace-nodes';
 import { pages } from '@pagespace/db/schema/core';
 import { conversationPageId } from '@pagespace/lib/conversations/conversation-page';
-
-export interface PastConversationRow {
-  conversationId: string;
-  title: string | null;
-  type: string;
-  /** The page id when `type === 'page'`, else null. */
-  agentPageId: string | null;
-  /** The agent page's own title (distinct from the conversation's own title), when `type === 'page'`. */
-  pageTitle: string | null;
-  /** Real recency — see `recencyExpr` below. Never simply `conversations.lastMessageAt`, which stays null forever for `type: 'page'`. */
-  lastMessageAt: Date | null;
-  createdAt: Date;
-  workspaceId: string | null;
-  /** '' when the session has no display name, mirroring `toAgentSessionDTO`'s `name ?? ''`. */
-  sessionName: string | null;
-  sessionEndedAt: Date | null;
-  /** Resolved from the page's drive, the session's drive, or (for `type: 'client'`) the conversation's own contextId. Null only for a driveless global-assistant conversation. */
-  driveId: string | null;
-}
+// The row shape is declared ONCE, in the wire contract both ends import, so
+// the client cannot silently drift from what this file actually emits — see
+// that file's header for the bug that motivated it.
+import type { PastConversationServerRow } from './past-conversation-dto';
 
 export interface ListAllConversationsPaginatedInput {
   limit?: number;
@@ -50,7 +35,7 @@ export interface ListAllConversationsPaginatedInput {
 }
 
 export interface PaginatedPastConversationsResult {
-  conversations: PastConversationRow[];
+  conversations: PastConversationServerRow[];
   pagination: {
     hasMore: boolean;
     nextCursor: string | null;

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -29,11 +29,21 @@ export interface SessionRefreshResult {
  */
 export class ApiRequestError extends Error {
   readonly status: number;
+  /**
+   * The parsed JSON error body, when the response had one — `undefined`
+   * otherwise (non-JSON body, or a caller that constructed this directly).
+   * Some refusals carry more than a message: a claim's 409 names the
+   * workspace that already owns the conversation, which is what lets the
+   * caller recover instead of degrading. Typed `unknown` on purpose — it is
+   * unvalidated wire data, and every reader must narrow it itself.
+   */
+  readonly body: unknown;
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, body?: unknown) {
     super(message);
     this.name = 'ApiRequestError';
     this.status = status;
+    this.body = body;
   }
 }
 
@@ -1227,7 +1237,7 @@ class AuthFetch {
       // Try to parse JSON error response and extract error message
       try {
         const json = JSON.parse(text);
-        throw new ApiRequestError(json.error || json.message || text, response.status);
+        throw new ApiRequestError(json.error || json.message || text, response.status, json);
       } catch (parseError) {
         // If parsing fails, it's not JSON - use the raw text
         if (parseError instanceof SyntaxError) {


### PR DESCRIPTION
The past-conversations list lives **on** the Agents surface, so a click on a row belongs on that surface. Instead, every row — including conversations that already had a workspace — ejected the user to `/dashboard`.

## The bug

An unchecked client/server boundary left by the `agent_sessions` → `agent_workspaces` rename.

**The server sends `workspaceId`** (`workspace-conversations-runtime.ts`, `conversations/route.ts`). Confirmed live against a real server:

```json
{"conversationId":"i76ias…","title":"A: already in a workspace","type":"page",
 "workspaceId":"lp1hqoxwnosndzcplv28ilgx","sessionName":"Existing Workspace", …}
```

**The client read `sessionId`** — in *two* hand-written copies of the row shape (`PastConversationRow` in `resolveNavigationTarget.ts`, `ConversationRowDTO` in `AgentsPastConversationsList.tsx`), plus untyped literals in `AgentsSurface.test.tsx`.

### Why it compiled

Those interfaces were handed to `useSWR<T>` / `fetchWithAuth` as generic type **arguments**. That is an *assertion* about data crossing an untyped boundary, not a *check* of it. Both hand-declarations were consistent with each other and wrong about the wire, so nothing failed to compile.

### Why no test caught it

Same reason. Every fixture on both sides was written against the same wrong belief, so the tests agreed with the bug. `resolveNavigationTarget.test.ts` already asserted `pane` for a bound row — using a field that never arrives.

### The consequence chain

1. `row.workspaceId` was `undefined` at runtime → the "already bound → open in place" branch never fired.
2. Every row resolved to `claimable`.
3. The claim POSTed, and a conversation that already had a node got **409 "That conversation already belongs to a session"** — because it did.
4. The catch classified any non-quota refusal as "degrade silently" → `router.push('/dashboard…')`.

The owner's *"it does open a pane/session, you just aren't navigated to it"* is step 3 exactly: the session already existed, which is **why** it 409'd.

## What changed

### 1. One declaration of the wire shape, both ends derived from it

New `apps/web/src/lib/agent-workspaces/past-conversation-dto.ts` (types only, no runtime imports — safe in a client bundle):

- server row = `PastConversationServerRow`, derived from the DTO (`OmitStrict` + `Date` timestamps + raw `string` type)
- client navigation input = a **`Pick`** of the DTO
- both components and all test fixtures import it; the three hand-declarations are gone

A rename now **fails to compile** on both ends.

### 2. A 409 navigates to the workspace that already owns the conversation

`POST /api/agent-workspaces` returns the owning `workspaceId` on both claim conflicts — the preflight, and the lost-race `not_found` after the atomic claim — and the client `selectConversation`s into it.

Disclosure is gated on `checkSessionAccess`, the same centralized check every other workspace route uses. **An earlier revision of this PR gated it only on the ownership 404 — that was wrong** (caught in review): owning the conversation is not access to the workspace holding it, since any accepted drive member may create their own conversation inside another member's drive session and that membership can lapse. The listing route already masks `workspaceId` in that exact situation (`maskOrDrop`), so the ungated 409 disclosed what the listing deliberately hides. Both 409s now omit the id unless the caller can actually open that workspace; the client falls back correctly when none is named.

The 409 recovery also revalidates `isAgentWorkspacesKey` before selecting — the panes render off that shared listing, and a workspace that won the race was minted by another tab, so this tab's cache has never seen it. And `claimConflictWorkspaceId` validates the id with `isCuid` (the validator `IdSchema` uses everywhere) rather than just "nonempty", since the value goes straight into the store and the URL.

`ApiRequestError` now carries the parsed error body (`readonly body: unknown`) so callers can act on more than the message.

### 3. Fallbacks unchanged in scope

`navigateFallback` still handles quota/capability refusals and `resolveNavigationTarget`'s `unavailable` cases (`type: 'client'`, a `page` row whose `driveId` was masked). Neither widened nor narrowed. A 409 that names no workspace (the `type: 'client'` refusal) still falls back.

## Tests

**The regression that would have caught this** — `conversations/__tests__/wire-contract.test.ts` hand-declares nothing: it drives the **real** route handler, takes the **real** JSON off its response (including `NextResponse.json`'s `Date` handling), and hands it to the **real** `resolveNavigationTarget`. Plus a type-level bidirectional assignability assertion between the serialized server row and the DTO, checked by `bun run typecheck`.

Also: `resolveNavigationTarget` unit cases (bound → `pane`; global/page unbound → `claimable`; `client` → `unavailable`; page with null `driveId` → `unavailable`), list-component cases (bound row issues no claim POST; a 409 naming a workspace selects it and never pushes; a 409 naming none still falls back; quota still falls back), `claimConflictWorkspaceId` unit cases, and route cases for both 409 bodies.

### Mutation checks — every one broke the source and watched the named test go red, then restored

| Mutation | Result |
|---|---|
| `resolveNavigationTarget` reads a never-set field (the original bug, re-created) | 4 test files red |
| Rename `workspaceId` on the DTO | **typecheck fails** — 8 errors across route, runtime and tests |
| Route emits `sessionId` at runtime only, behind a cast (types cannot see it) | wire-contract red: `expected undefined to be 'workspace-1'`, `expected { kind: 'claimable' } to deeply equal { kind: 'pane' }` |
| Server 409 stops naming the workspace | route tests red |
| Client stops acting on the 409's workspace | list test red |
| `claimConflictWorkspaceId` drops its status guard | spawn-refusal test red |
| `navigateFallback` removed | quota/capability tests red |
| Drop the 409's `checkSessionAccess` gate | route tests red — both 409s disclose |
| Drop the 409 path's cache revalidation | list test red |
| Weaken `isCuid` back to a nonempty check | spawn-refusal test red |

### Deliberate test changes, not weakenings

Fixtures in four files moved `sessionId` → `workspaceId`. They asserted correct *behaviour* against a row shape that cannot arrive — which is precisely why they stayed green through the bug. `AgentsSurface.test.tsx`'s inline `json: async () => ({…})` literals (checked by nothing) now go through a typed helper. `ClaimableFallback`'s `page` variant lost an unconditionally-null, never-read `sessionId` that read misleadingly after the rename.

## Gates

```
bun run typecheck   Tasks: 17 successful, 17 total
bun run lint        Tasks: 15 successful, 15 total   (warnings only, all pre-existing)
bun run knip:check  [ok] knip: 4 issue(s), all within baseline (4)
bun run --filter web test
                    Test Files  16 failed | 1113 passed | 1 skipped (1130)
                    Tests       10 failed | 16664 passed | 159 skipped (16833)
```

The 16 failing files are all `*.integration.test.ts` + `activity-tools`, every one failing with `Test database not reachable — connect ECONNREFUSED 127.0.0.1:5432`. Same set and counts as the pre-change baseline; none touches this diff.

## Manual verification — not claimed from unit tests

Production build (`next build` + `next start`, since dev-mode `eval` is blocked by the app's own CSP), a freshly migrated Postgres seeded with the three row kinds, driven through real Chromium at **1440×900 and 390×844**:

| Row | URL after click | Claim POSTs | Result |
|---|---|---|---|
| already in a workspace | `/dashboard/agents?workspace=f6fobc…&c=…&agent=…` | **0** | pane |
| global assistant, never had one | `/dashboard/agents?workspace=yjc7gf…&c=…` | 1 | pane |
| page agent, never had one | `/dashboard/agents?workspace=x4nqxf…&c=…&agent=…` | 1 | pane |

All six runs: `ALL CHECKS PASSED`. Zero navigations away from `/dashboard/agents`. Screenshots confirm the real message history rendered in the pane, and on the narrow viewport the pane takes the full width with the "All conversations" control back to the list.

## Known follow-up, deliberately not fixed here

Review flagged that a pane opened for a workspace owned by **another** drive member gets no conversation directory, because `GET /api/agent-workspaces` filters `ownerId === requesterId`. Verified real. Two things bound it:

- The pane is **not** blank — the node tree loads via the nodes route, which gates on `checkSessionAccess` (drive membership, not ownership), so the chat renders. What degrades is `conversationsReady`: agent-switch / New Conversation disabled, closing a non-last pane a no-op.
- The lost-membership half is now closed server-side by the access gate above.

Fixing the remainder means giving `AgentPanes` a per-workspace conversation source, or widening that listing to accessible shared sessions — a change to a different contract (the sidebar reads the same listing) than a field-mismatch bug fix should make. It is pre-existing in that listing; this PR only makes the `pane` branch reachable, and a partly-degraded pane is still strictly better than ejecting to `/dashboard`.

## Acceptance criteria

1. ✅ Bound row → pane, no dashboard navigation, no claim POST
2. ✅ Global conversation with no workspace → claims and opens as a pane
3. ✅ Page-agent conversation with no workspace → same
4. ✅ A 409 navigates to the owning workspace, in the Agents surface
5. ✅ Quota refusals and `unavailable` cases route to their existing fallbacks, unchanged
6. ✅ A rename breaks the build (mutation-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqTh7yHzjNpQsh2fEaxFHS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Past conversations now open in the Agents pane when possible.
  * Eligible conversations without an existing session can now create one automatically.
  * When a conversation is already claimed, navigation directs you to its owning workspace when available.
  * Conversations that cannot open in Agents continue to use the dashboard fallback.
  * Improved handling of stale conversation entries and claim conflicts without exposing inaccessible workspace details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
