### PR TITLE
feat(voice): what the server does while it is on the call

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,11 @@ CSRF_SECRET=your_csrf_secret_here_generate_a_secure_random_string
 ENCRYPTION_KEY=your_encryption_key_here_32_byte_hex_string
 
 # Application URLs
-# WEB_APP_URL is also used for Origin header validation (CSRF defense-in-depth)
+# WEB_APP_URL is also used for Origin header validation (CSRF defense-in-depth),
+# and — since audio-native voice — as apps/realtime's address for the web tier: a
+# live call calls back to {WEB_APP_URL}/api/internal/voice/bridge to run tools and
+# persist transcripts. Unset, a voice call still connects and still bills; it just
+# runs without tools or a transcript.
 WEB_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_ADMIN_APP_URL=http://localhost:3005

--- a/apps/realtime/src/__tests__/realtime-attach-handler.test.ts
+++ b/apps/realtime/src/__tests__/realtime-attach-handler.test.ts
@@ -22,6 +22,8 @@ import {
   type AttachOptions,
   type RealtimeCallSession,
 } from '../voice/realtime-call-session';
+import type { CallMeter, CallMeterOptions, MeterStopReason } from '../voice/call-metering';
+import type { VoiceCallRuntime, VoiceCallRuntimeOptions } from '../voice/voice-call-runtime';
 
 const VALID = {
   callId: 'rtc_u0_abc',
@@ -29,7 +31,25 @@ const VALID = {
   userId: 'u1',
   conversationId: 'conv1',
   tools: [{ type: 'function', name: 'read_page', description: 'Read.', parameters: {} }],
+  model: 'gpt-realtime-2.1',
+  subscriptionTier: 'pro',
 };
+
+/** A meter that records what it was told to do, without a ledger. */
+function fakeMeter(): CallMeter & { stops: MeterStopReason[] } {
+  const stops: MeterStopReason[] = [];
+  return {
+    stops,
+    record: vi.fn(),
+    touch: vi.fn(),
+    settle: vi.fn(async () => {}),
+    stop: vi.fn(async (reason: MeterStopReason) => {
+      stops.push(reason);
+    }),
+    billedDollars: 0,
+    stopped: false,
+  };
+}
 
 function fakeSession(options: AttachOptions): RealtimeCallSession {
   let ended = false;
@@ -52,6 +72,14 @@ function deps(overrides: Partial<AttachHandlerDeps> = {}): AttachHandlerDeps {
   return {
     registry: new RealtimeCallRegistry(),
     attach: vi.fn(async (options: AttachOptions) => fakeSession(options)),
+    startMeter: vi.fn(async (_options: CallMeterOptions) => ({
+      ok: true as const,
+      meter: fakeMeter(),
+    })),
+    startRuntime: vi.fn(
+      (_options: VoiceCallRuntimeOptions): VoiceCallRuntime => ({ stop: vi.fn(async () => {}) }),
+    ),
+    bridge: { send: vi.fn(async () => ({ ok: false as const, error: 'not used' })) },
     ...overrides,
   };
 }
@@ -285,5 +313,183 @@ describe('handleRealtimeAttachRequest — failures and teardown', () => {
     expect(registry.size).toBe(2);
     expect(registry.get(VALID.callId)?.userId).toBe('u1');
     expect(registry.get('rtc_two')?.userId).toBe('u2');
+  });
+});
+
+describe('handleRealtimeAttachRequest — metering and the runtime', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given the credit gate refuses, should 402 WITHOUT opening a socket', async () => {
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    const result = await handleRealtimeAttachRequest(
+      deps({
+        attach,
+        startMeter: vi.fn(async () => ({ ok: false as const, reason: 'insufficient_credits' })),
+      }),
+      JSON.stringify(VALID),
+    );
+
+    expect(result.status).toBe(402);
+    expect((result.body as { error: string }).error).toContain('insufficient_credits');
+    // The whole point of gating before the attach: an unaffordable call must
+    // not get as far as a socket that has already started billing.
+    expect(attach).not.toHaveBeenCalled();
+  });
+
+  it('given the user is already on their per-user limit, should 429 without attaching', async () => {
+    const registry = new RealtimeCallRegistry(8);
+    const attach = vi.fn(async (options: AttachOptions) => fakeSession(options));
+    const d = deps({ registry, attach, maxCallsPerUser: 1 });
+
+    const first = await handleRealtimeAttachRequest(d, JSON.stringify(VALID));
+    expect(first.status).toBe(200);
+
+    const second = await handleRealtimeAttachRequest(
+      d,
+      JSON.stringify({ ...VALID, callId: 'rtc_second' }),
+    );
+
+    expect(second.status).toBe(429);
+    expect((second.body as { error: string }).error).toContain('this user');
+    expect(attach).toHaveBeenCalledTimes(1);
+  });
+
+  it('given the per-user limit is reached by ONE user, should still admit a different user', async () => {
+    // The deployment cap cannot express this and the per-user cap must not be
+    // mistaken for it: one person's limit is not everyone's.
+    const registry = new RealtimeCallRegistry(8);
+    const d = deps({ registry, maxCallsPerUser: 1 });
+
+    await handleRealtimeAttachRequest(d, JSON.stringify(VALID));
+    const other = await handleRealtimeAttachRequest(
+      d,
+      JSON.stringify({ ...VALID, callId: 'rtc_other', userId: 'u2' }),
+    );
+
+    expect(other.status).toBe(200);
+    expect(registry.size).toBe(2);
+  });
+
+  it('given a valid payload, should start the runtime with the seed, the secret and the call context', async () => {
+    const startRuntime = vi.fn(
+      (_options: VoiceCallRuntimeOptions): VoiceCallRuntime => ({ stop: vi.fn(async () => {}) }),
+    );
+    const seed = [
+      {
+        type: 'conversation.item.create',
+        item: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+      },
+    ];
+
+    await handleRealtimeAttachRequest(
+      deps({ startRuntime }),
+      JSON.stringify({ ...VALID, seed, timezone: 'America/New_York' }),
+    );
+
+    expect(startRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: VALID.secret,
+        seed,
+        timezone: 'America/New_York',
+      }),
+    );
+  });
+
+  it('given the tier and model on the payload, should meter against them rather than a default', async () => {
+    const startMeter = vi.fn(async (_options: CallMeterOptions) => ({
+      ok: true as const,
+      meter: fakeMeter(),
+    }));
+
+    await handleRealtimeAttachRequest(
+      deps({ startMeter }),
+      JSON.stringify({ ...VALID, model: 'gpt-realtime', subscriptionTier: 'plus' }),
+    );
+
+    expect(startMeter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gpt-realtime',
+        tier: 'plus',
+        callId: VALID.callId,
+        userId: 'u1',
+        conversationId: 'conv1',
+      }),
+    );
+  });
+
+  it('given the attach fails AFTER the hold was taken, should stop the meter so the hold is released', async () => {
+    const meter = fakeMeter();
+    const result = await handleRealtimeAttachRequest(
+      deps({
+        startMeter: vi.fn(async () => ({ ok: true as const, meter })),
+        attach: vi.fn(async () => {
+          throw new RealtimeAttachError('socket_error', 'nope');
+        }),
+      }),
+      JSON.stringify(VALID),
+    );
+
+    expect(result.status).toBe(502);
+    // Otherwise the reservation sits against the user's balance until its TTL,
+    // for a call that never happened.
+    expect(meter.stops).toEqual(['call_ended']);
+  });
+
+  it('given the session closes later, should stop the runtime as well as deregister', async () => {
+    const registry = new RealtimeCallRegistry();
+    const stop = vi.fn(async () => {});
+    let closeIt: (() => void) | undefined;
+    const attach = vi.fn(async (options: AttachOptions) => {
+      closeIt = () => options.onClosed?.(options.callId);
+      return fakeSession(options);
+    });
+
+    await handleRealtimeAttachRequest(
+      deps({ registry, attach, startRuntime: vi.fn(() => ({ stop })) }),
+      JSON.stringify(VALID),
+    );
+
+    closeIt?.();
+
+    expect(registry.size).toBe(0);
+    expect(stop).toHaveBeenCalledWith('call_ended');
+  });
+
+  it('given the meter hits a limit, should tear the call down through the runtime', async () => {
+    // The meter owns the ledger, not the socket, so a limit it hits has to be
+    // routed to the thing that can also hang up the browser.
+    let onLimit: ((reason: MeterStopReason, message: string) => void) | undefined;
+    const stop = vi.fn(async () => {});
+
+    await handleRealtimeAttachRequest(
+      deps({
+        startMeter: vi.fn(async (options: CallMeterOptions) => {
+          onLimit = options.onLimit;
+          return { ok: true as const, meter: fakeMeter() };
+        }),
+        startRuntime: vi.fn(() => ({ stop })),
+      }),
+      JSON.stringify(VALID),
+    );
+
+    onLimit?.('idle_timeout', 'silence');
+
+    expect(stop).toHaveBeenCalledWith('idle_timeout');
+  });
+
+  it('given no model, should 400 — an unpriced call bills nothing', async () => {
+    const { model: _omitted, ...withoutModel } = VALID;
+    const result = await handleRealtimeAttachRequest(deps(), JSON.stringify(withoutModel));
+    expect(result.status).toBe(400);
+  });
+
+  it('given no seed, should default to none rather than refuse', async () => {
+    const startRuntime = vi.fn(
+      (_options: VoiceCallRuntimeOptions): VoiceCallRuntime => ({ stop: vi.fn(async () => {}) }),
+    );
+    const result = await handleRealtimeAttachRequest(deps({ startRuntime }), JSON.stringify(VALID));
+
+    expect(result.status).toBe(200);
+    expect(startRuntime).toHaveBeenCalledWith(expect.objectContaining({ seed: [] }));
   });
 });

--- a/apps/realtime/src/voice/__tests__/call-metering.test.ts
+++ b/apps/realtime/src/voice/__tests__/call-metering.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Metering tests. No ledger, no timers, no clock: the gate, the settle sink,
+ * the hold release and every timer are injected, so what is exercised is the
+ * decision tree — hold, accumulate, settle, re-hold, stop — rather than
+ * Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    realtime: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import { startCallMeter, type CallMeterOptions, type MeterStopReason } from '../call-metering';
+import type { RealtimeUsage } from '@pagespace/lib/monitoring/voice-pricing';
+
+const usage = (over: Partial<RealtimeUsage> = {}): RealtimeUsage => ({
+  input_tokens: 100,
+  output_tokens: 50,
+  total_tokens: 150,
+  input_token_details: { text_tokens: 20, audio_tokens: 80, image_tokens: 0 },
+  output_token_details: { text_tokens: 10, audio_tokens: 40 },
+  ...over,
+});
+
+/** Hand-cranked timers: nothing fires until a test says so. */
+function fakeTimers() {
+  const intervals: { fn: () => void; ms: number; id: number }[] = [];
+  const timeouts: { fn: () => void; ms: number; id: number }[] = [];
+  let nextId = 1;
+
+  return {
+    intervals,
+    timeouts,
+    setIntervalFn: ((fn: () => void, ms: number) => {
+      const id = nextId++;
+      intervals.push({ fn, ms, id });
+      return id as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval,
+    clearIntervalFn: ((id: unknown) => {
+      const index = intervals.findIndex((entry) => entry.id === id);
+      if (index >= 0) intervals.splice(index, 1);
+    }) as unknown as typeof clearInterval,
+    setTimeoutFn: ((fn: () => void, ms: number) => {
+      const id = nextId++;
+      timeouts.push({ fn, ms, id });
+      return id as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setTimeout,
+    clearTimeoutFn: ((id: unknown) => {
+      const index = timeouts.findIndex((entry) => entry.id === id);
+      if (index >= 0) timeouts.splice(index, 1);
+    }) as unknown as typeof clearTimeout,
+    /** The settle interval is created first, the idle sweep second. */
+    fireSettle: () => intervals[0]?.fn(),
+    fireIdleSweep: () => intervals[1]?.fn(),
+    fireDurationCap: () => timeouts[0]?.fn(),
+  };
+}
+
+type Harness = ReturnType<typeof fakeTimers> & {
+  gate: ReturnType<typeof vi.fn>;
+  track: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+  limits: { reason: MeterStopReason; message: string }[];
+  now: () => number;
+  advance: (ms: number) => void;
+};
+
+function harness(over: Partial<CallMeterOptions> = {}) {
+  const timers = fakeTimers();
+  let holdCounter = 0;
+  const gate = vi.fn(async () => ({
+    allowed: true,
+    reason: 'ok' as const,
+    holdId: `hold-${++holdCounter}`,
+  }));
+  const track = vi.fn(async () => {});
+  const release = vi.fn(async () => {});
+  const limits: { reason: MeterStopReason; message: string }[] = [];
+  let clock = 1_000;
+
+  const options: CallMeterOptions = {
+    callId: 'rtc_1',
+    userId: 'u1',
+    conversationId: 'conv1',
+    tier: 'pro',
+    model: 'gpt-realtime-2.1',
+    onLimit: (reason, message) => limits.push({ reason, message }),
+    setIntervalFn: timers.setIntervalFn,
+    clearIntervalFn: timers.clearIntervalFn,
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+    nowFn: () => clock,
+    gate: gate as unknown as CallMeterOptions['gate'],
+    track: track as unknown as CallMeterOptions['track'],
+    release: release as unknown as CallMeterOptions['release'],
+    ...over,
+  };
+
+  const h: Harness = {
+    ...timers,
+    gate,
+    track,
+    release,
+    limits,
+    now: () => clock,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+
+  return { options, h };
+}
+
+describe('startCallMeter — the opening hold', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given the gate allows, should start and hold', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+
+    expect(started.ok).toBe(true);
+    expect(h.gate).toHaveBeenCalledTimes(1);
+  });
+
+  it('given the gate refuses, should refuse with its reason and start nothing', async () => {
+    const { options, h } = harness({
+      gate: (async () => ({ allowed: false, reason: 'insufficient_credits' })) as unknown as CallMeterOptions['gate'],
+    });
+    const started = await startCallMeter(options);
+
+    expect(started).toEqual({ ok: false, reason: 'insufficient_credits' });
+    expect(h.intervals).toHaveLength(0);
+    expect(h.timeouts).toHaveLength(0);
+  });
+
+  it('should gate on the PER-USER concurrency limit, not just the balance', async () => {
+    const { options, h } = harness();
+    await startCallMeter(options);
+
+    expect(h.gate).toHaveBeenCalledWith(
+      'u1',
+      'pro',
+      expect.objectContaining({ maxInFlight: expect.any(Number), estCostCents: expect.any(Number) }),
+    );
+  });
+});
+
+describe('startCallMeter — settling', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given usage across two responses, should settle their SUM once', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.track).toHaveBeenCalledTimes(1);
+    const call = h.track.mock.calls[0][0];
+    expect(call.inputTokens).toBe(200);
+    expect(call.outputTokens).toBe(100);
+    expect(call.providerCostDollars).toBeGreaterThan(0);
+  });
+
+  it('should settle against the hold it opened, then take a NEW hold for the next window', async () => {
+    // `trackUsage` takes ownership of the hold, so a long call that did not
+    // re-hold would run the rest of its length unreserved.
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.track.mock.calls[0][0].holdId).toBe('hold-1');
+    expect(h.gate).toHaveBeenCalledTimes(2);
+
+    started.meter.record(usage());
+    await started.meter.settle();
+    expect(h.track.mock.calls[1][0].holdId).toBe('hold-2');
+  });
+
+  it('given nothing was spent, should settle nothing and keep the existing hold', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    await started.meter.settle();
+
+    expect(h.track).not.toHaveBeenCalled();
+    // No second gate call: the hold was never consumed, so there is nothing to
+    // replace.
+    expect(h.gate).toHaveBeenCalledTimes(1);
+  });
+
+  it('given the re-hold is refused, should report credit exhaustion as a limit', async () => {
+    let calls = 0;
+    const gate = vi.fn(async () => {
+      calls += 1;
+      return calls === 1
+        ? { allowed: true, reason: 'ok' as const, holdId: 'hold-1' }
+        : { allowed: false, reason: 'insufficient_credits' as const };
+    });
+    const { options, h } = harness({ gate: gate as unknown as CallMeterOptions['gate'] });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.limits).toEqual([
+      { reason: 'credit_exhausted', message: expect.any(String) },
+    ]);
+  });
+
+  it('given the settle sink throws, should keep the call up rather than take it down', async () => {
+    const { options, h } = harness({
+      track: (async () => {
+        throw new Error('ledger unreachable');
+      }) as unknown as CallMeterOptions['track'],
+    });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await expect(started.meter.settle()).resolves.toBeUndefined();
+    expect(h.limits).toEqual([]);
+  });
+
+  it('should settle on its own interval without being asked', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    h.fireSettle();
+    await started.meter.settle();
+
+    expect(h.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('given overlapping settles, should serialize them so one window is never billed twice', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await Promise.all([started.meter.settle(), started.meter.settle(), started.meter.settle()]);
+
+    expect(h.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stamp the usage row as deterministic voice-realtime spend', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.track.mock.calls[0][0]).toMatchObject({
+      provider: 'openai_voice',
+      model: 'gpt-realtime-2.1',
+      source: 'voice',
+      costSource: 'list_price',
+      conversationId: 'conv1',
+      metadata: expect.objectContaining({ type: 'voice_realtime', callId: 'rtc_1' }),
+    });
+  });
+
+  it('given an unpriceable model, should still settle — at zero, loudly', async () => {
+    const { options, h } = harness({ model: 'gpt-realtime-9-unreleased' });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.track.mock.calls[0][0].providerCostDollars).toBe(0);
+  });
+});
+
+describe('startCallMeter — limits', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given no activity for longer than the idle timeout, should report an idle limit', async () => {
+    const { options, h } = harness({ idleTimeoutMs: 10_000 });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    h.advance(10_001);
+    h.fireIdleSweep();
+
+    expect(h.limits.map((limit) => limit.reason)).toEqual(['idle_timeout']);
+  });
+
+  it('given someone is still talking, should NOT report an idle limit', async () => {
+    const { options, h } = harness({ idleTimeoutMs: 10_000 });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    h.advance(9_000);
+    started.meter.touch();
+    h.advance(9_000);
+    h.fireIdleSweep();
+
+    expect(h.limits).toEqual([]);
+  });
+
+  it('given recorded usage, should count as activity', async () => {
+    // Usage means a response happened, which means someone is in the room.
+    const { options, h } = harness({ idleTimeoutMs: 10_000 });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    h.advance(9_000);
+    started.meter.record(usage());
+    h.advance(9_000);
+    h.fireIdleSweep();
+
+    expect(h.limits).toEqual([]);
+  });
+
+  it('given the duration cap elapses, should report it', async () => {
+    const { options, h } = harness({ maxDurationMs: 600_000 });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    h.fireDurationCap();
+
+    expect(h.limits.map((limit) => limit.reason)).toEqual(['duration_cap']);
+    expect(h.timeouts[0].ms).toBe(600_000);
+  });
+});
+
+describe('startCallMeter — stopping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should settle the FINAL window before releasing anything', async () => {
+    // The last thing said in a call is usually the most expensive part of it.
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.stop('call_ended');
+
+    expect(h.track).toHaveBeenCalledTimes(1);
+    expect(h.track.mock.calls[0][0].inputTokens).toBe(100);
+  });
+
+  it('given an unspent hold at the end, should release it rather than leave it to its TTL', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    await started.meter.stop('call_ended');
+
+    expect(h.release).toHaveBeenCalledWith('hold-1');
+  });
+
+  it('given the final window WAS settled, should release nothing and take no fresh hold', async () => {
+    // `trackUsage` already took the reservation on the way out, and a call that
+    // has stopped has no next window to reserve for. Re-holding here would open
+    // a reservation nothing will ever settle.
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.stop('call_ended');
+
+    expect(h.track).toHaveBeenCalledTimes(1);
+    expect(h.release).not.toHaveBeenCalled();
+    expect(h.gate).toHaveBeenCalledTimes(1);
+  });
+
+  it('given the settle threw, should release that hold and still re-hold for the next window', async () => {
+    // Whether the sink consumed the reservation before throwing is unknowable,
+    // and releasing covers both: an already-settled hold deletes nothing, and
+    // an unreached one is freed instead of pinning the balance for its TTL.
+    const { options, h } = harness({
+      track: (async () => {
+        throw new Error('ledger unreachable');
+      }) as unknown as CallMeterOptions['track'],
+    });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.release).toHaveBeenCalledWith('hold-1');
+    expect(h.gate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should clear every timer so a stopped call cannot fire a limit', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    await started.meter.stop('duration_cap');
+
+    expect(h.intervals).toHaveLength(0);
+    expect(h.timeouts).toHaveLength(0);
+  });
+
+  it('should be idempotent', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    await started.meter.stop('call_ended');
+    await started.meter.stop('call_ended');
+
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(started.meter.stopped).toBe(true);
+  });
+
+  it('given a failing hold release, should not throw out of teardown', async () => {
+    const { options } = harness({
+      release: (async () => {
+        throw new Error('ledger unreachable');
+      }) as unknown as CallMeterOptions['release'],
+    });
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    await expect(started.meter.stop('call_ended')).resolves.toBeUndefined();
+  });
+
+  it('should report the total billed across every settle', async () => {
+    const { options } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    started.meter.record(usage());
+    await started.meter.settle();
+    const afterFirst = started.meter.billedDollars;
+
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(afterFirst).toBeGreaterThan(0);
+    expect(started.meter.billedDollars).toBeCloseTo(afterFirst * 2, 10);
+  });
+
+  it('given the meter is stopped, should ignore further usage', async () => {
+    const { options, h } = harness();
+    const started = await startCallMeter(options);
+    if (!started.ok) throw new Error('expected a meter');
+
+    await started.meter.stop('call_ended');
+    h.track.mockClear();
+    started.meter.record(usage());
+    await started.meter.settle();
+
+    expect(h.track).not.toHaveBeenCalled();
+  });
+});

--- a/apps/realtime/src/voice/__tests__/usage-accumulator.test.ts
+++ b/apps/realtime/src/voice/__tests__/usage-accumulator.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRealtimeCostDollars } from '@pagespace/lib/monitoring/voice-pricing';
+import type { RealtimeUsage } from '@pagespace/lib/monitoring/voice-pricing';
+import { addUsage, hasUnattributedTokens, isUsageEmpty } from '../usage-accumulator';
+
+const usage = (over: Partial<RealtimeUsage> = {}): RealtimeUsage => ({
+  input_tokens: 10,
+  output_tokens: 5,
+  total_tokens: 15,
+  input_token_details: { text_tokens: 4, audio_tokens: 6, image_tokens: 0 },
+  output_token_details: { text_tokens: 2, audio_tokens: 3 },
+  ...over,
+});
+
+describe('addUsage', () => {
+  it('given two responses, should sum the totals', () => {
+    const total = addUsage(usage(), usage());
+
+    expect(total.input_tokens).toBe(20);
+    expect(total.output_tokens).toBe(10);
+    expect(total.total_tokens).toBe(30);
+  });
+
+  it('given two responses, should sum EACH modality separately', () => {
+    // Modality is the cost driver — audio input is 8x text input — so a
+    // blended total would be unpriceable.
+    const total = addUsage(usage(), usage());
+
+    expect(total.input_token_details).toMatchObject({
+      text_tokens: 8,
+      audio_tokens: 12,
+      image_tokens: 0,
+    });
+    expect(total.output_token_details).toMatchObject({ text_tokens: 4, audio_tokens: 6 });
+  });
+
+  it('given no prior total, should start from the first response', () => {
+    expect(addUsage(undefined, usage()).input_tokens).toBe(10);
+  });
+
+  it('given no new usage, should leave the running total unchanged', () => {
+    const total = addUsage(usage(), undefined);
+    expect(total.input_tokens).toBe(10);
+    expect(total.input_token_details).toMatchObject({ text_tokens: 4, audio_tokens: 6 });
+  });
+
+  it('given both sides absent, should produce an empty total rather than undefined', () => {
+    expect(isUsageEmpty(addUsage(undefined, undefined))).toBe(true);
+  });
+
+  it('given cached tokens, should keep them as their own subtotal and NOT fold them into the gross', () => {
+    // `cached_tokens` is a SUBSET of `input_tokens`. Folding it in would bill
+    // every cache hit twice.
+    const total = addUsage(
+      usage({ input_token_details: { text_tokens: 10, audio_tokens: 0, image_tokens: 0, cached_tokens: 4 } }),
+      usage({ input_token_details: { text_tokens: 10, audio_tokens: 0, image_tokens: 0, cached_tokens: 6 } }),
+    );
+
+    expect(total.input_token_details?.text_tokens).toBe(20);
+    expect(total.input_token_details?.cached_tokens).toBe(10);
+  });
+
+  it('given cached token DETAILS, should sum them per modality', () => {
+    const total = addUsage(
+      usage({
+        input_token_details: {
+          text_tokens: 10,
+          audio_tokens: 10,
+          image_tokens: 0,
+          cached_tokens: 4,
+          cached_tokens_details: { text_tokens: 1, audio_tokens: 3 },
+        },
+      }),
+      usage({
+        input_token_details: {
+          text_tokens: 10,
+          audio_tokens: 10,
+          image_tokens: 0,
+          cached_tokens: 2,
+          cached_tokens_details: { text_tokens: 2, audio_tokens: 0 },
+        },
+      }),
+    );
+
+    expect(total.input_token_details?.cached_tokens_details).toMatchObject({
+      text_tokens: 3,
+      audio_tokens: 3,
+      image_tokens: 0,
+    });
+  });
+
+  it('given only one side has cached details, should still carry them', () => {
+    const total = addUsage(
+      usage({ input_token_details: { text_tokens: 4, audio_tokens: 0, image_tokens: 0 } }),
+      usage({
+        input_token_details: {
+          text_tokens: 4,
+          audio_tokens: 0,
+          image_tokens: 0,
+          cached_tokens_details: { text_tokens: 2 },
+        },
+      }),
+    );
+
+    expect(total.input_token_details?.cached_tokens_details).toMatchObject({ text_tokens: 2 });
+  });
+
+  it('given only ONE side carries detail blocks, should keep them rather than drop the whole block', () => {
+    // Pricing reads only the detail blocks, so dropping them because one frame
+    // lacked them would silently bill the call at zero.
+    const total = addUsage(
+      { input_tokens: 3, output_tokens: 0, total_tokens: 3 },
+      usage(),
+    );
+
+    expect(total.input_token_details).toMatchObject({ text_tokens: 4, audio_tokens: 6 });
+    expect(total.output_token_details).toMatchObject({ audio_tokens: 3 });
+  });
+
+  it('given malformed wire values, should contribute zero rather than NaN', () => {
+    const malformed = {
+      input_tokens: 'lots' as unknown as number,
+      output_tokens: Number.NaN,
+      total_tokens: -5,
+      input_token_details: { text_tokens: undefined, audio_tokens: -1, image_tokens: Number.NaN },
+    } as RealtimeUsage;
+
+    const total = addUsage(usage(), malformed);
+
+    expect(total.input_tokens).toBe(10);
+    expect(total.output_tokens).toBe(5);
+    expect(total.total_tokens).toBe(15);
+    expect(Number.isNaN(total.input_token_details?.audio_tokens ?? 0)).toBe(false);
+    // A NaN reaching the ledger is the one outcome this must never allow.
+    expect(Number.isNaN(calculateRealtimeCostDollars('gpt-realtime-2.1', total))).toBe(false);
+  });
+
+  it('given a summed total, should price as the sum of its parts', () => {
+    const one = calculateRealtimeCostDollars('gpt-realtime-2.1', usage());
+    const summed = calculateRealtimeCostDollars('gpt-realtime-2.1', addUsage(usage(), usage()));
+
+    expect(summed).toBeCloseTo(one * 2, 10);
+  });
+
+  it('given three responses folded in order, should equal the same three folded in any order', () => {
+    const a = usage({ input_token_details: { text_tokens: 1, audio_tokens: 2, image_tokens: 3 } });
+    const b = usage({ input_token_details: { text_tokens: 4, audio_tokens: 5, image_tokens: 6 } });
+    const c = usage({ input_token_details: { text_tokens: 7, audio_tokens: 8, image_tokens: 9 } });
+
+    expect(addUsage(addUsage(a, b), c)).toEqual(addUsage(addUsage(c, b), a));
+  });
+});
+
+describe('isUsageEmpty', () => {
+  it('given no usage at all, should be empty', () => {
+    expect(isUsageEmpty(undefined)).toBe(true);
+    expect(isUsageEmpty({})).toBe(true);
+  });
+
+  it('given all-zero counts, should be empty so an idle window settles nothing', () => {
+    expect(
+      isUsageEmpty({
+        input_tokens: 0,
+        output_tokens: 0,
+        total_tokens: 0,
+        input_token_details: { text_tokens: 0, audio_tokens: 0, image_tokens: 0 },
+      }),
+    ).toBe(true);
+  });
+
+  it('given any spend, should not be empty', () => {
+    expect(isUsageEmpty(usage())).toBe(false);
+    expect(isUsageEmpty({ input_token_details: { audio_tokens: 1 } })).toBe(false);
+    expect(isUsageEmpty({ output_token_details: { text_tokens: 1 } })).toBe(false);
+    expect(isUsageEmpty({ total_tokens: 1 })).toBe(false);
+  });
+});
+
+describe('hasUnattributedTokens', () => {
+  it('given totals with no modality breakdown, should report it — that portion bills $0', () => {
+    expect(hasUnattributedTokens({ input_tokens: 100, output_tokens: 50 })).toBe(true);
+    expect(calculateRealtimeCostDollars('gpt-realtime-2.1', { input_tokens: 100 })).toBe(0);
+  });
+
+  it('given attributed tokens, should report nothing', () => {
+    expect(hasUnattributedTokens(usage())).toBe(false);
+  });
+
+  it('given output-only attribution, should count as attributed', () => {
+    expect(
+      hasUnattributedTokens({ input_tokens: 5, output_token_details: { audio_tokens: 5 } }),
+    ).toBe(false);
+  });
+
+  it('given no usage or no reported totals, should report nothing', () => {
+    expect(hasUnattributedTokens(undefined)).toBe(false);
+    expect(hasUnattributedTokens({})).toBe(false);
+  });
+});

--- a/apps/realtime/src/voice/__tests__/voice-bridge-client.test.ts
+++ b/apps/realtime/src/voice/__tests__/voice-bridge-client.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    realtime: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import {
+  createVoiceBridgeClient,
+  TOOL_DISPATCH_TIMEOUT_MS,
+  TRANSCRIPT_TIMEOUT_MS,
+} from '../voice-bridge-client';
+import {
+  VOICE_CALLBACK_ROUTES,
+  type VoiceBridgeRequest,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+
+const TOOL_REQUEST: VoiceBridgeRequest = {
+  kind: 'tool',
+  callId: 'rtc_1',
+  userId: 'u1',
+  name: 'read_page',
+  argumentsJson: '{"pageId":"p1"}',
+};
+
+const TRANSCRIPT_REQUEST: VoiceBridgeRequest = {
+  kind: 'transcript',
+  callId: 'rtc_1',
+  userId: 'u1',
+  conversationId: 'conv1',
+  role: 'user',
+  text: 'hello',
+};
+
+const okResponse = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+describe('createVoiceBridgeClient', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a request, should POST it signed to the bridge route on the web tier', async () => {
+    const fetchFn = vi.fn(async () => okResponse({ ok: true, kind: 'tool', output: 'Done.' }));
+    const signHeaders = vi.fn(() => ({ 'X-Broadcast-Signature': 't=1,v1=sig' }));
+
+    const client = createVoiceBridgeClient({
+      webUrl: 'http://web:3000',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      signHeaders,
+    });
+    const result = await client.send(TOOL_REQUEST);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      `http://web:3000${VOICE_CALLBACK_ROUTES.bridge}`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(TOOL_REQUEST),
+        headers: { 'X-Broadcast-Signature': 't=1,v1=sig' },
+      }),
+    );
+    // Signed over the EXACT body sent, or the receiver's HMAC check fails.
+    expect(signHeaders).toHaveBeenCalledWith(JSON.stringify(TOOL_REQUEST));
+    expect(result).toEqual({ ok: true, kind: 'tool', output: 'Done.' });
+  });
+
+  it('given no web url, should degrade rather than throw — a call with no bridge is still a call', async () => {
+    const fetchFn = vi.fn();
+    const client = createVoiceBridgeClient({
+      webUrl: undefined,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    const result = await client.send(TOOL_REQUEST);
+
+    expect(result).toMatchObject({ ok: false });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('given a non-2xx answer, should report a failure carrying the status', async () => {
+    const client = createVoiceBridgeClient({
+      webUrl: 'http://web:3000',
+      fetchFn: (async () => ({ ok: false, status: 503 })) as unknown as typeof fetch,
+      signHeaders: () => ({}),
+    });
+
+    const result = await client.send(TOOL_REQUEST);
+
+    expect(result).toEqual({ ok: false, error: 'Voice bridge returned 503' });
+  });
+
+  it('given the web tier is unreachable, should report a failure rather than reject', async () => {
+    const client = createVoiceBridgeClient({
+      webUrl: 'http://web:3000',
+      fetchFn: (async () => {
+        throw new Error('ECONNREFUSED');
+      }) as unknown as typeof fetch,
+      signHeaders: () => ({}),
+    });
+
+    await expect(client.send(TOOL_REQUEST)).resolves.toEqual({
+      ok: false,
+      error: 'Voice bridge is unreachable',
+    });
+  });
+
+  it('should give a tool dispatch a TIGHTER deadline than a transcript', () => {
+    // A tool call is inside the live turn — the model has stopped and a slow hop
+    // is heard as silence. Nothing waits on a transcript.
+    expect(TOOL_DISPATCH_TIMEOUT_MS).toBeGreaterThan(TRANSCRIPT_TIMEOUT_MS);
+  });
+
+  it('given a transcript, should still post it to the same route', async () => {
+    const fetchFn = vi.fn(async () =>
+      okResponse({ ok: true, kind: 'transcript', saved: true, messageId: 'm1', rev: 3 }),
+    );
+    const client = createVoiceBridgeClient({
+      webUrl: 'http://web:3000',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      signHeaders: () => ({}),
+    });
+
+    const result = await client.send(TRANSCRIPT_REQUEST);
+
+    expect(result).toMatchObject({ ok: true, kind: 'transcript', saved: true });
+  });
+});

--- a/apps/realtime/src/voice/__tests__/voice-call-runtime.test.ts
+++ b/apps/realtime/src/voice/__tests__/voice-call-runtime.test.ts
@@ -1,0 +1,492 @@
+/**
+ * What the server does on the socket, exercised by feeding frames in and
+ * watching what goes out. The session, the bridge, the meter and the hangup are
+ * all fakes, so nothing here opens a connection or touches a ledger.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    realtime: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import { startVoiceCallRuntime } from '../voice-call-runtime';
+import type { RealtimeCallSession } from '../realtime-call-session';
+import type { VoiceBridgeClient } from '../voice-bridge-client';
+import type { CallMeter } from '../call-metering';
+import type { VoiceBridgeRequest } from '@pagespace/lib/realtime/voice-bridge-contract';
+
+const SEED = [
+  {
+    type: 'conversation.item.create' as const,
+    item: {
+      type: 'message' as const,
+      role: 'user' as const,
+      content: [{ type: 'input_text' as const, text: 'earlier question' }],
+    },
+  },
+];
+
+function fakeSession(over: Partial<RealtimeCallSession> = {}) {
+  const sent: Record<string, unknown>[] = [];
+  let listener: ((event: unknown) => void) | undefined;
+  let unsubscribed = false;
+  const session: RealtimeCallSession & {
+    sent: Record<string, unknown>[];
+    emit: (event: unknown) => void;
+    unsubscribed: () => boolean;
+  } = {
+    callId: 'rtc_1',
+    userId: 'u1',
+    conversationId: 'conv1',
+    subscribe: (fn) => {
+      listener = fn;
+      return () => {
+        unsubscribed = true;
+      };
+    },
+    send: (event) => {
+      sent.push(event);
+    },
+    end: vi.fn(),
+    ended: false,
+    ...over,
+    sent,
+    emit: (event: unknown) => listener?.(event),
+    unsubscribed: () => unsubscribed,
+  };
+  return session;
+}
+
+function fakeMeter() {
+  return {
+    record: vi.fn(),
+    touch: vi.fn(),
+    settle: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    billedDollars: 0,
+    stopped: false,
+  } satisfies CallMeter;
+}
+
+function fakeBridge(
+  respond: (request: VoiceBridgeRequest) => Awaited<ReturnType<VoiceBridgeClient['send']>> = () => ({
+    ok: true,
+    kind: 'tool',
+    output: 'Two pages.',
+  }),
+) {
+  const requests: VoiceBridgeRequest[] = [];
+  return {
+    requests,
+    client: {
+      send: vi.fn(async (request: VoiceBridgeRequest) => {
+        requests.push(request);
+        return respond(request);
+      }),
+    } as VoiceBridgeClient,
+  };
+}
+
+const responseDone = (over: Record<string, unknown> = {}) => ({
+  type: 'response.done',
+  response: { output: [], ...over },
+});
+
+const toolCall = (over: Record<string, unknown> = {}) => ({
+  type: 'function_call',
+  name: 'list_pages',
+  call_id: 'call_1',
+  arguments: '{\n  "driveId": "d1"\n}',
+  ...over,
+});
+
+/** Lets the runtime's un-awaited bridge work settle before assertions. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('startVoiceCallRuntime — seeding', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a seed, should send every item immediately', async () => {
+    const session = fakeSession();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: SEED,
+    });
+
+    expect(session.sent).toEqual(SEED);
+  });
+
+  it('given an empty seed, should send nothing — a fresh conversation seeds nothing', () => {
+    const session = fakeSession();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    expect(session.sent).toEqual([]);
+  });
+});
+
+describe('startVoiceCallRuntime — tool dispatch', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a function call, should dispatch it and answer with a STRING output then response.create', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(bridge.requests[0]).toMatchObject({
+      kind: 'tool',
+      name: 'list_pages',
+      argumentsJson: '{\n  "driveId": "d1"\n}',
+      userId: 'u1',
+      conversationId: 'conv1',
+    });
+    expect(session.sent[0]).toEqual({
+      type: 'conversation.item.create',
+      item: { type: 'function_call_output', call_id: 'call_1', output: 'Two pages.' },
+    });
+    expect(typeof (session.sent[0].item as { output: unknown }).output).toBe('string');
+    // Without this the model holds the result and never speaks.
+    expect(session.sent[1]).toEqual({ type: 'response.create' });
+  });
+
+  it('given the call context, should forward timezone and location so tools resolve "this page"', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+      timezone: 'America/New_York',
+      locationContext: { currentPage: { id: 'p1', title: 'Notes', type: 'DOCUMENT', path: '/n' } },
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(bridge.requests[0]).toMatchObject({
+      timezone: 'America/New_York',
+      locationContext: { currentPage: { id: 'p1' } },
+    });
+  });
+
+  it('given TWO calls in one turn, should answer both and send exactly ONE response.create', async () => {
+    // A response per output would have the model start speaking about the first
+    // tool and interrupt itself when the second landed.
+    const session = fakeSession();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(
+      responseDone({ output: [toolCall(), toolCall({ call_id: 'call_2', name: 'read_page' })] }),
+    );
+    await flush();
+
+    const outputs = session.sent.filter((event) => event.type === 'conversation.item.create');
+    const creates = session.sent.filter((event) => event.type === 'response.create');
+    expect(outputs).toHaveLength(2);
+    expect(creates).toHaveLength(1);
+  });
+
+  it('given the bridge is down, should STILL answer the call so the model is never left waiting', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge(() => ({ ok: false, error: 'Voice bridge is unreachable' }));
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(session.sent[0]).toMatchObject({
+      item: { type: 'function_call_output', call_id: 'call_1' },
+    });
+    expect(typeof (session.sent[0].item as { output: unknown }).output).toBe('string');
+    expect(session.sent[1]).toEqual({ type: 'response.create' });
+  });
+
+  it('given a response with no tool calls, should send nothing back', async () => {
+    const session = fakeSession();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone());
+    await flush();
+
+    expect(session.sent).toEqual([]);
+  });
+});
+
+describe('startVoiceCallRuntime — transcripts', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a user transcript, should persist it as a user turn', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge(() => ({ ok: true, kind: 'transcript', saved: true, messageId: 'm1', rev: 2 }));
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'where are my notes?',
+    });
+    await flush();
+
+    expect(bridge.requests[0]).toMatchObject({
+      kind: 'transcript',
+      role: 'user',
+      text: 'where are my notes?',
+      conversationId: 'conv1',
+    });
+  });
+
+  it('given an assistant transcript, should persist it as an assistant turn', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge(() => ({ ok: true, kind: 'transcript', saved: true, messageId: 'm1', rev: 2 }));
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit({ type: 'response.output_audio_transcript.done', transcript: 'In your Inbox.' });
+    await flush();
+
+    expect(bridge.requests[0]).toMatchObject({ kind: 'transcript', role: 'assistant' });
+  });
+
+  it('given an UNBOUND call, should skip persistence without failing the call', async () => {
+    // Binding state must never gate a call: it still runs tools and still meters.
+    const session = fakeSession({ conversationId: undefined });
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'hello',
+    });
+    await flush();
+
+    expect(bridge.requests.filter((request) => request.kind === 'transcript')).toEqual([]);
+  });
+});
+
+describe('startVoiceCallRuntime — metering', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a response with usage, should record it', async () => {
+    const session = fakeSession();
+    const meter = fakeMeter();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter,
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ usage: { input_tokens: 7, output_tokens: 3 } }));
+
+    expect(meter.record).toHaveBeenCalledWith({ input_tokens: 7, output_tokens: 3 });
+  });
+
+  it('given a response that BOTH carries usage and asks for a tool, should record the usage too', async () => {
+    const session = fakeSession();
+    const meter = fakeMeter();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter,
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()], usage: { input_tokens: 7 } }));
+    await flush();
+
+    expect(meter.record).toHaveBeenCalledWith({ input_tokens: 7 });
+  });
+
+  it('given conversational activity, should keep the idle timer alive', () => {
+    const session = fakeSession();
+    const meter = fakeMeter();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter,
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit({ type: 'input_audio_buffer.speech_started' });
+
+    expect(meter.touch).toHaveBeenCalled();
+  });
+
+  it('given only housekeeping frames, should NOT count them as activity', () => {
+    // Otherwise the idle reaper is permanently unreachable — an abandoned call
+    // still receives rate-limit updates.
+    const session = fakeSession();
+    const meter = fakeMeter();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter,
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit({
+      type: 'rate_limits.updated',
+      rate_limits: [{ name: 'tokens', limit: 40000, remaining: 100 }],
+    });
+
+    expect(meter.touch).not.toHaveBeenCalled();
+  });
+
+  it('given a malformed frame, should not throw into the socket', () => {
+    const session = fakeSession();
+    startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    expect(() => session.emit(undefined)).not.toThrow();
+    expect(() => session.emit('a string')).not.toThrow();
+    expect(() => session.emit({ type: 42 })).not.toThrow();
+  });
+});
+
+describe('startVoiceCallRuntime — teardown', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('given a limit was hit, should settle the meter, hang up the BROWSER, then end the session', async () => {
+    // Closing our own socket does not end the caller's WebRTC session; without
+    // the hangup, every limit would be half a limit.
+    const order: string[] = [];
+    const session = fakeSession({ end: vi.fn(() => order.push('end')) });
+    const meter = fakeMeter();
+    meter.stop = vi.fn(async () => {
+      order.push('meter');
+    });
+    const hangUp = vi.fn(async () => {
+      order.push('hangup');
+      return true;
+    });
+
+    const runtime = startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter,
+      secret: 'ek_secret',
+      seed: [],
+      hangUp,
+    });
+
+    await runtime.stop('duration_cap');
+
+    expect(order).toEqual(['meter', 'hangup', 'end']);
+    expect(hangUp).toHaveBeenCalledWith('rtc_1', 'ek_secret');
+    expect(meter.stop).toHaveBeenCalledWith('duration_cap');
+  });
+
+  it('given the CALL ended on its own, should not try to hang up a call OpenAI already tore down', async () => {
+    const hangUp = vi.fn(async () => true);
+    const runtime = startVoiceCallRuntime({
+      session: fakeSession(),
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+      hangUp,
+    });
+
+    await runtime.stop('call_ended');
+
+    expect(hangUp).not.toHaveBeenCalled();
+  });
+
+  it('should stop listening on teardown', async () => {
+    const session = fakeSession();
+    const runtime = startVoiceCallRuntime({
+      session,
+      bridge: fakeBridge().client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+      hangUp: vi.fn(async () => true),
+    });
+
+    await runtime.stop('call_ended');
+
+    expect(session.unsubscribed()).toBe(true);
+  });
+
+  it('should be idempotent — a call torn down twice settles once', async () => {
+    const meter = fakeMeter();
+    const runtime = startVoiceCallRuntime({
+      session: fakeSession(),
+      bridge: fakeBridge().client,
+      meter,
+      secret: 'ek_1',
+      seed: [],
+      hangUp: vi.fn(async () => true),
+    });
+
+    await Promise.all([runtime.stop('idle_timeout'), runtime.stop('call_ended')]);
+
+    expect(meter.stop).toHaveBeenCalledTimes(1);
+    expect(meter.stop).toHaveBeenCalledWith('idle_timeout');
+  });
+});

--- a/apps/realtime/src/voice/attach-handler.ts
+++ b/apps/realtime/src/voice/attach-handler.ts
@@ -8,6 +8,19 @@
  * — the web tier already gated voice on the user's tier at the one policy site,
  * exactly as the shell bridge does.
  *
+ * ADMISSION ORDER IS DELIBERATE, and each step refuses something the next one
+ * could not:
+ *   1. the DEPLOYMENT concurrency slot, claimed synchronously (the account's
+ *      40,000 tokens/minute is shared by every session on our key);
+ *   2. the PER-USER call count, which the deployment cap structurally cannot
+ *      express — eight calls spread over eight people is fine, eight held by
+ *      one person is not;
+ *   3. the CREDIT hold, taken before a socket exists, because a voice call has
+ *      no natural end at which an unaffordable one would be noticed.
+ * Only then is an OpenAI socket opened. Every one of those refusals costs the
+ * caller nothing; opening the socket first and refusing afterwards would have
+ * already started the meter.
+ *
  * The handler itself takes its dependencies as arguments and returns
  * `{ status, body }`, the shape `shell-io.ts` established, so the whole
  * admission path is testable without a socket, a signature, or a server.
@@ -17,6 +30,8 @@ import {
   realtimeAttachPayloadSchema,
   type RealtimeAttachResult,
 } from '@pagespace/lib/realtime/voice-bridge-contract';
+import { REALTIME_MAX_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   attachToCall,
@@ -25,15 +40,32 @@ import {
   type RealtimeCallSession,
 } from './realtime-call-session';
 import { realtimeCallRegistry, type RealtimeCallRegistry } from './realtime-call-registry';
+import { createVoiceBridgeClient, type VoiceBridgeClient } from './voice-bridge-client';
+import { startCallMeter, type CallMeterOptions, type CallMeterStart } from './call-metering';
+import {
+  startVoiceCallRuntime,
+  type VoiceCallRuntime,
+  type VoiceCallRuntimeOptions,
+} from './voice-call-runtime';
 
 export type AttachHandlerDeps = {
   readonly registry: RealtimeCallRegistry;
   readonly attach: (options: AttachOptions) => Promise<RealtimeCallSession>;
+  readonly startMeter: (options: CallMeterOptions) => Promise<CallMeterStart>;
+  readonly startRuntime: (options: VoiceCallRuntimeOptions) => VoiceCallRuntime;
+  readonly bridge: VoiceBridgeClient;
+  readonly maxCallsPerUser?: number;
 };
 
 export const defaultAttachHandlerDeps: AttachHandlerDeps = {
   registry: realtimeCallRegistry,
   attach: attachToCall,
+  startMeter: startCallMeter,
+  startRuntime: startVoiceCallRuntime,
+  // `WEB_APP_URL` is this process's address for the web tier. It was previously
+  // only a CORS origin here, because nothing in this app called web; the voice
+  // bridge is the first thing that does.
+  bridge: createVoiceBridgeClient({ webUrl: process.env.WEB_APP_URL }),
 };
 
 export type AttachHandlerResponse = {
@@ -42,13 +74,14 @@ export type AttachHandlerResponse = {
 };
 
 /**
- * Validate, admit, attach, register.
+ * Validate, admit, meter, attach, register, run.
  *
- * The failure statuses are chosen so the web tier can tell apart the three
- * things it might do about them: 400 means the payload was wrong (fix the
- * caller), 429 means we are full (retry later), 502 means OpenAI would not give
- * us the session (the call is degraded, not the request). All three still let
- * the browser keep a working audio call — web treats the whole handoff as
+ * The failure statuses are chosen so the web tier can tell apart the things it
+ * might do about them: 400 means the payload was wrong (fix the caller), 429
+ * means we are full or the user is over their own limit (retry later), 402
+ * means they cannot afford the call, 502 means OpenAI would not give us the
+ * session (the call is degraded, not the request). All of them still let the
+ * browser keep a working audio call — web treats the whole handoff as
  * best-effort — so the distinction exists for operators, not for control flow.
  */
 export const handleRealtimeAttachRequest = async (
@@ -70,7 +103,18 @@ export const handleRealtimeAttachRequest = async (
     return { status: 400, body: { success: false, error: reason } };
   }
 
-  const { callId, secret, userId, conversationId, tools } = parsed.data;
+  const {
+    callId,
+    secret,
+    userId,
+    conversationId,
+    tools,
+    model,
+    subscriptionTier,
+    timezone,
+    locationContext,
+    seed,
+  } = parsed.data;
 
   // Claimed synchronously, before the first `await`. Checking the live count
   // and attaching afterwards would let every simultaneous request past a cap of
@@ -87,7 +131,56 @@ export const handleRealtimeAttachRequest = async (
     };
   }
 
+  let meter: CallMeterStart | undefined;
+
   try {
+    const perUserCap = deps.maxCallsPerUser ?? REALTIME_MAX_INFLIGHT;
+    const usersCalls = deps.registry.getForUser(userId).length;
+    if (usersCalls >= perUserCap) {
+      // Enforced here as well as through the credit gate's `maxInFlight`,
+      // because that gate is a no-op when billing is disabled — and a
+      // tenant/onprem deployment still has one OpenAI key with one rate limit.
+      loggers.realtime.warn('Realtime attach refused: user is already on their limit of calls', {
+        callId,
+        userId,
+        usersCalls,
+        perUserCap,
+      });
+      return {
+        status: 429,
+        body: { success: false, error: 'Too many concurrent voice calls for this user' },
+      };
+    }
+
+    // The hold comes BEFORE the socket. Voice is the one AI path with no
+    // natural end at which an unaffordable call would be noticed.
+    let runtime: VoiceCallRuntime | undefined;
+    meter = await deps.startMeter({
+      callId,
+      userId,
+      ...(conversationId === undefined ? {} : { conversationId }),
+      tier: subscriptionTier as SubscriptionTier,
+      model,
+      // The meter cannot end a call by itself — it owns the ledger, not the
+      // socket — so a limit it hits is reported here and torn down through the
+      // runtime, which is the thing that can also hang up the browser.
+      onLimit: (reason) => {
+        void runtime?.stop(reason);
+      },
+    });
+    if (!meter.ok) {
+      loggers.realtime.info('Realtime attach refused: credit gate', {
+        callId,
+        userId,
+        reason: meter.reason,
+      });
+      return {
+        status: 402,
+        body: { success: false, error: `Voice call refused: ${meter.reason}` },
+      };
+    }
+    const startedMeter = meter.meter;
+
     const session = await deps.attach({
       callId,
       secret,
@@ -96,15 +189,33 @@ export const handleRealtimeAttachRequest = async (
       tools,
       // Deregistration is wired at attach time rather than after the await, so
       // a socket that dies during the handshake cannot leave an entry behind.
-      onClosed: (id) => deps.registry.unregister(id),
+      // The runtime teardown rides along: a call that ends for ANY reason —
+      // the caller hanging up, a dropped socket, the duration backstop — has to
+      // settle its final window and release its hold.
+      onClosed: (id) => {
+        deps.registry.unregister(id);
+        void runtime?.stop('call_ended');
+      },
     });
     deps.registry.register(session);
+
+    runtime = deps.startRuntime({
+      session,
+      bridge: deps.bridge,
+      meter: startedMeter,
+      secret,
+      seed,
+      ...(timezone === undefined ? {} : { timezone }),
+      ...(locationContext === undefined ? {} : { locationContext }),
+    });
 
     loggers.realtime.info('Realtime voice call attached', {
       callId,
       userId,
       conversationId,
       toolCount: tools.length,
+      seedItems: seed.length,
+      model,
       live: deps.registry.size,
     });
     return { status: 200, body: { success: true, callId } };
@@ -115,6 +226,9 @@ export const handleRealtimeAttachRequest = async (
       error instanceof Error ? error : new Error(String(error)),
       { callId, userId, code },
     );
+    // The hold was taken before the socket and there is now no call to spend
+    // it. Left alone it would sit against the user's balance until its TTL.
+    if (meter?.ok) await meter.meter.stop('call_ended');
     return {
       status: 502,
       body: {

--- a/apps/realtime/src/voice/call-hangup.ts
+++ b/apps/realtime/src/voice/call-hangup.ts
@@ -1,0 +1,67 @@
+/**
+ * Ending a call from the server side.
+ *
+ * Closing our own attached socket stops US listening; it does NOT end the
+ * browser's WebRTC session. Without this, every limit the metering layer
+ * enforces would be half a limit: we would stop billing and stop transcribing
+ * while the user carried on talking to a model nobody was watching. That is
+ * worse than not having the limit, so the caps and the hangup ship together.
+ *
+ * `POST /v1/realtime/calls/{call_id}/hangup` ends a call started over either
+ * SIP or WebRTC, addressed by the same `rtc_…` id the `Location` header handed
+ * back at call creation, and answers 200 when teardown begins.
+ *
+ * CREDENTIAL. This process holds exactly one credential for the call: that
+ * call's own ephemeral secret, which is what authenticated the attach and stays
+ * valid for the socket's life. The managed API key is not here (it never leaves
+ * the web tier), so the secret is what is used. If OpenAI refuses it, the
+ * failure is logged and our side still tears down — a hangup that does not land
+ * degrades to "we stop participating", never to "we keep billing".
+ */
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+export const REALTIME_HANGUP_URL = 'https://api.openai.com/v1/realtime/calls';
+
+/** Teardown is not something a caller waits on for long. */
+const HANGUP_TIMEOUT_MS = 5_000;
+
+export type HangupDeps = {
+  readonly fetchFn?: typeof fetch;
+};
+
+/**
+ * Ask OpenAI to end the call. Never throws: every caller is already in a
+ * teardown path, and a failure here must not stop the rest of it.
+ */
+export const hangUpCall = async (
+  callId: string,
+  secret: string,
+  deps: HangupDeps = {},
+): Promise<boolean> => {
+  const fetchFn = deps.fetchFn ?? fetch;
+  try {
+    const response = await fetchFn(
+      `${REALTIME_HANGUP_URL}/${encodeURIComponent(callId)}/hangup`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${secret}` },
+        signal: AbortSignal.timeout(HANGUP_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) {
+      loggers.realtime.warn('Realtime voice hangup was refused', {
+        callId,
+        status: response.status,
+      });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    loggers.realtime.warn('Realtime voice hangup failed', {
+      callId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return false;
+  }
+};

--- a/apps/realtime/src/voice/call-metering.ts
+++ b/apps/realtime/src/voice/call-metering.ts
@@ -1,0 +1,341 @@
+/**
+ * Billing a call that is still happening.
+ *
+ * Every other AI path in PageSpace holds credits, runs, and settles once. A
+ * voice call cannot: it lasts minutes, its cost arrives incrementally as a
+ * `usage` object per `response.done`, and a single hold covering the whole
+ * thing would be a guess at a conversation that has not happened yet. So this
+ * settles CONTINUOUSLY — hold, talk for a window, settle the window exactly,
+ * re-hold for the next — which also means a user who runs out of credit
+ * mid-sentence is stopped mid-call rather than discovered at hangup.
+ *
+ * WHY THIS RUNS IN `apps/realtime` AND NOT OVER THE BRIDGE. Its entire
+ * dependency set — `canConsumeAI`, `releaseHold`, `AIMonitoring.trackUsage`,
+ * `calculateRealtimeCostDollars` — already lives in `@pagespace/lib`, which this
+ * app depends on directly. Tools and transcripts cross to `apps/web` because
+ * their owners (the tool registry, `messageRepository`) genuinely cannot move;
+ * metering has no such constraint, and routing it through an HTTP hop would add
+ * a failure mode between the socket that sees the usage and the ledger that
+ * records it, for nothing. The rule is the same either way: the work runs where
+ * its owner lives.
+ *
+ * THREE LIMITS, THREE DIFFERENT FAILURES, and they are not interchangeable:
+ *   - the IDLE timeout catches the abandoned call — a pinned tab with a hot mic
+ *     that bills for room noise, because server VAD fires happily on ambient
+ *     sound;
+ *   - the DURATION cap catches the call nobody ever hangs up, and is bounded by
+ *     `CREDIT_HOLD_TTL_SECONDS`: a session outliving its own reservation's TTL
+ *     would have that reservation swept out from under it mid-call;
+ *   - the CONCURRENCY caps catch the account-wide constraint — 40,000
+ *     tokens/minute shared by every session on our key — which no per-call
+ *     limit can see.
+ *
+ * `apps/realtime`'s own `MAX_CALL_DURATION_MS` (one hour) is NOT a duplicate of
+ * the duration cap here. That one is a socket-leak backstop for a call this
+ * layer somehow stopped supervising; this one is the product limit, an order of
+ * magnitude tighter, and it is the one that normally fires.
+ */
+
+import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { releaseHold } from '@pagespace/lib/billing/credit-consume';
+import {
+  REALTIME_IDLE_TIMEOUT_SECONDS,
+  REALTIME_MAX_SESSION_SECONDS,
+  REALTIME_SESSION_HOLD_ESTIMATE_CENTS,
+  REALTIME_MAX_INFLIGHT,
+} from '@pagespace/lib/billing/credit-pricing';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import {
+  calculateRealtimeCostDollars,
+  type RealtimeUsage,
+} from '@pagespace/lib/monitoring/voice-pricing';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { addUsage, hasUnattributedTokens, isUsageEmpty } from './usage-accumulator';
+
+/**
+ * How often an in-progress call flushes what it has spent.
+ *
+ * Chosen against `REALTIME_SESSION_HOLD_ESTIMATE_CENTS` (10¢, roughly 1.5–2
+ * minutes of live conversation): the window has to be comfortably shorter than
+ * what one hold covers, or the unsettled tail routinely exceeds the
+ * reservation and the hold stops bounding anything. A minute leaves ~2x
+ * headroom while keeping the settle count for a full-length call in single
+ * digits.
+ */
+export const SETTLE_INTERVAL_MS = 60_000;
+
+export type MeterStopReason =
+  | 'call_ended'
+  | 'idle_timeout'
+  | 'duration_cap'
+  | 'credit_exhausted';
+
+export type CallMeter = {
+  /** Fold one response's usage into the running total. */
+  record(usage: RealtimeUsage | undefined): void;
+  /** Note conversational activity, restarting the idle countdown. */
+  touch(): void;
+  /** Flush and re-hold now. Exposed for the timer and for tests. */
+  settle(): Promise<void>;
+  /** Final flush + hold release. Idempotent. */
+  stop(reason: MeterStopReason): Promise<void>;
+  /** Everything billed so far, across every settle. */
+  readonly billedDollars: number;
+  readonly stopped: boolean;
+};
+
+export type CallMeterOptions = {
+  readonly callId: string;
+  readonly userId: string;
+  readonly conversationId?: string;
+  readonly tier: SubscriptionTier;
+  readonly model: string;
+  /** Called when a limit is hit and the call must be torn down. */
+  readonly onLimit: (reason: MeterStopReason, message: string) => void;
+  readonly idleTimeoutMs?: number;
+  readonly maxDurationMs?: number;
+  readonly settleIntervalMs?: number;
+  /** Injected so tests need neither real timers nor a real ledger. */
+  readonly setIntervalFn?: typeof setInterval;
+  readonly clearIntervalFn?: typeof clearInterval;
+  readonly setTimeoutFn?: typeof setTimeout;
+  readonly clearTimeoutFn?: typeof clearTimeout;
+  readonly nowFn?: () => number;
+  readonly gate?: typeof canConsumeAI;
+  readonly release?: typeof releaseHold;
+  readonly track?: typeof AIMonitoring.trackUsage;
+};
+
+export type CallMeterStart =
+  | { readonly ok: true; readonly meter: CallMeter }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * Take the opening hold and start supervising the call.
+ *
+ * A refusal here means the call must not attach at all — the reservation is the
+ * only thing standing between a free-tier account and an unbounded audio bill,
+ * and unlike a text turn there is no natural end at which to notice.
+ */
+export const startCallMeter = async (
+  options: CallMeterOptions,
+): Promise<CallMeterStart> => {
+  const {
+    callId,
+    userId,
+    conversationId,
+    tier,
+    model,
+    onLimit,
+    idleTimeoutMs = REALTIME_IDLE_TIMEOUT_SECONDS * 1000,
+    maxDurationMs = REALTIME_MAX_SESSION_SECONDS * 1000,
+    settleIntervalMs = SETTLE_INTERVAL_MS,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+    nowFn = Date.now,
+    gate = canConsumeAI,
+    release = releaseHold,
+    track = AIMonitoring.trackUsage,
+  } = options;
+
+  const opening = await gate(userId, tier, {
+    estCostCents: REALTIME_SESSION_HOLD_ESTIMATE_CENTS,
+    // Per-USER concurrency. The registry's own cap is per-DEPLOYMENT and cannot
+    // express this one: two users at the global limit is fine, one user holding
+    // eight calls is not.
+    maxInFlight: REALTIME_MAX_INFLIGHT,
+  });
+  if (!opening.allowed) {
+    return { ok: false, reason: opening.reason };
+  }
+
+  let holdId = opening.holdId;
+  let pending: RealtimeUsage | undefined;
+  let billedDollars = 0;
+  let stopped = false;
+  let settling: Promise<void> = Promise.resolve();
+
+  const startedAt = nowFn();
+  let lastActivityAt = startedAt;
+
+  /**
+   * Flush the pending window.
+   *
+   * `trackUsage` TAKES OWNERSHIP of the hold — it settles the real cost against
+   * it and releases it — so a new hold has to be opened for the next window, and
+   * `holdId` is cleared first so no path can hand the same reservation to two
+   * settles. A refused re-hold ends the call: the user is out of credit, and
+   * the honest response is to stop talking rather than keep spending.
+   */
+  const flush = async (): Promise<void> => {
+    if (stopped && pending === undefined) return;
+
+    const usage = pending;
+    pending = undefined;
+
+    if (usage && !isUsageEmpty(usage)) {
+      if (hasUnattributedTokens(usage)) {
+        // Priced at zero by design (a token with no modality cannot be priced —
+        // audio input is 8x text input). Reported because a call that bills
+        // nothing is otherwise indistinguishable from a quiet one.
+        loggers.realtime.warn(
+          'Realtime voice usage reported tokens with no modality attached; that portion bills $0',
+          { callId, userId, model },
+        );
+      }
+
+      const costDollars = calculateRealtimeCostDollars(model, usage);
+      billedDollars += costDollars;
+      const settledHoldId = holdId;
+      holdId = undefined;
+
+      try {
+        await track({
+          userId,
+          provider: 'openai_voice',
+          model,
+          source: 'voice',
+          providerCostDollars: costDollars,
+          duration: nowFn() - startedAt,
+          success: true,
+          ...(settledHoldId === undefined ? {} : { holdId: settledHoldId }),
+          ...(conversationId === undefined ? {} : { conversationId }),
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cachedInputTokens: usage.input_token_details?.cached_tokens ?? 0,
+          // Deterministic: the exact quantity OpenAI reported, times the
+          // published rate. Not a live provider figure and not a token guess.
+          costSource: 'list_price',
+          metadata: {
+            type: 'voice_realtime',
+            callId,
+            audioInputTokens: usage.input_token_details?.audio_tokens ?? 0,
+            audioOutputTokens: usage.output_token_details?.audio_tokens ?? 0,
+          },
+        });
+      } catch (error) {
+        // A failed settle must not take the call down — the user is mid-sentence.
+        loggers.realtime.error(
+          'Realtime voice usage settle failed; this window is unbilled',
+          error instanceof Error ? error : new Error(String(error)),
+          { callId, userId },
+        );
+        // Whether `trackUsage` got far enough to consume the reservation is
+        // unknowable from here, and the two outcomes want opposite handling.
+        // Releasing covers both: a hold it already settled is a row that no
+        // longer exists, so the delete is a no-op, and one it never reached is
+        // freed instead of sitting against the balance until its TTL. Control
+        // then falls through to taking a fresh hold for the next window.
+        if (settledHoldId !== undefined) {
+          await release(settledHoldId).catch(() => {
+            // Nothing further to do: it expires on its TTL.
+          });
+        }
+      }
+    }
+
+    if (stopped || holdId !== undefined) return;
+
+    const next = await gate(userId, tier, {
+      estCostCents: REALTIME_SESSION_HOLD_ESTIMATE_CENTS,
+      maxInFlight: REALTIME_MAX_INFLIGHT,
+    });
+    if (!next.allowed) {
+      loggers.realtime.info('Realtime voice call stopped: no credit for the next window', {
+        callId,
+        userId,
+        reason: next.reason,
+      });
+      onLimit('credit_exhausted', 'This call ran out of credits.');
+      return;
+    }
+    holdId = next.holdId;
+  };
+
+  /** Settles never overlap: each one chains onto the last. */
+  const enqueueFlush = (): Promise<void> => {
+    settling = settling.then(flush, flush);
+    return settling;
+  };
+
+  const settleTimer = setIntervalFn(() => {
+    void enqueueFlush();
+  }, settleIntervalMs);
+
+  const idleTimer = setIntervalFn(() => {
+    if (nowFn() - lastActivityAt < idleTimeoutMs) return;
+    loggers.realtime.info('Realtime voice call stopped: idle', {
+      callId,
+      userId,
+      idleMs: nowFn() - lastActivityAt,
+    });
+    onLimit('idle_timeout', 'The call ended after a long silence.');
+  }, Math.max(1_000, Math.floor(idleTimeoutMs / 4)));
+
+  const durationTimer = setTimeoutFn(() => {
+    loggers.realtime.info('Realtime voice call stopped: duration cap', {
+      callId,
+      userId,
+      maxDurationMs,
+    });
+    onLimit('duration_cap', 'The call reached its maximum length.');
+  }, maxDurationMs);
+
+  const meter: CallMeter = {
+    record(usage) {
+      if (stopped || usage === undefined) return;
+      pending = addUsage(pending, usage);
+      lastActivityAt = nowFn();
+    },
+    touch() {
+      lastActivityAt = nowFn();
+    },
+    settle() {
+      return enqueueFlush();
+    },
+    async stop(reason) {
+      if (stopped) return;
+      stopped = true;
+      clearIntervalFn(settleTimer);
+      clearIntervalFn(idleTimer);
+      clearTimeoutFn(durationTimer);
+
+      // The final window still has to settle — the last thing said in a call is
+      // usually the most expensive part of it.
+      await enqueueFlush();
+
+      if (holdId !== undefined) {
+        const abandoned = holdId;
+        holdId = undefined;
+        // Nothing left to bill against it. Released rather than left to its TTL
+        // so the user's spendable balance frees immediately.
+        await release(abandoned).catch((error: unknown) => {
+          loggers.realtime.warn('Realtime voice hold release failed; it will expire on its TTL', {
+            callId,
+            userId,
+            error: error instanceof Error ? error.message : 'unknown',
+          });
+        });
+      }
+
+      loggers.realtime.info('Realtime voice call metered', {
+        callId,
+        userId,
+        reason,
+        billedDollars,
+        durationMs: nowFn() - startedAt,
+      });
+    },
+    get billedDollars() {
+      return billedDollars;
+    },
+    get stopped() {
+      return stopped;
+    },
+  };
+
+  return { ok: true, meter };
+};

--- a/apps/realtime/src/voice/usage-accumulator.ts
+++ b/apps/realtime/src/voice/usage-accumulator.ts
@@ -1,0 +1,145 @@
+/**
+ * Adding up what a call cost, one response at a time.
+ *
+ * `usage` is per RESPONSE — measured, and it is the fact the whole metering
+ * design hangs off. Every `response.done` reports what that one response spent;
+ * a CALL total exists only because something keeps the running sum. This is
+ * that something, and it is pure so the arithmetic can be checked without a
+ * socket, a clock or a ledger.
+ *
+ * Two asymmetries in the wire shape are preserved rather than smoothed away,
+ * because `calculateRealtimeCostDollars` prices from the per-modality DETAIL
+ * blocks and ignores the totals — an accumulator that summed only
+ * `input_tokens`/`output_tokens` would produce a tidy number that bills zero:
+ *   - caching is INPUT-ONLY: there is no cached figure on the output side;
+ *   - `cached_tokens` is a SUBSET of `input_tokens`, never an addition, so it
+ *     is summed as its own subtotal and never folded into the gross.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+import type {
+  RealtimeCachedTokenDetails,
+  RealtimeUsage,
+} from '@pagespace/lib/monitoring/voice-pricing';
+
+/** Anything not a finite, non-negative number contributes nothing. */
+const count = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+
+const addCachedDetails = (
+  a: RealtimeCachedTokenDetails | undefined,
+  b: RealtimeCachedTokenDetails | undefined,
+): RealtimeCachedTokenDetails | undefined => {
+  if (!a && !b) return undefined;
+  return {
+    text_tokens: count(a?.text_tokens) + count(b?.text_tokens),
+    audio_tokens: count(a?.audio_tokens) + count(b?.audio_tokens),
+    image_tokens: count(a?.image_tokens) + count(b?.image_tokens),
+  };
+};
+
+/**
+ * Sum two usage objects into one.
+ *
+ * Associative and commutative over well-formed input, and total over malformed
+ * input: a frame with a `null` usage, a string where a number should be, or no
+ * detail blocks at all adds zero rather than poisoning the running sum with
+ * `NaN`. A `NaN` here would propagate into the cost and from there into the
+ * ledger, which is the one place a wire-shape surprise must not reach.
+ *
+ * The detail blocks are materialized whenever EITHER side has one, so a total
+ * built from partial frames still prices — the pricing function reads only the
+ * detail blocks, so dropping them because one frame lacked them would silently
+ * bill the call at zero.
+ */
+export const addUsage = (
+  total: RealtimeUsage | undefined,
+  next: RealtimeUsage | undefined,
+): RealtimeUsage => {
+  const a = total ?? {};
+  const b = next ?? {};
+
+  const inputA = a.input_token_details;
+  const inputB = b.input_token_details;
+  const outputA = a.output_token_details;
+  const outputB = b.output_token_details;
+
+  return {
+    input_tokens: count(a.input_tokens) + count(b.input_tokens),
+    output_tokens: count(a.output_tokens) + count(b.output_tokens),
+    total_tokens: count(a.total_tokens) + count(b.total_tokens),
+    ...(inputA || inputB
+      ? {
+          input_token_details: {
+            text_tokens: count(inputA?.text_tokens) + count(inputB?.text_tokens),
+            audio_tokens: count(inputA?.audio_tokens) + count(inputB?.audio_tokens),
+            image_tokens: count(inputA?.image_tokens) + count(inputB?.image_tokens),
+            // A SUBSET of the gross figures above, kept as its own subtotal so
+            // the cache-read rate applies to it and the full rate to the
+            // remainder — never both to the same token.
+            cached_tokens: count(inputA?.cached_tokens) + count(inputB?.cached_tokens),
+            ...(addCachedDetails(inputA?.cached_tokens_details, inputB?.cached_tokens_details)
+              ? {
+                  cached_tokens_details: addCachedDetails(
+                    inputA?.cached_tokens_details,
+                    inputB?.cached_tokens_details,
+                  ),
+                }
+              : {}),
+          },
+        }
+      : {}),
+    ...(outputA || outputB
+      ? {
+          output_token_details: {
+            text_tokens: count(outputA?.text_tokens) + count(outputB?.text_tokens),
+            audio_tokens: count(outputA?.audio_tokens) + count(outputB?.audio_tokens),
+          },
+        }
+      : {}),
+  };
+};
+
+/** True when nothing was actually spent — used to skip an empty settle. */
+export const isUsageEmpty = (usage: RealtimeUsage | undefined): boolean => {
+  if (!usage) return true;
+  const input = usage.input_token_details;
+  const output = usage.output_token_details;
+  return (
+    count(usage.input_tokens) === 0 &&
+    count(usage.output_tokens) === 0 &&
+    count(usage.total_tokens) === 0 &&
+    count(input?.text_tokens) === 0 &&
+    count(input?.audio_tokens) === 0 &&
+    count(input?.image_tokens) === 0 &&
+    count(output?.text_tokens) === 0 &&
+    count(output?.audio_tokens) === 0
+  );
+};
+
+/**
+ * True when a usage object reports totals but attributes NONE of them to a
+ * modality.
+ *
+ * `calculateRealtimeCostDollars` deliberately refuses to guess a modality for
+ * an unattributed total — audio input costs eight times text input, so guessing
+ * over-charges half the time — and bills it at zero. That is the right call
+ * there and the wrong thing to be silent about here: this is the layer that can
+ * see the whole session, so it is the layer that reports a payload shape which
+ * would otherwise show up only as a suspiciously cheap call.
+ */
+export const hasUnattributedTokens = (usage: RealtimeUsage | undefined): boolean => {
+  if (!usage) return false;
+  const reported = count(usage.input_tokens) + count(usage.output_tokens);
+  if (reported === 0) return false;
+  const input = usage.input_token_details;
+  const output = usage.output_token_details;
+  const attributed =
+    count(input?.text_tokens) +
+    count(input?.audio_tokens) +
+    count(input?.image_tokens) +
+    count(output?.text_tokens) +
+    count(output?.audio_tokens);
+  return attributed === 0;
+};

--- a/apps/realtime/src/voice/voice-bridge-client.ts
+++ b/apps/realtime/src/voice/voice-bridge-client.ts
@@ -1,0 +1,108 @@
+/**
+ * Calling back into the web tier while a call is live.
+ *
+ * The mirror of `apps/web/src/lib/ai/realtime/call-handshake.ts`'s handoff: same
+ * HMAC (`REALTIME_BROADCAST_SECRET` is symmetric), same JSON body, opposite
+ * direction. It exists because two things that happen on this socket are owned
+ * by `apps/web` and cannot move — the tool registry with the permission checks
+ * the tools run internally, and `messageRepository`, whose write is the same
+ * transaction that bumps `conversations.rev` and emits the events every chat
+ * surface already subscribes to. See `VOICE_CALLBACK_ROUTES` for the full
+ * argument, including why metering is deliberately NOT routed through here.
+ *
+ * TIMEOUTS ARE ASYMMETRIC ON PURPOSE. A tool dispatch is inside the live turn:
+ * the model has stopped and is waiting for `function_call_output`, so a slow
+ * hop is heard as silence and the only acceptable outcome is a bounded wait
+ * followed by something the model can say. A transcript is not in the loop at
+ * all — nobody is waiting on it — so it gets a longer budget and its failure is
+ * a dropped row, logged.
+ */
+
+import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  VOICE_CALLBACK_ROUTES,
+  type VoiceBridgeRequest,
+  type VoiceBridgeResponse,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+
+/**
+ * A tool call the caller is waiting through. Long enough for a real page read
+ * or a search, short enough that a dead web tier does not hold the conversation
+ * open indefinitely — past this the model is told the tool timed out and can
+ * say so, which is a far better turn than an unbounded pause.
+ */
+export const TOOL_DISPATCH_TIMEOUT_MS = 20_000;
+
+/** Nothing is blocked on a transcript, so it can afford to wait longer. */
+export const TRANSCRIPT_TIMEOUT_MS = 10_000;
+
+export type VoiceBridgeClient = {
+  send(request: VoiceBridgeRequest): Promise<VoiceBridgeResponse>;
+};
+
+export type VoiceBridgeClientOptions = {
+  /** `WEB_APP_URL` in this process. Unset disables the bridge (see below). */
+  readonly webUrl: string | undefined;
+  readonly fetchFn?: typeof fetch;
+  readonly signHeaders?: (body: string) => Record<string, string>;
+};
+
+/**
+ * Build the client.
+ *
+ * An unset web URL is a DEGRADE, not a throw — the same trade the outbound
+ * direction makes for an unset `INTERNAL_REALTIME_URL`. A voice call with no
+ * bridge still connects, still hears, still speaks, and still bills correctly;
+ * it just cannot run tools or write transcripts. Refusing to attach instead
+ * would trade a partly-working call for no call.
+ */
+export const createVoiceBridgeClient = (
+  options: VoiceBridgeClientOptions,
+): VoiceBridgeClient => {
+  const {
+    webUrl,
+    fetchFn = fetch,
+    signHeaders = createSignedBroadcastHeaders,
+  } = options;
+
+  return {
+    async send(request) {
+      if (!webUrl) {
+        return { ok: false, error: 'Voice bridge is not configured (WEB_APP_URL unset)' };
+      }
+
+      const body = JSON.stringify(request);
+      const timeoutMs =
+        request.kind === 'tool' ? TOOL_DISPATCH_TIMEOUT_MS : TRANSCRIPT_TIMEOUT_MS;
+
+      try {
+        const response = await fetchFn(`${webUrl}${VOICE_CALLBACK_ROUTES.bridge}`, {
+          method: 'POST',
+          headers: signHeaders(body),
+          body,
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+
+        if (!response.ok) {
+          loggers.realtime.warn('Voice bridge call was refused by the web tier', {
+            kind: request.kind,
+            callId: request.callId,
+            status: response.status,
+          });
+          return { ok: false, error: `Voice bridge returned ${response.status}` };
+        }
+
+        const parsed = (await response.json()) as VoiceBridgeResponse;
+        return parsed;
+      } catch (error) {
+        loggers.realtime.error(
+          'Voice bridge call failed',
+          error instanceof Error ? error : new Error(String(error)),
+          { kind: request.kind, callId: request.callId },
+        );
+        return { ok: false, error: 'Voice bridge is unreachable' };
+      }
+    },
+  };
+};

--- a/apps/realtime/src/voice/voice-call-runtime.ts
+++ b/apps/realtime/src/voice/voice-call-runtime.ts
@@ -1,0 +1,243 @@
+/**
+ * WHAT THE SERVER DOES WHILE IT IS ON THE CALL.
+ *
+ * C-A got us onto the socket and holds it open. This is everything that
+ * happens on it: the session is seeded from the bound conversation, tool calls
+ * are dispatched and answered, both sides of the exchange are written into that
+ * conversation as ordinary messages, and every response's usage is metered.
+ *
+ * These are one module rather than four because they are one event loop. They
+ * consume the same frames, in the same order, from the same subscription — a
+ * `response.done` carries a tool call AND the usage for the turn that produced
+ * it, and the same silence that means "no transcript to write" also means "the
+ * idle timer should be running". Split apart, each would need its own copy of
+ * the frame plumbing and its own theory of when the call ended.
+ *
+ * The module owns no connection and no registry entry. It takes a
+ * `RealtimeCallSession`, subscribes, and sends client events back — the seam
+ * `realtime-call-session.ts` documents as belonging to exactly this layer.
+ */
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  buildFunctionOutput,
+  extractFunctionCalls,
+  extractRateLimits,
+  extractTranscript,
+  extractUsage,
+  RESPONSE_CREATE,
+  type FunctionCall,
+} from '@pagespace/lib/realtime/voice-events';
+import type {
+  RealtimeSeedEventWire,
+  VoiceLocationContext,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+import type { RealtimeCallSession } from './realtime-call-session';
+import type { VoiceBridgeClient } from './voice-bridge-client';
+import type { CallMeter, MeterStopReason } from './call-metering';
+import { hangUpCall } from './call-hangup';
+
+/**
+ * Events that mean a human is still in the room.
+ *
+ * NOT "any inbound frame": `rate_limits.updated` and other housekeeping arrive
+ * on a call nobody is participating in, and treating them as activity would
+ * make the idle reaper permanently unreachable — which is the failure mode it
+ * exists to prevent.
+ */
+const ACTIVITY_EVENTS = new Set([
+  'input_audio_buffer.speech_started',
+  'input_audio_buffer.committed',
+  'conversation.item.input_audio_transcription.completed',
+  'response.done',
+]);
+
+const eventType = (event: unknown): string | undefined => {
+  if (typeof event !== 'object' || event === null) return undefined;
+  const type = (event as { type?: unknown }).type;
+  return typeof type === 'string' ? type : undefined;
+};
+
+export type VoiceCallRuntimeOptions = {
+  readonly session: RealtimeCallSession;
+  readonly bridge: VoiceBridgeClient;
+  readonly meter: CallMeter;
+  /** That call's own ephemeral secret — the only credential this process holds. */
+  readonly secret: string;
+  readonly seed: readonly RealtimeSeedEventWire[];
+  readonly timezone?: string;
+  readonly locationContext?: VoiceLocationContext;
+  readonly hangUp?: typeof hangUpCall;
+};
+
+export type VoiceCallRuntime = {
+  /** Tear down: stop listening, settle the meter, end the call. Idempotent. */
+  stop(reason: MeterStopReason): Promise<void>;
+};
+
+/**
+ * Wire the runtime onto a session that has already reached `session.updated`.
+ *
+ * The seed goes out FIRST and synchronously, before the first frame can be
+ * handled: it is the history the model answers against, and an item that lands
+ * after the caller has spoken is history the reply has already missed.
+ */
+export const startVoiceCallRuntime = (
+  options: VoiceCallRuntimeOptions,
+): VoiceCallRuntime => {
+  const { session, bridge, meter, secret, seed, timezone, locationContext } = options;
+  const hangUp = options.hangUp ?? hangUpCall;
+  const { callId, userId, conversationId } = session;
+
+  let stopping: Promise<void> | undefined;
+
+  for (const item of seed) {
+    session.send(item as unknown as Record<string, unknown>);
+  }
+  if (seed.length > 0) {
+    loggers.realtime.debug('Realtime voice session seeded from its conversation', {
+      callId,
+      conversationId,
+      items: seed.length,
+    });
+  }
+
+  /**
+   * Answer one tool call.
+   *
+   * `function_call_output` MUST carry a string, and a `response.create` MUST
+   * follow it or the model sits on the result without speaking. Both hold on
+   * every path below, including failure: a bridge that is down produces a
+   * sentence about that rather than silence, because the one unrecoverable
+   * outcome is a tool call the model never gets an answer to.
+   */
+  const answerToolCall = async (call: FunctionCall): Promise<void> => {
+    const response = await bridge.send({
+      kind: 'tool',
+      callId,
+      userId,
+      ...(conversationId === undefined ? {} : { conversationId }),
+      name: call.name,
+      argumentsJson: call.argumentsJson,
+      ...(timezone === undefined ? {} : { timezone }),
+      ...(locationContext === undefined ? {} : { locationContext }),
+    });
+
+    const output =
+      response.ok && response.kind === 'tool'
+        ? response.output
+        : "I couldn't run that just now. Ask me again in a moment.";
+
+    if (!response.ok) {
+      loggers.realtime.warn('Realtime voice tool call could not be dispatched', {
+        callId,
+        userId,
+        tool: call.name,
+        error: response.error,
+      });
+    }
+
+    session.send(buildFunctionOutput(call.callId, output));
+  };
+
+  const handleToolCalls = async (calls: readonly FunctionCall[]): Promise<void> => {
+    // Concurrent, then ONE `response.create`. A response per output would have
+    // the model start speaking about the first tool while the second is still
+    // running, and interrupt itself when the second landed.
+    await Promise.all(calls.map((call) => answerToolCall(call)));
+    if (session.ended) return;
+    session.send(RESPONSE_CREATE);
+  };
+
+  const persistTranscript = async (role: 'user' | 'assistant', text: string): Promise<void> => {
+    if (!conversationId) {
+      // An unbound call is a real, supported state — it still runs tools and
+      // still meters. There is simply no thread to write into.
+      return;
+    }
+    const response = await bridge.send({
+      kind: 'transcript',
+      callId,
+      userId,
+      conversationId,
+      role,
+      text,
+    });
+    if (!response.ok) {
+      loggers.realtime.warn('Realtime voice transcript was not persisted', {
+        callId,
+        conversationId,
+        role,
+        error: response.error,
+      });
+    }
+  };
+
+  const unsubscribe = session.subscribe((event) => {
+    const type = eventType(event);
+
+    if (type && ACTIVITY_EVENTS.has(type)) {
+      meter.touch();
+    }
+
+    // Usage first: a `response.done` that also carries tool calls is still the
+    // response whose cost has to be recorded, and dispatch is async.
+    const usage = extractUsage(event);
+    if (usage) meter.record(usage);
+
+    for (const snapshot of extractRateLimits(event)) {
+      // The account ceiling is 40,000 tokens/minute across every session on the
+      // key, which is what the deployment-wide concurrency cap is sized
+      // against. Logged so that sizing can be checked against reality rather
+      // than rediscovered as throttling.
+      if (snapshot.remaining <= snapshot.limit * 0.1) {
+        loggers.realtime.warn('Realtime account rate limit is nearly exhausted', {
+          callId,
+          name: snapshot.name,
+          limit: snapshot.limit,
+          remaining: snapshot.remaining,
+        });
+      }
+    }
+
+    const calls = extractFunctionCalls(event);
+    if (calls.length > 0) {
+      void handleToolCalls(calls).catch((error: unknown) => {
+        loggers.realtime.error(
+          'Realtime voice tool dispatch failed',
+          error instanceof Error ? error : new Error(String(error)),
+          { callId, userId },
+        );
+      });
+    }
+
+    const transcript = extractTranscript(event);
+    if (transcript) {
+      // Not awaited: the transcript is the durable record, not part of the live
+      // turn, and blocking the event loop on a database write would put a chat
+      // persistence latency inside a spoken conversation.
+      void persistTranscript(transcript.role, transcript.text);
+    }
+  });
+
+  const stop = (reason: MeterStopReason): Promise<void> => {
+    if (stopping) return stopping;
+    stopping = (async () => {
+      unsubscribe();
+      // Metering settles BEFORE the call is torn down: the final window is
+      // usually the most expensive part of the call, and a teardown that raced
+      // it would drop it.
+      await meter.stop(reason);
+      // Ends the BROWSER's call, not just our view of it. Skipped for
+      // 'call_ended', where the socket closing is what told us in the first
+      // place and OpenAI has already torn the call down.
+      if (reason !== 'call_ended') {
+        await hangUp(callId, secret);
+      }
+      session.end(reason);
+    })();
+    return stopping;
+  };
+
+  return { stop };
+};

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
@@ -228,6 +228,7 @@ const mockChatMessage = (overrides: Partial<{
   editedAt: null,
   toolCalls: null,
   toolResults: null,
+  source: null,
   status: overrides.status || 'complete' as const,
 });
 

--- a/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
@@ -98,6 +98,7 @@ const mockUnifiedPageMessageWithAuthor = (overrides: Partial<{
   editedAt: null,
   toolCalls: null,
   toolResults: null,
+  source: null,
   status: overrides.status || 'complete' as const,
 });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
@@ -137,6 +137,7 @@ const mockMessage = (overrides: Partial<{
   editedAt: null as Date | null,
   toolCalls: null as unknown,
   toolResults: null as unknown,
+  source: null,
 });
 
 const createContext = (id: string, messageId: string) => ({

--- a/apps/web/src/app/api/internal/voice/bridge/route.ts
+++ b/apps/web/src/app/api/internal/voice/bridge/route.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/internal/voice/bridge
+ *
+ * The realtime server, mid-call, asking the web tier to do the two things only
+ * the web tier can: run a PageSpace tool with real permissions, and write a
+ * spoken turn into the bound conversation.
+ *
+ * SERVER-TO-SERVER ONLY. There is no user session on this request — the caller
+ * is `apps/realtime`, holding a socket on behalf of a user who authenticated
+ * minutes ago at `POST /api/voice/realtime/call`. It proves that with an HMAC
+ * over the raw body, the same signature `/api/broadcast` and `/api/realtime/attach`
+ * use, verified BEFORE the body is parsed. The acting user id is then taken
+ * from the signed payload and every downstream permission check runs against
+ * it — a valid signature authenticates the SERVICE, never the user, so nothing
+ * below treats it as authorization for a particular person's data.
+ *
+ * NOT rate-limited or credit-gated here: the call it belongs to was gated at
+ * handshake, and its spend is metered continuously by the process holding the
+ * socket (see `apps/realtime/src/voice/call-metering.ts`). A second gate on
+ * this hop would bill the same call twice.
+ */
+
+import { NextResponse } from 'next/server';
+import { verifyBroadcastSignature } from '@pagespace/lib/auth/broadcast-auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { resolveRealtimeModel } from '@/lib/ai/realtime/session';
+import { handleVoiceBridgeRequest } from '@/lib/ai/realtime/bridge-handler';
+import {
+  voiceToolDispatchDeps,
+  voiceTranscriptDeps,
+} from '@/lib/ai/realtime/voice-runtime-deps';
+
+/**
+ * A tool result and a transcript are both small. The cap exists so a caller
+ * that can sign cannot make us buffer an arbitrary body — the same reason the
+ * realtime server caps the bodies it reads on the outbound leg.
+ */
+const MAX_BODY_BYTES = 256 * 1024;
+
+export async function POST(request: Request) {
+  try {
+    const rawBody = await request.text();
+
+    if (rawBody.length > MAX_BODY_BYTES) {
+      return NextResponse.json({ ok: false, error: 'Payload too large' }, { status: 413 });
+    }
+
+    const signature = request.headers.get('x-broadcast-signature');
+    if (!signature || !verifyBroadcastSignature(signature, rawBody)) {
+      loggers.ai.warn('Voice bridge request failed signature verification');
+      return NextResponse.json({ ok: false, error: 'Authentication failed' }, { status: 401 });
+    }
+
+    const result = await handleVoiceBridgeRequest(
+      {
+        toolDeps: voiceToolDispatchDeps,
+        transcriptDeps: voiceTranscriptDeps,
+        model: resolveRealtimeModel(process.env),
+      },
+      rawBody,
+    );
+
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    loggers.ai.error('Voice bridge request failed', error as Error);
+    return NextResponse.json({ ok: false, error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
@@ -247,6 +247,7 @@ describe('POST /api/v1/chat/completions — back-fill tool results', () => {
       editedAt: null,
       toolCalls: JSON.stringify([{ toolCallId: 'tc-1', toolName: 'Read', input: {} }]),
       toolResults: null,
+      source: null,
       status: 'complete' as const,
     }]);
 
@@ -321,6 +322,7 @@ describe('POST /api/v1/chat/completions — back-fill tool results', () => {
       editedAt: null,
       toolCalls: JSON.stringify([{ toolCallId: 'tc-1', toolName: 'Read', input: {} }]),
       toolResults: null,
+      source: null,
       status: 'complete' as const,
     }]);
 

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -634,8 +634,8 @@ describe('POST /api/v1/chat/completions', () => {
 
   test('thread mode: calls getMessagesForPage with pageId and conversationId', async () => {
     const dbMessages = [
-      { id: 'db-1', pageId: 'page-123', conversationId: 'conv-abc', userId: 'user-1', role: 'user', content: 'Prior message', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const },
-      { id: 'db-2', pageId: 'page-123', conversationId: 'conv-abc', userId: null, role: 'assistant', content: 'Prior response', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const },
+      { id: 'db-1', pageId: 'page-123', conversationId: 'conv-abc', userId: 'user-1', role: 'user', content: 'Prior message', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const, source: null },
+      { id: 'db-2', pageId: 'page-123', conversationId: 'conv-abc', userId: null, role: 'assistant', content: 'Prior response', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const, source: null },
     ];
     vi.mocked(messageRepository.getMessagesForPage).mockResolvedValueOnce(dbMessages);
     const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
@@ -669,8 +669,8 @@ describe('POST /api/v1/chat/completions', () => {
 
   test('thread mode: DB history messages are prepended before the new user message', async () => {
     const dbMessages = [
-      { id: 'db-1', pageId: 'page-123', conversationId: 'conv-abc', userId: 'user-1', role: 'user', content: 'Prior question', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const },
-      { id: 'db-2', pageId: 'page-123', conversationId: 'conv-abc', userId: null, role: 'assistant', content: 'Prior answer', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const },
+      { id: 'db-1', pageId: 'page-123', conversationId: 'conv-abc', userId: 'user-1', role: 'user', content: 'Prior question', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const, source: null },
+      { id: 'db-2', pageId: 'page-123', conversationId: 'conv-abc', userId: null, role: 'assistant', content: 'Prior answer', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null, status: 'complete' as const, source: null },
     ];
     vi.mocked(messageRepository.getMessagesForPage).mockResolvedValueOnce(dbMessages);
     await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));

--- a/apps/web/src/app/api/v1/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/conversations/__tests__/route.test.ts
@@ -389,6 +389,7 @@ describe('GET /api/v1/conversations/[id]', () => {
         editedAt: null,
         toolCalls: null,
         toolResults: null,
+        source: null,
         status: 'complete' as const,
       },
     ]);

--- a/apps/web/src/app/api/voice/realtime/call/route.ts
+++ b/apps/web/src/app/api/voice/realtime/call/route.ts
@@ -33,6 +33,9 @@ import { resolveRealtimeModel } from '@/lib/ai/realtime/session';
 import { buildRealtimeTools } from '@/lib/ai/realtime/tools';
 import { buildPageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { runCallHandshake } from '@/lib/ai/realtime/call-handshake';
+import { loadRealtimeSeed } from '@/lib/ai/realtime/seed-loader';
+import { voiceSeedDeps } from '@/lib/ai/realtime/voice-runtime-deps';
+import { voiceLocationContextSchema } from '@pagespace/lib/realtime/voice-bridge-contract';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -48,10 +51,17 @@ export async function POST(request: Request) {
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
+    // Read once, used twice: the entitlement gate here, and the credit gate the
+    // realtime server runs when it starts metering the call. Still only read
+    // when billing is on — `canConsumeAI` short-circuits to unlimited otherwise,
+    // so the tier it would be handed is a value nothing reads, and a DB round
+    // trip for it on every onprem/tenant call would buy nothing.
+    let tier: SubscriptionTier = 'free';
+
     // Free users can't use voice at all — same gate, same message as STT/TTS.
     if (isBillingEnabled()) {
       const user = await aiSettingsRepository.getUserSettings(userId);
-      const tier = (user?.subscriptionTier ?? 'free') as SubscriptionTier;
+      tier = (user?.subscriptionTier ?? 'free') as SubscriptionTier;
       if (!PAID_TIERS.has(tier)) {
         return NextResponse.json(
           {
@@ -78,6 +88,14 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => undefined);
     const sdp = (body as { sdp?: unknown } | undefined)?.sdp;
     const conversationIdRaw = (body as { conversationId?: unknown } | undefined)?.conversationId;
+    const timezoneRaw = (body as { timezone?: unknown } | undefined)?.timezone;
+    // Parsed rather than trusted: it is forwarded into a `ToolExecutionContext`,
+    // and the tools read page/drive ids off it. Permissions still decide access
+    // — a location is a default, never an authorization — but a malformed one
+    // should be dropped at the edge rather than carried across two processes.
+    const locationContext = voiceLocationContextSchema.safeParse(
+      (body as { locationContext?: unknown } | undefined)?.locationContext,
+    );
 
     if (typeof sdp !== 'string' || sdp.length === 0) {
       return NextResponse.json(
@@ -92,6 +110,20 @@ export async function POST(request: Request) {
       );
     }
 
+    const conversationId =
+      typeof conversationIdRaw === 'string' && conversationIdRaw.length > 0
+        ? conversationIdRaw
+        : undefined;
+
+    // Voice starts on a conversation that already exists: the thread is replayed
+    // into the session as text before the model speaks. Hard-capped, and an
+    // empty seed is a normal outcome (a fresh thread, or one this caller may
+    // not read) — never a reason to fail the call.
+    const seed = await loadRealtimeSeed(voiceSeedDeps, {
+      userId,
+      ...(conversationId === undefined ? {} : { conversationId }),
+    });
+
     const result = await runCallHandshake(
       {
         fetch,
@@ -105,6 +137,7 @@ export async function POST(request: Request) {
         // decision. The realtime server cannot build these itself — the
         // registry lives in this app — so they ride the signed internal hop.
         tools: buildRealtimeTools(buildPageSpaceTools()),
+        subscriptionTier: tier,
         internalRealtimeUrl: process.env.INTERNAL_REALTIME_URL,
         signHeaders: createSignedBroadcastHeaders,
         logger: loggers.ai,
@@ -112,9 +145,12 @@ export async function POST(request: Request) {
       {
         offerSdp: sdp,
         userId,
-        ...(typeof conversationIdRaw === 'string' && conversationIdRaw.length > 0
-          ? { conversationId: conversationIdRaw }
+        ...(conversationId === undefined ? {} : { conversationId }),
+        seed,
+        ...(typeof timezoneRaw === 'string' && timezoneRaw.length > 0
+          ? { timezone: timezoneRaw }
           : {}),
+        ...(locationContext.success ? { locationContext: locationContext.data } : {}),
       }
     );
 

--- a/apps/web/src/lib/ai/realtime/__tests__/bridge-handler.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/bridge-handler.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { Tool } from 'ai';
+import { handleVoiceBridgeRequest, type VoiceBridgeDeps } from '../bridge-handler';
+import type { TranscriptPersistenceDeps } from '../transcript-persistence';
+
+const tool = (execute: () => unknown): Tool =>
+  ({
+    description: 'Read a page.',
+    inputSchema: z.object({ pageId: z.string() }),
+    execute,
+  }) as unknown as Tool;
+
+const transcriptDeps = (
+  over: Partial<TranscriptPersistenceDeps> = {},
+): TranscriptPersistenceDeps => ({
+  loadConversation: vi.fn(async () => ({
+    id: 'conv1',
+    userId: 'u1',
+    isShared: false,
+    type: 'global',
+    contextId: null,
+    isActive: true,
+  })),
+  createConversation: vi.fn(async () => undefined),
+  canAccess: vi.fn(async () => true),
+  saveGlobalMessage: vi.fn(async () => ({ saved: true, rev: 4 })),
+  savePageMessage: vi.fn(async () => ({ saved: true, rev: 4 })),
+  newMessageId: () => 'msg-1',
+  logger: { warn: vi.fn() },
+  ...over,
+});
+
+const deps = (over: Partial<VoiceBridgeDeps> = {}): VoiceBridgeDeps => ({
+  toolDeps: () => ({
+    tools: { read_page: tool(() => ({ title: 'Notes' })) },
+    logger: { warn: vi.fn(), error: vi.fn() },
+  }),
+  transcriptDeps: transcriptDeps(),
+  model: 'gpt-realtime-2.1',
+  ...over,
+});
+
+const toolBody = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    kind: 'tool',
+    callId: 'rtc_1',
+    userId: 'u1',
+    name: 'read_page',
+    argumentsJson: '{"pageId":"p1"}',
+    ...over,
+  });
+
+const transcriptBody = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    kind: 'transcript',
+    callId: 'rtc_1',
+    userId: 'u1',
+    conversationId: 'conv1',
+    role: 'user',
+    text: 'hello',
+    ...over,
+  });
+
+describe('handleVoiceBridgeRequest — validation', () => {
+  it('given malformed JSON, should 400', async () => {
+    const result = await handleVoiceBridgeRequest(deps(), 'not json');
+    expect(result.status).toBe(400);
+    expect(result.body).toEqual({ ok: false, error: 'Invalid JSON' });
+  });
+
+  it('given an unknown kind, should 400 rather than guess', async () => {
+    const result = await handleVoiceBridgeRequest(deps(), JSON.stringify({ kind: 'delete' }));
+    expect(result.status).toBe(400);
+  });
+
+  it('given a call id that is not an rtc_ id, should 400', async () => {
+    const result = await handleVoiceBridgeRequest(deps(), toolBody({ callId: 'sess_1' }));
+    expect(result.status).toBe(400);
+  });
+
+  it('given a transcript with no conversation, should 400 — there is nowhere to write it', async () => {
+    const result = await handleVoiceBridgeRequest(
+      deps(),
+      JSON.stringify({
+        kind: 'transcript',
+        callId: 'rtc_1',
+        userId: 'u1',
+        role: 'user',
+        text: 'hello',
+      }),
+    );
+    expect(result.status).toBe(400);
+  });
+});
+
+describe('handleVoiceBridgeRequest — tool dispatch', () => {
+  it('given a tool call, should run it and answer with a string output', async () => {
+    const result = await handleVoiceBridgeRequest(deps(), toolBody());
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ ok: true, kind: 'tool', output: '{"title":"Notes"}' });
+  });
+
+  it('given a tool that fails, should still answer 200 — the model is blocked until it does', async () => {
+    // "The tool refused" is not a transport failure. A non-200 here would leave
+    // the realtime server with nothing to put in `function_call_output`.
+    const result = await handleVoiceBridgeRequest(deps(), toolBody({ name: 'nonexistent' }));
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({ ok: true, kind: 'tool' });
+    expect((result.body as { output: string }).output).toContain('no tool called');
+  });
+
+  it('should forward the call context to the dispatcher', async () => {
+    const execute = vi.fn(() => 'ok');
+    const result = await handleVoiceBridgeRequest(
+      deps({
+        toolDeps: () => ({
+          tools: { read_page: tool(execute) },
+          logger: { warn: vi.fn(), error: vi.fn() },
+        }),
+      }),
+      toolBody({
+        conversationId: 'conv1',
+        timezone: 'America/New_York',
+        locationContext: { currentDrive: { id: 'd1', name: 'Work', slug: 'work' } },
+      }),
+    );
+
+    expect(result.status).toBe(200);
+    expect(execute).toHaveBeenCalled();
+  });
+
+  it('should build the tool set per request rather than reuse one across calls', async () => {
+    // `buildPageSpaceTools` has env-dependent branches; a frozen set would pin
+    // whatever the environment looked like at import time.
+    const toolDeps = vi.fn(() => ({
+      tools: { read_page: tool(() => 'ok') },
+      logger: { warn: vi.fn(), error: vi.fn() },
+    }));
+    const d = deps({ toolDeps });
+
+    await handleVoiceBridgeRequest(d, toolBody());
+    await handleVoiceBridgeRequest(d, toolBody());
+
+    expect(toolDeps).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('handleVoiceBridgeRequest — transcripts', () => {
+  it('given a spoken turn, should persist it and report the post-write rev', async () => {
+    const result = await handleVoiceBridgeRequest(deps(), transcriptBody());
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({
+      ok: true,
+      kind: 'transcript',
+      saved: true,
+      messageId: 'msg-1',
+      rev: 4,
+    });
+  });
+
+  it('given a refused write, should report saved:false at 200 rather than an error status', async () => {
+    // A refusal is an outcome, not a transport failure: the realtime server's
+    // only sane response either way is to log it and keep the call up.
+    const result = await handleVoiceBridgeRequest(
+      deps({ transcriptDeps: transcriptDeps({ canAccess: vi.fn(async () => false) }) }),
+      transcriptBody({ userId: 'someone-else' }),
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({ ok: true, kind: 'transcript', saved: false, messageId: null });
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/call-handshake.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/call-handshake.test.ts
@@ -92,6 +92,7 @@ function harness(
     apiKey: 'sk-managed-key',
     model: overrides.model ?? 'gpt-realtime-2.1',
     tools: overrides.tools ?? TOOLS,
+    subscriptionTier: 'pro',
     internalRealtimeUrl:
       'internalRealtimeUrl' in overrides ? overrides.internalRealtimeUrl : 'http://realtime:4000',
     signHeaders: vi.fn((body: string) => ({
@@ -205,11 +206,61 @@ describe('runCallHandshake — the handoff to the realtime server', () => {
       userId: 'u1',
       conversationId: 'conv1',
       tools: TOOLS,
+      // The realtime server meters the call itself and can derive neither:
+      // pricing is per-model, and the credit gate needs the tier.
+      model: 'gpt-realtime-2.1',
+      subscriptionTier: 'pro',
+      seed: [],
     });
 
     // Signed over the EXACT body posted — the HMAC is computed on those bytes.
     expect(deps.signHeaders).toHaveBeenCalledWith(String(handoff.init.body));
     expect((handoff.init.headers as Record<string, string>)['X-Broadcast-Signature']).toContain('v1=');
+  });
+
+  it('should carry the seed and the call context across to the realtime server', async () => {
+    // The seed is built HERE, behind the permission check, and rides the handoff
+    // so it is in the realtime server's hand before the model speaks.
+    const { deps, calls } = harness();
+    const seed = [
+      {
+        type: 'conversation.item.create' as const,
+        item: {
+          type: 'message' as const,
+          role: 'user' as const,
+          content: [{ type: 'input_text' as const, text: 'earlier question' }],
+        },
+      },
+    ];
+
+    await runCallHandshake(deps, {
+      offerSdp: OFFER_SDP,
+      userId: 'u1',
+      conversationId: 'conv1',
+      seed,
+      timezone: 'America/New_York',
+      locationContext: { currentPage: { id: 'p1', title: 'Notes', type: 'DOCUMENT', path: '/n' } },
+    });
+
+    const handoff = byUrl(calls, `http://realtime:4000${VOICE_BRIDGE_ROUTES.attach}`)!;
+    const body = JSON.parse(String(handoff.init.body));
+
+    expect(body.seed).toEqual(seed);
+    expect(body.timezone).toBe('America/New_York');
+    expect(body.locationContext).toEqual({
+      currentPage: { id: 'p1', title: 'Notes', type: 'DOCUMENT', path: '/n' },
+    });
+  });
+
+  it('given no timezone or location, should omit the keys rather than send undefined', async () => {
+    const { deps, calls } = harness();
+    await run(deps, 'conv1');
+
+    const handoff = byUrl(calls, `http://realtime:4000${VOICE_BRIDGE_ROUTES.attach}`)!;
+    const body = JSON.parse(String(handoff.init.body));
+
+    expect('timezone' in body).toBe(false);
+    expect('locationContext' in body).toBe(false);
   });
 
   it('given no conversationId, should omit the key rather than send undefined', async () => {

--- a/apps/web/src/lib/ai/realtime/__tests__/seed-loader.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/seed-loader.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  loadRealtimeSeed,
+  type SeedConversation,
+  type SeedLoaderDeps,
+} from '../seed-loader';
+
+const conversation = (over: Partial<SeedConversation> = {}): SeedConversation => ({
+  userId: 'u1',
+  isShared: false,
+  type: 'global',
+  contextId: null,
+  isActive: true,
+  ...over,
+});
+
+const history = [
+  { role: 'user', content: 'where are my notes?', createdAt: new Date(1) },
+  { role: 'assistant', content: 'In your Inbox.', createdAt: new Date(2) },
+];
+
+function deps(over: Partial<SeedLoaderDeps> = {}) {
+  const warn = vi.fn();
+  const base: SeedLoaderDeps = {
+    loadConversation: vi.fn(async () => conversation()),
+    canAccess: vi.fn(async () => true),
+    loadMessages: vi.fn(async () => history),
+    logger: { warn },
+    ...over,
+  };
+  return { deps: base, warn };
+}
+
+describe('loadRealtimeSeed', () => {
+  it('given a bound conversation with history, should build a seed from it', async () => {
+    const { deps: d } = deps();
+
+    const seed = await loadRealtimeSeed(d, { userId: 'u1', conversationId: 'conv1' });
+
+    expect(seed).toHaveLength(2);
+    expect(seed[0].item.role).toBe('user');
+    expect(seed[1].item.content[0]).toEqual({ type: 'text', text: 'In your Inbox.' });
+  });
+
+  it('given no conversation bound to the call, should seed nothing without reading anything', async () => {
+    const { deps: d } = deps();
+
+    expect(await loadRealtimeSeed(d, { userId: 'u1' })).toEqual([]);
+    expect(d.loadConversation).not.toHaveBeenCalled();
+  });
+
+  it('given a conversation with no row yet, should seed nothing — that is the ordinary case', async () => {
+    // A thread the user just opened has a client-minted id and no row until its
+    // first message lands.
+    const { deps: d, warn } = deps({ loadConversation: vi.fn(async () => undefined) });
+
+    expect(await loadRealtimeSeed(d, { userId: 'u1', conversationId: 'conv1' })).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('given a history-deleted conversation, should seed nothing', async () => {
+    const { deps: d } = deps({
+      loadConversation: vi.fn(async () => conversation({ isActive: false })),
+    });
+
+    expect(await loadRealtimeSeed(d, { userId: 'u1', conversationId: 'conv1' })).toEqual([]);
+  });
+
+  it('given a caller who cannot read the conversation, should seed nothing and say so', async () => {
+    const { deps: d, warn } = deps({ canAccess: vi.fn(async () => false) });
+
+    expect(await loadRealtimeSeed(d, { userId: 'intruder', conversationId: 'conv1' })).toEqual([]);
+    expect(d.loadMessages).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('given the read fails, should degrade to no history rather than fail the call', async () => {
+    // No history is strictly better than no call.
+    const { deps: d, warn } = deps({
+      loadMessages: vi.fn(async () => {
+        throw new Error('db unreachable');
+      }),
+    });
+
+    expect(await loadRealtimeSeed(d, { userId: 'u1', conversationId: 'conv1' })).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('given caps, should pass them through to the builder', async () => {
+    const many = Array.from({ length: 50 }, (_, index) => ({
+      role: 'user',
+      content: `m${index}`,
+      createdAt: new Date(index + 1),
+    }));
+    const { deps: d } = deps({ loadMessages: vi.fn(async () => many) });
+
+    const seed = await loadRealtimeSeed(d, {
+      userId: 'u1',
+      conversationId: 'conv1',
+      maxTurns: 3,
+    });
+
+    expect(seed).toHaveLength(3);
+    expect(seed[2].item.content[0].text).toBe('m49');
+  });
+
+  it('given no caps, should apply the builder defaults rather than pass undefined', async () => {
+    const many = Array.from({ length: 50 }, (_, index) => ({
+      role: 'user',
+      content: `m${index}`,
+      createdAt: new Date(index + 1),
+    }));
+    const { deps: d } = deps({ loadMessages: vi.fn(async () => many) });
+
+    const seed = await loadRealtimeSeed(d, { userId: 'u1', conversationId: 'conv1' });
+
+    expect(seed.length).toBeGreaterThan(0);
+    expect(seed.length).toBeLessThan(50);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/seed.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/seed.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRealtimeSeed,
+  DEFAULT_SEED_MAX_TOKENS,
+  DEFAULT_SEED_MAX_TURNS,
+  estimateSeedTokens,
+  SEED_CHARS_PER_TOKEN,
+  type SeedEvent,
+  type SeedMessage,
+} from '../seed';
+
+/** A message `n` minutes into the conversation, so ordering is explicit. */
+const at = (minute: number): Date => new Date(Date.UTC(2026, 0, 1, 0, minute, 0));
+
+const msg = (over: Partial<SeedMessage> = {}): SeedMessage => ({
+  role: 'user',
+  content: 'hello',
+  createdAt: at(0),
+  ...over,
+});
+
+/** The text of every emitted item, in emitted order. */
+const texts = (events: readonly SeedEvent[]): string[] =>
+  events.map((event) => event.item.content[0].text);
+
+const roles = (events: readonly SeedEvent[]): string[] =>
+  events.map((event) => event.item.role);
+
+/** `maxTokens` tokens' worth of a single repeated word, for budget arithmetic. */
+const wordsWorth = (tokens: number): string =>
+  'x'.repeat(tokens * SEED_CHARS_PER_TOKEN);
+
+describe('estimateSeedTokens', () => {
+  it('given text, should estimate at four characters per token', () => {
+    expect(estimateSeedTokens('12345678')).toBe(2);
+  });
+
+  it('given a partial token, should round up rather than lose it', () => {
+    expect(estimateSeedTokens('123')).toBe(1);
+  });
+
+  it('given an empty string, should estimate nothing', () => {
+    expect(estimateSeedTokens('')).toBe(0);
+  });
+});
+
+describe('buildRealtimeSeed', () => {
+  it('given an empty message list, should return an empty array', () => {
+    expect(buildRealtimeSeed([])).toEqual([]);
+  });
+
+  it('given only unseedable messages, should return an empty array', () => {
+    expect(
+      buildRealtimeSeed([
+        msg({ role: 'system', content: 'You are helpful.' }),
+        msg({ content: '   ' }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('given a user message, should emit a conversation.item.create with input_text', () => {
+    expect(buildRealtimeSeed([msg({ role: 'user', content: 'where are my notes?' })])).toEqual([
+      {
+        type: 'conversation.item.create',
+        item: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'where are my notes?' }],
+        },
+      },
+    ]);
+  });
+
+  it('given an assistant message, should emit it as TEXT content, never audio', () => {
+    const [event] = buildRealtimeSeed([msg({ role: 'assistant', content: 'In your Inbox.' })]);
+
+    expect(event).toEqual({
+      type: 'conversation.item.create',
+      item: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'In your Inbox.' }],
+      },
+    });
+    // The failure this guards is silent: an `input_audio`/`input_text` part on
+    // an assistant item is rejected as an opaque error event, not a message.
+    expect(JSON.stringify(event)).not.toContain('audio');
+    expect(JSON.stringify(event)).not.toContain('input_text');
+  });
+
+  it('given both sides of an exchange, should emit user AND assistant turns', () => {
+    const events = buildRealtimeSeed([
+      msg({ role: 'user', content: 'hi', createdAt: at(1) }),
+      msg({ role: 'assistant', content: 'hello', createdAt: at(2) }),
+    ]);
+
+    expect(roles(events)).toEqual(['user', 'assistant']);
+  });
+
+  it('given a system message among real turns, should skip it', () => {
+    const events = buildRealtimeSeed([
+      msg({ role: 'user', content: 'hi', createdAt: at(1) }),
+      msg({ role: 'system', content: 'You are helpful.', createdAt: at(2) }),
+      msg({ role: 'assistant', content: 'hello', createdAt: at(3) }),
+    ]);
+
+    expect(texts(events)).toEqual(['hi', 'hello']);
+  });
+
+  it('given a message with empty or whitespace-only content, should skip it rather than emit an empty item', () => {
+    const events = buildRealtimeSeed([
+      msg({ content: '', createdAt: at(1) }),
+      msg({ content: '   \n\t ', createdAt: at(2) }),
+      msg({ content: 'real', createdAt: at(3) }),
+    ]);
+
+    expect(texts(events)).toEqual(['real']);
+  });
+
+  it('given content with surrounding whitespace, should emit it trimmed', () => {
+    expect(texts(buildRealtimeSeed([msg({ content: '  spaced  ' })]))).toEqual(['spaced']);
+  });
+
+  it('given messages out of chronological order, should emit in chronological order', () => {
+    const events = buildRealtimeSeed([
+      msg({ content: 'third', createdAt: at(3) }),
+      msg({ content: 'first', createdAt: at(1) }),
+      msg({ content: 'second', createdAt: at(2) }),
+    ]);
+
+    expect(texts(events)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('given messages with identical timestamps, should keep their input order', () => {
+    const events = buildRealtimeSeed([
+      msg({ content: 'a', createdAt: at(1) }),
+      msg({ content: 'b', createdAt: at(1) }),
+    ]);
+
+    expect(texts(events)).toEqual(['a', 'b']);
+  });
+
+  it('given a string or numeric createdAt, should order by it', () => {
+    const events = buildRealtimeSeed([
+      msg({ content: 'later', createdAt: at(5).toISOString() }),
+      msg({ content: 'earlier', createdAt: at(1).getTime() }),
+    ]);
+
+    expect(texts(events)).toEqual(['earlier', 'later']);
+  });
+
+  it('given a missing or unparseable createdAt, should sort it oldest instead of dropping it', () => {
+    const events = buildRealtimeSeed([
+      msg({ content: 'dated', createdAt: at(1) }),
+      msg({ content: 'undated', createdAt: undefined }),
+      msg({ content: 'null-dated', createdAt: null }),
+      msg({ content: 'garbage-dated', createdAt: 'not a date' }),
+    ]);
+
+    expect(texts(events)).toEqual(['undated', 'null-dated', 'garbage-dated', 'dated']);
+  });
+
+  describe('the turn cap', () => {
+    it('given a conversation with 100 messages, should emit at most the cap and keep the most recent', () => {
+      const hundred = Array.from({ length: 100 }, (_, index) =>
+        msg({ content: `m${index}`, createdAt: at(index) }),
+      );
+
+      const events = buildRealtimeSeed(hundred);
+
+      expect(events).toHaveLength(DEFAULT_SEED_MAX_TURNS);
+      expect(texts(events)[0]).toBe(`m${100 - DEFAULT_SEED_MAX_TURNS}`);
+      expect(texts(events).at(-1)).toBe('m99');
+    });
+
+    it('given a configured turn cap, should honour it over the default', () => {
+      const ten = Array.from({ length: 10 }, (_, index) =>
+        msg({ content: `m${index}`, createdAt: at(index) }),
+      );
+
+      expect(texts(buildRealtimeSeed(ten, { maxTurns: 3 }))).toEqual(['m7', 'm8', 'm9']);
+    });
+
+    it('given fewer messages than the cap, should emit all of them', () => {
+      const three = Array.from({ length: 3 }, (_, index) =>
+        msg({ content: `m${index}`, createdAt: at(index) }),
+      );
+
+      expect(buildRealtimeSeed(three)).toHaveLength(3);
+    });
+
+    it('given a non-positive turn cap, should seed nothing', () => {
+      expect(buildRealtimeSeed([msg()], { maxTurns: 0 })).toEqual([]);
+    });
+  });
+
+  describe('the token budget', () => {
+    it('given messages exceeding the token budget, should drop oldest-first even when the turn count is already under its cap', () => {
+      // Three turns — well under DEFAULT_SEED_MAX_TURNS — but 300 tokens
+      // against a 250 budget, so exactly one has to go, and it is the oldest.
+      const events = buildRealtimeSeed(
+        [
+          msg({ content: `old ${wordsWorth(100)}`, createdAt: at(1) }),
+          msg({ content: `mid ${wordsWorth(100)}`, createdAt: at(2) }),
+          msg({ content: `new ${wordsWorth(100)}`, createdAt: at(3) }),
+        ],
+        { maxTokens: 250 },
+      );
+
+      expect(events).toHaveLength(2);
+      expect(texts(events)[0]).toContain('mid');
+      expect(texts(events)[1]).toContain('new');
+    });
+
+    it('given a budget that only fits the newest turn, should keep exactly that turn', () => {
+      const events = buildRealtimeSeed(
+        [
+          msg({ content: `old ${wordsWorth(100)}`, createdAt: at(1) }),
+          msg({ content: `new ${wordsWorth(100)}`, createdAt: at(2) }),
+        ],
+        { maxTokens: 120 },
+      );
+
+      expect(events).toHaveLength(1);
+      expect(texts(events)[0]).toContain('new');
+    });
+
+    it('given every turn inside the budget, should drop nothing', () => {
+      const events = buildRealtimeSeed(
+        [
+          msg({ content: 'short', createdAt: at(1) }),
+          msg({ content: 'also short', createdAt: at(2) }),
+        ],
+        { maxTokens: DEFAULT_SEED_MAX_TOKENS },
+      );
+
+      expect(events).toHaveLength(2);
+    });
+
+    it('given a single most-recent turn larger than the whole budget, should truncate it rather than return nothing', () => {
+      const events = buildRealtimeSeed(
+        [msg({ content: `${wordsWorth(500)} tail`, createdAt: at(1) })],
+        { maxTokens: 50 },
+      );
+
+      expect(events).toHaveLength(1);
+      const [text] = texts(events);
+      expect(estimateSeedTokens(text)).toBeLessThanOrEqual(50 + 12);
+      expect(text).toContain('earlier part of this message omitted');
+    });
+
+    it('given a long final turn after older ones, should drop the older ones AND truncate it', () => {
+      const events = buildRealtimeSeed(
+        [
+          msg({ content: 'old chatter', createdAt: at(1) }),
+          msg({ content: `${wordsWorth(500)} tail`, createdAt: at(2) }),
+        ],
+        { maxTokens: 50 },
+      );
+
+      expect(events).toHaveLength(1);
+      expect(texts(events)[0]).toContain('earlier part of this message omitted');
+    });
+
+    it('given truncation mid-sentence, should cut at a word boundary rather than sever a word', () => {
+      // 200 chars of "alpha beta " against a 10-token (40-char) budget, so the
+      // cut lands inside a word unless the boundary logic moves it back.
+      const events = buildRealtimeSeed(
+        [msg({ content: 'alpha beta '.repeat(40), createdAt: at(1) })],
+        { maxTokens: 10 },
+      );
+
+      const [text] = texts(events);
+      expect(text).toBe('alpha beta alpha beta alpha beta alpha… (earlier part of this message omitted)');
+    });
+
+    it('given truncation with no word boundary to cut on, should still fit the budget', () => {
+      const events = buildRealtimeSeed(
+        [msg({ content: 'y'.repeat(1000), createdAt: at(1) })],
+        { maxTokens: 10 },
+      );
+
+      expect(texts(events)[0].startsWith('y'.repeat(40))).toBe(true);
+      expect(texts(events)[0]).toContain('earlier part of this message omitted');
+    });
+
+    it('given a non-positive token budget, should seed nothing', () => {
+      expect(buildRealtimeSeed([msg()], { maxTokens: 0 })).toEqual([]);
+    });
+
+    it('given the defaults, should apply both caps together', () => {
+      // Each turn is a quarter of the default budget, so the token budget binds
+      // long before the turn cap does: 4 turns fit, the 5th does not.
+      const many = Array.from({ length: DEFAULT_SEED_MAX_TURNS }, (_, index) =>
+        msg({ content: `${index} ${wordsWorth(DEFAULT_SEED_MAX_TOKENS / 4)}`, createdAt: at(index) }),
+      );
+
+      const events = buildRealtimeSeed(many);
+
+      expect(events.length).toBeLessThan(DEFAULT_SEED_MAX_TURNS);
+      const total = texts(events).reduce((sum, text) => sum + estimateSeedTokens(text), 0);
+      expect(total).toBeLessThanOrEqual(DEFAULT_SEED_MAX_TOKENS);
+    });
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { Tool, ToolSet } from 'ai';
+import {
+  buildVoiceToolContext,
+  dispatchRealtimeToolCall,
+  formatToolResult,
+  MAX_SPOKEN_RESULT_CHARS,
+  parseToolArguments,
+  type RealtimeToolDispatchDeps,
+  type RealtimeToolDispatchRequest,
+} from '../tool-dispatch';
+import type { ToolExecutionContext } from '../../core/types';
+
+const logger = () => ({ warn: vi.fn(), error: vi.fn() });
+
+const request = (
+  over: Partial<RealtimeToolDispatchRequest> = {},
+): RealtimeToolDispatchRequest => ({
+  name: 'read_page',
+  argumentsJson: '{"pageId":"p1"}',
+  userId: 'u1',
+  callId: 'rtc_1',
+  ...over,
+});
+
+/** A tool whose execute records the options bag it was handed. */
+const spyTool = (execute: (args: unknown, options: unknown) => unknown): Tool =>
+  ({
+    description: 'Read a page.',
+    inputSchema: z.object({ pageId: z.string() }),
+    execute,
+  }) as unknown as Tool;
+
+const deps = (tools: ToolSet): RealtimeToolDispatchDeps => ({ tools, logger: logger() });
+
+describe('parseToolArguments', () => {
+  it('given a newline-laden JSON string, should parse it', () => {
+    expect(parseToolArguments('{\n  "pageId": "p1",\n  "lines": 20\n}')).toEqual({
+      ok: true,
+      args: { pageId: 'p1', lines: 20 },
+    });
+  });
+
+  it('given an absent or blank argument string, should read it as a no-argument call', () => {
+    expect(parseToolArguments('')).toEqual({ ok: true, args: {} });
+    expect(parseToolArguments('   \n ')).toEqual({ ok: true, args: {} });
+  });
+
+  it('given trailing junk after a complete object, should recover the object', () => {
+    // The string is assembled from streamed deltas; a double-appended payload is
+    // rare but real, and the common corruption is recoverable.
+    expect(parseToolArguments('{"pageId":"p1"}{"pageId":"p2"}')).toEqual({
+      ok: true,
+      args: { pageId: 'p1' },
+    });
+  });
+
+  it('given a nested object with trailing junk, should count braces rather than regex them', () => {
+    expect(parseToolArguments('{"a":{"b":{"c":1}}} trailing')).toEqual({
+      ok: true,
+      args: { a: { b: { c: 1 } } },
+    });
+  });
+
+  it('given braces inside a string value, should not mistake them for structure', () => {
+    expect(parseToolArguments('{"q":"a } b"} junk')).toEqual({
+      ok: true,
+      args: { q: 'a } b' },
+    });
+  });
+
+  it('given an escaped quote inside a string, should keep tracking the string correctly', () => {
+    expect(parseToolArguments('{"q":"say \\"} \\" now"} junk')).toEqual({
+      ok: true,
+      args: { q: 'say "} " now' },
+    });
+  });
+
+  it('given a truncated object, should report something the model can say', () => {
+    const parsed = parseToolArguments('{"pageId": "p1"');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.ok === false && parsed.message).toContain('could not be read');
+  });
+
+  it('given no object at all, should report rather than throw', () => {
+    expect(parseToolArguments('not json at all').ok).toBe(false);
+  });
+
+  it('given a valid JSON value that is not an object, should refuse it', () => {
+    // `null`, an array and a bare number all parse; none is an argument bag.
+    expect(parseToolArguments('null').ok).toBe(false);
+    expect(parseToolArguments('[1,2]').ok).toBe(false);
+    expect(parseToolArguments('42').ok).toBe(false);
+  });
+
+  it('given a recovered fragment that is still not an object, should refuse it', () => {
+    expect(parseToolArguments('oops {"a":1} but also {').ok).toBe(true);
+    expect(parseToolArguments('[{]').ok).toBe(false);
+  });
+});
+
+describe('formatToolResult', () => {
+  it('given a string result, should speak it as-is', () => {
+    expect(formatToolResult('Two pages.')).toBe('Two pages.');
+  });
+
+  it('given a structured result, should serialize it', () => {
+    expect(formatToolResult({ count: 2 })).toBe('{"count":2}');
+  });
+
+  it('given an empty or absent result, should still say something', () => {
+    expect(formatToolResult('')).toBe('Done.');
+    expect(formatToolResult(undefined)).toBe('Done.');
+    expect(formatToolResult(null)).toBe('Done.');
+  });
+
+  it('given a long result, should cut at a word boundary and say how much was left', () => {
+    const long = 'alpha beta '.repeat(500);
+    const spoken = formatToolResult(long);
+
+    expect(spoken.length).toBeLessThan(long.length);
+    expect(spoken).toContain('more characters were not read out');
+    // Never a severed word.
+    expect(spoken.split('…')[0].endsWith('beta') || spoken.split('…')[0].endsWith('alpha')).toBe(true);
+  });
+
+  it('given a long result with no spaces, should still cut it', () => {
+    const spoken = formatToolResult('x'.repeat(5000));
+    expect(spoken.length).toBeLessThan(5000);
+  });
+
+  it('given a result exactly at the cap, should not truncate', () => {
+    const exact = 'y'.repeat(MAX_SPOKEN_RESULT_CHARS);
+    expect(formatToolResult(exact)).toBe(exact);
+  });
+
+  it('given a circular structure, should not throw', () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    expect(() => formatToolResult(circular)).not.toThrow();
+  });
+
+  it('given a value JSON.stringify drops, should fall back to a string', () => {
+    expect(formatToolResult(() => 1)).not.toBe('');
+  });
+});
+
+describe('buildVoiceToolContext', () => {
+  it('should carry the acting user, the conversation, the timezone and the location', () => {
+    const context = buildVoiceToolContext(
+      request({
+        conversationId: 'conv1',
+        timezone: 'America/New_York',
+        locationContext: { currentPage: { id: 'p1', title: 'N', type: 'DOCUMENT', path: '/n' } },
+      }),
+      'gpt-realtime-2.1',
+    );
+
+    expect(context).toMatchObject({
+      userId: 'u1',
+      conversationId: 'conv1',
+      timezone: 'America/New_York',
+      locationContext: { currentPage: { id: 'p1' } },
+      aiProvider: 'openai_voice',
+      aiModel: 'gpt-realtime-2.1',
+    });
+  });
+
+  it('should mark the turn as a user request at depth zero, not a sub-agent run', () => {
+    const context = buildVoiceToolContext(request(), 'gpt-realtime-2.1');
+    expect(context.requestOrigin).toBe('user');
+    expect(context.agentCallDepth).toBe(0);
+  });
+
+  it('given no conversation, timezone or location, should omit them rather than send undefined', () => {
+    const context = buildVoiceToolContext(request(), 'gpt-realtime-2.1');
+    expect('conversationId' in context).toBe(false);
+    expect('timezone' in context).toBe(false);
+    expect('locationContext' in context).toBe(false);
+  });
+});
+
+describe('dispatchRealtimeToolCall', () => {
+  it('given a real tool, should run it and return its formatted result', async () => {
+    const execute = vi.fn(async () => ({ title: 'Notes' }));
+    const output = await dispatchRealtimeToolCall(
+      deps({ read_page: spyTool(execute) }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+
+    expect(execute).toHaveBeenCalled();
+    expect(output).toBe('{"title":"Notes"}');
+  });
+
+  it('should hand the tool a ToolExecutionContext carrying the REAL acting user', async () => {
+    // The single security-relevant thing this module does: every PageSpace tool
+    // enforces access internally against the userId on this context.
+    let seen: ToolExecutionContext | undefined;
+    await dispatchRealtimeToolCall(
+      deps({
+        read_page: spyTool((_args, options) => {
+          seen = (options as { experimental_context: ToolExecutionContext }).experimental_context;
+          return 'ok';
+        }),
+      }),
+      request({ userId: 'the-real-user', conversationId: 'conv1' }),
+      'gpt-realtime-2.1',
+    );
+
+    expect(seen?.userId).toBe('the-real-user');
+    expect(seen?.conversationId).toBe('conv1');
+  });
+
+  it('should pass the options bag under experimental_context, as the tools read it', async () => {
+    let options: unknown;
+    await dispatchRealtimeToolCall(
+      deps({
+        read_page: spyTool((_args, opts) => {
+          options = opts;
+          return 'ok';
+        }),
+      }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+
+    expect(options).toMatchObject({ toolCallId: 'rtc_1', messages: [] });
+    expect((options as { experimental_context?: unknown }).experimental_context).toBeDefined();
+  });
+
+  it('given a tool name that was never advertised, should tell the model how to recover', async () => {
+    const output = await dispatchRealtimeToolCall(
+      deps({ read_page: spyTool(() => 'ok') }),
+      request({ name: 'delete_everything' }),
+      'gpt-realtime-2.1',
+    );
+
+    expect(output).toContain('no tool called "delete_everything"');
+    expect(output).toContain('tool_search');
+  });
+
+  it('given a tool with no implementation, should say so rather than hang', async () => {
+    const output = await dispatchRealtimeToolCall(
+      deps({
+        read_page: { description: 'x', inputSchema: z.object({}) } as unknown as Tool,
+      }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+
+    expect(output).toContain('cannot be run');
+  });
+
+  it('given unreadable arguments, should answer with a sentence rather than run the tool', async () => {
+    const execute = vi.fn();
+    const output = await dispatchRealtimeToolCall(
+      deps({ read_page: spyTool(execute) }),
+      request({ argumentsJson: '{"pageId": ' }),
+      'gpt-realtime-2.1',
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(output).toContain('could not be read');
+  });
+
+  it('given arguments the tool schema rejects, should report the schema, not run the tool', async () => {
+    const execute = vi.fn();
+    const output = await dispatchRealtimeToolCall(
+      deps({ read_page: spyTool(execute) }),
+      request({ argumentsJson: '{"pageId": 42}' }),
+      'gpt-realtime-2.1',
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(output).toContain('Invalid parameters');
+    expect(output).toContain('select:read_page');
+  });
+
+  it('given the tool validates the arguments, should pass the PARSED value through', async () => {
+    let received: unknown;
+    await dispatchRealtimeToolCall(
+      deps({
+        read_page: spyTool((args) => {
+          received = args;
+          return 'ok';
+        }),
+      }),
+      request({ argumentsJson: '{"pageId":"p1","extra":"dropped"}' }),
+      'gpt-realtime-2.1',
+    );
+
+    expect(received).toEqual({ pageId: 'p1' });
+  });
+
+  it('given a throwing tool (a permission refusal), should turn it into something speakable', async () => {
+    const output = await dispatchRealtimeToolCall(
+      deps({
+        read_page: spyTool(() => {
+          throw new Error("You don't have access to that page");
+        }),
+      }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+
+    expect(output).toContain("You don't have access to that page");
+  });
+
+  it('given a tool that throws a non-Error, should still answer', async () => {
+    const output = await dispatchRealtimeToolCall(
+      deps({
+        read_page: spyTool(() => {
+          throw 'nope';
+        }),
+      }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+
+    expect(output).toContain('nope');
+  });
+
+  it('given a huge tool result, should truncate before returning it', async () => {
+    const output = await dispatchRealtimeToolCall(
+      deps({ read_page: spyTool(() => 'word '.repeat(5000)) }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+
+    expect(output.length).toBeLessThan(1000);
+    expect(output).toContain('were not read out');
+  });
+
+  it('should ALWAYS return a string — function_call_output cannot carry anything else', async () => {
+    const cases = [
+      dispatchRealtimeToolCall(deps({}), request(), 'gpt-realtime-2.1'),
+      dispatchRealtimeToolCall(
+        deps({ read_page: spyTool(() => undefined) }),
+        request(),
+        'gpt-realtime-2.1',
+      ),
+      dispatchRealtimeToolCall(
+        deps({ read_page: spyTool(() => ({ nested: { deep: true } })) }),
+        request(),
+        'gpt-realtime-2.1',
+      ),
+    ];
+
+    for (const output of await Promise.all(cases)) {
+      expect(typeof output).toBe('string');
+    }
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/transcript-persistence.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/transcript-persistence.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MESSAGE_SOURCE_VOICE } from '@pagespace/db/schema/conversations';
+import {
+  persistVoiceTranscript,
+  type TranscriptConversation,
+  type TranscriptPersistenceDeps,
+  type TranscriptRequest,
+} from '../transcript-persistence';
+
+type GlobalSaveArgs = Parameters<TranscriptPersistenceDeps['saveGlobalMessage']>[0];
+type PageSaveArgs = Parameters<TranscriptPersistenceDeps['savePageMessage']>[0];
+
+const conversation = (over: Partial<TranscriptConversation> = {}): TranscriptConversation => ({
+  id: 'conv1',
+  userId: 'u1',
+  isShared: false,
+  type: 'global',
+  contextId: null,
+  isActive: true,
+  ...over,
+});
+
+const request = (over: Partial<TranscriptRequest> = {}): TranscriptRequest => ({
+  callId: 'rtc_1',
+  userId: 'u1',
+  conversationId: 'conv1',
+  role: 'user',
+  text: 'where are my notes?',
+  ...over,
+});
+
+function deps(over: Partial<TranscriptPersistenceDeps> = {}) {
+  // Typed parameters, not `vi.fn(async () => …)`: without them the mock's
+  // argument list infers as `[]` and `mock.calls[0][0]` does not type-check.
+  const saveGlobalMessage = vi.fn(async (_args: GlobalSaveArgs) => ({ saved: true, rev: 7 }));
+  const savePageMessage = vi.fn(async (_args: PageSaveArgs) => ({ saved: true, rev: 9 }));
+  const base: TranscriptPersistenceDeps = {
+    loadConversation: vi.fn(async () => conversation()),
+    createConversation: vi.fn(async () => conversation()),
+    canAccess: vi.fn(async () => true),
+    saveGlobalMessage,
+    savePageMessage,
+    newMessageId: () => 'msg-1',
+    logger: { warn: vi.fn() },
+    ...over,
+  };
+  return { deps: base, saveGlobalMessage, savePageMessage };
+}
+
+describe('persistVoiceTranscript — global conversations', () => {
+  it('given a spoken user turn, should write it as an ordinary message row', async () => {
+    const { deps: d, saveGlobalMessage } = deps();
+
+    const result = await persistVoiceTranscript(d, request());
+
+    expect(saveGlobalMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 'msg-1',
+        conversationId: 'conv1',
+        role: 'user',
+        content: 'where are my notes?',
+        userId: 'u1',
+      }),
+    );
+    expect(result).toEqual({ saved: true, messageId: 'msg-1', rev: 7 });
+  });
+
+  it('should mark the row as voice-authored so the UI and the seed can tell it apart', async () => {
+    const { deps: d, saveGlobalMessage } = deps();
+    await persistVoiceTranscript(d, request());
+
+    expect(saveGlobalMessage.mock.calls[0][0]).toMatchObject({ source: MESSAGE_SOURCE_VOICE });
+  });
+
+  it('given the assistant spoke, should write an assistant row against the same conversation', async () => {
+    const { deps: d, saveGlobalMessage } = deps();
+    await persistVoiceTranscript(d, request({ role: 'assistant', text: 'In your Inbox.' }));
+
+    expect(saveGlobalMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'assistant', content: 'In your Inbox.' }),
+    );
+  });
+
+  it('should attribute the row to the conversation OWNER, matching every other global write', async () => {
+    const { deps: d, saveGlobalMessage } = deps({
+      loadConversation: vi.fn(async () => conversation({ userId: 'owner' })),
+      canAccess: vi.fn(async () => true),
+    });
+
+    await persistVoiceTranscript(d, request({ userId: 'owner' }));
+
+    expect(saveGlobalMessage.mock.calls[0][0].userId).toBe('owner');
+  });
+
+  it('should trim the text before writing it', async () => {
+    const { deps: d, saveGlobalMessage } = deps();
+    await persistVoiceTranscript(d, request({ text: '  spoken  ' }));
+
+    expect(saveGlobalMessage.mock.calls[0][0].content).toBe('spoken');
+  });
+
+  it('given a save that was skipped, should report saved:false with no message id', async () => {
+    const { deps: d } = deps({
+      saveGlobalMessage: vi.fn(async (_args: GlobalSaveArgs) => ({ saved: false, rev: 0 })),
+    });
+
+    expect(await persistVoiceTranscript(d, request())).toEqual({
+      saved: false,
+      messageId: null,
+      rev: 0,
+    });
+  });
+});
+
+describe('persistVoiceTranscript — page conversations', () => {
+  const pageConversation = conversation({ type: 'page', contextId: 'page-1' });
+
+  it('given a page thread, should write through the page path with its page id', async () => {
+    const { deps: d, savePageMessage } = deps({
+      loadConversation: vi.fn(async () => pageConversation),
+    });
+
+    const result = await persistVoiceTranscript(d, request());
+
+    expect(savePageMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ pageId: 'page-1', role: 'user', userId: 'u1', sourceAgentId: null }),
+    );
+    expect(result.rev).toBe(9);
+  });
+
+  it('given the AGENT spoke, should attribute the row to the agent page, not to a human', async () => {
+    // The attribution rule the `messages` table documents: a human author, or
+    // NULL with `sourceAgentId` naming the agent that wrote it.
+    const { deps: d, savePageMessage } = deps({
+      loadConversation: vi.fn(async () => pageConversation),
+    });
+
+    await persistVoiceTranscript(d, request({ role: 'assistant' }));
+
+    expect(savePageMessage.mock.calls[0][0]).toMatchObject({
+      userId: null,
+      sourceAgentId: 'page-1',
+    });
+  });
+
+  it('given a page conversation with no page, should refuse rather than guess', async () => {
+    const { deps: d, savePageMessage } = deps({
+      loadConversation: vi.fn(async () => conversation({ type: 'page', contextId: null })),
+    });
+
+    const result = await persistVoiceTranscript(d, request());
+
+    expect(result.skipped).toBe('unsupported_conversation_type');
+    expect(savePageMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('persistVoiceTranscript — refusals', () => {
+  it('given a blank transcript, should skip rather than write an empty turn', async () => {
+    const { deps: d, saveGlobalMessage } = deps();
+
+    const result = await persistVoiceTranscript(d, request({ text: '   ' }));
+
+    expect(result.skipped).toBe('blank');
+    expect(saveGlobalMessage).not.toHaveBeenCalled();
+  });
+
+  it('given a caller who cannot access the conversation, should refuse the write', async () => {
+    const { deps: d, saveGlobalMessage } = deps({ canAccess: vi.fn(async () => false) });
+
+    const result = await persistVoiceTranscript(d, request({ userId: 'someone-else' }));
+
+    expect(result.skipped).toBe('no_access');
+    expect(saveGlobalMessage).not.toHaveBeenCalled();
+  });
+
+  it('given the thread was deleted from history mid-call, should drop the turn', async () => {
+    // Writing under it would put the turn somewhere no listing can reach.
+    const { deps: d, saveGlobalMessage } = deps({
+      loadConversation: vi.fn(async () => conversation({ isActive: false })),
+    });
+
+    const result = await persistVoiceTranscript(d, request());
+
+    expect(result.skipped).toBe('history_deleted');
+    expect(saveGlobalMessage).not.toHaveBeenCalled();
+  });
+
+  it('given a drive or client thread, should refuse rather than invent a binding', async () => {
+    for (const type of ['drive', 'client']) {
+      const { deps: d, saveGlobalMessage, savePageMessage } = deps({
+        loadConversation: vi.fn(async () => conversation({ type })),
+      });
+
+      const result = await persistVoiceTranscript(d, request());
+
+      expect(result.skipped).toBe('unsupported_conversation_type');
+      expect(saveGlobalMessage).not.toHaveBeenCalled();
+      expect(savePageMessage).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe('persistVoiceTranscript — lazy conversation creation', () => {
+  it('given no conversation row yet, should create it the way the typed path does and write', async () => {
+    const createConversation = vi.fn(async () => conversation());
+    const { deps: d, saveGlobalMessage } = deps({
+      loadConversation: vi.fn(async () => undefined),
+      createConversation,
+    });
+
+    const result = await persistVoiceTranscript(d, request());
+
+    expect(createConversation).toHaveBeenCalledWith('u1', 'conv1');
+    expect(saveGlobalMessage).toHaveBeenCalled();
+    expect(result.saved).toBe(true);
+  });
+
+  it('given the id belongs to someone else, should report rather than write', async () => {
+    const { deps: d, saveGlobalMessage } = deps({
+      loadConversation: vi.fn(async () => undefined),
+      createConversation: vi.fn(async () => undefined),
+    });
+
+    const result = await persistVoiceTranscript(d, request());
+
+    expect(result.skipped).toBe('create_failed');
+    expect(saveGlobalMessage).not.toHaveBeenCalled();
+  });
+
+  it('given a freshly created conversation, should not also re-check access against it', async () => {
+    // `resolveOrCreateConversation` already enforces owner + type; a second
+    // check here would be a second permission model for the same decision.
+    const canAccess = vi.fn(async () => false);
+    const { deps: d, saveGlobalMessage } = deps({
+      loadConversation: vi.fn(async () => undefined),
+      canAccess,
+    });
+
+    await persistVoiceTranscript(d, request());
+
+    expect(canAccess).not.toHaveBeenCalled();
+    expect(saveGlobalMessage).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-bridge-contract-drift.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-bridge-contract-drift.test.ts
@@ -16,8 +16,11 @@ import { describe, expect, it } from 'vitest';
 import {
   realtimeToolSchema,
   realtimeAttachPayloadSchema,
+  realtimeSeedEventSchema,
+  type RealtimeSeedEventWire,
 } from '@pagespace/lib/realtime/voice-bridge-contract';
 import { buildRealtimeTools } from '../tools';
+import { buildRealtimeSeed, type SeedEvent } from '../seed';
 import { buildPageSpaceTools } from '../../core/ai-tools';
 import type { RealtimeTool } from '../session';
 
@@ -40,6 +43,7 @@ describe('realtime tool wire shape', () => {
       secret: 'ek_secret',
       userId: 'u1',
       tools,
+      model: 'gpt-realtime-2.1',
     });
 
     expect(parsed.success).toBe(true);
@@ -69,5 +73,75 @@ describe('realtime tool wire shape', () => {
       function: { name: 'read_page', description: 'Read.', parameters: {} },
     };
     expect(realtimeToolSchema.safeParse(nested).success).toBe(false);
+  });
+});
+
+/**
+ * The seed's two declarations, guarded the same way and for a sharper reason:
+ * the content-part type differs by role (`input_text` for the user, `text` for
+ * the assistant) and getting it wrong is not a validation error on the wire —
+ * it is an opaque `error` event on a socket that then just sits there.
+ */
+describe('realtime seed wire shape', () => {
+  const history = [
+    { role: 'user', content: 'where are my notes?', createdAt: new Date(1) },
+    { role: 'assistant', content: 'In your Inbox.', createdAt: new Date(2) },
+  ];
+
+  it('given a built seed, every item should satisfy the shared schema', () => {
+    const seed = buildRealtimeSeed(history);
+    expect(seed).toHaveLength(2);
+
+    for (const item of seed) {
+      expect(realtimeSeedEventSchema.safeParse(item).success).toBe(true);
+    }
+  });
+
+  it('should carry a built seed through the attach payload unchanged', () => {
+    const seed = buildRealtimeSeed(history);
+
+    const parsed = realtimeAttachPayloadSchema.safeParse({
+      callId: 'rtc_u0_abc',
+      secret: 'ek_secret',
+      userId: 'u1',
+      model: 'gpt-realtime-2.1',
+      seed,
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.seed).toEqual(seed);
+  });
+
+  it('a SeedEvent should be assignable to the wire type in both directions', () => {
+    const fromApp: SeedEvent = {
+      type: 'conversation.item.create',
+      item: { type: 'message', role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+    };
+    const onWire: RealtimeSeedEventWire = realtimeSeedEventSchema.parse(fromApp);
+    const backToApp: SeedEvent = onWire;
+
+    expect(backToApp).toEqual(fromApp);
+  });
+
+  it('should reject an audio content part — assistant audio cannot be seeded at all', () => {
+    expect(
+      realtimeSeedEventSchema.safeParse({
+        type: 'conversation.item.create',
+        item: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'input_audio', text: '' }],
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('should reject an item with no content at all', () => {
+    expect(
+      realtimeSeedEventSchema.safeParse({
+        type: 'conversation.item.create',
+        item: { type: 'message', role: 'user', content: [] },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/realtime/bridge-handler.ts
+++ b/apps/web/src/lib/ai/realtime/bridge-handler.ts
@@ -1,0 +1,112 @@
+/**
+ * The return hop's handler: what the web tier does when the realtime server
+ * asks it to run a tool or persist a spoken turn.
+ *
+ * Separated from the route so the whole dispatch tree is testable without a
+ * request, a signature or a server — the shape `attach-handler.ts` established
+ * on the other side of the same seam, deliberately mirrored so the two ends of
+ * one boundary read the same way.
+ *
+ * The HMAC check does NOT live here. It runs in the route, over the RAW body,
+ * before anything is parsed — a caller that cannot sign is not a caller whose
+ * JSON we should be reading.
+ */
+
+import {
+  voiceBridgeRequestSchema,
+  type VoiceBridgeResponse,
+} from '@pagespace/lib/realtime/voice-bridge-contract';
+import { dispatchRealtimeToolCall, type RealtimeToolDispatchDeps } from './tool-dispatch';
+import {
+  persistVoiceTranscript,
+  type TranscriptPersistenceDeps,
+} from './transcript-persistence';
+
+export type VoiceBridgeDeps = {
+  readonly toolDeps: () => RealtimeToolDispatchDeps;
+  readonly transcriptDeps: TranscriptPersistenceDeps;
+  /** Resolved from env at the edge, for tool-call attribution. */
+  readonly model: string;
+};
+
+export type VoiceBridgeHandlerResponse = {
+  readonly status: number;
+  readonly body: VoiceBridgeResponse;
+};
+
+/**
+ * Validate, then do the one thing the payload asked for.
+ *
+ * A TOOL dispatch never answers non-200 for a tool-level failure. The realtime
+ * server's next move is `function_call_output`, and the model is blocked until
+ * it arrives — so "the tool refused" and "the tool threw" both come back as a
+ * successful response whose `output` is a sentence the model can say. Only a
+ * malformed payload (a bug on our own wire) is a 400.
+ */
+export const handleVoiceBridgeRequest = async (
+  deps: VoiceBridgeDeps,
+  rawBody: string,
+): Promise<VoiceBridgeHandlerResponse> => {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawBody);
+  } catch {
+    return { status: 400, body: { ok: false, error: 'Invalid JSON' } };
+  }
+
+  const parsed = voiceBridgeRequestSchema.safeParse(json);
+  if (!parsed.success) {
+    return {
+      status: 400,
+      body: {
+        ok: false,
+        error: parsed.error.issues[0]?.message ?? 'Invalid voice bridge payload',
+      },
+    };
+  }
+
+  const request = parsed.data;
+
+  if (request.kind === 'tool') {
+    const output = await dispatchRealtimeToolCall(
+      deps.toolDeps(),
+      {
+        name: request.name,
+        argumentsJson: request.argumentsJson,
+        userId: request.userId,
+        callId: request.callId,
+        ...(request.conversationId === undefined
+          ? {}
+          : { conversationId: request.conversationId }),
+        ...(request.timezone === undefined ? {} : { timezone: request.timezone }),
+        ...(request.locationContext === undefined
+          ? {}
+          : { locationContext: request.locationContext }),
+      },
+      deps.model,
+    );
+    return { status: 200, body: { ok: true, kind: 'tool', output } };
+  }
+
+  const result = await persistVoiceTranscript(deps.transcriptDeps, {
+    callId: request.callId,
+    userId: request.userId,
+    conversationId: request.conversationId,
+    role: request.role,
+    text: request.text,
+  });
+
+  // A refused or skipped transcript is still a 200: it is an outcome, not a
+  // transport failure, and the realtime server's only sane response either way
+  // is to log it and keep the call up. `saved: false` says what happened.
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      kind: 'transcript',
+      saved: result.saved,
+      messageId: result.messageId,
+      rev: result.rev,
+    },
+  };
+};

--- a/apps/web/src/lib/ai/realtime/call-handshake.ts
+++ b/apps/web/src/lib/ai/realtime/call-handshake.ts
@@ -41,6 +41,8 @@ import {
   REALTIME_CALL_ID_PREFIX,
   VOICE_BRIDGE_ROUTES,
   type RealtimeAttachPayload,
+  type RealtimeSeedEventWire,
+  type VoiceLocationContext,
 } from '@pagespace/lib/realtime/voice-bridge-contract';
 
 /**
@@ -99,6 +101,13 @@ export type HandshakeDeps = {
   readonly model: string;
   /** Realtime tool definitions, forwarded to the realtime server unchanged. */
   readonly tools: readonly RealtimeTool[];
+  /**
+   * The caller's tier, already read for the entitlement gate one function
+   * earlier. Forwarded rather than re-read because the realtime server meters
+   * the call and the credit gate needs it — and a tier cannot change inside one
+   * call, so a second DB round trip would buy nothing.
+   */
+  readonly subscriptionTier: string;
   /** Unset means "no realtime server configured": degrade, do not fail. */
   readonly internalRealtimeUrl: string | undefined;
   /** `createSignedBroadcastHeaders`, injected so tests need no HMAC secret. */
@@ -110,6 +119,17 @@ export type HandshakeInput = {
   readonly offerSdp: string;
   readonly userId: string;
   readonly conversationId?: string;
+  /**
+   * The bound conversation's history, already loaded and capped
+   * (`loadRealtimeSeed`). Built here rather than fetched by the realtime server
+   * because the repositories and the access predicate live in this app — and
+   * because the browser is already in a call by the time the handoff happens,
+   * so the seed must arrive WITH it, not a round trip later.
+   */
+  readonly seed?: readonly RealtimeSeedEventWire[];
+  /** Threaded into the tool-execution context the realtime server dispatches with. */
+  readonly timezone?: string;
+  readonly locationContext?: VoiceLocationContext;
 };
 
 /** Upstream calls are short; a hung one must not hold the request open. */
@@ -183,6 +203,13 @@ const handOff = async (
     userId: input.userId,
     ...(input.conversationId === undefined ? {} : { conversationId: input.conversationId }),
     tools: [...deps.tools],
+    model: deps.model,
+    subscriptionTier: deps.subscriptionTier,
+    ...(input.timezone === undefined ? {} : { timezone: input.timezone }),
+    ...(input.locationContext === undefined
+      ? {}
+      : { locationContext: input.locationContext }),
+    seed: [...(input.seed ?? [])],
   };
   const body = JSON.stringify(payload);
 

--- a/apps/web/src/lib/ai/realtime/seed-loader.ts
+++ b/apps/web/src/lib/ai/realtime/seed-loader.ts
@@ -1,0 +1,80 @@
+/**
+ * Loading the bound conversation's history and turning it into a seed.
+ *
+ * The IO half of `seed.ts`: read the thread, check the caller may see it, hand
+ * the rows to the pure builder. It runs at HANDSHAKE time, in the web tier,
+ * because that is where the repositories and the permission predicate live —
+ * and the result rides the attach payload so the seed is already in the
+ * realtime server's hand when the socket reaches `session.updated`, rather than
+ * costing a round trip while the caller waits to be heard.
+ *
+ * A seed is never a reason to fail a call. Every unhappy path below returns an
+ * empty seed: an unbound call, a conversation that does not exist yet (the
+ * common case — a fresh thread's row is created by its first message), one the
+ * caller may not read, or a read that failed. The call still connects, still
+ * runs tools, still meters; it simply starts without history, which is exactly
+ * what a new conversation does anyway.
+ */
+
+import { buildRealtimeSeed, type SeedEvent, type SeedMessage } from './seed';
+
+/** The conversation facts the access check needs. A `conversations` row satisfies it. */
+export type SeedConversation = {
+  readonly userId: string;
+  readonly isShared: boolean;
+  readonly type: string;
+  readonly contextId: string | null;
+  readonly isActive: boolean;
+};
+
+export type SeedLoaderDeps = {
+  readonly loadConversation: (conversationId: string) => Promise<SeedConversation | undefined>;
+  readonly canAccess: (userId: string, conversation: SeedConversation) => Promise<boolean>;
+  readonly loadMessages: (conversationId: string) => Promise<readonly SeedMessage[]>;
+  readonly logger: {
+    readonly warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+};
+
+export type SeedLoaderRequest = {
+  readonly userId: string;
+  readonly conversationId?: string;
+  readonly maxTurns?: number;
+  readonly maxTokens?: number;
+};
+
+export const loadRealtimeSeed = async (
+  deps: SeedLoaderDeps,
+  request: SeedLoaderRequest,
+): Promise<SeedEvent[]> => {
+  if (!request.conversationId) return [];
+
+  try {
+    const conversation = await deps.loadConversation(request.conversationId);
+    // No row is the ORDINARY case, not an error: a thread the user just opened
+    // has a client-minted id and no row until its first message lands.
+    if (!conversation || !conversation.isActive) return [];
+
+    if (!(await deps.canAccess(request.userId, conversation))) {
+      deps.logger.warn('Realtime voice seed refused: caller cannot access the conversation', {
+        userId: request.userId,
+        conversationId: request.conversationId,
+      });
+      return [];
+    }
+
+    const messages = await deps.loadMessages(request.conversationId);
+    return buildRealtimeSeed(messages, {
+      ...(request.maxTurns === undefined ? {} : { maxTurns: request.maxTurns }),
+      ...(request.maxTokens === undefined ? {} : { maxTokens: request.maxTokens }),
+    });
+  } catch (error) {
+    // Degrading to no history is strictly better than degrading to no call.
+    deps.logger.warn('Realtime voice seed could not be loaded; starting without history', {
+      userId: request.userId,
+      conversationId: request.conversationId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return [];
+  }
+};

--- a/apps/web/src/lib/ai/realtime/seed.ts
+++ b/apps/web/src/lib/ai/realtime/seed.ts
@@ -1,0 +1,212 @@
+/**
+ * Prior conversation turns, projected onto the `conversation.item.create`
+ * client events that give a realtime session its history.
+ *
+ * This is the mechanism behind "start voice on a thread you were already
+ * typing in": the model cannot be handed the thread, so the thread is replayed
+ * into the session as text items before it speaks. The SAME function reseeds a
+ * fresh session when one hits the API's session ceiling — a reseed is a cold
+ * session plus this history, which is exactly what a cold start is.
+ *
+ * THE CAP IS THE POINT, NOT A GUARD. Realtime cannot take assistant AUDIO as
+ * history, so prior turns can only be injected as TEXT (see the item shapes
+ * below). Injecting a LARGE text history into a session with audio output
+ * enabled is a documented, widely-reported way to get NO AUDIO AT ALL, and it
+ * worsens as the history grows. So a seed that is merely "complete" is a seed
+ * that silently mutes the call. Both caps below are therefore hard, and the
+ * most recent turns are what survive them — latency and liveness win a live
+ * turn; completeness happens in the thread afterwards.
+ *
+ * ITEM SHAPES, and they are NOT symmetric — this is the part that is easy to
+ * get wrong and hard to debug, because a wrong content-part type is rejected
+ * as an opaque `error` event rather than as a validation message:
+ *   - a `role: 'user'` item takes content parts of type `input_text`
+ *   - a `role: 'assistant'` item takes content parts of type `text`
+ * Verified against the Realtime conversations guide (which shows the user item
+ * verbatim) and openai/openai-realtime-api-beta#57, which added assistant/user
+ * history injection and documents the same split — along with the limitation
+ * that assistant AUDIO items cannot be populated at all, which is precisely
+ * why this module exists.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state. The
+ * caller loads the messages and hands them in.
+ */
+
+/**
+ * The minimum a caller must carry per message. Structural on purpose: a full
+ * `messages` row (`packages/db/src/schema/conversations.ts`) satisfies it, and
+ * so does a hand-built literal in a test, so nothing is forced to construct DB
+ * rows to build a seed.
+ *
+ * `role` is `string` rather than a union because that is what the column is —
+ * narrowing happens here, once, instead of at every call site.
+ */
+export type SeedMessage = {
+  readonly role: string;
+  readonly content: string;
+  /** `messages.createdAt`. Anything `Date`-constructible; absent sorts oldest. */
+  readonly createdAt?: Date | string | number | null;
+};
+
+/** One `conversation.item.create` client event, ready to send. */
+export type SeedEvent = {
+  readonly type: 'conversation.item.create';
+  readonly item: {
+    readonly type: 'message';
+    readonly role: 'user' | 'assistant';
+    // Not a `readonly` array: this shape must be assignable to
+    // `RealtimeSeedEventWire` (the zod-inferred wire type on the attach
+    // payload), and a readonly array is not assignable to a mutable one. A
+    // drift guard in the tests asserts the two agree in both directions.
+    readonly content: { readonly type: 'input_text' | 'text'; readonly text: string }[];
+  };
+};
+
+export type SeedOptions = {
+  /** Hard ceiling on turns emitted. Most recent kept. */
+  readonly maxTurns?: number;
+  /** Hard ceiling on ESTIMATED tokens across the emitted turns. */
+  readonly maxTokens?: number;
+};
+
+/**
+ * Twenty turns is about ten exchanges — enough for the model to know what
+ * "that one" refers to, and short enough to stay well inside the range where
+ * seeded sessions reliably still speak.
+ */
+export const DEFAULT_SEED_MAX_TURNS = 20;
+
+/**
+ * ~4k tokens of history. The turn cap alone does not bound anything: twenty
+ * turns of pasted document is a different quantity from twenty turns of
+ * conversation, and it is the QUANTITY that mutes the session.
+ */
+export const DEFAULT_SEED_MAX_TOKENS = 4000;
+
+/**
+ * Chars per token. A deliberate ESTIMATE, not a measurement: pulling a real
+ * tokenizer in would add a dependency (and its vocabulary download) to a
+ * module whose only job is to stay conservatively under a soft failure
+ * threshold. Four is the usual English approximation and errs toward
+ * over-counting on prose, which is the safe direction — over-count and the
+ * seed is a little shorter than it could be; under-count and the call goes
+ * silent.
+ */
+export const SEED_CHARS_PER_TOKEN = 4;
+
+/** Deterministic token estimate for one string. See {@link SEED_CHARS_PER_TOKEN}. */
+export const estimateSeedTokens = (text: string): number =>
+  Math.ceil(text.length / SEED_CHARS_PER_TOKEN);
+
+/** Roles a seed can carry. `system` is deliberately absent — see `buildRealtimeSeed`. */
+type SeedRole = 'user' | 'assistant';
+
+const isSeedRole = (role: string): role is SeedRole =>
+  role === 'user' || role === 'assistant';
+
+/**
+ * Sort key. An absent/unparseable `createdAt` sorts oldest rather than being
+ * dropped: a row with no timestamp is still something that was said, and
+ * `Array.prototype.sort` is stable, so same-key rows keep their input order.
+ */
+const sortKey = (message: SeedMessage): number => {
+  const raw = message.createdAt;
+  if (raw === undefined || raw === null) return Number.NEGATIVE_INFINITY;
+  const time = raw instanceof Date ? raw.getTime() : new Date(raw).getTime();
+  return Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time;
+};
+
+/**
+ * Cut to a word boundary and say what was left out, so the model is never
+ * handed a severed word and never treats a truncation as the end of a turn.
+ *
+ * Carries no "already short enough" guard: it is called only after the
+ * estimate has exceeded the budget, and `ceil(len / 4) > maxTokens` implies
+ * `len > maxTokens * 4`, so the guard would be unreachable.
+ */
+const truncateToTokens = (text: string, maxTokens: number): string => {
+  const maxChars = maxTokens * SEED_CHARS_PER_TOKEN;
+  const window = text.slice(0, maxChars);
+  const lastSpace = window.lastIndexOf(' ');
+  const head = (lastSpace > 0 ? window.slice(0, lastSpace) : window).trimEnd();
+  return `${head}… (earlier part of this message omitted)`;
+};
+
+const toEvent = (role: SeedRole, text: string): SeedEvent => ({
+  type: 'conversation.item.create',
+  item: {
+    type: 'message',
+    role,
+    // The asymmetry that has to be right: `input_text` for the user's side,
+    // `text` for the assistant's. Never `input_audio` — assistant audio cannot
+    // be injected as history at all, which is why the assistant's own turns
+    // come back as text even though they were originally spoken.
+    content: [{ type: role === 'user' ? 'input_text' : 'text', text }],
+  },
+});
+
+/**
+ * Build the ordered seed for a conversation.
+ *
+ * Order of operations, and each step is load-bearing:
+ *  1. drop anything unseedable — a non user/assistant role (a `system` row is
+ *     the app's own instruction, which the session's `instructions` already
+ *     carry; replaying it as a turn would have the model answer it) and any
+ *     blank/whitespace-only content (an empty item is a turn that says
+ *     nothing, and a streaming placeholder is exactly that);
+ *  2. sort chronologically, because "the most recent N" is meaningless over an
+ *     unordered list and callers should not have to guarantee order;
+ *  3. take the most recent `maxTurns`;
+ *  4. drop oldest-first until the estimate is inside `maxTokens` — the turn cap
+ *     can be satisfied while the token budget is not, so this runs regardless.
+ *
+ * The one exception to "drop": if the single most recent turn ALONE exceeds the
+ * budget, it is truncated rather than dropped. Dropping it would return an
+ * empty seed for a conversation that plainly has context — the caller asked to
+ * continue a thread, and answering "there is no thread" because its last
+ * message was long is the one outcome nobody wants. The cap still holds
+ * absolutely; only the way it is met changes.
+ *
+ * An empty (or entirely unseedable) list returns `[]`: a fresh conversation
+ * seeds nothing, and sending zero items is how that is said.
+ */
+export const buildRealtimeSeed = (
+  messages: readonly SeedMessage[],
+  options: SeedOptions = {},
+): SeedEvent[] => {
+  const maxTurns = options.maxTurns ?? DEFAULT_SEED_MAX_TURNS;
+  const maxTokens = options.maxTokens ?? DEFAULT_SEED_MAX_TOKENS;
+
+  if (maxTurns <= 0 || maxTokens <= 0) return [];
+
+  const seedable = messages
+    .filter((message) => isSeedRole(message.role) && message.content.trim().length > 0)
+    .map((message) => ({
+      role: message.role as SeedRole,
+      text: message.content.trim(),
+      key: sortKey(message),
+    }));
+
+  const ordered = [...seedable].sort((a, b) => a.key - b.key);
+  const window = ordered.slice(Math.max(0, ordered.length - maxTurns));
+
+  let tokens = window.reduce((total, turn) => total + estimateSeedTokens(turn.text), 0);
+  let start = 0;
+  // `window.length - 1` and not `window.length`: the last turn is never dropped,
+  // only truncated below.
+  while (tokens > maxTokens && start < window.length - 1) {
+    tokens -= estimateSeedTokens(window[start].text);
+    start += 1;
+  }
+
+  const kept = window.slice(start);
+  if (kept.length === 0) return [];
+
+  if (tokens > maxTokens) {
+    // Only reachable with exactly one turn left (the loop above stops there).
+    const only = kept[0];
+    return [toEvent(only.role, truncateToTokens(only.text, maxTokens))];
+  }
+
+  return kept.map((turn) => toEvent(turn.role, turn.text));
+};

--- a/apps/web/src/lib/ai/realtime/session-state.ts
+++ b/apps/web/src/lib/ai/realtime/session-state.ts
@@ -1,4 +1,4 @@
-import { extractTranscript, type TranscriptEntry } from './events';
+import { extractTranscript, type TranscriptEntry } from '@pagespace/lib/realtime/voice-events';
 
 /**
  * Everything the voice UI shows, as a pure reducer. The hook owns the wiring;

--- a/apps/web/src/lib/ai/realtime/tool-dispatch.ts
+++ b/apps/web/src/lib/ai/realtime/tool-dispatch.ts
@@ -1,0 +1,295 @@
+/**
+ * Running the tool the model asked for, out loud.
+ *
+ * The realtime server hears `function_call` on the socket and posts here; this
+ * module turns that into a real PageSpace tool invocation and a string the
+ * model can speak. It is the only place in the voice plane where a tool runs,
+ * and it runs them through the SAME registry, the SAME `ToolExecutionContext`
+ * and therefore the SAME permission checks the text stack uses.
+ *
+ * PERMISSIONS ARE NOT RE-IMPLEMENTED HERE, and that is the design, not an
+ * omission. Every PageSpace tool enforces access INSIDE itself — `canActorViewPage`,
+ * `canActorAccessDrive`, `resolveActorAccessiblePagesInDrive` — against the
+ * `userId` on the context it is handed. So the single security-relevant thing
+ * this module does is build that context from the REAL acting user and pass it
+ * unchanged. A second permission layer here would be a second thing to keep in
+ * step with `packages/lib/src/permissions/`, and the first time they disagreed,
+ * one of them would be wrong.
+ *
+ * Two shapes on the wire are load-bearing and are handled defensively:
+ *   - `function_call.arguments` is a newline-laden STRING, not an object, and
+ *     is not guaranteed to parse;
+ *   - `function_call_output.output` must be a STRING — so everything below
+ *     returns one, including every failure.
+ *
+ * WHY RESULTS ARE TRUNCATED. A spoken answer cannot be skimmed. A full page
+ * read is a two-minute monologue that the user cannot scan, interrupt usefully,
+ * or remember — and in a live turn latency wins, with completeness happening in
+ * the thread afterwards. The reference prototype
+ * (`~/production/pagespace-voice/src/core/present.ts`) solves this with a
+ * hand-written presenter per tool; that does not scale to PageSpace's registry
+ * of dozens, and a curated presenter list would be a second tool surface that
+ * drifts every time a tool is added. So the cap is generic and structural: cut
+ * at a word boundary, say how much was left out, and tell the model how to get
+ * the rest — the same contract `truncateForSpeech` offers, applied uniformly.
+ */
+
+import type { Tool, ToolSet } from 'ai';
+import type { z } from 'zod';
+import type { ToolExecutionContext } from '../core/types';
+import type { VoiceLocationContext } from '@pagespace/lib/realtime/voice-bridge-contract';
+
+/**
+ * How much of a tool result is worth reading aloud. 700 characters is roughly
+ * 45 seconds of speech — already long for a spoken answer, and past the point
+ * where a listener retains the beginning.
+ */
+export const MAX_SPOKEN_RESULT_CHARS = 700;
+
+/** Parsed arguments, or the sentence to say instead. */
+type ParsedArguments =
+  | { readonly ok: true; readonly args: Record<string, unknown> }
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * Parse `function_call.arguments`.
+ *
+ * Absent or blank means a no-argument tool, not a malformed call — the model
+ * omits the field entirely for tools that take nothing.
+ *
+ * The recovery pass matters more than it looks: the string is assembled from
+ * streamed deltas, so a truncated or double-appended payload is a real (if
+ * rare) outcome, and it arrives as plain text with embedded newlines rather
+ * than as anything JSON-shaped. Taking the first balanced object turns the
+ * common corruption — trailing junk after a complete object — into a working
+ * call instead of an apology. Anything else becomes a sentence the model can
+ * say, because the one thing that must not happen is a tool call with no
+ * answer: the model waits for `function_call_output` and the call goes silent.
+ */
+export const parseToolArguments = (argumentsJson: string): ParsedArguments => {
+  const trimmed = argumentsJson.trim();
+  if (trimmed.length === 0) return { ok: true, args: {} };
+
+  const asObject = (value: unknown): ParsedArguments =>
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? { ok: true, args: value as Record<string, unknown> }
+      : {
+          ok: false,
+          message: 'The arguments for that tool were not an object. Try the call again.',
+        };
+
+  try {
+    return asObject(JSON.parse(trimmed));
+  } catch {
+    const recovered = firstBalancedObject(trimmed);
+    if (recovered === undefined) {
+      return {
+        ok: false,
+        message: 'The arguments for that tool could not be read. Try the call again.',
+      };
+    }
+    try {
+      return asObject(JSON.parse(recovered));
+    } catch {
+      return {
+        ok: false,
+        message: 'The arguments for that tool could not be read. Try the call again.',
+      };
+    }
+  }
+};
+
+/**
+ * The first `{…}` whose braces balance, ignoring braces inside strings. Written
+ * out rather than regexed because a regex cannot count nesting, and the payloads
+ * that need recovering are exactly the nested ones.
+ */
+const firstBalancedObject = (text: string): string | undefined => {
+  const start = text.indexOf('{');
+  if (start === -1) return undefined;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && inString) {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(start, index + 1);
+    }
+  }
+  return undefined;
+};
+
+/**
+ * A tool's return value as one speakable string, capped.
+ *
+ * A string result is spoken as-is; anything else is serialized, because the
+ * model reads JSON perfectly well and inventing prose for an arbitrary shape
+ * would mean guessing at a schema this module does not know.
+ */
+export const formatToolResult = (
+  value: unknown,
+  maxChars: number = MAX_SPOKEN_RESULT_CHARS,
+): string => {
+  const text = typeof value === 'string' ? value : safeStringify(value);
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 'Done.';
+  if (trimmed.length <= maxChars) return trimmed;
+
+  const window = trimmed.slice(0, maxChars);
+  const lastSpace = window.lastIndexOf(' ');
+  const head = (lastSpace > 0 ? window.slice(0, lastSpace) : window).trimEnd();
+  const omitted = trimmed.length - head.length;
+  // The continuation hint is for the MODEL, not the user: it is what turns a
+  // cut-off result into "I can read you the rest if you want" instead of the
+  // model asserting the content ended there.
+  return `${head}… (${omitted} more characters were not read out; call the tool again for a specific part if the user asks for more.)`;
+};
+
+/**
+ * `JSON.stringify` returns `undefined` for a function/symbol and THROWS on a
+ * circular structure or a bigint. A tool result is not ours, so neither
+ * outcome may reach the socket as a non-string.
+ */
+const safeStringify = (value: unknown): string => {
+  if (value === undefined || value === null) return '';
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export type RealtimeToolDispatchRequest = {
+  readonly name: string;
+  readonly argumentsJson: string;
+  readonly userId: string;
+  readonly conversationId?: string;
+  readonly timezone?: string;
+  readonly locationContext?: VoiceLocationContext;
+  readonly callId: string;
+};
+
+export type RealtimeToolDispatchDeps = {
+  /** The set the session advertised — `buildRealtimeToolSet(buildPageSpaceTools())`. */
+  readonly tools: ToolSet;
+  readonly logger: {
+    readonly warn: (message: string, meta?: Record<string, unknown>) => void;
+    readonly error: (message: string, error: Error, meta?: Record<string, unknown>) => void;
+  };
+  readonly maxChars?: number;
+};
+
+/**
+ * The `ToolExecutionContext` a voice turn runs under.
+ *
+ * `requestOrigin: 'user'` and `agentCallDepth: 0` because a spoken turn is a
+ * person talking, not an agent calling an agent — the fields that gate
+ * agent-chain behaviour have to say so or a voice call would be attributed as
+ * a sub-agent run.
+ *
+ * `enabledTools` is left undefined (unrestricted): the restriction that matters
+ * already happened when `buildRealtimeToolSet` decided what to advertise, and
+ * an allowlist here would be a third place tool exposure is decided.
+ */
+export const buildVoiceToolContext = (
+  request: RealtimeToolDispatchRequest,
+  model: string,
+): ToolExecutionContext => ({
+  userId: request.userId,
+  ...(request.conversationId === undefined ? {} : { conversationId: request.conversationId }),
+  ...(request.timezone === undefined ? {} : { timezone: request.timezone }),
+  ...(request.locationContext === undefined
+    ? {}
+    : { locationContext: request.locationContext }),
+  aiProvider: 'openai_voice',
+  aiModel: model,
+  requestOrigin: 'user',
+  agentCallDepth: 0,
+});
+
+/**
+ * Parse, validate, execute, format. Always resolves to a string, never throws:
+ * the caller's next move is `function_call_output`, and there is no version of
+ * this that may leave the model without one.
+ *
+ * Validation mirrors `createExecuteTool` — the tool's own zod `inputSchema`,
+ * `safeParse`, and an error message that tells the model how to recover rather
+ * than just that it failed.
+ */
+export const dispatchRealtimeToolCall = async (
+  deps: RealtimeToolDispatchDeps,
+  request: RealtimeToolDispatchRequest,
+  model: string,
+): Promise<string> => {
+  const tool: Tool | undefined = deps.tools[request.name];
+  if (!tool) {
+    deps.logger.warn('Realtime voice tool call named an unadvertised tool', {
+      callId: request.callId,
+      userId: request.userId,
+      tool: request.name,
+    });
+    return `There is no tool called "${request.name}". Use tool_search to find the right one.`;
+  }
+  if (!tool.execute) {
+    return `The tool "${request.name}" cannot be run.`;
+  }
+
+  const parsed = parseToolArguments(request.argumentsJson);
+  if (!parsed.ok) {
+    deps.logger.warn('Realtime voice tool call had unreadable arguments', {
+      callId: request.callId,
+      userId: request.userId,
+      tool: request.name,
+    });
+    return parsed.message;
+  }
+
+  const validated = (tool.inputSchema as z.ZodType).safeParse(parsed.args);
+  if (!validated.success) {
+    return `Invalid parameters for "${request.name}": ${validated.error.message}. Call tool_search("select:${request.name}") for the correct schema.`;
+  }
+
+  const context = buildVoiceToolContext(request, model);
+
+  try {
+    const result = await (tool.execute as (args: unknown, options: unknown) => unknown)(
+      validated.data,
+      // The AI SDK's options bag, as the tools read it. `experimental_context`
+      // is the only member any PageSpace tool actually destructures; the other
+      // two are present because the SDK's own signature carries them and a tool
+      // that grows a use for them should not break on voice.
+      { experimental_context: context, toolCallId: request.callId, messages: [] },
+    );
+    return formatToolResult(result, deps.maxChars);
+  } catch (error) {
+    // A throwing tool is a normal outcome (permission denied, missing page),
+    // and the model has to be able to say something about it. The message is
+    // reported because it is written for a user; the stack is not.
+    deps.logger.error(
+      'Realtime voice tool execution failed',
+      error instanceof Error ? error : new Error(String(error)),
+      { callId: request.callId, userId: request.userId, tool: request.name },
+    );
+    const message = error instanceof Error ? error.message : String(error);
+    return formatToolResult(`That didn't work: ${message}`, deps.maxChars);
+  }
+};

--- a/apps/web/src/lib/ai/realtime/tools.ts
+++ b/apps/web/src/lib/ai/realtime/tools.ts
@@ -99,13 +99,34 @@ export function toRealtimeTool(name: string, tool: Tool): RealtimeTool {
  * matches the text stack's catalog.
  */
 export function buildRealtimeTools(tools: ToolSet): readonly RealtimeTool[] {
+  return Object.entries(buildRealtimeToolSet(tools)).map(([name, tool]) =>
+    toRealtimeTool(name, tool),
+  );
+}
+
+/**
+ * The EXECUTABLE set behind those definitions — the same objects, before the
+ * projection onto the wire shape.
+ *
+ * Split out from `buildRealtimeTools` so that what the session ADVERTISES and
+ * what the dispatcher RUNS are one expression evaluated twice, not two lists
+ * that agree today. They are built in different processes (definitions ride the
+ * attach payload to `apps/realtime`; execution happens back here on the bridge),
+ * which is exactly the arrangement where two hand-kept lists drift — the model
+ * would call a name nothing answers, and the call would hang on a tool result
+ * that never comes.
+ *
+ * It is also what makes `execute_tool` work over voice unchanged: the deferred
+ * half is captured in the closure this returns, so a spoken request that
+ * reaches a non-core tool goes through the SAME allowlist re-check and the SAME
+ * `safeParse` the text stack uses.
+ */
+export function buildRealtimeToolSet(tools: ToolSet): ToolSet {
   const { coreTools, nonCoreTools } = splitToolsForExposure(tools);
 
-  const upfront: ToolSet = {
+  return {
     ...coreTools,
     tool_search: createToolSearchTool(tools),
     execute_tool: createExecuteTool(nonCoreTools),
   };
-
-  return Object.entries(upfront).map(([name, tool]) => toRealtimeTool(name, tool));
 }

--- a/apps/web/src/lib/ai/realtime/transcript-persistence.ts
+++ b/apps/web/src/lib/ai/realtime/transcript-persistence.ts
@@ -1,0 +1,216 @@
+/**
+ * What was said, written into the conversation as ordinary messages.
+ *
+ * THIS IS THE THESIS MADE LITERAL. Voice is a second transport onto a
+ * conversation PageSpace already has: you speak into a thread that existed
+ * before the call and still exists after you hang up. Audio is ephemeral; the
+ * transcript is the artifact of record. So a spoken turn does not become a
+ * "voice message" in a "voice history" — it becomes a `messages` row, in the
+ * same table, in the same conversation, that the same readers read.
+ *
+ * WHY THERE IS NO NEW CLIENT WIRING. Going through `messageRepository` means
+ * going through the write that bumps `conversations.rev` IN-TRANSACTION and
+ * then emits the `conversation:*` events. The sidebar, GlobalAssistantView and
+ * page-agent chat already subscribe to those, so a spoken sentence appears in
+ * an open thread live, for free — and it does so because this code is NOT a
+ * second writer, not because anything was taught about voice. A direct INSERT
+ * here would have been shorter and would have silently cost all of that.
+ *
+ * PERMISSIONS come from `canAccessConversation` — the same predicate the
+ * realtime `join_conversation` handler and the stream-subscription routes use.
+ * It resolves to owner-only for a global conversation (a shared global thread
+ * has no page to share through) and owner-or-(shared AND page access) for a
+ * page one, which is the write rule the page-agent messages route already
+ * applies. One predicate, not a voice-shaped variant of it.
+ *
+ * Every dependency arrives as an argument, so the whole decision tree below is
+ * exercisable without a database.
+ */
+
+import { MESSAGE_SOURCE_VOICE } from '@pagespace/db/schema/conversations';
+
+/** The conversation facts this module needs. A `conversations` row satisfies it. */
+export type TranscriptConversation = {
+  readonly id: string;
+  readonly userId: string;
+  readonly isShared: boolean;
+  readonly type: string;
+  readonly contextId: string | null;
+  readonly isActive: boolean;
+};
+
+export type TranscriptRequest = {
+  readonly callId: string;
+  readonly userId: string;
+  readonly conversationId: string;
+  readonly role: 'user' | 'assistant';
+  readonly text: string;
+};
+
+export type TranscriptWriteResult = {
+  readonly saved: boolean;
+  readonly messageId: string | null;
+  readonly rev: number;
+  /** Why nothing was written. Absent on success. */
+  readonly skipped?:
+    | 'no_access'
+    | 'history_deleted'
+    | 'unsupported_conversation_type'
+    | 'blank'
+    | 'create_failed';
+};
+
+type SaveArgs = {
+  readonly messageId: string;
+  readonly conversationId: string;
+  readonly role: 'user' | 'assistant';
+  readonly content: string;
+  readonly source: string;
+};
+
+export type TranscriptPersistenceDeps = {
+  readonly loadConversation: (
+    conversationId: string,
+  ) => Promise<TranscriptConversation | undefined>;
+  /** Lazy first-message creation, exactly as the typed path does it. */
+  readonly createConversation: (
+    userId: string,
+    conversationId: string,
+  ) => Promise<TranscriptConversation | undefined>;
+  readonly canAccess: (
+    userId: string,
+    conversation: TranscriptConversation,
+  ) => Promise<boolean>;
+  readonly saveGlobalMessage: (
+    args: SaveArgs & { readonly userId: string },
+  ) => Promise<{ saved: boolean; rev: number }>;
+  readonly savePageMessage: (
+    args: SaveArgs & {
+      readonly pageId: string;
+      readonly userId: string | null;
+      readonly sourceAgentId: string | null;
+    },
+  ) => Promise<{ saved: boolean; rev: number }>;
+  readonly newMessageId: () => string;
+  readonly logger: {
+    readonly warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+};
+
+const NOTHING: TranscriptWriteResult = { saved: false, messageId: null, rev: 0 };
+
+/**
+ * Persist one spoken turn.
+ *
+ * The conversation may not exist yet: a call started from a fresh thread binds
+ * to a client-minted cuid whose row is created by its first message, exactly
+ * as typing into that thread would. That path yields a GLOBAL conversation,
+ * because a client-minted id with no row is by construction not a page thread.
+ *
+ * A conversation that DOES exist decides its own shape:
+ *   - `global` — the row carries the owner's `userId` on both sides, matching
+ *     every other global write (the global assistant is not an agent page, so
+ *     there is no agent id to attribute an assistant row to);
+ *   - `page` — the assistant row is agent-authored: `userId: null` with
+ *     `sourceAgentId` naming the agent page, which is the attribution rule the
+ *     `messages` table documents;
+ *   - anything else (`drive`, `client`) is refused rather than guessed at. A
+ *     `client` thread is an API-managed conversation whose page is claimed
+ *     write-once by its first completion; writing a spoken turn into one would
+ *     be this module inventing a binding nobody asked for.
+ */
+export const persistVoiceTranscript = async (
+  deps: TranscriptPersistenceDeps,
+  request: TranscriptRequest,
+): Promise<TranscriptWriteResult> => {
+  const content = request.text.trim();
+  if (content.length === 0) {
+    // A blank transcript is a real event — the model heard breath, or the
+    // transcriber returned nothing — and an empty message row is worse than
+    // no row: it renders as a turn that said nothing.
+    return { ...NOTHING, skipped: 'blank' };
+  }
+
+  const existing = await deps.loadConversation(request.conversationId);
+
+  if (!existing) {
+    const created = await deps.createConversation(request.userId, request.conversationId);
+    if (!created) {
+      deps.logger.warn('Voice transcript could not resolve or create its conversation', {
+        callId: request.callId,
+        userId: request.userId,
+        conversationId: request.conversationId,
+      });
+      return { ...NOTHING, skipped: 'create_failed' };
+    }
+    return writeGlobal(deps, request, created, content);
+  }
+
+  if (!existing.isActive) {
+    // History-deleted mid-call. Writing under it would put the turn somewhere
+    // no listing can reach — the same reason the typed path's beforeSave hook
+    // re-checks this inside its transaction.
+    deps.logger.warn('Voice transcript dropped: conversation was deleted from history', {
+      callId: request.callId,
+      conversationId: request.conversationId,
+    });
+    return { ...NOTHING, skipped: 'history_deleted' };
+  }
+
+  if (!(await deps.canAccess(request.userId, existing))) {
+    deps.logger.warn('Voice transcript refused: caller cannot access the conversation', {
+      callId: request.callId,
+      userId: request.userId,
+      conversationId: request.conversationId,
+    });
+    return { ...NOTHING, skipped: 'no_access' };
+  }
+
+  if (existing.type === 'global') {
+    return writeGlobal(deps, request, existing, content);
+  }
+
+  if (existing.type === 'page' && existing.contextId) {
+    const messageId = deps.newMessageId();
+    const result = await deps.savePageMessage({
+      messageId,
+      conversationId: request.conversationId,
+      role: request.role,
+      content,
+      source: MESSAGE_SOURCE_VOICE,
+      pageId: existing.contextId,
+      // The attribution rule: a human author, or NULL for an agent-authored row.
+      userId: request.role === 'user' ? request.userId : null,
+      sourceAgentId: request.role === 'assistant' ? existing.contextId : null,
+    });
+    return { saved: result.saved, messageId: result.saved ? messageId : null, rev: result.rev };
+  }
+
+  deps.logger.warn('Voice transcript dropped: unsupported conversation type', {
+    callId: request.callId,
+    conversationId: request.conversationId,
+    type: existing.type,
+  });
+  return { ...NOTHING, skipped: 'unsupported_conversation_type' };
+};
+
+const writeGlobal = async (
+  deps: TranscriptPersistenceDeps,
+  request: TranscriptRequest,
+  conversation: TranscriptConversation,
+  content: string,
+): Promise<TranscriptWriteResult> => {
+  const messageId = deps.newMessageId();
+  const result = await deps.saveGlobalMessage({
+    messageId,
+    conversationId: request.conversationId,
+    role: request.role,
+    content,
+    source: MESSAGE_SOURCE_VOICE,
+    // The conversation's OWNER, not the speaker: they are the same person on
+    // every path that reaches here (a global thread is owner-only), and taking
+    // it off the row keeps this consistent with every other global write.
+    userId: conversation.userId,
+  });
+  return { saved: result.saved, messageId: result.saved ? messageId : null, rev: result.rev };
+};

--- a/apps/web/src/lib/ai/realtime/voice-runtime-deps.ts
+++ b/apps/web/src/lib/ai/realtime/voice-runtime-deps.ts
@@ -1,0 +1,102 @@
+/**
+ * The real wiring behind the voice plane's web-side work.
+ *
+ * `seed-loader.ts`, `transcript-persistence.ts` and `tool-dispatch.ts` all take
+ * their dependencies as arguments so their decision trees are exercisable
+ * without a database. This is the one module that binds those arguments to the
+ * live repositories, the live permission predicate and the live tool registry —
+ * so there is exactly one place where "the real thing" is chosen, shared by the
+ * two routes that need it (the handshake, which seeds; and the bridge, which
+ * dispatches and persists).
+ */
+
+import { createId } from '@paralleldrive/cuid2';
+import { canAccessConversation } from '@pagespace/lib/permissions/conversation-access';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { messageRepository } from '@/lib/repositories/message-repository';
+import {
+  resolveOrCreateConversation,
+  ConversationHistoryDeletedError,
+  ConversationOwnershipError,
+} from '@/lib/repositories/resolve-or-create-conversation';
+import { buildPageSpaceTools } from '@/lib/ai/core/ai-tools';
+import { buildRealtimeToolSet } from './tools';
+import type { SeedLoaderDeps, SeedConversation } from './seed-loader';
+import type {
+  TranscriptPersistenceDeps,
+  TranscriptConversation,
+} from './transcript-persistence';
+import type { RealtimeToolDispatchDeps } from './tool-dispatch';
+
+/**
+ * The subset of a `conversations` row both consumers need. Narrowed here rather
+ * than passing the whole row so neither module can quietly start depending on a
+ * column it was not given.
+ */
+const narrow = (
+  row: Awaited<ReturnType<typeof conversationRepository.getConversation>>,
+): (SeedConversation & TranscriptConversation) | undefined =>
+  row
+    ? {
+        id: row.id,
+        userId: row.userId,
+        isShared: row.isShared,
+        type: row.type,
+        contextId: row.contextId,
+        isActive: row.isActive,
+      }
+    : undefined;
+
+const loadConversation = async (conversationId: string) =>
+  narrow(await conversationRepository.getConversation(conversationId));
+
+export const voiceSeedDeps: SeedLoaderDeps = {
+  loadConversation,
+  canAccess: (userId, conversation) => canAccessConversation(userId, conversation),
+  // Streaming placeholders stay excluded (the default): an empty mid-flight row
+  // is not a turn, and `buildRealtimeSeed` would drop it anyway.
+  loadMessages: (conversationId) =>
+    messageRepository.getMessagesByConversationId(conversationId),
+  logger: loggers.ai,
+};
+
+export const voiceTranscriptDeps: TranscriptPersistenceDeps = {
+  loadConversation,
+  createConversation: async (userId, conversationId) => {
+    try {
+      const { conversation } = await resolveOrCreateConversation(userId, conversationId);
+      return narrow(conversation);
+    } catch (error) {
+      // Both are refusals with a name on them, not crashes: an id belonging to
+      // someone else, and an id whose thread was deleted from history. Either
+      // way the turn has nowhere to go, and the caller reports that.
+      if (
+        error instanceof ConversationOwnershipError ||
+        error instanceof ConversationHistoryDeletedError
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  },
+  canAccess: (userId, conversation) => canAccessConversation(userId, conversation),
+  saveGlobalMessage: (args) => messageRepository.saveGlobalMessage(args),
+  savePageMessage: (args) => messageRepository.savePageMessage(args),
+  newMessageId: () => createId(),
+  logger: loggers.ai,
+};
+
+/**
+ * The executable tool set, built the SAME way the session's advertised
+ * definitions were (`buildRealtimeToolSet`), from the same registry factory.
+ *
+ * Built per request rather than at module load, for the reason `tools.ts`
+ * gives: `buildPageSpaceTools` has env-dependent branches (the code-execution
+ * kill switch), so freezing its result into a module-level constant would pin
+ * whatever the environment looked like at import time.
+ */
+export const voiceToolDispatchDeps = (): RealtimeToolDispatchDeps => ({
+  tools: buildRealtimeToolSet(buildPageSpaceTools()),
+  logger: loggers.ai,
+});

--- a/apps/web/src/lib/repositories/message-repository.ts
+++ b/apps/web/src/lib/repositories/message-repository.ts
@@ -111,6 +111,7 @@ async function savePageMessageRow({
   sourceAgentId,
   mentionNotify,
   status = 'complete',
+  source,
   dbClient,
 }: {
   messageId: string;
@@ -125,6 +126,7 @@ async function savePageMessageRow({
   sourceAgentId?: string | null;
   mentionNotify?: { driveId: string; triggeredByUserId: string; mentionerName?: string };
   status?: 'complete' | 'interrupted';
+  source?: string | null;
   dbClient: DbExecutor;
 }): Promise<void> {
   let structuredContent = content;
@@ -153,6 +155,7 @@ async function savePageMessageRow({
     toolResultsJson,
     sourceAgentId: sourceAgentId ?? null,
     status,
+    source: source ?? null,
     createdAt,
   });
 
@@ -189,6 +192,7 @@ async function saveGlobalMessageRow({
   toolResults,
   uiMessage,
   status = 'complete',
+  source,
   dbClient,
 }: {
   messageId: string;
@@ -200,6 +204,7 @@ async function saveGlobalMessageRow({
   toolResults?: ToolResult[];
   uiMessage?: UIMessage;
   status?: 'complete' | 'interrupted';
+  source?: string | null;
   dbClient: DbExecutor;
 }): Promise<void> {
   let structuredContent = content;
@@ -233,6 +238,10 @@ async function saveGlobalMessageRow({
       // id to attribute: NULL means "platform-authored, source not recorded",
       // which is exactly the attribution rule's second clause.
       sourceAgentId: null,
+      // INSERT only, deliberately absent from the conflict set below: a
+      // message's authoring transport is a fact about how it was made, and a
+      // later terminal write to the same id does not change that.
+      source: source ?? null,
     })
     .onConflictDoUpdate({
       target: messages.id,
@@ -287,6 +296,8 @@ export interface UnifiedMessageRow {
   toolCalls: unknown | null;
   toolResults: unknown | null;
   status: 'streaming' | 'complete' | 'interrupted';
+  /** The transport that authored the row: 'voice' for a spoken turn, null for typed. */
+  source: string | null;
 }
 
 /**
@@ -325,6 +336,7 @@ const unifiedColumns = {
   toolCalls: messages.toolCalls,
   toolResults: messages.toolResults,
   status: messages.status,
+  source: messages.source,
 } as const;
 
 export type BeforeSaveHook = (
@@ -596,6 +608,8 @@ export const messageRepository = {
     sourceAgentId?: string | null;
     mentionNotify?: { driveId: string; triggeredByUserId: string; mentionerName?: string };
     status?: 'complete' | 'interrupted';
+    /** Authoring transport — `MESSAGE_SOURCE_VOICE` for a spoken turn. */
+    source?: string | null;
     triggeredBy?: ConversationEventTriggeredBy;
     beforeSave?: BeforeSaveHook;
   }): Promise<MessageWriteResult> {
@@ -653,6 +667,8 @@ export const messageRepository = {
     toolResults?: ToolResult[];
     uiMessage?: UIMessage;
     status?: 'complete' | 'interrupted';
+    /** Authoring transport — `MESSAGE_SOURCE_VOICE` for a spoken turn. */
+    source?: string | null;
     triggeredBy?: ConversationEventTriggeredBy;
     beforeSave?: BeforeSaveHook;
   }): Promise<MessageWriteResult> {

--- a/apps/web/src/lib/repositories/unified-message-leg.ts
+++ b/apps/web/src/lib/repositories/unified-message-leg.ts
@@ -57,6 +57,13 @@ export interface UnifiedPageMessageRow {
   toolResultsJson: string | null;
   sourceAgentId: string | null;
   status: 'streaming' | 'complete' | 'interrupted';
+  /**
+   * The transport that authored the row — `MESSAGE_SOURCE_VOICE` for a spoken
+   * turn, null/omitted for a typed one. Set on INSERT only, never in the
+   * conflict action below: a message's transport is a fact about how it was
+   * made, and a later terminal write to the same id does not change that.
+   */
+  source?: string | null;
   /** Omit to let the column default to now(). */
   createdAt?: Date;
 }
@@ -92,6 +99,7 @@ export async function upsertUnifiedPageMessage(
       isActive: true,
       status: row.status,
       sourceAgentId: row.sourceAgentId,
+      source: row.source ?? null,
     })
     .onConflictDoUpdate({
       target: messages.id,

--- a/docs/2.0-architecture/agent-sessions.md
+++ b/docs/2.0-architecture/agent-sessions.md
@@ -430,9 +430,20 @@ nothing for the length of the deploy, invisibly, with no signal the client could
 on.
 
 Realtime-first inverts that into the benign case: an old web client simply never emits
-the new joins, and the new handlers idle until it reloads. Nothing depends on web-first —
-realtime makes no outbound HTTP calls to web at all (`WEB_APP_URL` is a CORS origin),
+the new joins, and the new handlers idle until it reloads. Nothing depends on web-first,
 and both services deploy after the migration step they share.
+
+**Amended by the voice bridge.** This section used to add "realtime makes no outbound HTTP
+calls to web at all (`WEB_APP_URL` is a CORS origin)" as a supporting fact. That stopped
+being true when audio-native voice landed: `apps/realtime` holds the OpenAI realtime socket
+for the life of a call and calls **back** into web at `/api/internal/voice/bridge`
+(`VOICE_CALLBACK_ROUTES`) to run tools and persist transcripts, because the tool registry
+and `messageRepository` live in web and cannot move. The ORDERING is unchanged — new
+realtime against old web is still the benign direction — because every hop on that bridge
+is best-effort per call: an unrecognised route answers 404, the client reports a failure,
+and the call degrades to audio without tools or transcripts rather than dropping. Metering
+is unaffected either way; it runs inside `apps/realtime` against `@pagespace/lib` and
+crosses no process boundary.
 
 ## 4. Vocabulary
 

--- a/packages/db/drizzle/0256_violet_blur.sql
+++ b/packages/db/drizzle/0256_violet_blur.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "source" text;

--- a/packages/db/drizzle/meta/0256_snapshot.json
+++ b/packages/db/drizzle/meta/0256_snapshot.json
@@ -1,0 +1,21309 @@
+{
+  "id": "b1391a9d-d02a-4e72-a523-78848a82d19e",
+  "prevId": "57e1df3c-e447-4a3d-a10b-9f95a9ac9fb6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-5.6-luna'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starterSkillsInstalledAt": {
+          "name": "starterSkillsInstalledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorites_item_type_consistency_chk": {
+          "name": "favorites_item_type_consistency_chk",
+          "value": "((\"itemType\" = 'page' AND \"pageId\" IS NOT NULL AND \"driveId\" IS NULL) OR (\"itemType\" = 'drive' AND \"driveId\" IS NOT NULL AND \"pageId\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_tags": {
+      "name": "page_tags",
+      "schema": "",
+      "columns": {
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_tags_pageId_pages_id_fk": {
+          "name": "page_tags_pageId_pages_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_tags_tagId_tags_id_fk": {
+          "name": "page_tags_tagId_tags_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "page_tags_pageId_tagId_pk": {
+          "name": "page_tags_pageId_tagId_pk",
+          "columns": [
+            "pageId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "sandboxEnabled": {
+          "name": "sandboxEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedInWorkspaceAt": {
+          "name": "closedInWorkspaceAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planPageId": {
+          "name": "planPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_workspace_id_idx": {
+          "name": "conversations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_plan_page_id_idx": {
+          "name": "conversations_plan_page_id_idx",
+          "columns": [
+            {
+              "expression": "planPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_agent_page_id_idx": {
+          "name": "conversations_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_workspaceId_agent_workspaces_id_fk": {
+          "name": "conversations_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_agentPageId_pages_id_fk": {
+          "name": "conversations_agentPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_planPageId_pages_id_fk": {
+          "name": "conversations_planPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "planPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_global_context_null_chk": {
+          "name": "conversations_global_context_null_chk",
+          "value": "\"conversations\".\"type\" <> 'global' OR \"conversations\".\"contextId\" IS NULL"
+        },
+        "conversations_page_context_present_chk": {
+          "name": "conversations_page_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'page' OR \"conversations\".\"contextId\" IS NOT NULL"
+        },
+        "conversations_drive_context_present_chk": {
+          "name": "conversations_drive_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'drive' OR \"conversations\".\"contextId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sourceAgentId_pages_id_fk": {
+          "name": "messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "activity_logs_content_size_limit": {
+          "name": "activity_logs_content_size_limit",
+          "value": "\"activity_logs\".\"contentSize\" IS NULL OR \"activity_logs\".\"contentSize\" <= 1048576"
+        },
+        "activity_logs_stream_pair": {
+          "name": "activity_logs_stream_pair",
+          "value": "(\"activity_logs\".\"streamId\" IS NULL) = (\"activity_logs\".\"streamSeq\" IS NULL)"
+        },
+        "activity_logs_change_group_pair": {
+          "name": "activity_logs_change_group_pair",
+          "value": "(\"activity_logs\".\"changeGroupId\" IS NULL) = (\"activity_logs\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "siem_delivery_cursors_delivered_cursor_pair": {
+          "name": "siem_delivery_cursors_delivered_cursor_pair",
+          "value": "(\"siem_delivery_cursors\".\"lastDeliveredId\" IS NULL) = (\"siem_delivery_cursors\".\"lastDeliveredAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drive_backups_change_group_pair": {
+          "name": "drive_backups_change_group_pair",
+          "value": "(\"drive_backups\".\"changeGroupId\" IS NULL) = (\"drive_backups\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "page_versions_change_group_pair": {
+          "name": "page_versions_change_group_pair",
+          "value": "(\"page_versions\".\"changeGroupId\" IS NULL) = (\"page_versions\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_user_expires_idx": {
+          "name": "pending_uploads_user_expires_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_userId_users_id_fk": {
+          "name": "pending_uploads_userId_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_assignees_has_assignee": {
+          "name": "task_assignees_has_assignee",
+          "value": "(\"userId\" IS NOT NULL OR \"agentPageId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_scope_chk": {
+          "name": "integration_connections_scope_chk",
+          "value": "(\"integration_connections\".\"user_id\" IS NOT NULL AND \"integration_connections\".\"drive_id\" IS NULL) OR (\"integration_connections\".\"user_id\" IS NULL AND \"integration_connections\".\"drive_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_steps": {
+      "name": "workflow_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolName": {
+          "name": "toolName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStepStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_steps_run_position_idx": {
+          "name": "workflow_run_steps_run_position_idx",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_steps_runId_workflow_runs_id_fk": {
+          "name": "workflow_run_steps_runId_workflow_runs_id_fk",
+          "tableFrom": "workflow_run_steps",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_pending_abort_intents": {
+      "name": "ai_pending_abort_intents",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ai_pending_abort_intents_conversation_id_user_id_pk": {
+          "name": "ai_pending_abort_intents_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "raw_parts_count": {
+          "name": "raw_parts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_user_status_idx": {
+          "name": "ai_stream_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_sessions_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageWebhookId": {
+          "name": "pageWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_id_idx": {
+          "name": "webhook_triggers_page_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_workflow_unique": {
+          "name": "webhook_triggers_page_webhook_workflow_unique",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_triggers\".\"pageWebhookId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_pageWebhookId_page_webhooks_id_fk": {
+          "name": "webhook_triggers_pageWebhookId_page_webhooks_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "page_webhooks",
+          "columnsFrom": [
+            "pageWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_triggers_anchor_chk": {
+          "name": "webhook_triggers_anchor_chk",
+          "value": "(\"webhook_triggers\".\"connectionId\" IS NOT NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NULL) OR (\"webhook_triggers\".\"connectionId\" IS NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_bridge_enabled": {
+          "name": "theme_bridge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_balances_monthly_remaining_nonneg": {
+          "name": "credit_balances_monthly_remaining_nonneg",
+          "value": "\"credit_balances\".\"monthlyRemainingCents\" >= 0"
+        },
+        "credit_balances_monthly_allowance_nonneg": {
+          "name": "credit_balances_monthly_allowance_nonneg",
+          "value": "\"credit_balances\".\"monthlyAllowanceCents\" >= 0"
+        },
+        "credit_balances_topup_remaining_nonneg": {
+          "name": "credit_balances_topup_remaining_nonneg",
+          "value": "\"credit_balances\".\"topupRemainingCents\" >= 0"
+        },
+        "credit_balances_debt_cents_nonneg": {
+          "name": "credit_balances_debt_cents_nonneg",
+          "value": "\"credit_balances\".\"debtCents\" >= 0"
+        },
+        "credit_balances_pending_millicents_range": {
+          "name": "credit_balances_pending_millicents_range",
+          "value": "\"credit_balances\".\"pendingMillicents\" >= 0 AND \"credit_balances\".\"pendingMillicents\" < 1000"
+        },
+        "credit_balances_period_order": {
+          "name": "credit_balances_period_order",
+          "value": "\"credit_balances\".\"monthlyPeriodStart\" IS NULL OR \"credit_balances\".\"monthlyPeriodEnd\" IS NULL OR \"credit_balances\".\"monthlyPeriodStart\" <= \"credit_balances\".\"monthlyPeriodEnd\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_holds_est_cents_nonneg": {
+          "name": "credit_holds_est_cents_nonneg",
+          "value": "\"credit_holds\".\"estCents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "commands_scope_chk": {
+          "name": "commands_scope_chk",
+          "value": "(\"commands\".\"user_id\" IS NOT NULL AND \"commands\".\"drive_id\" IS NULL) OR (\"commands\".\"user_id\" IS NULL AND \"commands\".\"drive_id\" IS NOT NULL)"
+        },
+        "commands_type_chk": {
+          "name": "commands_type_chk",
+          "value": "\"commands\".\"type\" IN ('document', 'prompt_template', 'builtin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_compactions_source_chk": {
+          "name": "conversation_compactions_source_chk",
+          "value": "\"conversation_compactions\".\"source\" IN ('page', 'global')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machine_sprite_reclaims": {
+      "name": "machine_sprite_reclaims",
+      "schema": "",
+      "columns": {
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_sprite_reclaims_recorded_at_idx": {
+          "name": "machine_sprite_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_recipients": {
+      "name": "broadcast_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_recipient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_unique": {
+          "name": "broadcast_recipients_broadcast_user_unique",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "broadcast_recipients_broadcast_status_idx": {
+          "name": "broadcast_recipients_broadcast_status_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_recipients_broadcast_id_email_broadcasts_id_fk": {
+          "name": "broadcast_recipients_broadcast_id_email_broadcasts_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "email_broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcast_recipients_user_id_users_id_fk": {
+          "name": "broadcast_recipients_user_id_users_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_templates": {
+      "name": "broadcast_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_templates_active_idx": {
+          "name": "broadcast_templates_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_templates_created_by_user_id_users_id_fk": {
+          "name": "broadcast_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "broadcast_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_broadcasts": {
+      "name": "email_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "email_broadcast_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'transactional'"
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "email_broadcast_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRODUCT_UPDATE'"
+        },
+        "audience_definition": {
+          "name": "audience_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "send_limit": {
+          "name": "send_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "total_targeted": {
+          "name": "total_targeted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_broadcasts_status_idx": {
+          "name": "email_broadcasts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_at_idx": {
+          "name": "email_broadcasts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_by_idx": {
+          "name": "email_broadcasts_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_broadcasts_template_id_broadcast_templates_id_fk": {
+          "name": "email_broadcasts_template_id_broadcast_templates_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "broadcast_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_broadcasts_created_by_user_id_users_id_fk": {
+          "name": "email_broadcasts_created_by_user_id_users_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_webhooks": {
+      "name": "page_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookSecretEncrypted": {
+          "name": "webhookSecretEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_webhooks_page_id_idx": {
+          "name": "page_webhooks_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_webhooks_token_idx": {
+          "name": "page_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_webhooks_pageId_pages_id_fk": {
+          "name": "page_webhooks_pageId_pages_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_webhooks_createdBy_users_id_fk": {
+          "name": "page_webhooks_createdBy_users_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_webhooks_webhookToken_unique": {
+          "name": "page_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_shells": {
+      "name": "agent_workspace_shells",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteExecId": {
+          "name": "spriteExecId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTail": {
+          "name": "coldTail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailAt": {
+          "name": "coldTailAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailHasOutput": {
+          "name": "coldTailHasOutput",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_shells_workspace_id_idx": {
+          "name": "agent_workspace_shells_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_shells_workspace_name_idx": {
+          "name": "agent_workspace_shells_workspace_name_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_shells_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_shells_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_shells_ownerId_users_id_fk": {
+          "name": "agent_workspace_shells_ownerId_users_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspaces": {
+      "name": "agent_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspaces_drive_id_idx": {
+          "name": "agent_workspaces_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_owner_id_idx": {
+          "name": "agent_workspaces_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_live_sprite_idx": {
+          "name": "agent_workspaces_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_workspaces\".\"sandboxId\" IS NOT NULL AND \"agent_workspaces\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_driveId_drives_id_fk": {
+          "name": "agent_workspaces_driveId_drives_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_ownerId_users_id_fk": {
+          "name": "agent_workspaces_ownerId_users_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_layout_ops": {
+      "name": "agent_workspace_layout_ops",
+      "schema": "",
+      "columns": {
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opId": {
+          "name": "opId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_layout_ops_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_layout_ops_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_layout_ops",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_layout_ops_workspaceId_opId_pk": {
+          "name": "agent_workspace_layout_ops_workspaceId_opId_pk",
+          "columns": [
+            "workspaceId",
+            "opId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_layout_revs": {
+      "name": "agent_workspace_layout_revs",
+      "schema": "",
+      "columns": {
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_layout_revs_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_layout_revs_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_layout_revs",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_pane_columns": {
+      "name": "agent_workspace_pane_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderIndex": {
+          "name": "orderIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widthFraction": {
+          "name": "widthFraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_pane_columns_workspace_idx": {
+          "name": "agent_workspace_pane_columns_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_pane_columns_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_pane_columns_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_pane_columns",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_pane_columns_workspaceId_id_pk": {
+          "name": "agent_workspace_pane_columns_workspaceId_id_pk",
+          "columns": [
+            "workspaceId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_panes": {
+      "name": "agent_workspace_panes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnId": {
+          "name": "columnId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderIndex": {
+          "name": "orderIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heightFraction": {
+          "name": "heightFraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_panes_workspace_idx": {
+          "name": "agent_workspace_panes_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_panes_workspaceId_columnId_agent_workspace_pane_columns_workspaceId_id_fk": {
+          "name": "agent_workspace_panes_workspaceId_columnId_agent_workspace_pane_columns_workspaceId_id_fk",
+          "tableFrom": "agent_workspace_panes",
+          "tableTo": "agent_workspace_pane_columns",
+          "columnsFrom": [
+            "workspaceId",
+            "columnId"
+          ],
+          "columnsTo": [
+            "workspaceId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_panes_workspaceId_id_pk": {
+          "name": "agent_workspace_panes_workspaceId_id_pk",
+          "columns": [
+            "workspaceId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_node_revs": {
+      "name": "agent_workspace_node_revs",
+      "schema": "",
+      "columns": {
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_node_revs_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_node_revs_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_node_revs",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_nodes": {
+      "name": "agent_workspace_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "axis": {
+          "name": "axis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraction": {
+          "name": "fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_nodes_one_root_idx": {
+          "name": "agent_workspace_nodes_one_root_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"nodeType\" = 'root'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_chat_target_idx": {
+          "name": "agent_workspace_nodes_chat_target_idx",
+          "columns": [
+            {
+              "expression": "targetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"targetKind\" = 'chat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_parent_idx": {
+          "name": "agent_workspace_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_nodes_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_nodes_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk": {
+          "name": "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspace_nodes",
+          "columnsFrom": [
+            "rootId",
+            "parentId"
+          ],
+          "columnsTo": [
+            "rootId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_nodes_rootId_id_pk": {
+          "name": "agent_workspace_nodes_rootId_id_pk",
+          "columns": [
+            "rootId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspace_nodes_root_no_parent_chk": {
+          "name": "agent_workspace_nodes_root_no_parent_chk",
+          "value": "(\"agent_workspace_nodes\".\"nodeType\" = 'root') = (\"agent_workspace_nodes\".\"parentId\" IS NULL)"
+        },
+        "agent_workspace_nodes_node_type_chk": {
+          "name": "agent_workspace_nodes_node_type_chk",
+          "value": "\"agent_workspace_nodes\".\"nodeType\" IN ('root', 'split', 'pane')"
+        },
+        "agent_workspace_nodes_target_kind_chk": {
+          "name": "agent_workspace_nodes_target_kind_chk",
+          "value": "\"agent_workspace_nodes\".\"targetKind\" IS NULL OR \"agent_workspace_nodes\".\"targetKind\" IN ('chat', 'terminal', 'page')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED",
+        "PRODUCT_UPDATE"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.WorkflowRunStepStatus": {
+      "name": "WorkflowRunStepStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "skipped"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    },
+    "public.broadcast_recipient_status": {
+      "name": "broadcast_recipient_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_broadcast_content_mode": {
+      "name": "email_broadcast_content_mode",
+      "schema": "public",
+      "values": [
+        "compose",
+        "template"
+      ]
+    },
+    "public.email_broadcast_engine": {
+      "name": "email_broadcast_engine",
+      "schema": "public",
+      "values": [
+        "transactional",
+        "resend_broadcast"
+      ]
+    },
+    "public.email_broadcast_status": {
+      "name": "email_broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "queued",
+        "in_progress",
+        "paused",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1793,6 +1793,13 @@
       "when": 1786296184692,
       "tag": "0255_clear_phil_sheldon",
       "breakpoints": true
+    },
+    {
+      "idx": 256,
+      "version": "7",
+      "when": 1786393593872,
+      "tag": "0256_violet_blur",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -197,6 +197,13 @@ export const conversations = pgTable('conversations', {
  * the backfill or forced us to invent attribution we do not have. The rule is
  * documented and tested, not enforced by the database.
  */
+/**
+ * The value `messages.source` carries for a turn spoken into a live voice call.
+ * Named once so the UI's glyph check, the realtime writer and the seed builder
+ * cannot drift onto three spellings of one string.
+ */
+export const MESSAGE_SOURCE_VOICE = 'voice';
+
 export const messages = pgTable('messages', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
   conversationId: text('conversationId').notNull().references(() => conversations.id, { onDelete: 'cascade' }),
@@ -230,6 +237,26 @@ export const messages = pgTable('messages', {
    * conversation's business (`derivedPageId()`).
    */
   sourceAgentId: text('sourceAgentId').references(() => pages.id, { onDelete: 'set null' }),
+  /**
+   * The TRANSPORT this row was authored over — `'voice'` for a turn spoken into
+   * a live realtime call, NULL for a typed one.
+   *
+   * A column and not a jsonb flag because it is a fact about the row that two
+   * unrelated readers need cheaply: the UI, to mark a spoken turn (the mic
+   * glyph) so a thread is honest about how it was made; and the realtime SEED
+   * builder, which replays prior turns into a new call and can only tell a
+   * spoken turn from a typed one if the row says so.
+   *
+   * NULLABLE, not `default 'text'`: purely widening, so every pre-existing row
+   * and every INSERT from old code during a rolling deploy stays valid, and
+   * "unknown/typed" needs no backfill to be correct. Read it through
+   * {@link MESSAGE_SOURCE_VOICE} rather than a string literal.
+   *
+   * NOT an enum column and NOT CHECK-constrained: a one-way CHECK on a table
+   * this size is a migration hazard for a value with exactly one non-null
+   * member today, and the write path is a single repository.
+   */
+  source: text('source'),
 }, (table) => ({
   conversationIdx: index('messages_conversation_id_idx').on(table.conversationId),
   conversationCreatedAtIdx: index('messages_conversation_id_created_at_idx').on(table.conversationId, table.createdAt),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1657,6 +1657,11 @@
       "import": "./dist/realtime/voice-bridge-contract.js",
       "require": "./dist/realtime/voice-bridge-contract.js"
     },
+    "./realtime/voice-events": {
+      "types": "./dist/realtime/voice-events.d.ts",
+      "import": "./dist/realtime/voice-events.js",
+      "require": "./dist/realtime/voice-events.js"
+    },
     "./permissions/share-link-service": {
       "types": "./dist/permissions/share-link-service.d.ts",
       "import": "./dist/permissions/share-link-service.js",

--- a/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
@@ -279,13 +279,25 @@ describe('calculateRealtimeCostDollars — cached total with no modality breakdo
 
 describe('calculateRealtimeCostDollars — malformed input bills 0, never negative or NaN', () => {
   it('returns 0 for an unpriced model even with a fully valid usage object', () => {
-    // gpt-realtime-2.1 is entitled on this key (a wss realtime socket opens fine); it
-    // simply has no row in the table yet, because it is not served over the WebRTC
-    // calls endpoint we use. Unpriced means billed 0, never billed at another
-    // model's rates.
-    expect(calculateRealtimeCostDollars('gpt-realtime-2.1', MEASURED_USAGE)).toBe(0);
+    // Unpriced means billed 0, never billed at another model's rates. The mini
+    // is the live example: `/v1/models` lists it and `OPENAI_REALTIME_MODEL`
+    // could point at it, but only its audio rates are published in a form worth
+    // copying — and half a rate table bills wrongly in a direction nobody
+    // notices. Adding it means adding VERIFIED rates in the same change.
+    expect(calculateRealtimeCostDollars('gpt-realtime-2.1-mini', MEASURED_USAGE)).toBe(0);
     expect(calculateRealtimeCostDollars('whisper-1', MEASURED_USAGE)).toBe(0);
     expect(calculateRealtimeCostDollars('', MEASURED_USAGE)).toBe(0);
+  });
+
+  it('prices gpt-realtime-2.1 — the model the app actually pins — rather than billing it 0', () => {
+    // This is the failure the closed union exists to make loud: the default
+    // model having no row is not a conservative default, it is a call that
+    // bills nothing. 2.1 publishes the same rate card as gpt-realtime, verified
+    // against its own pricing table rather than assumed from the family name.
+    const priced = calculateRealtimeCostDollars('gpt-realtime-2.1', MEASURED_USAGE);
+
+    expect(priced).toBeGreaterThan(0);
+    expect(priced).toBe(calculateRealtimeCostDollars('gpt-realtime', MEASURED_USAGE));
   });
 
   it('returns 0 for absent usage', () => {

--- a/packages/lib/src/monitoring/voice-pricing.ts
+++ b/packages/lib/src/monitoring/voice-pricing.ts
@@ -126,14 +126,21 @@ export function estimateVoiceHoldCents(model: string, quantity: VoiceUsageQuanti
  * at 0 rather than being billed at another model's rates — so bumping that env var
  * means adding its published rates here in the same change.
  *
- * Only `gpt-realtime` is listed because it is the only model the transport we use can
- * currently reach. `gpt-realtime-2.1` IS entitled on this key — a
- * `wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1` socket opens fine — but it
- * is not yet SERVED over the WebRTC path: `POST /v1/realtime/calls` answers
- * `403 model_not_found` for 2.1 where `gpt-realtime` returns 201. When 2.1 does reach
- * that endpoint, it needs its own row here (its rates differ) before the env var moves.
+ * `gpt-realtime-2.1` is the DEFAULT the app now pins (`DEFAULT_REALTIME_MODEL`), and it
+ * had to be added here in the same change that made the server meter a live call: an
+ * unpriced default is not a conservative default, it is a call that bills nothing.
+ * (The earlier note here said 2.1 was entitled but not served over WebRTC —
+ * `POST /v1/realtime/calls` answered `403 model_not_found`. That was true of the
+ * ACCOUNT, not the transport: once the project allowlisted 2.1 the same endpoint
+ * returned 201 for a real browser SDP offer.)
+ *
+ * `gpt-realtime-2.1-mini` is deliberately absent. It exists and `/v1/models` lists it,
+ * but only its audio rates are published in a form worth copying, and half a rate table
+ * bills wrongly in a direction nobody notices. Pointing `OPENAI_REALTIME_MODEL` at it
+ * means adding its verified rates here in the same change — which is exactly the rule
+ * this closed union exists to enforce.
  */
-export type RealtimeModel = 'gpt-realtime';
+export type RealtimeModel = 'gpt-realtime' | 'gpt-realtime-2.1';
 
 /** USD per token for each input modality. */
 export interface RealtimeInputRates {
@@ -167,23 +174,34 @@ export interface RealtimeModelRates {
  *   audio   $32         $0.40        $64
  *   image    $5         $0.50          —
  */
-export const REALTIME_RATES: Record<RealtimeModel, RealtimeModelRates> = {
-  'gpt-realtime': {
-    input: {
-      text: envFloat('REALTIME_INPUT_TEXT_USD_PER_TOKEN', 4 / 1_000_000),
-      audio: envFloat('REALTIME_INPUT_AUDIO_USD_PER_TOKEN', 32 / 1_000_000),
-      image: envFloat('REALTIME_INPUT_IMAGE_USD_PER_TOKEN', 5 / 1_000_000),
-    },
-    cachedInput: {
-      text: envFloat('REALTIME_CACHED_INPUT_TEXT_USD_PER_TOKEN', 0.4 / 1_000_000),
-      audio: envFloat('REALTIME_CACHED_INPUT_AUDIO_USD_PER_TOKEN', 0.4 / 1_000_000),
-      image: envFloat('REALTIME_CACHED_INPUT_IMAGE_USD_PER_TOKEN', 0.5 / 1_000_000),
-    },
-    output: {
-      text: envFloat('REALTIME_OUTPUT_TEXT_USD_PER_TOKEN', 24 / 1_000_000),
-      audio: envFloat('REALTIME_OUTPUT_AUDIO_USD_PER_TOKEN', 64 / 1_000_000),
-    },
+const publishedRates = (): RealtimeModelRates => ({
+  input: {
+    text: envFloat('REALTIME_INPUT_TEXT_USD_PER_TOKEN', 4 / 1_000_000),
+    audio: envFloat('REALTIME_INPUT_AUDIO_USD_PER_TOKEN', 32 / 1_000_000),
+    image: envFloat('REALTIME_INPUT_IMAGE_USD_PER_TOKEN', 5 / 1_000_000),
   },
+  cachedInput: {
+    text: envFloat('REALTIME_CACHED_INPUT_TEXT_USD_PER_TOKEN', 0.4 / 1_000_000),
+    audio: envFloat('REALTIME_CACHED_INPUT_AUDIO_USD_PER_TOKEN', 0.4 / 1_000_000),
+    image: envFloat('REALTIME_CACHED_INPUT_IMAGE_USD_PER_TOKEN', 0.5 / 1_000_000),
+  },
+  output: {
+    text: envFloat('REALTIME_OUTPUT_TEXT_USD_PER_TOKEN', 24 / 1_000_000),
+    audio: envFloat('REALTIME_OUTPUT_AUDIO_USD_PER_TOKEN', 64 / 1_000_000),
+  },
+});
+
+/**
+ * `gpt-realtime` and `gpt-realtime-2.1` publish the SAME rate card, verified
+ * against each model's own pricing table rather than assumed from the family
+ * name — so they share one builder and one set of env overrides instead of two
+ * copies that could be edited apart. A future model whose rates diverge gets
+ * its own literal here; that is the point at which the env vars need splitting,
+ * and not before.
+ */
+export const REALTIME_RATES: Record<RealtimeModel, RealtimeModelRates> = {
+  'gpt-realtime': publishedRates(),
+  'gpt-realtime-2.1': publishedRates(),
 };
 
 /** Per-modality breakdown of the cached SUBSET of input tokens. */

--- a/packages/lib/src/realtime/__tests__/voice-events.test.ts
+++ b/packages/lib/src/realtime/__tests__/voice-events.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   buildFunctionOutput,
   extractFunctionCalls,
+  extractRateLimits,
   extractTranscript,
+  extractUsage,
   parseEvent,
   RESPONSE_CREATE,
-} from '../events';
+} from '../voice-events';
 
 const call = (over: Record<string, unknown> = {}) => ({
   type: 'function_call',
@@ -205,5 +207,84 @@ describe('parseEvent', () => {
     // string is not an event.
     expect(parseEvent(42)).toBeUndefined();
     expect(parseEvent(null)).toBeUndefined();
+  });
+});
+
+describe('extractUsage', () => {
+  it('given a completed response, should extract its usage', () => {
+    expect(
+      extractUsage({
+        type: 'response.done',
+        response: {
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            input_token_details: { audio_tokens: 80, text_tokens: 20 },
+          },
+        },
+      }),
+    ).toEqual({
+      input_tokens: 100,
+      output_tokens: 50,
+      input_token_details: { audio_tokens: 80, text_tokens: 20 },
+    });
+  });
+
+  it('given a response with no usage, should return undefined rather than an empty object', () => {
+    // An interrupted or errored response reports none, and the accumulator must
+    // not have to tell "no usage" from "zero usage".
+    expect(extractUsage({ type: 'response.done', response: {} })).toBeUndefined();
+  });
+
+  it('given any other event, should return undefined', () => {
+    expect(extractUsage({ type: 'response.created', response: { usage: { input_tokens: 5 } } }))
+      .toBeUndefined();
+    expect(extractUsage({ type: 'session.updated' })).toBeUndefined();
+  });
+
+  it('given a malformed frame, should return undefined rather than throw', () => {
+    expect(extractUsage(undefined)).toBeUndefined();
+    expect(extractUsage('a string')).toBeUndefined();
+    expect(extractUsage({ type: 'response.done' })).toBeUndefined();
+    expect(extractUsage({ type: 'response.done', response: 'nope' })).toBeUndefined();
+    expect(extractUsage({ type: 'response.done', response: { usage: 7 } })).toBeUndefined();
+  });
+});
+
+describe('extractRateLimits', () => {
+  it('given a rate-limit update, should extract each named limit', () => {
+    expect(
+      extractRateLimits({
+        type: 'rate_limits.updated',
+        rate_limits: [
+          { name: 'tokens', limit: 40000, remaining: 39000, reset_seconds: 60 },
+          { name: 'requests', limit: 100, remaining: 99 },
+        ],
+      }),
+    ).toEqual([
+      { name: 'tokens', limit: 40000, remaining: 39000 },
+      { name: 'requests', limit: 100, remaining: 99 },
+    ]);
+  });
+
+  it('given entries missing a name or a number, should skip just those', () => {
+    expect(
+      extractRateLimits({
+        type: 'rate_limits.updated',
+        rate_limits: [
+          { limit: 1, remaining: 1 },
+          { name: 'tokens', limit: 'lots', remaining: 1 },
+          { name: 'tokens', limit: 1, remaining: null },
+          { name: 'ok', limit: 2, remaining: 1 },
+        ],
+      }),
+    ).toEqual([{ name: 'ok', limit: 2, remaining: 1 }]);
+  });
+
+  it('given any other event or a malformed frame, should return nothing', () => {
+    expect(extractRateLimits({ type: 'response.done' })).toEqual([]);
+    expect(extractRateLimits({ type: 'rate_limits.updated' })).toEqual([]);
+    expect(extractRateLimits({ type: 'rate_limits.updated', rate_limits: 'nope' })).toEqual([]);
+    expect(extractRateLimits(undefined)).toEqual([]);
   });
 });

--- a/packages/lib/src/realtime/voice-bridge-contract.ts
+++ b/packages/lib/src/realtime/voice-bridge-contract.ts
@@ -35,6 +35,41 @@ export const VOICE_BRIDGE_ROUTES = {
 } as const;
 
 /**
+ * The RETURN hop: routes `apps/realtime` posts back to on the web tier while a
+ * call is live.
+ *
+ * This direction did not exist before voice — until now `apps/realtime` made no
+ * outbound HTTP calls to web at all, and `docs/2.0-architecture/agent-sessions.md`
+ * §3d said so while reasoning about deploy order. That statement is updated in
+ * the same change that adds this, because it stops being true here.
+ *
+ * WHY IT HAS TO EXIST. The socket lives in `apps/realtime` (only a long-lived
+ * process can hold a call for its whole life), but two of the things that
+ * happen ON that socket are owned by `apps/web` and cannot move:
+ *   - TOOL EXECUTION needs the AI SDK tool registry, its `@/`-aliased imports,
+ *     and the permission functions the tools call INTO (`canActorViewPage`,
+ *     `resolveActorAccessiblePagesInDrive`). Re-implementing any of that on the
+ *     realtime side would be the second permission model this system must never
+ *     grow.
+ *   - TRANSCRIPT PERSISTENCE needs `messageRepository`, whose write is the same
+ *     transaction that bumps `conversations.rev` and emits the `conversation:*`
+ *     events every chat surface already subscribes to. A second writer would be
+ *     a second owner of that invariant.
+ *
+ * METERING is deliberately NOT here. Its whole dependency set — `canConsumeAI`,
+ * `AIMonitoring`, `calculateRealtimeCostDollars` — already lives in
+ * `@pagespace/lib`, which `apps/realtime` depends on directly, so routing it
+ * through an HTTP hop would add a failure mode and buy nothing. The rule is the
+ * same one C-A applied to tools: the work runs where its owner lives.
+ *
+ * Signed with the SAME HMAC as the outbound direction (`REALTIME_BROADCAST_SECRET`
+ * is symmetric), so the web route can prove the caller is the realtime server.
+ */
+export const VOICE_CALLBACK_ROUTES = {
+  bridge: '/api/internal/voice/bridge',
+} as const;
+
+/**
  * The three id spaces a realtime call runs on are NOT interchangeable, and the
  * one this payload carries is the CALL id. Measured shapes:
  * - `rtc_…`  — the call, returned in the `Location` header of `/v1/realtime/calls`
@@ -89,12 +124,80 @@ export const realtimeToolSchema = z.object({
 export type RealtimeToolWire = z.infer<typeof realtimeToolSchema>;
 
 /**
+ * Where the user is standing, as the tools need it.
+ *
+ * Mirrors the `locationContext` member of `ToolExecutionContext`
+ * (`apps/web/src/lib/ai/core/types.ts`) — the same duplication trade as
+ * `realtimeToolSchema` above, for the same reason, with the same drift guard.
+ * It travels because a spoken "what's on this page?" is answerable only if the
+ * dispatcher knows which page "this" is, and the realtime server is the only
+ * party that can tell it: navigating mid-call updates this rather than
+ * rebinding the session.
+ */
+export const voiceLocationContextSchema = z.object({
+  currentPage: z
+    .object({
+      id: z.string(),
+      title: z.string(),
+      type: z.string(),
+      path: z.string(),
+      isTaskLinked: z.boolean().optional(),
+    })
+    .optional(),
+  currentDrive: z
+    .object({ id: z.string(), name: z.string(), slug: z.string() })
+    .optional(),
+  breadcrumbs: z.array(z.string()).optional(),
+});
+
+export type VoiceLocationContext = z.infer<typeof voiceLocationContextSchema>;
+
+/**
+ * One `conversation.item.create` message item, as the seed carries it.
+ *
+ * Typed exactly rather than as an opaque record because the two content-part
+ * types are NOT interchangeable and getting them backwards fails silently:
+ * a `role: 'user'` item takes `input_text`, a `role: 'assistant'` item takes
+ * `text`, and the wrong one comes back as an opaque `error` event on a socket
+ * that then just sits there. Mirrors `SeedEvent` in
+ * `apps/web/src/lib/ai/realtime/seed.ts`, with a drift guard in the web tests.
+ *
+ * Assistant AUDIO is unrepresentable here on purpose — the Realtime API cannot
+ * take it as history at all, which is the entire reason a seed is text.
+ */
+export const realtimeSeedEventSchema = z.object({
+  type: z.literal('conversation.item.create'),
+  item: z.object({
+    type: z.literal('message'),
+    role: z.enum(['user', 'assistant']),
+    content: z
+      .array(z.object({ type: z.enum(['input_text', 'text']), text: z.string() }))
+      .min(1),
+  }),
+});
+
+export type RealtimeSeedEventWire = z.infer<typeof realtimeSeedEventSchema>;
+
+/**
  * What `POST /api/realtime/attach` receives.
  *
  * `conversationId` is optional because voice is a second transport onto a
  * conversation that may not exist yet at handshake time — a call that has not
  * been bound to a thread still attaches, still runs tools, and still meters.
  * Refusing to attach without one would make the binding state gate the call.
+ *
+ * `model` and `subscriptionTier` ride along because the realtime server meters
+ * the call itself and cannot derive either: the model is resolved from env at
+ * the web edge (`resolveRealtimeModel`) and pricing is per-model, while the
+ * tier was already read for the entitlement gate one function earlier and
+ * re-reading it here would be a second DB round trip for a fact that cannot
+ * change inside one call.
+ *
+ * `seed` is built web-side for the same reason `tools` is: it comes out of the
+ * bound conversation's messages, behind a permission check, in the process that
+ * owns the repositories. Shipping it in this payload rather than fetching it
+ * over the return hop also keeps it off the critical path — the browser is
+ * already in a call, and the seed must land before the model speaks.
  */
 export const realtimeAttachPayloadSchema = z.object({
   callId: realtimeCallIdSchema,
@@ -102,9 +205,89 @@ export const realtimeAttachPayloadSchema = z.object({
   userId: z.string().min(1),
   conversationId: z.string().min(1).optional(),
   tools: z.array(realtimeToolSchema).default([]),
+  model: z.string().min(1),
+  subscriptionTier: z.string().min(1).default('free'),
+  timezone: z.string().min(1).optional(),
+  locationContext: voiceLocationContextSchema.optional(),
+  seed: z.array(realtimeSeedEventSchema).default([]),
 });
 
 export type RealtimeAttachPayload = z.infer<typeof realtimeAttachPayloadSchema>;
+
+/* ------------------------------------------------------------------------- *
+ * THE RETURN HOP — realtime -> web, for the life of the call.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Run one tool the model asked for, with PageSpace's real registry and real
+ * permissions, and give back something speakable.
+ *
+ * `argumentsJson` crosses as the RAW STRING the model produced, not as a parsed
+ * object. That is deliberate: `function_call.arguments` arrives as a
+ * newline-laden string that is not always valid JSON, and re-serializing a
+ * half-parsed version of it here would move the parse failure to the wrong
+ * side of the boundary — the dispatcher is where a malformed argument string
+ * has to become a sentence the model can say.
+ *
+ * `timezone` and `locationContext` are echoed back rather than looked up: the
+ * web tier holds no per-call state (a call is served by whichever instance
+ * answers, and PROVEN FACT #2 is that per-call state cannot live in one
+ * instance's memory), so the process that owns the call is the one that
+ * remembers its context.
+ */
+export const voiceToolDispatchSchema = z.object({
+  kind: z.literal('tool'),
+  callId: realtimeCallIdSchema,
+  userId: z.string().min(1),
+  conversationId: z.string().min(1).optional(),
+  name: z.string().min(1),
+  argumentsJson: z.string(),
+  timezone: z.string().min(1).optional(),
+  locationContext: voiceLocationContextSchema.optional(),
+});
+
+/**
+ * Write one spoken turn into the bound conversation as an ordinary message.
+ *
+ * `conversationId` is REQUIRED here where it is optional on the attach: an
+ * unbound call still runs tools and still meters, but there is nowhere to
+ * write its transcript, so the realtime side simply does not make this call.
+ */
+export const voiceTranscriptSchema = z.object({
+  kind: z.literal('transcript'),
+  callId: realtimeCallIdSchema,
+  userId: z.string().min(1),
+  conversationId: z.string().min(1),
+  role: z.enum(['user', 'assistant']),
+  text: z.string().min(1),
+});
+
+export const voiceBridgeRequestSchema = z.discriminatedUnion('kind', [
+  voiceToolDispatchSchema,
+  voiceTranscriptSchema,
+]);
+
+export type VoiceToolDispatchRequest = z.infer<typeof voiceToolDispatchSchema>;
+export type VoiceTranscriptRequest = z.infer<typeof voiceTranscriptSchema>;
+export type VoiceBridgeRequest = z.infer<typeof voiceBridgeRequestSchema>;
+
+/**
+ * What the bridge answers.
+ *
+ * A tool result is ALWAYS a string — `function_call_output.output` must be one,
+ * and a shape that could return an object would invite a caller to hand the
+ * socket something the model rejects.
+ */
+export type VoiceBridgeResponse =
+  | { readonly ok: true; readonly kind: 'tool'; readonly output: string }
+  | {
+      readonly ok: true;
+      readonly kind: 'transcript';
+      readonly saved: boolean;
+      readonly messageId: string | null;
+      readonly rev: number;
+    }
+  | { readonly ok: false; readonly error: string };
 
 /** What the attach endpoint answers. Never echoes the secret. */
 export type RealtimeAttachResult =

--- a/packages/lib/src/realtime/voice-events.ts
+++ b/packages/lib/src/realtime/voice-events.ts
@@ -11,8 +11,16 @@
  * `response.audio_transcript.done` (earlier) — because the event was renamed
  * across releases and some deployments still emit the old name.
  *
+ * IN `packages/lib` AND NOT IN `apps/web`, where it started: the process that
+ * actually reads this event stream is `apps/realtime`, which holds the server
+ * socket for the life of a call and has no dependency edge to the web app. A
+ * pure description of a wire format consumed by two apps is precisely what this
+ * package is for — the same reasoning that put `voice-bridge-contract.ts` here.
+ *
  * Pure: no I/O, no clock, no randomness, no module-level mutable state.
  */
+
+import type { RealtimeUsage } from '../monitoring/voice-pricing';
 
 export type FunctionCall = {
   readonly callId: string;
@@ -99,6 +107,59 @@ export const extractTranscript = (
   }
 
   return undefined;
+};
+
+/**
+ * The `usage` block on a completed response.
+ *
+ * USAGE IS PER RESPONSE, NOT PER CALL — measured, and it is the single fact
+ * that decides where the metering code can live. A `response.done` reports what
+ * that one response cost; a call's total exists only if something accumulates
+ * them, which is why the server socket is held for the whole call rather than
+ * opened per turn.
+ *
+ * Returns undefined for every other event and for a `response.done` that
+ * carries no usage (an interrupted or errored response reports none), so the
+ * accumulator never has to distinguish "no usage" from "zero usage".
+ */
+export const extractUsage = (event: unknown): RealtimeUsage | undefined => {
+  const record = asRecord(event);
+  if (!record || record.type !== 'response.done') return undefined;
+  const usage = asRecord(asRecord(record.response)?.usage);
+  return usage as RealtimeUsage | undefined;
+};
+
+/**
+ * The per-minute token budget OpenAI reports on `rate_limits.updated`.
+ *
+ * Measured at 40,000 tokens/minute for this account, shared by every session on
+ * the key. Surfaced so the metering layer can log how close the deployment is
+ * running to the ceiling the global concurrency cap is sized against, rather
+ * than discovering it as throttling on calls that were already going fine.
+ */
+export type RateLimitSnapshot = {
+  readonly name: string;
+  readonly limit: number;
+  readonly remaining: number;
+};
+
+export const extractRateLimits = (event: unknown): RateLimitSnapshot[] => {
+  const record = asRecord(event);
+  if (!record || record.type !== 'rate_limits.updated') return [];
+  const raw = record.rate_limits;
+  if (!Array.isArray(raw)) return [];
+
+  const snapshots: RateLimitSnapshot[] = [];
+  for (const entry of raw) {
+    const item = asRecord(entry);
+    const name = asString(item?.name);
+    if (!item || !name) continue;
+    const limit = item.limit;
+    const remaining = item.remaining;
+    if (typeof limit !== 'number' || typeof remaining !== 'number') continue;
+    snapshots.push({ name, limit, remaining });
+  }
+  return snapshots;
 };
 
 /** The client event that hands a tool's result back to the model. */


### PR DESCRIPTION
## Why

C-A landed the call plane: our web tier mints, relays the browser's SDP, and hands the call to `apps/realtime`, which holds the WebSocket for the call's life. **This is everything the server DOES on that socket.**

Four things, one chunk, because they are one event loop. A `response.done` carries a tool call *and* the usage for the turn that produced it. The same silence that means "no transcript to write" means "the idle timer should be running". Split apart, each would need its own copy of the frame plumbing and its own theory of when the call ended.

After this, a live call driven entirely server-side can seed itself from an existing text thread, answer a spoken question by calling a real permission-checked PageSpace tool, write both sides into that conversation as ordinary text rows that existing surfaces render live, and bill accurately.

---

## PART 1 — the seed (`apps/web/src/lib/ai/realtime/seed.ts`, pure)

`buildRealtimeSeed(messages, opts?)` → ordered `conversation.item.create` events. Hard-capped at 20 turns / ~4k estimated tokens, both configurable, most recent kept, oldest dropped first.

**The cap is the feature, not a guard.** Realtime cannot take assistant *audio* as history, so prior turns can only be injected as text — and injecting a large text history into a session with audio output enabled is a documented, widely-reported way to get **no audio at all**, worsening as history grows. A seed that is merely "complete" is a seed that silently mutes the call.

**The content-part type is not symmetric, and getting it wrong fails silently** — a wrong part type comes back as an opaque `error` event on a socket that then just sits there:

| item role | content part type |
|---|---|
| `user` | `input_text` |
| `assistant` | `text` |

Verified against the [Realtime conversations guide](https://developers.openai.com/api/docs/guides/realtime-conversations) (which shows the user item verbatim) and [openai/openai-realtime-api-beta#57](https://github.com/openai/openai-realtime-api-beta/pull/57), which added history injection and documents the same split — along with the limitation that assistant audio items cannot be populated at all, which is why this module exists.

**One deliberate exception to "drop".** If the single most recent turn alone exceeds the budget it is *truncated*, not dropped. Returning an empty seed for a conversation that plainly has context — because its last message was long — is the one outcome nobody wants. The cap still holds absolutely; only how it is met changes.

Token estimation is a documented `chars/4` heuristic, deterministic, no tokenizer dependency. It errs toward over-counting on prose, which is the safe direction: over-count and the seed is a little shorter; under-count and the call goes silent.

**Wiring.** `seed-loader.ts` reads the thread behind `canAccessConversation` and the result rides the attach payload, so the seed is in the realtime server's hand when the socket reaches `session.updated` rather than a round trip later. Every unhappy path returns an empty seed — unbound call, no conversation row yet (the common case), no access, read failed. **A seed is never a reason to fail a call.**

The same function is what reseeds a fresh session against the API's session ceiling: a reseed is a cold session plus this history.

## PART 2 — tool dispatch (`tool-dispatch.ts`)

- **Arguments parsed defensively.** `function_call.arguments` is a newline-laden *string* assembled from streamed deltas and is not guaranteed to parse. Falls back to taking the first *balance-counted* `{…}` — braces inside strings and escaped quotes tracked, because a regex cannot count nesting and the payloads needing recovery are the nested ones. Anything unrecoverable becomes a sentence the model can say: the one thing that must never happen is a tool call with no answer.
- **Advertised and executed cannot drift.** `buildRealtimeToolSet` was extracted from `buildRealtimeTools` so the two are one expression evaluated twice — in two processes (definitions ride the attach payload; execution happens back on the bridge). That is exactly the arrangement where two hand-kept lists drift, and the symptom would be the model calling a name nothing answers. `tool_search` / `execute_tool` work over this socket unchanged.
- **Permissions come for free, deliberately.** Every PageSpace tool enforces access *inside itself* against the `userId` on its context. So the only security-relevant thing this module does is build that context from the real acting user and pass it unchanged. A second permission layer here would be a second thing to keep in step with `packages/lib/src/permissions/`.
- **Always returns a string**, on every path including failure.

### Result truncation — the choice, as asked

The reference prototype (`~/production/pagespace-voice/src/core/present.ts`) formats results with a **hand-written presenter per tool**. That does not scale to PageSpace's registry of dozens, and a curated presenter list would be a second tool surface that drifts every time a tool is added — the exact failure `buildRealtimeTools` avoids by refusing to curate a "voice subset".

So the cap is **generic and structural**: cut at a word boundary at 700 chars (~45s of speech, already past where a listener retains the beginning), say how much was omitted, and tell the model how to get the rest. Same contract `truncateForSpeech` offers, applied uniformly. A string result is spoken as-is; anything else is serialized, because the model reads JSON fine and inventing prose for an arbitrary shape means guessing at a schema this module does not know.

Latency wins a live turn; completeness happens in the thread after.

## PART 3 — transcript persistence

Written through `messageRepository`, so the write, the in-transaction `conversations.rev` bump and the `conversation:*` emit are **the same ones the typed path uses**. The sidebar, GlobalAssistantView and page-agent chat update live with **zero new client wiring** — not because anything was taught about voice, but because this is not a second writer. A direct INSERT would have been shorter and would have silently cost all of it.

- **Global** → `saveGlobalMessage`. **Page** → `savePageMessage` with the agent page; assistant rows attributed `userId: null` + `sourceAgentId`, per the `messages` table's own attribution rule. **Drive/client** threads refused rather than guessed at — a `client` thread's page is claimed write-once by its first completion, and writing into one would invent a binding nobody asked for.
- Lazy first-message creation via `resolveOrCreateConversation`, exactly as typing into a fresh thread does.
- `canAccessConversation` — the same predicate the realtime `join_conversation` handler and the stream-subscription routes use. Owner-only for global; owner-or-(shared AND page access) for page, which is the write rule the page-agent messages route already applies.

**Marking voice rows.** New nullable `messages.source` column (migration `0256`, one line). Nullable rather than `default 'text'` so it is purely widening — every pre-existing row and every old-code INSERT during a rolling deploy stays valid. Set on INSERT only, never in the conflict action: a message's authoring transport is a fact about how it was made, and a later terminal write to the same id does not change it.

## PART 4 — metering (in `apps/realtime`, no HTTP hop)

- **Usage is per response**, so `usage-accumulator.ts` folds it **per modality**. Summing only `input_tokens`/`output_tokens` would produce a tidy number that prices at **zero** — `calculateRealtimeCostDollars` prices from the detail blocks and deliberately refuses to guess a modality for an unattributed total. Cached tokens stay a subset, never an addition. Malformed wire values contribute 0, never `NaN`.
- **Continuous settlement**: hold → talk for a window → settle that window exactly → re-hold. `trackUsage` takes ownership of the hold, so a long call that did not re-hold would run the rest of its length unreserved. A refused re-hold ends the call *mid-conversation* rather than being discovered at hangup.
- **Three limits, three different failures**: idle timeout (the abandoned call — server VAD bills for room noise), duration cap (bounded by `CREDIT_HOLD_TTL_SECONDS`, or a session outlives its own reservation), and concurrency per-user *and* per-deployment (the account's 40,000 tokens/min is shared by every session on our key; the per-user cap is enforced in the registry too, because the credit gate is a no-op when billing is off).
- `MAX_CALL_DURATION_MS` (1h) is **not** a duplicate — it stays what its doc says, a socket-leak backstop an order of magnitude looser than the product limit.

### Pricing hole found and closed

`REALTIME_RATES` had **no row for `gpt-realtime-2.1`** — the model `DEFAULT_REALTIME_MODEL` pins. An unpriced default is not a conservative default; it is a call that **bills nothing**. Added, with rates verified against [2.1's own pricing table](https://developers.openai.com/api/docs/models/gpt-realtime-2.1) rather than assumed from the family name (identical card to `gpt-realtime`). The stale comment claiming 2.1 was not served over WebRTC is corrected. `gpt-realtime-2.1-mini` is deliberately left unpriced — only its audio rates are published in a form worth copying, and half a rate table bills wrongly in a direction nobody notices; a test now pins both halves of that rule.

---

## The process boundary, decided deliberately

`apps/realtime` now calls **back** into web at `/api/internal/voice/bridge`, signed with the same symmetric HMAC (`REALTIME_BROADCAST_SECRET`), verified over the raw body before anything is parsed. The signature authenticates the *service*, never the user — the acting `userId` comes from the signed payload and every downstream check runs against it.

| concern | where it runs | why |
|---|---|---|
| tool execution | **web** | registry lives behind `@/` aliases; tools call `canActorViewPage` etc. internally |
| transcripts | **web** | `messageRepository`'s write *is* the rev bump + emit; a second writer = a second owner of that invariant |
| **metering** | **realtime** | `canConsumeAI`, `AIMonitoring`, `calculateRealtimeCostDollars` are all already in `@pagespace/lib`, which this app depends on directly |

Following C-A's precedent (payload shape declared once in `packages/lib`, both sides parse with it) rather than inventing a second pattern. Metering is the case where the precedent says *don't* cross: an HTTP hop between the socket that sees the usage and the ledger that records it would add a failure mode and buy nothing. **The work runs where its owner lives.**

`events.ts` moved to `packages/lib/src/realtime/voice-events.ts` (+ `extractUsage`, `extractRateLimits`): the process that reads this stream is `apps/realtime`, which has no dependency edge to the web app.

### A documented invariant this breaks

`docs/2.0-architecture/agent-sessions.md` §3d asserted *"realtime makes no outbound HTTP calls to web at all"* while reasoning about deploy order. That stops being true here, so **the section is amended in this change** rather than left stale. The deploy **order is unchanged** — every bridge hop is best-effort per call, so new realtime against old web degrades to audio without tools or transcripts rather than dropping calls.

---

## NOT VERIFIED

**The server-side hangup credential is inferred, not measured.** When a limit fires, closing our own socket does not end the browser's WebRTC session — so `call-hangup.ts` calls `POST /v1/realtime/calls/{call_id}/hangup`, without which every limit would be half a limit (we stop billing and transcribing while the user keeps talking to a model nobody is watching).

I authenticate it with **that call's own ephemeral secret**, reasoning from the measured fact that the same secret authenticates the attach and stays valid for the socket's life. **I did not test this against a live call.** The managed API key never leaves the web tier, so the ephemeral secret is the only credential this process holds; if OpenAI refuses it, the failure is logged and our side still tears down — a hangup that does not land degrades to "we stop participating", never to "we keep billing". Worth confirming on a real call.

Everything else below was run.

---

## Gate

- **Typecheck** — 16/16 non-web packages clean under `turbo run typecheck --force` (no cache). Web clean under `cd apps/web && bunx tsc --noEmit`, the authoritative signal. Turbo's `web#typecheck` fails with `TS6053: File '.next/types/**' not found` because turbo runs it in parallel with `web:build`, which regenerates those files mid-run — the documented race, not this diff.
- **Lint** — 15/15 clean.
- **Tests** — realtime **1093 passed**; lib **9244 passed**; web **16868 passed**. All remaining failures are DB-only suites failing with `DATABASE_URL must point at a migrated Postgres` in a worktree with no test database.
- **`seed.ts`: 100% branch coverage**, and the cap **mutation-checked** as required — turn cap removed → 2 red; keeps oldest instead of newest → 2 red; token-budget loop disabled → 3 red; assistant emitted as `input_text` → 1 red; green on restore.

No changelog entry, following the four prior voice chunks — the epic gets one when voice ships to users.
