### PR TITLE
fix(memory): the backfill skipped exactly the users who lost their memory

### DIFF
--- a/scripts/__tests__/backfill-memory-pages.integration.test.ts
+++ b/scripts/__tests__/backfill-memory-pages.integration.test.ts
@@ -129,6 +129,65 @@ describe('backfill-memory-pages (Postgres)', () => {
     expect(await readPage(first.bioPageId)).toMatchObject({ content: 'Hand-edited by the user' });
   });
 
+  it('rescues a user whose pages were provisioned before this ever ran', async () => {
+    // THE ORDERING THAT STRANDED PEOPLE.
+    //
+    // Opening Settings self-heals a pointerless profile by provisioning EMPTY
+    // pages, which sets all four pointers and copies nothing. From that moment
+    // the read path prefers the (empty) pages over the columns, so the user's
+    // memory stops being injected — and a backfill that selects rows by
+    // "pointers missing" skips them forever, because the pointers are set.
+    //
+    // Nothing recovers that state on its own: the content is not deleted, just
+    // orphaned in columns nothing reads. So the work list has to be keyed on
+    // the content, not the pointers.
+    await seedLegacyProfile();
+
+    // Provision empty pages exactly the way the settings GET route does.
+    const { rows } = await db.execute(
+      sql`SELECT id FROM drives WHERE "ownerId" = ${USER_ID} AND kind = 'HOME'`,
+    );
+    const driveId = (rows[0] as { id: string }).id;
+    for (const [field, title] of [
+      ['memoryFolderId', 'Memory'],
+      ['bioPageId', 'About You'],
+      ['writingStylePageId', 'Communication'],
+      ['rulesPageId', 'Rules'],
+    ]) {
+      const pageId = `pre_${field}`;
+      await db.execute(
+        sql`INSERT INTO pages (id, title, type, position, "driveId", content, "updatedAt")
+            VALUES (${pageId}, ${title}, 'DOCUMENT', 0, ${driveId}, '', now())`,
+      );
+      await db.execute(
+        sql`UPDATE user_personalization SET ${sql.raw(`"${field}"`)} = ${pageId} WHERE "userId" = ${USER_ID}`,
+      );
+    }
+
+    const summary = await runBackfill();
+
+    // The row must be SEEN at all — this is what the pointer-only predicate missed.
+    expect(summary.scanned).toBe(1);
+    expect(summary.fieldsCopied).toBe(3);
+
+    const profile = await readProfile();
+    expect(await readPage(profile.bioPageId)).toMatchObject({ content: 'Legacy bio' });
+    expect(await readPage(profile.writingStylePageId)).toMatchObject({ content: 'Legacy style' });
+    expect(await readPage(profile.rulesPageId)).toMatchObject({ content: 'Legacy rules' });
+    expect(profile.bio).toBeNull();
+  });
+
+  it('leaves a fully migrated row alone, so the work list keeps shrinking', async () => {
+    // The other half of the predicate change: widening it must not turn the
+    // backfill into a re-scan that rewrites everyone on every run.
+    await seedLegacyProfile();
+    await runBackfill();
+
+    const second = await runBackfill();
+
+    expect(second.scanned).toBe(0);
+  });
+
   it('retires the column of a field whose page already had content', async () => {
     // The leak this guards: the reader ignores a column as soon as its pointer
     // is set, so a column left populated here is invisible — until a hard-delete

--- a/scripts/__tests__/backfill-memory-pages.integration.test.ts
+++ b/scripts/__tests__/backfill-memory-pages.integration.test.ts
@@ -177,6 +177,54 @@ describe('backfill-memory-pages (Postgres)', () => {
     expect(profile.bio).toBeNull();
   });
 
+  it('does not resurrect a page the user deliberately emptied', async () => {
+    // The other side of the rescue. A stranded user's pages are empty because
+    // they were provisioned empty — but a user who typed into one and then
+    // cleared it also has an empty page, and `content = ''` cannot tell the two
+    // apart. Restoring the legacy text there would undo an erasure the product
+    // explicitly tells people to perform ("clear the page" is the documented
+    // way to erase what memory says about you).
+    //
+    // `revision` separates them: provisioning inserts at 0, and every mutation
+    // increments, so a written-then-cleared page is above 0.
+    await seedLegacyProfile();
+
+    const { rows } = await db.execute(
+      sql`SELECT id FROM drives WHERE "ownerId" = ${USER_ID} AND kind = 'HOME'`,
+    );
+    const driveId = (rows[0] as { id: string }).id;
+    for (const [field, title] of [
+      ['memoryFolderId', 'Memory'],
+      ['bioPageId', 'About You'],
+      ['writingStylePageId', 'Communication'],
+      ['rulesPageId', 'Rules'],
+    ]) {
+      const pageId = `cleared_${field}`;
+      // `bio` is the one the user wrote in and then emptied again (revision 2);
+      // the rest are untouched provisioned pages.
+      const revision = field === 'bioPageId' ? 2 : 0;
+      await db.execute(
+        sql`INSERT INTO pages (id, title, type, position, "driveId", content, revision, "updatedAt")
+            VALUES (${pageId}, ${title}, 'DOCUMENT', 0, ${driveId}, '', ${revision}, now())`,
+      );
+      await db.execute(
+        sql`UPDATE user_personalization SET ${sql.raw(`"${field}"`)} = ${pageId} WHERE "userId" = ${USER_ID}`,
+      );
+    }
+
+    await runBackfill();
+
+    const profile = await readProfile();
+    // The erased page stays erased...
+    expect(await readPage(profile.bioPageId)).toMatchObject({ content: '' });
+    // ...while the untouched ones are still rescued.
+    expect(await readPage(profile.writingStylePageId)).toMatchObject({ content: 'Legacy style' });
+    expect(await readPage(profile.rulesPageId)).toMatchObject({ content: 'Legacy rules' });
+    // And the column goes either way, so the erasure cannot be undone by a
+    // later run rather than this one.
+    expect(profile.bio).toBeNull();
+  });
+
   it('leaves a fully migrated row alone, so the work list keeps shrinking', async () => {
     // The other half of the predicate change: widening it must not turn the
     // backfill into a re-scan that rewrites everyone on every run.

--- a/scripts/backfill-memory-pages.ts
+++ b/scripts/backfill-memory-pages.ts
@@ -162,14 +162,33 @@ export async function runBackfill({
           for (const field of populated) {
             const content = (row[LEGACY_COLUMN[field]] ?? '').trim();
 
-            // Copy into the page only while it is still empty. This is what
-            // makes a re-run safe: once the page has content — from the first
-            // run, the memory cron, or the user typing in it — we never touch
-            // it again.
+            // Copy into the page only while it is still empty AND has never
+            // been touched. Both halves are load-bearing:
+            //
+            //   content = ''   → a re-run never overwrites what is there now
+            //   revision = 0   → and never overwrites what someone DELETED
+            //
+            // `revision` is the only thing that separates a page provisioned
+            // empty by the settings screen from one a user deliberately
+            // emptied: both are `content = ''`. Provisioning inserts at the
+            // schema default of 0 and `applyPageMutation` increments on every
+            // mutation, so a page that was written to and then cleared is at 2.
+            //
+            // Without this, widening the work list above to include populated
+            // legacy columns would resurrect text a user had just erased —
+            // while MEMORY_PAGE_DELETE_ERROR is telling them that clearing the
+            // page is how you erase it. The column is still retired below, so
+            // their erasure sticks rather than lying in wait for a later run.
             const updated = await tx
               .update(pages)
               .set({ content, contentMode: 'markdown', updatedAt: new Date() })
-              .where(and(eq(pages.id, pageIdFor[field]), eq(pages.content, '')))
+              .where(
+                and(
+                  eq(pages.id, pageIdFor[field]),
+                  eq(pages.content, ''),
+                  eq(pages.revision, 0),
+                ),
+              )
               .returning({ id: pages.id });
 
             if (updated.length > 0) {

--- a/scripts/backfill-memory-pages.ts
+++ b/scripts/backfill-memory-pages.ts
@@ -3,7 +3,7 @@ import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { userPersonalization } from '@pagespace/db/schema/personalization';
-import { and, asc, eq, gt, isNull, or } from '@pagespace/db/operators';
+import { and, asc, eq, gt, isNotNull, isNull, or } from '@pagespace/db/operators';
 import {
   provisionMemoryPages,
   MEMORY_FIELDS,
@@ -95,13 +95,32 @@ export async function runBackfill({
       .where(
         and(
           gt(userPersonalization.id, cursor),
-          // Only rows that still need work: no folder pointer yet, or a field
-          // whose page pointer was never written.
+          // Rows that still need work. This asks TWO questions, and the second
+          // one is the important one:
+          //
+          //   1. pointers missing  → pages have never been provisioned
+          //   2. legacy column still holds content → content has not been moved
+          //
+          // (2) is not implied by (1). The settings screen self-heals a
+          // pointerless profile by provisioning EMPTY pages, so a user who
+          // opened Settings before this ran has all four pointers set and all
+          // three columns still full. Selecting on pointers alone skipped
+          // exactly those users — permanently, since the pointers never go back
+          // to null — while the read path had already switched to the (empty)
+          // pages. Their memory silently stopped being injected and nothing
+          // would ever have copied it across.
+          //
+          // A migrated row is excluded by both arms: its pointers are set AND
+          // its columns were cleared in the same transaction that filled the
+          // pages, so this stays a shrinking work list rather than a re-scan.
           or(
             isNull(userPersonalization.memoryFolderId),
             isNull(userPersonalization.bioPageId),
             isNull(userPersonalization.writingStylePageId),
             isNull(userPersonalization.rulesPageId),
+            isNotNull(userPersonalization.bio),
+            isNotNull(userPersonalization.writingStyle),
+            isNotNull(userPersonalization.rules),
           ),
         ),
       )


### PR DESCRIPTION
Follow-up to #2379. **This is a live data-loss path on master** — worth landing before the backfill is run, and before more people open Settings → Personalization.

## What happens today

The backfill's work list asks *"are the pointers missing?"*. That is not the same question as *"has the content been moved?"*, and the gap between them strands users.

Opening Settings self-heals a pointerless profile by provisioning **empty** pages. That sets all four pointers and copies nothing — deliberately, so it cannot race the backfill. But from that moment the read path prefers the pages over the legacy columns:

```ts
if (pointer) return pageContent[field] ?? '';   // personalization-utils
```

So the user's profile stops being injected into any prompt. And because the pointers are now set, the backfill's `isNull(...)` predicate excludes them — **permanently**, since pointers never go back to null. Their content sits in columns nothing reads, and nothing would ever have copied it across.

The changelog entry actively invites people to go look at their memory pages, so this was likely to be reached rather than theoretical.

## The fix

The work list now also selects rows whose legacy columns still hold content. It asks both questions:

1. pointers missing → pages were never provisioned
2. legacy column still populated → content has not been moved

Recovery is automatic — nothing was deleted, only orphaned, so a single run restores everyone. A fully migrated row is still excluded by **both** arms (pointers set *and* columns cleared in the same transaction that filled the pages), so this stays a shrinking work list rather than a re-scan.

## Not resurrecting deliberate erasures (review finding)

Widening the work list alone would have re-enrolled a profile whose page the user has **since cleared** — and `content = ''` cannot tell a deliberately emptied page from one the settings screen provisioned empty. That would restore stale text while `MEMORY_PAGE_DELETE_ERROR` is telling the same user that clearing the page *is* how you erase what memory holds.

`revision` separates them exactly: provisioning inserts at the schema default of `0`, and `applyPageMutation` increments on every mutation, so a written-then-cleared page sits above 0. The copy requires `content = '' AND revision = 0`.

Revision rather than timestamps: provisioning writes `createdAt` and `updatedAt` from the same `Date` object, so equality there is exact but fragile — any later code touching `updatedAt` without a real edit would silently start skipping fields. Revision only moves through the mutation path itself.

It fails safe in the right direction. A page anyone has touched is left alone, so the worst case is a stranded user not getting their old text back automatically — never erased text coming back. The legacy column is retired either way, so the erasure sticks instead of waiting for a later run to undo it.

## Verification

Against a real Postgres, and the new test reproduces the shipped bug rather than merely passing:

- reverting the predicate makes it fail with `expected +0 to be 1` — `scanned: 0` for a user who has content to move, i.e. the row was never even looked at
- a second test pins that a fully migrated row is still skipped, so widening the predicate has not turned this into a rewrite-everyone pass
- a third reproduces the erasure case: removing the `revision` arm turns it red with `expected { title: 'About You' } to match object { content: '' }` — the erased page refilled with legacy text — while untouched sibling fields are still rescued in the same run
- full `scripts/` suite: 15 files, 298 tests passing · `lint:scripts` clean · `typecheck` 17/17

## Checking exposure

Users currently stranded — pointers set, pages empty, columns still populated:

```sql
SELECT count(*) FROM user_personalization
WHERE "bioPageId" IS NOT NULL
  AND (bio IS NOT NULL OR "writingStyle" IS NOT NULL OR rules IS NOT NULL);
```

Anything above zero is someone whose memory is not being injected right now. Running the backfill after this lands fixes them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-page backfill to restore only genuinely empty, unmodified pages.
  * Preserved pages that users intentionally cleared.
  * Ensured legacy content is cleaned up while selectively restoring missing pages.
  * Avoided repeated processing for profiles that have already been fully migrated.

* **Tests**
  * Added integration coverage for restoration, deletion preservation, migration cleanup, and repeat-scan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
