### PR TITLE
feat(voice): price gpt-realtime token usage and add realtime session constants

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-pricing.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-pricing.test.ts
@@ -44,3 +44,74 @@ describe('MACHINE_MARKUP_BPS floor clamp', () => {
     expect(MACHINE_MARKUP_BPS).toBe(15000);
   });
 });
+
+describe('realtime session constants', () => {
+  const KEYS = [
+    'REALTIME_SESSION_HOLD_ESTIMATE_CENTS',
+    'REALTIME_MAX_SESSION_SECONDS',
+    'REALTIME_IDLE_TIMEOUT_SECONDS',
+    'REALTIME_MAX_INFLIGHT',
+    'REALTIME_MAX_GLOBAL_SESSIONS',
+    'CREDIT_HOLD_TTL_SECONDS',
+  ];
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of KEYS) delete process.env[key];
+  });
+
+  it('defaults: 10c hold, 600s max session, 120s idle, 2 per user, 8 global', async () => {
+    const c = await import('../credit-pricing');
+    expect(c.REALTIME_SESSION_HOLD_ESTIMATE_CENTS).toBe(10);
+    expect(c.REALTIME_MAX_SESSION_SECONDS).toBe(600);
+    expect(c.REALTIME_IDLE_TIMEOUT_SECONDS).toBe(120);
+    expect(c.REALTIME_MAX_INFLIGHT).toBe(2);
+    expect(c.REALTIME_MAX_GLOBAL_SESSIONS).toBe(8);
+  });
+
+  it('keeps a session shorter than the hold TTL, so the reconcile cron cannot sweep a live call', async () => {
+    // The load-bearing invariant behind REALTIME_MAX_SESSION_SECONDS' default: a
+    // session that outlived CREDIT_HOLD_TTL_SECONDS would have its own reservation
+    // reclaimed mid-call. Raising the cap requires raising the TTL in the same change.
+    const { REALTIME_MAX_SESSION_SECONDS, CREDIT_HOLD_TTL_SECONDS } = await import(
+      '../credit-pricing'
+    );
+    expect(REALTIME_MAX_SESSION_SECONDS).toBeLessThan(CREDIT_HOLD_TTL_SECONDS);
+    // ...with a real settle margin, not merely one second under.
+    expect(CREDIT_HOLD_TTL_SECONDS - REALTIME_MAX_SESSION_SECONDS).toBeGreaterThanOrEqual(300);
+  });
+
+  it('reaps an idle session well before the hard duration cap fires', async () => {
+    const { REALTIME_IDLE_TIMEOUT_SECONDS, REALTIME_MAX_SESSION_SECONDS } = await import(
+      '../credit-pricing'
+    );
+    expect(REALTIME_IDLE_TIMEOUT_SECONDS).toBeLessThan(REALTIME_MAX_SESSION_SECONDS);
+  });
+
+  it('caps global concurrency at or under what 40,000 tokens/min supports', async () => {
+    // PROVEN: the OpenAI account is limited to 40k tokens/min across ALL sessions on
+    // our key. A continuously-talking session burns roughly 4k tokens/min, so the
+    // global cap must stay at or below ~10 or we throttle calls already in progress.
+    const { REALTIME_MAX_GLOBAL_SESSIONS } = await import('../credit-pricing');
+    expect(REALTIME_MAX_GLOBAL_SESSIONS).toBeLessThanOrEqual(40_000 / 4_000);
+    expect(REALTIME_MAX_GLOBAL_SESSIONS).toBeGreaterThan(0);
+  });
+
+  it('allows more than one session per user so a zombie session is not a lockout', async () => {
+    const { REALTIME_MAX_INFLIGHT, REALTIME_MAX_GLOBAL_SESSIONS } = await import(
+      '../credit-pricing'
+    );
+    expect(REALTIME_MAX_INFLIGHT).toBeGreaterThanOrEqual(2);
+    expect(REALTIME_MAX_INFLIGHT).toBeLessThan(REALTIME_MAX_GLOBAL_SESSIONS);
+  });
+
+  it('takes env overrides, and ignores garbage in favour of the documented default', async () => {
+    process.env.REALTIME_MAX_SESSION_SECONDS = '300';
+    process.env.REALTIME_MAX_GLOBAL_SESSIONS = 'nope';
+    const { REALTIME_MAX_SESSION_SECONDS, REALTIME_MAX_GLOBAL_SESSIONS } = await import(
+      '../credit-pricing'
+    );
+    expect(REALTIME_MAX_SESSION_SECONDS).toBe(300);
+    expect(REALTIME_MAX_GLOBAL_SESSIONS).toBe(8);
+  });
+});

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -120,6 +120,75 @@ export const VOICE_HOLD_ESTIMATE_CENTS = envInt('VOICE_HOLD_ESTIMATE_CENTS', 2);
 export const VOICE_MAX_INFLIGHT = envInt('VOICE_MAX_INFLIGHT', 4);
 
 /**
+ * Per-SESSION hold estimate for an audio-native realtime call. Realtime differs from
+ * every other hold in this file in a way that lets it be small: usage arrives
+ * INCREMENTALLY, as a `usage` object on each `response.done`, so the session settles
+ * continuously as it talks rather than once at the end. The hold therefore only has to
+ * cover the window between settles plus the session's opening moments — not the whole
+ * call — and a long conversation is billed as it happens instead of arriving as one
+ * surprise at hangup.
+ *
+ * 10¢ is roughly 1.5–2 minutes of live conversation at the 1.5x markup (a chatty minute
+ * runs a few cents of real cost, dominated by audio output at $64/1M tokens). Like every
+ * hold here it is an ESTIMATE, not a cap: the real cost always settles exactly via
+ * consumeCredits, {@link REALTIME_MAX_SESSION_SECONDS} bounds the tail of a single
+ * session, and {@link REALTIME_MAX_INFLIGHT} bounds concurrent overdraw. Tune via env.
+ */
+export const REALTIME_SESSION_HOLD_ESTIMATE_CENTS = envInt('REALTIME_SESSION_HOLD_ESTIMATE_CENTS', 10);
+
+/**
+ * Hard ceiling on a single realtime session's wall-clock duration — the backstop for a
+ * call nobody ever hangs up (a pinned-open tab with a hot mic bills for room noise:
+ * server VAD happily fires on ambient sound).
+ *
+ * The 600s default is NOT arbitrary — it is bounded by {@link CREDIT_HOLD_TTL_SECONDS}
+ * (900s), the age at which the reconcile cron may sweep a hold. A session allowed to
+ * outlive that would have its own reservation reclaimed out from under it mid-call. 600s
+ * leaves a 5-minute settle margin inside that TTL. Raising this REQUIRES raising the hold
+ * TTL in the same change; ten minutes is also a generous ceiling for one voice session,
+ * and starting another call is free.
+ */
+export const REALTIME_MAX_SESSION_SECONDS = envInt('REALTIME_MAX_SESSION_SECONDS', 600);
+
+/**
+ * Reap a realtime session after this long with no conversational activity. Distinct from
+ * the hard duration cap: this catches the ABANDONED call — the user walked away or
+ * switched apps — which otherwise keeps a WebRTC session open, holds a concurrency slot,
+ * and streams ambient audio into a model that bills per input token. 120s is far longer
+ * than any natural pause in speech, so it cannot cut off someone who is merely thinking,
+ * while still freeing the slot promptly.
+ */
+export const REALTIME_IDLE_TIMEOUT_SECONDS = envInt('REALTIME_IDLE_TIMEOUT_SECONDS', 120);
+
+/**
+ * Max concurrent realtime sessions per user. Voice is physically exclusive — one mouth,
+ * one pair of ears — so the semantically "correct" cap is 1. The default is 2 on purpose:
+ * a call ends on hard refresh, but the server-side session record can linger until the
+ * idle reaper catches it, and a cap of 1 would lock the user out of reconnecting for up to
+ * {@link REALTIME_IDLE_TIMEOUT_SECONDS}. The spare slot makes a zombie session an
+ * annoyance instead of a lockout, while still refusing the many-simultaneous-calls
+ * overdraw that {@link VOICE_MAX_INFLIGHT} exists to prevent on the STT/TTS path.
+ */
+export const REALTIME_MAX_INFLIGHT = envInt('REALTIME_MAX_INFLIGHT', 2);
+
+/**
+ * Max concurrent realtime sessions across the WHOLE deployment — a ceiling the per-user
+ * cap structurally cannot enforce, because the binding constraint is not per user: the
+ * OpenAI account is rate-limited to 40,000 tokens/MINUTE (measured live via
+ * `rate_limits.updated`), shared by every session on our key. Past that ceiling OpenAI
+ * throttles, and the failure lands on whichever calls happen to be in flight — including
+ * calls that were already going fine. A global cap converts that into a clean refusal at
+ * session start.
+ *
+ * Sizing: a continuously-talking session burns roughly 4,000 tokens/min once audio in,
+ * audio out and replayed conversation context are counted, which puts the account ceiling
+ * near 10 concurrent sessions. The default of 8 leaves headroom, since a long model
+ * response bursts well above the average. Raise it only alongside the account's rate
+ * limit — this number is a fact about the OpenAI account, not a product decision.
+ */
+export const REALTIME_MAX_GLOBAL_SESSIONS = envInt('REALTIME_MAX_GLOBAL_SESSIONS', 8);
+
+/**
  * Flat per-call hold estimate for AI image generation. The real cost isn't known
  * until OpenRouter responds (it varies by image model and resolution), so the gate
  * reserves this approximate amount up front. A single image runs ~$0.05–0.10 real

--- a/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { calculateVoiceCostDollars, estimateVoiceHoldCents, VOICE_RATES } from '../voice-pricing';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  calculateVoiceCostDollars,
+  estimateVoiceHoldCents,
+  VOICE_RATES,
+  calculateRealtimeCostDollars,
+  REALTIME_RATES,
+  type RealtimeUsage,
+} from '../voice-pricing';
 
 describe('calculateVoiceCostDollars — Whisper STT', () => {
   it('bills 60s of audio at the published $0.006/min rate', () => {
@@ -71,5 +78,300 @@ describe('VOICE_RATES defaults pinned to OpenAI published audio pricing', () => 
   it('tts-1 = $15/1M chars, tts-1-hd = $30/1M chars', () => {
     expect(VOICE_RATES['tts-1'].usdPerChar).toBeCloseTo(15 / 1_000_000, 12);
     expect(VOICE_RATES['tts-1-hd'].usdPerChar).toBeCloseTo(30 / 1_000_000, 12);
+  });
+});
+
+/* ---------------------------------------------------------------- *
+ * REALTIME (audio-native) token pricing
+ * ---------------------------------------------------------------- */
+
+/** The exact `usage` object measured off a live `response.done` frame. */
+const MEASURED_USAGE: RealtimeUsage = {
+  total_tokens: 168,
+  input_tokens: 52,
+  output_tokens: 116,
+  input_token_details: {
+    text_tokens: 11,
+    audio_tokens: 41,
+    image_tokens: 0,
+    cached_tokens: 0,
+    cached_tokens_details: { text_tokens: 0, audio_tokens: 0, image_tokens: 0 },
+  },
+  output_token_details: { text_tokens: 30, audio_tokens: 86 },
+};
+
+describe('REALTIME_RATES defaults pinned to OpenAI published gpt-realtime pricing', () => {
+  const rates = REALTIME_RATES['gpt-realtime'];
+
+  it('input = $4 text / $32 audio / $5 image per 1M tokens', () => {
+    expect(rates.input.text).toBeCloseTo(4 / 1_000_000, 12);
+    expect(rates.input.audio).toBeCloseTo(32 / 1_000_000, 12);
+    expect(rates.input.image).toBeCloseTo(5 / 1_000_000, 12);
+  });
+
+  it('cached input = $0.40 text / $0.40 audio / $0.50 image per 1M tokens', () => {
+    expect(rates.cachedInput.text).toBeCloseTo(0.4 / 1_000_000, 12);
+    expect(rates.cachedInput.audio).toBeCloseTo(0.4 / 1_000_000, 12);
+    expect(rates.cachedInput.image).toBeCloseTo(0.5 / 1_000_000, 12);
+  });
+
+  it('output = $24 text / $64 audio per 1M tokens', () => {
+    expect(rates.output.text).toBeCloseTo(24 / 1_000_000, 12);
+    expect(rates.output.audio).toBeCloseTo(64 / 1_000_000, 12);
+  });
+
+  it('models no cached or image rate on the OUTPUT side — caching is input-only', () => {
+    // Asymmetry guard: if someone ever "symmetrizes" this table, this fails.
+    expect(Object.keys(rates.output).sort()).toEqual(['audio', 'text']);
+  });
+
+  it('prices audio above text on both sides — per-modality metering is the whole point', () => {
+    expect(rates.input.audio).toBeGreaterThan(rates.input.text);
+    expect(rates.output.audio).toBeGreaterThan(rates.output.text);
+  });
+});
+
+describe('calculateRealtimeCostDollars — the measured usage object', () => {
+  it('sums the verbatim measured frame at published per-modality rates', () => {
+    // in : 11 text x $4/1M     = 0.000044
+    //      41 audio x $32/1M   = 0.001312
+    //       0 image            = 0
+    // out: 30 text x $24/1M    = 0.000720
+    //      86 audio x $64/1M   = 0.005504
+    //                    total = 0.007580
+    expect(calculateRealtimeCostDollars('gpt-realtime', MEASURED_USAGE)).toBe(0.00758);
+  });
+
+  it('is dominated by audio OUTPUT — the cost driver a blended total would hide', () => {
+    const audioOut = 86 * (64 / 1_000_000);
+    expect(audioOut / 0.00758).toBeGreaterThan(0.7);
+  });
+
+  it('prices input alone when the output details are absent', () => {
+    expect(
+      calculateRealtimeCostDollars('gpt-realtime', {
+        input_token_details: MEASURED_USAGE.input_token_details,
+      }),
+    ).toBe(0.001356);
+  });
+
+  it('prices output alone when the input details are absent', () => {
+    expect(
+      calculateRealtimeCostDollars('gpt-realtime', {
+        output_token_details: MEASURED_USAGE.output_token_details,
+      }),
+    ).toBe(0.006224);
+  });
+
+  it('bills 0 for a usage object carrying only totals — an unattributed token has no price', () => {
+    // input_tokens/output_tokens without a modality split cannot be priced (audio
+    // input is 8x text input); guessing would over-charge, so it bills nothing.
+    expect(
+      calculateRealtimeCostDollars('gpt-realtime', {
+        total_tokens: 168,
+        input_tokens: 52,
+        output_tokens: 116,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('calculateRealtimeCostDollars — cached input is a SUBSET, never double counted', () => {
+  it('bills the cached slice at the cached rate and the REMAINDER at the full input rate', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_tokens: 100,
+      input_token_details: {
+        audio_tokens: 100,
+        cached_tokens: 40,
+        cached_tokens_details: { audio_tokens: 40 },
+      },
+    });
+    // 40 cached x $0.40/1M + 60 fresh x $32/1M = 0.000016 + 0.001920
+    expect(cost).toBe(0.001936);
+  });
+
+  it('never bills the same token twice (the double-count guard)', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: {
+        audio_tokens: 100,
+        cached_tokens: 40,
+        cached_tokens_details: { audio_tokens: 40 },
+      },
+    });
+    const allAtFullRate = 100 * (32 / 1_000_000); // 0.0032
+    const doubleCounted = allAtFullRate + 40 * (0.4 / 1_000_000); // 0.003216
+    const allAtCachedRate = 100 * (0.4 / 1_000_000); // 0.00004
+
+    expect(cost).not.toBe(doubleCounted);
+    expect(cost).toBeLessThan(allAtFullRate);
+    expect(cost).toBeGreaterThan(allAtCachedRate);
+  });
+
+  it('clamps a cached count that overshoots its own modality, never going negative', () => {
+    // Malformed: 500 cached audio tokens out of 100 total. Unclamped this would
+    // make the fresh remainder -400 and subtract money from the bill.
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: {
+        audio_tokens: 100,
+        cached_tokens: 500,
+        cached_tokens_details: { audio_tokens: 500 },
+      },
+    });
+    expect(cost).toBe(0.00004); // all 100 at the cached rate, floor'd there
+    expect(cost).toBeGreaterThan(0);
+  });
+
+  it('prices image tokens, cached and fresh, at their own distinct rates', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: {
+        image_tokens: 1000,
+        cached_tokens: 200,
+        cached_tokens_details: { image_tokens: 200 },
+      },
+    });
+    // 200 x $0.50/1M + 800 x $5/1M = 0.0001 + 0.004
+    expect(cost).toBe(0.0041);
+  });
+
+  it('bills everything at the full rate when nothing is cached', () => {
+    expect(
+      calculateRealtimeCostDollars('gpt-realtime', {
+        input_token_details: { audio_tokens: 100, cached_tokens: 0 },
+      }),
+    ).toBe(0.0032);
+  });
+});
+
+describe('calculateRealtimeCostDollars — cached total with no modality breakdown', () => {
+  it('apportions the reported cached total across modalities by input share', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: { text_tokens: 50, audio_tokens: 50, cached_tokens: 50 },
+    });
+    // share = 50/100 -> 25 cached + 25 fresh of each modality:
+    // 25 x ($0.40 + $4 + $0.40 + $32)/1M = 25 x 36.8/1M
+    expect(cost).toBe(0.00092);
+  });
+
+  it('caps the apportioned share at 1 when the reported total overshoots the input', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: { audio_tokens: 100, cached_tokens: 999 },
+    });
+    expect(cost).toBe(0.00004); // all 100 cached, none double counted
+  });
+
+  it('bills nothing when a cached total is reported against no input tokens at all', () => {
+    expect(
+      calculateRealtimeCostDollars('gpt-realtime', { input_token_details: { cached_tokens: 40 } }),
+    ).toBe(0);
+  });
+
+  it('ignores an all-zero cached_tokens_details block and falls back to the reported total', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: {
+        audio_tokens: 100,
+        cached_tokens: 100,
+        cached_tokens_details: { text_tokens: 0, audio_tokens: 0, image_tokens: 0 },
+      },
+    });
+    expect(cost).toBe(0.00004);
+  });
+});
+
+describe('calculateRealtimeCostDollars — malformed input bills 0, never negative or NaN', () => {
+  it('returns 0 for an unpriced model even with a fully valid usage object', () => {
+    // gpt-realtime-2.1 is entitled on this key (a wss realtime socket opens fine); it
+    // simply has no row in the table yet, because it is not served over the WebRTC
+    // calls endpoint we use. Unpriced means billed 0, never billed at another
+    // model's rates.
+    expect(calculateRealtimeCostDollars('gpt-realtime-2.1', MEASURED_USAGE)).toBe(0);
+    expect(calculateRealtimeCostDollars('whisper-1', MEASURED_USAGE)).toBe(0);
+    expect(calculateRealtimeCostDollars('', MEASURED_USAGE)).toBe(0);
+  });
+
+  it('returns 0 for absent usage', () => {
+    expect(calculateRealtimeCostDollars('gpt-realtime', null)).toBe(0);
+    expect(calculateRealtimeCostDollars('gpt-realtime', undefined)).toBe(0);
+    expect(calculateRealtimeCostDollars('gpt-realtime', {})).toBe(0);
+  });
+
+  it('treats negative, NaN and Infinite counts as 0 rather than crediting the ledger', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: {
+        text_tokens: -100,
+        audio_tokens: Number.NaN,
+        image_tokens: Number.POSITIVE_INFINITY,
+      },
+      output_token_details: { text_tokens: -1, audio_tokens: 86 },
+    });
+    // Only the one valid quantity survives: 86 audio out x $64/1M.
+    expect(cost).toBe(0.005504);
+    expect(Number.isNaN(cost)).toBe(false);
+  });
+
+  it('never returns a negative charge from a fully malformed frame', () => {
+    const cost = calculateRealtimeCostDollars('gpt-realtime', {
+      input_token_details: {
+        audio_tokens: -50,
+        cached_tokens: -10,
+        cached_tokens_details: { audio_tokens: -10 },
+      },
+      output_token_details: { text_tokens: Number.NaN },
+    });
+    expect(cost).toBe(0);
+  });
+});
+
+describe('REALTIME_RATES env overrides', () => {
+  const KEYS = [
+    'REALTIME_INPUT_TEXT_USD_PER_TOKEN',
+    'REALTIME_INPUT_AUDIO_USD_PER_TOKEN',
+    'REALTIME_INPUT_IMAGE_USD_PER_TOKEN',
+    'REALTIME_CACHED_INPUT_TEXT_USD_PER_TOKEN',
+    'REALTIME_CACHED_INPUT_AUDIO_USD_PER_TOKEN',
+    'REALTIME_CACHED_INPUT_IMAGE_USD_PER_TOKEN',
+    'REALTIME_OUTPUT_TEXT_USD_PER_TOKEN',
+    'REALTIME_OUTPUT_AUDIO_USD_PER_TOKEN',
+  ];
+
+  // Rates resolve at module-import time, so each case re-imports the module.
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of KEYS) delete process.env[key];
+  });
+  afterEach(() => {
+    for (const key of KEYS) delete process.env[key];
+  });
+
+  it('applies a valid override, so the fallback cases below are not vacuous', async () => {
+    process.env.REALTIME_OUTPUT_AUDIO_USD_PER_TOKEN = '0.0001';
+    const { REALTIME_RATES: overridden, calculateRealtimeCostDollars: calc } = await import(
+      '../voice-pricing'
+    );
+    expect(overridden['gpt-realtime'].output.audio).toBe(0.0001);
+    expect(calc('gpt-realtime', { output_token_details: { audio_tokens: 100 } })).toBe(0.01);
+  });
+
+  it('falls back to the published default for a non-numeric override', async () => {
+    process.env.REALTIME_INPUT_AUDIO_USD_PER_TOKEN = 'garbage';
+    const { REALTIME_RATES: overridden } = await import('../voice-pricing');
+    expect(overridden['gpt-realtime'].input.audio).toBeCloseTo(32 / 1_000_000, 12);
+  });
+
+  it('falls back to the published default for a negative override', async () => {
+    process.env.REALTIME_OUTPUT_TEXT_USD_PER_TOKEN = '-1';
+    const { REALTIME_RATES: overridden } = await import('../voice-pricing');
+    expect(overridden['gpt-realtime'].output.text).toBeCloseTo(24 / 1_000_000, 12);
+  });
+
+  it('falls back to the published default for an empty override', async () => {
+    process.env.REALTIME_CACHED_INPUT_IMAGE_USD_PER_TOKEN = '   ';
+    const { REALTIME_RATES: overridden } = await import('../voice-pricing');
+    expect(overridden['gpt-realtime'].cachedInput.image).toBeCloseTo(0.5 / 1_000_000, 12);
+  });
+
+  it('honours an explicit zero rate (a free tier is a real price, not garbage)', async () => {
+    process.env.REALTIME_INPUT_TEXT_USD_PER_TOKEN = '0';
+    const { REALTIME_RATES: overridden } = await import('../voice-pricing');
+    expect(overridden['gpt-realtime'].input.text).toBe(0);
   });
 });

--- a/packages/lib/src/monitoring/voice-pricing.ts
+++ b/packages/lib/src/monitoring/voice-pricing.ts
@@ -21,6 +21,11 @@
  *
  * Rates are env-overridable so the founder can track an OpenAI price change without
  * a deploy. Defaults pinned to OpenAI's published audio pricing (see the unit test).
+ *
+ * The REALTIME section at the bottom of this file prices the audio-native path
+ * (`gpt-realtime`), which bills TOKENS per modality rather than seconds/characters.
+ * It is additive: the whisper/tts rates and behaviour above are untouched, because
+ * on-demand TTS (Read Aloud) is a separate feature that is NOT being retired.
  */
 
 import { MARKUP_BPS } from '../billing/credit-pricing';
@@ -88,4 +93,240 @@ export function estimateVoiceHoldCents(model: string, quantity: VoiceUsageQuanti
   const charged = calculateVoiceCostDollars(model, quantity) * (MARKUP_BPS / 10_000) * 100;
   if (!Number.isFinite(charged) || charged <= 0) return 1;
   return Math.max(1, Math.ceil(charged));
+}
+
+/* ------------------------------------------------------------------------- *
+ * REALTIME (audio-native) — token-metered, per modality.
+ *
+ * The STT/TTS path above bills a quantity we choose (seconds we uploaded,
+ * characters we sent). The realtime API instead REPORTS what it billed, as a
+ * `usage` object on every `response.done` — so here the exact quantity comes
+ * off the wire and this table only supplies the rate. Still deterministic,
+ * still real cost rather than an estimate.
+ *
+ * Three asymmetries in that wire shape are load-bearing and are modelled, not
+ * smoothed over:
+ *   1. Caching is INPUT-ONLY. There is no cached figure on the output side, so
+ *      the output rate type has no `cached` member to fill in wrongly.
+ *   2. `cached_tokens` is a SUBSET of `input_tokens`, not an addition. Cached
+ *      tokens are billed at the cached rate and only the REMAINDER at the full
+ *      input rate — billing both would double-count every cache hit.
+ *   3. Modality is the cost driver, not volume: one short spoken sentence
+ *      measured 30 text + 86 audio output tokens, and audio output is ~2.7x the
+ *      text rate. A single blended total would hide that entirely, so input and
+ *      output are each priced per modality and summed.
+ *
+ * Like the audio rates above this returns PRE-markup cost and is env-overridable
+ * per rate, so an OpenAI price change is an env change rather than a deploy.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Realtime models we can price. Deliberately a closed union: `OPENAI_REALTIME_MODEL`
+ * can point the app at a newer realtime model, but a model with no row here prices
+ * at 0 rather than being billed at another model's rates — so bumping that env var
+ * means adding its published rates here in the same change.
+ *
+ * Only `gpt-realtime` is listed because it is the only model the transport we use can
+ * currently reach. `gpt-realtime-2.1` IS entitled on this key — a
+ * `wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1` socket opens fine — but it
+ * is not yet SERVED over the WebRTC path: `POST /v1/realtime/calls` answers
+ * `403 model_not_found` for 2.1 where `gpt-realtime` returns 201. When 2.1 does reach
+ * that endpoint, it needs its own row here (its rates differ) before the env var moves.
+ */
+export type RealtimeModel = 'gpt-realtime';
+
+/** USD per token for each input modality. */
+export interface RealtimeInputRates {
+  text: number;
+  audio: number;
+  image: number;
+}
+
+/**
+ * USD per token for each output modality. No `image` (the model does not emit
+ * images) and no cached variant (see asymmetry 1 above) — the type refuses to
+ * describe a price that does not exist.
+ */
+export interface RealtimeOutputRates {
+  text: number;
+  audio: number;
+}
+
+export interface RealtimeModelRates {
+  input: RealtimeInputRates;
+  /** Cache-read rate, charged on the cached SUBSET of the input tokens. */
+  cachedInput: RealtimeInputRates;
+  output: RealtimeOutputRates;
+}
+
+/**
+ * Published `gpt-realtime` rates, in USD per TOKEN (OpenAI publishes per 1M):
+ *
+ *          input    cached input    output
+ *   text     $4         $0.40        $24
+ *   audio   $32         $0.40        $64
+ *   image    $5         $0.50          —
+ */
+export const REALTIME_RATES: Record<RealtimeModel, RealtimeModelRates> = {
+  'gpt-realtime': {
+    input: {
+      text: envFloat('REALTIME_INPUT_TEXT_USD_PER_TOKEN', 4 / 1_000_000),
+      audio: envFloat('REALTIME_INPUT_AUDIO_USD_PER_TOKEN', 32 / 1_000_000),
+      image: envFloat('REALTIME_INPUT_IMAGE_USD_PER_TOKEN', 5 / 1_000_000),
+    },
+    cachedInput: {
+      text: envFloat('REALTIME_CACHED_INPUT_TEXT_USD_PER_TOKEN', 0.4 / 1_000_000),
+      audio: envFloat('REALTIME_CACHED_INPUT_AUDIO_USD_PER_TOKEN', 0.4 / 1_000_000),
+      image: envFloat('REALTIME_CACHED_INPUT_IMAGE_USD_PER_TOKEN', 0.5 / 1_000_000),
+    },
+    output: {
+      text: envFloat('REALTIME_OUTPUT_TEXT_USD_PER_TOKEN', 24 / 1_000_000),
+      audio: envFloat('REALTIME_OUTPUT_AUDIO_USD_PER_TOKEN', 64 / 1_000_000),
+    },
+  },
+};
+
+/** Per-modality breakdown of the cached SUBSET of input tokens. */
+export interface RealtimeCachedTokenDetails {
+  text_tokens?: number;
+  audio_tokens?: number;
+  image_tokens?: number;
+}
+
+/** `usage.input_token_details` as it arrives on the wire. */
+export interface RealtimeInputTokenDetails extends RealtimeCachedTokenDetails {
+  /** Cached tokens — a SUBSET of `input_tokens`, already counted in the modality fields. */
+  cached_tokens?: number;
+  cached_tokens_details?: RealtimeCachedTokenDetails;
+}
+
+/** `usage.output_token_details` — no image, no cache (see asymmetry 1). */
+export interface RealtimeOutputTokenDetails {
+  text_tokens?: number;
+  audio_tokens?: number;
+}
+
+/**
+ * The `usage` object carried on every realtime `response.done`. Usage is per
+ * RESPONSE, not per call, so a session's cost is the sum over its responses —
+ * every field is optional because it comes off the wire and none of it is ours.
+ */
+export interface RealtimeUsage {
+  total_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  input_token_details?: RealtimeInputTokenDetails;
+  output_token_details?: RealtimeOutputTokenDetails;
+}
+
+/** Sanitize one wire token count: anything not a finite, non-negative number counts as 0. */
+function tokenCount(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+/**
+ * Sanitized token counts per input modality. Structurally identical to
+ * {@link RealtimeInputRates} but a distinct name, so a reader is never left
+ * wondering whether a given triple holds dollars or tokens.
+ */
+interface RealtimeInputTokens {
+  text: number;
+  audio: number;
+  image: number;
+}
+
+/**
+ * How many of each modality's input tokens were cache reads.
+ *
+ * Preferred source is `cached_tokens_details`, which splits the cached subset by
+ * modality directly; each modality is clamped to its own gross count so a
+ * malformed payload can never make the fresh remainder negative (which would
+ * subtract money from the bill).
+ *
+ * If that block is absent but a `cached_tokens` TOTAL is reported, the total is
+ * apportioned across modalities in proportion to their share of the input. The
+ * approximation is cheap to be wrong about: cached text and cached audio are the
+ * same rate ($0.40/1M), so the split only matters for the image slice, and
+ * ignoring the reported total instead would over-bill the customer for tokens
+ * OpenAI charged us a tenth of a cent for.
+ */
+function resolveCachedInputTokens(
+  details: RealtimeInputTokenDetails,
+  gross: RealtimeInputTokens,
+): RealtimeInputTokens {
+  const split = details.cached_tokens_details;
+  const detailed = {
+    text: tokenCount(split?.text_tokens),
+    audio: tokenCount(split?.audio_tokens),
+    image: tokenCount(split?.image_tokens),
+  };
+
+  if (detailed.text + detailed.audio + detailed.image > 0) {
+    return {
+      text: Math.min(detailed.text, gross.text),
+      audio: Math.min(detailed.audio, gross.audio),
+      image: Math.min(detailed.image, gross.image),
+    };
+  }
+
+  const reported = tokenCount(details.cached_tokens);
+  const grossTotal = gross.text + gross.audio + gross.image;
+  if (reported <= 0 || grossTotal <= 0) return { text: 0, audio: 0, image: 0 };
+
+  // min() keeps the share at or below 1, so no modality's cached slice can
+  // exceed its gross count even if the reported total overshoots the details.
+  const share = Math.min(reported, grossTotal) / grossTotal;
+  return { text: gross.text * share, audio: gross.audio * share, image: gross.image * share };
+}
+
+/**
+ * Real provider cost (USD, pre-markup) for ONE realtime response's `usage` object.
+ * A call's total is the sum across its responses, accumulated by whatever holds the
+ * server socket open for the session's lifetime.
+ *
+ * Returns 0 for an unknown model, absent usage, or quantities that are missing,
+ * negative or NaN — never a negative or NaN charge, so a malformed frame is billed
+ * nothing rather than corrupting the ledger.
+ *
+ * Cost is built strictly from the per-modality detail blocks; the `input_tokens` /
+ * `output_tokens` totals are deliberately NOT used as a fallback. A total with no
+ * modality attached cannot be priced (audio input costs 8x text input), and guessing
+ * a modality would over-charge the customer half the time — so an unattributed total
+ * bills 0 and the metering layer, which can see the whole session, is the right place
+ * to notice a payload that shape.
+ */
+export function calculateRealtimeCostDollars(
+  model: string,
+  usage: RealtimeUsage | null | undefined,
+): number {
+  const rates: RealtimeModelRates | undefined = REALTIME_RATES[model as RealtimeModel];
+  if (!rates || !usage) return 0;
+
+  let dollars = 0;
+
+  const input = usage.input_token_details;
+  if (input) {
+    const gross: RealtimeInputTokens = {
+      text: tokenCount(input.text_tokens),
+      audio: tokenCount(input.audio_tokens),
+      image: tokenCount(input.image_tokens),
+    };
+    const cached = resolveCachedInputTokens(input, gross);
+    // Cached at the cache-read rate, the REMAINDER at the full input rate —
+    // never both for the same token (see asymmetry 2).
+    dollars +=
+      cached.text * rates.cachedInput.text + (gross.text - cached.text) * rates.input.text;
+    dollars +=
+      cached.audio * rates.cachedInput.audio + (gross.audio - cached.audio) * rates.input.audio;
+    dollars +=
+      cached.image * rates.cachedInput.image + (gross.image - cached.image) * rates.input.image;
+  }
+
+  const output = usage.output_token_details;
+  if (output) {
+    dollars += tokenCount(output.text_tokens) * rates.output.text;
+    dollars += tokenCount(output.audio_tokens) * rates.output.audio;
+  }
+
+  return Number(dollars.toFixed(6));
 }


### PR DESCRIPTION
Third leaf of the audio-native voice epic. Realtime bills **tokens per modality**, not audio-seconds and characters, so it needs its own table beside the existing whisper/tts rates.

Rates measured against the live API in the W0 spike, not guessed — including the `usage` shape, which is **not** the Chat Completions shape (`input_tokens`/`output_tokens`, with per-modality detail nested one level down).

Three asymmetries built against rather than around:
- **Caching is input-only** — there is no cached figure on the output side, and the rate type refuses to model one.
- **`cached_tokens` is a SUBSET of `input_tokens`**, so cached is billed at the cached rate and only the *remainder* at the full rate. Double-counting here would silently overcharge every call.
- Audio output dominates cost (86 audio vs 30 text tokens for one short spoken sentence), so metering is per-modality — a single total would hide the actual cost driver.

Also adds realtime session constants (hold estimate, max duration, idle timeout, concurrency cap) — the account's measured ceiling is 40,000 tokens/min, so unbounded concurrent calls would hit it.

Verification: 52 tests pass; rates asserted against published figures. Mutation-checked the double-count guard — replacing `(gross − cached)` with `gross` turns 6 tests red.

Additive only: the existing whisper/tts rates and behavior are untouched, because open PR #2173 (Read Aloud) depends on the tts path.