### PR TITLE
feat(voice): the browser holds the mic and the speaker, and nothing else

### DIFF
--- a/apps/web/src/app/api/voice/realtime/call/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/realtime/call/__tests__/route.test.ts
@@ -51,6 +51,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 }));
 
 import { POST } from '../route';
+import { REALTIME_MAX_SESSION_SECONDS } from '@pagespace/lib/billing/credit-pricing';
 
 const SECRET = 'ek_never_leaves_the_server';
 const TOOLS = [{ type: 'function' as const, name: 'read_page', description: 'r', parameters: {} }];
@@ -184,7 +185,19 @@ describe('POST /api/voice/realtime/call', () => {
       callId: 'rtc_abc',
       answerSdp: 'v=0 answer',
       attached: true,
+      maxDurationMs: REALTIME_MAX_SESSION_SECONDS * 1000,
     });
+  });
+
+  it('should report the server-enforced duration cap so the client can chain ahead of it', async () => {
+    // The browser cannot read REALTIME_MAX_SESSION_SECONDS, and the realtime
+    // server hangs the call up when it passes. Without this field the client
+    // would have to keep its own copy of a server env var.
+    const res = await POST(callRequest({ sdp: 'v=0 offer' }));
+
+    const body = (await res.json()) as { maxDurationMs?: unknown };
+    expect(body.maxDurationMs).toBe(REALTIME_MAX_SESSION_SECONDS * 1000);
+    expect(typeof body.maxDurationMs).toBe('number');
   });
 
   it('given the realtime server was unreachable, should still return 200 with attached:false', async () => {

--- a/apps/web/src/app/api/voice/realtime/call/route.ts
+++ b/apps/web/src/app/api/voice/realtime/call/route.ts
@@ -26,6 +26,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
+import { REALTIME_MAX_SESSION_SECONDS } from '@pagespace/lib/billing/credit-pricing';
 import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
@@ -188,10 +189,28 @@ export async function POST(request: Request) {
     });
 
     // The ephemeral secret is deliberately absent: it never leaves the server.
+    //
+    // `maxDurationMs` is here because the CLIENT cannot derive it and needs it.
+    // A call is hung up by the realtime server once it passes
+    // REALTIME_MAX_SESSION_SECONDS — a per-deployment env value the browser has
+    // no access to — and the browser's job is to chain into a fresh call bound
+    // to the same conversation shortly BEFORE that lands, so a long
+    // conversation outlives the ceiling that bounds a single call. The
+    // alternative is a client-side copy of a server env var, which is a copy
+    // that drifts, and whose failure mode is a user cut off mid-sentence on the
+    // one deployment that tuned it.
+    //
+    // The realtime server also caps a socket at an hour, so the true ceiling is
+    // the smaller of the two. That constant lives in `apps/realtime` and is not
+    // importable here (there is no dependency edge, deliberately), so this
+    // reports the cap THIS tier owns — correct unless a deployment sets
+    // REALTIME_MAX_SESSION_SECONDS above 3600, at which point the socket's hour
+    // binds first and the chain lands late rather than early.
     return NextResponse.json({
       callId: result.callId,
       answerSdp: result.answerSdp,
       attached: result.attached,
+      maxDurationMs: REALTIME_MAX_SESSION_SECONDS * 1000,
     });
   } catch (error) {
     loggers.ai.error('Realtime voice call error', error as Error);

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -13,6 +13,7 @@ import RightPanel from "@/components/layout/right-sidebar";
 import { NavigationProvider } from "@/components/layout/NavigationProvider";
 import { TabBar } from "@/components/layout/tabs";
 import { GlobalChatProvider } from "@/contexts/GlobalChatContext";
+import { VoiceSessionProvider } from "@/contexts/VoiceSessionContext";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { motion, AnimatePresence } from "motion/react";
 import { DebugPanel } from "./DebugPanel";
@@ -336,6 +337,19 @@ function Layout({ children }: LayoutProps) {
 
   return (
     <NavigationProvider>
+      {/*
+        THE app-wide voice session. Mounted HERE — above the panel group, not
+        inside RightPanel — because `rightPanelVisible && …` below unmounts the
+        right sidebar outright when it closes, and a session owned by the panel
+        would hang up the user's call every time they collapsed it. Voice is a
+        transport onto a conversation, not a property of a panel; the sidebar is
+        its home, not its owner.
+
+        Outside GlobalChatProvider rather than inside it: this provider consumes
+        nothing from it, and a session that cannot be interrupted by anything
+        below it is the whole point.
+      */}
+      <VoiceSessionProvider>
       <GlobalChatProvider>
         <div
           className="flex flex-col overflow-hidden bg-gradient-to-br from-background via-background to-muted/10"
@@ -518,6 +532,7 @@ function Layout({ children }: LayoutProps) {
         </>
         )}
       </GlobalChatProvider>
+      </VoiceSessionProvider>
     </NavigationProvider>
   );
 }

--- a/apps/web/src/components/layout/__tests__/Layout.voice-session.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Layout.voice-session.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * WHERE the voice session is mounted, asserted against the REAL Layout tree.
+ *
+ * `VoiceSessionContext.test.tsx` proves the provider survives a child
+ * unmounting — but it mounts its own provider, so it says nothing about Layout.
+ * Replace `<VoiceSessionProvider>` in Layout with a passthrough and that whole
+ * suite still passes, while every call in production would hang up the moment
+ * the user closed the sidebar. This file is the guard for that: the provider
+ * must be a real ANCESTOR of the `rightPanelVisible && …` region, in the tree
+ * Layout actually renders.
+ *
+ * Everything heavy is mocked EXCEPT the thing under test: `VoiceSessionProvider`
+ * is the real one, mounted by the real Layout. `RightPanel` is replaced by a
+ * probe that CONSUMES the session, so a provider that is missing, or that has
+ * been moved inside the panel, fails at render rather than subtly.
+ */
+
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useVoiceSession,
+  useVoiceSessionControls,
+} from '@/contexts/VoiceSessionContext';
+
+const { layoutState, mockConnect, stopSpy, setMicSpy } = vi.hoisted(() => ({
+  layoutState: {
+    leftSidebarOpen: false,
+    rightSidebarOpen: true,
+    leftSheetOpen: false,
+    rightSheetOpen: false,
+    leftOverlayOpen: false,
+    leftSidebarSize: '20',
+    rightSidebarSize: '20',
+    toggleLeftSidebar: () => {},
+    toggleRightSidebar: () => {},
+    setRightSidebarOpen: () => {},
+    setLeftSheetOpen: () => {},
+    setRightSheetOpen: () => {},
+    setLeftOverlayOpen: () => {},
+    setLeftSidebarSize: () => {},
+    setRightSidebarSize: () => {},
+  } as Record<string, unknown>,
+  mockConnect: vi.fn(),
+  stopSpy: vi.fn(),
+  setMicSpy: vi.fn(),
+}));
+
+// The handshake is not what this file is about — the provider is real, the
+// network is not.
+vi.mock('@/lib/ai/realtime/connect', () => ({
+  connectVoiceCall: mockConnect,
+  VOICE_CALL_ROUTE: '/api/voice/realtime/call',
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isLoading: false, isAuthenticated: true }),
+}));
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => undefined }));
+vi.mock('@/hooks/useAccessRevocation', () => ({
+  useAccessRevocation: () => undefined,
+}));
+vi.mock('@/hooks/useNotificationToasts', () => ({
+  useNotificationToasts: () => undefined,
+}));
+vi.mock('@/hooks/useDesktopNotifications', () => ({
+  useDesktopNotifications: () => undefined,
+}));
+vi.mock('@/hooks/useIosBadgeSync', () => ({ useIosBadgeSync: () => undefined }));
+vi.mock('@/hooks/usePerformanceMonitor', () => ({
+  usePerformanceMonitor: () => undefined,
+}));
+vi.mock('@/hooks/useIOSKeyboardInit', () => ({
+  useIOSKeyboardInit: () => undefined,
+}));
+vi.mock('@/hooks/useMobileKeyboard', () => ({ dismissKeyboard: () => {} }));
+vi.mock('@/hooks/useTabSync', () => ({ useTabSync: () => undefined }));
+vi.mock('@/hooks/useHasHydrated', () => ({ useHasHydrated: () => true }));
+// Desktop: neither sheet mode nor overlay mode, so `rightPanelVisible` is
+// exactly `rightSidebarOpen` — the gate this test drives.
+vi.mock('@/hooks/useBreakpoint', () => ({ useBreakpoint: () => false }));
+vi.mock('@/hooks/useDeviceTier', () => ({
+  useDeviceTier: () => ({ isTablet: false }),
+}));
+vi.mock('@/stores/useLayoutStore', () => ({
+  useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(layoutState),
+}));
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: {
+    getState: () => ({
+      clearAllSessions: () => {},
+      clearStaleSessions: () => {},
+    }),
+  },
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {}, replace: () => {}, prefetch: () => {} }),
+}));
+
+vi.mock('@/components/layout/main-header', () => ({
+  default: () => <div data-testid="top-bar" />,
+}));
+vi.mock('@/components/layout/left-sidebar/MemoizedSidebar', () => ({
+  default: () => <div data-testid="left-sidebar" />,
+}));
+vi.mock('@/components/layout/middle-content/CenterPanel', () => ({
+  default: () => <div data-testid="center-panel" />,
+}));
+vi.mock('@/components/layout/tabs', () => ({ TabBar: () => <div /> }));
+vi.mock('@/components/layout/DebugPanel', () => ({ DebugPanel: () => <div /> }));
+vi.mock('@/components/ai/voice', () => ({ VoiceModeBorder: () => <div /> }));
+vi.mock('@/components/layout/NavigationProvider', () => ({
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  GlobalChatProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SheetTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SheetDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+vi.mock('motion/react', () => ({
+  motion: { div: ({ children }: { children: React.ReactNode }) => <div>{children}</div> },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+/**
+ * Stands in for the real `RightPanel`, and consumes the voice session the way
+ * the voice UI will. If `VoiceSessionProvider` is not an ancestor of this — it
+ * was deleted, made a passthrough, or moved INSIDE the panel — these hooks
+ * throw and every test in this file goes red.
+ */
+vi.mock('@/components/layout/right-sidebar', () => {
+  // Named and capitalised so it is a component to the rules-of-hooks lint, not
+  // an anonymous `default` that happens to call hooks.
+  const RightPanelProbe = () => {
+    const { status, callId } = useVoiceSession();
+    const { start } = useVoiceSessionControls();
+    return (
+      <button
+        type="button"
+        data-testid="right-panel"
+        data-call={callId ?? ''}
+        onClick={() =>
+          void start({ conversationId: 'conv-layout', type: 'global' })
+        }
+      >
+        {status}
+      </button>
+    );
+  };
+  return { default: RightPanelProbe };
+});
+
+import Layout from '../Layout';
+
+/** Rendered as Layout's children — inside the tree, outside the sidebar gate. */
+const seen: { status?: string; callId?: string | null } = {};
+function PersistentProbe() {
+  const { status, callId } = useVoiceSession();
+  seen.status = status;
+  seen.callId = callId;
+  return <div data-testid="persistent" />;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  layoutState.rightSidebarOpen = true;
+  mockConnect.mockResolvedValue({
+    ok: true,
+    connection: {
+      callId: 'rtc_layout_call',
+      attached: true,
+      // No cap reported: this file is about placement, not chaining, and a
+      // chain timer would only add a way for it to be flaky.
+      maxDurationMs: undefined,
+      microphone: { getTracks: () => [], getAudioTracks: () => [] },
+      setMicrophoneEnabled: setMicSpy,
+      stop: stopSpy,
+    },
+  });
+});
+
+describe('Layout — where the voice session is mounted', () => {
+  it('should render the sidebar panel INSIDE the voice session', () => {
+    // The panel reads the session directly. Rendering at all is the assertion:
+    // a missing or passthrough provider throws out of these hooks.
+    const view = render(
+      <Layout>
+        <PersistentProbe />
+      </Layout>,
+    );
+
+    expect(view.getByTestId('right-panel').textContent).toBe('idle');
+    expect(seen.status).toBe('idle');
+  });
+
+  it('given the sidebar closes mid-call, should keep the call alive', async () => {
+    // The whole reason the provider sits above the panel group. Started from
+    // inside the panel, the way the real trigger will be.
+    const view = render(
+      <Layout>
+        <PersistentProbe />
+      </Layout>,
+    );
+
+    await act(async () => {
+      view.getByTestId('right-panel').click();
+    });
+    expect(seen.status).toBe('connected');
+    expect(seen.callId).toBe('rtc_layout_call');
+
+    // Close the sidebar: `rightPanelVisible` goes false and the panel unmounts.
+    layoutState.rightSidebarOpen = false;
+    await act(async () => {
+      view.rerender(
+        <Layout>
+          <PersistentProbe />
+        </Layout>,
+      );
+    });
+
+    expect(view.queryByTestId('right-panel')).toBeNull();
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(seen.status).toBe('connected');
+    expect(seen.callId).toBe('rtc_layout_call');
+  });
+
+  it('given the sidebar reopens, should find the same call still running', async () => {
+    const view = render(
+      <Layout>
+        <PersistentProbe />
+      </Layout>,
+    );
+    await act(async () => {
+      view.getByTestId('right-panel').click();
+    });
+
+    layoutState.rightSidebarOpen = false;
+    await act(async () => {
+      view.rerender(
+        <Layout>
+          <PersistentProbe />
+        </Layout>,
+      );
+    });
+
+    layoutState.rightSidebarOpen = true;
+    await act(async () => {
+      view.rerender(
+        <Layout>
+          <PersistentProbe />
+        </Layout>,
+      );
+    });
+
+    // One call for the whole cycle — reopening did not start a second.
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(view.getByTestId('right-panel').dataset.call).toBe('rtc_layout_call');
+    expect(view.getByTestId('right-panel').textContent).toBe('connected');
+  });
+});

--- a/apps/web/src/contexts/VoiceSessionContext.tsx
+++ b/apps/web/src/contexts/VoiceSessionContext.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  connectVoiceCall,
+  type VoiceConnectDeps,
+  type VoiceConnection,
+} from '@/lib/ai/realtime/connect';
+import {
+  initialSessionState,
+  sessionReducer,
+  type SessionState,
+} from '@/lib/ai/realtime/session-state';
+import { chainDelayMs } from '@/lib/ai/realtime/chain-schedule';
+import { decideBind, type VoiceTarget } from '@/lib/ai/realtime/voice-target';
+import type { VoiceLocationContext } from '@pagespace/lib/realtime/voice-bridge-contract';
+
+/**
+ * THE voice session. One per app, above everything that can unmount.
+ *
+ * WHY IT LIVES IN `Layout` AND NOT IN THE SIDEBAR. `RightPanel` is unmounted
+ * outright when the sidebar closes (`Layout.tsx`: `rightPanelVisible && …`), so
+ * a session owned by the panel would hang up every time somebody collapsed it.
+ * The sidebar is voice's HOME, not its OWNER — and that distinction is the
+ * difference between a call you can walk away from and a call that is a
+ * property of a panel.
+ *
+ * WHAT THIS OWNS: the peer connection, the microphone, the `<audio>` element the
+ * model is heard through, the binding to a conversation, and the chain that
+ * carries one conversation across the ceiling on a single call. Everything it
+ * DECIDES lives in pure modules beside it — `sessionReducer` (what the UI
+ * shows), `decideBind` (navigate vs rebind), `chainDelayMs` (when to hand off).
+ * This file is the wiring, and it holds no decisions of its own.
+ *
+ * WHAT IT DOES NOT OWN: any UI. No button, no orb, no panel. The trigger and the
+ * call chrome are a separate concern that consumes this provider through
+ * `useVoiceSessionControls()` and `useVoiceSession()` — see the seam note at the
+ * bottom of this file.
+ *
+ * LIFECYCLE, as settled:
+ *  - Client-side navigation does NOT touch the session. Where the user is
+ *    standing is `locationContext`, which travels with the call; where the user
+ *    is TALKING is the conversation, which does not change because they walked
+ *    to another page.
+ *  - The agent switcher DOES rebind — a different agent is a different
+ *    conversation with a different history, and no live session can serve it.
+ *  - A hard refresh ends the call. That is deliberate: audio is ephemeral, the
+ *    transcript in the thread is the artifact of record, and there is nothing to
+ *    recover that the conversation does not already hold. There is no
+ *    reconnect-on-load path here and there should not be one.
+ */
+
+export type VoiceSessionState = SessionState & {
+  /** The conversation this session is speaking into, once bound. */
+  readonly target: VoiceTarget | null;
+  /** The `rtc_…` id of the call currently carrying the session. */
+  readonly callId: string | null;
+  /**
+   * Whether the realtime server took this call. `false` means audio works but
+   * tools, transcript persistence and metering do not — the UI is expected to
+   * say so rather than imply full capability.
+   */
+  readonly attached: boolean;
+  /** The user's own voice, for metering. Changes once per call, not per frame. */
+  readonly localStream: MediaStream | null;
+  /** The model's voice. Already routed to the speaker; here for visualisation. */
+  readonly remoteStream: MediaStream | null;
+};
+
+export type VoiceSessionControls = {
+  /**
+   * Talk to this conversation. Idempotent for the target already bound — a
+   * second press, or a re-render handing back the same target, must not restart
+   * a call mid-sentence. A DIFFERENT target rebinds.
+   */
+  readonly start: (target: VoiceTarget) => Promise<void>;
+  /** Hang up. Safe to call when nothing is running. */
+  readonly stop: () => void;
+  /**
+   * Tell the session where the user is now standing. Does NOT rebind and does
+   * not interrupt: navigating is not switching who you are talking to.
+   */
+  readonly setLocationContext: (
+    locationContext: VoiceLocationContext | undefined,
+  ) => void;
+};
+
+/** Test seam. Production passes nothing and gets the real browser APIs. */
+export type VoiceSessionDeps = Pick<
+  VoiceConnectDeps,
+  'fetchImpl' | 'createPeerConnection' | 'getUserMedia' | 'createMediaStream'
+>;
+
+/**
+ * Two tiers, following `GlobalChatContext`: the controls never change identity,
+ * so a button that only starts and stops a call does not re-render on every
+ * transcript line.
+ */
+const VoiceSessionStateContext = createContext<VoiceSessionState | undefined>(
+  undefined,
+);
+const VoiceSessionControlsContext = createContext<
+  VoiceSessionControls | undefined
+>(undefined);
+
+/**
+ * One attempt at holding the call — a first connect or a chain. Identity is the
+ * object itself: handlers close over their own attempt and compare against the
+ * refs below, which is how the events of a call being replaced stay separate
+ * from the events of the call replacing it, without either one guessing.
+ */
+type Attempt = {
+  readonly target: VoiceTarget;
+  connection: VoiceConnection | null;
+  /** Held back until the swap when chaining, so the old call is not cut off. */
+  remoteStream: MediaStream | null;
+};
+
+export function VoiceSessionProvider({
+  children,
+  deps,
+}: {
+  children: ReactNode;
+  deps?: VoiceSessionDeps;
+}) {
+  const [state, dispatch] = useReducer(sessionReducer, initialSessionState);
+  const [target, setTarget] = useState<VoiceTarget | null>(null);
+  const [callId, setCallId] = useState<string | null>(null);
+  const [attached, setAttached] = useState(false);
+  const [localStream, setLocalStream] = useState<MediaStream | null>(null);
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  /** The attempt currently feeding the speaker and the UI. */
+  const activeRef = useRef<Attempt | null>(null);
+  /** The attempt being negotiated. A newer one supersedes it. */
+  const pendingRef = useRef<Attempt | null>(null);
+  /**
+   * The target a live-or-connecting session is bound to. Held in a ref, not
+   * read from state, because `start` must decide against what is true NOW —
+   * a second press in the same tick would otherwise see a stale value and open
+   * a second call.
+   */
+  const boundTargetRef = useRef<VoiceTarget | null>(null);
+  const chainTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /**
+   * Where the user is standing, kept current by navigation. Not state: it
+   * changes on every route change and nothing renders from it.
+   *
+   * KNOWN GAP, stated rather than papered over: this reaches the model's tools
+   * only when a call STARTS or CHAINS. The merged server exposes no hop for
+   * updating a live call's context (`VOICE_BRIDGE_ROUTES` has `attach` and
+   * nothing else), so between chains the tools answer "this page" with the page
+   * the call started on. The fix belongs on the server contract — an update
+   * route the realtime server applies to its held context — not to a client
+   * that would otherwise have to fake it by rebinding, which is exactly the
+   * behaviour the design forbids.
+   */
+  const locationRef = useRef<VoiceLocationContext | undefined>(undefined);
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+  const beginAttemptRef = useRef<
+    | ((target: VoiceTarget, options: { chained: boolean }) => Promise<void>)
+    | null
+  >(null);
+
+  const clearChainTimer = useCallback(() => {
+    if (chainTimerRef.current !== null) {
+      clearTimeout(chainTimerRef.current);
+      chainTimerRef.current = null;
+    }
+  }, []);
+
+  /** Drop everything holding a microphone or a socket. Renders nothing. */
+  const teardown = useCallback(() => {
+    clearChainTimer();
+    pendingRef.current?.connection?.stop();
+    pendingRef.current = null;
+    activeRef.current?.connection?.stop();
+    activeRef.current = null;
+    boundTargetRef.current = null;
+  }, [clearChainTimer]);
+
+  const clearSessionState = useCallback(() => {
+    setCallId(null);
+    setAttached(false);
+    // Holding a stream whose tracks are stopped leaves anything metering it
+    // tapping a dead graph.
+    setLocalStream(null);
+    setRemoteStream(null);
+    if (audioRef.current) {
+      audioRef.current.srcObject = null;
+    }
+  }, []);
+
+  /** Point the speaker at a stream. The only place `srcObject` is written. */
+  const playRemote = useCallback((stream: MediaStream) => {
+    if (audioRef.current) {
+      audioRef.current.srcObject = stream;
+    }
+    setRemoteStream(stream);
+  }, []);
+
+  const beginAttempt = useCallback(
+    async (
+      nextTarget: VoiceTarget,
+      options: { readonly chained: boolean },
+    ): Promise<void> => {
+      const previous = activeRef.current;
+      const attempt: Attempt = {
+        target: nextTarget,
+        connection: null,
+        remoteStream: null,
+      };
+      pendingRef.current = attempt;
+      boundTargetRef.current = nextTarget;
+
+      const result = await connectVoiceCall({
+        ...depsRef.current,
+        target: nextTarget,
+        ...(locationRef.current === undefined
+          ? {}
+          : { locationContext: locationRef.current }),
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        // Chaining reuses the microphone already granted — cloned inside
+        // `connect`, so stopping the outgoing call cannot take the incoming
+        // call's audio with it — and starts silent so both sessions cannot hear
+        // the same sentence during the moment they overlap.
+        ...(options.chained && previous?.connection
+          ? {
+              microphone: previous.connection.microphone,
+              microphoneEnabled: false,
+            }
+          : {}),
+        onEvent: (event) => {
+          // A chained call is silent until the swap; its events are not what
+          // the user is hearing, and showing them would double the transcript.
+          if (activeRef.current === attempt) {
+            dispatch({ type: 'event', event });
+          }
+        },
+        onRemoteTrack: (stream) => {
+          attempt.remoteStream = stream;
+          if (activeRef.current === attempt) playRemote(stream);
+        },
+        onConnectionLost: () => {
+          // Only the call the user is actually on is a dropped call. A pending
+          // chain that dies is handled by its own failure path, and the call it
+          // was replacing is still up.
+          if (activeRef.current !== attempt) return;
+          teardown();
+          clearSessionState();
+          dispatch({ type: 'failed', message: 'The voice connection dropped.' });
+        },
+      });
+
+      // Superseded while negotiating: a newer start, a rebind, or a hangup
+      // happened. Whatever we just opened is not wanted — and must not be left
+      // holding a microphone.
+      if (pendingRef.current !== attempt) {
+        if (result.ok) result.connection.stop();
+        return;
+      }
+      pendingRef.current = null;
+
+      if (!result.ok) {
+        if (options.chained) {
+          // The call being replaced is still live and still fine. Reporting a
+          // failure here would be a lie about a working session; the server's
+          // own cap will end it, and that surfaces as an ordinary drop.
+          console.error(
+            `[voice] chain failed, staying on the current call: ${result.detail}`,
+          );
+          return;
+        }
+        boundTargetRef.current = null;
+        clearSessionState();
+        setTarget(null);
+        dispatch({ type: 'failed', message: result.message });
+        return;
+      }
+
+      // The swap. The incoming call becomes the one being heard BEFORE the
+      // outgoing one is stopped, so there is no moment with no session.
+      activeRef.current = attempt;
+      attempt.connection = result.connection;
+      result.connection.setMicrophoneEnabled(true);
+      if (attempt.remoteStream) playRemote(attempt.remoteStream);
+
+      if (options.chained && previous?.connection) {
+        previous.connection.stop();
+      }
+
+      setTarget(nextTarget);
+      setCallId(result.connection.callId);
+      setAttached(result.connection.attached);
+      setLocalStream(result.connection.microphone);
+      dispatch({ type: 'connected' });
+
+      // Each call schedules its own successor from its own reported ceiling.
+      clearChainTimer();
+      const delay = chainDelayMs(result.connection.maxDurationMs);
+      if (delay !== undefined) {
+        chainTimerRef.current = setTimeout(() => {
+          chainTimerRef.current = null;
+          // Through a ref, because a chain is this function scheduling itself
+          // and a callback cannot list itself as its own dependency.
+          void beginAttemptRef.current?.(nextTarget, { chained: true });
+        }, delay);
+      }
+    },
+    [clearChainTimer, clearSessionState, playRemote, teardown],
+  );
+  beginAttemptRef.current = beginAttempt;
+
+  const start = useCallback(
+    async (nextTarget: VoiceTarget): Promise<void> => {
+      const decision = decideBind(boundTargetRef.current, nextTarget);
+      if (decision === 'none') return;
+
+      if (decision === 'rebind') {
+        // A deliberate switch: the old conversation's call has nothing to do
+        // with the new one, so it goes before the new one is opened.
+        teardown();
+        clearSessionState();
+      }
+
+      setTarget(nextTarget);
+      dispatch({ type: 'connecting' });
+      await beginAttempt(nextTarget, { chained: false });
+    },
+    [beginAttempt, clearSessionState, teardown],
+  );
+
+  const stop = useCallback(() => {
+    teardown();
+    clearSessionState();
+    setTarget(null);
+    dispatch({ type: 'disconnected' });
+  }, [clearSessionState, teardown]);
+
+  const setLocationContext = useCallback(
+    (locationContext: VoiceLocationContext | undefined) => {
+      locationRef.current = locationContext;
+    },
+    [],
+  );
+
+  // Unmounting the provider means the app is going away (a hard refresh, a sign
+  // out). Leaving here without this keeps the microphone live in a page nobody
+  // is looking at.
+  useEffect(() => teardown, [teardown]);
+
+  const stateValue: VoiceSessionState = useMemo(
+    () => ({
+      ...state,
+      target,
+      callId,
+      attached,
+      localStream,
+      remoteStream,
+    }),
+    [state, target, callId, attached, localStream, remoteStream],
+  );
+
+  const controlsValue: VoiceSessionControls = useMemo(
+    () => ({ start, stop, setLocationContext }),
+    [start, stop, setLocationContext],
+  );
+
+  return (
+    <VoiceSessionStateContext.Provider value={stateValue}>
+      <VoiceSessionControlsContext.Provider value={controlsValue}>
+        {/*
+          THE speaker. Rendered here rather than by whatever chrome is on screen
+          because the call outlives every panel that could show it — a sink that
+          unmounts with the sidebar would silence the model the moment somebody
+          collapsed it.
+        */}
+        <audio
+          ref={audioRef}
+          autoPlay
+          data-testid="voice-session-audio"
+          className="sr-only"
+        />
+        {children}
+      </VoiceSessionControlsContext.Provider>
+    </VoiceSessionStateContext.Provider>
+  );
+}
+
+/**
+ * What the call is doing. Re-renders as the conversation moves — use it for the
+ * orb, the live transcript, the connection state.
+ */
+export function useVoiceSession(): VoiceSessionState {
+  const context = useContext(VoiceSessionStateContext);
+  if (!context) {
+    throw new Error('useVoiceSession must be used within a VoiceSessionProvider');
+  }
+  return context;
+}
+
+/**
+ * How to start and stop it. Stable identity — a trigger that only starts a call
+ * does not re-render as the call talks.
+ *
+ * ── THE SEAM FOR THE VOICE UI (chunk C-D) ────────────────────────────────────
+ * Everything on screen is built on these two hooks and nothing else:
+ *   - a trigger, anywhere on any route, calls
+ *     `start({ conversationId, type, contextId?, agentPageId? })`;
+ *   - the agent switcher calls `start(…)` with the new agent's target and gets a
+ *     rebind for free — it does not stop and start;
+ *   - route changes call `setLocationContext(…)` and MUST NOT call `start`;
+ *   - call chrome reads `useVoiceSession()` for `status`, `error`, `transcript`,
+ *     `userSpeaking`, `tools`, `attached` and the two streams.
+ * The `<audio>` element and the microphone belong to this provider. UI that
+ * mounts its own sink, or that owns a session per panel, is the failure mode
+ * this file exists to prevent.
+ */
+export function useVoiceSessionControls(): VoiceSessionControls {
+  const context = useContext(VoiceSessionControlsContext);
+  if (!context) {
+    throw new Error(
+      'useVoiceSessionControls must be used within a VoiceSessionProvider',
+    );
+  }
+  return context;
+}

--- a/apps/web/src/contexts/__tests__/VoiceSessionContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/VoiceSessionContext.test.tsx
@@ -1,0 +1,665 @@
+/**
+ * The session lifecycle, driven end to end through the REAL handshake against
+ * fake browser APIs — no live network, no real microphone.
+ *
+ * These assert the four things that make voice a transport rather than a panel
+ * feature: closing the sidebar does not hang up, navigating does not rebind,
+ * switching agent DOES rebind, and a conversation outlives the ceiling on a
+ * single call.
+ */
+
+import React, { useEffect } from 'react';
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  VoiceSessionProvider,
+  useVoiceSession,
+  useVoiceSessionControls,
+  type VoiceSessionControls,
+  type VoiceSessionDeps,
+  type VoiceSessionState,
+} from '../VoiceSessionContext';
+import type { VoiceTarget } from '@/lib/ai/realtime/voice-target';
+import { CHAIN_LEAD_MS } from '@/lib/ai/realtime/chain-schedule';
+import {
+  FakePeerConnection,
+  asPeer,
+  asStream,
+  fakeCreateMediaStream,
+  fakeStream,
+  respondWith,
+} from '@/lib/ai/realtime/__tests__/webrtc-fakes';
+
+const MAX_DURATION_MS = 600_000;
+
+const GLOBAL_TARGET: VoiceTarget = { conversationId: 'conv-global', type: 'global' };
+const AGENT_TARGET: VoiceTarget = {
+  conversationId: 'conv-agent',
+  type: 'page',
+  contextId: 'page-1',
+  agentPageId: 'agent-1',
+};
+
+type Probe = {
+  state: VoiceSessionState;
+  controls: VoiceSessionControls;
+};
+
+const probe: Probe = {} as Probe;
+
+/** Sits inside the provider for the whole test; never unmounts. */
+function StateProbe() {
+  probe.state = useVoiceSession();
+  probe.controls = useVoiceSessionControls();
+  return null;
+}
+
+/**
+ * Stands in for `RightPanel` — the surface that hosts the voice trigger AND is
+ * unmounted outright when the sidebar closes. It both starts calls and reads
+ * session state, so a session scoped to it would die with it.
+ */
+function SidebarPanel() {
+  const { status, callId } = useVoiceSession();
+  const { start } = useVoiceSessionControls();
+  return (
+    <button
+      type="button"
+      data-testid="panel"
+      data-call={callId ?? ''}
+      onClick={() => void start(GLOBAL_TARGET)}
+    >
+      {status}
+    </button>
+  );
+}
+
+type Harness = {
+  readonly peers: FakePeerConnection[];
+  readonly bodies: Record<string, unknown>[];
+  readonly microphone: ReturnType<typeof fakeStream>;
+  readonly micGrants: () => number;
+  readonly deps: VoiceSessionDeps;
+};
+
+const harness = (
+  respond: (attempt: number) => Response = (attempt) =>
+    respondWith({
+      body: {
+        callId: `rtc_call_${attempt}`,
+        answerSdp: `v=0 answer ${attempt}`,
+        attached: true,
+        maxDurationMs: MAX_DURATION_MS,
+      },
+    }),
+): Harness => {
+  const peers: FakePeerConnection[] = [];
+  const bodies: Record<string, unknown>[] = [];
+  const microphone = fakeStream('mic-device');
+  let grants = 0;
+  let attempts = 0;
+
+  return {
+    peers,
+    bodies,
+    microphone,
+    micGrants: () => grants,
+    deps: {
+      fetchImpl: async (_url, init) => {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        attempts += 1;
+        return respond(attempts);
+      },
+      createPeerConnection: () => {
+        const peer = new FakePeerConnection();
+        peers.push(peer);
+        return asPeer(peer);
+      },
+      getUserMedia: async () => {
+        grants += 1;
+        return asStream(microphone);
+      },
+      createMediaStream: fakeCreateMediaStream,
+    },
+  };
+};
+
+/** `route` stands in for whatever page the router is currently showing. */
+function App({
+  deps,
+  showPanel = true,
+  route = '/dashboard/a',
+}: {
+  deps: VoiceSessionDeps;
+  showPanel?: boolean;
+  route?: string;
+}) {
+  return (
+    <VoiceSessionProvider deps={deps}>
+      <StateProbe />
+      <RouteView route={route} />
+      {showPanel && <SidebarPanel />}
+    </VoiceSessionProvider>
+  );
+}
+
+/** A page that reports where the user is standing, the way navigation does. */
+function RouteView({ route }: { route: string }) {
+  const { setLocationContext } = useVoiceSessionControls();
+  useEffect(() => {
+    setLocationContext({
+      currentPage: { id: route, title: route, type: 'DOCUMENT', path: route },
+    });
+  }, [route, setLocationContext]);
+  return <div data-testid="route">{route}</div>;
+}
+
+const startCall = async (target: VoiceTarget = GLOBAL_TARGET) => {
+  await act(async () => {
+    await probe.controls.start(target);
+  });
+};
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('VoiceSessionProvider — starting a call', () => {
+  it('given a target, should bind the session to that conversation', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.callId).toBe('rtc_call_1');
+    expect(probe.state.attached).toBe(true);
+    expect(probe.state.target).toEqual(GLOBAL_TARGET);
+    expect(h.bodies[0]).toMatchObject({ conversationId: 'conv-global' });
+  });
+
+  it('should carry where the user is standing into the call', async () => {
+    const h = harness();
+    render(<App deps={h.deps} route="/dashboard/notes" />);
+
+    await startCall();
+
+    expect(h.bodies[0].locationContext).toMatchObject({
+      currentPage: { id: '/dashboard/notes' },
+    });
+  });
+
+  it('given the same target again, should not open a second call', async () => {
+    // A second press, or a re-render handing back the same target, must not
+    // restart a conversation mid-sentence.
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    await startCall({ ...GLOBAL_TARGET });
+
+    expect(h.peers).toHaveLength(1);
+    expect(probe.state.callId).toBe('rtc_call_1');
+  });
+
+  it('given the microphone is denied vs missing, should surface different messages', async () => {
+    const denied = harness();
+    const missing = harness();
+    const fail = (name: string) => async () => {
+      const error = new Error(name);
+      error.name = name;
+      throw error;
+    };
+
+    const first = render(
+      <App deps={{ ...denied.deps, getUserMedia: fail('NotAllowedError') }} />,
+    );
+    await startCall();
+    const deniedMessage = probe.state.error;
+    first.unmount();
+
+    render(
+      <App deps={{ ...missing.deps, getUserMedia: fail('NotFoundError') }} />,
+    );
+    await startCall();
+    const missingMessage = probe.state.error;
+
+    expect(probe.state.status).toBe('error');
+    expect(deniedMessage).toBeDefined();
+    expect(missingMessage).toBeDefined();
+    expect(deniedMessage).not.toBe(missingMessage);
+  });
+
+  it('given a failed start, should clear the binding so it can be retried', async () => {
+    let failNext = true;
+    const h = harness((attempt) =>
+      failNext
+        ? respondWith({ status: 502, body: { message: 'nope' } })
+        : respondWith({
+            body: {
+              callId: `rtc_call_${attempt}`,
+              answerSdp: 'v=0 answer',
+              attached: true,
+              maxDurationMs: MAX_DURATION_MS,
+            },
+          }),
+    );
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    expect(probe.state.status).toBe('error');
+    expect(probe.state.target).toBeNull();
+
+    failNext = false;
+    await startCall();
+
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.target).toEqual(GLOBAL_TARGET);
+  });
+});
+
+describe('VoiceSessionProvider — surviving the UI', () => {
+  it('given the sidebar closes mid-call, should keep the session alive', async () => {
+    // This is the entire reason the provider sits above RightPanel rather than
+    // inside it: the panel is unmounted outright when the sidebar closes. The
+    // call is deliberately STARTED from inside the panel here — a session
+    // scoped to the surface that started it would hang up on close.
+    const h = harness();
+    const view = render(<App deps={h.deps} showPanel />);
+
+    await act(async () => {
+      view.getByTestId('panel').click();
+    });
+    expect(probe.state.callId).toBe('rtc_call_1');
+
+    await act(async () => {
+      view.rerender(<App deps={h.deps} showPanel={false} />);
+    });
+
+    expect(view.queryByTestId('panel')).toBeNull();
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.callId).toBe('rtc_call_1');
+    expect(h.peers[0].closed).toBe(false);
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(false);
+
+    // Reopening finds the same call still running, not a new one.
+    await act(async () => {
+      view.rerender(<App deps={h.deps} showPanel />);
+    });
+
+    expect(view.getByTestId('panel').dataset.call).toBe('rtc_call_1');
+    expect(view.getByTestId('panel').textContent).toBe('connected');
+    expect(h.peers).toHaveLength(1);
+  });
+
+  it('given client-side navigation, should keep the same session and the same conversation', async () => {
+    const h = harness();
+    const view = render(<App deps={h.deps} route="/dashboard/a" />);
+    await startCall();
+
+    await act(async () => {
+      view.rerender(<App deps={h.deps} route="/dashboard/b" />);
+    });
+
+    expect(view.getByTestId('route').textContent).toBe('/dashboard/b');
+    expect(h.peers).toHaveLength(1);
+    expect(probe.state.callId).toBe('rtc_call_1');
+    expect(probe.state.target).toEqual(GLOBAL_TARGET);
+    expect(probe.state.status).toBe('connected');
+  });
+
+  it('given the provider unmounts, should stop the microphone', async () => {
+    const h = harness();
+    const view = render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      view.unmount();
+    });
+
+    expect(h.peers[0].closed).toBe(true);
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+  });
+});
+
+describe('VoiceSessionProvider — rebinding', () => {
+  it('given the agent switcher changes agent, should rebind to the new conversation', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall(GLOBAL_TARGET);
+    await startCall(AGENT_TARGET);
+
+    expect(h.peers).toHaveLength(2);
+    expect(h.peers[0].closed).toBe(true);
+    expect(probe.state.target).toEqual(AGENT_TARGET);
+    expect(probe.state.callId).toBe('rtc_call_2');
+    expect(h.bodies[1]).toMatchObject({ conversationId: 'conv-agent' });
+  });
+
+  it('given the same conversation under a different agent, should still rebind', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall(AGENT_TARGET);
+    await startCall({ ...AGENT_TARGET, agentPageId: 'agent-2' });
+
+    expect(h.peers).toHaveLength(2);
+    expect(h.peers[0].closed).toBe(true);
+    expect(probe.state.target?.agentPageId).toBe('agent-2');
+  });
+});
+
+describe('VoiceSessionProvider — chaining past the duration cap', () => {
+  it('should mint a fresh call before the cap without changing the conversation', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    expect(probe.state.callId).toBe('rtc_call_1');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    expect(h.peers).toHaveLength(2);
+    expect(probe.state.callId).toBe('rtc_call_2');
+    // The transport changed; the conversation did not.
+    expect(probe.state.target).toEqual(GLOBAL_TARGET);
+    expect(h.bodies.map((b) => b.conversationId)).toEqual([
+      'conv-global',
+      'conv-global',
+    ]);
+    expect(probe.state.status).toBe('connected');
+  });
+
+  it('should hand the microphone over rather than prompt for it again', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    expect(h.micGrants()).toBe(1);
+    // The outgoing call is closed, the incoming one carries a live clone.
+    expect(h.peers[0].closed).toBe(true);
+    expect(h.peers[1].closed).toBe(false);
+    expect(h.peers[1].addedTracks.map((t) => t.id)).toEqual([
+      'mic-device:clone',
+    ]);
+    expect(h.peers[1].addedTracks.every((t) => t.enabled)).toBe(true);
+  });
+
+  it('given the outgoing call is still talking, should not report it as a drop', async () => {
+    // Stopping the replaced call drives it to `closed`, which is a lost state.
+    vi.useFakeTimers();
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.error).toBeUndefined();
+  });
+
+  it('should keep chaining, so a conversation is not capped at two calls', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    for (let i = 0; i < 2; i += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+      });
+    }
+
+    expect(probe.state.callId).toBe('rtc_call_3');
+    expect(h.peers).toHaveLength(3);
+  });
+
+  it('given no cap is reported, should not chain at all', async () => {
+    vi.useFakeTimers();
+    const h = harness((attempt) =>
+      respondWith({
+        body: {
+          callId: `rtc_call_${attempt}`,
+          answerSdp: 'v=0 answer',
+          attached: true,
+        },
+      }),
+    );
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    });
+
+    expect(h.peers).toHaveLength(1);
+    expect(probe.state.callId).toBe('rtc_call_1');
+  });
+
+  it('given the chain fails, should stay on the working call rather than claim a failure', async () => {
+    vi.useFakeTimers();
+    const h = harness((attempt) =>
+      attempt === 1
+        ? respondWith({
+            body: {
+              callId: 'rtc_call_1',
+              answerSdp: 'v=0 answer',
+              attached: true,
+              maxDurationMs: MAX_DURATION_MS,
+            },
+          })
+        : respondWith({ status: 502, body: { message: 'upstream is down' } }),
+    );
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.callId).toBe('rtc_call_1');
+    expect(h.peers[0].closed).toBe(false);
+  });
+
+  it('given the user hangs up mid-chain, should not leave the new call holding the mic', async () => {
+    // The dangerous window: a replacement call is already negotiating — peer
+    // open, mic clone live — when the user hangs up. Nothing is watching it any
+    // more, so if the superseded attempt is not torn down on arrival it holds
+    // the microphone open for a session that no longer exists.
+    vi.useFakeTimers();
+    let release: (() => void) | undefined;
+    const h = harness();
+    const suspendSecondCall: VoiceSessionDeps = {
+      ...h.deps,
+      fetchImpl: async (url, init) => {
+        const response = await h.deps.fetchImpl!(url, init);
+        if (h.bodies.length > 1) {
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        }
+        return response;
+      },
+    };
+    render(<App deps={suspendSecondCall} />);
+
+    await startCall();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    // The replacement is open and waiting on its answer.
+    expect(h.peers).toHaveLength(2);
+    expect(release).toBeDefined();
+
+    await act(async () => {
+      probe.controls.stop();
+    });
+    await act(async () => {
+      release?.();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(probe.state.status).toBe('idle');
+    expect(h.peers.every((peer) => peer.closed)).toBe(true);
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+  });
+});
+
+describe('VoiceSessionProvider — ending a call', () => {
+  it('given the connection drops, should name the failure and stop the microphone', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      h.peers[0].transitionTo('failed');
+    });
+
+    expect(probe.state.status).toBe('error');
+    expect(probe.state.error).toBe('The voice connection dropped.');
+    expect(probe.state.callId).toBeNull();
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+  });
+
+  it('given a hangup, should go idle and release the microphone', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      probe.controls.stop();
+    });
+
+    expect(probe.state.status).toBe('idle');
+    expect(probe.state.error).toBeUndefined();
+    expect(probe.state.callId).toBeNull();
+    expect(probe.state.target).toBeNull();
+    expect(h.peers[0].closed).toBe(true);
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+  });
+
+  it('given a hangup with nothing running, should do nothing', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await act(async () => {
+      probe.controls.stop();
+    });
+
+    expect(probe.state.status).toBe('idle');
+    expect(h.peers).toHaveLength(0);
+  });
+
+  it('given a hangup, should let the next call start clean', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await startCall();
+    await act(async () => {
+      probe.controls.stop();
+    });
+    await startCall();
+
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.callId).toBe('rtc_call_2');
+  });
+});
+
+describe('VoiceSessionProvider — the seam for the voice UI', () => {
+  it('given a consumer mounted outside the provider, should say so rather than fail silently', () => {
+    // Voice UI that renders outside Layout would otherwise read an undefined
+    // session and appear to work while owning nothing.
+    function Orphan() {
+      useVoiceSession();
+      return null;
+    }
+    function OrphanControls() {
+      useVoiceSessionControls();
+      return null;
+    }
+
+    expect(() => render(<Orphan />)).toThrow(/VoiceSessionProvider/);
+    expect(() => render(<OrphanControls />)).toThrow(/VoiceSessionProvider/);
+  });
+});
+
+describe('VoiceSessionProvider — the live event stream', () => {
+  it('should drive the UI from the call the user is actually on', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      h.peers[0].events.deliver(
+        JSON.stringify({ type: 'input_audio_buffer.speech_started' }),
+      );
+    });
+    expect(probe.state.userSpeaking).toBe(true);
+
+    await act(async () => {
+      h.peers[0].events.deliver(
+        JSON.stringify({ type: 'input_audio_buffer.speech_stopped' }),
+      );
+    });
+    expect(probe.state.userSpeaking).toBe(false);
+  });
+
+  it('given a call being replaced, should not double up the transcript', async () => {
+    // Both calls are briefly live during a chain. Only the one being heard may
+    // speak into the UI.
+    vi.useFakeTimers();
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    await act(async () => {
+      h.peers[1].events.deliver(
+        JSON.stringify({ type: 'input_audio_buffer.speech_started' }),
+      );
+      // The replaced call's channel is closed, but a frame already in flight
+      // must not reach the UI either.
+      h.peers[0].events.deliver(
+        JSON.stringify({ type: 'input_audio_buffer.speech_stopped' }),
+      );
+    });
+
+    expect(probe.state.userSpeaking).toBe(true);
+  });
+
+  it('should route the model’s voice to the audio element', async () => {
+    const h = harness();
+    const view = render(<App deps={h.deps} />);
+    await startCall();
+
+    const modelVoice = fakeStream('model-voice');
+    await act(async () => {
+      h.peers[0].deliverRemoteTrack(modelVoice);
+    });
+
+    const audio = view.getByTestId('voice-session-audio') as HTMLAudioElement;
+    expect(audio.srcObject).toBe(modelVoice);
+    expect(probe.state.remoteStream).toBe(modelVoice);
+  });
+});

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -4,34 +4,12 @@ import { useRef, useCallback, useEffect } from 'react';
 import { useVoiceModeStore, type TTSVoice, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { splitOversizedForTts } from '@/lib/voice/chunkForTts';
+// Shared with the audio-native path: same API, same five failures, and the
+// desktop-shell branch inside it is not one to keep two copies of.
+import { getMicPermissionErrorMessage } from '@/lib/voice/mic-errors';
 import { createId } from '@paralleldrive/cuid2';
 
 const TTS_MAX_CHARS = 1500;
-
-function getMicPermissionErrorMessage(err: unknown): string {
-  const isDesktop = typeof window !== 'undefined' && !!window.electron?.isDesktop;
-
-  if (err instanceof DOMException) {
-    if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
-      if (isDesktop) {
-        return 'Microphone access was blocked. Allow PageSpace in System Settings > Privacy & Security > Microphone, then try again.';
-      }
-      return 'Microphone access was blocked. Please allow microphone permissions in your browser settings and try again.';
-    }
-    if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
-      return 'No microphone was detected. Connect a microphone and try again.';
-    }
-    if (err.name === 'NotReadableError' || err.name === 'TrackStartError') {
-      return 'Your microphone is busy in another app. Close other apps using the mic and try again.';
-    }
-  }
-
-  if (err instanceof TypeError) {
-    return 'This browser does not support microphone capture for voice mode.';
-  }
-
-  return 'Unable to start voice mode because microphone access failed. Please try again.';
-}
 
 function getTranscriptionErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message.trim()) {

--- a/apps/web/src/lib/ai/realtime/__tests__/chain-schedule.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/chain-schedule.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAIN_LEAD_MS,
+  MIN_CHAIN_DELAY_MS,
+  chainDelayMs,
+} from '../chain-schedule';
+
+describe('chainDelayMs', () => {
+  it('given the default 10-minute cap, should chain a lead time before it', () => {
+    expect(chainDelayMs(600_000)).toBe(600_000 - CHAIN_LEAD_MS);
+  });
+
+  it('given the hour-long socket ceiling, should still chain ahead of it', () => {
+    expect(chainDelayMs(3_600_000)).toBe(3_600_000 - CHAIN_LEAD_MS);
+  });
+
+  it('given no cap reported, should not chain', () => {
+    // Nothing known to get ahead of — chaining on a guess would churn calls.
+    expect(chainDelayMs(undefined)).toBeUndefined();
+  });
+
+  it('given a nonsensical cap, should not chain', () => {
+    expect(chainDelayMs(0)).toBeUndefined();
+    expect(chainDelayMs(-1)).toBeUndefined();
+    expect(chainDelayMs(Number.NaN)).toBeUndefined();
+    expect(chainDelayMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it('given a cap too short to get ahead of, should not chain', () => {
+    // A handshake needs more headroom than the whole call has left; the honest
+    // outcome is one call that ends at its cap, not a session spent handing off.
+    expect(chainDelayMs(CHAIN_LEAD_MS + MIN_CHAIN_DELAY_MS - 1)).toBeUndefined();
+  });
+
+  it('given a cap exactly at the churn floor, should chain', () => {
+    expect(chainDelayMs(CHAIN_LEAD_MS + MIN_CHAIN_DELAY_MS)).toBe(
+      MIN_CHAIN_DELAY_MS,
+    );
+  });
+
+  it('given explicit lead and floor overrides, should honour them', () => {
+    expect(chainDelayMs(100_000, 10_000, 1_000)).toBe(90_000);
+    expect(chainDelayMs(100_000, 10_000, 95_000)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/connect.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/connect.test.ts
@@ -1,0 +1,475 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  VOICE_CALL_ROUTE,
+  connectVoiceCall,
+  failureForStatus,
+  type VoiceConnectDeps,
+} from '../connect';
+import type { VoiceTarget } from '../voice-target';
+import {
+  CALL_OK,
+  FakePeerConnection,
+  asPeer,
+  asStream,
+  fakeCreateMediaStream,
+  fakeStream,
+  respondWith,
+} from './webrtc-fakes';
+
+const TARGET: VoiceTarget = { conversationId: 'conv-1', type: 'global' };
+
+const named = (name: string): Error => {
+  const error = new Error(name);
+  error.name = name;
+  return error;
+};
+
+type Harness = {
+  readonly peer: FakePeerConnection;
+  readonly microphone: ReturnType<typeof fakeStream>;
+  readonly fetchImpl: ReturnType<typeof vi.fn>;
+  readonly events: unknown[];
+  readonly remoteStreams: MediaStream[];
+  readonly lost: ReturnType<typeof vi.fn>;
+  readonly deps: VoiceConnectDeps;
+};
+
+const harness = (
+  overrides: Partial<VoiceConnectDeps> = {},
+  response: Response = respondWith({ body: CALL_OK }),
+): Harness => {
+  const peer = new FakePeerConnection();
+  const microphone = fakeStream('mic-1');
+  const events: unknown[] = [];
+  const remoteStreams: MediaStream[] = [];
+  const lost = vi.fn();
+  const fetchImpl = vi.fn(async () => response);
+
+  const deps: VoiceConnectDeps = {
+    target: TARGET,
+    onEvent: (event) => events.push(event),
+    onRemoteTrack: (stream) => remoteStreams.push(stream),
+    onConnectionLost: lost,
+    fetchImpl: fetchImpl as unknown as VoiceConnectDeps['fetchImpl'],
+    createPeerConnection: () => asPeer(peer),
+    getUserMedia: async () => asStream(microphone),
+    createMediaStream: fakeCreateMediaStream,
+    ...overrides,
+  };
+
+  return { peer, microphone, fetchImpl, events, remoteStreams, lost, deps };
+};
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('failureForStatus', () => {
+  it('given each status the route can refuse with, should name a distinct failure', () => {
+    expect(failureForStatus(401)).toBe('unauthorized');
+    expect(failureForStatus(403)).toBe('not-entitled');
+    expect(failureForStatus(503)).toBe('unavailable');
+    expect(failureForStatus(502)).toBe('call-rejected');
+    expect(failureForStatus(400)).toBe('signaling-failed');
+    expect(failureForStatus(500)).toBe('signaling-failed');
+  });
+});
+
+describe('connectVoiceCall — the handshake', () => {
+  it('given a working route, should return the call and apply the answer', async () => {
+    const h = harness();
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.connection.callId).toBe('rtc_call_one');
+    expect(result.connection.attached).toBe(true);
+    expect(result.connection.maxDurationMs).toBe(600_000);
+    expect(h.peer.remoteDescription).toEqual({
+      type: 'answer',
+      sdp: 'v=0 fake answer',
+    });
+    expect(h.peer.addedTracks.map((t) => t.id)).toEqual(['mic-1']);
+  });
+
+  it('should post the offer and the bound conversation to OUR route only', async () => {
+    // The page must never hold an OpenAI credential, which starts with never
+    // talking to api.openai.com.
+    const h = harness();
+
+    await connectVoiceCall(h.deps);
+
+    expect(h.fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = h.fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(VOICE_CALL_ROUTE);
+    expect(url).not.toContain('openai.com');
+    expect(JSON.parse(String(init.body))).toEqual({
+      sdp: 'v=0 fake offer',
+      conversationId: 'conv-1',
+    });
+  });
+
+  it('given a location and timezone, should forward both for the tools', async () => {
+    const locationContext = {
+      currentPage: { id: 'p1', title: 'Notes', type: 'DOCUMENT', path: '/notes' },
+    };
+    const h = harness({ locationContext, timezone: 'America/Chicago' });
+
+    await connectVoiceCall(h.deps);
+
+    const [, init] = h.fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      timezone: 'America/Chicago',
+      locationContext,
+    });
+  });
+
+  it('should open the oai-events channel and surface parsed frames only', async () => {
+    const h = harness();
+
+    await connectVoiceCall(h.deps);
+    expect(h.peer.events.label).toBe('oai-events');
+
+    h.peer.events.deliver(JSON.stringify({ type: 'response.done' }));
+    h.peer.events.deliver('not json at all');
+    h.peer.events.deliver(JSON.stringify({ type: 'session.updated' }));
+
+    expect(h.events).toEqual([
+      { type: 'response.done' },
+      { type: 'session.updated' },
+    ]);
+  });
+
+  it('should surface the model’s voice as a remote stream', async () => {
+    const h = harness();
+    await connectVoiceCall(h.deps);
+
+    const modelVoice = fakeStream('model-1');
+    h.peer.deliverRemoteTrack(modelVoice);
+
+    expect(h.remoteStreams).toEqual([modelVoice]);
+  });
+});
+
+describe('connectVoiceCall — the microphone', () => {
+  it('given a denied prompt vs a missing device, should give different reasons and different advice', async () => {
+    const denied = await connectVoiceCall(
+      harness({
+        getUserMedia: async () => {
+          throw named('NotAllowedError');
+        },
+      }).deps,
+    );
+    const missing = await connectVoiceCall(
+      harness({
+        getUserMedia: async () => {
+          throw named('NotFoundError');
+        },
+      }).deps,
+    );
+
+    expect(denied.ok).toBe(false);
+    expect(missing.ok).toBe(false);
+    if (denied.ok || missing.ok) return;
+    expect(denied.reason).toBe('mic-denied');
+    expect(missing.reason).toBe('mic-missing');
+    expect(denied.message).not.toBe(missing.message);
+  });
+
+  it('given a mic held by another app, should say so rather than blame permissions', async () => {
+    const result = await connectVoiceCall(
+      harness({
+        getUserMedia: async () => {
+          throw named('NotReadableError');
+        },
+      }).deps,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('mic-busy');
+    expect(result.message).toContain('busy in another app');
+  });
+
+  it('given a refused microphone, should not open a peer connection at all', async () => {
+    // No permission, no call: there is nothing to offer and nothing to clean up.
+    const h = harness({
+      getUserMedia: async () => {
+        throw named('NotAllowedError');
+      },
+    });
+
+    await connectVoiceCall(h.deps);
+
+    expect(h.fetchImpl).not.toHaveBeenCalled();
+    expect(h.peer.addedTracks).toEqual([]);
+  });
+
+  it('given a microphone to reuse, should clone it and leave the original running', async () => {
+    // Chaining depends on this: the call being replaced stops its own tracks,
+    // and the new call must survive that without a second permission prompt.
+    const existing = fakeStream('mic-original');
+    const h = harness({ microphone: asStream(existing), getUserMedia: undefined });
+
+    const result = await connectVoiceCall({
+      ...h.deps,
+      getUserMedia: async () => {
+        throw new Error('getUserMedia must not be called when reusing a mic');
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(h.peer.addedTracks.map((t) => t.id)).toEqual(['mic-original:clone']);
+
+    result.connection.stop();
+    expect(existing.tracks.map((t) => t.stopped)).toEqual([false]);
+  });
+
+  it('given a microphone with no audio tracks to reuse, should refuse rather than offer silence', async () => {
+    // A call built on an empty stream negotiates fine and then never hears
+    // anything — the failure has to land here, where it is still explicable.
+    const h = harness({ microphone: asStream(fakeStream()) });
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('mic-unknown');
+    expect(h.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('given a chained call, should be able to start silent and be unsilenced at the swap', async () => {
+    const existing = fakeStream('mic-original');
+    const h = harness({
+      microphone: asStream(existing),
+      microphoneEnabled: false,
+    });
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(h.peer.addedTracks.map((t) => t.enabled)).toEqual([false]);
+
+    result.connection.setMicrophoneEnabled(true);
+    expect(h.peer.addedTracks.map((t) => t.enabled)).toEqual([true]);
+  });
+});
+
+describe('connectVoiceCall — refusals from our route', () => {
+  const refusal = async (status: number, body: unknown) => {
+    const h = harness({}, respondWith({ status, body }));
+    const result = await connectVoiceCall(h.deps);
+    return { h, result };
+  };
+
+  it('given a free-tier account, should carry the server’s own upgrade sentence', async () => {
+    const { result } = await refusal(403, {
+      error: 'Pro plan required',
+      message: 'Voice mode requires a Pro or above subscription.',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('not-entitled');
+    expect(result.message).toBe(
+      'Voice mode requires a Pro or above subscription.',
+    );
+  });
+
+  it('given OpenAI refused the model, should name the failure and keep the code for debugging', async () => {
+    const { result } = await refusal(502, {
+      error: 'Voice call failed',
+      code: 'realtime_call_rejected',
+      message: 'OpenAI rejected the realtime call.',
+      upstreamStatus: 403,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('call-rejected');
+    expect(result.detail).toContain('realtime_call_rejected');
+    expect(result.detail).toContain('502');
+  });
+
+  it('given an unconfigured deployment, should say so', async () => {
+    const { result } = await refusal(503, {
+      error: 'Voice mode unavailable',
+      message: 'Voice mode is not configured on this deployment.',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('unavailable');
+  });
+
+  it('given a signed-out session, should say the session expired', async () => {
+    const { result } = await refusal(401, { error: 'Unauthorized' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('unauthorized');
+    expect(result.message).toBe('Unauthorized');
+  });
+
+  it('given a non-JSON error body, should still speak a sentence and keep the raw text', async () => {
+    const h = harness(
+      {},
+      respondWith({ status: 502, text: '<html>bad gateway</html>' }),
+    );
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toBe(
+      'The voice service refused the call. Check the server logs.',
+    );
+    expect(result.detail).toContain('bad gateway');
+  });
+
+  it('given any refusal, should stop the microphone and close the connection', async () => {
+    const h = harness({}, respondWith({ status: 502, body: {} }));
+
+    await connectVoiceCall(h.deps);
+
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+    expect(h.peer.closed).toBe(true);
+  });
+});
+
+describe('connectVoiceCall — broken handshakes', () => {
+  it('given the route is unreachable, should fail by name and leak nothing', async () => {
+    const h = harness();
+    const result = await connectVoiceCall({
+      ...h.deps,
+      fetchImpl: async () => {
+        throw new Error('offline');
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('signaling-failed');
+    expect(result.detail).toContain(VOICE_CALL_ROUTE);
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+    expect(h.peer.closed).toBe(true);
+  });
+
+  it('given the transport cannot make an offer, should name that step', async () => {
+    const h = harness();
+    h.peer.failOn = 'createOffer';
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toContain('createOffer');
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+  });
+
+  it('given a 200 with no answer SDP, should refuse rather than sit on a dead call', async () => {
+    const h = harness(
+      {},
+      respondWith({ body: { callId: 'rtc_x', attached: true } }),
+    );
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toContain('answer SDP');
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+    expect(h.peer.closed).toBe(true);
+  });
+
+  it('given a 200 with no call id, should refuse', async () => {
+    const h = harness(
+      {},
+      respondWith({ body: { answerSdp: 'v=0 answer', attached: true } }),
+    );
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.detail).toContain('callId');
+  });
+
+  it('given an answer the transport rejects, should clean up', async () => {
+    const h = harness();
+    h.peer.failOn = 'setRemoteDescription';
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('signaling-failed');
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+    expect(h.peer.closed).toBe(true);
+  });
+
+  it('given a server with no realtime attach, should still hand back a working call marked degraded', async () => {
+    const h = harness(
+      {},
+      respondWith({ body: { ...CALL_OK, attached: false } }),
+    );
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.connection.attached).toBe(false);
+  });
+
+  it('given no cap reported, should report none rather than invent one', async () => {
+    const h = harness(
+      {},
+      respondWith({ body: { ...CALL_OK, maxDurationMs: 'soon' } }),
+    );
+
+    const result = await connectVoiceCall(h.deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.connection.maxDurationMs).toBeUndefined();
+  });
+});
+
+describe('connectVoiceCall — losing the connection', () => {
+  it('given the peer connection drops, should report the loss once per drop', async () => {
+    const h = harness();
+    await connectVoiceCall(h.deps);
+
+    h.peer.transitionTo('connected');
+    expect(h.lost).not.toHaveBeenCalled();
+
+    h.peer.transitionTo('failed');
+    expect(h.lost).toHaveBeenCalledTimes(1);
+  });
+
+  it('given ICE gives up, should treat disconnected as a loss', async () => {
+    const h = harness();
+    await connectVoiceCall(h.deps);
+
+    h.peer.transitionTo('disconnected');
+
+    expect(h.lost).toHaveBeenCalledTimes(1);
+  });
+
+  it('given a deliberate hangup, should NOT report it as a dropped connection', async () => {
+    // Closing drives the connection to `closed`, which is a lost state. A user
+    // who hangs up must not be shown an error for doing so.
+    const h = harness();
+    const result = await connectVoiceCall(h.deps);
+    if (!result.ok) throw new Error('expected a connection');
+
+    result.connection.stop();
+
+    expect(h.lost).not.toHaveBeenCalled();
+    expect(h.peer.closed).toBe(true);
+    expect(h.microphone.tracks.every((t) => t.stopped)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-target.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { decideBind, sameVoiceTarget, type VoiceTarget } from '../voice-target';
+
+const GLOBAL: VoiceTarget = { conversationId: 'conv-1', type: 'global' };
+const PAGE: VoiceTarget = {
+  conversationId: 'conv-2',
+  type: 'page',
+  contextId: 'page-1',
+  agentPageId: 'agent-1',
+};
+
+describe('sameVoiceTarget', () => {
+  it('given two targets with identical fields, should call them the same binding', () => {
+    expect(sameVoiceTarget(PAGE, { ...PAGE })).toBe(true);
+  });
+
+  it('given a different conversation, should call it a different binding', () => {
+    expect(sameVoiceTarget(GLOBAL, { ...GLOBAL, conversationId: 'conv-9' })).toBe(
+      false,
+    );
+  });
+
+  it('given the same conversation under a different agent, should call it a different binding', () => {
+    // The switcher can move agents while a conversation id is still resolving;
+    // matching on conversationId alone would keep talking to the old agent.
+    expect(sameVoiceTarget(PAGE, { ...PAGE, agentPageId: 'agent-2' })).toBe(
+      false,
+    );
+  });
+
+  it('given the same conversation in a different context, should call it a different binding', () => {
+    expect(sameVoiceTarget(PAGE, { ...PAGE, contextId: 'page-9' })).toBe(false);
+    expect(sameVoiceTarget(PAGE, { ...PAGE, type: 'drive' })).toBe(false);
+  });
+
+  it('given two unbound sessions, should call them the same', () => {
+    expect(sameVoiceTarget(null, null)).toBe(true);
+  });
+
+  it('given one unbound session, should call it different', () => {
+    expect(sameVoiceTarget(null, GLOBAL)).toBe(false);
+    expect(sameVoiceTarget(GLOBAL, null)).toBe(false);
+  });
+});
+
+describe('decideBind', () => {
+  it('given nothing bound, should start', () => {
+    expect(decideBind(null, GLOBAL)).toBe('start');
+  });
+
+  it('given the target already bound, should do nothing', () => {
+    // A second press, or a re-render handing back the same target, must not
+    // restart a call mid-sentence.
+    expect(decideBind(GLOBAL, { ...GLOBAL })).toBe('none');
+  });
+
+  it('given a deliberately different agent, should rebind', () => {
+    expect(decideBind(PAGE, { ...PAGE, agentPageId: 'agent-2' })).toBe('rebind');
+  });
+
+  it('given a different conversation, should rebind', () => {
+    expect(decideBind(GLOBAL, PAGE)).toBe('rebind');
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/webrtc-fakes.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/webrtc-fakes.ts
@@ -1,0 +1,169 @@
+/**
+ * Fakes for the three browser capabilities a voice call needs: a peer
+ * connection, a microphone, and a data channel.
+ *
+ * jsdom implements none of them, and a live call cannot be a unit test — so
+ * these stand in, and they record enough (tracks stopped, connections closed,
+ * descriptions applied) that teardown can be ASSERTED rather than assumed. A
+ * leaked microphone is invisible in production until someone notices the
+ * recording indicator is still on.
+ */
+
+export class FakeTrack {
+  public enabled = true;
+  public stopped = false;
+  public readonly kind = 'audio';
+
+  constructor(public readonly id: string) {}
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  /** A clone shares the device but is independent: stopping one leaves the other live. */
+  clone(): FakeTrack {
+    return new FakeTrack(`${this.id}:clone`);
+  }
+}
+
+export class FakeStream {
+  constructor(public readonly tracks: FakeTrack[]) {}
+
+  getTracks(): FakeTrack[] {
+    return this.tracks;
+  }
+
+  getAudioTracks(): FakeTrack[] {
+    return this.tracks;
+  }
+}
+
+export const fakeStream = (...ids: string[]): FakeStream =>
+  new FakeStream(ids.map((id) => new FakeTrack(id)));
+
+export class FakeDataChannel {
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+  public closed = false;
+
+  constructor(public readonly label: string) {}
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Drive a frame in from the model. */
+  deliver(data: unknown): void {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+}
+
+export class FakePeerConnection {
+  public connectionState: RTCPeerConnectionState = 'new';
+  public onconnectionstatechange: (() => void) | null = null;
+  public ontrack: ((event: RTCTrackEvent) => void) | null = null;
+  public closed = false;
+  public readonly addedTracks: FakeTrack[] = [];
+  public readonly channels: FakeDataChannel[] = [];
+  public localDescription: RTCSessionDescriptionInit | null = null;
+  public remoteDescription: RTCSessionDescriptionInit | null = null;
+  /** Set to make `createOffer` reject, standing in for a broken transport. */
+  public failOn: 'createOffer' | 'setRemoteDescription' | null = null;
+
+  constructor(public readonly offerSdp = 'v=0 fake offer') {}
+
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    if (this.failOn === 'createOffer') throw new Error('no transport');
+    return { type: 'offer', sdp: this.offerSdp };
+  }
+
+  async setLocalDescription(
+    description: RTCSessionDescriptionInit,
+  ): Promise<void> {
+    this.localDescription = description;
+  }
+
+  async setRemoteDescription(
+    description: RTCSessionDescriptionInit,
+  ): Promise<void> {
+    if (this.failOn === 'setRemoteDescription') {
+      throw new Error('unparseable answer');
+    }
+    this.remoteDescription = description;
+  }
+
+  addTrack(track: FakeTrack): void {
+    this.addedTracks.push(track);
+  }
+
+  createDataChannel(label: string): FakeDataChannel {
+    const channel = new FakeDataChannel(label);
+    this.channels.push(channel);
+    return channel;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.connectionState = 'closed';
+    // Real peer connections DO fire the state change on close. Firing it here
+    // is what proves `stop` detaches the handler rather than relying on the
+    // caller to ignore a loss it caused itself.
+    this.onconnectionstatechange?.();
+  }
+
+  /** Drive a spontaneous connection state change, the way a dropped call does. */
+  transitionTo(state: RTCPeerConnectionState): void {
+    this.connectionState = state;
+    this.onconnectionstatechange?.();
+  }
+
+  /** Deliver the model's voice. */
+  deliverRemoteTrack(stream: FakeStream): void {
+    this.ontrack?.({ streams: [stream] } as unknown as RTCTrackEvent);
+  }
+
+  get events(): FakeDataChannel {
+    const channel = this.channels[0];
+    if (!channel) throw new Error('no data channel was opened');
+    return channel;
+  }
+}
+
+/** The shapes above, narrowed to what the production types demand. */
+export const asPeer = (peer: FakePeerConnection): RTCPeerConnection =>
+  peer as unknown as RTCPeerConnection;
+
+export const asStream = (stream: FakeStream): MediaStream =>
+  stream as unknown as MediaStream;
+
+/** `new MediaStream(tracks)` does not exist in jsdom; this is its stand-in. */
+export const fakeCreateMediaStream = (tracks: MediaStreamTrack[]): MediaStream =>
+  asStream(new FakeStream(tracks as unknown as FakeTrack[]));
+
+export type JsonResponse = {
+  readonly status?: number;
+  readonly body?: unknown;
+  /** Raw text, for asserting a non-JSON error body is handled. */
+  readonly text?: string;
+};
+
+/** A `fetch` stand-in returning one canned response. */
+export const respondWith = ({
+  status = 200,
+  body,
+  text,
+}: JsonResponse): Response => {
+  const payload = text ?? JSON.stringify(body ?? {});
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => payload,
+    json: async () => JSON.parse(payload) as unknown,
+  } as unknown as Response;
+};
+
+export const CALL_OK = {
+  callId: 'rtc_call_one',
+  answerSdp: 'v=0 fake answer',
+  attached: true,
+  maxDurationMs: 600_000,
+};

--- a/apps/web/src/lib/ai/realtime/chain-schedule.ts
+++ b/apps/web/src/lib/ai/realtime/chain-schedule.ts
@@ -1,0 +1,55 @@
+/**
+ * When to chain a live call into a fresh one.
+ *
+ * A realtime call has a hard server-enforced ceiling (`REALTIME_MAX_SESSION_SECONDS`,
+ * plus the socket's own hour) after which the realtime server hangs it up. That
+ * ceiling exists to bound a call nobody ended; it is not a limit on how long a
+ * CONVERSATION may last, and the two must not be confused. So shortly before it
+ * lands, the client mints a NEW call bound to the same conversation, which the
+ * server reseeds from that conversation's thread — the transcript is the durable
+ * layer, so the new session picks up knowing what was already said. The
+ * conversation id never changes; only the transport underneath it does.
+ *
+ * The ceiling is server-owned and env-tunable, which is why it is READ FROM THE
+ * HANDSHAKE RESPONSE rather than restated here. A client-side copy of a server
+ * env var is a copy that drifts, and the failure mode of drift is a user cut off
+ * mid-sentence on the one deployment that tuned it.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state. The
+ * caller owns the timer; this module only says how long it should be.
+ */
+
+/**
+ * Headroom before the cap. It covers a whole handshake — mint, relay to OpenAI,
+ * the internal attach — whose own upstream timeout is 15s, plus the moment of
+ * swapping which stream feeds the speaker.
+ */
+export const CHAIN_LEAD_MS = 20_000;
+
+/**
+ * A floor on how often calls may be churned. Below this, chaining costs more
+ * than it buys: every chain is two concurrent calls, a fresh seed replay, and a
+ * new hold against the credit gate.
+ */
+export const MIN_CHAIN_DELAY_MS = 30_000;
+
+/**
+ * How long after connecting to start the next call, or `undefined` for "do not
+ * chain this one".
+ *
+ * `undefined` is returned for a cap that is absent, nonsensical, or too short to
+ * get ahead of. That last case is deliberate: when the ceiling is tighter than
+ * the headroom a handshake needs, the honest outcome is to let the call end at
+ * its cap and report it, not to spend the entire session handing off.
+ */
+export const chainDelayMs = (
+  maxDurationMs: number | undefined,
+  leadMs: number = CHAIN_LEAD_MS,
+  minDelayMs: number = MIN_CHAIN_DELAY_MS,
+): number | undefined => {
+  if (maxDurationMs === undefined) return undefined;
+  if (!Number.isFinite(maxDurationMs) || maxDurationMs <= 0) return undefined;
+
+  const delay = maxDurationMs - leadMs;
+  return delay >= minDelayMs ? delay : undefined;
+};

--- a/apps/web/src/lib/ai/realtime/connect.ts
+++ b/apps/web/src/lib/ai/realtime/connect.ts
@@ -1,0 +1,400 @@
+/**
+ * The browser half of a live voice call: microphone in, model's voice out,
+ * event stream on a data channel — and NOT ONE LINE of OpenAI credential
+ * handling.
+ *
+ * The page opens a peer connection, adds the mic track, opens the `oai-events`
+ * data channel, and POSTs its SDP offer to OUR route
+ * (`POST /api/voice/realtime/call`), which relays it to OpenAI and answers with
+ * the answer SDP. `api.openai.com` is never contacted from here, no ephemeral
+ * secret ever reaches the page, and the tool schemas are not sent to the client
+ * at all — they ride a signed server-to-server hop the browser cannot see.
+ *
+ * WHY THE MICROPHONE IS ASKED FOR FIRST, which is the reverse of the prototype's
+ * order. The prototype asked its server for a secret before touching the mic, so
+ * a misconfigured deployment could not trigger a permission prompt for nothing.
+ * With a relay route that is not available: the route's input IS the SDP offer,
+ * and an offer cannot exist before there is a track to offer. The trade is a
+ * prompt that can be followed by a 503 — and the far larger prize is that the
+ * page holds no credential.
+ *
+ * Isolated from React on purpose. Every effect is a parameter, so the whole
+ * handshake runs against fakes with no live network and no real microphone.
+ */
+
+import { REALTIME_DATA_CHANNEL } from './session';
+import type { VoiceTarget } from './voice-target';
+import { parseEvent } from '@pagespace/lib/realtime/voice-events';
+import type { VoiceLocationContext } from '@pagespace/lib/realtime/voice-bridge-contract';
+import {
+  classifyMicFailure,
+  getMicPermissionErrorMessage,
+  type MicFailure,
+} from '@/lib/voice/mic-errors';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+/** Our own route. The OpenAI endpoints are the server's business, not ours. */
+export const VOICE_CALL_ROUTE = '/api/voice/realtime/call';
+
+/**
+ * What the route can refuse us with, as distinct from what the microphone can.
+ * Kept separate from the `mic-*` cases below because these five all carry a
+ * sentence the SERVER wrote — the upgrade prompt, the unconfigured deployment —
+ * and ours are only the fallback for when it did not.
+ */
+export type RouteFailure =
+  /** Signed out — the route refused before it ever looked at the offer. */
+  | 'unauthorized'
+  /** Authenticated, but the plan does not include voice. */
+  | 'not-entitled'
+  /** This deployment has no managed voice key configured. */
+  | 'unavailable'
+  /** Our server reached OpenAI and OpenAI refused the call. */
+  | 'call-rejected'
+  /** The handshake broke on our side of the wire: SDP, transport, or route. */
+  | 'signaling-failed';
+
+/**
+ * Every distinct thing that can go wrong, named. The five `mic-*` cases are
+ * generated from `MicFailure` rather than restated, so the two lists cannot
+ * drift: a denied prompt and an absent device are different outcomes needing
+ * opposite advice, and flattening them into one "voice failed" is what makes a
+ * user try the wrong fix.
+ */
+export type VoiceConnectFailure = `mic-${MicFailure}` | RouteFailure;
+
+export type VoiceConnection = {
+  /** The `rtc_…` id. Not the session (`sess_…`) and not a function call (`call_…`). */
+  readonly callId: string;
+  /**
+   * Whether the realtime server took the call. `false` is a WORKING audio call
+   * with no tools, no transcript persistence and no metering — the server
+   * reports that honestly rather than implying full capability, so the UI can.
+   */
+  readonly attached: boolean;
+  /** The server-enforced ceiling on this call, for chaining ahead of it. */
+  readonly maxDurationMs: number | undefined;
+  /** The stream this connection OWNS. Stopped by `stop`, and only by `stop`. */
+  readonly microphone: MediaStream;
+  /** Silence or unsilence the mic without renegotiating or dropping the call. */
+  readonly setMicrophoneEnabled: (enabled: boolean) => void;
+  readonly stop: () => void;
+};
+
+export type VoiceConnectFailed = {
+  readonly ok: false;
+  readonly reason: VoiceConnectFailure;
+  /** One sentence, for a human. */
+  readonly message: string;
+  /** Which step broke, for whoever has to debug it. */
+  readonly detail: string;
+};
+
+export type VoiceConnectResult =
+  | { readonly ok: true; readonly connection: VoiceConnection }
+  | VoiceConnectFailed;
+
+export type VoiceConnectDeps = {
+  /** The conversation this call speaks into. */
+  readonly target: VoiceTarget;
+  /** Where the user is standing, for the tools. A default, never an authorization. */
+  readonly locationContext?: VoiceLocationContext;
+  readonly timezone?: string;
+  /**
+   * An already-granted microphone to reuse. Its tracks are CLONED, never
+   * adopted: a chained call must keep working after the call it replaced stops
+   * its own tracks, and a clone is independent of the original while sharing
+   * the same device — so the user is prompted once and the recording indicator
+   * never blinks between calls.
+   */
+  readonly microphone?: MediaStream;
+  /**
+   * Whether the mic is live from the moment the call connects. A chained call
+   * starts silent so two sessions cannot both hear the same sentence during the
+   * moment they overlap.
+   */
+  readonly microphoneEnabled?: boolean;
+  readonly onEvent: (event: unknown) => void;
+  readonly onRemoteTrack: (stream: MediaStream) => void;
+  /** The connection left a usable state on its own. Never fired by `stop`. */
+  readonly onConnectionLost: () => void;
+
+  // Seams. Defaults are the real thing; tests hand in fakes.
+  readonly fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>;
+  readonly createPeerConnection?: () => RTCPeerConnection;
+  readonly getUserMedia?: (
+    constraints: MediaStreamConstraints,
+  ) => Promise<MediaStream>;
+  /** Only reached when reusing a microphone; jsdom has no `MediaStream`. */
+  readonly createMediaStream?: (tracks: MediaStreamTrack[]) => MediaStream;
+};
+
+const ROUTE_MESSAGES: Record<RouteFailure, string> = {
+  unauthorized: 'Your session expired. Sign in again to start a voice call.',
+  'not-entitled': 'Voice calls need a Pro plan or above.',
+  unavailable: 'Voice mode is not configured on this deployment.',
+  'call-rejected': 'The voice service refused the call. Check the server logs.',
+  'signaling-failed': 'Could not reach the voice service.',
+};
+
+export const describeThrown = (error: unknown): string =>
+  error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : `non-error thrown: ${String(error)}`;
+
+/**
+ * States a peer connection does not come back from. `disconnected` is included
+ * even though ICE can sometimes recover from it: a voice call that has already
+ * stopped carrying audio has failed as far as the person talking is concerned,
+ * and silently waiting on a maybe-recovery is worse than saying so.
+ */
+const LOST_STATES = new Set<RTCPeerConnectionState>([
+  'failed',
+  'disconnected',
+  'closed',
+]);
+
+/** Map our route's status onto a named failure. */
+export const failureForStatus = (status: number): RouteFailure => {
+  if (status === 401) return 'unauthorized';
+  if (status === 403) return 'not-entitled';
+  if (status === 503) return 'unavailable';
+  if (status === 502) return 'call-rejected';
+  return 'signaling-failed';
+};
+
+/**
+ * Read the route's error body without letting a non-JSON one throw over the
+ * real error. The route speaks `{ error, message, code, upstream, … }`;
+ * `message` is the sentence written for a human, `error` the short label.
+ */
+const readRouteError = async (
+  response: Response,
+): Promise<{ message: string | undefined; detail: string }> => {
+  const text = await response.text().catch(() => '');
+  let message: string | undefined;
+  let code: string | undefined;
+  try {
+    const body: unknown = JSON.parse(text);
+    if (typeof body === 'object' && body !== null) {
+      const record = body as Record<string, unknown>;
+      const spoken = record.message ?? record.error;
+      if (typeof spoken === 'string' && spoken.length > 0) message = spoken;
+      if (typeof record.code === 'string') code = record.code;
+    }
+  } catch {
+    // Not JSON. The raw text is still the best detail available.
+  }
+  return {
+    message,
+    detail: `${VOICE_CALL_ROUTE} returned ${response.status}${
+      code === undefined ? '' : ` (${code})`
+    }: ${text.slice(0, 300)}`,
+  };
+};
+
+const failure = (
+  reason: VoiceConnectFailure,
+  detail: string,
+  message: string,
+): VoiceConnectFailed => {
+  // The UI shows one speakable sentence; the console carries the cause.
+  console.error(`[voice] ${reason}: ${detail}`);
+  return { ok: false, reason, message, detail };
+};
+
+type MicResult =
+  | { readonly ok: true; readonly stream: MediaStream }
+  | VoiceConnectFailed;
+
+/**
+ * The call's own microphone: a fresh grant, or independent clones of one the
+ * caller already holds.
+ */
+const acquireMicrophone = async (
+  deps: VoiceConnectDeps,
+  getUserMedia: (c: MediaStreamConstraints) => Promise<MediaStream>,
+  createMediaStream: (tracks: MediaStreamTrack[]) => MediaStream,
+): Promise<MicResult> => {
+  if (deps.microphone) {
+    const clones = deps.microphone
+      .getAudioTracks()
+      .map((track) => track.clone());
+    if (clones.length === 0) {
+      return failure(
+        'mic-unknown',
+        'the microphone handed in for reuse carried no audio tracks',
+        getMicPermissionErrorMessage(undefined),
+      );
+    }
+    return { ok: true, stream: createMediaStream(clones) };
+  }
+
+  try {
+    return { ok: true, stream: await getUserMedia({ audio: true }) };
+  } catch (error) {
+    return failure(
+      `mic-${classifyMicFailure(error)}`,
+      describeThrown(error),
+      getMicPermissionErrorMessage(error),
+    );
+  }
+};
+
+export const connectVoiceCall = async (
+  deps: VoiceConnectDeps,
+): Promise<VoiceConnectResult> => {
+  const fetchImpl = deps.fetchImpl ?? fetchWithAuth;
+  const createPeerConnection =
+    deps.createPeerConnection ?? (() => new RTCPeerConnection());
+  const getUserMedia =
+    deps.getUserMedia ??
+    ((constraints: MediaStreamConstraints) =>
+      navigator.mediaDevices.getUserMedia(constraints));
+  const createMediaStream =
+    deps.createMediaStream ?? ((tracks: MediaStreamTrack[]) => new MediaStream(tracks));
+
+  const acquired = await acquireMicrophone(deps, getUserMedia, createMediaStream);
+  if (!acquired.ok) return acquired;
+  const microphone = acquired.stream;
+
+  const setMicrophoneEnabled = (next: boolean) => {
+    for (const track of microphone.getAudioTracks()) {
+      track.enabled = next;
+    }
+  };
+  setMicrophoneEnabled(deps.microphoneEnabled ?? true);
+
+  const peer = createPeerConnection();
+
+  /**
+   * Teardown. The state handler is detached BEFORE closing, because closing
+   * drives the connection to `closed` — which is in `LOST_STATES` — and a
+   * deliberate hangup reported as a connection loss would show the user an
+   * error for something they just did.
+   */
+  const stop = () => {
+    peer.onconnectionstatechange = null;
+    peer.ontrack = null;
+    for (const track of microphone.getTracks()) {
+      track.stop();
+    }
+    peer.close();
+  };
+
+  peer.ontrack = (event: RTCTrackEvent) => {
+    const stream = event.streams[0];
+    if (stream) deps.onRemoteTrack(stream);
+  };
+  peer.onconnectionstatechange = () => {
+    if (LOST_STATES.has(peer.connectionState)) {
+      deps.onConnectionLost();
+    }
+  };
+
+  for (const track of microphone.getTracks()) {
+    peer.addTrack(track, microphone);
+  }
+
+  const channel = peer.createDataChannel(REALTIME_DATA_CHANNEL);
+  channel.onmessage = (message: MessageEvent) => {
+    const event = parseEvent(message.data);
+    if (event !== undefined) {
+      deps.onEvent(event);
+    }
+  };
+
+  // Each step is named so a failure says which one broke. "Handshake failed" is
+  // what makes somebody re-debug this stack from scratch.
+  let step = 'createOffer';
+  let response: Response;
+  try {
+    const offer = await peer.createOffer();
+
+    step = 'setLocalDescription';
+    await peer.setLocalDescription(offer);
+
+    step = `POST ${VOICE_CALL_ROUTE}`;
+    response = await fetchImpl(VOICE_CALL_ROUTE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sdp: offer.sdp,
+        conversationId: deps.target.conversationId,
+        ...(deps.timezone === undefined ? {} : { timezone: deps.timezone }),
+        ...(deps.locationContext === undefined
+          ? {}
+          : { locationContext: deps.locationContext }),
+      }),
+    });
+  } catch (error) {
+    stop();
+    return failure(
+      'signaling-failed',
+      `${step} — ${describeThrown(error)}`,
+      ROUTE_MESSAGES['signaling-failed'],
+    );
+  }
+
+  if (!response.ok) {
+    stop();
+    const reason = failureForStatus(response.status);
+    const { message, detail } = await readRouteError(response);
+    // The route writes the sentence for its own refusals; ours is the fallback,
+    // never the override — it is the one that knows about the upgrade path.
+    return failure(reason, detail, message ?? ROUTE_MESSAGES[reason]);
+  }
+
+  let callId: string;
+  let attached: boolean;
+  let maxDurationMs: number | undefined;
+  try {
+    const body = (await response.json()) as {
+      callId?: unknown;
+      answerSdp?: unknown;
+      attached?: unknown;
+      maxDurationMs?: unknown;
+    };
+    if (typeof body.callId !== 'string' || body.callId.length === 0) {
+      stop();
+      return failure(
+        'signaling-failed',
+        'call response carried no callId',
+        ROUTE_MESSAGES['signaling-failed'],
+      );
+    }
+    if (typeof body.answerSdp !== 'string' || body.answerSdp.length === 0) {
+      stop();
+      return failure(
+        'signaling-failed',
+        'call response carried no answer SDP',
+        ROUTE_MESSAGES['signaling-failed'],
+      );
+    }
+    callId = body.callId;
+    attached = body.attached === true;
+    maxDurationMs =
+      typeof body.maxDurationMs === 'number' ? body.maxDurationMs : undefined;
+
+    await peer.setRemoteDescription({ type: 'answer', sdp: body.answerSdp });
+  } catch (error) {
+    stop();
+    return failure(
+      'signaling-failed',
+      `answer — ${describeThrown(error)}`,
+      ROUTE_MESSAGES['signaling-failed'],
+    );
+  }
+
+  return {
+    ok: true,
+    connection: {
+      callId,
+      attached,
+      maxDurationMs,
+      microphone,
+      setMicrophoneEnabled,
+      stop,
+    },
+  };
+};

--- a/apps/web/src/lib/ai/realtime/voice-target.ts
+++ b/apps/web/src/lib/ai/realtime/voice-target.ts
@@ -1,0 +1,78 @@
+/**
+ * What a voice session is bound TO, and when that binding has actually changed.
+ *
+ * Voice is a second transport onto a conversation that already exists, so a
+ * session is addressed the way every other chat surface addresses one: by
+ * conversation, plus the context that conversation belongs to. The target is
+ * NOT a panel, a route, or a UI mode — those come and go under a live call.
+ *
+ * The distinction this module exists to draw is the one the whole lifecycle
+ * turns on: NAVIGATING is not REBINDING. Walking to another page changes where
+ * the user is standing (`locationContext`, which the tools read) and must leave
+ * the call alone; deliberately choosing a different agent in the switcher
+ * changes who is being talked to, and that is a different conversation with a
+ * different history — it cannot be served by the session already running.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+/**
+ * Mirrors the shape the rest of the app already uses for a conversation
+ * (`conversationState.createAndSetActiveConversation`, `useConversationSubscription`)
+ * rather than inventing a voice-only address. A second addressing scheme would
+ * be the beginning of a second substrate.
+ */
+export type VoiceTarget = {
+  /**
+   * The thread the spoken turns are written into. Required: an unbound call
+   * would still connect and still meter, but its transcript would have nowhere
+   * to land — and the transcript is the artifact of record, not the audio.
+   */
+  readonly conversationId: string;
+  readonly type: 'global' | 'page' | 'drive';
+  /** The page or drive the conversation hangs off, when it hangs off one. */
+  readonly contextId?: string;
+  /** Set when the target is a page agent rather than the global assistant. */
+  readonly agentPageId?: string;
+};
+
+/**
+ * Two targets are the same binding when every addressing field matches.
+ *
+ * `conversationId` alone is deliberately NOT the test. It is very nearly
+ * sufficient — but the agent switcher can move a session to a different agent
+ * while the app is still resolving a conversation id, and treating those as one
+ * binding would silently keep talking to the previous agent through a session
+ * the user believes they switched.
+ */
+export const sameVoiceTarget = (
+  a: VoiceTarget | null,
+  b: VoiceTarget | null,
+): boolean => {
+  if (a === null || b === null) return a === b;
+  return (
+    a.conversationId === b.conversationId &&
+    a.type === b.type &&
+    a.contextId === b.contextId &&
+    a.agentPageId === b.agentPageId
+  );
+};
+
+/**
+ * Whether a request to talk to `next` has to tear down the call bound to
+ * `current`.
+ *
+ * `'none'` means the caller asked for the session it already has — pressing the
+ * voice button twice, or a re-render handing the same target back — and the
+ * live call must survive that, because the alternative is a UI event silently
+ * restarting a conversation mid-sentence.
+ */
+export type BindDecision = 'start' | 'rebind' | 'none';
+
+export const decideBind = (
+  current: VoiceTarget | null,
+  next: VoiceTarget,
+): BindDecision => {
+  if (current === null) return 'start';
+  return sameVoiceTarget(current, next) ? 'none' : 'rebind';
+};

--- a/apps/web/src/lib/voice/__tests__/mic-errors.test.ts
+++ b/apps/web/src/lib/voice/__tests__/mic-errors.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyMicFailure,
+  getMicPermissionErrorMessage,
+  micFailureMessage,
+  type MicFailure,
+} from '../mic-errors';
+
+const named = (name: string): Error => {
+  const error = new Error(name);
+  error.name = name;
+  return error;
+};
+
+describe('classifyMicFailure', () => {
+  it('given a refused prompt, should classify it as denied', () => {
+    expect(classifyMicFailure(named('NotAllowedError'))).toBe('denied');
+    expect(classifyMicFailure(named('PermissionDeniedError'))).toBe('denied');
+  });
+
+  it('given no capture device, should classify it as missing', () => {
+    expect(classifyMicFailure(named('NotFoundError'))).toBe('missing');
+    expect(classifyMicFailure(named('DevicesNotFoundError'))).toBe('missing');
+  });
+
+  it('given a device another app holds, should classify it as busy', () => {
+    expect(classifyMicFailure(named('NotReadableError'))).toBe('busy');
+    expect(classifyMicFailure(named('TrackStartError'))).toBe('busy');
+  });
+
+  it('given a browser with no getUserMedia, should classify it as unsupported', () => {
+    expect(classifyMicFailure(new TypeError('mediaDevices is undefined'))).toBe(
+      'unsupported',
+    );
+  });
+
+  it('given something unrecognised, should classify it as unknown', () => {
+    expect(classifyMicFailure(named('SomeNewError'))).toBe('unknown');
+    expect(classifyMicFailure('not an error at all')).toBe('unknown');
+    expect(classifyMicFailure(undefined)).toBe('unknown');
+    expect(classifyMicFailure(null)).toBe('unknown');
+  });
+
+  it('given a real DOMException, should classify it by name like any other error', () => {
+    expect(
+      classifyMicFailure(new DOMException('denied', 'NotAllowedError')),
+    ).toBe('denied');
+  });
+});
+
+describe('micFailureMessage', () => {
+  const ALL: MicFailure[] = [
+    'denied',
+    'missing',
+    'busy',
+    'unsupported',
+    'unknown',
+  ];
+
+  it('given each distinct failure, should give a distinct message', () => {
+    const messages = ALL.map((failure) => micFailureMessage(failure, false));
+    expect(new Set(messages).size).toBe(ALL.length);
+  });
+
+  it('given a denied prompt, should point at the OS on desktop and the browser on web', () => {
+    const desktop = micFailureMessage('denied', true);
+    const web = micFailureMessage('denied', false);
+
+    expect(desktop).toContain('System Settings');
+    expect(desktop).not.toContain('browser settings');
+    expect(web).toContain('browser settings');
+    expect(web).not.toContain('System Settings');
+  });
+
+  it('given a missing device, should say the same thing in both shells', () => {
+    // Plugging in a microphone is not a per-shell instruction.
+    expect(micFailureMessage('missing', true)).toBe(
+      micFailureMessage('missing', false),
+    );
+  });
+});
+
+describe('getMicPermissionErrorMessage', () => {
+  it('given denied vs missing, should surface different advice', () => {
+    const denied = getMicPermissionErrorMessage(named('NotAllowedError'), false);
+    const missing = getMicPermissionErrorMessage(named('NotFoundError'), false);
+
+    expect(denied).not.toBe(missing);
+    expect(denied).toContain('blocked');
+    expect(missing).toContain('No microphone was detected');
+  });
+
+  it('given the desktop shell, should route a denial to System Settings', () => {
+    expect(
+      getMicPermissionErrorMessage(named('NotAllowedError'), true),
+    ).toContain('System Settings');
+  });
+
+  it('given no explicit shell, should detect it from the window itself', () => {
+    // The default argument is what every real call site uses; if it stopped
+    // consulting the shell, desktop users would be sent to a settings screen
+    // their app does not have.
+    const electron = window.electron;
+    try {
+      expect(getMicPermissionErrorMessage(named('NotAllowedError'))).toContain(
+        'browser settings',
+      );
+
+      (window as { electron?: unknown }).electron = { isDesktop: true };
+      expect(getMicPermissionErrorMessage(named('NotAllowedError'))).toContain(
+        'System Settings',
+      );
+    } finally {
+      (window as { electron?: unknown }).electron = electron;
+    }
+  });
+});

--- a/apps/web/src/lib/voice/mic-errors.ts
+++ b/apps/web/src/lib/voice/mic-errors.ts
@@ -1,0 +1,94 @@
+/**
+ * Why `getUserMedia` failed, and what to tell the user about it.
+ *
+ * Extracted from `useVoiceMode` rather than reimplemented alongside it: the
+ * audio-native path asks for the same microphone through the same API and hits
+ * the same five failures, and the desktop branch below is the reason a fresh
+ * port would be a regression. In an Electron shell a blocked prompt is NOT
+ * fixable in browser settings — the block lives in macOS System Settings, and a
+ * message that says "check your browser settings" sends the user somewhere that
+ * has no such control.
+ *
+ * Denied and missing are DIFFERENT outcomes on purpose. They look identical on
+ * screen ("voice didn't start") and need opposite advice: one is a permission to
+ * grant, the other is hardware to plug in.
+ *
+ * Pure: `classifyMicFailure` and `micFailureMessage` do no I/O and read no
+ * globals. `isDesktopShell` is the one environment read, isolated so the message
+ * table can be tested for both shells without a fake `window`.
+ */
+
+export type MicFailure =
+  /** The prompt was refused, or a policy refuses it standing. */
+  | 'denied'
+  /** No capture device exists to grant. */
+  | 'missing'
+  /** A device exists but another app holds it. */
+  | 'busy'
+  /** This browser has no `getUserMedia` to call. */
+  | 'unsupported'
+  | 'unknown';
+
+/**
+ * Classified by `name`, not by `instanceof DOMException`: the spec-named errors
+ * are what identify the failure, and narrowing to one constructor first means a
+ * correctly-named error thrown by a shim or a test double falls through to the
+ * generic message.
+ */
+export const classifyMicFailure = (error: unknown): MicFailure => {
+  const name =
+    typeof error === 'object' && error !== null && 'name' in error
+      ? (error as { name?: unknown }).name
+      : undefined;
+
+  switch (name) {
+    case 'NotAllowedError':
+    case 'PermissionDeniedError':
+      return 'denied';
+    case 'NotFoundError':
+    case 'DevicesNotFoundError':
+      return 'missing';
+    case 'NotReadableError':
+    case 'TrackStartError':
+      return 'busy';
+    // A missing `navigator.mediaDevices` is a TypeError, not a DOMException:
+    // the capability is absent rather than refused.
+    case 'TypeError':
+      return 'unsupported';
+    default:
+      return 'unknown';
+  }
+};
+
+/** Whether this is the Electron desktop shell, where "browser settings" is wrong advice. */
+export const isDesktopShell = (): boolean =>
+  typeof window !== 'undefined' && !!window.electron?.isDesktop;
+
+export const micFailureMessage = (
+  failure: MicFailure,
+  isDesktop: boolean,
+): string => {
+  switch (failure) {
+    case 'denied':
+      return isDesktop
+        ? 'Microphone access was blocked. Allow PageSpace in System Settings > Privacy & Security > Microphone, then try again.'
+        : 'Microphone access was blocked. Please allow microphone permissions in your browser settings and try again.';
+    case 'missing':
+      return 'No microphone was detected. Connect a microphone and try again.';
+    case 'busy':
+      return 'Your microphone is busy in another app. Close other apps using the mic and try again.';
+    case 'unsupported':
+      return 'This browser does not support microphone capture for voice mode.';
+    case 'unknown':
+      return 'Unable to start voice mode because microphone access failed. Please try again.';
+  }
+};
+
+/**
+ * The one call site both voice paths use. `isDesktop` is a parameter with an
+ * environment-reading default so the table above stays testable in both shells.
+ */
+export const getMicPermissionErrorMessage = (
+  error: unknown,
+  isDesktop: boolean = isDesktopShell(),
+): string => micFailureMessage(classifyMicFailure(error), isDesktop);


### PR DESCRIPTION
## C-C — the browser holds the mic and the speaker

The server side has been merged and working since #2393/#2395. **Nothing had ever driven it from a browser.** This is that half: the first real end-to-end exercise of the relay route from a page.

The page creates the peer connection, adds the mic track, opens the `oai-events` data channel, POSTs its SDP offer to `POST /api/voice/realtime/call`, and applies the answer. It never contacts `api.openai.com`, never holds an ephemeral secret, and is never sent a tool schema.

### What's here

| File | What it is |
|---|---|
| `lib/ai/realtime/connect.ts` | The handshake against **our** route. Every effect is a parameter. |
| `lib/ai/realtime/voice-target.ts` | **Pure.** Navigating vs rebinding. |
| `lib/ai/realtime/chain-schedule.ts` | **Pure.** When to hand off ahead of the cap. |
| `lib/voice/mic-errors.ts` | Extracted from `useVoiceMode`, now shared by both paths. |
| `contexts/VoiceSessionContext.tsx` | The session. Wiring only — it holds no decisions. |

### Why the provider is in `Layout` and not the sidebar

`RightPanel` is unmounted outright when the sidebar closes (`Layout.tsx`: `rightPanelVisible && …`). A session owned by the panel would hang up every time somebody collapsed it. The sidebar is voice's *home*, not its *owner*.

The test **starts a call from inside the panel**, then unmounts the panel, then remounts it and finds the same `callId` still running — the property is asserted, not just arranged.

### Chaining past the cap

A *call* has a server-enforced ceiling. A *conversation* does not.

Before the cap lands, the client mints a fresh call on the **same `conversationId`**, which the server reseeds from that thread — the transcript is the durable layer, so the new session already knows what was said. The swap is **make-before-break**, so there is never a moment with no session. The microphone is handed over as an **independent track clone**: one permission prompt for the whole conversation, no blink in the recording indicator, and stopping the outgoing call cannot take the incoming call's audio with it. The replacement negotiates **muted**, so two live sessions cannot both hear the same sentence.

---

## ⚠️ Three things about the server contract — flagged, not worked around

**1. The route now reports `maxDurationMs` (I changed the contract).**
Chaining needs to know when the server will hang up. `REALTIME_MAX_SESSION_SECONDS` is per-deployment env the browser cannot read, so the call route now returns it. The alternative was a client-side copy of a server env var — a copy that drifts, whose failure mode is a user cut off mid-sentence on the one deployment that tuned it. Additive; existing fields unchanged.

Caveat in the code: `apps/realtime`'s own hour-long socket ceiling (`MAX_CALL_DURATION_MS`) is not importable from web (no dependency edge, deliberately), so the route reports the cap *this* tier owns. Correct unless a deployment sets `REALTIME_MAX_SESSION_SECONDS` above 3600.

**2. There is no hop for updating a live call's `locationContext`.** ← the real gap
"Navigating mid-call updates `locationContext` instead of rebinding" is a settled decision, but `VOICE_BRIDGE_ROUTES` has `attach` and nothing else. The provider does its half — it tracks the latest location and carries it into every call it opens — but **between chains, the tools answer "what's on this page?" with the page the call started on.** The fix belongs on the server contract (an update route the realtime server applies to its held context), not in a client that would otherwise have to fake it by rebinding, which is exactly what the design forbids.

**3. There is no client-facing hangup.** When the user hangs up or hard-refreshes, the browser closes the peer connection; nothing tells the realtime server, which holds its socket until `REALTIME_IDLE_TIMEOUT_SECONDS` (120s) reaps it. No audio flows in that window so nothing bills, but the concurrency slot is held. Bounded, not free.

---

## The seam for C-D (voice UI) — build on exactly this

The UI chunk consumes two hooks and nothing else. **Do not mount an `<audio>` element and do not own a session per panel** — that is the failure mode this provider exists to prevent.

```ts
const { start, stop, setLocationContext } = useVoiceSessionControls(); // stable identity
const { status, error, transcript, userSpeaking, tools,
        attached, callId, target, localStream, remoteStream } = useVoiceSession();
```

- **Trigger, on any route:** `start({ conversationId, type, contextId?, agentPageId? })`.
- **Agent switcher:** call `start(…)` with the new agent's target. It rebinds *for free* — do not `stop()` then `start()`, that discards the make-before-break path and flashes an idle state.
- **Route changes:** call `setLocationContext(…)`. **Never** call `start` on navigation.
- **Idempotent:** `start` with the target already bound is a no-op, so a re-render handing back the same target cannot restart a call mid-sentence.
- **`attached: false`** is a working audio call with no tools, no transcript, no metering. Say so in the UI rather than implying full capability.
- The `<audio>` element and the microphone belong to the provider.

## Not in scope, deliberately

No UI chrome (that's C-D). **No changelog entry** — voice is not user-reachable until C-D lands a trigger, matching what #2387/#2388/#2391/#2395 did.

## Gate

- `bun run typecheck` (monorepo root) — **17/17**
- `bun run lint` — **15/15**
- 345 voice-related tests green; full web suite 16,996 passed, the only failures being the known DB-gated integration files ("Test database not reachable"), which fail identically on the base branch.
- Coverage of the new modules: 96.8% stmts / 91.97% branch / 100% funcs.
- **Mutation-checked, not asserted on faith** — each of these was broken in the source and watched go red, then restored: detaching the connection-state handler before close (a hangup must not read as a drop), cloning the reused mic, cleanup on route refusal, mic handover on chain, the active-attempt guard on events, and teardown on a dropped connection.

Tests drive fakes for `RTCPeerConnection`/`getUserMedia`/`fetch`. No live network, no real microphone.

Base: `pu/gpt-realtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhbBndG131JyacZCqXrF5w
