### PR TITLE
feat(voice): adapt the tool registry to realtime function definitions (W1-A2)

### DIFF
--- a/apps/web/src/lib/ai/realtime/__tests__/tools.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tools.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { Tool, ToolSet } from 'ai';
+import { buildRealtimeTools, toRealtimeTool } from '../tools';
+import { CORE_TOOL_NAMES } from '../../core/stub-tools';
+import { createToolSearchTool } from '../../tools/tool-search-tool';
+import { createExecuteTool } from '../../tools/execute-tool';
+// The REAL registry, unmocked on purpose — see the regression-guard case below.
+import { buildPageSpaceTools } from '../../core/ai-tools';
+
+const fakeTool = (over: Partial<Tool> = {}): Tool =>
+  ({
+    description: 'A tool.',
+    inputSchema: z.object({ pageId: z.string() }),
+    execute: async () => ({}),
+    ...over,
+  }) as Tool;
+
+/** A set with one core tool and one deferrable tool. */
+const smallSet = (): ToolSet => ({
+  read_page: fakeTool({ description: 'Read a page.' }),
+  rename_drive: fakeTool({ description: 'Rename a drive.' }),
+});
+
+const names = (tools: readonly { name: string }[]) => tools.map((t) => t.name);
+
+/** Every key anywhere in a JSON value, at any depth. */
+function deepKeys(value: unknown): string[] {
+  if (Array.isArray(value)) return value.flatMap(deepKeys);
+  if (typeof value !== 'object' || value === null) return [];
+  return Object.entries(value as Record<string, unknown>).flatMap(([k, v]) => [
+    k,
+    ...deepKeys(v),
+  ]);
+}
+
+describe('buildRealtimeTools', () => {
+  it('given the full PageSpace ToolSet, should emit exactly the core tools plus the two scaffolding tools', () => {
+    const registry = buildPageSpaceTools({ codeExecutionEnabled: true });
+    const emitted = names(buildRealtimeTools(registry));
+    const registryCoreNames = Object.keys(registry).filter((n) => CORE_TOOL_NAMES.has(n));
+
+    expect(new Set(emitted)).toEqual(
+      new Set([...registryCoreNames, 'tool_search', 'execute_tool']),
+    );
+    // No duplicates: the scaffolding must not collide with a registry name.
+    expect(emitted.length).toBe(registryCoreNames.length + 2);
+
+    // `registryCoreNames` is CORE_TOOL_NAMES minus any name with no tool behind
+    // it, which is why it — not CORE_TOOL_NAMES itself — is the expectation.
+    // Today `get_page_details` is such a name: it is listed in stub-tools.ts but
+    // defined by no tool module, so nothing can be emitted for it. Splitting a
+    // set of names against a set of tools can only ever yield tools that exist.
+    expect([...CORE_TOOL_NAMES].filter((n) => !registryCoreNames.includes(n))).toEqual([
+      'get_page_details',
+    ]);
+  });
+
+  it('given the full PageSpace ToolSet, should defer every non-core tool rather than front-loading it', () => {
+    const registry = buildPageSpaceTools({ codeExecutionEnabled: true });
+    const emitted = new Set(names(buildRealtimeTools(registry)));
+    const nonCore = Object.keys(registry).filter((n) => !CORE_TOOL_NAMES.has(n));
+
+    // The registry is big enough for deferral to be the point of the split.
+    expect(nonCore.length).toBeGreaterThan(CORE_TOOL_NAMES.size);
+    for (const name of nonCore) {
+      expect(emitted.has(name)).toBe(false);
+    }
+  });
+
+  it('given EVERY tool in the real registry, should convert without throwing', () => {
+    // The regression guard: a `z.date()`/`z.bigint()`/`z.map()`/transform added to
+    // any tool input is unrepresentable in JSON Schema and makes z.toJSONSchema
+    // throw. This case fails the moment that lands, in whichever module it lands.
+    //
+    // It drives `toRealtimeTool` directly, NOT buildRealtimeTools: the latter
+    // converts only the upfront half, so a deferred tool — which is most of the
+    // registry — would never have its schema touched and the guard would pass
+    // vacuously. (Mutation-checked: adding `z.date()` to a deferred tool goes red
+    // here and stays green through buildRealtimeTools.)
+    const registry = buildPageSpaceTools({ codeExecutionEnabled: true });
+    expect(Object.keys(registry).length).toBeGreaterThan(50);
+
+    for (const [name, tool] of Object.entries(registry)) {
+      expect(
+        () => toRealtimeTool(name, tool),
+        `tool "${name}" is not representable as realtime parameters`,
+      ).not.toThrow();
+    }
+    expect(() => buildRealtimeTools(registry)).not.toThrow();
+  });
+
+  it('given an unrepresentable input schema, should throw rather than emit a lie', () => {
+    // The loud failure the guard above is guarding. A mis-described parameter
+    // would have the model confidently sending a value the tool cannot parse.
+    expect(() =>
+      toRealtimeTool('read_page', fakeTool({ inputSchema: z.object({ when: z.date() }) })),
+    ).toThrow(/Date cannot be represented in JSON Schema/);
+  });
+
+  it('given any tool, should emit the FLAT realtime function shape', () => {
+    for (const tool of buildRealtimeTools(smallSet())) {
+      expect(tool.type).toBe('function');
+      expect(typeof tool.name).toBe('string');
+      expect(typeof tool.description).toBe('string');
+      expect(tool.parameters).toBeTypeOf('object');
+      // Flat — NOT nested under a `function` key the way Chat Completions nests.
+      expect(tool).not.toHaveProperty('function');
+      expect(Object.keys(tool).sort()).toEqual([
+        'description',
+        'name',
+        'parameters',
+        'type',
+      ]);
+    }
+  });
+
+  it('given a zod-object inputSchema, should emit inlined JSON Schema parameters', () => {
+    const [readPage] = buildRealtimeTools({
+      read_page: fakeTool({
+        description: 'Read a page.',
+        inputSchema: z.object({
+          pageId: z.string().describe('The page to read'),
+          lines: z.number().optional(),
+        }),
+      }),
+    });
+
+    expect(readPage.parameters).toEqual({
+      type: 'object',
+      properties: {
+        pageId: { type: 'string', description: 'The page to read' },
+        lines: { type: 'number' },
+      },
+      required: ['pageId'],
+      additionalProperties: false,
+    });
+  });
+
+  it('given a schema that reuses a sub-schema, should inline it with no $ref/$defs', () => {
+    const shared = z.object({ id: z.string() });
+    const [tool] = buildRealtimeTools({
+      read_page: fakeTool({
+        inputSchema: z.object({ from: shared, to: shared }),
+      }),
+    });
+
+    const keys = deepKeys(tool.parameters);
+    expect(keys).not.toContain('$ref');
+    expect(keys).not.toContain('$defs');
+    expect(keys.filter((k) => k.startsWith('$'))).toEqual([]);
+    // Inlined means BOTH occurrences carry the real shape, not a pointer.
+    expect(tool.parameters).toMatchObject({
+      properties: {
+        from: { type: 'object', properties: { id: { type: 'string' } } },
+        to: { type: 'object', properties: { id: { type: 'string' } } },
+      },
+    });
+  });
+
+  it('given a schema, should drop the $schema dialect annotation from parameters', () => {
+    // z.toJSONSchema emits `$schema` at the root; it describes the document, not
+    // the parameter contract, and OpenAI function schemas never carry it.
+    const raw = z.toJSONSchema(z.object({ pageId: z.string() })) as Record<string, unknown>;
+    expect(raw.$schema).toBeDefined();
+
+    const [tool] = buildRealtimeTools({ read_page: fakeTool() });
+    expect(tool.parameters).not.toHaveProperty('$schema');
+  });
+
+  it('given a tool with no description, should still emit a valid definition', () => {
+    const [tool] = buildRealtimeTools({
+      read_page: fakeTool({ description: undefined }),
+    });
+
+    expect(tool).toEqual({
+      type: 'function',
+      name: 'read_page',
+      description: '',
+      parameters: {
+        type: 'object',
+        properties: { pageId: { type: 'string' } },
+        required: ['pageId'],
+        additionalProperties: false,
+      },
+    });
+  });
+
+  it('given a tool with a description, should carry it through verbatim', () => {
+    const [tool] = buildRealtimeTools({
+      read_page: fakeTool({ description: 'Read a page aloud.' }),
+    });
+    expect(tool.description).toBe('Read a page aloud.');
+  });
+
+  it('given the scaffolding tools, should describe them exactly as the text stack does', () => {
+    // Built from the same factories, so voice and text cannot describe the two
+    // discovery tools differently.
+    const set = smallSet();
+    const emitted = buildRealtimeTools(set);
+    const search = emitted.find((t) => t.name === 'tool_search');
+    const execute = emitted.find((t) => t.name === 'execute_tool');
+
+    expect(search?.description).toBe(createToolSearchTool(set).description);
+    expect(execute?.description).toBe(createExecuteTool({}).description);
+    expect(search?.parameters).toMatchObject({
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    });
+    // `parameters` carries a zod `.default({})` yet still lands in `required`:
+    // z.toJSONSchema defaults to `io: 'output'`, where a defaulted field is
+    // always present. Kept as-is rather than switched to `io: 'input'` — the
+    // text stack's tool_search renders the same schema the same way, and a
+    // field the model must always send (as `{}`) costs nothing.
+    expect(execute?.parameters).toMatchObject({
+      type: 'object',
+      properties: { tool_name: { type: 'string' }, parameters: { type: 'object' } },
+      required: ['tool_name', 'parameters'],
+    });
+  });
+
+  it('given an empty tool set, should still emit the discovery scaffolding', () => {
+    expect(names(buildRealtimeTools({}))).toEqual(['tool_search', 'execute_tool']);
+  });
+
+  it('given composer-toggled tools, should defer them like any other non-core tool', () => {
+    // A voice call has no composer toggles, so `web_search`/`generate_image` get
+    // no always-upfront rescue — they are reachable through execute_tool.
+    const emitted = names(
+      buildRealtimeTools({
+        read_page: fakeTool(),
+        web_search: fakeTool(),
+        generate_image: fakeTool(),
+      }),
+    );
+    expect(emitted).toEqual(['read_page', 'tool_search', 'execute_tool']);
+  });
+
+  it('given the same tool set twice, should be pure — equal output, input untouched', () => {
+    const set = smallSet();
+    const snapshot = Object.keys(set);
+    expect(buildRealtimeTools(set)).toEqual(buildRealtimeTools(set));
+    expect(Object.keys(set)).toEqual(snapshot);
+    expect(set).not.toHaveProperty('tool_search');
+  });
+});

--- a/apps/web/src/lib/ai/realtime/tools.ts
+++ b/apps/web/src/lib/ai/realtime/tools.ts
@@ -1,0 +1,111 @@
+/**
+ * PageSpace's AI SDK tool registry, projected onto the realtime wire shape.
+ *
+ * Voice is a second transport onto the conversations PageSpace already has, not
+ * a second capability surface — so the realtime session gets the SAME exposure
+ * split the text stack uses (`splitToolsForExposure`), and the SAME
+ * tool_search / execute_tool scaffolding built by the SAME factories. Nothing
+ * here curates a "voice subset": a curated list would be a second tool surface
+ * that silently drifts from the text one every time a tool is added.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state. The
+ * registry is a parameter, never a module-load import — building it has
+ * env-dependent branches (the code-execution kill switch) that must stay the
+ * caller's decision.
+ */
+
+import { z } from 'zod';
+import type { Tool, ToolSet } from 'ai';
+import { splitToolsForExposure } from '../tools/tool-exposure';
+import { createToolSearchTool } from '../tools/tool-search-tool';
+import { createExecuteTool } from '../tools/execute-tool';
+import type { RealtimeTool } from './session';
+
+/**
+ * Convert one tool's zod `inputSchema` to the plain JSON Schema the realtime
+ * `parameters` field carries. Same call the text stack's tool_search uses
+ * (`z.toJSONSchema`), so both surfaces describe a tool identically.
+ *
+ * Two things are load-bearing about zod v4's defaults here, both verified
+ * against this registry:
+ * - `reused: 'inline'` — schemas come back fully inlined, with no `$ref`/`$defs`.
+ *   The realtime API takes `parameters` standalone, with nowhere to hang a
+ *   definitions block, so a `$ref` would dangle.
+ * - `unrepresentable: 'throw'` — a `z.date()`/`z.bigint()`/`z.map()` in a tool
+ *   input throws rather than emitting a lie. That throw is deliberate and is
+ *   asserted against the real registry in the tests: a silently mis-described
+ *   parameter is worse than a loud failure at session build.
+ *
+ * The third default, `io: 'output'`, makes a field carrying a zod `.default()`
+ * come back as `required` — `execute_tool.parameters` is the live example. Left
+ * alone rather than switched to `io: 'input'`: the text stack renders the same
+ * schema the same way, and the only cost is that the model always sends the
+ * field explicitly instead of letting the default fill it in.
+ *
+ * `$schema` is dropped: it is a dialect annotation about the document, not part
+ * of the parameter contract, and OpenAI's own function schemas never carry it
+ * (strict schema validation rejects unsupported top-level keywords outright).
+ */
+function toRealtimeParameters(inputSchema: Tool['inputSchema']): Record<string, unknown> {
+  const parameters = { ...(z.toJSONSchema(inputSchema as z.ZodType) as Record<string, unknown>) };
+  delete parameters.$schema;
+  return parameters;
+}
+
+/**
+ * Realtime function tools are FLAT — `{ type, name, description, parameters }` —
+ * not nested under a `function` key the way Chat Completions nests them.
+ *
+ * A missing description degrades to `''` rather than omitting the key: the
+ * model loses the hint, but the definition stays structurally valid and the
+ * tool stays callable. Dropping the whole tool would silently shrink voice's
+ * capabilities relative to text.
+ *
+ * Exported for the registry-wide conversion guard: `buildRealtimeTools` only
+ * converts the upfront half, so testing through it alone would never touch a
+ * deferred tool's schema and an unrepresentable one could sit in the registry
+ * unnoticed until a caller went looking for it.
+ */
+export function toRealtimeTool(name: string, tool: Tool): RealtimeTool {
+  return {
+    type: 'function',
+    name,
+    description: tool.description ?? '',
+    parameters: toRealtimeParameters(tool.inputSchema),
+  };
+}
+
+/**
+ * Project a tool set onto the realtime tool definitions sent with the session.
+ *
+ * Emits the core tools with full schemas plus `tool_search` and `execute_tool`;
+ * everything else is reachable through those two, exactly as in the Global
+ * Assistant (`global-chat-turn.ts`). Front-loading every tool instead would
+ * spend the session's context on schemas before the caller has said a word.
+ *
+ * `splitToolsForExposure` is called with NO always-upfront set. That set exists
+ * to rescue composer-toggled tools (`web_search`, `generate_image`) from
+ * execute_tool's allowlist re-check on the text routes — a voice call has no
+ * composer toggles, so those tools defer like any other non-core tool and stay
+ * reachable through execute_tool.
+ *
+ * The scaffolding is built by the real factories rather than hand-written
+ * literals so the two tools cannot describe themselves differently to voice
+ * than to text. Only their name/description/parameters are read here; wiring
+ * their `execute` to the live call is the caller's job.
+ *
+ * `tool_search` receives the WHOLE set, not just the deferred half — core tools
+ * are directly callable, so letting the model look one up is harmless, and it
+ * matches the text stack's catalog.
+ */
+export function buildRealtimeTools(tools: ToolSet): readonly RealtimeTool[] {
+  const { coreTools, nonCoreTools } = splitToolsForExposure(tools);
+
+  const upfront: ToolSet = {
+    ...coreTools,
+    tool_search: createToolSearchTool(tools),
+    execute_tool: createExecuteTool(nonCoreTools),
+  };
+
+  return Object.entries(upfront).map(([name, tool]) => toRealtimeTool(name, tool));
+}


### PR DESCRIPTION
## What

`apps/web/src/lib/ai/realtime/tools.ts` — a pure adapter from PageSpace's AI SDK `ToolSet` to the flat `{type,name,description,parameters}` shape the realtime transport carries (`RealtimeTool`, imported from A1's `session.ts`).

Emits the core tools with full schemas plus `tool_search` and `execute_tool`; everything else defers behind those two.

## Why it reuses instead of curating

Voice is a second transport onto conversations PageSpace already has, not a second capability surface. So:

- the split is `splitToolsForExposure` — the same function the text stack uses;
- `tool_search`/`execute_tool` are built by the same factories the Global Assistant uses, so the two discovery tools cannot describe themselves differently to voice than to text;
- schema conversion is the same `z.toJSONSchema` call `tool-search-tool.ts` already makes.

A curated "voice subset" would be a second tool surface that drifts every time a tool is added.

## Decisions worth a look

- **No always-upfront set.** `ALWAYS_UPFRONT_TOOLS` rescues composer-toggled tools (`web_search`, `generate_image`) from `execute_tool`'s allowlist re-check on the text routes. A voice call has no composer toggles, so they defer like anything else and stay reachable through `execute_tool`.
- **`$schema` is stripped** from `parameters`. It is a dialect annotation about the document, not part of the parameter contract, and OpenAI strict schema validation rejects unsupported top-level keywords.
- **`io: 'output'` left alone**, so a field carrying a zod `.default()` lands in `required` (`execute_tool.parameters` is the live example). The text stack renders it identically; the only cost is the model sending the field explicitly.
- **`toRealtimeTool` is exported.** `buildRealtimeTools` converts only the upfront half, so a registry-wide guard driven through it alone passes vacuously for the deferred majority — which is most of the registry. The guard drives the converter directly instead.

## Notes from the work

- `get_page_details` is listed in `CORE_TOOL_NAMES` but defined by no tool module anywhere in the repo. Nothing can be emitted for it, so the registry assertion expects `CORE_TOOL_NAMES ∩ registry` and pins the discrepancy explicitly. Pre-existing; `stub-tools.ts` is untouched.

## Verification

- 14 tests, **100% statements/branches/functions/lines** on `tools.ts`.
- **Mutation-checked, 8 mutations, each confirmed red then restored**: keep `$schema` (4 red) · drop the description fallback (1) · `type: 'function'` → `'tool'` (2) · pass `ALWAYS_UPFRONT_TOOLS` (3) · front-load everything (3) · drop `execute_tool` (4) · hand-write the `tool_search` description (1) · **`z.date()` added to a real deferred registry tool** (1 red, naming the culprit tool — this is the one that exposed and then proved the guard).
- `bun run typecheck` at the monorepo root: 15/15 other packages pass; `web` passes via the authoritative direct `cd apps/web && bun run typecheck` (exit 0) — turbo's parallel `build` wipes `.next/types` under the task and produces the known `TS6053` wall.
- `bun run lint` clean (the one warning is pre-existing in `useVoiceMode.ts`).
- `bun run --filter web test -- src/lib/ai/`: 3559 passed, 1 file failed — `activity-tools.test.ts`, which throws "Test database not reachable" before running any case.

Additive only: no existing file modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yZkd6fkVQ4bJVoUAqCHH4