### PR TITLE
feat(voice): port the pure realtime core

### DIFF
--- a/apps/web/src/lib/ai/realtime/__tests__/events.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/events.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFunctionOutput,
+  extractFunctionCalls,
+  extractTranscript,
+  parseEvent,
+  RESPONSE_CREATE,
+} from '../events';
+
+const call = (over: Record<string, unknown> = {}) => ({
+  type: 'function_call',
+  name: 'read_page',
+  call_id: 'call_1',
+  arguments: '{"pageId":"p1"}',
+  ...over,
+});
+
+const responseDone = (output: unknown[]) => ({
+  type: 'response.done',
+  response: { output },
+});
+
+describe('extractFunctionCalls', () => {
+  it('given a completed response with a call, should extract it', () => {
+    expect(extractFunctionCalls(responseDone([call()]))).toEqual([
+      { callId: 'call_1', name: 'read_page', argumentsJson: '{"pageId":"p1"}' },
+    ]);
+  });
+
+  it('given two calls in one turn, should extract both with id, name and arguments', () => {
+    expect(
+      extractFunctionCalls(
+        responseDone([
+          call(),
+          call({
+            call_id: 'call_2',
+            name: 'list_pages',
+            arguments: undefined,
+          }),
+        ]),
+      ),
+    ).toEqual([
+      { callId: 'call_1', name: 'read_page', argumentsJson: '{"pageId":"p1"}' },
+      // Absent arguments = a no-argument tool, not a malformed call.
+      { callId: 'call_2', name: 'list_pages', argumentsJson: '{}' },
+    ]);
+  });
+
+  it('given a tool with empty-string arguments, should default to an empty object', () => {
+    const [only] = extractFunctionCalls(responseDone([call({ arguments: '' })]));
+    expect(only.argumentsJson).toBe('{}');
+  });
+
+  it('given a tool with non-string arguments, should default to an empty object', () => {
+    const [only] = extractFunctionCalls(responseDone([call({ arguments: 7 })]));
+    expect(only.argumentsJson).toBe('{}');
+  });
+
+  it('given non-call output items, should ignore them', () => {
+    expect(
+      extractFunctionCalls(responseDone([{ type: 'message' }, call()])),
+    ).toHaveLength(1);
+  });
+
+  it('given a malformed item, should skip it rather than throw', () => {
+    expect(extractFunctionCalls(responseDone([null, 'nope']))).toEqual([]);
+  });
+
+  it('given a call missing its id, should skip it', () => {
+    expect(
+      extractFunctionCalls(responseDone([call({ call_id: undefined })])),
+    ).toEqual([]);
+  });
+
+  it('given a call missing its name, should skip it', () => {
+    expect(
+      extractFunctionCalls(responseDone([call({ name: undefined })])),
+    ).toEqual([]);
+  });
+
+  it('given a different event type, should return nothing', () => {
+    expect(extractFunctionCalls({ type: 'response.created' })).toEqual([]);
+  });
+
+  it('given output that is not an array, should return nothing', () => {
+    expect(
+      extractFunctionCalls({ type: 'response.done', response: { output: 'x' } }),
+    ).toEqual([]);
+  });
+
+  it('given no response object, should return nothing', () => {
+    expect(extractFunctionCalls({ type: 'response.done' })).toEqual([]);
+  });
+
+  it('given a non-object event, should return nothing', () => {
+    expect(extractFunctionCalls(null)).toEqual([]);
+    expect(extractFunctionCalls('response.done')).toEqual([]);
+  });
+});
+
+describe('extractTranscript', () => {
+  it('given a completed input transcription, should attribute it to the user', () => {
+    expect(
+      extractTranscript({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'read my notes',
+      }),
+    ).toEqual({ role: 'user', text: 'read my notes' });
+  });
+
+  it('given the current assistant transcript event, should attribute it to the assistant', () => {
+    expect(
+      extractTranscript({
+        type: 'response.output_audio_transcript.done',
+        transcript: 'Here you go.',
+      }),
+    ).toEqual({ role: 'assistant', text: 'Here you go.' });
+  });
+
+  it('given the older assistant transcript name, should extract it identically', () => {
+    const current = extractTranscript({
+      type: 'response.output_audio_transcript.done',
+      transcript: 'Here you go.',
+    });
+    const older = extractTranscript({
+      type: 'response.audio_transcript.done',
+      transcript: 'Here you go.',
+    });
+    expect(older).toEqual(current);
+    expect(older).toEqual({ role: 'assistant', text: 'Here you go.' });
+  });
+
+  it('given an empty user transcript, should return nothing', () => {
+    expect(
+      extractTranscript({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: '',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('given an empty assistant transcript, should return nothing', () => {
+    expect(
+      extractTranscript({
+        type: 'response.audio_transcript.done',
+        transcript: '',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('given an unrelated event, should return nothing', () => {
+    expect(extractTranscript({ type: 'response.created' })).toBeUndefined();
+  });
+
+  it('given an event with no type, should return nothing', () => {
+    expect(extractTranscript({})).toBeUndefined();
+  });
+
+  it('given an event with a non-string type, should return nothing', () => {
+    expect(extractTranscript({ type: 7 })).toBeUndefined();
+  });
+
+  it('given a non-object, should return nothing', () => {
+    expect(extractTranscript(undefined)).toBeUndefined();
+    expect(extractTranscript(null)).toBeUndefined();
+  });
+});
+
+describe('buildFunctionOutput', () => {
+  it('given a result, should address it to the originating call', () => {
+    expect(buildFunctionOutput('call_1', 'Done.')).toEqual({
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: 'Done.',
+      },
+    });
+  });
+});
+
+describe('RESPONSE_CREATE', () => {
+  it('given tool output was sent, should prompt the model to speak', () => {
+    expect(RESPONSE_CREATE).toEqual({ type: 'response.create' });
+  });
+});
+
+describe('parseEvent', () => {
+  it('given a JSON frame, should parse it', () => {
+    expect(parseEvent('{"type":"x"}')).toEqual({ type: 'x' });
+  });
+
+  it('given a malformed frame, should return undefined rather than throw', () => {
+    expect(() => parseEvent('{oops')).not.toThrow();
+    expect(parseEvent('{oops')).toBeUndefined();
+  });
+
+  it('given binary data, should return undefined', () => {
+    expect(parseEvent(new ArrayBuffer(2))).toBeUndefined();
+  });
+
+  it('given an already-decoded frame, should return undefined rather than pass it through', () => {
+    // JSON.parse coerces these to parseable strings ('42', 'null'), so only the
+    // non-string guard keeps them out — a frame the channel never delivers as a
+    // string is not an event.
+    expect(parseEvent(42)).toBeUndefined();
+    expect(parseEvent(null)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/session-state.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/session-state.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  initialSessionState,
+  sessionReducer,
+  type SessionAction,
+  type SessionState,
+} from '../session-state';
+
+const after = (
+  actions: SessionAction[],
+  from: SessionState = initialSessionState,
+): SessionState => actions.reduce(sessionReducer, from);
+
+const said = (type: string, transcript: string): SessionAction => ({
+  type: 'event',
+  event: { type, transcript },
+});
+
+const SPEAKING: SessionAction = {
+  type: 'event',
+  event: { type: 'input_audio_buffer.speech_started' },
+};
+const STOPPED: SessionAction = {
+  type: 'event',
+  event: { type: 'input_audio_buffer.speech_stopped' },
+};
+
+describe('initialSessionState', () => {
+  it('given nothing has happened, should be idle and empty', () => {
+    expect(initialSessionState).toEqual({
+      status: 'idle',
+      error: undefined,
+      userSpeaking: false,
+      transcript: [],
+      tools: [],
+    });
+  });
+});
+
+describe('connection lifecycle', () => {
+  it('given a start, should move to connecting and clear any old error', () => {
+    const state = after([
+      { type: 'failed', message: 'old' },
+      { type: 'connecting' },
+    ]);
+    expect(state.status).toBe('connecting');
+    expect(state.error).toBeUndefined();
+  });
+
+  it('given success, should move to connected', () => {
+    expect(after([{ type: 'connecting' }, { type: 'connected' }]).status).toBe(
+      'connected',
+    );
+  });
+
+  it('given a session that failed and reconnected, should clear the error', () => {
+    const state = after([
+      { type: 'failed', message: 'boom' },
+      { type: 'connected' },
+    ]);
+    expect(state.error).toBeUndefined();
+  });
+
+  it('given a failure, should record the message and stop listening', () => {
+    expect(after([SPEAKING, { type: 'failed', message: 'mic denied' }])).toMatchObject(
+      { status: 'error', error: 'mic denied', userSpeaking: false },
+    );
+  });
+
+  it('given a failure mid-conversation, should keep the transcript', () => {
+    const state = after([
+      said('conversation.item.input_audio_transcription.completed', 'hello'),
+      said('response.output_audio_transcript.done', 'hi there'),
+      { type: 'failed', message: 'dropped' },
+    ]);
+    expect(state.transcript).toEqual([
+      { role: 'user', text: 'hello' },
+      { role: 'assistant', text: 'hi there' },
+    ]);
+  });
+
+  it('given a failure after a tool ran, should keep the tool record too', () => {
+    const state = after([
+      { type: 'tool', name: 'read_page', speech: 'Notes: hi' },
+      { type: 'failed', message: 'dropped' },
+    ]);
+    expect(state.tools).toHaveLength(1);
+  });
+
+  it('given a disconnect, should return to idle and stop listening', () => {
+    expect(
+      after([{ type: 'connected' }, SPEAKING, { type: 'disconnected' }]),
+    ).toMatchObject({ status: 'idle', userSpeaking: false });
+  });
+
+  it('given a disconnect after a conversation, should keep the transcript', () => {
+    const state = after([
+      said('conversation.item.input_audio_transcription.completed', 'hello'),
+      { type: 'disconnected' },
+    ]);
+    expect(state.transcript).toHaveLength(1);
+  });
+});
+
+describe('listening state', () => {
+  it('given speech starts, should mark the user as speaking', () => {
+    expect(after([SPEAKING]).userSpeaking).toBe(true);
+  });
+
+  it('given speech stops, should clear it', () => {
+    expect(after([SPEAKING, STOPPED]).userSpeaking).toBe(false);
+  });
+
+  it('given connection state, should stay independent of listening state', () => {
+    const state = after([{ type: 'connected' }, SPEAKING]);
+    expect(state.status).toBe('connected');
+    expect(state.userSpeaking).toBe(true);
+  });
+});
+
+describe('transcript', () => {
+  it('given both sides speaking, should record them in order', () => {
+    const state = after([
+      said('conversation.item.input_audio_transcription.completed', 'read my notes'),
+      said('response.output_audio_transcript.done', 'Here they are.'),
+    ]);
+    expect(state.transcript).toEqual([
+      { role: 'user', text: 'read my notes' },
+      { role: 'assistant', text: 'Here they are.' },
+    ]);
+  });
+
+  it('given the older assistant event name, should record it the same way', () => {
+    expect(
+      after([said('response.audio_transcript.done', 'Here they are.')]).transcript,
+    ).toEqual([{ role: 'assistant', text: 'Here they are.' }]);
+  });
+
+  it('given an irrelevant event, should return the same state object', () => {
+    const start = initialSessionState;
+    expect(sessionReducer(start, { type: 'event', event: { type: 'x' } })).toBe(
+      start,
+    );
+  });
+
+  it('given a non-object event, should not throw', () => {
+    const start = initialSessionState;
+    expect(sessionReducer(start, { type: 'event', event: null })).toBe(start);
+    expect(sessionReducer(start, { type: 'event', event: 'nope' })).toBe(start);
+  });
+
+  it('given an event with a non-string type, should not throw', () => {
+    const start = initialSessionState;
+    expect(sessionReducer(start, { type: 'event', event: { type: 7 } })).toBe(
+      start,
+    );
+  });
+});
+
+describe('tool activity', () => {
+  it('given tools ran, should record what they were and what they said, in order', () => {
+    const state = after([
+      { type: 'tool', name: 'read_page', speech: 'Notes: hi' },
+      { type: 'tool', name: 'list_pages', speech: 'You have 1 page' },
+    ]);
+    expect(state.tools).toEqual([
+      { name: 'read_page', speech: 'Notes: hi' },
+      { name: 'list_pages', speech: 'You have 1 page' },
+    ]);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/session.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/session.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSessionConfig,
+  CLIENT_SECRETS_URL,
+  DEFAULT_REALTIME_MODEL,
+  extractClientSecret,
+  REALTIME_CALLS_URL,
+  REALTIME_DATA_CHANNEL,
+  REALTIME_MODEL_ENV_VAR,
+  REALTIME_VOICE,
+  resolveRealtimeModel,
+  SDP_CONTENT_TYPE,
+  type RealtimeTool,
+} from '../session';
+
+const tool: RealtimeTool = {
+  type: 'function',
+  name: 'read_page',
+  description: 'Read a page aloud.',
+  parameters: { type: 'object', properties: { pageId: { type: 'string' } } },
+};
+
+describe('buildSessionConfig', () => {
+  it('given the realtime API, should declare the session type and default model', () => {
+    const { session } = buildSessionConfig();
+    expect(session.type).toBe('realtime');
+    expect(session.model).toBe(DEFAULT_REALTIME_MODEL);
+    // Not gpt-realtime-2.1: access is per-account and /v1/realtime/calls 403s
+    // at connect time, so the default is the model this account can reach.
+    expect(DEFAULT_REALTIME_MODEL).toBe('gpt-realtime');
+  });
+
+  it('given speech output, should set the default voice', () => {
+    expect(buildSessionConfig().session.audio.output.voice).toBe(
+      REALTIME_VOICE,
+    );
+    expect(REALTIME_VOICE).toBe('marin');
+  });
+
+  it('given no options, should match the documented client_secrets body', () => {
+    expect(buildSessionConfig()).toEqual({
+      session: {
+        type: 'realtime',
+        model: 'gpt-realtime',
+        audio: { output: { voice: 'marin' } },
+        tools: [],
+        tool_choice: 'auto',
+      },
+    });
+  });
+
+  it('given a model override, should use it instead of the default', () => {
+    expect(buildSessionConfig({ model: 'gpt-realtime-2.1' }).session.model).toBe(
+      'gpt-realtime-2.1',
+    );
+  });
+
+  it('given a voice override, should use it instead of the default', () => {
+    expect(buildSessionConfig({ voice: 'cedar' }).session.audio.output.voice).toBe(
+      'cedar',
+    );
+  });
+
+  it('given tools, should declare them flat with tool_choice auto', () => {
+    const { session } = buildSessionConfig({ tools: [tool] });
+    expect(session.tools).toEqual([tool]);
+    expect(session.tool_choice).toBe('auto');
+  });
+
+  it('given instructions, should include them', () => {
+    expect(buildSessionConfig({ instructions: 'Be brief.' }).session).toMatchObject(
+      { instructions: 'Be brief.' },
+    );
+  });
+
+  it('given an empty instructions string, should still send it rather than drop it', () => {
+    expect(buildSessionConfig({ instructions: '' }).session).toHaveProperty(
+      'instructions',
+      '',
+    );
+  });
+
+  it('given no instructions, should omit the key rather than send an empty one', () => {
+    expect(buildSessionConfig().session).not.toHaveProperty('instructions');
+  });
+});
+
+describe('resolveRealtimeModel', () => {
+  it('given no override, should use the default model', () => {
+    expect(resolveRealtimeModel({})).toBe(DEFAULT_REALTIME_MODEL);
+  });
+
+  it('given an override, should use it — the env var is the path to a newer model', () => {
+    expect(
+      resolveRealtimeModel({ [REALTIME_MODEL_ENV_VAR]: 'gpt-realtime-2.1' }),
+    ).toBe('gpt-realtime-2.1');
+  });
+
+  it('given an override with surrounding whitespace, should trim it', () => {
+    expect(
+      resolveRealtimeModel({ [REALTIME_MODEL_ENV_VAR]: '  gpt-realtime-2.1  ' }),
+    ).toBe('gpt-realtime-2.1');
+  });
+
+  it('given a blank override, should fall back to the default', () => {
+    expect(resolveRealtimeModel({ [REALTIME_MODEL_ENV_VAR]: '   ' })).toBe(
+      DEFAULT_REALTIME_MODEL,
+    );
+    expect(resolveRealtimeModel({ [REALTIME_MODEL_ENV_VAR]: '' })).toBe(
+      DEFAULT_REALTIME_MODEL,
+    );
+  });
+
+  it('given an explicitly undefined override, should fall back to the default', () => {
+    expect(resolveRealtimeModel({ [REALTIME_MODEL_ENV_VAR]: undefined })).toBe(
+      DEFAULT_REALTIME_MODEL,
+    );
+  });
+
+  it('given a resolved model, should be usable as the session model', () => {
+    const model = resolveRealtimeModel({
+      [REALTIME_MODEL_ENV_VAR]: 'gpt-realtime-2.1',
+    });
+    expect(buildSessionConfig({ model }).session.model).toBe('gpt-realtime-2.1');
+  });
+});
+
+describe('endpoints', () => {
+  it('given the mint step, should point at client_secrets', () => {
+    expect(CLIENT_SECRETS_URL).toBe(
+      'https://api.openai.com/v1/realtime/client_secrets',
+    );
+  });
+
+  it('given the connect step, should POST SDP to calls on the oai-events channel', () => {
+    expect(REALTIME_CALLS_URL).toBe('https://api.openai.com/v1/realtime/calls');
+    expect(SDP_CONTENT_TYPE).toBe('application/sdp');
+    expect(REALTIME_DATA_CHANNEL).toBe('oai-events');
+  });
+});
+
+describe('extractClientSecret', () => {
+  it('given the documented shape, should return the secret', () => {
+    expect(extractClientSecret({ value: 'ek_123' })).toBe('ek_123');
+  });
+
+  it('given a missing value, should return undefined', () => {
+    expect(extractClientSecret({})).toBeUndefined();
+  });
+
+  it('given an empty value, should treat it as missing', () => {
+    expect(extractClientSecret({ value: '' })).toBeUndefined();
+  });
+
+  it('given a non-string value, should treat it as missing', () => {
+    expect(extractClientSecret({ value: 42 })).toBeUndefined();
+  });
+
+  it('given null, should not throw', () => {
+    expect(extractClientSecret(null)).toBeUndefined();
+  });
+
+  it('given a non-object, should not throw', () => {
+    expect(extractClientSecret('ek_123')).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/realtime/events.ts
+++ b/apps/web/src/lib/ai/realtime/events.ts
@@ -1,0 +1,130 @@
+/**
+ * Realtime data-channel events, parsed purely.
+ *
+ * Shapes verified against the OpenAI Realtime docs: the model announces tool
+ * calls as `function_call` items inside `response.done`, and the client answers
+ * with a `conversation.item.create` carrying a `function_call_output`, then
+ * `response.create`.
+ *
+ * Assistant transcripts are read from the streaming transcript-done event under
+ * BOTH names — `response.output_audio_transcript.done` (current) and
+ * `response.audio_transcript.done` (earlier) — because the event was renamed
+ * across releases and some deployments still emit the old name.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+export type FunctionCall = {
+  readonly callId: string;
+  readonly name: string;
+  readonly argumentsJson: string;
+};
+
+export type TranscriptEntry = {
+  readonly role: 'user' | 'assistant';
+  readonly text: string;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const outputItems = (event: Record<string, unknown>): unknown[] => {
+  const response = asRecord(event.response);
+  const output = response?.output;
+  return Array.isArray(output) ? output : [];
+};
+
+/** Tool calls the model wants run. Empty for every other event. */
+export const extractFunctionCalls = (event: unknown): FunctionCall[] => {
+  const record = asRecord(event);
+  if (!record || record.type !== 'response.done') {
+    return [];
+  }
+  const calls: FunctionCall[] = [];
+  for (const raw of outputItems(record)) {
+    const item = asRecord(raw);
+    if (!item || item.type !== 'function_call') {
+      continue;
+    }
+    const callId = asString(item.call_id);
+    const name = asString(item.name);
+    if (!callId || !name) {
+      continue;
+    }
+    calls.push({
+      callId,
+      name,
+      // Absent arguments mean a no-argument tool, not a malformed call.
+      argumentsJson: asString(item.arguments) ?? '{}',
+    });
+  }
+  return calls;
+};
+
+const USER_TRANSCRIPT_TYPE =
+  'conversation.item.input_audio_transcription.completed';
+
+/**
+ * Both names are required: `response.audio_transcript.done` was renamed to
+ * `response.output_audio_transcript.done`, and deployments straddle the change.
+ */
+const ASSISTANT_TRANSCRIPT_TYPES = new Set([
+  'response.output_audio_transcript.done',
+  'response.audio_transcript.done',
+]);
+
+/** What was said, for the on-screen record. */
+export const extractTranscript = (
+  event: unknown,
+): TranscriptEntry | undefined => {
+  const record = asRecord(event);
+  const type = asString(record?.type);
+  if (!record || !type) {
+    return undefined;
+  }
+
+  if (type === USER_TRANSCRIPT_TYPE) {
+    const text = asString(record.transcript);
+    return text ? { role: 'user', text } : undefined;
+  }
+
+  if (ASSISTANT_TRANSCRIPT_TYPES.has(type)) {
+    const text = asString(record.transcript);
+    return text ? { role: 'assistant', text } : undefined;
+  }
+
+  return undefined;
+};
+
+/** The client event that hands a tool's result back to the model. */
+export const buildFunctionOutput = (
+  callId: string,
+  output: string,
+): Record<string, unknown> => ({
+  type: 'conversation.item.create',
+  item: {
+    type: 'function_call_output',
+    call_id: callId,
+    output,
+  },
+});
+
+/** Told to speak after tool output lands. */
+export const RESPONSE_CREATE = { type: 'response.create' } as const;
+
+/** Data channel frames arrive as strings; a malformed one must not throw. */
+export const parseEvent = (data: unknown): unknown => {
+  if (typeof data !== 'string') {
+    return undefined;
+  }
+  try {
+    return JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+};

--- a/apps/web/src/lib/ai/realtime/session-state.ts
+++ b/apps/web/src/lib/ai/realtime/session-state.ts
@@ -1,0 +1,99 @@
+import { extractTranscript, type TranscriptEntry } from './events';
+
+/**
+ * Everything the voice UI shows, as a pure reducer. The hook owns the wiring;
+ * it owns no decisions, so what appears on screen is testable without a
+ * browser, a peer connection, or a microphone.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+export type ToolActivity = {
+  readonly name: string;
+  readonly speech: string;
+};
+
+export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'error';
+
+export type SessionState = {
+  readonly status: ConnectionStatus;
+  readonly error: string | undefined;
+  /** Whether the user is mid-utterance — distinct from being connected. */
+  readonly userSpeaking: boolean;
+  readonly transcript: readonly TranscriptEntry[];
+  readonly tools: readonly ToolActivity[];
+};
+
+export const initialSessionState: SessionState = {
+  status: 'idle',
+  error: undefined,
+  userSpeaking: false,
+  transcript: [],
+  tools: [],
+};
+
+export type SessionAction =
+  | { readonly type: 'connecting' }
+  | { readonly type: 'connected' }
+  | { readonly type: 'failed'; readonly message: string }
+  | { readonly type: 'disconnected' }
+  | { readonly type: 'event'; readonly event: unknown }
+  | { readonly type: 'tool'; readonly name: string; readonly speech: string };
+
+const SPEECH_STARTED = 'input_audio_buffer.speech_started';
+const SPEECH_STOPPED = 'input_audio_buffer.speech_stopped';
+
+const eventType = (event: unknown): string | undefined => {
+  if (typeof event !== 'object' || event === null) {
+    return undefined;
+  }
+  const type = (event as { type?: unknown }).type;
+  return typeof type === 'string' ? type : undefined;
+};
+
+export const sessionReducer = (
+  state: SessionState,
+  action: SessionAction,
+): SessionState => {
+  switch (action.type) {
+    case 'connecting':
+      return { ...state, status: 'connecting', error: undefined };
+
+    case 'connected':
+      return { ...state, status: 'connected', error: undefined };
+
+    case 'failed':
+      // Keep the transcript: a drop mid-conversation must not erase the record.
+      return {
+        ...state,
+        status: 'error',
+        error: action.message,
+        userSpeaking: false,
+      };
+
+    case 'disconnected':
+      return { ...state, status: 'idle', userSpeaking: false };
+
+    case 'tool':
+      return {
+        ...state,
+        tools: [...state.tools, { name: action.name, speech: action.speech }],
+      };
+
+    case 'event': {
+      const type = eventType(action.event);
+      if (type === SPEECH_STARTED) {
+        return { ...state, userSpeaking: true };
+      }
+      if (type === SPEECH_STOPPED) {
+        return { ...state, userSpeaking: false };
+      }
+      const entry = extractTranscript(action.event);
+      // Same object back when nothing changed — an unrelated event must not
+      // churn identity and re-render the UI.
+      return entry
+        ? { ...state, transcript: [...state.transcript, entry] }
+        : state;
+    }
+  }
+};

--- a/apps/web/src/lib/ai/realtime/session.ts
+++ b/apps/web/src/lib/ai/realtime/session.ts
@@ -1,0 +1,113 @@
+/**
+ * The realtime session config and the two OpenAI endpoints a call touches.
+ *
+ * Shape verified against the OpenAI Realtime docs:
+ * `POST /v1/realtime/client_secrets` takes `{ session: {...} }`, and tools are
+ * flat `{ type: 'function', name, description, parameters }` entries — not
+ * nested under a `function` key the way Chat Completions nests them.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state. Nothing
+ * here reads `process.env` — the caller passes the env bag in.
+ */
+
+/**
+ * `gpt-realtime`, not `gpt-realtime-2.1`, because model access is per-account:
+ * `client_secrets` accepts ANY model string and mints a secret, then
+ * `/v1/realtime/calls` 403s `model_not_found` at connect time if the account
+ * lacks it — so a wrong default fails late, mid-connect, not at config time.
+ * This account 403s on `gpt-realtime-2.1` and 201s on `gpt-realtime`, and the
+ * working prototype runs `gpt-realtime` too. Move to 2.1 by setting
+ * OPENAI_REALTIME_MODEL once the account has it, rather than editing this.
+ */
+export const DEFAULT_REALTIME_MODEL = 'gpt-realtime';
+export const REALTIME_VOICE = 'marin';
+
+/** The env var that overrides the model, named once so callers can't drift. */
+export const REALTIME_MODEL_ENV_VAR = 'OPENAI_REALTIME_MODEL';
+
+export type EnvBag = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Pure env resolution: an unset, blank, or whitespace-only override is not an
+ * override. Callers hand in `process.env` at the edge.
+ */
+export const resolveRealtimeModel = (env: EnvBag): string =>
+  env[REALTIME_MODEL_ENV_VAR]?.trim() || DEFAULT_REALTIME_MODEL;
+
+/**
+ * A tool as the realtime transport carries it. This is the wire shape only —
+ * PageSpace's own tool registry is the source of truth for which tools exist
+ * and what they do, and maps into this type elsewhere.
+ */
+export type RealtimeTool = {
+  readonly type: 'function';
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+export type SessionConfig = {
+  readonly session: {
+    readonly type: 'realtime';
+    readonly model: string;
+    readonly instructions?: string;
+    readonly audio: { readonly output: { readonly voice: string } };
+    readonly tools: readonly RealtimeTool[];
+    readonly tool_choice: 'auto';
+  };
+};
+
+export type SessionOptions = {
+  readonly model?: string;
+  readonly voice?: string;
+  readonly instructions?: string;
+  readonly tools?: readonly RealtimeTool[];
+};
+
+/**
+ * The `client_secrets` request body. `instructions` is omitted rather than sent
+ * empty when absent — an empty string is an instruction ("say nothing about
+ * yourself"), not the absence of one.
+ */
+export const buildSessionConfig = (
+  options: SessionOptions = {},
+): SessionConfig => ({
+  session: {
+    type: 'realtime',
+    model: options.model ?? DEFAULT_REALTIME_MODEL,
+    ...(options.instructions === undefined
+      ? {}
+      : { instructions: options.instructions }),
+    audio: { output: { voice: options.voice ?? REALTIME_VOICE } },
+    tools: options.tools ?? [],
+    tool_choice: 'auto',
+  },
+});
+
+/** Where the server mints the ephemeral secret. */
+export const CLIENT_SECRETS_URL =
+  'https://api.openai.com/v1/realtime/client_secrets';
+
+/**
+ * Where the browser POSTs its SDP offer once it holds an ephemeral secret. The
+ * model is NOT passed here — it was fixed when the secret was minted.
+ */
+export const REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls';
+
+/** The SDP offer/answer content type `/v1/realtime/calls` speaks. */
+export const SDP_CONTENT_TYPE = 'application/sdp';
+
+/** The data channel the realtime event stream rides on. */
+export const REALTIME_DATA_CHANNEL = 'oai-events';
+
+/**
+ * The mint response carries the secret under `value`. Narrow defensively —
+ * a shape change should surface as a clear failure, not `undefined` on the wire.
+ */
+export const extractClientSecret = (payload: unknown): string | undefined => {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
+  }
+  const value = (payload as { value?: unknown }).value;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};


### PR DESCRIPTION
First leaf of the audio-native voice epic. Adds the pure, I/O-free realtime core under `apps/web/src/lib/ai/realtime/`, ported from the working `pagespace-voice` prototype.

- `events.ts` — `extractFunctionCalls`, `extractTranscript` (handles **both** `response.output_audio_transcript.done` and the legacy `response.audio_transcript.done`), `buildFunctionOutput`, `parseEvent`
- `session.ts` — session config builder, `resolveRealtimeModel(env)`, and the `RealtimeTool` wire type
- `session-state.ts` — the UI reducer; a failed connection preserves the transcript

**`DEFAULT_REALTIME_MODEL = 'gpt-realtime'`, not 2.1** — the W0 spike proved `gpt-realtime-2.1` is not on this account (mint returns 200, then `/v1/realtime/calls` 403s `model_not_found`), and the prototype's own `.env` pins `gpt-realtime`. `OPENAI_REALTIME_MODEL` remains the upgrade path.

Verification: 68 tests pass; `tsc --noEmit` clean; mutation-checked the dual transcript-event-name coverage (deleting the legacy name turns exactly one test red).

Pure only — no I/O, no clock, no randomness. 888 insertions, no lockfile noise.