### PR TITLE
fix(voice): pin gpt-realtime-2.1 now that the project allowlists it

### DIFF
--- a/apps/web/src/lib/ai/realtime/__tests__/session.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/session.test.ts
@@ -25,9 +25,11 @@ describe('buildSessionConfig', () => {
     const { session } = buildSessionConfig();
     expect(session.type).toBe('realtime');
     expect(session.model).toBe(DEFAULT_REALTIME_MODEL);
-    // Not gpt-realtime-2.1: access is per-account and /v1/realtime/calls 403s
-    // at connect time, so the default is the model this account can reach.
-    expect(DEFAULT_REALTIME_MODEL).toBe('gpt-realtime');
+    // Pinned: access is per-account and /v1/realtime/calls 403s at connect time
+    // for an unentitled model, so a change here must be verified against that
+    // endpoint (mint returns 200 regardless) and overridden per-environment via
+    // OPENAI_REALTIME_MODEL rather than edited.
+    expect(DEFAULT_REALTIME_MODEL).toBe('gpt-realtime-2.1');
   });
 
   it('given speech output, should set the default voice', () => {
@@ -41,7 +43,7 @@ describe('buildSessionConfig', () => {
     expect(buildSessionConfig()).toEqual({
       session: {
         type: 'realtime',
-        model: 'gpt-realtime',
+        model: 'gpt-realtime-2.1',
         audio: { output: { voice: 'marin' } },
         tools: [],
         tool_choice: 'auto',

--- a/apps/web/src/lib/ai/realtime/session.ts
+++ b/apps/web/src/lib/ai/realtime/session.ts
@@ -11,15 +11,20 @@
  */
 
 /**
- * `gpt-realtime`, not `gpt-realtime-2.1`, because model access is per-account:
- * `client_secrets` accepts ANY model string and mints a secret, then
- * `/v1/realtime/calls` 403s `model_not_found` at connect time if the account
- * lacks it — so a wrong default fails late, mid-connect, not at config time.
- * This account 403s on `gpt-realtime-2.1` and 201s on `gpt-realtime`, and the
- * working prototype runs `gpt-realtime` too. Move to 2.1 by setting
- * OPENAI_REALTIME_MODEL once the account has it, rather than editing this.
+ * Model access is per-account, and it fails LATE: `client_secrets` accepts any
+ * model string and mints a secret, then `/v1/realtime/calls` 403s
+ * `model_not_found` at connect time if the project lacks it. So mint success is
+ * never proof of model access — surface model-config errors from the calls
+ * response, not the mint response. (A plain `wss://…?model=X` socket opens even
+ * for an unentitled model, so it is useless as a probe; `GET /v1/models` and
+ * `/v1/realtime/calls` are the reliable signals.)
+ *
+ * `gpt-realtime-2.1` was not on this project until it was added to the
+ * allowlist; `/v1/realtime/calls` now returns 201 for it, verified with a real
+ * browser SDP offer. Override per-environment with OPENAI_REALTIME_MODEL rather
+ * than editing this — a deployment whose project lacks 2.1 needs `gpt-realtime`.
  */
-export const DEFAULT_REALTIME_MODEL = 'gpt-realtime';
+export const DEFAULT_REALTIME_MODEL = 'gpt-realtime-2.1';
 export const REALTIME_VOICE = 'marin';
 
 /** The env var that overrides the model, named once so callers can't drift. */


### PR DESCRIPTION
Follow-up to #2387. The default was `gpt-realtime` because `/v1/realtime/calls` returned `403 model_not_found` for 2.1 — a genuine entitlement gap, not a bad model id. 2.1 has since been added to the project allowlist: `GET /v1/models` now lists `gpt-realtime-2.1` and `gpt-realtime-2.1-mini`, and the WebRTC calls endpoint returns **201**, verified with a real browser SDP offer on the same key.

Keeps two hard-won lessons in the comment:
- **Mint success is not proof of model access** — `client_secrets` returns 200 for a model `/v1/realtime/calls` will reject, so model-config errors must be surfaced from the calls response.
- **A plain `wss://…?model=X` socket opens even for an unentitled model**, so it is useless as an entitlement probe. Only `GET /v1/models` and `/v1/realtime/calls` are reliable.

`OPENAI_REALTIME_MODEL` remains the per-environment override — a deployment whose project lacks 2.1 still needs `gpt-realtime`.

Verification: 82 tests pass, `tsc --noEmit` clean.