### PR TITLE
feat(voice): the talk button, and voice as a mode on the chat surface (C-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **A microphone in the top bar, on every page, that talks to whichever assistant you are already
+  looking at** — there is no separate voice screen and nothing to set up first. Press it on a page
+  and the assistant sidebar opens in voice mode, talking to the agent you had selected there; press
+  it on the dashboard and it talks to the assistant already in the middle of your screen. Nothing
+  connects until you press it.
+- **A spoken conversation is the same conversation you can read and type in** — voice is a way into
+  a thread that already existed and still exists after you hang up. What is said appears in that
+  thread as ordinary messages while the call is running, marked with a small microphone so you can
+  tell later what was spoken and what was typed. There is no separate voice history to go looking
+  for, and nothing to replay.
+- **The call survives you walking around the app** — moving between pages does not end it or move it
+  to a different assistant; it just tells the assistant where you now are. Closing the sidebar
+  minimizes the call rather than hanging up, and the top-bar microphone stays lit so you can get
+  back to it. Deliberately choosing a different agent in the sidebar's switcher does move the call,
+  because that is a different conversation. Ending a call is the End button on the call itself, and
+  refreshing the page ends it too.
+- **When voice cannot start, it says which problem you have** — a microphone you declined is
+  different from a microphone you do not have, and the two now get different advice and only the
+  fixable one offers to try again. If the call connects but the transcript service does not, the
+  call says so rather than letting you talk for ten minutes into something that was never going to
+  be saved.
+
 ### Fixed
 
 - **A second agent in a session stays put instead of flashing up and vanishing** — opening a chat

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -13,6 +13,7 @@ import type { ConversationMessage, TextPart } from './message-types';
 import { isTextGroupPart, isProcessedToolPart, isFileGroupPart, isCommandExecutionPart, isToolRunGroupPart } from './message-types';
 import { CommandExecutionIndicator } from '@/components/messages/CommandExecutionIndicator';
 import { ImageMessageContent } from './ImageMessageContent';
+import { SpokenTurnGlyph, isSpokenTurn } from './SpokenTurnGlyph';
 import styles from './CompactMessageRenderer.module.css';
 
 interface CompactTextBlockProps {
@@ -30,6 +31,8 @@ interface CompactTextBlockProps {
   onCancelEdit?: () => void;
   /** Whether this message is currently being streamed (for progressive markdown rendering) */
   isStreaming?: boolean;
+  /** Turn was spoken into a live voice call, not typed. */
+  spoken?: boolean;
 }
 
 /**
@@ -49,7 +52,8 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
   isEditing,
   onSaveEdit,
   onCancelEdit,
-  isStreaming = false
+  isStreaming = false,
+  spoken = false
 }) => {
   const content = parts.map(part => part.text).join('');
 
@@ -90,13 +94,14 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
           </div>
           {/* Always show footer with buttons; timestamp only when createdAt exists */}
           <div className="flex items-center justify-between mt-1">
-            <div className="text-[10px] text-gray-500">
+            <div className="flex items-center gap-1 text-[10px] text-gray-500">
               {createdAt && (
                 <>
                   {new Date(createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   {editedAt && <span className="ml-1">(edited)</span>}
                 </>
               )}
+              {spoken && <SpokenTurnGlyph />}
             </div>
             {onEdit && onDelete && !isEditing && (
               <MessageActionButtons
@@ -262,6 +267,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
                 onSaveEdit={handleSaveEdit}
                 onCancelEdit={() => setIsEditing(false)}
                 isStreaming={isStreaming}
+                spoken={isSpokenTurn(message)}
               />
             );
           } else if (isFileGroupPart(group)) {

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -14,6 +14,7 @@ import { useMessageRendererState } from './useMessageRendererState';
 import type { ConversationMessage, TextPart } from './message-types';
 import { isTextGroupPart, isProcessedToolPart, isFileGroupPart, isCommandExecutionPart, isToolRunGroupPart } from './message-types';
 import { ImageMessageContent } from './ImageMessageContent';
+import { SpokenTurnGlyph, isSpokenTurn } from './SpokenTurnGlyph';
 import { CommandExecutionIndicator } from '@/components/messages/CommandExecutionIndicator';
 
 interface TextBlockProps {
@@ -31,6 +32,8 @@ interface TextBlockProps {
   onCancelEdit?: () => void;
   /** Whether this message is currently being streamed (for progressive markdown rendering) */
   isStreaming?: boolean;
+  /** Turn was spoken into a live voice call, not typed. */
+  spoken?: boolean;
 }
 
 /**
@@ -49,7 +52,8 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
   isEditing,
   onSaveEdit,
   onCancelEdit,
-  isStreaming = false
+  isStreaming = false,
+  spoken = false
 }) => {
   const content = parts.map(part => part.text).join('');
 
@@ -89,13 +93,14 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
           </div>
           {/* Always show footer with buttons; timestamp only when createdAt exists */}
           <div className="flex items-center justify-between mt-2">
-            <div className="text-xs text-gray-500">
+            <div className="flex items-center gap-1.5 text-xs text-gray-500">
               {createdAt && (
                 <>
                   {new Date(createdAt).toLocaleTimeString()}
                   {editedAt && <span className="ml-2">(edited)</span>}
                 </>
               )}
+              {spoken && <SpokenTurnGlyph />}
             </div>
             {onEdit && onDelete && !isEditing && (
               <MessageActionButtons
@@ -267,6 +272,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 onSaveEdit={handleSaveEdit}
                 onCancelEdit={() => setIsEditing(false)}
                 isStreaming={isStreaming}
+                spoken={isSpokenTurn(message)}
               />
             );
           } else if (isFileGroupPart(group)) {

--- a/apps/web/src/components/ai/shared/chat/SpokenTurnGlyph.tsx
+++ b/apps/web/src/components/ai/shared/chat/SpokenTurnGlyph.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Mic } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { VOICE_MESSAGE_SOURCE } from '@/lib/ai/realtime/message-source';
+import type { ConversationMessage } from './message-types';
+
+/**
+ * The mark on a turn that was SPOKEN rather than typed.
+ *
+ * WHY THE THREAD HAS TO SAY. Audio is ephemeral and the transcript is the
+ * artifact of record — so what lands in the conversation is all that survives a
+ * call, and it lands next to typed messages that look exactly like it. A
+ * dictated sentence reads differently: it runs long, it repeats itself, it
+ * carries whatever the transcriber heard. A reader who does not know it was
+ * spoken reads it as someone typing carelessly, and an AGENT re-reading the
+ * thread has the same problem. One glyph is the whole fix.
+ *
+ * Compared through the named constant rather than a `'voice'` literal: it
+ * exists precisely so the UI's check, the realtime writer and the seed builder
+ * cannot end up on three spellings of one string (see `message-source.ts` for
+ * why the browser reads its own copy, and where the drift guard lives).
+ */
+export const isSpokenTurn = (message: Pick<ConversationMessage, 'source'>): boolean =>
+  message.source === VOICE_MESSAGE_SOURCE;
+
+export const SpokenTurnGlyph: React.FC<{ className?: string }> = ({ className }) => (
+  <span
+    data-testid="spoken-turn-glyph"
+    title="Spoken in a voice call"
+    className={cn('inline-flex items-center', className)}
+  >
+    <Mic className="h-3 w-3" aria-hidden="true" />
+    {/* Named for screen readers, which get nothing from an icon. */}
+    <span className="sr-only">Spoken in a voice call</span>
+  </span>
+);

--- a/apps/web/src/components/ai/shared/chat/__tests__/SpokenTurnGlyph.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/SpokenTurnGlyph.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * A spoken turn is marked in the thread, in BOTH renderers.
+ *
+ * The transcript is the artifact of record — it is all that survives a call —
+ * and it lands beside typed messages that look exactly like it. A dictated
+ * sentence runs long, repeats itself, and carries whatever the transcriber
+ * heard; read as typing it looks careless. The glyph is the whole fix, and it
+ * has to be in both renderers because a conversation opened in the sidebar and
+ * the same conversation opened in the main view are the same conversation.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MESSAGE_SOURCE_VOICE } from '@pagespace/db/schema/conversations';
+import type { ConversationMessage } from '../message-types';
+
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'u1', name: 'Me' } }) }));
+vi.mock('@/hooks/useTasks', () => ({ useTasks: () => ({ tasks: [], isLoading: false }) }));
+
+import { CompactMessageRenderer } from '../CompactMessageRenderer';
+import { MessageRenderer } from '../MessageRenderer';
+
+const message = (source: string | null): ConversationMessage =>
+  ({
+    id: 'm1',
+    role: 'user',
+    parts: [{ type: 'text', text: 'what is on this page' }],
+    createdAt: new Date('2026-01-01T10:00:00Z'),
+    messageType: 'standard',
+    source,
+  }) as ConversationMessage;
+
+describe.each([
+  ['CompactMessageRenderer', CompactMessageRenderer],
+  ['MessageRenderer', MessageRenderer],
+])('%s — marking a spoken turn', (_name, Renderer) => {
+  it('should mark a voice-authored row', () => {
+    render(<Renderer message={message(MESSAGE_SOURCE_VOICE)} />);
+    expect(screen.getByTestId('spoken-turn-glyph')).toBeInTheDocument();
+    // Named for screen readers, which get nothing from an icon.
+    expect(screen.getByText('Spoken in a voice call')).toBeInTheDocument();
+  });
+
+  it('should leave a typed row unmarked', () => {
+    render(<Renderer message={message(null)} />);
+    expect(screen.queryByTestId('spoken-turn-glyph')).not.toBeInTheDocument();
+  });
+
+  it('should not mark a row that merely mentions voice', () => {
+    // The check is on the transport column, not on anything in the content.
+    render(<Renderer message={{ ...message('typed'), source: 'typed' }} />);
+    expect(screen.queryByTestId('spoken-turn-glyph')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/message-types.ts
+++ b/apps/web/src/components/ai/shared/chat/message-types.ts
@@ -23,6 +23,19 @@ export interface ConversationMessage extends UIMessage {
    * read as `'complete'` server-side by default.
    */
   status?: 'streaming' | 'complete' | 'interrupted';
+  /**
+   * The TRANSPORT this row was authored over (see `messages.source`) —
+   * `'voice'` for a turn spoken into a live realtime call, null/absent for a
+   * typed one.
+   *
+   * Rendered as a mic glyph rather than left invisible because a thread that
+   * mixes spoken and typed turns without saying which is which is a thread that
+   * misrepresents itself: the phrasing, the length and the errors of a spoken
+   * sentence are all different, and a reader who does not know it was dictated
+   * reads it as sloppy typing. Compared through {@link MESSAGE_SOURCE_VOICE},
+   * never a bare string literal.
+   */
+  source?: string | null;
 }
 
 /**

--- a/apps/web/src/components/ai/voice/realtime/VoiceCallBar.tsx
+++ b/apps/web/src/components/ai/voice/realtime/VoiceCallBar.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { Loader2, Mic, MicOff, PhoneOff } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useAudioLevel } from '@/hooks/voice/useAudioLevel';
+import { useVoiceSession, useVoiceSessionControls } from '@/contexts/VoiceSessionContext';
+import { describeCall, isCallLive } from '@/lib/ai/realtime/call-chrome';
+
+export interface VoiceCallBarProps {
+  /** The assistant this call is bound to, named the way the surface names it. */
+  assistantName: string;
+  className?: string;
+}
+
+const METER_BARS = 5;
+
+/**
+ * The live call, as a header on the chat surface it belongs to.
+ *
+ * VOICE IS A MODE, NOT A PANEL. This bar sits above the SAME message list, in
+ * the SAME conversation, on the surface that was already showing that
+ * conversation. It is not a fourth sidebar tab and not an overlay, because
+ * either of those would make the spoken turns a separate place with a separate
+ * history — and the whole claim of audio-native voice here is that there is one
+ * substrate and speaking is just another way into it.
+ *
+ * WHY IT SHOWS NO ERROR STATE. A failed connect clears the binding in the
+ * provider (`setTarget(null)`), so there is no longer a conversation for this
+ * bar to belong to — and a surface that reported an error for a call it can no
+ * longer identify would report OTHER surfaces' failures too. Failures are the
+ * nav trigger's job, as a toast, which reaches the user on every route
+ * including the ones where this panel is collapsed and this component does not
+ * exist. One reporter, and the one that is always mounted.
+ *
+ * WHAT IT DELIBERATELY DOES NOT RENDER: the transcript. Spoken turns are
+ * written into the conversation by the realtime server and arrive on the
+ * ordinary `conversation:*` socket events, so they appear in the message list
+ * below as ordinary messages, marked with a mic glyph. Rendering them here as
+ * well would be a second copy of the record, drifting from the first, and would
+ * be exactly the "second history" the design forbids. The one thing shown is
+ * the CURRENT utterance — which has not been persisted yet and therefore exists
+ * nowhere else.
+ */
+export function VoiceCallBar({ assistantName, className }: VoiceCallBarProps) {
+  const { status, error, failure, attached, target, userSpeaking, transcript, tools, localStream, muted } =
+    useVoiceSession();
+  const { stop, setMuted } = useVoiceSessionControls();
+
+  const chrome = describeCall({ status, error, failure, attached, bound: target !== null });
+  const live = isCallLive(chrome.state);
+
+  // Metered from the user's own microphone, and only while unmuted: a meter
+  // that keeps moving after mute is a UI telling the user they are still being
+  // heard when the entire point of the button they just pressed is that they
+  // are not.
+  const level = useAudioLevel(localStream, live && !muted);
+
+  const latest = transcript.length > 0 ? transcript[transcript.length - 1] : undefined;
+  const latestTool = tools.length > 0 ? tools[tools.length - 1] : undefined;
+
+  const statusLine = (() => {
+    if (chrome.state === 'connecting') return 'Connecting…';
+    if (muted) return 'Muted';
+    if (latestTool) return latestTool.speech;
+    if (userSpeaking) return 'Listening…';
+    return `Talking to ${assistantName}`;
+  })();
+
+  return (
+    <div
+      data-testid="voice-call-bar"
+      data-voice-state={chrome.state}
+      className={cn(
+        'flex flex-col gap-1 border-b border-[var(--separator)] bg-primary/5 px-3 py-2',
+        chrome.state === 'degraded' && 'bg-amber-500/10',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {/* Level meter — the "is it hearing me" signal, before any words exist. */}
+        <div
+          data-testid="voice-level-meter"
+          aria-hidden="true"
+          className="flex h-5 shrink-0 items-end gap-0.5"
+        >
+          {Array.from({ length: METER_BARS }, (_, index) => {
+            const lit = level > index / METER_BARS;
+            return (
+              <span
+                key={index}
+                className={cn(
+                  'w-0.5 rounded-full transition-all duration-75',
+                  lit ? 'bg-primary' : 'bg-muted-foreground/25',
+                )}
+                style={{ height: `${6 + index * 3}px` }}
+              />
+            );
+          })}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          {latest ? (
+            <p className="truncate text-xs italic text-muted-foreground">
+              &ldquo;{latest.text}&rdquo;
+            </p>
+          ) : (
+            <p className="truncate text-xs text-muted-foreground">{statusLine}</p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-0.5">
+          {chrome.state === 'connecting' ? (
+            <Loader2
+              data-testid="voice-call-connecting"
+              className="h-4 w-4 animate-spin text-muted-foreground"
+            />
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => setMuted(!muted)}
+              disabled={!live}
+              aria-pressed={muted}
+              aria-label={muted ? 'Unmute microphone' : 'Mute microphone'}
+              data-testid="voice-mute-toggle"
+            >
+              {muted ? (
+                <MicOff className="h-3.5 w-3.5 text-destructive" />
+              ) : (
+                <Mic className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          )}
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+            onClick={stop}
+            aria-label="End voice call"
+            data-testid="voice-end-call"
+          >
+            <PhoneOff className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/*
+        The degradation notice. Told, never inferred: a call whose transcript is
+        not being written looks exactly like one whose transcript is, right up
+        until the user hangs up and finds nothing in the thread. It stays
+        visible for the whole call rather than fading, because the fact it
+        states is true for the whole call.
+      */}
+      {chrome.state === 'degraded' && chrome.detail && (
+        <p
+          data-testid="voice-call-detail"
+          className="text-[11px] leading-tight text-amber-700 dark:text-amber-400"
+        >
+          {chrome.detail}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ai/voice/realtime/VoiceCallBarForConversation.tsx
+++ b/apps/web/src/components/ai/voice/realtime/VoiceCallBarForConversation.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useVoiceSession } from '@/contexts/VoiceSessionContext';
+import { isCallOnConversation } from '@/lib/ai/realtime/voice-binding';
+import { VoiceCallBar } from './VoiceCallBar';
+
+export interface VoiceCallBarForConversationProps {
+  /** The conversation this surface is showing. `null` while it is resolving. */
+  conversationId: string | null;
+  /** How this surface names the assistant on screen. */
+  assistantName: string;
+}
+
+/**
+ * The call header, IF the live call is on this surface's conversation.
+ *
+ * WHY THIS EXISTS AS A COMPONENT rather than as an `&&` inside each chat
+ * surface. It is mounted by `SidebarChatTab` and `GlobalAssistantView`, both of
+ * which are ~1000-line files with enormous hook graphs that the repo does not
+ * render in tests. A gate written inline in each would be two copies of one
+ * decision, in the two files least likely to be covered — and the decision has
+ * a specific wrong answer that looks right: keying on WHICH SURFACE STARTED THE
+ * CALL instead of on the conversation. That version works until the user walks
+ * from the sidebar to the dashboard mid-call, at which point the call is live
+ * with no chrome anywhere and no way to end it but the nav trigger.
+ *
+ * Here, the decision is one line, in one place, and exercisable against a real
+ * session.
+ */
+export function VoiceCallBarForConversation({
+  conversationId,
+  assistantName,
+}: VoiceCallBarForConversationProps) {
+  const { target } = useVoiceSession();
+  if (!isCallOnConversation(target, conversationId)) return null;
+  return <VoiceCallBar assistantName={assistantName} />;
+}

--- a/apps/web/src/components/ai/voice/realtime/VoiceNavTrigger.tsx
+++ b/apps/web/src/components/ai/voice/realtime/VoiceNavTrigger.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { Loader2, Mic, MicOff } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useDriveStore } from '@/hooks/useDrive';
+import { useVoiceBinding } from '@/hooks/voice/useVoiceBinding';
+import { useVoiceSession, useVoiceSessionControls } from '@/contexts/VoiceSessionContext';
+import { resolveLocationContext } from '@/lib/ai/shared/resolveLocationContext';
+import { toVoiceLocationContext } from '@/lib/ai/realtime/voice-location';
+import { describeCall, isCallLive } from '@/lib/ai/realtime/call-chrome';
+import type { VoiceSurface } from '@/lib/ai/realtime/voice-binding';
+
+export interface VoiceNavTriggerProps {
+  /**
+   * Bring the conversation the call is on into view. OPEN-ONLY — see
+   * `decideReveal`. Given the surface because the dashboard needs no panel
+   * opened at all: the conversation is already in the centre of the screen.
+   */
+  onReveal: (surface: VoiceSurface) => void;
+  className?: string;
+}
+
+/**
+ * THE one voice control, in the one piece of chrome that is on every route.
+ *
+ * It is a single button with two jobs and, deliberately, no third:
+ *   - nothing running: start a call on whatever assistant is in view;
+ *   - call running: it IS the live indicator, and pressing it brings that call
+ *     back into view.
+ *
+ * IT NEVER HANGS UP. Ending a call is the call header's End button and only
+ * that. A trigger that toggled would mean the live indicator is also the
+ * destroy button — one control with two meanings, where the destructive one
+ * fires on exactly the press a user makes when they want to see the call again.
+ *
+ * NOTHING CONNECTS UNTIL IT IS PRESSED. No microphone, no negotiation, no
+ * permission prompt on page load — the whole voice stack is inert until this
+ * button is used, which is why it can be mounted app-wide without cost.
+ *
+ * WHY IT RESOLVES THE LOCATION BEFORE STARTING. The tools' sense of place
+ * reaches the model only when a call STARTS or CHAINS (see the KNOWN GAP note
+ * in `VoiceSessionContext`), so a call opened before the location is known
+ * answers "what's on this page?" about nowhere for its entire life. One resolve
+ * ahead of a WebRTC handshake and a permission prompt is a latency cost that
+ * buys the first spoken question actually working.
+ */
+export function VoiceNavTrigger({ onReveal, className }: VoiceNavTriggerProps) {
+  const pathname = usePathname();
+  // No `drives` SUBSCRIPTION: the list is read fresh from the store at press
+  // time, below. Subscribing would re-render this button on every drive-store
+  // write for a value it only needs once, at the moment it is used.
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  const { status, error, failure, attached, target, userSpeaking } = useVoiceSession();
+  const { start, setLocationContext } = useVoiceSessionControls();
+  const binding = useVoiceBinding();
+
+  const [isStarting, setIsStarting] = useState(false);
+
+  const chrome = describeCall({ status, error, failure, attached, bound: target !== null });
+  const live = isCallLive(chrome.state);
+
+  /**
+   * The sidebar can be closed when a call fails, and the call header is the
+   * only other thing that would report it — so a failure with the panel shut
+   * would be a button that does nothing, forever, with no explanation. The
+   * toast is what makes the microphone honest on every route.
+   *
+   * Keyed on the SENTENCE, not on `status`: two consecutive attempts that fail
+   * the same way should not stack two identical toasts, and two that fail
+   * differently must both be told.
+   */
+  const reportedRef = useRef<string | null>(null);
+  /**
+   * `handlePress` is declared below and the toast needs to call it, so the
+   * toast's action reaches it through a ref rather than by hoisting the
+   * callback above the effect that would then have to depend on it.
+   */
+  const pressRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    if (chrome.state !== 'error') {
+      reportedRef.current = null;
+      return;
+    }
+    const sentence = chrome.detail;
+    if (sentence === null || reportedRef.current === sentence) return;
+    reportedRef.current = sentence;
+    toast.error(sentence, {
+      // A Try again offered for a MISSING microphone is a button guaranteed to
+      // fail — it teaches the user that voice is broken when the truth is that
+      // they have no capture device. `canRetry` is that distinction, carried
+      // all the way from `classifyMicFailure`.
+      ...(chrome.canRetry
+        ? { action: { label: 'Try again', onClick: () => pressRef.current() } }
+        : {}),
+    });
+  }, [chrome.state, chrome.detail, chrome.canRetry]);
+
+  const handlePress = useCallback(async () => {
+    // Already up: this press is "show me the call", never "end it".
+    if (live) {
+      onReveal(binding.surface);
+      return;
+    }
+
+    // The conversation for the assistant in view has not resolved yet. The
+    // button is disabled in this state; this is the belt to that suspenders.
+    if (binding.kind !== 'ready' || isStarting) return;
+
+    onReveal(binding.surface);
+    setIsStarting(true);
+    try {
+      // Drives are cached for five minutes, so this is usually free — but the
+      // drive is half of what a location IS, and a call started before the
+      // store populated would be permanently placeless.
+      await fetchDrives();
+      const { locationContext } = await resolveLocationContext(
+        pathname,
+        useDriveStore.getState().drives,
+      );
+      setLocationContext(toVoiceLocationContext(locationContext));
+      await start(binding.target);
+    } finally {
+      setIsStarting(false);
+    }
+  }, [
+    live,
+    binding,
+    isStarting,
+    onReveal,
+    fetchDrives,
+    pathname,
+    setLocationContext,
+    start,
+  ]);
+  pressRef.current = () => void handlePress();
+
+  const busy = chrome.state === 'connecting' || isStarting;
+  // Disabled ONLY while the target is still resolving with nothing running.
+  // Never disabled during a live call: that press is the way back to it.
+  const disabled = !live && (binding.kind !== 'ready' || isStarting);
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={() => void handlePress()}
+      disabled={disabled}
+      aria-label={chrome.label}
+      aria-live="polite"
+      data-testid="voice-nav-trigger"
+      data-voice-state={chrome.state}
+      data-voice-surface={binding.surface}
+      className={cn('relative', className)}
+    >
+      {busy ? (
+        <Loader2 className="h-5 w-5 animate-spin" />
+      ) : chrome.state === 'error' ? (
+        <MicOff className="h-5 w-5 text-destructive" />
+      ) : (
+        <Mic
+          className={cn(
+            'h-5 w-5',
+            chrome.state === 'live' && 'text-primary',
+            // Amber, not red: a call with no transcript is degraded, not broken,
+            // and colouring it as a failure would tell the user to hang up a
+            // call that is working.
+            chrome.state === 'degraded' && 'text-amber-500',
+          )}
+        />
+      )}
+
+      {/*
+        The live dot. Present for `live` AND `degraded` because both are calls
+        in progress — whether the transcript is being written is what the colour
+        says, not whether the microphone is open.
+      */}
+      {(chrome.state === 'live' || chrome.state === 'degraded') && (
+        <span
+          data-testid="voice-live-dot"
+          className={cn(
+            'absolute right-1 top-1 h-2 w-2 rounded-full',
+            chrome.state === 'degraded' ? 'bg-amber-500' : 'bg-primary',
+            userSpeaking && 'animate-pulse',
+          )}
+        />
+      )}
+    </Button>
+  );
+}

--- a/apps/web/src/components/ai/voice/realtime/VoiceSessionBridge.tsx
+++ b/apps/web/src/components/ai/voice/realtime/VoiceSessionBridge.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+import { useDriveStore } from '@/hooks/useDrive';
+import { useVoiceBinding } from '@/hooks/voice/useVoiceBinding';
+import { useVoiceRebindStore } from '@/stores/useVoiceRebindStore';
+import { useVoiceSession, useVoiceSessionControls } from '@/contexts/VoiceSessionContext';
+import { resolveLocationContext } from '@/lib/ai/shared/resolveLocationContext';
+import { toVoiceLocationContext } from '@/lib/ai/realtime/voice-location';
+import { rebindAction } from '@/lib/ai/realtime/voice-rebind';
+import { describeCall, isCallLive } from '@/lib/ai/realtime/call-chrome';
+
+/**
+ * The two things that must happen to a live call while nobody is looking at it.
+ *
+ * Renders NOTHING, and that is the point. Both jobs below outlive every panel
+ * that could show a call — the sidebar is unmounted outright when collapsed —
+ * so neither can live in the chat surfaces. Mounted once, in `Layout`, beside
+ * the trigger that is likewise on every route.
+ *
+ * ── 1. WHERE THE USER IS STANDING ────────────────────────────────────────────
+ * Navigating updates `locationContext` and MUST NOT touch the session. This is
+ * the effect that makes that true, and it is deliberately the ONLY thing in the
+ * app that reacts to a route change with a live call running. It calls
+ * `setLocationContext` and never `start` — a `start` here would be the settled
+ * rule inverted, and the symptom would be a call that hangs up every time the
+ * user opens a page.
+ *
+ * It runs only while a call is live. When nothing is running there is no
+ * session to inform, and resolving a location on every navigation for every
+ * user — two API calls a route — to serve a feature nobody has started would be
+ * a cost paid by people who never press the microphone. The FIRST call's
+ * location is resolved by the trigger, at press time, for the same reason.
+ *
+ * ── 2. FOLLOWING THE AGENT SWITCHER ──────────────────────────────────────────
+ * The switcher records an intent (`useVoiceRebindStore`); this applies it once
+ * the newly chosen agent's conversation has resolved. The decision itself is
+ * `rebindAction`, which is pure and tested — including the case this whole
+ * arrangement exists to make impossible, where a route change and a deliberate
+ * switch look identical in the derived target.
+ */
+export function VoiceSessionBridge() {
+  const pathname = usePathname();
+  const drives = useDriveStore((state) => state.drives);
+
+  const { status, error, failure, attached, target } = useVoiceSession();
+  const { start, setLocationContext } = useVoiceSessionControls();
+
+  const binding = useVoiceBinding();
+  const intent = useVoiceRebindStore((state) => state.intent);
+  const clearRebind = useVoiceRebindStore((state) => state.clearRebind);
+
+  const chrome = describeCall({
+    status,
+    error,
+    failure,
+    attached,
+    bound: target !== null,
+  });
+  const callIsLive = isCallLive(chrome.state);
+
+  // 1. Location, while a call is live. No `start`, ever.
+  useEffect(() => {
+    if (!callIsLive) return;
+    let ignore = false;
+
+    void resolveLocationContext(pathname, drives).then(({ locationContext }) => {
+      if (ignore) return;
+      setLocationContext(toVoiceLocationContext(locationContext));
+    });
+
+    return () => {
+      ignore = true;
+    };
+  }, [callIsLive, pathname, drives, setLocationContext]);
+
+  // 2. The switcher's intent, applied when the app has caught up.
+  useEffect(() => {
+    const action = rebindAction(intent, binding, callIsLive);
+    if (action.kind === 'wait') return;
+    if (action.kind === 'clear') {
+      clearRebind();
+      return;
+    }
+    // Clear FIRST: `start` is async, and an intent still standing when this
+    // effect re-runs on the resulting state change would ask for the same
+    // rebind a second time.
+    clearRebind();
+    void start(action.target);
+  }, [intent, binding, callIsLive, clearRebind, start]);
+
+  return null;
+}

--- a/apps/web/src/components/ai/voice/realtime/__tests__/VoiceCallBar.test.tsx
+++ b/apps/web/src/components/ai/voice/realtime/__tests__/VoiceCallBar.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * The call header, driven through the REAL provider so that pressing Mute
+ * actually reaches a microphone track and pressing End actually closes a peer
+ * connection. A version of this file that mocked the session would pass with
+ * buttons wired to nothing.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  VoiceSessionProvider,
+  useVoiceSessionControls,
+  type VoiceSessionDeps,
+} from '@/contexts/VoiceSessionContext';
+import {
+  FakePeerConnection,
+  asPeer,
+  asStream,
+  fakeCreateMediaStream,
+  fakeStream,
+  respondWith,
+} from '@/lib/ai/realtime/__tests__/webrtc-fakes';
+import { VoiceCallBar } from '../VoiceCallBar';
+
+const TARGET = { conversationId: 'conv-a', type: 'global' as const };
+
+const harness = (attached = true) => {
+  const peers: FakePeerConnection[] = [];
+  const microphone = fakeStream('mic-device');
+  const deps: VoiceSessionDeps = {
+    fetchImpl: async () =>
+      respondWith({
+        body: { callId: 'rtc_1', answerSdp: 'v=0 answer', attached },
+      }),
+    createPeerConnection: () => {
+      const peer = new FakePeerConnection();
+      peers.push(peer);
+      return asPeer(peer);
+    },
+    getUserMedia: async () => asStream(microphone),
+    createMediaStream: fakeCreateMediaStream,
+  };
+  return { peers, deps };
+};
+
+function StartButton() {
+  const { start } = useVoiceSessionControls();
+  return <button type="button" data-testid="start" onClick={() => void start(TARGET)} />;
+}
+
+const renderBar = (deps: VoiceSessionDeps) =>
+  render(
+    <VoiceSessionProvider deps={deps}>
+      <StartButton />
+      <VoiceCallBar assistantName="Agent A" />
+    </VoiceSessionProvider>,
+  );
+
+const startCall = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('start'));
+  });
+  await waitFor(() =>
+    expect(screen.getByTestId('voice-call-bar')).not.toHaveAttribute(
+      'data-voice-state',
+      'connecting',
+    ),
+  );
+};
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('VoiceCallBar — the controls actually reach the call', () => {
+  it('should silence the microphone track when muted, and restore it when unmuted', async () => {
+    const h = harness();
+    renderBar(h.deps);
+    await startCall();
+
+    expect(h.peers[0].addedTracks.map((t) => t.enabled)).toEqual([true]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-mute-toggle'));
+    });
+
+    expect(h.peers[0].addedTracks.map((t) => t.enabled)).toEqual([false]);
+    expect(screen.getByTestId('voice-mute-toggle')).toHaveAttribute('aria-pressed', 'true');
+    // The call is untouched — mute is not a hang-up with extra steps.
+    expect(h.peers[0].closed).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-mute-toggle'));
+    });
+    expect(h.peers[0].addedTracks.map((t) => t.enabled)).toEqual([true]);
+  });
+
+  it('should end the call from the End button — the ONLY control that hangs up', async () => {
+    const h = harness();
+    renderBar(h.deps);
+    await startCall();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-end-call'));
+    });
+
+    expect(h.peers[0].closed).toBe(true);
+    // The session is genuinely down, not merely visually reset: the surfaces
+    // gate this bar on the binding, and Mute has nothing left to act on.
+    expect(screen.getByTestId('voice-call-bar')).toHaveAttribute('data-voice-state', 'idle');
+    expect(screen.getByTestId('voice-mute-toggle')).toBeDisabled();
+  });
+});
+
+describe('VoiceCallBar — telling the truth about what the call can do', () => {
+  it('should say nothing extra when the call is fully capable', async () => {
+    const h = harness(true);
+    renderBar(h.deps);
+    await startCall();
+
+    expect(screen.getByTestId('voice-call-bar')).toHaveAttribute('data-voice-state', 'live');
+    expect(screen.queryByTestId('voice-call-detail')).not.toBeInTheDocument();
+  });
+
+  it('should warn, in the bar, when nothing said will reach the thread', async () => {
+    // `attached: false` is a WORKING audio call with no transcript, no tools and
+    // no metering. It looks identical to a good one until the user hangs up and
+    // finds the conversation empty.
+    const h = harness(false);
+    renderBar(h.deps);
+    await startCall();
+
+    expect(screen.getByTestId('voice-call-bar')).toHaveAttribute('data-voice-state', 'degraded');
+    expect(screen.getByTestId('voice-call-detail').textContent).toMatch(/saved|transcript/i);
+  });
+});
+
+describe('VoiceCallBar — the current utterance, and nothing more', () => {
+  it('should show what is being said before it has been persisted anywhere', async () => {
+    const h = harness();
+    renderBar(h.deps);
+    await startCall();
+
+    await act(async () => {
+      h.peers[0].events.deliver(
+        JSON.stringify({
+          type: 'conversation.item.input_audio_transcription.completed',
+          transcript: 'what is on this page',
+        }),
+      );
+    });
+
+    expect(screen.getByTestId('voice-call-bar').textContent).toContain('what is on this page');
+  });
+
+  it('should render NO transcript history — that is the message list\'s job', async () => {
+    // Spoken turns are written into the conversation and arrive on the ordinary
+    // `conversation:*` events. A second copy here would be a second history,
+    // free to drift from the one of record.
+    const h = harness();
+    renderBar(h.deps);
+    await startCall();
+
+    await act(async () => {
+      for (const transcript of ['first thing', 'second thing', 'third thing']) {
+        h.peers[0].events.deliver(
+          JSON.stringify({
+            type: 'conversation.item.input_audio_transcription.completed',
+            transcript,
+          }),
+        );
+      }
+    });
+
+    const text = screen.getByTestId('voice-call-bar').textContent ?? '';
+    expect(text).toContain('third thing');
+    expect(text).not.toContain('first thing');
+    expect(text).not.toContain('second thing');
+  });
+});

--- a/apps/web/src/components/ai/voice/realtime/__tests__/VoiceCallBarForConversation.test.tsx
+++ b/apps/web/src/components/ai/voice/realtime/__tests__/VoiceCallBarForConversation.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * WHICH surface shows the call, against a real session.
+ *
+ * The wrong answer that looks right is "the surface that started the call".
+ * That version works until the user walks from the sidebar to the dashboard
+ * mid-call, at which point the call is live with its chrome nowhere — no mute,
+ * no End, no indication of which thread is being spoken into. Keying on the
+ * CONVERSATION is what makes the chrome follow the thread instead of the panel.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  VoiceSessionProvider,
+  useVoiceSessionControls,
+  type VoiceSessionDeps,
+} from '@/contexts/VoiceSessionContext';
+import {
+  FakePeerConnection,
+  asPeer,
+  asStream,
+  fakeCreateMediaStream,
+  fakeStream,
+  respondWith,
+} from '@/lib/ai/realtime/__tests__/webrtc-fakes';
+import { VoiceCallBarForConversation } from '../VoiceCallBarForConversation';
+
+const deps = (): VoiceSessionDeps => ({
+  fetchImpl: async () =>
+    respondWith({ body: { callId: 'rtc_1', answerSdp: 'v=0 answer', attached: true } }),
+  createPeerConnection: () => asPeer(new FakePeerConnection()),
+  getUserMedia: async () => asStream(fakeStream('mic-device')),
+  createMediaStream: fakeCreateMediaStream,
+});
+
+/** Two surfaces mounted at once, each showing a different conversation. */
+function Surfaces({ conversationId }: { conversationId: string }) {
+  const { start } = useVoiceSessionControls();
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="start"
+        onClick={() => void start({ conversationId, type: 'global' })}
+      />
+      <div data-testid="surface-a">
+        <VoiceCallBarForConversation conversationId="conv-a" assistantName="Agent A" />
+      </div>
+      <div data-testid="surface-b">
+        <VoiceCallBarForConversation conversationId="conv-b" assistantName="Agent B" />
+      </div>
+      <div data-testid="surface-unresolved">
+        <VoiceCallBarForConversation conversationId={null} assistantName="Loading" />
+      </div>
+    </>
+  );
+}
+
+const renderSurfaces = (conversationId: string) =>
+  render(
+    <VoiceSessionProvider deps={deps()}>
+      <Surfaces conversationId={conversationId} />
+    </VoiceSessionProvider>,
+  );
+
+const barIn = (surface: string) =>
+  screen.getByTestId(surface).querySelector('[data-testid="voice-call-bar"]');
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('VoiceCallBarForConversation', () => {
+  it('should show the chrome on the surface holding the call\'s conversation, and NOWHERE else', async () => {
+    renderSurfaces('conv-a');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('start'));
+    });
+    await waitFor(() => expect(barIn('surface-a')).not.toBeNull());
+
+    expect(barIn('surface-b')).toBeNull();
+    expect(barIn('surface-unresolved')).toBeNull();
+  });
+
+  it('should follow the conversation, not the surface that started the call', async () => {
+    renderSurfaces('conv-b');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('start'));
+    });
+    await waitFor(() => expect(barIn('surface-b')).not.toBeNull());
+
+    expect(barIn('surface-a')).toBeNull();
+  });
+
+  it('should show nothing at all when no call is running', () => {
+    renderSurfaces('conv-a');
+
+    expect(barIn('surface-a')).toBeNull();
+    expect(barIn('surface-b')).toBeNull();
+  });
+
+  it('should name the assistant the way its own surface names it', async () => {
+    renderSurfaces('conv-a');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('start'));
+    });
+    await waitFor(() => expect(barIn('surface-a')).not.toBeNull());
+
+    expect(barIn('surface-a')?.textContent).toContain('Agent A');
+  });
+});

--- a/apps/web/src/components/ai/voice/realtime/__tests__/VoiceNavTrigger.test.tsx
+++ b/apps/web/src/components/ai/voice/realtime/__tests__/VoiceNavTrigger.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * The one voice control, driven end to end against the REAL session provider
+ * and the REAL binding hook. Only the network (`connectVoiceCall`), the router
+ * and the location resolver are fakes.
+ *
+ * Mocking `useVoiceBinding` here would have made the whole file vacuous: the
+ * behaviour worth guarding is precisely that the button binds to the assistant
+ * in view, which is a fact about the stores, the route and the hook together.
+ * So the stores are real and driven with `setState`.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VoiceSessionProvider } from '@/contexts/VoiceSessionContext';
+import { useSidebarAgentStore } from '@/hooks/page-agents';
+import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { micFailureMessage } from '@/lib/voice/mic-errors';
+
+const { mockConnect, routeState, globalConversation, toastError, stopSpy, setMicSpy } =
+  vi.hoisted(() => ({
+    mockConnect: vi.fn(),
+    routeState: { pathname: '/dashboard/drive-1/page-1', params: {} as Record<string, string> },
+    globalConversation: { currentConversationId: null as string | null },
+    toastError: vi.fn(),
+    stopSpy: vi.fn(),
+    setMicSpy: vi.fn(),
+  }));
+
+vi.mock('@/lib/ai/realtime/connect', () => ({
+  connectVoiceCall: mockConnect,
+  VOICE_CALL_ROUTE: '/api/voice/realtime/call',
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => routeState.pathname,
+  useParams: () => routeState.params,
+}));
+
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  useGlobalChatConversation: () => globalConversation,
+}));
+
+vi.mock('@/hooks/useDrive', () => {
+  const state = { drives: [] as unknown[], fetchDrives: vi.fn().mockResolvedValue(undefined) };
+  const useDriveStore = (selector: (s: typeof state) => unknown) => selector(state);
+  useDriveStore.getState = () => state;
+  return { useDriveStore };
+});
+
+vi.mock('@/lib/ai/shared/resolveLocationContext', () => ({
+  resolveLocationContext: vi.fn().mockResolvedValue({ label: null, locationContext: null }),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: toastError, success: vi.fn() } }));
+
+import { VoiceNavTrigger } from '../VoiceNavTrigger';
+
+const onReveal = vi.fn();
+
+const renderTrigger = () =>
+  render(
+    <VoiceSessionProvider>
+      <VoiceNavTrigger onReveal={onReveal} />
+    </VoiceSessionProvider>,
+  );
+
+const liveConnection = {
+  callId: 'rtc_1',
+  attached: true,
+  maxDurationMs: undefined,
+  microphone: { getTracks: () => [], getAudioTracks: () => [] },
+  setMicrophoneEnabled: setMicSpy,
+  stop: stopSpy,
+};
+
+const agent = {
+  id: 'agent-a',
+  title: 'Agent A',
+  driveId: 'd1',
+  driveName: 'D',
+  systemPrompt: '',
+  aiProvider: 'openai',
+  aiModel: 'gpt-4',
+  enabledTools: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  routeState.pathname = '/dashboard/drive-1/page-1';
+  routeState.params = { driveId: 'drive-1', pageId: 'page-1' };
+  globalConversation.currentConversationId = null;
+  useSidebarAgentStore.setState({ selectedAgent: null, conversationId: null });
+  usePageAgentDashboardStore.setState({ selectedAgent: null, conversationId: null });
+  mockConnect.mockResolvedValue({ ok: true, connection: liveConnection });
+});
+
+afterEach(() => {
+  useSidebarAgentStore.setState({ selectedAgent: null, conversationId: null });
+  usePageAgentDashboardStore.setState({ selectedAgent: null, conversationId: null });
+});
+
+describe('VoiceNavTrigger — nothing connects until it is pressed', () => {
+  it('should open no call, and ask for no microphone, on mount', () => {
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-a' });
+    renderTrigger();
+
+    expect(mockConnect).not.toHaveBeenCalled();
+    expect(screen.getByTestId('voice-nav-trigger')).toHaveAttribute('data-voice-state', 'idle');
+  });
+});
+
+describe('VoiceNavTrigger — binding to the assistant in view', () => {
+  it('should bind a page route to the SIDEBAR agent and reveal the sidebar', async () => {
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-sidebar' });
+    // A different pair sitting in the dashboard store: picking that one is the
+    // failure this asserts against.
+    usePageAgentDashboardStore.setState({
+      selectedAgent: { ...agent, id: 'agent-dash' },
+      conversationId: 'conv-dashboard',
+    });
+
+    renderTrigger();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
+    expect(mockConnect.mock.calls[0][0].target).toEqual({
+      conversationId: 'conv-sidebar',
+      type: 'page',
+      contextId: 'agent-a',
+      agentPageId: 'agent-a',
+    });
+    expect(onReveal).toHaveBeenCalledWith('sidebar');
+  });
+
+  it('should bind the dashboard to the view already on screen, not to the sidebar', async () => {
+    // The dashboard's right sidebar has NO chat tab. A trigger that bound to it
+    // there would be a dead press on the app's most-visited route.
+    routeState.pathname = '/dashboard';
+    routeState.params = {};
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-sidebar' });
+    globalConversation.currentConversationId = 'conv-global';
+
+    renderTrigger();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
+    expect(mockConnect.mock.calls[0][0].target).toEqual({
+      conversationId: 'conv-global',
+      type: 'global',
+    });
+    expect(onReveal).toHaveBeenCalledWith('dashboard');
+  });
+
+  it('should refuse to start while the conversation is still resolving', () => {
+    // An agent chosen a moment ago, its conversation not yet resolved.
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: null });
+    renderTrigger();
+
+    const button = screen.getByTestId('voice-nav-trigger');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it('should carry the resolved location, so the first spoken question has a place', async () => {
+    const { resolveLocationContext } = await import('@/lib/ai/shared/resolveLocationContext');
+    vi.mocked(resolveLocationContext).mockResolvedValueOnce({
+      label: 'Notes',
+      locationContext: {
+        currentPage: { id: 'page-1', title: 'Notes', type: 'DOCUMENT', path: '/d/Notes' },
+        currentDrive: null,
+      },
+    });
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-a' });
+
+    renderTrigger();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
+    // Nulls converted to absence, per the wire schema.
+    expect(mockConnect.mock.calls[0][0].locationContext).toEqual({
+      currentPage: { id: 'page-1', title: 'Notes', type: 'DOCUMENT', path: '/d/Notes' },
+    });
+  });
+});
+
+describe('VoiceNavTrigger — the live indicator is not a hang-up button', () => {
+  it('should reveal the call, and NOT end it, when pressed while live', async () => {
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-a' });
+    renderTrigger();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('voice-nav-trigger')).toHaveAttribute('data-voice-state', 'live'),
+    );
+    expect(screen.getByTestId('voice-live-dot')).toBeInTheDocument();
+
+    onReveal.mockClear();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+
+    expect(onReveal).toHaveBeenCalledWith('sidebar');
+    // The two things a toggle would have done and this must never do.
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('voice-nav-trigger')).toHaveAttribute('data-voice-state', 'live');
+  });
+
+  it('should show a call the server never joined as degraded, not as failed', async () => {
+    mockConnect.mockResolvedValue({
+      ok: true,
+      connection: { ...liveConnection, attached: false },
+    });
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-a' });
+    renderTrigger();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('voice-nav-trigger')).toHaveAttribute(
+        'data-voice-state',
+        'degraded',
+      ),
+    );
+    // Still a call in progress: the dot is about whether the mic is open.
+    expect(screen.getByTestId('voice-live-dot')).toBeInTheDocument();
+  });
+});
+
+describe('VoiceNavTrigger — a refused microphone and an absent one are different', () => {
+  const failWith = (reason: string, message: string) => {
+    mockConnect.mockResolvedValue({ ok: false, reason, message, detail: 'detail' });
+  };
+
+  const press = async () => {
+    useSidebarAgentStore.setState({ selectedAgent: agent, conversationId: 'conv-a' });
+    renderTrigger();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+    });
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    // Let the trigger's own post-failure state settle before the test ends,
+    // so the failure path is not reported as an un-acted update.
+    await act(async () => {});
+  };
+
+  it('should tell a denied user how to grant it, and offer to try again', async () => {
+    const denied = micFailureMessage('denied', false);
+    failWith('mic-denied', denied);
+    await press();
+
+    expect(toastError.mock.calls[0][0]).toBe(denied);
+    expect(toastError.mock.calls[0][1]?.action?.label).toBe('Try again');
+  });
+
+  it('should tell a user with NO microphone something else, and offer no retry', async () => {
+    const missing = micFailureMessage('missing', false);
+    failWith('mic-missing', missing);
+    await press();
+
+    expect(toastError.mock.calls[0][0]).toBe(missing);
+    // Retrying cannot conjure hardware; a button that always fails teaches the
+    // wrong lesson.
+    expect(toastError.mock.calls[0][1]?.action).toBeUndefined();
+    // And the two sentences are genuinely different advice, not one message.
+    expect(missing).not.toBe(micFailureMessage('denied', false));
+  });
+
+  it('should report a failure even with every panel closed — it is the only reporter', async () => {
+    // No chat surface is rendered in this file at all. The toast is what makes
+    // the microphone honest on a route where the sidebar is collapsed.
+    failWith('unavailable', 'Voice is not configured for this deployment.');
+    await press();
+    expect(toastError).toHaveBeenCalledWith(
+      'Voice is not configured for this deployment.',
+      expect.anything(),
+    );
+  });
+});

--- a/apps/web/src/components/ai/voice/realtime/__tests__/VoiceSessionBridge.test.tsx
+++ b/apps/web/src/components/ai/voice/realtime/__tests__/VoiceSessionBridge.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * The settled rule, asserted against the real thing: NAVIGATING DOES NOT
+ * REBIND, SWITCHING DOES.
+ *
+ * Both arrive as the same change to the derived target, so the only way to tell
+ * these apart is a test that performs each one and counts calls. A regression
+ * here — the obvious "watch the target and call start" refactor — hangs up the
+ * user's call every time they open a page, and nothing else in the suite would
+ * notice.
+ *
+ * The provider, the bridge, the binding hook, the agent stores and the rebind
+ * store are all REAL. Only the network and the router are faked.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VoiceSessionProvider, useVoiceSessionControls } from '@/contexts/VoiceSessionContext';
+import { useSidebarAgentStore } from '@/hooks/page-agents';
+import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { useVoiceRebindStore } from '@/stores/useVoiceRebindStore';
+import { NO_REBIND_INTENT } from '@/lib/ai/realtime/voice-rebind';
+
+const { mockConnect, routeState, globalConversation, resolveSpy, stopSpy } = vi.hoisted(() => ({
+  mockConnect: vi.fn(),
+  routeState: { pathname: '/dashboard/drive-1/page-1', params: {} as Record<string, string> },
+  globalConversation: { currentConversationId: null as string | null },
+  resolveSpy: vi.fn(),
+  stopSpy: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/realtime/connect', () => ({
+  connectVoiceCall: mockConnect,
+  VOICE_CALL_ROUTE: '/api/voice/realtime/call',
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => routeState.pathname,
+  useParams: () => routeState.params,
+}));
+
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  useGlobalChatConversation: () => globalConversation,
+}));
+
+vi.mock('@/hooks/useDrive', () => {
+  const state = { drives: [] as unknown[], fetchDrives: vi.fn().mockResolvedValue(undefined) };
+  const useDriveStore = (selector: (s: typeof state) => unknown) => selector(state);
+  useDriveStore.getState = () => state;
+  return { useDriveStore };
+});
+
+vi.mock('@/lib/ai/shared/resolveLocationContext', () => ({
+  resolveLocationContext: resolveSpy,
+}));
+
+import { VoiceSessionBridge } from '../VoiceSessionBridge';
+
+const connection = (callId: string) => ({
+  callId,
+  attached: true,
+  maxDurationMs: undefined,
+  microphone: { getTracks: () => [], getAudioTracks: () => [] },
+  setMicrophoneEnabled: vi.fn(),
+  stop: stopSpy,
+});
+
+const agent = (id: string) => ({
+  id,
+  title: id,
+  driveId: 'd1',
+  driveName: 'D',
+  systemPrompt: '',
+  aiProvider: 'openai',
+  aiModel: 'gpt-4',
+  enabledTools: [],
+});
+
+/** Starts a call the way the trigger would, without dragging the trigger in. */
+function StartButton() {
+  const { start } = useVoiceSessionControls();
+  return (
+    <button
+      type="button"
+      data-testid="start"
+      onClick={() =>
+        void start({
+          conversationId: 'conv-a',
+          type: 'page',
+          contextId: 'agent-a',
+          agentPageId: 'agent-a',
+        })
+      }
+    />
+  );
+}
+
+/**
+ * A FRESH element each time. Handing `rerender` the identical element
+ * reference lets React bail out of the render entirely, and the navigation
+ * under test would then never reach the bridge.
+ */
+const tree = () => (
+  <VoiceSessionProvider>
+    <VoiceSessionBridge />
+    <StartButton />
+  </VoiceSessionProvider>
+);
+
+const renderBridge = () => render(tree());
+
+/**
+ * A route change. `usePathname` is a mock reading a mutable object, so moving
+ * it is not by itself something React re-renders for — the rerender is what
+ * makes this a navigation rather than a variable assignment.
+ */
+const navigateTo = async (
+  view: ReturnType<typeof render>,
+  pathname: string,
+) => {
+  await act(async () => {
+    routeState.pathname = pathname;
+    view.rerender(tree());
+  });
+};
+
+const startCall = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('start'));
+  });
+  await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  routeState.pathname = '/dashboard/drive-1/page-1';
+  routeState.params = { driveId: 'drive-1', pageId: 'page-1' };
+  globalConversation.currentConversationId = null;
+  resolveSpy.mockResolvedValue({ label: null, locationContext: null });
+  useSidebarAgentStore.setState({ selectedAgent: agent('agent-a'), conversationId: 'conv-a' });
+  usePageAgentDashboardStore.setState({ selectedAgent: null, conversationId: null });
+  useVoiceRebindStore.setState({ intent: NO_REBIND_INTENT });
+  mockConnect.mockImplementation(async () => ({ ok: true, connection: connection('rtc_1') }));
+});
+
+describe('VoiceSessionBridge — navigating', () => {
+  it('should NOT rebind when the route changes under a live call', async () => {
+    const view = renderBridge();
+    await startCall();
+
+    // Walk to a different page — and, to make it as tempting as possible for a
+    // target-watching implementation, to a page whose sidebar agent differs.
+    await act(async () => {
+      useSidebarAgentStore.setState({
+        selectedAgent: agent('agent-b'),
+        conversationId: 'conv-b',
+      });
+    });
+    await navigateTo(view, '/dashboard/drive-1/page-2');
+
+    // One call, still the first one. Nothing was torn down.
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  it('should update where the user is standing instead', async () => {
+    const view = renderBridge();
+    await startCall();
+    resolveSpy.mockClear();
+
+    await navigateTo(view, '/dashboard/drive-1/page-2');
+
+    await waitFor(() => expect(resolveSpy).toHaveBeenCalled());
+    expect(resolveSpy.mock.calls.at(-1)?.[0]).toBe('/dashboard/drive-1/page-2');
+    // And still exactly one call.
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should resolve nothing at all while no call is running', async () => {
+    // Two API calls per navigation, app-wide, for a feature nobody started.
+    const view = renderBridge();
+    await navigateTo(view, '/dashboard/drive-1/page-3');
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('VoiceSessionBridge — the agent switcher', () => {
+  it('should rebind the live call once the chosen agent\'s conversation resolves', async () => {
+    renderBridge();
+    await startCall();
+
+    // What the switcher does: record the intent, then let the store re-resolve.
+    await act(async () => {
+      useVoiceRebindStore.getState().requestRebind('agent-b');
+      useSidebarAgentStore.setState({ selectedAgent: agent('agent-b'), conversationId: null });
+    });
+
+    // Nothing yet — there is no conversation to bind to.
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useSidebarAgentStore.setState({ conversationId: 'conv-b' });
+    });
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(2));
+    expect(mockConnect.mock.calls[1][0].target).toEqual({
+      conversationId: 'conv-b',
+      type: 'page',
+      contextId: 'agent-b',
+      agentPageId: 'agent-b',
+    });
+    // A rebind tears the old call down — that is the difference from a chain.
+    expect(stopSpy).toHaveBeenCalled();
+    // And the intent is spent, not left to fire again.
+    expect(useVoiceRebindStore.getState().intent).toEqual(NO_REBIND_INTENT);
+  });
+
+  it('should carry the location learned WHILE navigating into the rebound call', async () => {
+    const view = renderBridge();
+    await startCall();
+
+    resolveSpy.mockResolvedValue({
+      label: 'Page 2',
+      locationContext: {
+        currentPage: { id: 'page-2', title: 'Page 2', type: 'DOCUMENT', path: '/d/Page 2' },
+        currentDrive: null,
+      },
+    });
+
+    await navigateTo(view, '/dashboard/drive-1/page-2');
+    await waitFor(() => expect(resolveSpy).toHaveBeenCalled());
+
+    await act(async () => {
+      useVoiceRebindStore.getState().requestRebind('agent-b');
+      useSidebarAgentStore.setState({ selectedAgent: agent('agent-b'), conversationId: 'conv-b' });
+    });
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(2));
+    expect(mockConnect.mock.calls[1][0].locationContext).toEqual({
+      currentPage: { id: 'page-2', title: 'Page 2', type: 'DOCUMENT', path: '/d/Page 2' },
+    });
+  });
+
+  it('should drop an intent recorded while nothing is live, rather than hoard it', async () => {
+    renderBridge();
+
+    await act(async () => {
+      useVoiceRebindStore.getState().requestRebind('agent-b');
+      useSidebarAgentStore.setState({ selectedAgent: agent('agent-b'), conversationId: 'conv-b' });
+    });
+
+    await waitFor(() =>
+      expect(useVoiceRebindStore.getState().intent).toEqual(NO_REBIND_INTENT),
+    );
+    // Switching agent with nothing running is just switching agent.
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ai/voice/realtime/index.ts
+++ b/apps/web/src/components/ai/voice/realtime/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The audio-native voice UI.
+ *
+ * Kept in its own directory beside the legacy `../` components (VoiceCallPanel
+ * and friends, which drive the Whisper -> text -> TTS path) because both exist
+ * at once for now: the old path still backs Read Aloud and is not retired until
+ * chunk C-E. Two directories is how a reader tells which era a component
+ * belongs to without reading it.
+ */
+export { VoiceNavTrigger, type VoiceNavTriggerProps } from './VoiceNavTrigger';
+export { VoiceCallBar, type VoiceCallBarProps } from './VoiceCallBar';
+export {
+  VoiceCallBarForConversation,
+  type VoiceCallBarForConversationProps,
+} from './VoiceCallBarForConversation';
+export { VoiceSessionBridge } from './VoiceSessionBridge';

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -36,6 +36,9 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { VoiceModeBorder } from "@/components/ai/voice";
+import { VoiceSessionBridge } from "@/components/ai/voice/realtime";
+import { decideReveal } from "@/lib/ai/realtime/voice-reveal";
+import type { VoiceSurface } from "@/lib/ai/realtime/voice-binding";
 import {
   LEFT_SIDEBAR_MAX_SIZE,
   MAIN_MIN_SIZE,
@@ -87,6 +90,7 @@ function Layout({ children }: LayoutProps) {
   // Desktop overlay state (1024-1279px) — transient, starts closed each load
   const leftOverlayOpen = useLayoutStore(state => state.leftOverlayOpen);
   const setLeftOverlayOpen = useLayoutStore(state => state.setLeftOverlayOpen);
+  const setRightSidebarPageTab = useLayoutStore(state => state.setRightSidebarPageTab);
 
   const hasHydrated = useHasHydrated();
   const shouldOverlaySidebarsDefault = useBreakpoint("(max-width: 1279px)");
@@ -284,6 +288,52 @@ function Layout({ children }: LayoutProps) {
     toggleRightSidebar,
   ]);
 
+  /**
+   * Bring the assistant into view for a voice call — OPEN-ONLY.
+   *
+   * NOT `handleRightPanelToggle`. That one closes an open sidebar, and the nav
+   * trigger's second job is being the way BACK to a minimized call: a toggle
+   * there means pressing the live indicator hides the call you pressed it to
+   * see. The breakpoint reasoning is the same and lives in `decideReveal`,
+   * where it can be tested at every breakpoint without a viewport.
+   */
+  const handleRevealAssistant = useCallback(
+    (surface: VoiceSurface) => {
+      const writes = decideReveal({
+        surface,
+        isSheetBreakpoint,
+        shouldOverlayRightSidebar,
+        shouldOverlayLeftSidebar,
+        rightSheetOpen,
+        leftSheetOpen,
+        rightSidebarOpen,
+        leftOverlayOpen,
+      });
+
+      if (writes.leftSheetOpen !== undefined) setLeftSheetOpen(writes.leftSheetOpen);
+      if (writes.rightSheetOpen !== undefined) setRightSheetOpen(writes.rightSheetOpen);
+      if (writes.leftOverlayOpen !== undefined) setLeftOverlayOpen(writes.leftOverlayOpen);
+      if (writes.rightSidebarOpen !== undefined) setRightSidebarOpen(writes.rightSidebarOpen);
+      // Voice is a mode on the CHAT surface, so revealing a call means the chat
+      // tab, not whichever tab the sidebar was left on.
+      if (writes.showChatTab) setRightSidebarPageTab('chat');
+    },
+    [
+      isSheetBreakpoint,
+      shouldOverlayRightSidebar,
+      shouldOverlayLeftSidebar,
+      rightSheetOpen,
+      leftSheetOpen,
+      rightSidebarOpen,
+      leftOverlayOpen,
+      setLeftSheetOpen,
+      setRightSheetOpen,
+      setLeftOverlayOpen,
+      setRightSidebarOpen,
+      setRightSidebarPageTab,
+    ],
+  );
+
   // Dismiss keyboard when tapping outside editable content (iOS Capacitor fix)
   // iOS contenteditable elements don't automatically blur on outside taps like regular inputs
   const handleLayoutClick = useCallback((e: React.MouseEvent) => {
@@ -351,6 +401,16 @@ function Layout({ children }: LayoutProps) {
       */}
       <VoiceSessionProvider>
       <GlobalChatProvider>
+        {/*
+          Renders nothing. It keeps a live call's sense of place current as the
+          user navigates (WITHOUT rebinding), and applies the agent switcher's
+          rebind once the new agent's conversation resolves. Mounted here, above
+          every panel, for the same reason the session itself is: both jobs
+          outlive the sidebar, which is unmounted whenever it is collapsed.
+          Inside GlobalChatProvider because the binding it computes reads the
+          global conversation from it.
+        */}
+        <VoiceSessionBridge />
         <div
           className="flex flex-col overflow-hidden bg-gradient-to-br from-background via-background to-muted/10"
           style={{ height: 'var(--app-height, 100dvh)' }}
@@ -359,6 +419,7 @@ function Layout({ children }: LayoutProps) {
           <TopBar
             onToggleLeftPanel={handleLeftPanelToggle}
             onToggleRightPanel={handleRightPanelToggle}
+            onRevealAssistant={handleRevealAssistant}
           />
 
           {/* TabBar: auto-hides when <=1 tab, accordion from TopBar */}

--- a/apps/web/src/components/layout/__tests__/Layout.voice-reveal.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Layout.voice-reveal.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Two structural guarantees about Layout that no behavioural test elsewhere can
+ * hold, asserted against the tree Layout actually renders:
+ *
+ *  1. `VoiceSessionBridge` is MOUNTED. It renders nothing, so deleting it is
+ *     invisible: navigation would silently stop updating a live call's sense of
+ *     place, and the agent switcher would silently stop moving calls. Both
+ *     failures are quiet and both are the feature.
+ *  2. Revealing the assistant OPENS and never CLOSES. `Layout` owns the
+ *     breakpoint facts, so this is the only place the wiring from the pure
+ *     `decideReveal` to the actual store writes can be checked.
+ *
+ * Everything heavy is mocked; the bridge and the reveal handler are real.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { layoutState, writes, revealFromTopBar } = vi.hoisted(() => ({
+  layoutState: {} as Record<string, unknown>,
+  writes: [] as Array<[string, unknown]>,
+  revealFromTopBar: { fire: (_surface: string) => {} },
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isLoading: false, isAuthenticated: true }),
+}));
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => undefined }));
+vi.mock('@/hooks/useAccessRevocation', () => ({ useAccessRevocation: () => undefined }));
+vi.mock('@/hooks/useNotificationToasts', () => ({ useNotificationToasts: () => undefined }));
+vi.mock('@/hooks/useDesktopNotifications', () => ({ useDesktopNotifications: () => undefined }));
+vi.mock('@/hooks/useIosBadgeSync', () => ({ useIosBadgeSync: () => undefined }));
+vi.mock('@/hooks/usePerformanceMonitor', () => ({ usePerformanceMonitor: () => undefined }));
+vi.mock('@/hooks/useIOSKeyboardInit', () => ({ useIOSKeyboardInit: () => undefined }));
+vi.mock('@/hooks/useMobileKeyboard', () => ({ dismissKeyboard: () => {} }));
+vi.mock('@/hooks/useTabSync', () => ({ useTabSync: () => undefined }));
+vi.mock('@/hooks/useHasHydrated', () => ({ useHasHydrated: () => true }));
+vi.mock('@/hooks/useBreakpoint', () => ({ useBreakpoint: () => false }));
+vi.mock('@/hooks/useDeviceTier', () => ({ useDeviceTier: () => ({ isTablet: false }) }));
+
+vi.mock('@/stores/useLayoutStore', () => ({
+  useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) => selector(layoutState),
+}));
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: {
+    getState: () => ({ clearAllSessions: () => {}, clearStaleSessions: () => {} }),
+  },
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {}, replace: () => {}, prefetch: () => {} }),
+  usePathname: () => '/dashboard/drive-1/page-1',
+  useParams: () => ({ driveId: 'drive-1', pageId: 'page-1' }),
+}));
+
+// The bridge renders nothing, so it is given a visible probe here — that is the
+// only way "is it mounted" can be asserted at all.
+vi.mock('@/components/ai/voice/realtime', () => ({
+  VoiceSessionBridge: () => <div data-testid="voice-session-bridge" />,
+  VoiceNavTrigger: () => <div />,
+  VoiceCallBar: () => <div />,
+}));
+
+vi.mock('@/components/layout/main-header', () => ({
+  default: ({ onRevealAssistant }: { onRevealAssistant: (surface: string) => void }) => {
+    revealFromTopBar.fire = onRevealAssistant;
+    return <div data-testid="top-bar" />;
+  },
+}));
+vi.mock('@/components/layout/left-sidebar/MemoizedSidebar', () => ({ default: () => <div /> }));
+vi.mock('@/components/layout/middle-content/CenterPanel', () => ({ default: () => <div /> }));
+vi.mock('@/components/layout/right-sidebar', () => ({ default: () => <div /> }));
+vi.mock('@/components/layout/tabs', () => ({ TabBar: () => <div /> }));
+vi.mock('@/components/layout/DebugPanel', () => ({ DebugPanel: () => <div /> }));
+vi.mock('@/components/ai/voice', () => ({ VoiceModeBorder: () => <div /> }));
+vi.mock('@/components/layout/NavigationProvider', () => ({
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  GlobalChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useGlobalChatConversation: () => ({ currentConversationId: null }),
+}));
+vi.mock('@/contexts/VoiceSessionContext', () => ({
+  VoiceSessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('motion/react', () => ({
+  motion: { div: ({ children }: { children: React.ReactNode }) => <div>{children}</div> },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import Layout from '../Layout';
+
+/**
+ * Layout writes to the layout store on mount (breakpoint reconciliation), so
+ * every assertion below is about what the REVEAL wrote — the log is cleared
+ * once the tree has settled.
+ */
+const renderAndReveal = (surface: 'sidebar' | 'dashboard') => {
+  const view = render(
+    <Layout>
+      <div />
+    </Layout>,
+  );
+  writes.length = 0;
+  revealFromTopBar.fire(surface);
+  return view;
+};
+
+const record = (key: string) => (value: unknown) => {
+  writes.push([key, value]);
+  layoutState[key] = value;
+};
+
+beforeEach(() => {
+  writes.length = 0;
+  Object.assign(layoutState, {
+    leftSidebarOpen: false,
+    rightSidebarOpen: false,
+    leftSheetOpen: false,
+    rightSheetOpen: false,
+    leftOverlayOpen: false,
+    rightSidebarPageTab: 'history',
+    leftSidebarSize: 20,
+    rightSidebarSize: 20,
+    toggleLeftSidebar: () => {},
+    toggleRightSidebar: () => record('rightSidebarOpen')('TOGGLED'),
+    setRightSidebarOpen: record('rightSidebarOpen'),
+    setLeftSheetOpen: record('leftSheetOpen'),
+    setRightSheetOpen: record('rightSheetOpen'),
+    setLeftOverlayOpen: record('leftOverlayOpen'),
+    setRightSidebarPageTab: record('rightSidebarPageTab'),
+    setLeftSidebarSize: () => {},
+    setRightSidebarSize: () => {},
+  });
+});
+
+describe('Layout — the voice bridge', () => {
+  it('should mount the bridge, which renders nothing and would vanish silently', () => {
+    render(
+      <Layout>
+        <div />
+      </Layout>,
+    );
+    expect(screen.getByTestId('voice-session-bridge')).toBeInTheDocument();
+  });
+});
+
+describe('Layout — revealing the assistant', () => {
+  it('should open the sidebar and bring the chat tab forward', () => {
+    renderAndReveal('sidebar');
+
+    expect(writes).toContainEqual(['rightSidebarOpen', true]);
+    // Voice is a mode on the CHAT surface, so it must not land on whatever tab
+    // the sidebar was left showing.
+    expect(writes).toContainEqual(['rightSidebarPageTab', 'chat']);
+  });
+
+  it('should never close an already-open sidebar, and never route through the toggle', () => {
+    layoutState.rightSidebarOpen = true;
+    renderAndReveal('sidebar');
+
+    // The failure this guards: pressing the live indicator hides the call.
+    expect(writes).not.toContainEqual(['rightSidebarOpen', false]);
+    expect(writes).not.toContainEqual(['rightSidebarOpen', 'TOGGLED']);
+  });
+
+  it('should open nothing on the dashboard, where the call renders in the centre', () => {
+    renderAndReveal('dashboard');
+
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/layout/__tests__/Layout.voice-session.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Layout.voice-session.test.tsx
@@ -38,6 +38,7 @@ const { layoutState, mockConnect, stopSpy, setMicSpy } = vi.hoisted(() => ({
     setLeftSheetOpen: () => {},
     setRightSheetOpen: () => {},
     setLeftOverlayOpen: () => {},
+    setRightSidebarPageTab: () => {},
     setLeftSidebarSize: () => {},
     setRightSidebarSize: () => {},
   } as Record<string, unknown>,
@@ -94,8 +95,22 @@ vi.mock('@/stores/useEditingStore', () => ({
     }),
   },
 }));
+// `usePathname`/`useParams` are here for the real `VoiceSessionBridge` that
+// Layout mounts — it is not what this file is about, but mocking it away would
+// let a refactor delete it from Layout with nothing going red.
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: () => {}, replace: () => {}, prefetch: () => {} }),
+  usePathname: () => '/dashboard/drive-1/page-1',
+  useParams: () => ({ driveId: 'drive-1', pageId: 'page-1' }),
+}));
+vi.mock('@/hooks/useDrive', () => {
+  const state = { drives: [] as unknown[], fetchDrives: () => Promise.resolve() };
+  const useDriveStore = (selector: (s: typeof state) => unknown) => selector(state);
+  useDriveStore.getState = () => state;
+  return { useDriveStore };
+});
+vi.mock('@/lib/ai/shared/resolveLocationContext', () => ({
+  resolveLocationContext: () => Promise.resolve({ label: null, locationContext: null }),
 }));
 
 vi.mock('@/components/layout/main-header', () => ({
@@ -119,6 +134,7 @@ vi.mock('@/contexts/GlobalChatContext', () => ({
   GlobalChatProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+  useGlobalChatConversation: () => ({ currentConversationId: null }),
 }));
 vi.mock('@/components/ui/resizable', () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (

--- a/apps/web/src/components/layout/main-header/__tests__/TopBar.voice-trigger.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/TopBar.voice-trigger.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * WHERE the voice trigger lives, asserted against the real TopBar.
+ *
+ * "One trigger on every route" is a structural claim, and the structure that
+ * makes it true is that the button is in the app-wide header rather than inside
+ * the assistant sidebar it usually reveals. Move it into the sidebar and every
+ * behavioural test of the trigger still passes, while voice quietly becomes a
+ * feature of a panel — unreachable on the dashboard, unreachable while the
+ * panel is collapsed, and unreachable as the way back to a minimized call.
+ *
+ * The trigger itself is a probe here: this file is about placement and about
+ * the reveal callback being wired to the OPEN-only handler rather than to the
+ * toggle.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { revealSpy, toggleSpy } = vi.hoisted(() => ({
+  revealSpy: vi.fn(),
+  toggleSpy: vi.fn(),
+}));
+
+vi.mock('@/components/ai/voice/realtime', () => ({
+  VoiceNavTrigger: ({ onReveal }: { onReveal: (surface: string) => void }) => (
+    <button type="button" data-testid="voice-nav-trigger" onClick={() => onReveal('sidebar')} />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
+}));
+vi.mock('@/components/notifications/NotificationBell', () => ({ default: () => <div /> }));
+vi.mock('@/components/notifications/VerifyEmailButton', () => ({ default: () => <div /> }));
+vi.mock('@/components/search/InlineSearch', () => ({ default: () => <div /> }));
+vi.mock('@/components/search/GlobalSearch', () => ({ default: () => <div /> }));
+vi.mock('@/components/shared/UserDropdown', () => ({ default: () => <div /> }));
+vi.mock('@/components/shared/RecentsDropdown', () => ({ default: () => <div /> }));
+vi.mock('@/components/billing/AiBalanceWidget', () => ({
+  AiBalanceWidget: () => <div data-testid="ai-balance" />,
+}));
+vi.mock('../NavButtons', () => ({ default: () => <div /> }));
+
+import TopBar from '../index';
+
+const renderTopBar = () =>
+  render(
+    <TopBar
+      onToggleLeftPanel={() => {}}
+      onToggleRightPanel={toggleSpy}
+      onRevealAssistant={revealSpy}
+    />,
+  );
+
+describe('TopBar — the voice trigger is app-wide chrome', () => {
+  it('should render the trigger in the header, beside the balance widget', () => {
+    renderTopBar();
+    expect(screen.getByTestId('voice-nav-trigger')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-balance')).toBeInTheDocument();
+  });
+
+  it('should wire the trigger to REVEAL, never to the sidebar toggle', () => {
+    // The distinction is the whole point: the same button is the live indicator
+    // for a call in progress, and a toggle would hide the call it was pressed
+    // to show.
+    renderTopBar();
+    fireEvent.click(screen.getByTestId('voice-nav-trigger'));
+
+    expect(revealSpy).toHaveBeenCalledWith('sidebar');
+    expect(toggleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/main-header/index.tsx
+++ b/apps/web/src/components/layout/main-header/index.tsx
@@ -12,14 +12,22 @@ import GlobalSearch from "@/components/search/GlobalSearch";
 import UserDropdown from "@/components/shared/UserDropdown";
 import RecentsDropdown from "@/components/shared/RecentsDropdown";
 import { AiBalanceWidget } from "@/components/billing/AiBalanceWidget";
+import { VoiceNavTrigger } from "@/components/ai/voice/realtime";
+import type { VoiceSurface } from "@/lib/ai/realtime/voice-binding";
 import NavButtons from "./NavButtons";
 
 interface TopBarProps {
   onToggleLeftPanel: () => void;
   onToggleRightPanel: () => void;
+  /**
+   * Bring the conversation a voice call is on into view — OPEN-ONLY, unlike
+   * `onToggleRightPanel`. Owned by `Layout` because only it knows which
+   * breakpoint's panel/sheet/overlay is the one to open.
+   */
+  onRevealAssistant: (surface: VoiceSurface) => void;
 }
 
-export default function TopBar({ onToggleLeftPanel, onToggleRightPanel }: TopBarProps) {
+export default function TopBar({ onToggleLeftPanel, onToggleRightPanel, onRevealAssistant }: TopBarProps) {
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
 
   return (
@@ -75,6 +83,14 @@ export default function TopBar({ onToggleLeftPanel, onToggleRightPanel }: TopBar
         </div>
 
         <div className="flex flex-shrink-0 items-center gap-2">
+          {/*
+            THE voice trigger, in the one piece of chrome that is on every
+            route. Voice is not a feature of a panel — it is a second transport
+            onto whatever conversation is already in view — so its one control
+            lives here and not inside the assistant sidebar it usually reveals.
+          */}
+          <VoiceNavTrigger onReveal={onRevealAssistant} />
+
           <AiBalanceWidget />
 
           <VerifyEmailButton />

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -55,6 +55,8 @@ import { useGlobalChatConfig, useGlobalChatConversation } from '@/contexts/Globa
 import { usePageAgentDashboardStore } from '@/stores/page-agents';
 import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
+import { VoiceCallBarForConversation } from '@/components/ai/voice/realtime';
+import { useVoiceRebindStore } from '@/stores/useVoiceRebindStore';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 
 // Shared hooks and components
@@ -198,6 +200,18 @@ const GlobalAssistantView: React.FC = () => {
   // SHARED HOOKS
   // ============================================
   const currentConversationId = selectedAgent ? agentConversationId : globalConversationId;
+
+  // The switcher is the voice switcher — see the twin of this comment in
+  // SidebarChatTab. Records an intent on the explicit act; navigation records
+  // nothing and therefore can never rebind.
+  const requestVoiceRebind = useVoiceRebindStore((state) => state.requestRebind);
+  const handleSelectAgentForVoice = useCallback(
+    (agent: Parameters<typeof selectAgent>[0]) => {
+      selectAgent(agent);
+      requestVoiceRebind(agent?.id ?? null);
+    },
+    [selectAgent, requestVoiceRebind],
+  );
 
   const { isLoading: isLoadingProviders, isAnyProviderConfigured, needsSetup } =
     useProviderSettings();
@@ -942,7 +956,7 @@ const GlobalAssistantView: React.FC = () => {
         <div className="flex items-center space-x-2">
           <AISelector
             selectedAgent={selectedAgent}
-            onSelectAgent={selectAgent}
+            onSelectAgent={handleSelectAgentForVoice}
             disabled={isStreaming}
           />
         </div>
@@ -978,6 +992,16 @@ const GlobalAssistantView: React.FC = () => {
           </Button>
         </div>
       </div>
+
+      {/*
+        Voice as a MODE on this surface — same conversation, same message list,
+        with the live call's chrome above it. Spoken turns arrive in that list as
+        ordinary messages, so there is no second transcript here.
+      */}
+      <VoiceCallBarForConversation
+        conversationId={currentConversationId}
+        assistantName={selectedAgent ? selectedAgent.title : 'Global Assistant'}
+      />
 
       {/* Usage Monitor */}
       {displayPreferences.showTokenCounts && (

--- a/apps/web/src/components/layout/right-sidebar/__tests__/RightPanel.page-tab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/__tests__/RightPanel.page-tab.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * The page-context tab is DRIVEN FROM THE STORE, not from panel-local state.
+ *
+ * This is the other half of the nav trigger's reveal. `Layout` writes
+ * `setRightSidebarPageTab('chat')` when it reveals a call — and a test on that
+ * side alone would pass happily while this panel kept its own `useState` and
+ * ignored the write entirely. The symptom would be a live call whose chrome the
+ * user cannot reach because the sidebar opened on History.
+ *
+ * The three tab bodies are stubs: this file is about which one is shown.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useLayoutStore } from '@/stores/useLayoutStore';
+
+vi.mock('@/hooks/useDashboardContext', () => ({
+  useDashboardContext: () => ({ isDashboardContext: false }),
+}));
+vi.mock('@/hooks/useMobileKeyboard', () => ({
+  useMobileKeyboard: () => ({ isOpen: false, height: 0 }),
+}));
+vi.mock('../ai-assistant/SidebarChatTab', () => ({
+  default: () => <div data-testid="tab-body-chat" />,
+}));
+vi.mock('../ai-assistant/SidebarHistoryTab', () => ({
+  default: () => <div data-testid="tab-body-history" />,
+}));
+vi.mock('../ai-assistant/SidebarActivityTab', () => ({
+  default: () => <div data-testid="tab-body-activity" />,
+}));
+
+import RightPanel from '../index';
+
+/**
+ * Every tab body is force-mounted (the panel keeps chat state alive across tab
+ * switches), so "which tab is shown" is Radix's `data-state` on the panel, not
+ * presence in the DOM — and not `toBeVisible`, since the hiding is a Tailwind
+ * class that jsdom does not compile.
+ */
+const panelState = (testId: string) =>
+  screen.getByTestId(testId).closest('[role="tabpanel"]')?.getAttribute('data-state');
+
+beforeEach(() => {
+  useLayoutStore.setState({ rightSidebarPageTab: 'chat' });
+});
+
+describe('RightPanel — the page-context tab comes from the layout store', () => {
+  it('should show whichever tab the store names', () => {
+    useLayoutStore.setState({ rightSidebarPageTab: 'history' });
+    render(<RightPanel />);
+
+    expect(panelState('tab-body-history')).toBe('active');
+    expect(panelState('tab-body-chat')).toBe('inactive');
+  });
+
+  it('should switch to chat when the store is driven there from OUTSIDE the panel', () => {
+    // Exactly what `Layout.handleRevealAssistant` does when the voice trigger
+    // reveals a call. Nothing inside this panel is touched.
+    useLayoutStore.setState({ rightSidebarPageTab: 'history' });
+    render(<RightPanel />);
+    expect(panelState('tab-body-history')).toBe('active');
+
+    act(() => {
+      useLayoutStore.getState().setRightSidebarPageTab('chat');
+    });
+
+    expect(panelState('tab-body-chat')).toBe('active');
+    expect(panelState('tab-body-history')).toBe('inactive');
+  });
+
+  it('should still write the user\'s own tab clicks back to the store', () => {
+    render(<RightPanel />);
+
+    const activityTab = screen.getByRole('tab', { name: /activity/i });
+    // Radix Tabs switches on mousedown, not on the synthetic click alone.
+    fireEvent.mouseDown(activityTab);
+    fireEvent.click(activityTab);
+
+    expect(useLayoutStore.getState().rightSidebarPageTab).toBe('activity');
+    expect(panelState('tab-body-activity')).toBe('active');
+  });
+
+  it('should default to chat, as the local state it replaced did', () => {
+    render(<RightPanel />);
+    expect(panelState('tab-body-chat')).toBe('active');
+  });
+});

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -52,6 +52,8 @@ import { useChatTransport, useSendHandoff, useConversationSendHandoff, HANDOFF_R
 import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
+import { VoiceCallBarForConversation } from '@/components/ai/voice/realtime';
+import { useVoiceRebindStore } from '@/stores/useVoiceRebindStore';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
@@ -910,9 +912,22 @@ const SidebarChatTab: React.FC = () => {
   });
 
   // Adapter for AgentSelector (converts SidebarAgentInfo to AgentInfo shape)
+  //
+  // THE SWITCHER IS THE VOICE SWITCHER. Choosing a different agent is the one
+  // explicit act that moves a live call — navigation never does, which is why
+  // the rebind is recorded HERE, on the click, and not derived from the target
+  // changing (a route change changes the target identically, and following that
+  // would hang the user's call up every time they opened a page).
+  //
+  // It records an INTENT rather than rebinding directly because `selectAgent`
+  // clears the conversation id and re-resolves it asynchronously — there is
+  // nothing to bind to yet at this moment. `VoiceSessionBridge` applies it when
+  // there is, and drops it if no call is running.
+  const requestVoiceRebind = useVoiceRebindStore((state) => state.requestRebind);
   const handleSelectAgent = useCallback((agent: SidebarAgentInfo | null) => {
     selectAgent(agent);
-  }, [selectAgent]);
+    requestVoiceRebind(agent?.id ?? null);
+  }, [selectAgent, requestVoiceRebind]);
 
   // Stop, for both modes (PR 5A, leaf 5.5.6). One action, no dispatcher.
   //
@@ -1019,6 +1034,18 @@ const SidebarChatTab: React.FC = () => {
           </div>
         )}
       </div>
+
+      {/*
+        Voice as a MODE on this surface, not a fourth tab and not an overlay:
+        the same message list below, with the live call's chrome above it. The
+        spoken turns themselves arrive as ordinary messages in that list (the
+        realtime server writes them through messageRepository, so they come down
+        the same `conversation:*` socket events every other message does).
+      */}
+      <VoiceCallBarForConversation
+        conversationId={currentConversationId}
+        assistantName={assistantName}
+      />
 
       {/* Message-load error (from the conversation cache) — shown above messages so
           it's always visible; a failed load keeps the prior snapshot. */}

--- a/apps/web/src/components/layout/right-sidebar/index.tsx
+++ b/apps/web/src/components/layout/right-sidebar/index.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef, memo, useCallback } from "react";
+import { useEffect, useRef, memo, useCallback } from "react";
 import { History, MessageSquare, Activity } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useSidebarAgentStore } from "@/hooks/page-agents";
 import { useDashboardContext } from "@/hooks/useDashboardContext";
 import { usePageAgentDashboardStore, type SidebarTab } from "@/stores/page-agents";
+import { useLayoutStore } from "@/stores/useLayoutStore";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useMobileKeyboard } from "@/hooks/useMobileKeyboard";
 
@@ -58,8 +59,13 @@ function RightPanel({ className, variant }: RightPanelProps) {
   // Chat tab is only shown when NOT on dashboard context
   const showChatTab = !isDashboardContext;
 
-  // Local tab state for page context (independent from dashboard)
-  const [localActiveTab, setLocalActiveTab] = useState<SidebarTab>(showChatTab ? "chat" : "history");
+  // Page-context tab state. In the layout store rather than local state (same
+  // default, same lifetime — it is not persisted) so that the nav-bar voice
+  // trigger can bring this tab to the front when it reveals a live call: a
+  // button in the header cannot reach a `useState` inside this panel, and the
+  // panel is unmounted entirely while the sidebar is collapsed.
+  const localActiveTab = useLayoutStore((state) => state.rightSidebarPageTab);
+  const setLocalActiveTab = useLayoutStore((state) => state.setRightSidebarPageTab);
 
   // Auto-switch to chat tab when navigating from dashboard to page context
   // This ensures streaming continues visibly in the sidebar

--- a/apps/web/src/contexts/VoiceSessionContext.tsx
+++ b/apps/web/src/contexts/VoiceSessionContext.tsx
@@ -75,6 +75,13 @@ export type VoiceSessionState = SessionState & {
   readonly localStream: MediaStream | null;
   /** The model's voice. Already routed to the speaker; here for visualisation. */
   readonly remoteStream: MediaStream | null;
+  /**
+   * Whether the microphone is silenced. Owned here, with the microphone itself
+   * — a mute held by whatever chrome is on screen would come back UNMUTED
+   * every time that chrome unmounted, which for a sidebar the user can collapse
+   * means a muted call quietly starts transmitting again.
+   */
+  readonly muted: boolean;
 };
 
 export type VoiceSessionControls = {
@@ -86,6 +93,19 @@ export type VoiceSessionControls = {
   readonly start: (target: VoiceTarget) => Promise<void>;
   /** Hang up. Safe to call when nothing is running. */
   readonly stop: () => void;
+  /**
+   * Silence or unsilence the microphone WITHOUT touching the call — no
+   * renegotiation, no reconnect, no gap in the session. Safe to call when
+   * nothing is running.
+   *
+   * Mute survives a CHAIN and is cleared by a HANGUP. Both halves matter: a
+   * chain is the same conversation continuing across the API's duration
+   * ceiling, and a mute that expired there would start transmitting a room the
+   * user believed was private; a new call after hanging up is a new
+   * conversation, and starting it silently muted is a call the user would
+   * spend thirty seconds talking into for nothing.
+   */
+  readonly setMuted: (muted: boolean) => void;
   /**
    * Tell the session where the user is now standing. Does NOT rebind and does
    * not interrupt: navigating is not switching who you are talking to.
@@ -139,6 +159,14 @@ export function VoiceSessionProvider({
   const [attached, setAttached] = useState(false);
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
+  const [muted, setMutedState] = useState(false);
+  /**
+   * Read at the moment a call goes live, which can be after the user has
+   * already pressed mute — held in a ref for the same reason `boundTargetRef`
+   * is: the connect path must see what is true NOW, not what was captured when
+   * the callback was created.
+   */
+  const mutedRef = useRef(false);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   /** The attempt currently feeding the speaker and the UI. */
@@ -286,7 +314,10 @@ export function VoiceSessionProvider({
         boundTargetRef.current = null;
         clearSessionState();
         setTarget(null);
-        dispatch({ type: 'failed', message: result.message });
+        // The classified reason travels with the sentence: the chrome branches
+        // on it to decide whether a Try again is honest (a denied prompt) or a
+        // guaranteed failure (no capture device at all).
+        dispatch({ type: 'failed', message: result.message, failure: result.reason });
         return;
       }
 
@@ -294,7 +325,11 @@ export function VoiceSessionProvider({
       // outgoing one is stopped, so there is no moment with no session.
       activeRef.current = attempt;
       attempt.connection = result.connection;
-      result.connection.setMicrophoneEnabled(true);
+      // NOT an unconditional `true`. A chained call is negotiated silent and
+      // opened here, so hardcoding `true` would unmute the user at the duration
+      // ceiling — in the middle of a call they had deliberately muted, without
+      // any control being touched.
+      result.connection.setMicrophoneEnabled(!mutedRef.current);
       if (attempt.remoteStream) playRemote(attempt.remoteStream);
 
       if (options.chained && previous?.connection) {
@@ -346,8 +381,20 @@ export function VoiceSessionProvider({
     teardown();
     clearSessionState();
     setTarget(null);
+    // A hangup ends the conversation, and with it the reason to stay muted.
+    mutedRef.current = false;
+    setMutedState(false);
     dispatch({ type: 'disconnected' });
   }, [clearSessionState, teardown]);
+
+  const setMuted = useCallback((next: boolean) => {
+    mutedRef.current = next;
+    setMutedState(next);
+    // Applied to the call being HEARD, never to a chain still negotiating: that
+    // one is deliberately silent until the swap, and unmuting it early is two
+    // sessions hearing the same sentence.
+    activeRef.current?.connection?.setMicrophoneEnabled(!next);
+  }, []);
 
   const setLocationContext = useCallback(
     (locationContext: VoiceLocationContext | undefined) => {
@@ -369,13 +416,14 @@ export function VoiceSessionProvider({
       attached,
       localStream,
       remoteStream,
+      muted,
     }),
-    [state, target, callId, attached, localStream, remoteStream],
+    [state, target, callId, attached, localStream, remoteStream, muted],
   );
 
   const controlsValue: VoiceSessionControls = useMemo(
-    () => ({ start, stop, setLocationContext }),
-    [start, stop, setLocationContext],
+    () => ({ start, stop, setLocationContext, setMuted }),
+    [start, stop, setLocationContext, setMuted],
   );
 
   return (
@@ -422,8 +470,14 @@ export function useVoiceSession(): VoiceSessionState {
  *   - the agent switcher calls `start(…)` with the new agent's target and gets a
  *     rebind for free — it does not stop and start;
  *   - route changes call `setLocationContext(…)` and MUST NOT call `start`;
- *   - call chrome reads `useVoiceSession()` for `status`, `error`, `transcript`,
- *     `userSpeaking`, `tools`, `attached` and the two streams.
+ *   - call chrome reads `useVoiceSession()` for `status`, `error`, `failure`,
+ *     `transcript`, `userSpeaking`, `tools`, `attached`, `muted` and the two
+ *     streams, and calls `setMuted(…)` to silence the mic mid-call.
+ * `failure` and `muted`/`setMuted` were added by chunk C-D, which found the
+ * original seam one field short in each direction: `error` alone is a sentence
+ * the UI cannot branch on (a denied prompt and an absent device need opposite
+ * affordances), and mute has to live with the microphone or it comes back
+ * un-muted every time the sidebar holding it is collapsed.
  * The `<audio>` element and the microphone belong to this provider. UI that
  * mounts its own sink, or that owns a session per panel, is the failure mode
  * this file exists to prevent.

--- a/apps/web/src/contexts/__tests__/VoiceSessionContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/VoiceSessionContext.test.tsx
@@ -663,3 +663,87 @@ describe('VoiceSessionProvider — the live event stream', () => {
     expect(probe.state.remoteStream).toBe(modelVoice);
   });
 });
+
+/**
+ * Mute belongs to the provider because the MICROPHONE does. Held by whatever
+ * chrome is on screen it would come back un-muted every time that chrome
+ * unmounted — and the chrome in question is a sidebar the user can collapse,
+ * so a muted call would quietly start transmitting the room again.
+ */
+describe('VoiceSessionProvider — muting', () => {
+  const tracksEnabled = (peer: FakePeerConnection) =>
+    peer.addedTracks.map((track) => track.enabled);
+
+  it('should silence the live microphone without touching the call', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    expect(tracksEnabled(h.peers[0])).toEqual([true]);
+
+    await act(async () => {
+      probe.controls.setMuted(true);
+    });
+
+    expect(probe.state.muted).toBe(true);
+    expect(tracksEnabled(h.peers[0])).toEqual([false]);
+    // Still the same call: no renegotiation, no reconnect, no gap.
+    expect(h.peers).toHaveLength(1);
+    expect(h.peers[0].closed).toBe(false);
+    expect(probe.state.status).toBe('connected');
+    expect(probe.state.callId).toBe('rtc_call_1');
+  });
+
+  it('should stay muted across a chain', async () => {
+    // A chained call is negotiated SILENT and opened at the swap. Opening it
+    // unconditionally would un-mute the user at the duration ceiling, in the
+    // middle of a call they had deliberately muted, with no control touched.
+    vi.useFakeTimers();
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      probe.controls.setMuted(true);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MAX_DURATION_MS - CHAIN_LEAD_MS);
+    });
+
+    expect(h.peers).toHaveLength(2);
+    expect(probe.state.callId).toBe('rtc_call_2');
+    expect(probe.state.muted).toBe(true);
+    expect(tracksEnabled(h.peers[1])).toEqual([false]);
+  });
+
+  it('should un-mute when the call ends, so the next one is not silently dead', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+    await startCall();
+
+    await act(async () => {
+      probe.controls.setMuted(true);
+    });
+    await act(async () => {
+      probe.controls.stop();
+    });
+
+    expect(probe.state.muted).toBe(false);
+
+    await startCall();
+    expect(tracksEnabled(h.peers[1])).toEqual([true]);
+  });
+
+  it('should be safe to press with nothing running', async () => {
+    const h = harness();
+    render(<App deps={h.deps} />);
+
+    await act(async () => {
+      probe.controls.setMuted(true);
+    });
+
+    expect(probe.state.muted).toBe(true);
+    expect(h.peers).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/voice/useAudioLevel.ts
+++ b/apps/web/src/hooks/voice/useAudioLevel.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * How loud a stream is right now, as a coarse level for a meter.
+ *
+ * WHY IT IS QUANTIZED AND NOT CONTINUOUS. The obvious implementation sets React
+ * state from a `requestAnimationFrame` loop, which re-renders the component
+ * sixty times a second for the whole call — and that component is inside the
+ * chat surface, above a virtualized message list. Rounding to a small number of
+ * buckets and only setting state when the BUCKET changes gives a meter that
+ * looks identical and re-renders a couple of times a second while somebody is
+ * speaking. A meter is a rough visual; it does not need float precision, and
+ * paying sixty renders a second for precision nobody can see is how a live call
+ * makes the rest of the app feel broken.
+ *
+ * WHY THE FAILURE MODE IS SILENCE, NOT AN ERROR. `AudioContext` is absent in
+ * jsdom, absent in some embedded webviews, and can be refused outright by an
+ * autoplay policy. None of that is a reason to interrupt a working voice call
+ * with an error — the audio still flows through the provider's `<audio>`
+ * element either way. A meter that cannot run simply reads zero.
+ *
+ * This hook is where the I/O lives, deliberately: everything it feeds is a pure
+ * render of a number.
+ */
+
+/** Buckets, not pixels: the meter has this many distinguishable heights. */
+const LEVELS = 8;
+
+type AudioContextConstructor = new () => AudioContext;
+
+const audioContextConstructor = (): AudioContextConstructor | null => {
+  if (typeof window === 'undefined') return null;
+  const w = window as unknown as {
+    AudioContext?: AudioContextConstructor;
+    webkitAudioContext?: AudioContextConstructor;
+  };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+};
+
+export function useAudioLevel(stream: MediaStream | null, active: boolean): number {
+  const [level, setLevel] = useState(0);
+  // The last bucket PUSHED to state. Kept in a ref so the loop can compare
+  // without depending on state, which would restart the effect every change.
+  const bucketRef = useRef(0);
+
+  useEffect(() => {
+    if (!active || !stream) {
+      bucketRef.current = 0;
+      setLevel(0);
+      return;
+    }
+
+    const Ctor = audioContextConstructor();
+    if (!Ctor || typeof requestAnimationFrame !== 'function') return;
+
+    let context: AudioContext;
+    let analyser: AnalyserNode;
+    let source: MediaStreamAudioSourceNode;
+    try {
+      context = new Ctor();
+      analyser = context.createAnalyser();
+      // Small FFT: we want an amplitude envelope, not a spectrum, and a smaller
+      // window costs less per frame.
+      analyser.fftSize = 256;
+      source = context.createMediaStreamSource(stream);
+      source.connect(analyser);
+    } catch {
+      // A stream with no live audio track, or a context the browser refused.
+      return;
+    }
+
+    const samples = new Uint8Array(analyser.frequencyBinCount);
+    let frame = 0;
+    let stopped = false;
+
+    const tick = () => {
+      if (stopped) return;
+      analyser.getByteTimeDomainData(samples);
+
+      // Peak deviation from the 128 midpoint — a cheap stand-in for amplitude
+      // that responds the way a person expects a mic meter to.
+      let peak = 0;
+      for (let i = 0; i < samples.length; i += 1) {
+        const deviation = Math.abs(samples[i] - 128);
+        if (deviation > peak) peak = deviation;
+      }
+
+      const normalized = Math.min(1, peak / 128);
+      const bucket = Math.round(normalized * LEVELS);
+      if (bucket !== bucketRef.current) {
+        bucketRef.current = bucket;
+        setLevel(bucket / LEVELS);
+      }
+
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+
+    return () => {
+      stopped = true;
+      cancelAnimationFrame(frame);
+      source.disconnect();
+      analyser.disconnect();
+      // The context holds a hardware audio thread; leaking one per call is a
+      // browser that eventually refuses to make any more of them.
+      void context.close().catch(() => {});
+      bucketRef.current = 0;
+    };
+  }, [stream, active]);
+
+  return level;
+}

--- a/apps/web/src/hooks/voice/useVoiceBinding.ts
+++ b/apps/web/src/hooks/voice/useVoiceBinding.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useDashboardContext } from '@/hooks/useDashboardContext';
+import { useSidebarAgentStore } from '@/hooks/page-agents';
+import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { useGlobalChatConversation } from '@/contexts/GlobalChatContext';
+import { resolveVoiceBinding, type VoiceBinding } from '@/lib/ai/realtime/voice-binding';
+
+/**
+ * The conversation the microphone would talk to, right now, on this route.
+ *
+ * This hook is ONLY the gather step — every store read, no decisions. What it
+ * gathers goes straight into `resolveVoiceBinding`, which is pure and where the
+ * "no second target picker" rule is actually enforced and tested.
+ *
+ * It is safe to mount anywhere inside `GlobalChatProvider`, which is where the
+ * nav-bar trigger lives — and that matters more than it looks. The trigger is
+ * on every route including ones where the sidebar is collapsed, so the binding
+ * must be answerable WITHOUT the chat surface being mounted. Reading zustand
+ * stores and the chat context (rather than asking the surface) is what makes
+ * that true.
+ */
+export function useVoiceBinding(): VoiceBinding {
+  const { isDashboardContext } = useDashboardContext();
+
+  const sidebarAgent = useSidebarAgentStore((state) => state.selectedAgent);
+  const sidebarConversationId = useSidebarAgentStore((state) => state.conversationId);
+  const dashboardAgent = usePageAgentDashboardStore((state) => state.selectedAgent);
+  const dashboardConversationId = usePageAgentDashboardStore((state) => state.conversationId);
+
+  const { currentConversationId: globalConversationId } = useGlobalChatConversation();
+
+  return useMemo(
+    () =>
+      resolveVoiceBinding({
+        isDashboardContext,
+        dashboardAgent: dashboardAgent ? { id: dashboardAgent.id } : null,
+        dashboardConversationId,
+        sidebarAgent: sidebarAgent ? { id: sidebarAgent.id } : null,
+        sidebarConversationId,
+        globalConversationId,
+      }),
+    [
+      isDashboardContext,
+      dashboardAgent,
+      dashboardConversationId,
+      sidebarAgent,
+      sidebarConversationId,
+      globalConversationId,
+    ],
+  );
+}

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
@@ -222,3 +222,47 @@ describe('sanitizeMessagesForModel', () => {
     expect(result[0].parts).toEqual([{ type: 'text', text: 'done' }]);
   });
 });
+
+/**
+ * The transport a row was authored over has to survive the trip to the UI, or
+ * the mic glyph has nothing to read. `unifiedColumns` already SELECTs
+ * `messages.source`; this is the step where it either reaches the renderer or
+ * is silently dropped on the floor.
+ */
+describe('convertDbMessageToUIMessage — the authoring transport', () => {
+  const row = (source: string | null, content: string) => ({
+    id: 'm1',
+    pageId: 'p1',
+    userId: 'u1',
+    role: 'user',
+    content,
+    toolCalls: null,
+    toolResults: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    isActive: true,
+    source,
+  });
+
+  it('should carry a spoken turn\'s source through to the UI message', async () => {
+    const converted = await convertDbMessageToUIMessage(row('voice', 'what is on this page'));
+    expect((converted as { source?: string | null }).source).toBe('voice');
+  });
+
+  it('should carry it through the STRUCTURED-content path too', async () => {
+    // Two code paths reconstruct a message; a field added to only one of them
+    // makes the glyph appear or vanish depending on whether the turn happened
+    // to have attachments or tool calls.
+    const structured = JSON.stringify({
+      textParts: ['what is on this page'],
+      partsOrder: [{ index: 0, type: 'text' }],
+      originalContent: 'what is on this page',
+    });
+    const converted = await convertDbMessageToUIMessage(row('voice', structured));
+    expect((converted as { source?: string | null }).source).toBe('voice');
+  });
+
+  it('should report a typed turn as null rather than undefined', async () => {
+    const converted = await convertDbMessageToUIMessage(row(null, 'typed'));
+    expect((converted as { source?: string | null }).source).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -94,7 +94,7 @@ interface ToolPart {
 /** Extended UIMessage with extra fields stored in our database */
 type MessageStatus = 'streaming' | 'complete' | 'interrupted';
 
-type ExtendedUIMessage = UIMessage & { editedAt?: Date | null; messageType: string; createdAt?: Date; userName?: string | null; status?: MessageStatus };
+type ExtendedUIMessage = UIMessage & { editedAt?: Date | null; messageType: string; createdAt?: Date; userName?: string | null; status?: MessageStatus; source?: string | null };
 
 interface DatabaseMessage {
   id: string;
@@ -118,6 +118,13 @@ interface DatabaseMessage {
   messageType?: 'standard' | 'todo_list';
   userName?: string | null;
   status?: MessageStatus;
+  /**
+   * The transport the row was authored over — `MESSAGE_SOURCE_VOICE` for a turn
+   * spoken into a live call, null for a typed one. Already selected by every
+   * unified reader (`unifiedColumns`); carried out to the UI here so a thread
+   * can be honest about how it was made.
+   */
+  source?: string | null;
 }
 
 
@@ -306,7 +313,7 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
 
     try {
       const structured = await reconstructFromStructuredContent(dbMessage, parsed);
-      return { ...structured, userName: dbMessage.userName, status: dbMessage.status } as ExtendedUIMessage;
+      return { ...structured, userName: dbMessage.userName, status: dbMessage.status, source: dbMessage.source ?? null } as ExtendedUIMessage;
     } catch (error) {
       // Reconstruction failed (e.g. S3 presign error) — fall back to the
       // original plain-text content rather than leaking the raw structured
@@ -321,6 +328,7 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
         messageType: dbMessage.messageType || 'standard',
         userName: dbMessage.userName,
         status: dbMessage.status,
+        source: dbMessage.source ?? null,
       } as ExtendedUIMessage;
     }
   }
@@ -337,6 +345,7 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
     messageType: dbMessage.messageType || 'standard',
     status: dbMessage.status,
     userName: dbMessage.userName,
+    source: dbMessage.source ?? null,
   } as ExtendedUIMessage;
 }
 

--- a/apps/web/src/lib/ai/realtime/__tests__/call-chrome.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/call-chrome.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { describeCall, isCallLive, type CallChromeFacts } from '../call-chrome';
+import { micFailureMessage } from '@/lib/voice/mic-errors';
+
+const facts = (overrides: Partial<CallChromeFacts> = {}): CallChromeFacts => ({
+  status: 'idle',
+  error: undefined,
+  failure: undefined,
+  attached: false,
+  bound: false,
+  ...overrides,
+});
+
+describe('describeCall — the two states a "voice failed" would flatten', () => {
+  it('should offer a retry for a REFUSED microphone', () => {
+    const chrome = describeCall(
+      facts({
+        status: 'error',
+        failure: 'mic-denied',
+        error: micFailureMessage('denied', false),
+      }),
+    );
+
+    expect(chrome.state).toBe('error');
+    expect(chrome.canRetry).toBe(true);
+  });
+
+  it('should NOT offer a retry when the microphone is ABSENT or unsupported', () => {
+    // Retrying cannot conjure hardware. A button that is guaranteed to fail
+    // teaches the user that voice is broken rather than that they have no
+    // capture device.
+    expect(
+      describeCall(facts({ status: 'error', failure: 'mic-missing', error: 'x' })).canRetry,
+    ).toBe(false);
+    expect(
+      describeCall(facts({ status: 'error', failure: 'mic-unsupported', error: 'x' })).canRetry,
+    ).toBe(false);
+
+    // A busy device IS retryable — the user closes the other app and tries again.
+    expect(
+      describeCall(facts({ status: 'error', failure: 'mic-busy', error: 'x' })).canRetry,
+    ).toBe(true);
+  });
+
+  it('should carry the connector\'s own sentence through, never a generic one', () => {
+    // The advice differs per failure and the advice is the entire point:
+    // "allow it in settings" vs "connect a microphone".
+    const denied = micFailureMessage('denied', false);
+    const missing = micFailureMessage('missing', false);
+    expect(denied).not.toBe(missing);
+
+    expect(describeCall(facts({ status: 'error', failure: 'mic-denied', error: denied })).detail).toBe(
+      denied,
+    );
+    expect(
+      describeCall(facts({ status: 'error', failure: 'mic-missing', error: missing })).detail,
+    ).toBe(missing);
+  });
+
+  it('should still say something when a failure arrived with no sentence', () => {
+    const chrome = describeCall(facts({ status: 'error' }));
+    expect(chrome.detail).toBeTruthy();
+    // Unclassified: assume retryable rather than lock the user out of trying.
+    expect(chrome.canRetry).toBe(true);
+  });
+});
+
+describe('describeCall — attached is not a detail', () => {
+  it('should distinguish a fully-capable call from one with no transcript', () => {
+    const full = describeCall(facts({ status: 'connected', attached: true, bound: true }));
+    const degraded = describeCall(facts({ status: 'connected', attached: false, bound: true }));
+
+    expect(full.state).toBe('live');
+    expect(full.detail).toBeNull();
+
+    // A working audio call whose words will not reach the thread. The user has
+    // to be TOLD, because it looks exactly like the working one.
+    expect(degraded.state).toBe('degraded');
+    expect(degraded.detail).toBeTruthy();
+    expect(degraded.detail).toMatch(/saved|transcript/i);
+  });
+
+  it('should treat both as live — the colour says what is degraded, not whether the mic is open', () => {
+    expect(isCallLive('live')).toBe(true);
+    expect(isCallLive('degraded')).toBe(true);
+    expect(isCallLive('connecting')).toBe(true);
+    expect(isCallLive('idle')).toBe(false);
+    expect(isCallLive('error')).toBe(false);
+  });
+});
+
+describe('describeCall — idle', () => {
+  it('should invite rather than report', () => {
+    expect(describeCall(facts()).state).toBe('idle');
+    expect(describeCall(facts()).label).toMatch(/start/i);
+  });
+
+  it('should never offer a retry for a state that has not failed', () => {
+    for (const status of ['idle', 'connecting', 'connected'] as const) {
+      expect(describeCall(facts({ status })).canRetry).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-binding.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-binding.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isCallOnConversation,
+  resolveVoiceBinding,
+  type VoiceBindingFacts,
+} from '../voice-binding';
+
+/**
+ * The rule under test is "there is no target picker" — every route has exactly
+ * one answer, derived from what is on screen. The cases that matter are the
+ * ones where a plausible implementation would get it wrong: crossing the two
+ * surfaces' pairs, and treating an unresolved conversation as "voice is
+ * unavailable" rather than "not yet".
+ */
+
+const facts = (overrides: Partial<VoiceBindingFacts> = {}): VoiceBindingFacts => ({
+  isDashboardContext: false,
+  dashboardAgent: null,
+  dashboardConversationId: null,
+  sidebarAgent: null,
+  sidebarConversationId: null,
+  globalConversationId: null,
+  ...overrides,
+});
+
+describe('resolveVoiceBinding — which conversation the mic talks to', () => {
+  it('should bind a page route to the SIDEBAR agent and the sidebar conversation', () => {
+    const binding = resolveVoiceBinding(
+      facts({
+        sidebarAgent: { id: 'agent-sidebar' },
+        sidebarConversationId: 'conv-sidebar',
+        // Present and DIFFERENT, so a implementation reading the wrong pair
+        // produces a visibly wrong answer instead of the same one by luck.
+        dashboardAgent: { id: 'agent-dashboard' },
+        dashboardConversationId: 'conv-dashboard',
+      }),
+    );
+
+    expect(binding).toEqual({
+      kind: 'ready',
+      surface: 'sidebar',
+      target: {
+        conversationId: 'conv-sidebar',
+        type: 'page',
+        contextId: 'agent-sidebar',
+        agentPageId: 'agent-sidebar',
+      },
+    });
+  });
+
+  it('should bind the dashboard to the DASHBOARD pair, where the sidebar has no chat tab', () => {
+    const binding = resolveVoiceBinding(
+      facts({
+        isDashboardContext: true,
+        sidebarAgent: { id: 'agent-sidebar' },
+        sidebarConversationId: 'conv-sidebar',
+        dashboardAgent: { id: 'agent-dashboard' },
+        dashboardConversationId: 'conv-dashboard',
+      }),
+    );
+
+    expect(binding).toEqual({
+      kind: 'ready',
+      surface: 'dashboard',
+      target: {
+        conversationId: 'conv-dashboard',
+        type: 'page',
+        contextId: 'agent-dashboard',
+        agentPageId: 'agent-dashboard',
+      },
+    });
+  });
+
+  it('should NEVER cross the pairs — an agent from one surface with the other surface\'s conversation', () => {
+    // The dashboard has an agent but no conversation yet; the sidebar has one
+    // sitting right there. Taking it would open a call to the dashboard's agent
+    // that writes its transcript into the sidebar agent's thread.
+    const binding = resolveVoiceBinding(
+      facts({
+        isDashboardContext: true,
+        dashboardAgent: { id: 'agent-dashboard' },
+        dashboardConversationId: null,
+        sidebarAgent: { id: 'agent-sidebar' },
+        sidebarConversationId: 'conv-sidebar',
+        globalConversationId: 'conv-global',
+      }),
+    );
+
+    expect(binding).toEqual({ kind: 'resolving', surface: 'dashboard' });
+  });
+
+  it('should fall back to the ONE global conversation when no agent is selected, on either surface', () => {
+    const onPage = resolveVoiceBinding(facts({ globalConversationId: 'conv-global' }));
+    const onDashboard = resolveVoiceBinding(
+      facts({ isDashboardContext: true, globalConversationId: 'conv-global' }),
+    );
+
+    expect(onPage).toEqual({
+      kind: 'ready',
+      surface: 'sidebar',
+      target: { conversationId: 'conv-global', type: 'global' },
+    });
+    // Same conversation, different surface: the global assistant is one
+    // assistant however you reach it.
+    expect(onDashboard).toEqual({
+      kind: 'ready',
+      surface: 'dashboard',
+      target: { conversationId: 'conv-global', type: 'global' },
+    });
+  });
+
+  it('should report resolving — not unavailable — while a conversation id is in flight', () => {
+    // What `selectAgent` leaves behind for a moment: an agent, no conversation.
+    expect(
+      resolveVoiceBinding(facts({ sidebarAgent: { id: 'agent-a' }, sidebarConversationId: null })),
+    ).toEqual({ kind: 'resolving', surface: 'sidebar' });
+
+    // And the global thread before it has been created.
+    expect(resolveVoiceBinding(facts())).toEqual({ kind: 'resolving', surface: 'sidebar' });
+  });
+
+  it('should address a page-agent conversation the way the repository writes it', () => {
+    // `conversationRepository.createConversation` writes type='page' with the
+    // AGENT PAGE in contextId, and `transcript-persistence` reads contextId
+    // back to decide where a spoken turn lands. If this drifts, transcripts go
+    // to the wrong page or are dropped as 'unsupported_conversation_type'.
+    const binding = resolveVoiceBinding(
+      facts({ sidebarAgent: { id: 'agent-a' }, sidebarConversationId: 'conv-a' }),
+    );
+
+    expect(binding.kind).toBe('ready');
+    if (binding.kind !== 'ready') return;
+    expect(binding.target.type).toBe('page');
+    expect(binding.target.contextId).toBe('agent-a');
+  });
+});
+
+describe('isCallOnConversation — which surface renders the call chrome', () => {
+  it('should match on the conversation, so a call follows its thread across surfaces', () => {
+    const target = { conversationId: 'conv-a', type: 'page' as const, contextId: 'agent-a' };
+    expect(isCallOnConversation(target, 'conv-a')).toBe(true);
+    expect(isCallOnConversation(target, 'conv-b')).toBe(false);
+  });
+
+  it('should be false when there is no call, and when the surface has no conversation', () => {
+    expect(isCallOnConversation(null, 'conv-a')).toBe(false);
+    expect(
+      isCallOnConversation({ conversationId: 'conv-a', type: 'global' }, null),
+    ).toBe(false);
+    // Two nulls are not a match: an unbound session and an unresolved surface
+    // are not "the same conversation".
+    expect(isCallOnConversation(null, null)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-location.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-location.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { voiceLocationContextSchema } from '@pagespace/lib/realtime/voice-bridge-contract';
+import { toVoiceLocationContext } from '../voice-location';
+import { VOICE_MESSAGE_SOURCE } from '../message-source';
+import { MESSAGE_SOURCE_VOICE } from '@pagespace/db/schema/conversations';
+
+/**
+ * The two types describe the same idea with different absence conventions
+ * (`T | null` on the chat side, `.optional()` on the wire). The failure this
+ * guards is silent: a `null` handed straight through fails the realtime
+ * server's zod parse, and the symptom is the model answering "this page"
+ * wrongly rather than an error anyone sees.
+ */
+describe('toVoiceLocationContext', () => {
+  it('should produce something the wire schema accepts', () => {
+    const wire = toVoiceLocationContext({
+      currentPage: { id: 'p1', title: 'Notes', type: 'DOCUMENT', path: '/drive/Notes' },
+      currentDrive: { id: 'd1', name: 'Drive', slug: 'drive' },
+      breadcrumbs: ['Drive', 'Notes'],
+    });
+
+    expect(voiceLocationContextSchema.safeParse(wire).success).toBe(true);
+  });
+
+  it('should convert the chat side\'s nulls to absence, not pass them through', () => {
+    const wire = toVoiceLocationContext({
+      currentPage: null,
+      currentDrive: { id: 'd1', name: 'Drive', slug: 'drive' },
+    });
+
+    expect(wire).not.toBeUndefined();
+    expect(wire).not.toHaveProperty('currentPage');
+    // The proof that it matters: the schema rejects the un-converted shape.
+    expect(
+      voiceLocationContextSchema.safeParse({
+        currentPage: null,
+        currentDrive: { id: 'd1', name: 'Drive', slug: 'drive' },
+      }).success,
+    ).toBe(false);
+    expect(voiceLocationContextSchema.safeParse(wire).success).toBe(true);
+  });
+
+  it('should return undefined for nowhere in particular, rather than an empty object', () => {
+    // A settings screen is a legitimate "no page, no drive". Sending `{}` would
+    // overwrite a location the live call already had with an empty one.
+    expect(toVoiceLocationContext(null)).toBeUndefined();
+    expect(toVoiceLocationContext(undefined)).toBeUndefined();
+    expect(toVoiceLocationContext({})).toBeUndefined();
+    expect(
+      toVoiceLocationContext({ currentPage: null, currentDrive: null, breadcrumbs: [] }),
+    ).toBeUndefined();
+  });
+
+  it('should keep the optional page flag only when it was set', () => {
+    const withFlag = toVoiceLocationContext({
+      currentPage: {
+        id: 'p1',
+        title: 'T',
+        type: 'DOCUMENT',
+        path: '/T',
+        isTaskLinked: true,
+      },
+    });
+    expect(withFlag?.currentPage?.isTaskLinked).toBe(true);
+
+    const withoutFlag = toVoiceLocationContext({
+      currentPage: { id: 'p1', title: 'T', type: 'DOCUMENT', path: '/T' },
+    });
+    expect(withoutFlag?.currentPage).not.toHaveProperty('isTaskLinked');
+  });
+});
+
+/**
+ * The drift guard promised by `message-source.ts`. Client components cannot
+ * import `@pagespace/db/schema`, so the browser reads its own copy of the
+ * value — this test is what stops the two from diverging. It runs in node,
+ * where importing the schema is free.
+ */
+describe('VOICE_MESSAGE_SOURCE — drift guard', () => {
+  it('should be exactly the value the database schema defines', () => {
+    expect(VOICE_MESSAGE_SOURCE).toBe(MESSAGE_SOURCE_VOICE);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-rebind.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-rebind.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { NO_REBIND_INTENT, rebindAction } from '../voice-rebind';
+import type { VoiceBinding } from '../voice-binding';
+
+/**
+ * THE distinction the whole voice lifecycle turns on: navigating must not
+ * rebind, switching agent must. Both look identical in the derived target, so
+ * every case below is really one question — did the user ASK for this?
+ */
+
+const ready = (agentPageId: string | null, conversationId: string): VoiceBinding =>
+  agentPageId === null
+    ? {
+        kind: 'ready',
+        surface: 'sidebar',
+        target: { conversationId, type: 'global' },
+      }
+    : {
+        kind: 'ready',
+        surface: 'sidebar',
+        target: {
+          conversationId,
+          type: 'page',
+          contextId: agentPageId,
+          agentPageId,
+        },
+      };
+
+const resolving: VoiceBinding = { kind: 'resolving', surface: 'sidebar' };
+
+describe('rebindAction — navigating vs switching', () => {
+  it('should do NOTHING when no switch was made, however the target changed', () => {
+    // This is navigation: the derived binding moved from one agent to another
+    // because the user walked to a different surface. No intent was recorded,
+    // so nothing happens — which is the entire reason the intent exists.
+    expect(rebindAction(NO_REBIND_INTENT, ready('agent-b', 'conv-b'), true)).toEqual({
+      kind: 'wait',
+    });
+  });
+
+  it('should rebind to the chosen agent once its conversation has resolved', () => {
+    const intent = { kind: 'pending' as const, agentPageId: 'agent-b' };
+
+    expect(rebindAction(intent, ready('agent-b', 'conv-b'), true)).toEqual({
+      kind: 'rebind',
+      target: {
+        conversationId: 'conv-b',
+        type: 'page',
+        contextId: 'agent-b',
+        agentPageId: 'agent-b',
+      },
+    });
+  });
+
+  it('should WAIT while the chosen agent\'s conversation is still being resolved', () => {
+    // `selectAgent` clears the conversation id first. Acting now would bind to
+    // nothing; guessing would bind to the wrong thread.
+    expect(
+      rebindAction({ kind: 'pending', agentPageId: 'agent-b' }, resolving, true),
+    ).toEqual({ kind: 'wait' });
+  });
+
+  it('should WAIT rather than rebind when the surface is showing someone else', () => {
+    // The user switched, then navigated before it resolved. Moving the call to
+    // whoever happens to be on screen now is not what was asked for.
+    expect(
+      rebindAction({ kind: 'pending', agentPageId: 'agent-b' }, ready('agent-c', 'conv-c'), true),
+    ).toEqual({ kind: 'wait' });
+  });
+
+  it('should treat the global assistant as a real destination, not as "no intent"', () => {
+    // Switching AWAY from an agent, back to the global assistant, is a rebind
+    // like any other. `null` here must not be read as "nothing was chosen".
+    expect(
+      rebindAction({ kind: 'pending', agentPageId: null }, ready(null, 'conv-global'), true),
+    ).toEqual({
+      kind: 'rebind',
+      target: { conversationId: 'conv-global', type: 'global' },
+    });
+  });
+
+  it('should drop the intent when no call is live', () => {
+    // Switching agent with nothing running is just switching agent. Holding the
+    // intent would make the NEXT press of the trigger — possibly minutes later,
+    // possibly after more switches — behave as a rebind of something it never
+    // asked about.
+    expect(
+      rebindAction({ kind: 'pending', agentPageId: 'agent-b' }, ready('agent-b', 'conv-b'), false),
+    ).toEqual({ kind: 'clear' });
+  });
+
+  it('should not clear an intent that does not exist', () => {
+    expect(rebindAction(NO_REBIND_INTENT, resolving, false)).toEqual({ kind: 'wait' });
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-reveal.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-reveal.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { decideReveal, type RevealFacts } from '../voice-reveal';
+
+/**
+ * "Reveal" is the half of the toggle that opens. The property that matters is
+ * negative and is asserted at every breakpoint: it must never produce a write
+ * that CLOSES the right sidebar, because the same button is the live indicator
+ * for a call in progress.
+ */
+
+const facts = (overrides: Partial<RevealFacts> = {}): RevealFacts => ({
+  surface: 'sidebar',
+  isSheetBreakpoint: false,
+  shouldOverlayRightSidebar: false,
+  shouldOverlayLeftSidebar: false,
+  rightSheetOpen: false,
+  leftSheetOpen: false,
+  rightSidebarOpen: false,
+  leftOverlayOpen: false,
+  ...overrides,
+});
+
+describe('decideReveal — open-only', () => {
+  it('should open the persistent sidebar and bring the chat tab forward', () => {
+    expect(decideReveal(facts())).toEqual({ rightSidebarOpen: true, showChatTab: true });
+  });
+
+  it('should open the sheet on mobile, closing the competing left sheet', () => {
+    expect(decideReveal(facts({ isSheetBreakpoint: true, leftSheetOpen: true }))).toEqual({
+      rightSheetOpen: true,
+      leftSheetOpen: false,
+      showChatTab: true,
+    });
+  });
+
+  it('should open the desktop overlay, collapsing the left one only when it is ALSO an overlay', () => {
+    const bothOverlay = decideReveal(
+      facts({
+        shouldOverlayRightSidebar: true,
+        shouldOverlayLeftSidebar: true,
+        leftOverlayOpen: true,
+      }),
+    );
+    expect(bothOverlay).toEqual({
+      rightSidebarOpen: true,
+      leftOverlayOpen: false,
+      showChatTab: true,
+    });
+
+    // A PERSISTENT left sidebar is not competing for the space, so it stays.
+    const leftPersistent = decideReveal(
+      facts({
+        shouldOverlayRightSidebar: true,
+        shouldOverlayLeftSidebar: false,
+        leftOverlayOpen: true,
+      }),
+    );
+    expect(leftPersistent).toEqual({ rightSidebarOpen: true, showChatTab: true });
+  });
+
+  it('should never emit a write that closes the right sidebar, at ANY breakpoint', () => {
+    const breakpoints: Array<Partial<RevealFacts>> = [
+      { isSheetBreakpoint: true },
+      { shouldOverlayRightSidebar: true },
+      {},
+    ];
+
+    for (const breakpoint of breakpoints) {
+      for (const alreadyOpen of [false, true]) {
+        const writes = decideReveal(
+          facts({ ...breakpoint, rightSidebarOpen: alreadyOpen, rightSheetOpen: alreadyOpen }),
+        );
+        expect(writes.rightSidebarOpen).not.toBe(false);
+        expect(writes.rightSheetOpen).not.toBe(false);
+      }
+    }
+  });
+
+  it('should be a genuine no-op when everything is already open', () => {
+    // Not merely harmless: pressing a live indicator must not re-render the app
+    // by writing values that are already set.
+    expect(decideReveal(facts({ rightSidebarOpen: true }))).toEqual({ showChatTab: true });
+    expect(
+      decideReveal(facts({ isSheetBreakpoint: true, rightSheetOpen: true, leftSheetOpen: true })),
+    ).toEqual({ showChatTab: true });
+  });
+
+  it('should open NOTHING on the dashboard, where the sidebar has no chat tab', () => {
+    // GlobalAssistantView already holds the centre of the screen there. Opening
+    // the sidebar would open a panel that cannot show the call.
+    expect(decideReveal(facts({ surface: 'dashboard' }))).toEqual({ showChatTab: false });
+    expect(
+      decideReveal(facts({ surface: 'dashboard', isSheetBreakpoint: true })),
+    ).toEqual({ showChatTab: false });
+  });
+});

--- a/apps/web/src/lib/ai/realtime/call-chrome.ts
+++ b/apps/web/src/lib/ai/realtime/call-chrome.ts
@@ -1,0 +1,123 @@
+/**
+ * What the call chrome SAYS, as a pure function of what the session is doing.
+ *
+ * Two surfaces render this — the nav-bar trigger, which is on every route, and
+ * the call header on the chat surface — and they must never disagree about
+ * whether a call is live. Deriving both from one function is what makes that
+ * structural rather than a matter of keeping two `cn(...)` ladders in step.
+ *
+ * THE DISTINCTION THIS FILE REFUSES TO FLATTEN. "Voice didn't start" is not one
+ * outcome. A refused permission prompt is fixable by the user in about four
+ * seconds; an absent capture device is not fixable at all until they plug
+ * something in, and a browser with no `getUserMedia` is not fixable by them
+ * ever. `classifyMicFailure` already draws those lines and `connect.ts` already
+ * carries the classification out as `mic-denied` / `mic-missing` /
+ * `mic-unsupported` / `mic-busy`; this module is where that reaches the screen,
+ * as the difference between a Try again button and no Try again button. A retry
+ * affordance offered for a missing microphone is a button that is guaranteed to
+ * fail, which teaches the user that voice is broken rather than that their
+ * hardware is absent.
+ *
+ * THE OTHER DISTINCTION: `attached` false is a WORKING audio call. The model
+ * hears you and answers. What it has not got is tools, transcript persistence
+ * and metering — so nothing said in it will be in the thread afterwards, which
+ * is the one promise voice makes. That earns its own state and its own
+ * sentence, never a silent downgrade dressed as a normal call.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+import type { ConnectionStatus } from './session-state';
+import type { VoiceConnectFailure } from './connect';
+
+export type CallChromeState =
+  /** Nothing running. The trigger is an invitation. */
+  | 'idle'
+  /** Negotiating. The microphone may already be open. */
+  | 'connecting'
+  /** Live, attached, fully capable. */
+  | 'live'
+  /** Live audio, but the server never joined: no tools, no transcript, no metering. */
+  | 'degraded'
+  | 'error';
+
+export type CallChrome = {
+  readonly state: CallChromeState;
+  /** Short enough for an icon button's accessible name. */
+  readonly label: string;
+  /** The sentence a header shows under the label. `null` when there is nothing to add. */
+  readonly detail: string | null;
+  /**
+   * Whether offering "Try again" is honest. False when the failure is the
+   * absence of a capability rather than the refusal of one — retrying cannot
+   * conjure a microphone or a `getUserMedia`.
+   */
+  readonly canRetry: boolean;
+};
+
+export type CallChromeFacts = {
+  readonly status: ConnectionStatus;
+  readonly error: string | undefined;
+  /** The classified reason behind `error`, when the session carried one out. */
+  readonly failure: VoiceConnectFailure | undefined;
+  readonly attached: boolean;
+  /** True while the session is bound to a conversation, even before it connects. */
+  readonly bound: boolean;
+};
+
+/**
+ * The two failures no retry can fix. Named as a set rather than tested inline
+ * so adding a case is one edit in one place, and so the test can assert the
+ * membership directly.
+ */
+const UNRETRYABLE: ReadonlySet<VoiceConnectFailure> = new Set<VoiceConnectFailure>([
+  'mic-missing',
+  'mic-unsupported',
+]);
+
+const DEGRADED_DETAIL =
+  'Connected, but the transcript service did not join — nothing said here will be saved to the thread.';
+
+export const describeCall = (facts: CallChromeFacts): CallChrome => {
+  if (facts.status === 'error') {
+    return {
+      state: 'error',
+      label: 'Voice failed',
+      // The sentence `connect.ts` wrote for this exact failure. Never replaced
+      // with a generic one here: the specific advice is the entire point.
+      detail: facts.error ?? 'Voice mode could not start.',
+      canRetry: facts.failure === undefined || !UNRETRYABLE.has(facts.failure),
+    };
+  }
+
+  if (facts.status === 'connecting') {
+    return {
+      state: 'connecting',
+      label: 'Connecting voice',
+      detail: null,
+      canRetry: false,
+    };
+  }
+
+  if (facts.status === 'connected') {
+    return facts.attached
+      ? { state: 'live', label: 'Voice call is live', detail: null, canRetry: false }
+      : {
+          state: 'degraded',
+          label: 'Voice call is live, without transcript',
+          detail: DEGRADED_DETAIL,
+          canRetry: false,
+        };
+  }
+
+  return {
+    state: 'idle',
+    label: facts.bound ? 'Talk to this conversation' : 'Start a voice call',
+    detail: null,
+    canRetry: false,
+  };
+};
+
+/** Whether a call is up in any capability. Used to decide reveal-vs-start. */
+export const isCallLive = (state: CallChromeState): boolean =>
+  state === 'connecting' || state === 'live' || state === 'degraded';

--- a/apps/web/src/lib/ai/realtime/message-source.ts
+++ b/apps/web/src/lib/ai/realtime/message-source.ts
@@ -1,0 +1,16 @@
+/**
+ * `messages.source`'s voice value, in a module the BROWSER can import.
+ *
+ * The definition lives in `@pagespace/db/schema/conversations`, and that is
+ * still the source of truth — but client components in this repo do not import
+ * from `@pagespace/db/schema` (it drags Drizzle's pg-core into the browser
+ * bundle), so the mic glyph cannot read it there. This is the same duplication
+ * trade `realtimeToolSchema` and `voiceLocationContextSchema` already make
+ * across the web/realtime boundary, with the same mitigation: a drift guard in
+ * the tests that imports BOTH and asserts they are the same string. A copy with
+ * a test that fails the moment it diverges is a copy that cannot silently rot.
+ *
+ * Pure: a constant. No I/O, no clock, no randomness, no module-level mutable
+ * state.
+ */
+export const VOICE_MESSAGE_SOURCE = 'voice';

--- a/apps/web/src/lib/ai/realtime/session-state.ts
+++ b/apps/web/src/lib/ai/realtime/session-state.ts
@@ -1,4 +1,9 @@
 import { extractTranscript, type TranscriptEntry } from '@pagespace/lib/realtime/voice-events';
+// Type-only, so no runtime edge is created from this pure module to the
+// browser-side connector: the union is DEFINED there because that is where the
+// failures are classified, and restating it here would be a second copy free to
+// drift from the one `connect.ts` actually emits.
+import type { VoiceConnectFailure } from './connect';
 
 /**
  * Everything the voice UI shows, as a pure reducer. The hook owns the wiring;
@@ -18,6 +23,17 @@ export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'error';
 export type SessionState = {
   readonly status: ConnectionStatus;
   readonly error: string | undefined;
+  /**
+   * WHY the last attempt failed, classified — not merely the sentence shown.
+   *
+   * `error` alone cannot be branched on: a denied permission prompt and an
+   * absent capture device are both "voice didn't start" as strings, and the UI
+   * has to treat them oppositely (one is retryable in four seconds, the other
+   * is not retryable at all). `connect.ts` already classifies every failure via
+   * `classifyMicFailure`; carrying the classification out is what lets the
+   * chrome offer — or withhold — a Try again that can actually work.
+   */
+  readonly failure: VoiceConnectFailure | undefined;
   /** Whether the user is mid-utterance — distinct from being connected. */
   readonly userSpeaking: boolean;
   readonly transcript: readonly TranscriptEntry[];
@@ -27,6 +43,7 @@ export type SessionState = {
 export const initialSessionState: SessionState = {
   status: 'idle',
   error: undefined,
+  failure: undefined,
   userSpeaking: false,
   transcript: [],
   tools: [],
@@ -35,7 +52,12 @@ export const initialSessionState: SessionState = {
 export type SessionAction =
   | { readonly type: 'connecting' }
   | { readonly type: 'connected' }
-  | { readonly type: 'failed'; readonly message: string }
+  | {
+      readonly type: 'failed';
+      readonly message: string;
+      /** Absent for failures with no classification — a dropped connection. */
+      readonly failure?: VoiceConnectFailure;
+    }
   | { readonly type: 'disconnected' }
   | { readonly type: 'event'; readonly event: unknown }
   | { readonly type: 'tool'; readonly name: string; readonly speech: string };
@@ -57,10 +79,10 @@ export const sessionReducer = (
 ): SessionState => {
   switch (action.type) {
     case 'connecting':
-      return { ...state, status: 'connecting', error: undefined };
+      return { ...state, status: 'connecting', error: undefined, failure: undefined };
 
     case 'connected':
-      return { ...state, status: 'connected', error: undefined };
+      return { ...state, status: 'connected', error: undefined, failure: undefined };
 
     case 'failed':
       // Keep the transcript: a drop mid-conversation must not erase the record.
@@ -68,11 +90,12 @@ export const sessionReducer = (
         ...state,
         status: 'error',
         error: action.message,
+        failure: action.failure,
         userSpeaking: false,
       };
 
     case 'disconnected':
-      return { ...state, status: 'idle', userSpeaking: false };
+      return { ...state, status: 'idle', userSpeaking: false, failure: undefined };
 
     case 'tool':
       return {

--- a/apps/web/src/lib/ai/realtime/voice-binding.ts
+++ b/apps/web/src/lib/ai/realtime/voice-binding.ts
@@ -1,0 +1,133 @@
+/**
+ * WHICH conversation the microphone talks to, decided from what is on screen.
+ *
+ * THE RULE THIS MODULE EXISTS TO ENFORCE: there is no voice target picker.
+ * Voice is not a feature with its own destination — it is a second transport
+ * onto the conversation the user is already looking at. So the target is
+ * DERIVED from the surface in view, never chosen, and every route has exactly
+ * one answer:
+ *
+ *   - On the dashboard, `GlobalAssistantView` is the conversation on screen and
+ *     the right sidebar has NO chat tab at all (`showChatTab = !isDashboardContext`).
+ *     Binding to the sidebar there would bind to a surface that does not exist.
+ *   - On every other route the sidebar's chat tab is the assistant in view, and
+ *     it keeps its own agent selection, independent of the dashboard's.
+ *
+ * Each surface is a PAIR — an agent selection and the conversation id that
+ * selection resolved to — and the pairs must never be crossed. Taking the
+ * dashboard's agent with the sidebar's conversation id would open a call to one
+ * agent that writes its transcript into another agent's thread, which is a data
+ * error the user cannot see until it has already happened.
+ *
+ * WHY 'resolving' IS A FIRST-CLASS ANSWER AND NOT `null`. Selecting an agent
+ * clears the conversation id and re-resolves it asynchronously (see
+ * `usePageAgentSidebarState`), so "no conversation id yet" is a normal, brief,
+ * self-healing state — not a failure and not a reason to say voice is
+ * unavailable. The trigger waits; it does not refuse and it does not invent a
+ * conversation.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+import type { VoiceTarget } from './voice-target';
+
+/** Where the call's chrome renders, which is the same place the conversation renders. */
+export type VoiceSurface = 'dashboard' | 'sidebar';
+
+/** The minimum an agent selection has to expose to be bindable. */
+export type VoiceBindingAgent = {
+  readonly id: string;
+};
+
+export type VoiceBindingFacts = {
+  /**
+   * `useDashboardContext().isDashboardContext` — true ONLY on `/dashboard` and
+   * a drive root, the two routes where `GlobalAssistantView` holds the centre.
+   */
+  readonly isDashboardContext: boolean;
+  /** `usePageAgentDashboardStore` — the pair the dashboard's centre panel shows. */
+  readonly dashboardAgent: VoiceBindingAgent | null;
+  readonly dashboardConversationId: string | null;
+  /** `useSidebarAgentStore` — the pair the sidebar's chat tab shows. */
+  readonly sidebarAgent: VoiceBindingAgent | null;
+  readonly sidebarConversationId: string | null;
+  /**
+   * `useGlobalChatConversation` — the global assistant thread, shared by BOTH
+   * surfaces when neither has an agent selected. One conversation, because the
+   * global assistant is one assistant however you reach it.
+   */
+  readonly globalConversationId: string | null;
+};
+
+export type VoiceBinding =
+  | {
+      readonly kind: 'ready';
+      readonly surface: VoiceSurface;
+      readonly target: VoiceTarget;
+    }
+  | {
+      /** The surface is known; its conversation id is still being resolved. */
+      readonly kind: 'resolving';
+      readonly surface: VoiceSurface;
+    };
+
+/**
+ * A page-agent conversation, addressed the way the rest of the app addresses
+ * one: `type: 'page'` with the AGENT PAGE in `contextId`. That is not an
+ * approximation — it is literally the row `conversationRepository.createConversation`
+ * writes (`type: 'page'`, `contextId: pageId`), and the same field the
+ * transcript writer reads back to decide where a spoken turn lands.
+ *
+ * `agentPageId` repeats it deliberately: `sameVoiceTarget` compares every
+ * addressing field, and carrying the agent explicitly is what lets a switch
+ * between two agents be recognised as a rebind even mid-resolution.
+ */
+const agentTarget = (agentId: string, conversationId: string): VoiceTarget => ({
+  conversationId,
+  type: 'page',
+  contextId: agentId,
+  agentPageId: agentId,
+});
+
+const globalTarget = (conversationId: string): VoiceTarget => ({
+  conversationId,
+  type: 'global',
+});
+
+export const resolveVoiceBinding = (facts: VoiceBindingFacts): VoiceBinding => {
+  const surface: VoiceSurface = facts.isDashboardContext ? 'dashboard' : 'sidebar';
+
+  // The pair, taken together or not at all.
+  const agent = facts.isDashboardContext ? facts.dashboardAgent : facts.sidebarAgent;
+  const agentConversationId = facts.isDashboardContext
+    ? facts.dashboardConversationId
+    : facts.sidebarConversationId;
+
+  if (agent) {
+    return agentConversationId
+      ? { kind: 'ready', surface, target: agentTarget(agent.id, agentConversationId) }
+      : { kind: 'resolving', surface };
+  }
+
+  return facts.globalConversationId
+    ? { kind: 'ready', surface, target: globalTarget(facts.globalConversationId) }
+    : { kind: 'resolving', surface };
+};
+
+/**
+ * Whether a live session is speaking into the conversation this surface is
+ * showing — the one test that decides whether a chat surface renders the call
+ * chrome.
+ *
+ * Deliberately keyed on the CONVERSATION and not on the surface: a call started
+ * from the sidebar and then walked to the dashboard is still that conversation's
+ * call, and the surface that happens to be showing that conversation is where
+ * its chrome belongs. Anything keyed on "which surface started it" would make
+ * the call a property of a panel, which is the failure mode the whole design is
+ * built to avoid.
+ */
+export const isCallOnConversation = (
+  target: VoiceTarget | null,
+  conversationId: string | null,
+): boolean =>
+  target !== null && conversationId !== null && target.conversationId === conversationId;

--- a/apps/web/src/lib/ai/realtime/voice-location.ts
+++ b/apps/web/src/lib/ai/realtime/voice-location.ts
@@ -1,0 +1,66 @@
+/**
+ * The app's `LocationContext` narrowed to the shape the voice bridge accepts.
+ *
+ * Two types describe the same idea and are NOT assignable to each other: the
+ * chat surfaces' `LocationContext` uses `T | null` for an absent page or drive
+ * (`chat-types.ts`), while `voiceLocationContextSchema` — which the realtime
+ * server parses with, and which rejects what it does not recognise — uses
+ * `.optional()`. A `null` handed straight through is a live call whose tools
+ * lose their sense of place at the first zod parse, and the failure surfaces as
+ * the model answering "this page" wrongly rather than as an error.
+ *
+ * So the conversion is written down once, here, instead of at each call site
+ * where it would be re-derived slightly differently.
+ *
+ * `undefined` out means "nowhere in particular" — a route with no page and no
+ * drive. That is a legitimate answer (the settings screen, a notification
+ * list), not an error, and the session treats it as "leave the tools' location
+ * unset" rather than inventing one.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+import type { LocationContext } from '@/lib/ai/shared/chat-types';
+import type { VoiceLocationContext } from '@pagespace/lib/realtime/voice-bridge-contract';
+
+export const toVoiceLocationContext = (
+  location: LocationContext | null | undefined,
+): VoiceLocationContext | undefined => {
+  if (!location) return undefined;
+
+  const currentPage = location.currentPage ?? undefined;
+  const currentDrive = location.currentDrive ?? undefined;
+  const breadcrumbs = location.breadcrumbs;
+
+  // Nothing recognisable to send. An empty object would still parse, but it
+  // would overwrite a location the call already had with an empty one.
+  if (!currentPage && !currentDrive && (!breadcrumbs || breadcrumbs.length === 0)) {
+    return undefined;
+  }
+
+  return {
+    ...(currentPage === undefined
+      ? {}
+      : {
+          currentPage: {
+            id: currentPage.id,
+            title: currentPage.title,
+            type: currentPage.type,
+            path: currentPage.path,
+            ...(currentPage.isTaskLinked === undefined
+              ? {}
+              : { isTaskLinked: currentPage.isTaskLinked }),
+          },
+        }),
+    ...(currentDrive === undefined
+      ? {}
+      : {
+          currentDrive: {
+            id: currentDrive.id,
+            name: currentDrive.name,
+            slug: currentDrive.slug,
+          },
+        }),
+    ...(breadcrumbs === undefined || breadcrumbs.length === 0 ? {} : { breadcrumbs }),
+  };
+};

--- a/apps/web/src/lib/ai/realtime/voice-rebind.ts
+++ b/apps/web/src/lib/ai/realtime/voice-rebind.ts
@@ -1,0 +1,80 @@
+/**
+ * How the agent switcher moves a LIVE call to a different agent.
+ *
+ * THE WHOLE PROBLEM IN ONE PARAGRAPH. Two things change the target the UI would
+ * compute: walking to another page, and choosing another agent. They must have
+ * opposite effects — navigating leaves the call alone (it only updates
+ * `locationContext`), switching rebinds it — and yet a naive "watch the derived
+ * target and call `start` when it changes" cannot tell them apart, because both
+ * arrive as the same state change. That effect is the single most likely wrong
+ * implementation of this feature, and it hangs up the user's call every time
+ * they open a page.
+ *
+ * So a rebind is driven by the SWITCH EVENT, never by the derived target. The
+ * switcher records an INTENT — "this call should be talking to agent X" — and
+ * this module decides, on each subsequent render, whether the app has caught up
+ * enough to act on it. Navigation records no intent, so navigation can never
+ * produce a rebind no matter what it does to the derived target.
+ *
+ * WHY THE INTENT HAS TO WAIT AT ALL. `selectAgent` clears the conversation id
+ * and re-resolves it asynchronously (`usePageAgentSidebarState` loads the most
+ * recent conversation, or creates one). There is no target to rebind to at the
+ * moment of the click, so acting immediately would either bind to the OLD
+ * conversation or bind to nothing. The intent is what carries the user's
+ * decision across that gap.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+import type { VoiceTarget } from './voice-target';
+import type { VoiceBinding } from './voice-binding';
+
+/**
+ * `agentPageId: null` is a real intent, not the absence of one — it is "switch
+ * this call to the global assistant", which the switcher expresses by selecting
+ * no agent. The absence of an intent is `{ kind: 'none' }`.
+ */
+export type RebindIntent =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'pending'; readonly agentPageId: string | null };
+
+export const NO_REBIND_INTENT: RebindIntent = { kind: 'none' };
+
+export type RebindAction =
+  /** Nothing to do yet — either no intent, or the app has not caught up. */
+  | { readonly kind: 'wait' }
+  /** Drop the intent: there is no live call for it to move. */
+  | { readonly kind: 'clear' }
+  /** Bind the live session to this target, then drop the intent. */
+  | { readonly kind: 'rebind'; readonly target: VoiceTarget };
+
+const WAIT: RebindAction = { kind: 'wait' };
+const CLEAR: RebindAction = { kind: 'clear' };
+
+/** Which agent a target addresses; `null` for the global assistant. */
+const agentOf = (target: VoiceTarget): string | null => target.agentPageId ?? null;
+
+export const rebindAction = (
+  intent: RebindIntent,
+  binding: VoiceBinding,
+  callIsLive: boolean,
+): RebindAction => {
+  if (intent.kind === 'none') return WAIT;
+
+  // A switch made with nothing running needs no rebind: the next press of the
+  // trigger binds to the new selection by the ordinary path. Holding the intent
+  // would make a later, unrelated press behave as though the user had asked for
+  // something they asked for minutes ago.
+  if (!callIsLive) return CLEAR;
+
+  // The conversation for the newly chosen agent has not resolved yet. Waiting
+  // is correct and self-healing; guessing is not.
+  if (binding.kind === 'resolving') return WAIT;
+
+  // The surface is showing someone other than who was chosen — the user
+  // navigated before the switch resolved. Still pending, still not a reason to
+  // move the call somewhere nobody asked for.
+  if (agentOf(binding.target) !== intent.agentPageId) return WAIT;
+
+  return { kind: 'rebind', target: binding.target };
+};

--- a/apps/web/src/lib/ai/realtime/voice-reveal.ts
+++ b/apps/web/src/lib/ai/realtime/voice-reveal.ts
@@ -1,0 +1,91 @@
+/**
+ * Bringing the call's conversation into view — OPEN ONLY, never toggle.
+ *
+ * The nav-bar trigger is both the way IN to a call and the way BACK to one that
+ * has been minimized, and those two jobs share one requirement: pressing it
+ * must never hide the thing it exists to show. `Layout.handleRightPanelToggle`
+ * cannot be reused for it, because a toggle pressed while the sidebar is
+ * already open closes it — which, for a live call, reads as "I pressed the live
+ * indicator and the call vanished". (It has not; the session lives above the
+ * panel. But the user cannot tell that from the outside, and a UI that looks
+ * like it hung up may as well have.)
+ *
+ * Hanging up is the call header's End button, and only that. One control, one
+ * meaning.
+ *
+ * THE BREAKPOINT REASONING IS COPIED, NOT INVENTED: the three cases below
+ * mirror `Layout.handleRightPanelToggle` exactly — sheet, desktop overlay,
+ * persistent — including its rule that opening one overlay closes the other,
+ * since two overlays open at once is what that rule exists to prevent. It is
+ * expressed as data here so the trigger can be tested at every breakpoint
+ * without a viewport.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+import type { VoiceSurface } from './voice-binding';
+
+export type RevealFacts = {
+  /**
+   * Where the conversation renders. On `'dashboard'` it is already on screen in
+   * the centre panel and the sidebar has no chat tab at all — revealing the
+   * sidebar there would open a panel that cannot show the call.
+   */
+  readonly surface: VoiceSurface;
+  readonly isSheetBreakpoint: boolean;
+  readonly shouldOverlayRightSidebar: boolean;
+  readonly shouldOverlayLeftSidebar: boolean;
+  readonly rightSheetOpen: boolean;
+  readonly leftSheetOpen: boolean;
+  readonly rightSidebarOpen: boolean;
+  readonly leftOverlayOpen: boolean;
+};
+
+/**
+ * The writes to apply. A field is present ONLY when it would change something,
+ * so a press with everything already open is genuinely a no-op rather than a
+ * cascade of store writes that re-render the app for nothing.
+ */
+export type RevealWrites = {
+  readonly rightSheetOpen?: boolean;
+  readonly leftSheetOpen?: boolean;
+  readonly rightSidebarOpen?: boolean;
+  readonly leftOverlayOpen?: boolean;
+  /**
+   * Whether to bring the sidebar's chat tab to the front. False on the
+   * dashboard, where there is no chat tab to bring forward.
+   */
+  readonly showChatTab: boolean;
+};
+
+const NOTHING_TO_REVEAL: RevealWrites = { showChatTab: false };
+
+export const decideReveal = (facts: RevealFacts): RevealWrites => {
+  if (facts.surface === 'dashboard') return NOTHING_TO_REVEAL;
+
+  if (facts.isSheetBreakpoint) {
+    return {
+      ...(facts.rightSheetOpen ? {} : { rightSheetOpen: true }),
+      // One sheet at a time, exactly as the toggle does it.
+      ...(facts.rightSheetOpen || !facts.leftSheetOpen ? {} : { leftSheetOpen: false }),
+      showChatTab: true,
+    };
+  }
+
+  if (facts.shouldOverlayRightSidebar) {
+    return {
+      ...(facts.rightSidebarOpen ? {} : { rightSidebarOpen: true }),
+      // Only when the LEFT is also an overlay: a persistent left sidebar is not
+      // competing for the same space and must not be collapsed.
+      ...(facts.rightSidebarOpen || !facts.shouldOverlayLeftSidebar || !facts.leftOverlayOpen
+        ? {}
+        : { leftOverlayOpen: false }),
+      showChatTab: true,
+    };
+  }
+
+  return {
+    ...(facts.rightSidebarOpen ? {} : { rightSidebarOpen: true }),
+    showChatTab: true,
+  };
+};

--- a/apps/web/src/lib/repositories/message-repository.ts
+++ b/apps/web/src/lib/repositories/message-repository.ts
@@ -355,29 +355,40 @@ const serverTriggered = (userId: string): ConversationEventTriggeredBy => ({
   browserSessionId: SERVER_TRIGGERED_BROWSER_SESSION,
 });
 
-/** Minimal UIMessage for events when the caller has no full UIMessage. */
+/**
+ * Minimal UIMessage for events when the caller has no full UIMessage.
+ *
+ * `source` rides along for the same reason `status` does: the broadcast is what
+ * every OPEN surface renders from, and a field carried only by the DB read is a
+ * field that appears when the page is refreshed and not before. For voice that
+ * means a spoken turn would arrive in the thread with no mic glyph and grow one
+ * later, which is a thread that changes its account of itself.
+ */
 const buildEventMessage = (args: {
   messageId: string;
   role: string;
   content: string;
   uiMessage?: UIMessage;
   status: string;
-}): UIMessage & { status?: string; createdAt?: Date } => {
+  source?: string | null;
+}): UIMessage & { status?: string; createdAt?: Date; source?: string | null } => {
   if (args.uiMessage) {
     return {
       ...(args.uiMessage as UIMessage),
       id: args.messageId,
       status: args.status,
+      source: args.source ?? null,
       createdAt: new Date(),
-    } as UIMessage & { status?: string; createdAt?: Date };
+    } as UIMessage & { status?: string; createdAt?: Date; source?: string | null };
   }
   return {
     id: args.messageId,
     role: args.role,
     parts: [{ type: 'text', text: args.content }],
     status: args.status,
+    source: args.source ?? null,
     createdAt: new Date(),
-  } as unknown as UIMessage & { status?: string; createdAt?: Date };
+  } as unknown as UIMessage & { status?: string; createdAt?: Date; source?: string | null };
 };
 
 const normalizeHook = async (
@@ -640,6 +651,7 @@ export const messageRepository = {
         content: args.content,
         uiMessage: args.uiMessage,
         status: args.status ?? 'complete',
+        source: args.source ?? null,
       }),
       fallbackCtx: {
         conversationId: args.conversationId,
@@ -699,6 +711,7 @@ export const messageRepository = {
         content: args.content,
         uiMessage: args.uiMessage,
         status: args.status ?? 'complete',
+        source: args.source ?? null,
       }),
       fallbackCtx: {
         conversationId: args.conversationId,

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { SidebarTab } from '@/stores/page-agents';
 
 type TaskListViewMode = 'table' | 'kanban' | 'editor';
 export type TaskListPageFilter = 'all' | 'active' | 'completed';
@@ -28,6 +29,20 @@ interface LayoutState {
   favoritesCollapsed: boolean;
   recentsCollapsed: boolean;
 
+  /**
+   * Which tab the right sidebar shows on a PAGE route (the dashboard has its
+   * own, in `usePageAgentDashboardStore`, because it is synced with the centre
+   * panel there).
+   *
+   * Lifted out of `RightPanel`'s local state so it can be driven from outside
+   * the panel: the nav-bar voice trigger has to bring the chat tab to the front
+   * when it reveals a call, and a panel-local `useState` is unreachable from a
+   * button in the header. NOT persisted — it starts on 'chat' every load,
+   * exactly as the local state it replaced did, so nothing about the first
+   * render changed.
+   */
+  rightSidebarPageTab: SidebarTab;
+
   // Mobile sheet state (NOT persisted - sheets start closed on page load)
   leftSheetOpen: boolean;
   rightSheetOpen: boolean;
@@ -49,6 +64,7 @@ interface LayoutState {
   setLeftSheetOpen: (open: boolean) => void;
   setRightSheetOpen: (open: boolean) => void;
   setLeftOverlayOpen: (open: boolean) => void;
+  setRightSidebarPageTab: (tab: SidebarTab) => void;
   setTaskListViewMode: (mode: TaskListViewMode) => void;
   setTaskListPageFilter: (pageId: string, filter: TaskListPageFilter) => void;
   setTasksDashboardFilter: (scopeKey: string, filters: StoredDashboardFilters) => void;
@@ -76,6 +92,8 @@ export const useLayoutStore = create<LayoutState>()(
       favoritesCollapsed: false,
       recentsCollapsed: false,
       rehydrated: false,
+
+      rightSidebarPageTab: 'chat',
 
       // Mobile sheet state (NOT persisted)
       leftSheetOpen: false,
@@ -133,6 +151,10 @@ export const useLayoutStore = create<LayoutState>()(
 
       setLeftOverlayOpen: (open: boolean) => {
         set({ leftOverlayOpen: open });
+      },
+
+      setRightSidebarPageTab: (tab: SidebarTab) => {
+        set({ rightSidebarPageTab: tab });
       },
 
       setDriveFooterCollapsed: (collapsed: boolean) => {

--- a/apps/web/src/stores/useVoiceRebindStore.ts
+++ b/apps/web/src/stores/useVoiceRebindStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { NO_REBIND_INTENT, type RebindIntent } from '@/lib/ai/realtime/voice-rebind';
+
+/**
+ * The user's decision to move a live call to a different agent, in transit.
+ *
+ * WHY A STORE AND NOT A PROP. The two ends are structurally separated and
+ * cannot be joined by a prop: the agent switcher lives inside the chat surfaces
+ * (`SidebarChatTab`, `GlobalAssistantView`), either of which can unmount — the
+ * sidebar is unmounted outright when it is collapsed — while the thing that
+ * ACTS on the decision has to outlive them, because resolving the new agent's
+ * conversation is asynchronous and the user may collapse the panel in the
+ * meantime. A callback owned by the surface would be a rebind that silently
+ * fails to happen for anyone who closed the sidebar at the wrong moment.
+ *
+ * WHY IT HOLDS AN INTENT AND NOT A TARGET. At the instant of the click there is
+ * no target: `selectAgent` clears the conversation id and re-resolves it. The
+ * only thing known then is WHO the user chose, which is exactly what this
+ * carries.
+ *
+ * Not persisted, and deliberately so: a call does not survive a reload, so an
+ * intent restored from storage would be a rebind request for a session that no
+ * longer exists.
+ */
+interface VoiceRebindState {
+  intent: RebindIntent;
+  /**
+   * "This call should be talking to this agent." `null` means the global
+   * assistant, which is a real destination and not the absence of one.
+   */
+  requestRebind: (agentPageId: string | null) => void;
+  /** Acted on, or abandoned because nothing is live. */
+  clearRebind: () => void;
+}
+
+export const useVoiceRebindStore = create<VoiceRebindState>()((set) => ({
+  intent: NO_REBIND_INTENT,
+  requestRebind: (agentPageId) => set({ intent: { kind: 'pending', agentPageId } }),
+  clearRebind: () =>
+    set((state) => (state.intent.kind === 'none' ? state : { intent: NO_REBIND_INTENT })),
+}));

--- a/packages/lib/src/realtime/voice-bridge-contract.ts
+++ b/packages/lib/src/realtime/voice-bridge-contract.ts
@@ -267,8 +267,12 @@ export const voiceBridgeRequestSchema = z.discriminatedUnion('kind', [
   voiceTranscriptSchema,
 ]);
 
-export type VoiceToolDispatchRequest = z.infer<typeof voiceToolDispatchSchema>;
-export type VoiceTranscriptRequest = z.infer<typeof voiceTranscriptSchema>;
+/**
+ * The union, and only the union. Per-member aliases were exported alongside it
+ * and never imported anywhere — every consumer takes the whole request and
+ * narrows on `kind`, which is what a discriminated union is for. Re-add one
+ * only when something actually needs to name a single member.
+ */
 export type VoiceBridgeRequest = z.infer<typeof voiceBridgeRequestSchema>;
 
 /**


### PR DESCRIPTION
The first part of the audio-native voice path **a human actually touches**. Everything beneath it — the pure core (#2387), the tool registry (#2388), pricing (#2391), the server joining the call (#2393), what it does while it's there (#2395), and the browser holding the mic (#2396) — is merged, tested, and has never been driven by a real person.

## The shape

**One trigger, in the nav bar, on every route.** Nothing connects until it is pressed — no microphone, no negotiation, no permission prompt on page load. It doubles as the live indicator and as the way back to a minimized call, and it **never hangs up**: a toggle there would mean pressing the live indicator hides the call you pressed it to see. Ending a call is the End button on the call itself.

**It binds to whatever assistant is in view.** On a page route: the right sidebar opens in voice mode, bound to its selected agent. On the dashboard — where `showChatTab = !isDashboardContext` means the sidebar has no chat tab at all — it binds to the `GlobalAssistantView` conversation already on screen and renders there. There is no second target picker anywhere.

**Voice is a mode on the chat surface**, not a fourth tab and not an overlay: the same message list, with a live call header above it (level meter, speaking state, mute, end). Spoken turns arrive in that list as ordinary messages — the realtime server writes them through `messageRepository`, so they ride the `conversation:*` events every surface already subscribes to. No new client wiring, and no second history.

**Closing the sidebar minimizes, it does not hang up.** The session lives above `RightPanel`; the nav mic stays lit.

## The decision that everything turns on

Navigating and switching agent arrive as the **same change to the derived target**. A "watch the target and call `start`" effect cannot tell them apart, and would hang the user's call up every time they opened a page. So a rebind is driven by the switch **event**: the switcher records an intent, and `rebindAction` applies it once the newly chosen agent's conversation has resolved (`selectAgent` clears the id and re-resolves it asynchronously, so there is nothing to bind to at the moment of the click). Navigation records nothing, so navigation can never rebind.

Every decision is a pure module beside the wiring — `resolveVoiceBinding`, `rebindAction`, `decideReveal`, `describeCall`, `toVoiceLocationContext` — testable without a browser, a peer connection or a microphone.

## Two things the merged seam was one field short on

Added at the provider rather than worked around in the UI:

- **`failure`** — the classified reason beside `error`. A sentence cannot be branched on, and a denied prompt and an absent capture device need opposite affordances. `classifyMicFailure` already draws the line and `connect.ts` already carries it; this is where it reaches the screen, as the difference between a Try again button and no Try again button. A retry offered for a missing microphone is guaranteed to fail, and teaches the user that voice is broken rather than that they have no device.
- **`muted` / `setMuted`** — mute has to live with the microphone. Held by the chrome it would come back un-muted every time the sidebar was collapsed. This also fixes a latent bug: the chain swap hardcoded `setMicrophoneEnabled(true)`, so reaching the duration ceiling un-muted a deliberately muted call, mid-conversation, with no control touched.

## Also

- `messages.source` now reaches the UI — through **both** the DB conversion and the broadcast, so the mic glyph does not appear only after a refresh. Both renderers mark a spoken turn. The browser reads its own copy of the value (client components here cannot import `@pagespace/db/schema`) with a drift guard test.
- The right sidebar's page-context tab moved from panel-local state into the layout store: a button in the header cannot reach a `useState` inside a panel that is unmounted while collapsed. Same default, same lifetime, not persisted.

## Acceptance criteria

| Criterion | Guarded by |
|---|---|
| Page route + mic → sidebar in voice mode, bound to the selected agent | `VoiceNavTrigger.test.tsx` |
| Dashboard (no sidebar chat tab) → binds to GlobalAssistantView instead | `VoiceNavTrigger.test.tsx`, `voice-binding.test.ts` |
| Live call + sidebar closed → indicator, and NOT a hang-up | `VoiceNavTrigger.test.tsx`, `Layout.voice-reveal.test.tsx` |
| Agent switcher → rebinds the live session | `VoiceSessionBridge.test.tsx` |
| Navigating → does NOT rebind | `VoiceSessionBridge.test.tsx` |
| Voice-authored row → renders distinguishably | `SpokenTurnGlyph.test.tsx`, `message-utils.test.ts` |
| Mic denied vs missing → surfaced differently | `call-chrome.test.ts`, `VoiceNavTrigger.test.tsx` |

## Assert structure, not arrangement

Every guarantee was verified by **breaking it and watching a test go red**, then restoring — 22 mutations, all caught:

crossing the two surfaces' agent/conversation pairs · rebinding on any derived-target change · `start` on navigation instead of `setLocationContext` · resolving location while idle · reveal as a toggle · reveal not raising the chat tab · the bridge deleted from `Layout` · the trigger hanging up while live · retry offered unconditionally · the failure reason dropped at the provider · the chain un-muting · hangup keeping the mute · the call bar keyed on "any live call" instead of the conversation · the glyph reading anything-non-null · the glyph dropped from one renderer only · the drift-guard constant diverging · `RightPanel` reverting to panel-local tab state · and more.

Two structural files exist only to hold guarantees nothing else could: `Layout.voice-reveal.test.tsx` (the bridge renders nothing, so deleting it is otherwise invisible) and `TopBar.voice-trigger.test.tsx` (move the trigger into the sidebar and every behavioural test still passes while voice quietly becomes a feature of a panel).

The chat surfaces are ~1000-line files the repo does not render in tests, so the "which surface shows the call" decision was **extracted** into `VoiceCallBarForConversation` rather than left as an `&&` in each — one line, one place, exercised against a real session.

## Not from this chunk

The branch's knip gate was already red: two per-member request types in `voice-bridge-contract.ts` (added by #2395) were exported and never imported anywhere. Removed — consumers narrow on the union's `kind`. Nothing else under `packages/` is touched.

## Gate

- `bun run typecheck` (monorepo) — **17/17**
- `bun run lint` — **15/15**
- `bun run knip:check` — within baseline
- web tests — **17085 passed**, 17 failing files are all the known Postgres-requiring integration suites (no test DB provisionable in this worktree; they self-report "Test database not reachable")

Old voice mode is untouched: `useVoiceMode.ts` and `/api/voice/*` stay, and Read Aloud's `/api/voice/synthesize` is not being retired at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyxC1FeYap8bU98cLzcXhH