### PR TITLE
fix: second agent pane disappears (broadcast race in handlePickAgent)

### DIFF
--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -788,7 +788,25 @@ export default function AgentPanes({
             sessionId,
           });
         }
-        const superseded = !isCurrent() || (showsSpinner && !stillMinting(nodeId, mint));
+        // The server's admit path binds the pane AND broadcasts
+        // workspace:nodes-updated BEFORE the HTTP response returns. That
+        // broadcast binds the pane to the new conversation, so by the time
+        // we check `stillMinting`, the node's target is no longer null and
+        // the check reads as "superseded" — even though nothing superseded
+        // it. Without this guard the cleanup below would DELETE the very
+        // conversation we just created, destroying the pane the user sees
+        // flash and then vanish. The first pane never hits this because it
+        // is placed by the initial-conversation effect, not handlePickAgent.
+        // Pages never hit it because bindPane is synchronous (no server
+        // round trip, no broadcast race).
+        const alreadyPlacedByServer =
+          nodeShowing(
+            useAgentWorkspaceStore.getState().workspaces[sessionId]?.nodes ?? [],
+            'chat',
+            conversationId,
+          ) !== undefined;
+        const superseded =
+          !isCurrent() || (showsSpinner && !stillMinting(nodeId, mint) && !alreadyPlacedByServer);
         if (showsSpinner) endMint(nodeId);
         if (superseded) {
           // A NEWER call for this node superseded this one, or the node was

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -640,6 +640,43 @@ describe('AgentPanes — the mint lifecycle', () => {
     await waitFor(() => expect(nodeShowingChat('new-id-1')).toBeDefined());
   });
 
+  it('does not clean up the conversation when the server broadcast binds the pane before the POST resolves', async () => {
+    let resolveMint!: (value: unknown) => void;
+    mockPost.mockReturnValue(new Promise((resolve) => (resolveMint = resolve)));
+    mockDel.mockResolvedValue({});
+    const withPicker = () => seat([rootNode, paneNode('n1', WS, 0, null)], []);
+    withPicker();
+    const user = userEvent.setup();
+    renderPanes({ initialConversation: null });
+
+    await user.click(await screen.findByText('Researcher'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+
+    // The server's admit path binds the pane AND broadcasts
+    // workspace:nodes-updated BEFORE the HTTP response returns. Simulate
+    // that broadcast arriving: the pane n1 is now bound to the new
+    // conversation.
+    act(() => {
+      useAgentWorkspaceStore.getState().applyRemoteUpdate({
+        workspaceId: WS,
+        rev: 2,
+        nodes: [
+          rootNode,
+          { nodeType: 'pane', id: 'n1', parentId: WS, position: 0, target: { kind: 'chat', id: 'new-id-1' } },
+        ],
+      });
+    });
+
+    // Now the POST resolves. Without the guard, stillMinting returns false
+    // (the pane is no longer unbound), so the code treats this as superseded
+    // and DELETEs the conversation — destroying the pane.
+    resolveMint({});
+
+    // The conversation is still in the tree, not cleaned up.
+    await waitFor(() => expect(nodeShowingChat('new-id-1')).toBeDefined());
+    expect(conversationDeletes().every((url) => !url.includes('new-id-1'))).toBe(true);
+  });
+
   it('cleans up the orphaned row when the pane is closed mid-mint', async () => {
     let resolveMint!: (value: unknown) => void;
     mockPost.mockReturnValue(new Promise((resolve) => (resolveMint = resolve)));


### PR DESCRIPTION
## Problem

Spawning a second+ agent/chat pane as a split causes it to flash briefly then disappear. No errors in server or browser console. Pages work fine.

## Root Cause

The server's `admit` path (`createConversationInSession` → `admitConversationNode`) binds the pane AND broadcasts `workspace:nodes-updated` **before** the HTTP response returns.

**The race:**
1. User picks agent in an unbound split pane
2. `beginMint` → spinner
3. POST creates conversation → server's `admit` binds pane → broadcasts
4. Broadcast arrives → pane briefly shows conversation
5. POST response arrives → `stillMinting(pane)` checks if pane is still unbound → it's not (server already bound it) → returns `false`
6. `superseded = true` → `cleanupOrphanedConversation(conv)` → DELETE → **pane disappears**

**Why the first pane works:** Placed by the `initialConversation` effect, not `handlePickAgent`.

**Why pages work:** `bindPane` is synchronous — no server POST, no `admit`, no broadcast race.

## Fix

Check if the conversation is already in the tree (placed by the server broadcast) before treating the mint as superseded:

```typescript
const alreadyPlacedByServer =
  nodeShowing(
    useAgentWorkspaceStore.getState().workspaces[sessionId]?.nodes ?? [],
    'chat',
    conversationId,
  ) !== undefined;
const superseded =
  !isCurrent() || (showsSpinner && !stillMinting(nodeId, mint) && !alreadyPlacedByServer);
```

If the server already bound the pane to our conversation, it's success — not supersession. `openConversation` then runs, finds the conversation already showing via `findShowing`, and just focuses it (no write).

## Test

Added regression test: `does not clean up the conversation when the server broadcast binds the pane before the POST resolves` — simulates the broadcast arriving mid-mint and asserts the conversation survives.

## Risk

Minimal. The guard only short-circuits the supersession path when the conversation we just created is already showing — which is success by definition. The actual supersession cases (pane closed mid-mint, newer pick for same node) are unaffected because the conversation won't be in the tree in those cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented successfully created conversations from being removed during a server-binding race.
  * Improved reliability when a conversation is bound before its creation request finishes.

* **Tests**
  * Added regression coverage for conversation creation during server workspace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->