### PR TITLE
feat(voice): get our server onto the realtime call, authenticated, and hold it

### DIFF
--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -231,6 +231,20 @@ vi.mock('../kick-handler', () => ({
   handleKickRequest: mockHandleKickRequest,
 }));
 
+// The voice attach endpoint receives a LIVE OpenAI ephemeral credential, so
+// what is asserted here is the wiring — that the signature gate runs before the
+// handler sees the body — not the handler's own behaviour (that has its own
+// suite). Mocked so no socket is ever opened by these tests.
+const mockHandleRealtimeAttachRequest = vi.fn().mockResolvedValue({
+  status: 200,
+  body: { success: true, callId: 'rtc_test' },
+});
+
+vi.mock('../voice/attach-handler', () => ({
+  handleRealtimeAttachRequest: mockHandleRealtimeAttachRequest,
+  defaultAttachHandlerDeps: { registry: {}, attach: vi.fn() },
+}));
+
 // ---------------------------------------------------------------------------
 // 2. Mock http.createServer and Socket.IO Server to capture callbacks
 // ---------------------------------------------------------------------------
@@ -697,6 +711,102 @@ describe('requestListener - /api/kick', () => {
 
     expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
     expect(mockHandleKickRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('requestListener - /api/realtime/attach', () => {
+  const attachBody = JSON.stringify({
+    callId: 'rtc_abc123',
+    secret: 'ek_secret_value',
+    userId: 'u1',
+    tools: [],
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHandleRealtimeAttachRequest.mockResolvedValue({
+      status: 200,
+      body: { success: true, callId: 'rtc_abc123' },
+    });
+  });
+
+  it('given a valid signature, should delegate the RAW body to the attach handler', async () => {
+    vi.mocked(verifyBroadcastSignature).mockReturnValue(true);
+
+    const req = createMockReq({
+      method: 'POST',
+      url: '/api/realtime/attach',
+      headers: { 'x-broadcast-signature': 'valid-sig' },
+    });
+    const res = createMockRes();
+
+    capturedRequestListener!(req, res);
+    req._emit('data', Buffer.from(attachBody));
+    req._emit('end');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // The raw body, byte for byte — it is what the HMAC was computed over.
+    expect(mockHandleRealtimeAttachRequest).toHaveBeenCalledWith(expect.anything(), attachBody);
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+  });
+
+  it('given NO signature, should 401 without the handler ever seeing the secret', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      url: '/api/realtime/attach',
+      headers: {},
+    });
+    const res = createMockRes();
+
+    capturedRequestListener!(req, res);
+    req._emit('data', Buffer.from(attachBody));
+    req._emit('end');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    expect(mockHandleRealtimeAttachRequest).not.toHaveBeenCalled();
+  });
+
+  it('given an INVALID signature, should 401 without the handler ever seeing the secret', async () => {
+    vi.mocked(verifyBroadcastSignature).mockReturnValue(false);
+
+    const req = createMockReq({
+      method: 'POST',
+      url: '/api/realtime/attach',
+      headers: { 'x-broadcast-signature': 'forged-sig' },
+    });
+    const res = createMockRes();
+
+    capturedRequestListener!(req, res);
+    req._emit('data', Buffer.from(attachBody));
+    req._emit('end');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    expect(mockHandleRealtimeAttachRequest).not.toHaveBeenCalled();
+  });
+
+  it('given the handler rejects, should 500 rather than leaving the request hanging', async () => {
+    vi.mocked(verifyBroadcastSignature).mockReturnValue(true);
+    mockHandleRealtimeAttachRequest.mockRejectedValue(new Error('boom'));
+
+    const req = createMockReq({
+      method: 'POST',
+      url: '/api/realtime/attach',
+      headers: { 'x-broadcast-signature': 'valid-sig' },
+    });
+    const res = createMockRes();
+
+    capturedRequestListener!(req, res);
+    req._emit('data', Buffer.from(attachBody));
+    req._emit('end');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(res.writeHead).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
   });
 });
 

--- a/apps/realtime/src/__tests__/realtime-attach-handler.test.ts
+++ b/apps/realtime/src/__tests__/realtime-attach-handler.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Attach-endpoint admission tests: what gets in, what is refused, and what the
+ * registry looks like afterwards. The attach itself is injected, so no socket
+ * is opened.
+ *
+ * The signature gate is NOT tested here — it lives in `index.ts`, ahead of this
+ * handler, and is covered against the real wiring in `index.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    realtime: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import { handleRealtimeAttachRequest, type AttachHandlerDeps } from '../voice/attach-handler';
+import { RealtimeCallRegistry } from '../voice/realtime-call-registry';
+import {
+  RealtimeAttachError,
+  type AttachOptions,
+  type RealtimeCallSession,
+} from '../voice/realtime-call-session';
+
+const VALID = {
+  callId: 'rtc_u0_abc',
+  secret: 'ek_live_secret',
+  userId: 'u1',
+  conversationId: 'conv1',
+  tools: [{ type: 'function', name: 'read_page', description: 'Read.', parameters: {} }],
+};
+
+function fakeSession(options: AttachOptions): RealtimeCallSession {
+  let ended = false;
+  return {
+    callId: options.callId,
+    userId: options.userId,
+    conversationId: options.conversationId,
+    subscribe: () => () => {},
+    send: vi.fn(),
+    end: vi.fn(() => {
+      ended = true;
+    }),
+    get ended() {
+      return ended;
+    },
+  };
+}
+
+function deps(overrides: Partial<AttachHandlerDeps> = {}): AttachHandlerDeps {
+  return {
+    registry: new RealtimeCallRegistry(),
+    attach: vi.fn(async (options: AttachOptions) => fakeSession(options)),
+    ...overrides,
+  };
+}
+
+describe('handleRealtimeAttachRequest — admission', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a valid payload, should attach and register the call', async () => {
+    const d = deps();
+    const result = await handleRealtimeAttachRequest(d, JSON.stringify(VALID));
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: true, callId: VALID.callId });
+    expect(d.registry.get(VALID.callId)?.userId).toBe('u1');
+  });
+
+  it('given a valid payload, should pass the secret and tools straight through to the attach', async () => {
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    await handleRealtimeAttachRequest(deps({ attach }), JSON.stringify(VALID));
+
+    expect(attach).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: VALID.callId,
+        secret: VALID.secret,
+        userId: 'u1',
+        conversationId: 'conv1',
+        tools: VALID.tools,
+      }),
+    );
+  });
+
+  it('given no conversationId, should still attach — binding state must not gate a call', async () => {
+    const { conversationId: _omitted, ...withoutConversation } = VALID;
+    const result = await handleRealtimeAttachRequest(
+      deps(),
+      JSON.stringify(withoutConversation),
+    );
+
+    expect(result.status).toBe(200);
+  });
+
+  it('given malformed JSON, should 400', async () => {
+    const result = await handleRealtimeAttachRequest(deps(), 'not json');
+    expect(result.status).toBe(400);
+    expect(result.body).toEqual({ success: false, error: 'Invalid JSON' });
+  });
+
+  it('given an API key where the ephemeral secret belongs, should 400 with a message naming the requirement', async () => {
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    const result = await handleRealtimeAttachRequest(
+      deps({ attach }),
+      JSON.stringify({ ...VALID, secret: 'sk-proj-an-api-key' }),
+    );
+
+    expect(result.status).toBe(400);
+    expect(result.body).toMatchObject({ success: false });
+    expect((result.body as { error: string }).error).toContain('ephemeral');
+    // Refused at the boundary — no socket is opened for a credential that
+    // cannot possibly address a call.
+    expect(attach).not.toHaveBeenCalled();
+  });
+
+  it('given a session id where the call id belongs, should 400 rather than attach to nothing', async () => {
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    const result = await handleRealtimeAttachRequest(
+      deps({ attach }),
+      JSON.stringify({ ...VALID, callId: 'sess_u0_abc' }),
+    );
+
+    expect(result.status).toBe(400);
+    expect((result.body as { error: string }).error).toContain('rtc_');
+    expect(attach).not.toHaveBeenCalled();
+  });
+
+  it('given a missing userId, should 400', async () => {
+    const { userId: _omitted, ...withoutUser } = VALID;
+    const result = await handleRealtimeAttachRequest(deps(), JSON.stringify(withoutUser));
+    expect(result.status).toBe(400);
+  });
+
+  it('given no tools key, should default to an empty tool set rather than refuse', async () => {
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    const { tools: _omitted, ...withoutTools } = VALID;
+
+    const result = await handleRealtimeAttachRequest(
+      deps({ attach }),
+      JSON.stringify(withoutTools),
+    );
+
+    expect(result.status).toBe(200);
+    expect(attach).toHaveBeenCalledWith(expect.objectContaining({ tools: [] }));
+  });
+
+  it('given the concurrency cap is reached, should 429 without attaching', async () => {
+    const registry = new RealtimeCallRegistry(1);
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    const d = deps({ registry, attach });
+
+    const first = await handleRealtimeAttachRequest(d, JSON.stringify(VALID));
+    expect(first.status).toBe(200);
+
+    const second = await handleRealtimeAttachRequest(
+      d,
+      JSON.stringify({ ...VALID, callId: 'rtc_second' }),
+    );
+
+    expect(second.status).toBe(429);
+    expect(attach).toHaveBeenCalledTimes(1);
+  });
+
+  it('given SIMULTANEOUS attaches against a cap of one, should admit exactly one', async () => {
+    // The race the reservation exists for: both requests reach the cap check
+    // before either finishes attaching, so a check-then-await-then-register
+    // cap would admit both.
+    const registry = new RealtimeCallRegistry(1);
+    let release: (() => void) | undefined;
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const attach = vi.fn(async (options: AttachOptions) => {
+      await inFlight;
+      return fakeSession(options);
+    });
+    const d = deps({ registry, attach });
+
+    const both = Promise.all([
+      handleRealtimeAttachRequest(d, JSON.stringify(VALID)),
+      handleRealtimeAttachRequest(d, JSON.stringify({ ...VALID, callId: 'rtc_second' })),
+    ]);
+    release?.();
+    const [a, b] = await both;
+
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual([200, 429]);
+    expect(attach).toHaveBeenCalledTimes(1);
+    expect(registry.size).toBe(1);
+  });
+
+  it('given a failed attach, should release its slot so the cap does not leak', async () => {
+    const registry = new RealtimeCallRegistry(1);
+    const failing = vi.fn(async () => {
+      throw new RealtimeAttachError('socket_error', 'nope');
+    });
+
+    const first = await handleRealtimeAttachRequest(deps({ registry, attach: failing }), JSON.stringify(VALID));
+    expect(first.status).toBe(502);
+    expect(registry.reserved).toBe(0);
+
+    // The cap must be usable again after a failure.
+    const second = await handleRealtimeAttachRequest(deps({ registry }), JSON.stringify(VALID));
+    expect(second.status).toBe(200);
+  });
+
+  it('given a rejected payload, should not consume a slot', async () => {
+    const registry = new RealtimeCallRegistry(1);
+    await handleRealtimeAttachRequest(deps({ registry }), 'not json');
+    await handleRealtimeAttachRequest(
+      deps({ registry }),
+      JSON.stringify({ ...VALID, secret: 'sk-api-key' }),
+    );
+
+    expect(registry.reserved).toBe(0);
+    expect(registry.atCapacity()).toBe(false);
+  });
+});
+
+describe('handleRealtimeAttachRequest — failures and teardown', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given the attach fails, should 502 with the named error and register nothing', async () => {
+    const registry = new RealtimeCallRegistry();
+    const attach = vi.fn(async () => {
+      throw new RealtimeAttachError(
+        'socket_closed_before_ready',
+        'Attach socket closed before ready.',
+      );
+    });
+
+    const result = await handleRealtimeAttachRequest(deps({ registry, attach }), JSON.stringify(VALID));
+
+    expect(result.status).toBe(502);
+    expect((result.body as { error: string }).error).toContain('closed before ready');
+    expect(registry.size).toBe(0);
+  });
+
+  it('given a non-Error throw, should still answer 502 rather than crash the endpoint', async () => {
+    const attach = vi.fn(async () => {
+      throw 'string failure';
+    });
+    const result = await handleRealtimeAttachRequest(deps({ attach }), JSON.stringify(VALID));
+    expect(result.status).toBe(502);
+  });
+
+  it('given the session closes later, should deregister via the onClosed the handler wired', async () => {
+    const registry = new RealtimeCallRegistry();
+    let closeIt: (() => void) | undefined;
+    const attach = vi.fn(async (options: AttachOptions) => {
+      closeIt = () => options.onClosed?.(options.callId);
+      return fakeSession(options);
+    });
+
+    await handleRealtimeAttachRequest(deps({ registry, attach }), JSON.stringify(VALID));
+    expect(registry.size).toBe(1);
+
+    closeIt?.();
+
+    expect(registry.size).toBe(0);
+  });
+
+  it('should never echo the secret back to the caller', async () => {
+    const d = deps();
+    const ok = await handleRealtimeAttachRequest(d, JSON.stringify(VALID));
+    const rejected = await handleRealtimeAttachRequest(
+      d,
+      JSON.stringify({ ...VALID, callId: 'nope' }),
+    );
+
+    expect(JSON.stringify(ok.body)).not.toContain(VALID.secret);
+    expect(JSON.stringify(rejected.body)).not.toContain(VALID.secret);
+  });
+
+  it('given two concurrent calls, should register both independently', async () => {
+    const registry = new RealtimeCallRegistry();
+    const d = deps({ registry });
+
+    await Promise.all([
+      handleRealtimeAttachRequest(d, JSON.stringify(VALID)),
+      handleRealtimeAttachRequest(d, JSON.stringify({ ...VALID, callId: 'rtc_two', userId: 'u2' })),
+    ]);
+
+    expect(registry.size).toBe(2);
+    expect(registry.get(VALID.callId)?.userId).toBe('u1');
+    expect(registry.get('rtc_two')?.userId).toBe('u2');
+  });
+});

--- a/apps/realtime/src/__tests__/realtime-call-registry.test.ts
+++ b/apps/realtime/src/__tests__/realtime-call-registry.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Registry tests. The registry is where a leaked call becomes a bill, so the
+ * cases that matter are the ones about entries NOT sticking around.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  RealtimeCallRegistry,
+  DEFAULT_MAX_CONCURRENT_CALLS,
+} from '../voice/realtime-call-registry';
+import type { RealtimeCallSession } from '../voice/realtime-call-session';
+
+function fakeSession(callId: string, userId = 'u1'): RealtimeCallSession {
+  let ended = false;
+  return {
+    callId,
+    userId,
+    conversationId: undefined,
+    subscribe: () => () => {},
+    send: vi.fn(),
+    end: vi.fn(() => {
+      ended = true;
+    }),
+    get ended() {
+      return ended;
+    },
+  };
+}
+
+describe('RealtimeCallRegistry', () => {
+  it('given a registered session, should find it by call id', () => {
+    const registry = new RealtimeCallRegistry();
+    const session = fakeSession('rtc_a');
+    registry.register(session);
+
+    expect(registry.get('rtc_a')).toBe(session);
+    expect(registry.size).toBe(1);
+    expect(registry.callIds()).toEqual(['rtc_a']);
+  });
+
+  it('given an unregister, should forget the call', () => {
+    const registry = new RealtimeCallRegistry();
+    registry.register(fakeSession('rtc_a'));
+    registry.unregister('rtc_a');
+
+    expect(registry.get('rtc_a')).toBeUndefined();
+    expect(registry.size).toBe(0);
+  });
+
+  it('given two calls, should keep their registry entries independent', () => {
+    const registry = new RealtimeCallRegistry();
+    const a = fakeSession('rtc_a', 'ua');
+    const b = fakeSession('rtc_b', 'ub');
+    registry.register(a);
+    registry.register(b);
+
+    registry.unregister('rtc_a');
+
+    expect(registry.get('rtc_a')).toBeUndefined();
+    expect(registry.get('rtc_b')).toBe(b);
+    expect(b.ended).toBe(false);
+  });
+
+  it('given a re-attach for the same call id, should end the old socket so only one bills', () => {
+    const registry = new RealtimeCallRegistry();
+    const first = fakeSession('rtc_a');
+    const second = fakeSession('rtc_a');
+    registry.register(first);
+    registry.register(second);
+
+    expect(first.end).toHaveBeenCalled();
+    expect(registry.get('rtc_a')).toBe(second);
+    expect(registry.size).toBe(1);
+  });
+
+  it('given the same session registered twice, should NOT end it', () => {
+    const registry = new RealtimeCallRegistry();
+    const session = fakeSession('rtc_a');
+    registry.register(session);
+    registry.register(session);
+
+    expect(session.end).not.toHaveBeenCalled();
+    expect(registry.size).toBe(1);
+  });
+
+  it('given calls for several users, should list one user\'s calls only', () => {
+    const registry = new RealtimeCallRegistry();
+    registry.register(fakeSession('rtc_a', 'ua'));
+    registry.register(fakeSession('rtc_b', 'ua'));
+    registry.register(fakeSession('rtc_c', 'ub'));
+
+    expect(registry.getForUser('ua').map((s) => s.callId)).toEqual(['rtc_a', 'rtc_b']);
+    expect(registry.getForUser('ub').map((s) => s.callId)).toEqual(['rtc_c']);
+    expect(registry.getForUser('nobody')).toEqual([]);
+  });
+
+  it('given the cap is reached, should report capacity — and free up as calls end', () => {
+    const registry = new RealtimeCallRegistry(2);
+    expect(registry.atCapacity()).toBe(false);
+
+    registry.register(fakeSession('rtc_a'));
+    expect(registry.atCapacity()).toBe(false);
+    registry.register(fakeSession('rtc_b'));
+    expect(registry.atCapacity()).toBe(true);
+
+    registry.unregister('rtc_a');
+    expect(registry.atCapacity()).toBe(false);
+  });
+
+  it('given a reserved slot, should count it toward capacity before any call registers', () => {
+    const registry = new RealtimeCallRegistry(1);
+
+    expect(registry.reserveSlot()).toBe(true);
+    expect(registry.reserved).toBe(1);
+    // Nothing is registered yet, and the registry is already full — this is the
+    // whole point: an in-flight attach occupies the cap.
+    expect(registry.size).toBe(0);
+    expect(registry.reserveSlot()).toBe(false);
+  });
+
+  it('given a released slot, should free the capacity again', () => {
+    const registry = new RealtimeCallRegistry(1);
+    registry.reserveSlot();
+    registry.releaseSlot();
+
+    expect(registry.reserved).toBe(0);
+    expect(registry.reserveSlot()).toBe(true);
+  });
+
+  it('given more releases than reserves, should not go negative and hand out phantom slots', () => {
+    const registry = new RealtimeCallRegistry(1);
+    registry.releaseSlot();
+    registry.releaseSlot();
+
+    expect(registry.reserved).toBe(0);
+    registry.register(fakeSession('rtc_a'));
+    expect(registry.atCapacity()).toBe(true);
+  });
+
+  it('given endAll, should end every call and empty the map', () => {
+    const registry = new RealtimeCallRegistry();
+    const a = fakeSession('rtc_a');
+    const b = fakeSession('rtc_b');
+    registry.register(a);
+    registry.register(b);
+
+    registry.endAll('shutdown');
+
+    expect(a.end).toHaveBeenCalledWith('shutdown');
+    expect(b.end).toHaveBeenCalledWith('shutdown');
+    expect(registry.size).toBe(0);
+  });
+
+  it('should default to a cap low enough to matter against a 40k tokens/min budget', () => {
+    expect(DEFAULT_MAX_CONCURRENT_CALLS).toBeGreaterThan(0);
+    expect(new RealtimeCallRegistry().atCapacity()).toBe(false);
+  });
+});

--- a/apps/realtime/src/__tests__/realtime-call-session.test.ts
+++ b/apps/realtime/src/__tests__/realtime-call-session.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Attach-socket tests. A fake socket stands in for the WebSocket everywhere, so
+ * nothing here touches the network.
+ *
+ * The two behaviours worth stating plainly, because both are counter-intuitive
+ * and both were measured against the live API:
+ * - readiness is `session.updated`, NEVER `session.created` (an attached socket
+ *   never sends the latter — the browser's data channel already consumed it);
+ * - the attach is authenticated by that call's own `ek_` ephemeral secret, and
+ *   an API key produces `404 call_id_not_found`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    realtime: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import {
+  attachToCall,
+  RealtimeAttachError,
+  REALTIME_ATTACH_URL,
+  type AttachSocket,
+  type AttachSocketFactory,
+} from '../voice/realtime-call-session';
+
+/** A socket whose every event can be driven from a test. */
+class FakeSocket implements AttachSocket {
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code?: number; reason?: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+
+  readonly sent: string[] = [];
+  closed = false;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** The frames the code under test sent, parsed. */
+  sentEvents(): Record<string, unknown>[] {
+    return this.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+  }
+
+  open(): void {
+    this.onopen?.(undefined);
+  }
+
+  receive(event: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(event) });
+  }
+
+  receiveRaw(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+}
+
+type Harness = {
+  readonly socket: FakeSocket;
+  readonly factory: AttachSocketFactory;
+  readonly urls: string[];
+  readonly headers: Record<string, string>[];
+};
+
+function harness(): Harness {
+  const socket = new FakeSocket();
+  const urls: string[] = [];
+  const headers: Record<string, string>[] = [];
+  const factory: AttachSocketFactory = (url, hdrs) => {
+    urls.push(url);
+    headers.push({ ...hdrs });
+    return socket;
+  };
+  return { socket, factory, urls, headers };
+}
+
+const CALL_ID = 'rtc_u0_test';
+const SECRET = 'ek_live_secret';
+
+const TOOLS = [
+  { type: 'function' as const, name: 'read_page', description: 'Read.', parameters: {} },
+];
+
+/** Attach and drive the socket to ready. */
+async function attachReady(h: Harness) {
+  const promise = attachToCall({
+    callId: CALL_ID,
+    secret: SECRET,
+    userId: 'u1',
+    tools: TOOLS,
+    socketFactory: h.factory,
+  });
+  h.socket.open();
+  h.socket.receive({ type: 'session.updated', session: {} });
+  return promise;
+}
+
+describe('attachToCall — credential', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given an API key instead of the ephemeral secret, should fail with a self-explaining named error and open NO socket', async () => {
+    const h = harness();
+    let opened = false;
+    const factory: AttachSocketFactory = (...args) => {
+      opened = true;
+      return h.factory(...args);
+    };
+
+    const error = await attachToCall({
+      callId: CALL_ID,
+      secret: 'sk-proj-an-api-key',
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: factory,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(RealtimeAttachError);
+    expect((error as RealtimeAttachError).code).toBe('ephemeral_secret_required');
+    // The message has to carry the fix, not just the fact.
+    expect((error as RealtimeAttachError).message).toContain('ek_');
+    expect((error as RealtimeAttachError).message).toContain('call_id_not_found');
+    expect(opened).toBe(false);
+  });
+
+  it('given the call secret, should authenticate with exactly Bearer <secret> on the call_id URL', async () => {
+    const h = harness();
+    await attachReady(h);
+
+    expect(h.headers[0]).toEqual({ Authorization: `Bearer ${SECRET}` });
+    expect(h.urls[0]).toBe(`${REALTIME_ATTACH_URL}?call_id=${CALL_ID}`);
+  });
+});
+
+describe('attachToCall — readiness', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given the socket opens, should push session.update carrying the tools', async () => {
+    const h = harness();
+    await attachReady(h);
+
+    const update = h.socket.sentEvents()[0];
+    expect(update.type).toBe('session.update');
+    expect((update.session as { tools: unknown[] }).tools).toEqual(TOOLS);
+  });
+
+  it('given session.created (never sent by a real attach) instead of session.updated, should NOT resolve', async () => {
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+    });
+
+    h.socket.open();
+    h.socket.receive({ type: 'session.created', session: {} });
+
+    const settled = await Promise.race([
+      promise.then(() => 'resolved'),
+      new Promise((r) => setTimeout(() => r('pending'), 10)),
+    ]);
+    expect(settled).toBe('pending');
+
+    // And it still resolves on the event that actually means ready.
+    h.socket.receive({ type: 'session.updated', session: {} });
+    await expect(promise).resolves.toMatchObject({ callId: CALL_ID });
+  });
+
+  it('given session.updated, should resolve a session carrying its identity', async () => {
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      conversationId: 'conv1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+    });
+    h.socket.open();
+    h.socket.receive({ type: 'session.updated', session: {} });
+
+    const session = await promise;
+    expect(session.callId).toBe(CALL_ID);
+    expect(session.userId).toBe('u1');
+    expect(session.conversationId).toBe('conv1');
+    expect(session.ended).toBe(false);
+  });
+
+  it('given session.update is rejected with an error event, should surface the upstream error and not report ready', async () => {
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+    });
+    h.socket.open();
+    h.socket.receive({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'unknown parameter' },
+    });
+
+    const error = await promise.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(RealtimeAttachError);
+    expect((error as RealtimeAttachError).code).toBe('session_update_rejected');
+    expect((error as RealtimeAttachError).upstream).toEqual({
+      type: 'invalid_request_error',
+      message: 'unknown parameter',
+    });
+  });
+
+  it('given the socket closes before ready, should name the ephemeral-secret cause', async () => {
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+    });
+    h.socket.onclose?.({ code: 1006 });
+
+    const error = await promise.catch((e: unknown) => e);
+    expect((error as RealtimeAttachError).code).toBe('socket_closed_before_ready');
+    expect((error as RealtimeAttachError).message).toContain('1006');
+    expect((error as RealtimeAttachError).message).toContain('ek_');
+  });
+
+  it('given the socket errors before ready, should reject with socket_error', async () => {
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+    });
+    h.socket.onerror?.(new Error('handshake failed'));
+
+    const error = await promise.catch((e: unknown) => e);
+    expect((error as RealtimeAttachError).code).toBe('socket_error');
+  });
+
+  it('given nothing ever arrives, should time out rather than hang forever', async () => {
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+      readyTimeoutMs: 5,
+    });
+    h.socket.open();
+
+    const error = await promise.catch((e: unknown) => e);
+    expect((error as RealtimeAttachError).code).toBe('attach_timeout');
+    // The message carries the fact that would otherwise be re-derived.
+    expect((error as RealtimeAttachError).message).toContain('session.created');
+  });
+});
+
+describe('attachToCall — event seam for B3/B4', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given subscribers, should fan every parsed event out to all of them', async () => {
+    const h = harness();
+    const session = await attachReady(h);
+
+    const seenA: unknown[] = [];
+    const seenB: unknown[] = [];
+    session.subscribe((e) => seenA.push(e));
+    session.subscribe((e) => seenB.push(e));
+
+    h.socket.receive({ type: 'response.done', response: { usage: { total_tokens: 7 } } });
+
+    expect(seenA).toEqual([{ type: 'response.done', response: { usage: { total_tokens: 7 } } }]);
+    expect(seenB).toEqual(seenA);
+  });
+
+  it('given unsubscribe, should stop delivering', async () => {
+    const h = harness();
+    const session = await attachReady(h);
+
+    const seen: unknown[] = [];
+    const off = session.subscribe((e) => seen.push(e));
+    h.socket.receive({ type: 'a' });
+    off();
+    h.socket.receive({ type: 'b' });
+
+    expect(seen).toEqual([{ type: 'a' }]);
+  });
+
+  it('given a subscriber that throws, should keep delivering to the others', async () => {
+    const h = harness();
+    const session = await attachReady(h);
+
+    const seen: unknown[] = [];
+    session.subscribe(() => {
+      throw new Error('bad subscriber');
+    });
+    session.subscribe((e) => seen.push(e));
+
+    expect(() => h.socket.receive({ type: 'a' })).not.toThrow();
+    expect(seen).toEqual([{ type: 'a' }]);
+  });
+
+  it('given a malformed frame, should ignore it instead of throwing into the socket', async () => {
+    const h = harness();
+    const session = await attachReady(h);
+
+    const seen: unknown[] = [];
+    session.subscribe((e) => seen.push(e));
+
+    expect(() => h.socket.receiveRaw('not json at all')).not.toThrow();
+    expect(() => h.socket.receiveRaw(new ArrayBuffer(4))).not.toThrow();
+    expect(seen).toEqual([]);
+  });
+
+  it('given send, should write the event as JSON — and stay silent once ended', async () => {
+    const h = harness();
+    const session = await attachReady(h);
+    const before = h.socket.sent.length;
+
+    session.send({ type: 'response.create' });
+    expect(JSON.parse(h.socket.sent[before])).toEqual({ type: 'response.create' });
+
+    session.end('test');
+    session.send({ type: 'response.create' });
+    expect(h.socket.sent.length).toBe(before + 1);
+  });
+});
+
+describe('attachToCall — teardown', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given the socket closes mid-call, should mark it ended and notify onClosed exactly once', async () => {
+    const h = harness();
+    const onClosed = vi.fn();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+      onClosed,
+    });
+    h.socket.open();
+    h.socket.receive({ type: 'session.updated', session: {} });
+    const session = await promise;
+
+    const closeHandler = h.socket.onclose;
+    closeHandler?.({ code: 1000 });
+
+    expect(session.ended).toBe(true);
+    expect(onClosed).toHaveBeenCalledTimes(1);
+    expect(onClosed).toHaveBeenCalledWith(CALL_ID);
+    expect(h.socket.closed).toBe(true);
+  });
+
+  it('given end() called twice, should tear down once and stay idempotent', async () => {
+    const h = harness();
+    const onClosed = vi.fn();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+      onClosed,
+    });
+    h.socket.open();
+    h.socket.receive({ type: 'session.updated', session: {} });
+    const session = await promise;
+
+    session.end('first');
+    session.end('second');
+
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it('given teardown, should drop subscribers so a late frame reaches nobody', async () => {
+    const h = harness();
+    const session = await attachReady(h);
+    const seen: unknown[] = [];
+    session.subscribe((e) => seen.push(e));
+
+    const deliverLate = h.socket.onmessage;
+    session.end('done');
+    deliverLate?.({ data: JSON.stringify({ type: 'response.done' }) });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('given the hard duration cap elapses, should end the call so it cannot bill silently', async () => {
+    const h = harness();
+    const onClosed = vi.fn();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+      onClosed,
+      maxDurationMs: 5,
+    });
+    h.socket.open();
+    h.socket.receive({ type: 'session.updated', session: {} });
+    const session = await promise;
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(session.ended).toBe(true);
+    expect(h.socket.closed).toBe(true);
+    expect(onClosed).toHaveBeenCalledWith(CALL_ID);
+  });
+
+  it('given a session that reached ready, should clear its timers so the process can exit', async () => {
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const h = harness();
+    const promise = attachToCall({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      tools: TOOLS,
+      socketFactory: h.factory,
+      clearTimeoutFn: clearTimeoutFn as unknown as typeof clearTimeout,
+    });
+    h.socket.open();
+    h.socket.receive({ type: 'session.updated', session: {} });
+    const session = await promise;
+    session.end('done');
+
+    // The ready timer is cleared on readiness; the duration timer on teardown.
+    expect(clearTimeoutFn).toHaveBeenCalled();
+  });
+});
+
+describe('attachToCall — concurrent calls', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given two calls attach at once, should keep their sockets and events independent', async () => {
+    const a = harness();
+    const b = harness();
+
+    const promiseA = attachToCall({
+      callId: 'rtc_a',
+      secret: 'ek_a',
+      userId: 'ua',
+      tools: TOOLS,
+      socketFactory: a.factory,
+    });
+    const promiseB = attachToCall({
+      callId: 'rtc_b',
+      secret: 'ek_b',
+      userId: 'ub',
+      tools: [],
+      socketFactory: b.factory,
+    });
+
+    a.socket.open();
+    b.socket.open();
+    a.socket.receive({ type: 'session.updated', session: {} });
+    b.socket.receive({ type: 'session.updated', session: {} });
+
+    const [sessionA, sessionB] = await Promise.all([promiseA, promiseB]);
+
+    expect(a.headers[0]).toEqual({ Authorization: 'Bearer ek_a' });
+    expect(b.headers[0]).toEqual({ Authorization: 'Bearer ek_b' });
+
+    const seenA: unknown[] = [];
+    const seenB: unknown[] = [];
+    sessionA.subscribe((e) => seenA.push(e));
+    sessionB.subscribe((e) => seenB.push(e));
+
+    a.socket.receive({ type: 'only.for.a' });
+
+    expect(seenA).toEqual([{ type: 'only.for.a' }]);
+    expect(seenB).toEqual([]);
+
+    // Ending one must not touch the other.
+    sessionA.end('done');
+    expect(sessionA.ended).toBe(true);
+    expect(sessionB.ended).toBe(false);
+    expect(b.socket.closed).toBe(false);
+  });
+});

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -53,6 +53,8 @@ import { buildShellCheckAuth } from './terminal/shell-access';
 import { deriveShellSessionKey } from './terminal/shell-session-key';
 import { handleShellReadRequest, handleShellSendRequest } from './terminal/shell-io';
 import { handleShellActivityRequest } from './terminal/shell-activity';
+import { VOICE_BRIDGE_ROUTES } from '@pagespace/lib/realtime/voice-bridge-contract';
+import { handleRealtimeAttachRequest, defaultAttachHandlerDeps } from './voice/attach-handler';
 import { checkAgentSessionAccess } from '@pagespace/lib/services/agent-workspaces/agent-workspace-access';
 import {
   resolveSessionTenantId,
@@ -954,6 +956,30 @@ const requestListener = (req: IncomingMessage, res: ServerResponse) => {
             const result = handleKickRequest(io, body);
             res.writeHead(result.status, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify(result.body));
+        });
+    } else if (req.method === 'POST' && req.url === VOICE_BRIDGE_ROUTES.attach) {
+        // Voice attach: the web tier hands over a live OpenAI realtime call so
+        // THIS process — which can hold a socket for the whole call, unlike a
+        // Next route handler — owns its tools, transcripts and metering.
+        //
+        // The body carries a live ephemeral OpenAI credential, so the signature
+        // check is not optional and runs before anything is parsed.
+        readCappedBody(body => {
+            const signatureHeader = req.headers['x-broadcast-signature'] as string;
+            if (!verifySignature(signatureHeader, body)) {
+                res.writeHead(401, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'Authentication failed' }));
+                return;
+            }
+
+            handleRealtimeAttachRequest(defaultAttachHandlerDeps, body).then((result) => {
+                res.writeHead(result.status, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(result.body));
+            }).catch((error: unknown) => {
+                loggers.realtime.error('Realtime attach request failed', error instanceof Error ? error : new Error(String(error)));
+                res.writeHead(500, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ success: false, error: 'Internal error' }));
+            });
         });
     } else {
         res.writeHead(404);

--- a/apps/realtime/src/voice/attach-handler.ts
+++ b/apps/realtime/src/voice/attach-handler.ts
@@ -1,0 +1,130 @@
+/**
+ * `POST /api/realtime/attach` — the web tier handing us a live call.
+ *
+ * The body carries a real OpenAI ephemeral credential, so this endpoint is at
+ * least as protected as `/api/broadcast`: the caller proves it is the web
+ * backend with an HMAC over the raw body, and that check runs in `index.ts`
+ * BEFORE this handler ever parses a field. Nothing here re-decides user access
+ * — the web tier already gated voice on the user's tier at the one policy site,
+ * exactly as the shell bridge does.
+ *
+ * The handler itself takes its dependencies as arguments and returns
+ * `{ status, body }`, the shape `shell-io.ts` established, so the whole
+ * admission path is testable without a socket, a signature, or a server.
+ */
+
+import {
+  realtimeAttachPayloadSchema,
+  type RealtimeAttachResult,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  attachToCall,
+  RealtimeAttachError,
+  type AttachOptions,
+  type RealtimeCallSession,
+} from './realtime-call-session';
+import { realtimeCallRegistry, type RealtimeCallRegistry } from './realtime-call-registry';
+
+export type AttachHandlerDeps = {
+  readonly registry: RealtimeCallRegistry;
+  readonly attach: (options: AttachOptions) => Promise<RealtimeCallSession>;
+};
+
+export const defaultAttachHandlerDeps: AttachHandlerDeps = {
+  registry: realtimeCallRegistry,
+  attach: attachToCall,
+};
+
+export type AttachHandlerResponse = {
+  readonly status: number;
+  readonly body: RealtimeAttachResult;
+};
+
+/**
+ * Validate, admit, attach, register.
+ *
+ * The failure statuses are chosen so the web tier can tell apart the three
+ * things it might do about them: 400 means the payload was wrong (fix the
+ * caller), 429 means we are full (retry later), 502 means OpenAI would not give
+ * us the session (the call is degraded, not the request). All three still let
+ * the browser keep a working audio call — web treats the whole handoff as
+ * best-effort — so the distinction exists for operators, not for control flow.
+ */
+export const handleRealtimeAttachRequest = async (
+  deps: AttachHandlerDeps,
+  rawBody: string,
+): Promise<AttachHandlerResponse> => {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawBody);
+  } catch {
+    return { status: 400, body: { success: false, error: 'Invalid JSON' } };
+  }
+
+  const parsed = realtimeAttachPayloadSchema.safeParse(json);
+  if (!parsed.success) {
+    // The message is reported but the payload is NOT logged: it held a secret.
+    const reason = parsed.error.issues[0]?.message ?? 'Invalid attach payload';
+    loggers.realtime.warn('Realtime attach payload rejected', { reason });
+    return { status: 400, body: { success: false, error: reason } };
+  }
+
+  const { callId, secret, userId, conversationId, tools } = parsed.data;
+
+  // Claimed synchronously, before the first `await`. Checking the live count
+  // and attaching afterwards would let every simultaneous request past a cap of
+  // one, because they would all observe the same pre-attach size.
+  if (!deps.registry.reserveSlot()) {
+    loggers.realtime.warn('Realtime attach refused: concurrent call cap reached', {
+      callId,
+      userId,
+      live: deps.registry.size,
+    });
+    return {
+      status: 429,
+      body: { success: false, error: 'Too many concurrent voice calls' },
+    };
+  }
+
+  try {
+    const session = await deps.attach({
+      callId,
+      secret,
+      userId,
+      conversationId,
+      tools,
+      // Deregistration is wired at attach time rather than after the await, so
+      // a socket that dies during the handshake cannot leave an entry behind.
+      onClosed: (id) => deps.registry.unregister(id),
+    });
+    deps.registry.register(session);
+
+    loggers.realtime.info('Realtime voice call attached', {
+      callId,
+      userId,
+      conversationId,
+      toolCount: tools.length,
+      live: deps.registry.size,
+    });
+    return { status: 200, body: { success: true, callId } };
+  } catch (error) {
+    const code = error instanceof RealtimeAttachError ? error.code : 'attach_failed';
+    loggers.realtime.error(
+      'Realtime voice attach failed',
+      error instanceof Error ? error : new Error(String(error)),
+      { callId, userId, code },
+    );
+    return {
+      status: 502,
+      body: {
+        success: false,
+        error: error instanceof Error ? error.message : 'Attach failed',
+      },
+    };
+  } finally {
+    // Released on every path: the slot's job ended the moment the call either
+    // entered the registry (where it is now counted) or failed to.
+    deps.registry.releaseSlot();
+  }
+};

--- a/apps/realtime/src/voice/realtime-call-registry.ts
+++ b/apps/realtime/src/voice/realtime-call-registry.ts
@@ -1,0 +1,114 @@
+/**
+ * Live voice calls, keyed by `rtc_…` call id.
+ *
+ * The lookup table the rest of the voice plane addresses through: B3 (tool
+ * dispatch), B4 (transcript persistence) and D3 (metering) all start from a
+ * call id and need the socket that call is on. Keeping that in one place is
+ * also what makes teardown checkable — a call that ends and stays in the map is
+ * a leak, and a leak here bills.
+ *
+ * Follows `socket-registry.ts`: a plain class holding Maps, plus a singleton for
+ * the service. Not a new registry idiom, and not a module-level Map hiding
+ * inside a function — the class is what makes it constructible per-test.
+ */
+
+import type { RealtimeCallSession } from './realtime-call-session';
+
+/**
+ * Concurrency ceiling. The account's realtime budget is 40,000 tokens/minute
+ * and a single spoken exchange spends hundreds, so a handful of simultaneous
+ * calls is enough to start throttling everyone at once. Capping admission is
+ * the only lever this process has: once a call is attached, its token spend is
+ * the model's to decide.
+ */
+export const DEFAULT_MAX_CONCURRENT_CALLS = 8;
+
+export class RealtimeCallRegistry {
+  private readonly calls = new Map<string, RealtimeCallSession>();
+
+  /**
+   * Slots claimed by attaches that are in flight but not yet registered.
+   *
+   * Without this the cap does not actually cap. Attaching is asynchronous, so
+   * "check the size, then await, then register" leaves a window in which every
+   * concurrent request sees the same pre-attach size and all of them pass —
+   * single-threaded JS does not help, because the gap spans an `await`. A slot
+   * is therefore claimed SYNCHRONOUSLY, before the first suspension point.
+   */
+  private pending = 0;
+
+  constructor(private readonly maxConcurrent: number = DEFAULT_MAX_CONCURRENT_CALLS) {}
+
+  /** True when another call would exceed the cap, counting in-flight attaches. */
+  atCapacity(): boolean {
+    return this.calls.size + this.pending >= this.maxConcurrent;
+  }
+
+  /**
+   * Claim a slot for an attach that is about to start. Returns false when full.
+   * Every successful reserve MUST be matched by exactly one `releaseSlot()`,
+   * whether the attach succeeded or failed — `register` deliberately does not
+   * release it, so the accounting has one owner instead of two.
+   */
+  reserveSlot(): boolean {
+    if (this.atCapacity()) return false;
+    this.pending += 1;
+    return true;
+  }
+
+  releaseSlot(): void {
+    if (this.pending > 0) this.pending -= 1;
+  }
+
+  /** In-flight attaches, for tests and diagnostics. */
+  get reserved(): number {
+    return this.pending;
+  }
+
+  register(session: RealtimeCallSession): void {
+    // A re-attach for the same call id replaces the old entry and ends it, so
+    // two sockets can never be billing for one conversation.
+    const existing = this.calls.get(session.callId);
+    if (existing && existing !== session) {
+      existing.end('replaced by a newer attach for the same call');
+    }
+    this.calls.set(session.callId, session);
+  }
+
+  get(callId: string): RealtimeCallSession | undefined {
+    return this.calls.get(callId);
+  }
+
+  /**
+   * Drop a call by id. Deregistration is deliberately separate from ending the
+   * session: the session's own teardown calls this, so ending from here too
+   * would recurse.
+   */
+  unregister(callId: string): void {
+    this.calls.delete(callId);
+  }
+
+  /** Every live call for one user — how a "hang up" from any surface finds it. */
+  getForUser(userId: string): RealtimeCallSession[] {
+    return Array.from(this.calls.values()).filter((s) => s.userId === userId);
+  }
+
+  callIds(): string[] {
+    return Array.from(this.calls.keys());
+  }
+
+  get size(): number {
+    return this.calls.size;
+  }
+
+  /** Ends every live call. For process shutdown, so nothing bills past exit. */
+  endAll(reason: string): void {
+    for (const session of Array.from(this.calls.values())) {
+      session.end(reason);
+    }
+    this.calls.clear();
+  }
+}
+
+/** Singleton for the realtime service, matching `socketRegistry`'s shape. */
+export const realtimeCallRegistry = new RealtimeCallRegistry();

--- a/apps/realtime/src/voice/realtime-call-session.ts
+++ b/apps/realtime/src/voice/realtime-call-session.ts
@@ -1,0 +1,356 @@
+/**
+ * One attached OpenAI realtime call, held open for its whole life.
+ *
+ * The browser is already in a WebRTC call. This opens a SECOND transport onto
+ * the SAME session — `wss://api.openai.com/v1/realtime?call_id=rtc_…` — from
+ * which the server owns tools, transcripts and metering while the browser owns
+ * only the mic and the speaker.
+ *
+ * WHY THIS LIVES IN `apps/realtime` AND NOT IN A NEXT ROUTE. `usage` arrives per
+ * `response.done` and call totals only exist if something accumulates them, so
+ * the socket must survive the whole call — up to an hour. A route handler
+ * cannot hold that. This app is a long-lived `tsx` process that already takes
+ * signed internal calls from web, so it is the host.
+ *
+ * TWO MEASURED FACTS SHAPE THE HANDSHAKE, and getting either wrong costs an
+ * afternoon of debugging a silent socket:
+ *
+ * 1. The attach is authenticated by the call's OWN EPHEMERAL SECRET. The API
+ *    key fails with `404 call_id_not_found` — it is not rejected as a
+ *    credential, it just cannot address a call — and a *fresh* ephemeral secret
+ *    fails too. Only the secret minted for this exact call works.
+ * 2. An attached socket is SILENT on connect. No `session.created` ever
+ *    arrives; that event fired on the browser's data channel before we got
+ *    here. Anything gated on `session.created` waits forever. Readiness is:
+ *    socket OPEN, then the `session.updated` reply to our own `session.update`.
+ *
+ * The socket factory is injected, so every path below is testable without a
+ * live call.
+ */
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  EPHEMERAL_SECRET_PREFIX,
+  type RealtimeToolWire,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+
+/** Where a server attaches to a call already in progress. */
+export const REALTIME_ATTACH_URL = 'wss://api.openai.com/v1/realtime';
+
+/**
+ * The socket surface this module actually uses. Declared structurally rather
+ * than as `WebSocket` so a test can supply a plain object: the DOM lib's
+ * `WebSocket` types `onmessage` as taking a `MessageEvent`, which would drag
+ * the whole DOM event hierarchy into a fake for no benefit.
+ */
+export type AttachSocket = {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((event: unknown) => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onclose: ((event: { code?: number; reason?: string }) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+};
+
+export type AttachSocketFactory = (
+  url: string,
+  headers: Readonly<Record<string, string>>,
+) => AttachSocket;
+
+/**
+ * The real factory. Node's global WebSocket DOES send custom headers — verified
+ * against a local upgrade handler, which saw the `Authorization` header
+ * arrive — but the option is a Node extension that the DOM constructor type
+ * does not describe (its second parameter is `protocols`). Hence the one cast,
+ * kept to this single line. No `ws` dependency is needed, and `apps/realtime`
+ * does not declare one.
+ */
+export const defaultAttachSocketFactory: AttachSocketFactory = (url, headers) =>
+  new WebSocket(url, { headers } as unknown as string[]) as unknown as AttachSocket;
+
+/** How long to wait for OPEN + `session.updated` before giving up. */
+export const ATTACH_READY_TIMEOUT_MS = 15_000;
+
+/**
+ * Hard ceiling on one call. A socket that leaks bills silently for as long as
+ * the model keeps the session warm, and nothing else in this process would
+ * notice — the browser hanging up is not something the server socket is told
+ * about in every failure mode. An hour is far past any real conversation.
+ */
+export const MAX_CALL_DURATION_MS = 60 * 60 * 1000;
+
+export type AttachFailureCode =
+  | 'ephemeral_secret_required'
+  | 'socket_closed_before_ready'
+  | 'session_update_rejected'
+  | 'attach_timeout'
+  | 'duration_cap_exceeded'
+  | 'socket_error';
+
+export class RealtimeAttachError extends Error {
+  constructor(
+    readonly code: AttachFailureCode,
+    message: string,
+    readonly upstream?: unknown,
+  ) {
+    super(message);
+    this.name = 'RealtimeAttachError';
+  }
+}
+
+/**
+ * The seam other leaves build on. B3 (tool dispatch) and B4 (transcript
+ * persistence) do NOT open sockets or parse frames — they take a session out of
+ * the registry, `subscribe` to its events, and `send` client events back. This
+ * module owns the connection, the handshake, the registry entry and teardown,
+ * and nothing above that line.
+ */
+export type RealtimeCallSession = {
+  readonly callId: string;
+  readonly userId: string;
+  readonly conversationId: string | undefined;
+  /** Every inbound event, already JSON-parsed. Returns an unsubscribe. */
+  subscribe(listener: (event: unknown) => void): () => void;
+  /** Send a client event. No-op once the session has ended. */
+  send(event: Record<string, unknown>): void;
+  /** Idempotent. Closes the socket and fires the close handlers. */
+  end(reason: string): void;
+  readonly ended: boolean;
+};
+
+export type AttachOptions = {
+  readonly callId: string;
+  readonly secret: string;
+  readonly userId: string;
+  readonly conversationId?: string;
+  readonly tools: readonly RealtimeToolWire[];
+  readonly socketFactory?: AttachSocketFactory;
+  /** Called once the session stops, for whatever reason. Used to deregister. */
+  readonly onClosed?: (callId: string) => void;
+  readonly readyTimeoutMs?: number;
+  readonly maxDurationMs?: number;
+  /** Injected so tests need no real timers. */
+  readonly setTimeoutFn?: typeof setTimeout;
+  readonly clearTimeoutFn?: typeof clearTimeout;
+};
+
+/** Frames arrive as strings; a malformed one must not throw into the socket. */
+const parseFrame = (data: unknown): unknown => {
+  if (typeof data !== 'string') return undefined;
+  try {
+    return JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+};
+
+const eventType = (event: unknown): string | undefined => {
+  if (typeof event !== 'object' || event === null) return undefined;
+  const type = (event as { type?: unknown }).type;
+  return typeof type === 'string' ? type : undefined;
+};
+
+/**
+ * Open a socket onto an existing call and drive it to ready.
+ *
+ * Resolves only after `session.updated` — the reply to our `session.update`,
+ * which is also the moment the tool set is live. Rejects with a NAMED error on
+ * every other outcome, because the failures here are otherwise
+ * indistinguishable: a wrong credential, an expired secret and a bad call id
+ * all present as the same bare `1006` close.
+ */
+export const attachToCall = (options: AttachOptions): Promise<RealtimeCallSession> => {
+  const {
+    callId,
+    secret,
+    userId,
+    conversationId,
+    tools,
+    socketFactory = defaultAttachSocketFactory,
+    onClosed,
+    readyTimeoutMs = ATTACH_READY_TIMEOUT_MS,
+    maxDurationMs = MAX_CALL_DURATION_MS,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  } = options;
+
+  // Checked before a socket is opened, because this is THE mistake this stack
+  // invites: the API key is the credential everywhere else, and here it is the
+  // one credential that cannot work. Failing at the door with a sentence that
+  // says so is the difference between a five-second fix and re-deriving
+  // `404 call_id_not_found` from a socket that closed without a word.
+  if (!secret.startsWith(EPHEMERAL_SECRET_PREFIX)) {
+    return Promise.reject(
+      new RealtimeAttachError(
+        'ephemeral_secret_required',
+        `Attaching to ${callId} requires that call's own ephemeral client secret ` +
+          `(${EPHEMERAL_SECRET_PREFIX}…). An API key cannot address a call — OpenAI ` +
+          'answers 404 call_id_not_found — and neither can a freshly minted secret.',
+      ),
+    );
+  }
+
+  return new Promise<RealtimeCallSession>((resolve, reject) => {
+    const listeners = new Set<(event: unknown) => void>();
+    let ready = false;
+    let ended = false;
+    let readyTimer: ReturnType<typeof setTimeout> | undefined;
+    let durationTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const socket = socketFactory(`${REALTIME_ATTACH_URL}?call_id=${encodeURIComponent(callId)}`, {
+      Authorization: `Bearer ${secret}`,
+    });
+
+    const clearTimers = () => {
+      if (readyTimer !== undefined) clearTimeoutFn(readyTimer);
+      if (durationTimer !== undefined) clearTimeoutFn(durationTimer);
+      readyTimer = undefined;
+      durationTimer = undefined;
+    };
+
+    /**
+     * The single teardown path. Every ending — clean close, socket error,
+     * timeout, explicit end, duration cap — funnels through here, so listeners
+     * cannot be left attached and the registry cannot keep a dead entry.
+     */
+    const teardown = (failure?: RealtimeAttachError) => {
+      if (ended) return;
+      ended = true;
+      clearTimers();
+      listeners.clear();
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      try {
+        socket.close();
+      } catch {
+        // Already closing or closed; the point was to stop billing, and it has.
+      }
+      onClosed?.(callId);
+      // A failure before readiness is the attach's answer; after readiness the
+      // promise is long settled and the close is just the call ending.
+      if (!ready && failure) reject(failure);
+    };
+
+    const session: RealtimeCallSession = {
+      callId,
+      userId,
+      conversationId,
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      send(event) {
+        if (ended) return;
+        socket.send(JSON.stringify(event));
+      },
+      end(reason) {
+        loggers.realtime.debug('Realtime voice session ended', { callId, userId, reason });
+        teardown();
+      },
+      get ended() {
+        return ended;
+      },
+    };
+
+    readyTimer = setTimeoutFn(() => {
+      teardown(
+        new RealtimeAttachError(
+          'attach_timeout',
+          `Attach to ${callId} did not reach session.updated within ${readyTimeoutMs}ms. ` +
+            'Note that an attached socket sends no session.created — readiness is ' +
+            'socket OPEN followed by the session.updated reply, and nothing else.',
+        ),
+      );
+    }, readyTimeoutMs);
+
+    durationTimer = setTimeoutFn(() => {
+      loggers.realtime.warn('Realtime voice call hit the hard duration cap', {
+        callId,
+        userId,
+        maxDurationMs,
+      });
+      teardown(
+        new RealtimeAttachError(
+          'duration_cap_exceeded',
+          `Call ${callId} exceeded the ${maxDurationMs}ms duration cap.`,
+        ),
+      );
+    }, maxDurationMs);
+
+    socket.onopen = () => {
+      // Tools land here, on the server socket, and therefore never touch the
+      // browser. This is also the event whose reply defines readiness.
+      socket.send(
+        JSON.stringify({
+          type: 'session.update',
+          session: { type: 'realtime', tools, tool_choice: 'auto' },
+        }),
+      );
+    };
+
+    socket.onmessage = (event) => {
+      const parsed = parseFrame(event.data);
+      if (parsed === undefined) return;
+      const type = eventType(parsed);
+
+      if (!ready) {
+        if (type === 'session.updated') {
+          ready = true;
+          if (readyTimer !== undefined) clearTimeoutFn(readyTimer);
+          readyTimer = undefined;
+          resolve(session);
+        } else if (type === 'error') {
+          // A rejected session.update answers with an `error` event and then
+          // sits there. Reporting ready anyway would hand B3 a session whose
+          // tools were never registered.
+          teardown(
+            new RealtimeAttachError(
+              'session_update_rejected',
+              `OpenAI rejected the session.update for ${callId}.`,
+              (parsed as { error?: unknown }).error,
+            ),
+          );
+          return;
+        }
+      }
+
+      // Fan out AFTER the readiness check so a subscriber added during
+      // `resolve` does not also receive the frame that resolved it twice.
+      for (const listener of listeners) {
+        try {
+          listener(parsed);
+        } catch (error) {
+          // One bad subscriber must not tear down a live call for the others.
+          loggers.realtime.error(
+            'Realtime voice event listener threw',
+            error instanceof Error ? error : new Error(String(error)),
+            { callId, eventType: type },
+          );
+        }
+      }
+    };
+
+    socket.onclose = (event) => {
+      teardown(
+        new RealtimeAttachError(
+          'socket_closed_before_ready',
+          `Attach socket for ${callId} closed before the session was ready ` +
+            `(code ${event?.code ?? 'unknown'}). The usual cause is a credential that ` +
+            `cannot address this call: it must be THIS call's own ephemeral secret ` +
+            `(${EPHEMERAL_SECRET_PREFIX}…), not an API key and not a fresh one.`,
+        ),
+      );
+    };
+
+    socket.onerror = () => {
+      teardown(
+        new RealtimeAttachError(
+          'socket_error',
+          `Attach socket for ${callId} errored before the session was ready.`,
+        ),
+      );
+    };
+  });
+};

--- a/apps/web/src/app/api/voice/realtime/call/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/realtime/call/__tests__/route.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Route tests: the gates in front of the handshake, and the shape of what comes
+ * back. The handshake itself is mocked — it has its own suite — so these assert
+ * the route's own decisions: who gets in, what the model is resolved from, and
+ * that the ephemeral secret never appears in a response body.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockAuth,
+  mockIsAuthError,
+  mockGetManagedKey,
+  mockIsBillingEnabled,
+  mockGetUserSettings,
+  mockRunCallHandshake,
+  mockBuildRealtimeTools,
+  mockSignHeaders,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+  mockGetManagedKey: vi.fn(),
+  mockIsBillingEnabled: vi.fn(),
+  mockGetUserSettings: vi.fn(),
+  mockRunCallHandshake: vi.fn(),
+  mockBuildRealtimeTools: vi.fn(),
+  mockSignHeaders: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: mockAuth,
+  isAuthError: mockIsAuthError,
+}));
+vi.mock('@/lib/ai/core/ai-utils', () => ({ getManagedProviderKey: mockGetManagedKey }));
+vi.mock('@pagespace/lib/deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
+vi.mock('@/lib/repositories/ai-settings-repository', () => ({
+  aiSettingsRepository: { getUserSettings: mockGetUserSettings },
+}));
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  PAID_TIERS: new Set(['pro', 'founder', 'business']),
+}));
+vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
+  createSignedBroadcastHeaders: mockSignHeaders,
+}));
+vi.mock('@/lib/ai/realtime/call-handshake', () => ({ runCallHandshake: mockRunCallHandshake }));
+vi.mock('@/lib/ai/realtime/tools', () => ({ buildRealtimeTools: mockBuildRealtimeTools }));
+vi.mock('@/lib/ai/core/ai-tools', () => ({ buildPageSpaceTools: () => ({}) }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+}));
+
+import { POST } from '../route';
+
+const SECRET = 'ek_never_leaves_the_server';
+const TOOLS = [{ type: 'function' as const, name: 'read_page', description: 'r', parameters: {} }];
+
+function callRequest(body: unknown) {
+  return new Request('http://localhost/api/voice/realtime/call', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/voice/realtime/call', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockAuth.mockResolvedValue({ userId: 'u1' });
+    mockIsAuthError.mockReturnValue(false);
+    mockGetManagedKey.mockReturnValue({ apiKey: 'sk-managed' });
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'pro' });
+    mockBuildRealtimeTools.mockReturnValue(TOOLS);
+    mockSignHeaders.mockReturnValue({ 'X-Broadcast-Signature': 't=1,v1=sig' });
+    mockRunCallHandshake.mockResolvedValue({
+      ok: true,
+      callId: 'rtc_abc',
+      answerSdp: 'v=0 answer',
+      attached: true,
+    });
+  });
+
+  it('given an unauthenticated request, should 401 without minting anything', async () => {
+    mockIsAuthError.mockReturnValue(true);
+    mockAuth.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+    });
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(401);
+    expect(mockRunCallHandshake).not.toHaveBeenCalled();
+    expect(mockGetManagedKey).not.toHaveBeenCalled();
+  });
+
+  it('given a free-tier user while billing is enabled, should 403 with the upgrade message', async () => {
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'free' });
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'Pro plan required',
+      upgradeUrl: '/settings/plan',
+    });
+    expect(mockRunCallHandshake).not.toHaveBeenCalled();
+  });
+
+  it('given billing is disabled, should let a free-tier user through', async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'free' });
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(200);
+    // The tier is never even looked up when billing is off.
+    expect(mockGetUserSettings).not.toHaveBeenCalled();
+  });
+
+  it('given no managed voice key, should 503', async () => {
+    mockGetManagedKey.mockReturnValue(undefined);
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(503);
+    expect(mockRunCallHandshake).not.toHaveBeenCalled();
+  });
+
+  it('given no SDP offer, should 400', async () => {
+    const res = await POST(callRequest({}));
+    expect(res.status).toBe(400);
+    expect(mockRunCallHandshake).not.toHaveBeenCalled();
+  });
+
+  it('given an oversized SDP offer, should 400 rather than relay it', async () => {
+    const res = await POST(callRequest({ sdp: 'x'.repeat(256 * 1024 + 1) }));
+    expect(res.status).toBe(400);
+    expect(mockRunCallHandshake).not.toHaveBeenCalled();
+  });
+
+  it('given OPENAI_REALTIME_MODEL is set, should hand THAT model to the handshake', async () => {
+    vi.stubEnv('OPENAI_REALTIME_MODEL', 'gpt-realtime-from-env');
+
+    await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(mockRunCallHandshake).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-realtime-from-env' }),
+      expect.anything(),
+    );
+  });
+
+  it('given no override, should resolve the default model rather than pass undefined', async () => {
+    vi.stubEnv('OPENAI_REALTIME_MODEL', '');
+
+    await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    const model = mockRunCallHandshake.mock.calls[0][0].model;
+    expect(typeof model).toBe('string');
+    expect(model.length).toBeGreaterThan(0);
+  });
+
+  it('should pass the built tool set and the real signer into the handshake', async () => {
+    await POST(callRequest({ sdp: 'v=0 offer', conversationId: 'conv1' }));
+
+    expect(mockRunCallHandshake).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: TOOLS, signHeaders: mockSignHeaders }),
+      expect.objectContaining({ offerSdp: 'v=0 offer', userId: 'u1', conversationId: 'conv1' }),
+    );
+  });
+
+  it('given a blank conversationId, should omit it rather than forward an empty string', async () => {
+    await POST(callRequest({ sdp: 'v=0 offer', conversationId: '' }));
+
+    expect(mockRunCallHandshake.mock.calls[0][1]).not.toHaveProperty('conversationId');
+  });
+
+  it('given a successful handshake, should return the callId, answer SDP and attach state', async () => {
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      callId: 'rtc_abc',
+      answerSdp: 'v=0 answer',
+      attached: true,
+    });
+  });
+
+  it('given the realtime server was unreachable, should still return 200 with attached:false', async () => {
+    mockRunCallHandshake.mockResolvedValue({
+      ok: true,
+      callId: 'rtc_abc',
+      answerSdp: 'v=0 answer',
+      attached: false,
+    });
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ attached: false });
+  });
+
+  it('given OpenAI rejected the model, should 502 carrying the upstream body and status', async () => {
+    const upstream = {
+      error: { message: 'model not found', code: 'model_not_found' },
+    };
+    mockRunCallHandshake.mockResolvedValue({
+      ok: false,
+      code: 'realtime_call_rejected',
+      message: 'OpenAI rejected the realtime call.',
+      upstream,
+      upstreamStatus: 403,
+    });
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    // 502, not 403 — a 403 here would be indistinguishable from the tier gate.
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'realtime_call_rejected',
+      upstreamStatus: 403,
+      upstream,
+    });
+  });
+
+  it('given the handshake throws, should 500 rather than leak the error', async () => {
+    mockRunCallHandshake.mockRejectedValue(new Error('boom'));
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to start voice call' });
+  });
+
+  it('should NEVER put the ephemeral secret in the response body', async () => {
+    // Even if a future handshake result carried one, the route must not echo it.
+    mockRunCallHandshake.mockResolvedValue({
+      ok: true,
+      callId: 'rtc_abc',
+      answerSdp: 'v=0 answer',
+      attached: true,
+      secret: SECRET,
+    });
+
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+    const text = await res.text();
+
+    expect(text).not.toContain(SECRET);
+    expect(text).not.toContain('ek_');
+  });
+});

--- a/apps/web/src/app/api/voice/realtime/call/route.ts
+++ b/apps/web/src/app/api/voice/realtime/call/route.ts
@@ -1,0 +1,167 @@
+/**
+ * Realtime Voice Call API Route
+ *
+ * POST /api/voice/realtime/call
+ *
+ * The browser's front door to a live voice call. It sends an SDP offer and gets
+ * an SDP answer back; this route does the whole handshake with OpenAI on its
+ * behalf, so the page never contacts `api.openai.com` and never holds a
+ * credential. Our server keeps the call id and hands the call's ephemeral
+ * secret straight to the realtime server, which attaches for the duration.
+ *
+ * Auth, tier gate and managed-key lookup follow `../transcribe/route.ts`
+ * exactly — voice is one feature with one entitlement, and a second auth shape
+ * here would be a second thing to keep in step.
+ *
+ * NOT metered here. A realtime call's cost accrues per `response.done` over its
+ * whole lifetime, on the socket the realtime server holds; a credit hold taken
+ * at handshake time could only ever be a guess at a call that has not happened
+ * yet. Metering belongs to the process that sees the usage events.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { getManagedProviderKey } from '@/lib/ai/core/ai-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
+import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
+import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
+import { resolveRealtimeModel } from '@/lib/ai/realtime/session';
+import { buildRealtimeTools } from '@/lib/ai/realtime/tools';
+import { buildPageSpaceTools } from '@/lib/ai/core/ai-tools';
+import { runCallHandshake } from '@/lib/ai/realtime/call-handshake';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+/**
+ * An SDP offer is a few kilobytes of text. The cap exists so an authenticated
+ * caller cannot make us relay an arbitrarily large body to OpenAI.
+ */
+const MAX_SDP_BYTES = 256 * 1024;
+
+export async function POST(request: Request) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const userId = auth.userId;
+
+    // Free users can't use voice at all — same gate, same message as STT/TTS.
+    if (isBillingEnabled()) {
+      const user = await aiSettingsRepository.getUserSettings(userId);
+      const tier = (user?.subscriptionTier ?? 'free') as SubscriptionTier;
+      if (!PAID_TIERS.has(tier)) {
+        return NextResponse.json(
+          {
+            error: 'Pro plan required',
+            message: 'Voice mode requires a Pro or above subscription.',
+            upgradeUrl: '/settings/plan',
+          },
+          { status: 403 }
+        );
+      }
+    }
+
+    const openAISettings = getManagedProviderKey('openai_voice');
+    if (!openAISettings?.apiKey) {
+      return NextResponse.json(
+        {
+          error: 'Voice mode unavailable',
+          message: 'Voice mode is not configured on this deployment.',
+        },
+        { status: 503 }
+      );
+    }
+
+    const body = await request.json().catch(() => undefined);
+    const sdp = (body as { sdp?: unknown } | undefined)?.sdp;
+    const conversationIdRaw = (body as { conversationId?: unknown } | undefined)?.conversationId;
+
+    if (typeof sdp !== 'string' || sdp.length === 0) {
+      return NextResponse.json(
+        { error: 'No SDP offer provided' },
+        { status: 400 }
+      );
+    }
+    if (sdp.length > MAX_SDP_BYTES) {
+      return NextResponse.json(
+        { error: 'SDP offer too large' },
+        { status: 400 }
+      );
+    }
+
+    const result = await runCallHandshake(
+      {
+        fetch,
+        apiKey: openAISettings.apiKey,
+        // Resolved explicitly rather than left to buildSessionConfig's default:
+        // the env override is the entire per-deployment model escape hatch, and
+        // a default applied deeper down would silently swallow it.
+        model: resolveRealtimeModel(process.env),
+        // Built here, at the edge, because the registry has env-dependent
+        // branches (the code-execution kill switch) that are the caller's
+        // decision. The realtime server cannot build these itself — the
+        // registry lives in this app — so they ride the signed internal hop.
+        tools: buildRealtimeTools(buildPageSpaceTools()),
+        internalRealtimeUrl: process.env.INTERNAL_REALTIME_URL,
+        signHeaders: createSignedBroadcastHeaders,
+        logger: loggers.ai,
+      },
+      {
+        offerSdp: sdp,
+        userId,
+        ...(typeof conversationIdRaw === 'string' && conversationIdRaw.length > 0
+          ? { conversationId: conversationIdRaw }
+          : {}),
+      }
+    );
+
+    if (!result.ok) {
+      loggers.ai.error(
+        'Realtime voice handshake failed',
+        new Error(result.message),
+        { userId, code: result.code, upstreamStatus: result.upstreamStatus }
+      );
+      // 502, not the upstream status: a bare 403 from OpenAI would be
+      // indistinguishable from THIS route's own 403 (free tier), and the two
+      // need entirely different fixes. The upstream status and body are
+      // reported as data instead — which is the only way a bad
+      // OPENAI_REALTIME_MODEL is ever visible, since the mint accepts it.
+      return NextResponse.json(
+        {
+          error: 'Voice call failed',
+          code: result.code,
+          message: result.message,
+          ...(result.upstreamStatus === undefined
+            ? {}
+            : { upstreamStatus: result.upstreamStatus }),
+          ...(result.upstream === undefined ? {} : { upstream: result.upstream }),
+        },
+        { status: 502 }
+      );
+    }
+
+    auditRequest(request, {
+      eventType: 'data.read',
+      userId,
+      resourceType: 'voice',
+      resourceId: result.callId,
+      details: { operation: 'realtime_call_start', attached: result.attached },
+    });
+
+    // The ephemeral secret is deliberately absent: it never leaves the server.
+    return NextResponse.json({
+      callId: result.callId,
+      answerSdp: result.answerSdp,
+      attached: result.attached,
+    });
+  } catch (error) {
+    loggers.ai.error('Realtime voice call error', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to start voice call' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/lib/ai/realtime/__tests__/call-handshake.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/call-handshake.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Handshake tests. Every network hop is an injected `fetch`, so nothing here
+ * reaches OpenAI or the realtime server.
+ *
+ * The cases that carry the most weight are the ones about a credential:
+ * the ephemeral secret must authenticate the CALL creation (not the API key),
+ * it must reach the realtime server, and it must never appear in what we hand
+ * back to the browser.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseCallId,
+  runCallHandshake,
+  type HandshakeDeps,
+  type HandshakeLogger,
+} from '../call-handshake';
+import { CLIENT_SECRETS_URL, REALTIME_CALLS_URL } from '../session';
+import { VOICE_BRIDGE_ROUTES } from '@pagespace/lib/realtime/voice-bridge-contract';
+
+const SECRET = 'ek_call_secret';
+const CALL_ID = 'rtc_u0_EBNOwQshLeDzYP6HmPHHV';
+const ANSWER_SDP = 'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n';
+const OFFER_SDP = 'v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n';
+
+const TOOLS = [
+  { type: 'function' as const, name: 'read_page', description: 'Read a page.', parameters: {} },
+];
+
+type FetchCall = { url: string; init: RequestInit };
+
+/** A response the handshake code can read like a real one. */
+function response(
+  init: {
+    ok?: boolean;
+    status?: number;
+    json?: unknown;
+    text?: string;
+    headers?: Record<string, string>;
+  } = {},
+): Response {
+  const headers = new Headers(init.headers ?? {});
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    headers,
+    json: async () => init.json,
+    text: async () => init.text ?? (init.json === undefined ? '' : JSON.stringify(init.json)),
+  } as unknown as Response;
+}
+
+const okMint = () => response({ json: { value: SECRET, expires_at: 1 } });
+const okCall = () =>
+  response({
+    status: 201,
+    text: ANSWER_SDP,
+    headers: { Location: `/v1/realtime/calls/${CALL_ID}` },
+  });
+const okHandoff = () => response({ json: { success: true } });
+
+function silentLogger(): HandshakeLogger {
+  return { warn: vi.fn(), error: vi.fn() };
+}
+
+/**
+ * Build deps whose fetch answers by hop: mint, then call, then handoff. Any
+ * hop can be overridden to fail.
+ */
+function harness(
+  overrides: {
+    mint?: () => Response;
+    call?: () => Response;
+    handoff?: () => Response | Promise<never>;
+    internalRealtimeUrl?: string | undefined;
+    model?: string;
+    tools?: HandshakeDeps['tools'];
+  } = {},
+) {
+  const calls: FetchCall[] = [];
+  const logger = silentLogger();
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init: init ?? {} });
+    if (url === CLIENT_SECRETS_URL) return (overrides.mint ?? okMint)();
+    if (url === REALTIME_CALLS_URL) return (overrides.call ?? okCall)();
+    return (overrides.handoff ?? okHandoff)();
+  });
+
+  const deps: HandshakeDeps = {
+    fetch: fetchMock as unknown as typeof fetch,
+    apiKey: 'sk-managed-key',
+    model: overrides.model ?? 'gpt-realtime-2.1',
+    tools: overrides.tools ?? TOOLS,
+    internalRealtimeUrl:
+      'internalRealtimeUrl' in overrides ? overrides.internalRealtimeUrl : 'http://realtime:4000',
+    signHeaders: vi.fn((body: string) => ({
+      'Content-Type': 'application/json',
+      'X-Broadcast-Signature': `t=1,v1=sig-over-${body.length}`,
+    })),
+    logger,
+  };
+
+  return { deps, calls, logger, fetchMock };
+}
+
+const run = (deps: HandshakeDeps, conversationId?: string) =>
+  runCallHandshake(deps, {
+    offerSdp: OFFER_SDP,
+    userId: 'u1',
+    ...(conversationId === undefined ? {} : { conversationId }),
+  });
+
+const byUrl = (calls: FetchCall[], url: string) => calls.find((c) => c.url === url);
+
+describe('parseCallId', () => {
+  it('given the relative Location OpenAI sends, should take the last segment', () => {
+    expect(parseCallId(`/v1/realtime/calls/${CALL_ID}`)).toBe(CALL_ID);
+  });
+
+  it('given an absolute URL, should still take the last segment', () => {
+    expect(parseCallId(`https://api.openai.com/v1/realtime/calls/${CALL_ID}`)).toBe(CALL_ID);
+  });
+
+  it('given a trailing slash or query, should ignore them', () => {
+    expect(parseCallId(`/v1/realtime/calls/${CALL_ID}/`)).toBe(CALL_ID);
+    expect(parseCallId(`/v1/realtime/calls/${CALL_ID}?x=1`)).toBe(CALL_ID);
+  });
+
+  it('given anything that is not an rtc_ id, should refuse rather than guess', () => {
+    expect(parseCallId(null)).toBeUndefined();
+    expect(parseCallId('')).toBeUndefined();
+    expect(parseCallId('/v1/realtime/calls/')).toBeUndefined();
+    // A session id is the id closest to hand at mint time, and it is wrong.
+    expect(parseCallId('/v1/realtime/calls/sess_u0_abc')).toBeUndefined();
+  });
+});
+
+describe('runCallHandshake — the happy path', () => {
+  it('should return the answer SDP and the call id', async () => {
+    const { deps } = harness();
+    const result = await run(deps);
+
+    expect(result).toEqual({
+      ok: true,
+      callId: CALL_ID,
+      answerSdp: ANSWER_SDP,
+      attached: true,
+    });
+  });
+
+  it('should mint with the model it was GIVEN, never a built-in default', async () => {
+    const { deps, calls } = harness({ model: 'gpt-realtime-from-env' });
+    await run(deps);
+
+    const mint = byUrl(calls, CLIENT_SECRETS_URL)!;
+    const body = JSON.parse(String(mint.init.body));
+    expect(body.session.model).toBe('gpt-realtime-from-env');
+  });
+
+  it('should mint with the API key and create the call with the EPHEMERAL secret', async () => {
+    const { deps, calls } = harness();
+    await run(deps);
+
+    const mint = byUrl(calls, CLIENT_SECRETS_URL)!;
+    const call = byUrl(calls, REALTIME_CALLS_URL)!;
+
+    expect((mint.init.headers as Record<string, string>).Authorization).toBe('Bearer sk-managed-key');
+    // The API key cannot create the call; only the freshly minted secret can.
+    expect((call.init.headers as Record<string, string>).Authorization).toBe(`Bearer ${SECRET}`);
+  });
+
+  it('should post the raw SDP offer as application/sdp', async () => {
+    const { deps, calls } = harness();
+    await run(deps);
+
+    const call = byUrl(calls, REALTIME_CALLS_URL)!;
+    expect((call.init.headers as Record<string, string>)['Content-Type']).toBe('application/sdp');
+    expect(call.init.body).toBe(OFFER_SDP);
+  });
+
+  it('should NOT mint the tools in — they belong to the socket that executes them', async () => {
+    const { deps, calls } = harness();
+    await run(deps);
+
+    const body = JSON.parse(String(byUrl(calls, CLIENT_SECRETS_URL)!.init.body));
+    // Advertising tools on a call that may never get a server attached would
+    // let the model call tools with nobody listening.
+    expect(body.session.tools).toEqual([]);
+  });
+});
+
+describe('runCallHandshake — the handoff to the realtime server', () => {
+  it('should post the call, the secret and the tools to the attach route, signed', async () => {
+    const { deps, calls } = harness();
+    await run(deps, 'conv1');
+
+    const handoff = byUrl(calls, `http://realtime:4000${VOICE_BRIDGE_ROUTES.attach}`)!;
+    expect(handoff).toBeDefined();
+
+    const body = JSON.parse(String(handoff.init.body));
+    expect(body).toEqual({
+      callId: CALL_ID,
+      secret: SECRET,
+      userId: 'u1',
+      conversationId: 'conv1',
+      tools: TOOLS,
+    });
+
+    // Signed over the EXACT body posted — the HMAC is computed on those bytes.
+    expect(deps.signHeaders).toHaveBeenCalledWith(String(handoff.init.body));
+    expect((handoff.init.headers as Record<string, string>)['X-Broadcast-Signature']).toContain('v1=');
+  });
+
+  it('given no conversationId, should omit the key rather than send undefined', async () => {
+    const { deps, calls } = harness();
+    await run(deps);
+
+    const handoff = byUrl(calls, `http://realtime:4000${VOICE_BRIDGE_ROUTES.attach}`)!;
+    expect(JSON.parse(String(handoff.init.body))).not.toHaveProperty('conversationId');
+  });
+
+  it('given INTERNAL_REALTIME_URL is unset, should still return the answer SDP and log why', async () => {
+    const { deps, calls, logger } = harness({ internalRealtimeUrl: undefined });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: true, answerSdp: ANSWER_SDP, attached: false });
+    // Two hops only: no handoff was attempted.
+    expect(calls).toHaveLength(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('INTERNAL_REALTIME_URL'),
+      expect.objectContaining({ callId: CALL_ID }),
+    );
+  });
+
+  it('given the realtime server answers non-200, should degrade to attached:false, not fail the call', async () => {
+    const { deps, logger } = harness({
+      handoff: () => response({ ok: false, status: 503, json: { error: 'down' } }),
+    });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: true, answerSdp: ANSWER_SDP, attached: false });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('given the handoff throws, should degrade rather than lose a working call', async () => {
+    const { deps, logger } = harness({
+      handoff: () => Promise.reject(new Error('ECONNREFUSED')),
+    });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: true, attached: false });
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe('runCallHandshake — named failures', () => {
+  it('given the mint fails, should report mint_failed with the upstream body', async () => {
+    const { deps, calls } = harness({
+      mint: () => response({ ok: false, status: 401, json: { error: { message: 'bad key' } } }),
+    });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'mint_failed',
+      upstreamStatus: 401,
+      upstream: { error: { message: 'bad key' } },
+    });
+    // Nothing downstream ran.
+    expect(calls).toHaveLength(1);
+  });
+
+  it('given the mint returns no secret, should report mint_missing_secret', async () => {
+    const { deps } = harness({ mint: () => response({ json: { expires_at: 1 } }) });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: false, code: 'mint_missing_secret' });
+  });
+
+  it('given OpenAI 403s model_not_found at /v1/realtime/calls, should surface the upstream body verbatim', async () => {
+    // The load-bearing case: the mint 200s for a model the project cannot use,
+    // so THIS is the only place a bad OPENAI_REALTIME_MODEL is ever visible.
+    const upstream = {
+      error: {
+        message: 'The model `gpt-realtime-2.1` does not exist or you do not have access to it.',
+        type: 'invalid_request_error',
+        code: 'model_not_found',
+      },
+    };
+    const { deps } = harness({ call: () => response({ ok: false, status: 403, json: upstream }) });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'realtime_call_rejected',
+      upstreamStatus: 403,
+      upstream,
+    });
+  });
+
+  it('given a non-JSON upstream error, should surface the raw text instead of dropping it', async () => {
+    const { deps } = harness({
+      call: () => response({ ok: false, status: 502, text: 'upstream exploded' }),
+    });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ code: 'realtime_call_rejected', upstream: 'upstream exploded' });
+  });
+
+  it('given no Location header, should fail loudly rather than return an undefined call id', async () => {
+    const { deps } = harness({ call: () => response({ status: 201, text: ANSWER_SDP }) });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: false, code: 'missing_call_location' });
+    expect(result).not.toHaveProperty('callId');
+  });
+
+  it('given a malformed Location, should fail with a named error', async () => {
+    const { deps } = harness({
+      call: () =>
+        response({
+          status: 201,
+          text: ANSWER_SDP,
+          headers: { Location: '/v1/realtime/calls/sess_wrong_id_space' },
+        }),
+    });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: false, code: 'malformed_call_location' });
+  });
+
+  it('given an empty answer SDP, should report missing_answer_sdp', async () => {
+    const { deps } = harness({
+      call: () =>
+        response({ status: 201, text: '', headers: { Location: `/v1/realtime/calls/${CALL_ID}` } }),
+    });
+    const result = await run(deps);
+
+    expect(result).toMatchObject({ ok: false, code: 'missing_answer_sdp' });
+  });
+
+  it('given a failure before the handoff, should never hand a secret to the realtime server', async () => {
+    const { deps, calls } = harness({ call: () => response({ ok: false, status: 403, json: {} }) });
+    await run(deps);
+
+    expect(byUrl(calls, `http://realtime:4000${VOICE_BRIDGE_ROUTES.attach}`)).toBeUndefined();
+  });
+});
+
+describe('runCallHandshake — the secret stays on the server', () => {
+  it('should not put the secret in the result on ANY path', async () => {
+    const outcomes = await Promise.all([
+      run(harness().deps),
+      run(harness({ internalRealtimeUrl: undefined }).deps),
+      run(harness({ call: () => response({ ok: false, status: 403, json: {} }) }).deps),
+      run(harness({ handoff: () => response({ ok: false, status: 500 }) }).deps),
+    ]);
+
+    for (const outcome of outcomes) {
+      expect(JSON.stringify(outcome)).not.toContain(SECRET);
+    }
+  });
+
+  it('should never log the secret', async () => {
+    const { deps, logger } = harness({
+      handoff: () => response({ ok: false, status: 503, json: { error: SECRET } }),
+    });
+    await run(deps);
+
+    const logged = JSON.stringify([
+      (logger.warn as ReturnType<typeof vi.fn>).mock.calls,
+      (logger.error as ReturnType<typeof vi.fn>).mock.calls,
+    ]);
+    expect(logged).not.toContain(SECRET);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-bridge-contract-drift.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-bridge-contract-drift.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Drift guard between the two declarations of one wire shape.
+ *
+ * `RealtimeTool` (this app) is what `buildRealtimeTools` produces; the shared
+ * `realtimeToolSchema` is what `apps/realtime` validates on arrival. They are
+ * deliberately separate declarations — the realtime server must not import from
+ * the web app — so the only thing keeping them honest is this file.
+ *
+ * The check runs against the REAL registry rather than a fixture: a fixture
+ * would keep passing after a registry change that the schema rejects, which is
+ * the exact failure this exists to catch (a call attaching with zero tools, or
+ * a 400 from the attach endpoint, for a reason nobody can see from here).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  realtimeToolSchema,
+  realtimeAttachPayloadSchema,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+import { buildRealtimeTools } from '../tools';
+import { buildPageSpaceTools } from '../../core/ai-tools';
+import type { RealtimeTool } from '../session';
+
+describe('realtime tool wire shape', () => {
+  it('given the real registry, every emitted tool should satisfy the shared schema', () => {
+    const tools = buildRealtimeTools(buildPageSpaceTools());
+    expect(tools.length).toBeGreaterThan(0);
+
+    for (const tool of tools) {
+      const parsed = realtimeToolSchema.safeParse(tool);
+      expect(parsed.success, `${tool.name} failed the shared schema`).toBe(true);
+    }
+  });
+
+  it('should carry the whole registry-built tool set through the attach payload intact', () => {
+    const tools = buildRealtimeTools(buildPageSpaceTools());
+
+    const parsed = realtimeAttachPayloadSchema.safeParse({
+      callId: 'rtc_u0_abc',
+      secret: 'ek_secret',
+      userId: 'u1',
+      tools,
+    });
+
+    expect(parsed.success).toBe(true);
+    // Not merely "valid" — unchanged. A schema that silently stripped
+    // `parameters` would still parse, and the model would get bare tool names.
+    expect(parsed.success && parsed.data.tools).toEqual(tools);
+  });
+
+  it('a RealtimeTool should be assignable to the wire type in both directions', () => {
+    // Compile-time half of the guard: if either declaration gains or loses a
+    // field, one of these assignments stops type-checking.
+    const fromApp: RealtimeTool = {
+      type: 'function',
+      name: 'read_page',
+      description: 'Read a page.',
+      parameters: { type: 'object', properties: {} },
+    };
+    const onWire = realtimeToolSchema.parse(fromApp);
+    const backToApp: RealtimeTool = onWire;
+
+    expect(backToApp).toEqual(fromApp);
+  });
+
+  it('should reject a Chat-Completions-shaped tool, which is the shape that would drift in', () => {
+    const nested = {
+      type: 'function',
+      function: { name: 'read_page', description: 'Read.', parameters: {} },
+    };
+    expect(realtimeToolSchema.safeParse(nested).success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/call-handshake.ts
+++ b/apps/web/src/lib/ai/realtime/call-handshake.ts
@@ -1,0 +1,311 @@
+/**
+ * The server-relay handshake: how a browser ends up in a WebRTC call with
+ * OpenAI while OUR server — not the browser — holds the call's credential.
+ *
+ * The browser sends us an SDP offer and gets an SDP answer back. In between,
+ * this module mints an ephemeral secret, relays the offer to OpenAI, reads the
+ * call id out of the `Location` header, and hands both to the long-lived
+ * realtime server over a signed internal request. The browser never contacts
+ * `api.openai.com` and never holds a credential.
+ *
+ * WHY RELAY INSTEAD OF LETTING THE BROWSER POST DIRECTLY. `Location` is exposed
+ * cross-origin (`access-control-expose-headers: Location, …`), so a direct
+ * browser POST does work — that was measured, not assumed. We relay anyway
+ * because the attach is authenticated by THAT CALL'S OWN ephemeral secret: a
+ * fresh secret fails, and the API key fails with `404 call_id_not_found`. The
+ * server has to hold the secret no matter what, so relaying is strictly LESS
+ * machinery than the alternative — one route, the secret never enters the page,
+ * and the call id arrives as a side effect of a request we already make.
+ *
+ * WHY THE MINT CARRIES NO TOOLS. `buildSessionConfig` is called with the model
+ * and nothing else; the tool set is pushed later, by the realtime server, in
+ * its own `session.update`. Minting the tools in as well would advertise them
+ * to the model on a call that may never get a server attached (see the
+ * `INTERNAL_REALTIME_URL` degrade path below) — the model would then try to
+ * call tools with nobody listening. Tools arrive with the thing that executes
+ * them, or not at all.
+ *
+ * Everything that touches the network arrives as a dependency, so the whole
+ * handshake is testable without a live call.
+ */
+
+import {
+  CLIENT_SECRETS_URL,
+  REALTIME_CALLS_URL,
+  SDP_CONTENT_TYPE,
+  buildSessionConfig,
+  extractClientSecret,
+  type RealtimeTool,
+} from './session';
+import {
+  REALTIME_CALL_ID_PREFIX,
+  VOICE_BRIDGE_ROUTES,
+  type RealtimeAttachPayload,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+
+/**
+ * Named failures. Every one of these is a distinct thing that went wrong at a
+ * distinct hop, and each is named because the alternative — one "handshake
+ * failed" — is what makes somebody re-debug this stack from scratch.
+ *
+ * `realtime_call_rejected` is the load-bearing one. `client_secrets` mints a
+ * secret for ANY model string, including a model this account cannot use, so
+ * mint success is not proof of model access: a bad `OPENAI_REALTIME_MODEL`
+ * surfaces here and ONLY here, as a 403 `model_not_found` from
+ * `/v1/realtime/calls`. That upstream body has to reach the caller intact or
+ * the misconfiguration is invisible.
+ */
+export type HandshakeErrorCode =
+  | 'mint_failed'
+  | 'mint_missing_secret'
+  | 'realtime_call_rejected'
+  | 'missing_call_location'
+  | 'malformed_call_location'
+  | 'missing_answer_sdp';
+
+export type HandshakeFailure = {
+  readonly ok: false;
+  readonly code: HandshakeErrorCode;
+  readonly message: string;
+  /** Verbatim upstream error body, when the failure came from OpenAI. */
+  readonly upstream?: unknown;
+  readonly upstreamStatus?: number;
+};
+
+export type HandshakeSuccess = {
+  readonly ok: true;
+  readonly callId: string;
+  readonly answerSdp: string;
+  /**
+   * Whether the realtime server took the call. `false` means the browser still
+   * gets a working audio call with no server-side features — see `handOff`.
+   */
+  readonly attached: boolean;
+};
+
+export type HandshakeResult = HandshakeSuccess | HandshakeFailure;
+
+/** Just enough logger to satisfy the call sites; the app's logger fits it. */
+export type HandshakeLogger = {
+  readonly warn: (message: string, meta?: Record<string, unknown>) => void;
+  readonly error: (message: string, error: Error, meta?: Record<string, unknown>) => void;
+};
+
+export type HandshakeDeps = {
+  readonly fetch: typeof fetch;
+  /** The managed OpenAI key. Mints the secret; never attaches to a call. */
+  readonly apiKey: string;
+  /** Resolved by the caller from env — never defaulted inside this module. */
+  readonly model: string;
+  /** Realtime tool definitions, forwarded to the realtime server unchanged. */
+  readonly tools: readonly RealtimeTool[];
+  /** Unset means "no realtime server configured": degrade, do not fail. */
+  readonly internalRealtimeUrl: string | undefined;
+  /** `createSignedBroadcastHeaders`, injected so tests need no HMAC secret. */
+  readonly signHeaders: (body: string) => Record<string, string>;
+  readonly logger: HandshakeLogger;
+};
+
+export type HandshakeInput = {
+  readonly offerSdp: string;
+  readonly userId: string;
+  readonly conversationId?: string;
+};
+
+/** Upstream calls are short; a hung one must not hold the request open. */
+const OPENAI_TIMEOUT_MS = 15_000;
+
+/**
+ * The internal hop gets the same 5s ceiling the DM broadcast uses: an unhealthy
+ * realtime server must not stall a handshake the browser is waiting on.
+ */
+const HANDOFF_TIMEOUT_MS = 5_000;
+
+/** Read an error body without letting a non-JSON one throw over the real error. */
+const readErrorBody = async (response: Response): Promise<unknown> => {
+  const text = await response.text().catch(() => '');
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+/**
+ * `Location` is a RELATIVE path (`/v1/realtime/calls/rtc_…`), so the call id is
+ * its last segment. Query and fragment are stripped first, and the `rtc_`
+ * prefix is asserted rather than assumed: returning an unvalidated last segment
+ * is how an `undefined`/garbage call id gets all the way to a socket that then
+ * closes with an unreadable `1006`.
+ */
+export const parseCallId = (location: string | null): string | undefined => {
+  if (!location) return undefined;
+  const path = location.split(/[?#]/)[0].replace(/\/+$/, '');
+  const segment = path.slice(path.lastIndexOf('/') + 1);
+  return segment.startsWith(REALTIME_CALL_ID_PREFIX) ? segment : undefined;
+};
+
+/**
+ * Hand the live call to the realtime server. Best-effort BY DESIGN: at this
+ * point the browser has a valid answer SDP and can hold a working audio call.
+ * Failing the handshake because the tool/transcript/metering plane is
+ * unreachable would trade a degraded call for no call at all.
+ *
+ * Returns whether the realtime server accepted it, so the caller can report the
+ * degrade honestly instead of implying full capability.
+ */
+const handOff = async (
+  deps: HandshakeDeps,
+  input: HandshakeInput,
+  callId: string,
+  secret: string,
+): Promise<boolean> => {
+  if (!deps.internalRealtimeUrl) {
+    deps.logger.warn(
+      'Realtime voice call has no server attach: INTERNAL_REALTIME_URL is unset',
+      { callId, userId: input.userId },
+    );
+    return false;
+  }
+
+  // Signed, not merely internal. A valid HMAC proves the sender is the web
+  // backend, and this body carries a live OpenAI credential — it must not be
+  // the one unauthenticated internal endpoint.
+  //
+  // Typed as the shared contract, not as an inline literal: this is the one
+  // place the sender's shape can be checked against what the receiver parses,
+  // and a mismatch caught here is a compile error rather than a 400 from
+  // another service.
+  const payload: RealtimeAttachPayload = {
+    callId,
+    secret,
+    userId: input.userId,
+    ...(input.conversationId === undefined ? {} : { conversationId: input.conversationId }),
+    tools: [...deps.tools],
+  };
+  const body = JSON.stringify(payload);
+
+  try {
+    const response = await deps.fetch(
+      `${deps.internalRealtimeUrl}${VOICE_BRIDGE_ROUTES.attach}`,
+      {
+        method: 'POST',
+        headers: deps.signHeaders(body),
+        body,
+        signal: AbortSignal.timeout(HANDOFF_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) {
+      // The response body is read but NOT logged verbatim: it is the reply to a
+      // request whose body held a secret, and nothing here is worth that risk.
+      deps.logger.warn('Realtime server refused the call attach', {
+        callId,
+        userId: input.userId,
+        status: response.status,
+      });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    deps.logger.error(
+      'Realtime server attach handoff failed',
+      error instanceof Error ? error : new Error(String(error)),
+      { callId, userId: input.userId },
+    );
+    return false;
+  }
+};
+
+/**
+ * Mint -> relay -> parse -> hand off. The secret exists only inside this
+ * function's frame: it is never returned, never logged, and never persisted —
+ * it lives ~60 seconds and the handoff is immediate.
+ */
+export const runCallHandshake = async (
+  deps: HandshakeDeps,
+  input: HandshakeInput,
+): Promise<HandshakeResult> => {
+  const mintResponse = await deps.fetch(CLIENT_SECRETS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${deps.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(buildSessionConfig({ model: deps.model })),
+    signal: AbortSignal.timeout(OPENAI_TIMEOUT_MS),
+  });
+
+  if (!mintResponse.ok) {
+    return {
+      ok: false,
+      code: 'mint_failed',
+      message: 'Could not mint a realtime session secret.',
+      upstream: await readErrorBody(mintResponse),
+      upstreamStatus: mintResponse.status,
+    };
+  }
+
+  const secret = extractClientSecret(await mintResponse.json().catch(() => undefined));
+  if (!secret) {
+    return {
+      ok: false,
+      code: 'mint_missing_secret',
+      message: 'Realtime mint succeeded but returned no client secret.',
+    };
+  }
+
+  // The ephemeral secret — not the API key — authenticates the call creation,
+  // and this is where a model the account cannot use finally 403s.
+  const callResponse = await deps.fetch(REALTIME_CALLS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      'Content-Type': SDP_CONTENT_TYPE,
+    },
+    body: input.offerSdp,
+    signal: AbortSignal.timeout(OPENAI_TIMEOUT_MS),
+  });
+
+  if (!callResponse.ok) {
+    return {
+      ok: false,
+      code: 'realtime_call_rejected',
+      message: 'OpenAI rejected the realtime call.',
+      upstream: await readErrorBody(callResponse),
+      upstreamStatus: callResponse.status,
+    };
+  }
+
+  const location = callResponse.headers.get('Location');
+  if (!location) {
+    return {
+      ok: false,
+      code: 'missing_call_location',
+      message:
+        'OpenAI accepted the call but sent no Location header, so it has no addressable call id.',
+    };
+  }
+
+  const callId = parseCallId(location);
+  if (!callId) {
+    return {
+      ok: false,
+      code: 'malformed_call_location',
+      message: `Location header did not carry an ${REALTIME_CALL_ID_PREFIX} call id.`,
+    };
+  }
+
+  const answerSdp = await callResponse.text();
+  if (!answerSdp) {
+    return {
+      ok: false,
+      code: 'missing_answer_sdp',
+      message: 'OpenAI accepted the call but returned an empty SDP answer.',
+    };
+  }
+
+  const attached = await handOff(deps, input, callId, secret);
+
+  return { ok: true, callId, answerSdp, attached };
+};

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1652,6 +1652,11 @@
       "import": "./dist/realtime/kick-client.js",
       "require": "./dist/realtime/kick-client.js"
     },
+    "./realtime/voice-bridge-contract": {
+      "types": "./dist/realtime/voice-bridge-contract.d.ts",
+      "import": "./dist/realtime/voice-bridge-contract.js",
+      "require": "./dist/realtime/voice-bridge-contract.js"
+    },
     "./permissions/share-link-service": {
       "types": "./dist/permissions/share-link-service.d.ts",
       "import": "./dist/permissions/share-link-service.js",

--- a/packages/lib/src/realtime/voice-bridge-contract.ts
+++ b/packages/lib/src/realtime/voice-bridge-contract.ts
@@ -1,0 +1,112 @@
+/**
+ * The web -> realtime handoff for a live OpenAI voice call.
+ *
+ * One payload crosses one process boundary, so — following the rule
+ * `shells-contract` sets down — its schema is declared exactly once, here, and
+ * both sides parse with it. The web tier builds the body; `apps/realtime`
+ * validates it after the HMAC check and before touching a socket.
+ *
+ * WHY THE TOOLS TRAVEL IN THIS PAYLOAD. `apps/realtime` cannot build the
+ * realtime tool definitions itself: the conversion (`buildRealtimeTools`) reads
+ * PageSpace's AI SDK tool registry, which lives in `apps/web/src/lib/ai` behind
+ * the `@/` alias, imports `ai`/`zod`, and has env-dependent branches. There is
+ * no dependency edge from `apps/realtime` to `apps/web` and there must not be
+ * one. So the side that owns the registry converts, and the wire shape below
+ * carries the result. The browser is still never sent a tool schema — this is a
+ * server-to-server hop, signed, on the internal network.
+ *
+ * The SECRET in this payload is a live OpenAI credential with ~60s of life and
+ * the capability to attach to a real call. Every field below is on the wire
+ * because the receiver cannot derive it; nothing extra is.
+ *
+ * Pure: schemas and constants only. No I/O, no clock, no randomness, no
+ * module-level mutable state.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Internal routes the web tier posts to on the realtime server. A single
+ * declaration for the same reason `SHELL_BRIDGE_ROUTES` is one: a route string
+ * written out per app is a route string that drifts per app.
+ */
+export const VOICE_BRIDGE_ROUTES = {
+  attach: '/api/realtime/attach',
+} as const;
+
+/**
+ * The three id spaces a realtime call runs on are NOT interchangeable, and the
+ * one this payload carries is the CALL id. Measured shapes:
+ * - `rtc_…`  — the call, returned in the `Location` header of `/v1/realtime/calls`
+ * - `sess_…` — the session, returned by the mint
+ * - `call_…` — one function call inside a response
+ *
+ * The prefix is checked here rather than trusted because `sess_…` is the id
+ * sitting closest to hand at mint time, and attaching with it fails as an
+ * opaque socket close rather than as a message anyone can read.
+ */
+export const REALTIME_CALL_ID_PREFIX = 'rtc_';
+
+/**
+ * OpenAI ephemeral client secrets are `ek_`-prefixed. Asserting the prefix is
+ * what turns the single most confusing failure in this stack — passing the API
+ * key (`sk-…`) where only that call's own ephemeral secret works — into a
+ * refusal at the boundary with a name on it, instead of a bare `1006` socket
+ * close ten seconds later.
+ */
+export const EPHEMERAL_SECRET_PREFIX = 'ek_';
+
+export const realtimeCallIdSchema = z
+  .string()
+  .min(1)
+  .startsWith(REALTIME_CALL_ID_PREFIX, 'callId must be an rtc_ call id');
+
+export const ephemeralSecretSchema = z
+  .string()
+  .min(1)
+  .startsWith(
+    EPHEMERAL_SECRET_PREFIX,
+    'secret must be the call\'s ephemeral client secret (ek_…), not an API key',
+  );
+
+/**
+ * A tool as the realtime transport carries it: FLAT, not nested under a
+ * `function` key the way Chat Completions nests them.
+ *
+ * This mirrors `RealtimeTool` in `apps/web/src/lib/ai/realtime/session.ts`. The
+ * duplication is deliberate and bounded: that type is the web app's internal
+ * shape, this is the validated wire shape, and the realtime server must not
+ * import from the web app to learn it. A drift guard in the web tests asserts
+ * the two agree.
+ */
+export const realtimeToolSchema = z.object({
+  type: z.literal('function'),
+  name: z.string().min(1),
+  description: z.string(),
+  parameters: z.record(z.string(), z.unknown()),
+});
+
+export type RealtimeToolWire = z.infer<typeof realtimeToolSchema>;
+
+/**
+ * What `POST /api/realtime/attach` receives.
+ *
+ * `conversationId` is optional because voice is a second transport onto a
+ * conversation that may not exist yet at handshake time — a call that has not
+ * been bound to a thread still attaches, still runs tools, and still meters.
+ * Refusing to attach without one would make the binding state gate the call.
+ */
+export const realtimeAttachPayloadSchema = z.object({
+  callId: realtimeCallIdSchema,
+  secret: ephemeralSecretSchema,
+  userId: z.string().min(1),
+  conversationId: z.string().min(1).optional(),
+  tools: z.array(realtimeToolSchema).default([]),
+});
+
+export type RealtimeAttachPayload = z.infer<typeof realtimeAttachPayloadSchema>;
+
+/** What the attach endpoint answers. Never echoes the secret. */
+export type RealtimeAttachResult =
+  | { readonly success: true; readonly callId: string }
+  | { readonly success: false; readonly error: string };


### PR DESCRIPTION
## C-A — the server-side call plane, end to end

The browser POSTs an SDP offer to our route and gets an answer back. In between, our server mints the ephemeral secret, relays the offer to OpenAI, reads the `call_id` out of `Location`, and hands the call to `apps/realtime` over an HMAC-signed internal request. `apps/realtime` opens a WebSocket onto the **same** session, lands `session.update` with the real tool set, registers the socket, and holds it for the call's life.

The browser never contacts `api.openai.com`, never holds a credential, and never sees a tool schema.

---

## Design decisions worth reviewing

### The tools are converted web-side and travel in the signed payload

**This is the one place the brief could not be followed literally**, and it is deliberate.

The brief says `apps/realtime` should `import { toRealtimeTools } from '@/lib/ai/realtime/tools'`. That import cannot exist:

- `apps/realtime`'s tsconfig has no `@/` alias (it maps to `apps/web/src`), and there is no dependency edge from `apps/realtime` to `apps/web` — nor should there be.
- `tools.ts` imports `ai`, `zod`, and the web-local registry (`tool-exposure`, `tool-search-tool`, `execute-tool`). Building it requires PageSpace's whole AI SDK tool registry.

So the side that owns the registry converts, and the wire shape carries the result: the route calls the real `buildRealtimeTools(buildPageSpaceTools())` (leaf A2, unmodified — the conversion is not rebuilt) and puts the output in the signed attach payload. This is a server-to-server hop, so the requirement that tool schemas never reach the browser is preserved.

Guarded by `voice-bridge-contract-drift.test.ts`, which validates the **real** registry's output against the shared schema in both directions.

### The mint carries no tools

`buildSessionConfig({ model })` only. Tools are pushed later by the realtime server's own `session.update`. Minting them in as well would advertise tools to the model on a call that may never get a server attached (the `INTERNAL_REALTIME_URL` degrade path) — the model would then call tools with nobody listening. Tools arrive with the thing that executes them, or not at all.

### Upstream errors are 502, not the upstream status

A bare 403 passed through from OpenAI would be indistinguishable from *this route's own* 403 (free tier), and the two need completely different fixes. The upstream status and body are reported as data instead. That matters because `/v1/realtime/calls` is the **only** place a bad `OPENAI_REALTIME_MODEL` is ever visible — the mint 200s for a model the project cannot use.

### Concurrency cap reserves synchronously

`atCapacity()` → `await attach()` → `register()` does not actually cap: the gap spans an `await`, so every simultaneous request observes the same pre-attach size and all pass. A slot is claimed before the first suspension point, and released in `finally`. There is a test that fails against the naive version.

---

## The seam C-B builds on

B3 (tool dispatch), B4 (persistence) and D3 (metering) do **not** open sockets or parse frames. They take a session out of the registry and use two methods:

```ts
const session = realtimeCallRegistry.get(callId);

const unsubscribe = session.subscribe((event: unknown) => { /* every inbound event, parsed */ });
session.send({ type: 'response.create' });
```

- `realtimeCallRegistry` — `get(callId)`, `getForUser(userId)`, `callIds()`, `size`, `endAll(reason)`.
- `RealtimeCallSession` — `callId`, `userId`, `conversationId`, `subscribe`, `send`, `end(reason)`, `ended`.
- Subscribers are fanned out to after the readiness check; a throwing subscriber is logged and cannot tear down a live call for the others.
- `usage` accumulation (D3) works because the socket lives for the whole call — that is the reason this is in `apps/realtime` and not a Next route.

This leaf owns the connection, the handshake, the registry and teardown. It does **not** implement tool execution, transcript persistence or metering.

---

## Acceptance criteria

**Part 1**
- [x] Unauthenticated → 401, nothing minted
- [x] Free tier while billing enabled → 403 with the transcribe route's shape
- [x] `OPENAI_REALTIME_MODEL` set → mints with that model, not the constant
- [x] 403 `model_not_found` at `/v1/realtime/calls` → upstream body surfaced verbatim
- [x] Location missing/malformed → named error, never an undefined callId
- [x] `INTERNAL_REALTIME_URL` unset → still returns answer SDP (`attached:false`), logs why
- [x] Secret appears nowhere in the response body — asserted on every path, plus a "never logged" test
- [x] Injected fetch, no live network

**Part 2**
- [x] Valid callId + that call's secret → ready on `session.updated`, never `session.created`
- [x] API key instead of the ephemeral secret → named, self-explaining error, no socket opened
- [x] Socket closes mid-call → deregistered, resources released
- [x] Two concurrent calls → independent sockets, registries and teardown
- [x] `session.update` rejected → upstream error surfaced, not reported ready
- [x] Fake WebSocket, exact `Authorization` header asserted
- [x] Unsigned request rejected — against the real `index.ts` wiring

---

## Verification

| Gate | Result |
|---|---|
| `bun run typecheck` (16 non-web packages, turbo) | 16/16 pass |
| `apps/web` typecheck (`tsc --noEmit`, authoritative) | pass |
| `bun run lint` (web + realtime) | pass, no findings in new files |
| `knip` | my only finding fixed; remaining findings are pre-existing, in files this PR never touches |
| realtime suite | 1014 pass |
| web realtime + voice suites | 134 pass |

Root `bun run typecheck` fails locally on the known turbo race (`build` runs parallel with `typecheck` and wipes `.next/types` mid-run, `TS6053`). Verified via the direct `tsc --noEmit` per the standing contract, with all 445 generated type files present.

**Mutation-checked** — every mechanism claimed as covered was broken and watched go red, then restored: readiness on `session.updated`, the `Bearer <secret>` header, the ephemeral-secret guard, `onClosed` deregistration, secret-in-response, `rtc_` validation, the signed handoff, the resolved model, the signature gate, and the concurrency race.

## Note

`RealtimeCallRegistry.endAll()` exists for process shutdown but is **not** wired to a signal handler. This server registers none today, and adding a `SIGTERM` listener would suppress Node's default termination and break container shutdown. Left for whoever owns process lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pYq7haTAw3E2zVKDp3t9W
