### PR TITLE
fix(dates): a plain "7pm" meant a different instant on every endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,28 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **A time you write as "7pm" is 7pm to you, wherever it is written** — a plain wall-clock time
+  ("2026-02-19T19:00:00", with no `Z` and no offset) was being read inconsistently across the app.
+  Creating a calendar event through an app or script without naming a timezone read it as UTC, so
+  "dinner at 7pm" was stored as 1pm for a US Central user, with no error and nothing to notice
+  until the reminder came at the wrong hour. Task due dates had the same gap in a different place:
+  the reminder timezone was resolved correctly but the due date itself was read in the server's
+  timezone, so a task and its own reminder could disagree — and because that server timezone
+  happens to match some of ours, it looked right in testing and drifted only in production. Cron
+  workflows created without a named timezone had it worst: "every day at 9am" meant 9am UTC, which
+  is 3am in Chicago.
+
+  All of these now follow one rule: a plain wall-clock time means whatever timezone the request
+  names, else the timezone on your profile, else UTC. Times that already carry a `Z` or an offset
+  are unaffected, as are dates with no time at all. Events and workflows remember the timezone they
+  were created in, so editing them later keeps the hour you meant, and asking an assistant to make
+  something now lands at the same instant as typing it in yourself.
+
+  Date *ranges* — the from/to on calendar views, activity history and exports — are unchanged in
+  what they return, but they no longer depend on where the server is running, so a boundary that
+  behaves one way in production behaves the same way on a developer's machine. Scheduled drive
+  backups deliberately keep their own timezone, which belongs to the drive rather than to whoever
+  last edited the setting.
 - **Your assistant's Conversation History is back to being just your assistant's, in the right
   order** — the sidebar's history had filled up with chats belonging to page agents, hundreds of
   them on a busy account, pushing the assistant's own threads down out of reach. The dates made no

--- a/apps/web/src/app/api/activities/export/route.ts
+++ b/apps/web/src/app/api/activities/export/route.ts
@@ -8,6 +8,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPPageScope, canPrincipalViewPage, isPrincipalDriveMember, getAllowedDriveIds } from '@/lib/auth';
 import { format } from 'date-fns';
+import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -15,8 +16,9 @@ const querySchema = z.object({
   context: z.enum(['user', 'drive', 'page']),
   driveId: z.string().optional(),
   pageId: z.string().optional(),
-  startDate: z.coerce.date().optional(),
-  endDate: z.coerce.date().optional(),
+  // Absolute instants, not wall-clock times — see optionalAbsoluteInstant.
+  startDate: optionalAbsoluteInstant,
+  endDate: optionalAbsoluteInstant,
   actorId: z.string().optional(),
   operation: z.string().optional(),
   resourceType: z.string().optional(),

--- a/apps/web/src/app/api/activities/export/route.ts
+++ b/apps/web/src/app/api/activities/export/route.ts
@@ -8,7 +8,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPPageScope, canPrincipalViewPage, isPrincipalDriveMember, getAllowedDriveIds } from '@/lib/auth';
 import { format } from 'date-fns';
-import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
+import { optionalAbsoluteInstant, exclusiveEndBound } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -52,6 +52,8 @@ export async function GET(request: Request) {
 
   const userId = auth.userId;
   const { searchParams } = new URL(request.url);
+  // Kept raw: only exclusiveEndBound can tell a date-only bound from an instant.
+  const rawEndDate = searchParams.get('endDate');
 
   try {
     const parseResult = querySchema.safeParse({
@@ -174,9 +176,9 @@ export async function GET(request: Request) {
       filterConditions.push(gte(activityLogs.timestamp, params.startDate));
     }
     if (params.endDate) {
-      const endOfDay = new Date(params.endDate);
-      endOfDay.setDate(endOfDay.getDate() + 1);
-      filterConditions.push(lt(activityLogs.timestamp, endOfDay));
+      // A date-only bound covers the whole day; an explicit instant means that
+      // instant. See exclusiveEndBound.
+      filterConditions.push(lt(activityLogs.timestamp, exclusiveEndBound(rawEndDate, params.endDate)));
     }
     if (params.actorId && params.context !== 'user') {
       filterConditions.push(eq(activityLogs.userId, params.actorId));

--- a/apps/web/src/app/api/activities/route.ts
+++ b/apps/web/src/app/api/activities/route.ts
@@ -7,6 +7,7 @@ import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPPageScope, canPrincipalViewPage, isPrincipalDriveMember, getAllowedDriveIds } from '@/lib/auth';
+import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -16,8 +17,9 @@ const querySchema = z.object({
   driveId: z.string().optional(),
   pageId: z.string().optional(),
   // Filter parameters
-  startDate: z.coerce.date().optional(),
-  endDate: z.coerce.date().optional(),
+  // Absolute instants, not wall-clock times — see optionalAbsoluteInstant.
+  startDate: optionalAbsoluteInstant,
+  endDate: optionalAbsoluteInstant,
   actorId: z.string().optional(),
   operation: z.string().optional(),
   resourceType: z.string().optional(),

--- a/apps/web/src/app/api/activities/route.ts
+++ b/apps/web/src/app/api/activities/route.ts
@@ -7,7 +7,7 @@ import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPPageScope, canPrincipalViewPage, isPrincipalDriveMember, getAllowedDriveIds } from '@/lib/auth';
-import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
+import { optionalAbsoluteInstant, exclusiveEndBound } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -47,6 +47,8 @@ export async function GET(request: Request) {
 
   const userId = auth.userId;
   const { searchParams } = new URL(request.url);
+  // Kept raw: only exclusiveEndBound can tell a date-only bound from an instant.
+  const rawEndDate = searchParams.get('endDate');
 
   auditRequest(request, { eventType: 'data.read', userId, resourceType: 'activities', resourceId: 'self' });
 
@@ -189,10 +191,9 @@ export async function GET(request: Request) {
       filterConditions.push(gte(activityLogs.timestamp, params.startDate));
     }
     if (params.endDate) {
-      // Add one day to endDate to include the full day
-      const endOfDay = new Date(params.endDate);
-      endOfDay.setDate(endOfDay.getDate() + 1);
-      filterConditions.push(lt(activityLogs.timestamp, endOfDay));
+      // A date-only bound covers the whole day; an explicit instant means that
+      // instant. See exclusiveEndBound.
+      filterConditions.push(lt(activityLogs.timestamp, exclusiveEndBound(rawEndDate, params.endDate)));
     }
     // actorId filter only applies in drive/page context (user context already filters by authenticated user)
     if (params.actorId && params.context !== 'user') {

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-access-event-scoped-creator.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-access-event-scoped-creator.test.ts
@@ -34,10 +34,7 @@ vi.mock('@pagespace/db/schema/calendar', () => ({
 vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
   calendarTriggers: { calendarEventId: 'calendarEventId', status: 'status' },
 }));
-vi.mock('../../../../../../lib/ai/core/timestamp-utils', () => ({
-  isNaiveISODatetime: vi.fn(() => false),
-  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
-}));
+// timestamp-utils is pure; the real parser is used rather than a partial stub.
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   isUserDriveMember: vi.fn(),
   isDriveOwnerOrAdmin: vi.fn(),

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
@@ -64,10 +64,7 @@ vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
   },
 }));
 
-vi.mock('../../../../../../lib/ai/core/timestamp-utils', () => ({
-  isNaiveISODatetime: vi.fn(() => false),
-  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
-}));
+// timestamp-utils is pure; the real parser is used rather than a partial stub.
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   isUserDriveMember: vi.fn(),

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-agent-trigger.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-agent-trigger.test.ts
@@ -52,10 +52,9 @@ vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
   resyncCalendarTriggerTimings: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../../../../../../lib/ai/core/timestamp-utils', () => ({
-  isNaiveISODatetime: vi.fn(() => false),
-  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
-}));
+// timestamp-utils is pure and cheap; these cases all pass absolute (Z) datetimes,
+// so the real parser is used rather than a stub that would have to fake the
+// naive-datetime rule.
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   isUserDriveMember: vi.fn(),

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-timezone-resolution.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-timezone-resolution.test.ts
@@ -243,6 +243,34 @@ describe('PATCH /api/calendar/events/[eventId] — timezone resolution', () => {
     }));
   });
 
+  /**
+   * What the request validated and what the column stores have to be the same
+   * string. `" America/Chicago "` resolves trimmed and `" "` resolves back to
+   * the event's own zone — writing the raw field back would leave the column
+   * holding a value nothing can schedule or render against, and the executor
+   * reads that column at fire time (PR #2405 review).
+   */
+  it('stores a space-padded timezone trimmed', async () => {
+    setupPatch({ timezone: 'UTC' });
+
+    const res = await PATCH(makeRequest({ timezone: '  America/Chicago  ' }), { params });
+
+    expect(res.status).toBe(200);
+    expect(setMock.mock.calls[0][0]).toMatchObject({ timezone: 'America/Chicago' });
+  });
+
+  it('stores the existing zone rather than whitespace when the field is blank', async () => {
+    setupPatch({ timezone: 'America/Chicago' });
+    profileWhere.mockResolvedValue([{ timezone: 'Asia/Tokyo' }]);
+
+    const res = await PATCH(makeRequest({ timezone: '   ' }), { params });
+
+    expect(res.status).toBe(200);
+    // Blank counts as absent, so resolution lands on the event's own zone — and
+    // that is what the column must hold, not the blank string.
+    expect(setMock.mock.calls[0][0]).toMatchObject({ timezone: 'America/Chicago' });
+  });
+
   it('hands the agent trigger the same resolved zone the datetimes were read in', async () => {
     setupPatch({ timezone: 'America/Chicago' });
 

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-timezone-resolution.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-timezone-resolution.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Contract test for PATCH /api/calendar/events/[eventId] timezone resolution (#2404).
+ *
+ * An edit reinterprets naive datetimes against: the body's timezone, else the
+ * event's own stored zone, else the caller's profile, else UTC. The stored zone
+ * is NOT NULL so the profile tier is a guard rather than a routine path, but
+ * the chain has to reach it — stopping one tier short is what left create
+ * booking events at the wrong instant in the first place.
+ *
+ * Equally pinned here: an edit that says nothing about the timezone must not
+ * REWRITE the event's stored zone. Resolution decides how to read this
+ * request's datetimes; it is not an implicit write of the caller's profile
+ * onto someone else's event.
+ *
+ * `timestamp-utils` and `personalization-utils` stay real — the naive→instant
+ * conversion and the profile lookup are the behaviour under test.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+const { profileWhere } = vi.hoisted(() => ({
+  profileWhere: vi.fn<() => Promise<Array<{ timezone: string | null }>>>(),
+}));
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server');
+  return { ...actual, after: vi.fn((fn: () => void) => fn()) };
+});
+
+vi.mock('@pagespace/db/db', () => {
+  const db = {
+    query: {
+      calendarEvents: { findFirst: vi.fn() },
+      eventAttendees: { findFirst: vi.fn() },
+    },
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn() })) })),
+    })),
+    // Stands in for getUserTimezone's profile read (and the attendee lookup,
+    // which ignores the rows).
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: profileWhere })) })),
+    transaction: vi.fn(),
+  };
+  return { db };
+});
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn(() => ({})),
+}));
+vi.mock('@pagespace/db/schema/calendar', () => ({
+  calendarEvents: { id: 'id', driveId: 'driveId', createdById: 'createdById', isTrashed: 'isTrashed' },
+  eventAttendees: { eventId: 'eventId', userId: 'userId' },
+}));
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: { calendarEventId: 'calendarEventId', id: 'id' },
+}));
+vi.mock('@pagespace/db/schema/workflow-runs', () => ({
+  workflowRuns: { sourceTable: 'sourceTable', sourceId: 'sourceId' },
+}));
+// Pulled in by personalization-utils, which stays real here.
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', timezone: 'timezone' } }));
+vi.mock('@pagespace/db/schema/personalization', () => ({ userPersonalization: { userId: 'userId' } }));
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({ readMemoryPages: vi.fn().mockResolvedValue({}) }));
+
+vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
+  upsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'trg-1' }),
+  removeCalendarTrigger: vi.fn().mockResolvedValue(undefined),
+  validateCalendarAgentTrigger: vi.fn().mockResolvedValue({ agentPageId: 'agent-1' }),
+  resyncCalendarTriggerTimings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: vi.fn().mockResolvedValue(true),
+  isDriveOwnerOrAdmin: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/services/calendar-event-drive-service', () => ({
+  isUserMemberOfAnyEventDrive: vi.fn().mockResolvedValue(false),
+  getAllDriveIdsForEvent: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn(), auditRequest: vi.fn() }));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => typeof r === 'object' && r !== null && 'error' in r),
+  checkMCPDriveScope: vi.fn(() => null),
+  isScopedMCPAuth: vi.fn(() => false),
+  isPrincipalDriveMember: vi.fn().mockResolvedValue(true),
+  isPrincipalDriveOwnerOrAdmin: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@/lib/websocket/calendar-events', () => ({
+  broadcastCalendarEvent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/integrations/google-calendar/push-service', () => ({
+  pushEventUpdateToGoogle: vi.fn().mockResolvedValue(undefined),
+  pushEventDeleteToGoogle: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { PATCH } from '../route';
+import { db } from '@pagespace/db/db';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { upsertCalendarTriggerWorkflowInTx } from '@/lib/workflows/calendar-trigger-helpers';
+
+const USER_ID = 'user_creator';
+const EVENT_ID = 'event_123';
+const DRIVE_ID = 'drive_456';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: USER_ID,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const baseEvent = {
+  id: EVENT_ID,
+  driveId: DRIVE_ID,
+  createdById: USER_ID,
+  pageId: null,
+  title: 'Dinner',
+  description: null,
+  location: null,
+  startAt: new Date('2026-02-19T19:00:00Z'),
+  endAt: new Date('2026-02-19T20:00:00Z'),
+  allDay: false,
+  timezone: 'UTC',
+  recurrenceRule: null,
+  recurrenceExceptions: [],
+  visibility: 'DRIVE' as const,
+  color: 'default',
+  metadata: null,
+  isTrashed: false,
+};
+
+/** Captures the column values the update writes. */
+let setMock: Mock;
+
+function setupPatch(event: Partial<typeof baseEvent> = {}) {
+  const storedEvent = { ...baseEvent, ...event };
+  (authenticateRequestWithOptions as Mock).mockResolvedValue(mockAuth());
+  (db.query.calendarEvents.findFirst as Mock).mockResolvedValue(storedEvent);
+
+  const returningMock = vi.fn().mockResolvedValue([storedEvent]);
+  const whereMock = vi.fn(() => ({ returning: returningMock }));
+  setMock = vi.fn(() => ({ where: whereMock }));
+  (db.update as Mock).mockReturnValue({ set: setMock });
+
+  const txStub = {
+    select: db.select,
+    update: db.update,
+    delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'wf-1' }]) })),
+    })),
+  };
+  (db.transaction as Mock).mockImplementation(async (cb: (tx: unknown) => unknown) => cb(txStub));
+}
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request(`http://localhost:3000/api/calendar/events/${EVENT_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const params = Promise.resolve({ eventId: EVENT_ID });
+
+/** The moved dinner, as a naive wall-clock time. */
+const movedToSeven = { startAt: '2026-02-19T19:00:00', endAt: '2026-02-19T20:00:00' };
+
+describe('PATCH /api/calendar/events/[eventId] — timezone resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    profileWhere.mockResolvedValue([]);
+  });
+
+  it('reinterprets a naive datetime in the timezone the body names', async () => {
+    setupPatch({ timezone: 'America/Chicago' });
+
+    const res = await PATCH(makeRequest({ ...movedToSeven, timezone: 'Asia/Tokyo' }), { params });
+
+    expect(res.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({
+      startAt: new Date('2026-02-19T10:00:00Z'),
+      timezone: 'Asia/Tokyo',
+    }));
+  });
+
+  it("uses the event's own stored zone, not the editor's profile, when the body omits one", async () => {
+    setupPatch({ timezone: 'America/Chicago' });
+    // A traveller editing from Tokyo must not drag the event's hour with them:
+    // the event's zone outranks the profile.
+    profileWhere.mockResolvedValue([{ timezone: 'Asia/Tokyo' }]);
+
+    const res = await PATCH(makeRequest(movedToSeven), { params });
+
+    expect(res.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({
+      startAt: new Date('2026-02-20T01:00:00Z'),
+    }));
+  });
+
+  it('leaves the stored zone untouched when the body does not name one', async () => {
+    setupPatch({ timezone: 'America/Chicago' });
+    profileWhere.mockResolvedValue([{ timezone: 'Asia/Tokyo' }]);
+
+    const res = await PATCH(makeRequest({ title: 'Dinner, later' }), { params });
+
+    expect(res.status).toBe(200);
+    // undefined = "no change" to Drizzle. Resolution reads this request; it must
+    // never quietly stamp the editor's profile zone onto the event row.
+    expect(setMock.mock.calls[0][0]).toMatchObject({ timezone: undefined });
+  });
+
+  it("falls back to the caller's profile when the event has no usable zone", async () => {
+    setupPatch({ timezone: '' });
+    profileWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+
+    const res = await PATCH(makeRequest(movedToSeven), { params });
+
+    expect(res.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({
+      startAt: new Date('2026-02-20T01:00:00Z'),
+    }));
+  });
+
+  it('falls back to UTC when neither the event nor the profile has a zone', async () => {
+    setupPatch({ timezone: '' });
+    profileWhere.mockResolvedValue([{ timezone: null }]);
+
+    const res = await PATCH(makeRequest(movedToSeven), { params });
+
+    expect(res.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith(expect.objectContaining({
+      startAt: new Date('2026-02-19T19:00:00Z'),
+    }));
+  });
+
+  it('hands the agent trigger the same resolved zone the datetimes were read in', async () => {
+    setupPatch({ timezone: 'America/Chicago' });
+
+    const res = await PATCH(makeRequest({
+      ...movedToSeven,
+      agentTrigger: { agentPageId: 'agent-1', prompt: 'prep dinner' },
+    }), { params });
+
+    expect(res.status).toBe(200);
+    expect(upsertCalendarTriggerWorkflowInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        timezone: 'America/Chicago',
+        triggerAt: new Date('2026-02-20T01:00:00Z'),
+      }),
+    );
+  });
+});

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -303,7 +303,12 @@ export async function PATCH(
           startAt: adjustedStartAt,
           endAt: adjustedEndAt,
           allDay: data.allDay,
-          timezone: data.timezone,
+          // Persist the CANONICAL zone the request resolved to, not the raw
+          // field. `" America/Chicago "` resolves and validates trimmed, and
+          // `" "` resolves to the event's existing zone — writing the raw string
+          // back would store a value nothing can schedule against. Absent stays
+          // undefined, which Drizzle reads as "no change".
+          timezone: data.timezone === undefined ? undefined : effectiveTimezone,
           recurrenceRule: data.recurrenceRule,
           visibility: data.visibility,
           color: data.color,

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -9,7 +9,8 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isPrin
 import { isUserMemberOfAnyEventDrive, getAllDriveIdsForEvent } from '@pagespace/lib/services/calendar-event-drive-service';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { pushEventUpdateToGoogle, pushEventDeleteToGoogle } from '@/lib/integrations/google-calendar/push-service';
-import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
+import { parseDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
 import {
   removeCalendarTrigger,
   resyncCalendarTriggerTimings,
@@ -232,14 +233,23 @@ export async function PATCH(
 
     const data = parseResult.data;
 
-    // Apply timezone-aware parsing for naive ISO datetimes.
-    // Use the provided timezone, or fall back to the existing event's timezone.
-    const effectiveTimezone = data.timezone ?? event.timezone ?? 'UTC';
-    const adjustedStartAt = (data.startAt && typeof body.startAt === 'string' && isNaiveISODatetime(body.startAt))
-      ? parseNaiveDatetimeInTimezone(body.startAt, effectiveTimezone)
+    // Apply timezone-aware parsing for naive ISO datetimes: the provided
+    // timezone, else the event's own stored timezone, else the caller's profile
+    // (resolveTimezone), else UTC.
+    //
+    // The stored column is NOT NULL, so the profile tier is a guard rather than
+    // a routine path — it costs no query when the event has a zone, and it keeps
+    // the fallback chain identical to create's (#2404) instead of stopping one
+    // tier short.
+    const effectiveTimezone = await resolveTimezone(
+      data.timezone?.trim() || event.timezone,
+      userId,
+    );
+    const adjustedStartAt = (data.startAt && typeof body.startAt === 'string')
+      ? parseDatetimeInTimezone(body.startAt, effectiveTimezone)
       : data.startAt;
-    const adjustedEndAt = (data.endAt && typeof body.endAt === 'string' && isNaiveISODatetime(body.endAt))
-      ? parseNaiveDatetimeInTimezone(body.endAt, effectiveTimezone)
+    const adjustedEndAt = (data.endAt && typeof body.endAt === 'string')
+      ? parseDatetimeInTimezone(body.endAt, effectiveTimezone)
       : data.endAt;
 
     // Validate dates if both are provided
@@ -318,7 +328,7 @@ export async function PATCH(
           scheduledById: userId,
           calendarEventId: eventId,
           triggerAt: newStartAt,
-          timezone: data.timezone ?? event.timezone ?? 'UTC',
+          timezone: effectiveTimezone,
           agentTrigger: data.agentTrigger,
           recurrenceRule: effectiveRecurrenceRule,
           recurrenceExceptions: event.recurrenceExceptions ?? [],

--- a/apps/web/src/app/api/calendar/events/__tests__/get-listing-range-instants.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/get-listing-range-instants.test.ts
@@ -1,16 +1,22 @@
 /**
- * #1846 Codex P2 (2nd round): GET /api/calendar/events (context=user) must
- * list back a personal (driveless) event that a scoped MCP token itself
- * created (the create fix in this same PR would otherwise produce a
- * permanently unlistable event), while still excluding a driveless event
- * created by a DIFFERENT user (identity-scoped condition + the
- * scoped-token cap filter must both allow the caller's own creation through).
+ * GET /api/calendar/events range bounds are absolute instants (#2404).
+ *
+ * `startDate`/`endDate` used to be plain `z.coerce.date()`, so a naive value
+ * went through `new Date("2026-02-19T19:00:00")` — which the spec parses in the
+ * *server process's* local zone. That is UTC in deployment but the developer's
+ * zone under `next dev`, so a range query silently meant different windows in
+ * different environments and boundary bugs would not reproduce locally.
+ *
+ * This file runs with TZ deliberately set away from UTC: under the old schema
+ * these assertions would read the bounds as Chicago wall-clock times.
  */
+process.env.TZ = 'America/Chicago';
+
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 
 vi.mock('next/server', async () => {
   const actual = await vi.importActual<typeof import('next/server')>('next/server');
-  return { ...actual, after: vi.fn((fn) => fn()) };
+  return { ...actual, after: vi.fn((fn: () => void) => fn()) };
 });
 
 vi.mock('@pagespace/db/operators', () => ({
@@ -36,6 +42,9 @@ vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
 }));
 vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id', driveId: 'driveId' } }));
 vi.mock('@pagespace/db/schema/workflow-runs', () => ({ workflowRuns: { id: 'id' } }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', timezone: 'timezone' } }));
+vi.mock('@pagespace/db/schema/personalization', () => ({ userPersonalization: { userId: 'userId' } }));
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({ readMemoryPages: vi.fn().mockResolvedValue({}) }));
 
 vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
   upsertCalendarTriggerWorkflowInTx: vi.fn(),
@@ -46,7 +55,6 @@ vi.mock('@pagespace/lib/services/drive-member-service', () => ({
 }));
 vi.mock('@/lib/websocket/calendar-events', () => ({ broadcastCalendarEvent: vi.fn() }));
 vi.mock('@/lib/integrations/google-calendar/push-service', () => ({ pushEventToGoogle: vi.fn() }));
-// timestamp-utils is pure; the real parser is used rather than a partial stub.
 vi.mock('@/lib/workflows/recurrence-utils', () => ({
   expandRecurringEvents: vi.fn((events: unknown[]) => events),
 }));
@@ -56,9 +64,6 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
 }));
 
-const CREATOR_ID = 'user-creator';
-const OUTSIDER_ID = 'user-outsider';
-
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((r: unknown) => typeof r === 'object' && r !== null && 'error' in r),
@@ -67,79 +72,55 @@ vi.mock('@/lib/auth', () => ({
   isPrincipalDriveMember: vi.fn(),
   getPrincipalDriveIds: vi.fn().mockResolvedValue([]),
   canPrincipalViewPage: vi.fn(),
-  isScopedMCPAuth: (auth: { tokenType?: string; allowedDriveIds?: string[] }) =>
-    auth?.tokenType === 'mcp' && ((auth.allowedDriveIds?.length ?? 0) > 0),
+  isScopedMCPAuth: vi.fn(() => false),
 }));
-
-const PERSONAL_EVENT = {
-  id: 'evt-personal',
-  driveId: null,
-  createdById: CREATOR_ID,
-  visibility: 'PRIVATE',
-  isTrashed: false,
-  startAt: new Date('2026-07-04T10:00:00Z'),
-  endAt: new Date('2026-07-04T11:00:00Z'),
-  recurrenceRule: null,
-};
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
-    query: {
-      calendarEvents: { findMany: vi.fn() },
-    },
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn().mockResolvedValue([]),
-      })),
-    })),
+    query: { calendarEvents: { findMany: vi.fn() } },
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
   },
 }));
 
 import { GET } from '../route';
 import { db } from '@pagespace/db/db';
+import { lte } from '@pagespace/db/operators';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 
-const mockScopedMcpAuth = (userId: string) => ({
-  userId,
-  tokenType: 'mcp' as const,
-  tokenId: 'mcp-token-1',
-  allowedDriveIds: ['some-other-drive'],
-});
-
-function makeGetRequest(): Request {
+function makeGetRequest(startDate: string, endDate: string): Request {
   const url = new URL('http://localhost:3000/api/calendar/events');
   url.searchParams.set('context', 'user');
-  url.searchParams.set('startDate', '2026-07-01T00:00:00Z');
-  url.searchParams.set('endDate', '2026-07-31T00:00:00Z');
+  url.searchParams.set('startDate', startDate);
+  url.searchParams.set('endDate', endDate);
   return new Request(url.toString(), { method: 'GET' });
 }
 
-describe('GET /api/calendar/events (context=user) — scoped token + personal events', () => {
+/** The upper bound the route compares startAt against. */
+function upperBound(): Date {
+  const call = (lte as Mock).mock.calls.find(([column]) => column === 'startAt');
+  return call?.[1] as Date;
+}
+
+describe('GET /api/calendar/events — range bounds are absolute instants', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (db.query.calendarEvents.findMany as Mock).mockResolvedValue([PERSONAL_EVENT]);
+    (authenticateRequestWithOptions as Mock).mockResolvedValue({ userId: 'user-1', tokenType: 'session' });
+    (db.query.calendarEvents.findMany as Mock).mockResolvedValue([]);
   });
 
-  it('lists a personal event a scoped MCP token created itself', async () => {
-    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(CREATOR_ID));
+  it('reads a naive range bound as UTC, not as the server process local time', async () => {
+    const response = await GET(makeGetRequest('2026-02-19T00:00:00', '2026-02-19T19:00:00'));
 
-    const response = await GET(makeGetRequest());
     expect(response.status).toBe(200);
-    const body = await response.json();
-
-    expect(body.events.map((e: { id: string }) => e.id)).toContain('evt-personal');
+    // Under TZ=America/Chicago, an unpinned `new Date()` would make this
+    // 2026-02-20T01:00:00Z — a window six hours wider than the caller asked for.
+    expect(upperBound()).toEqual(new Date('2026-02-19T19:00:00Z'));
   });
 
-  it('does not leak a personal event created by a different user to a scoped MCP token', async () => {
-    // The event fixture is fixed to CREATOR_ID; a different caller querying
-    // under a scoped token must not see it even if it somehow surfaced
-    // (e.g. via the attendee branch) — the final cap filter must exclude it.
-    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(OUTSIDER_ID));
+  it('leaves a bound that already carries an offset alone', async () => {
+    const response = await GET(makeGetRequest('2026-02-19T00:00:00Z', '2026-02-19T19:00:00+09:00'));
 
-    const response = await GET(makeGetRequest());
     expect(response.status).toBe(200);
-    const body = await response.json();
-
-    expect(body.events.map((e: { id: string }) => e.id)).not.toContain('evt-personal');
+    expect(upperBound()).toEqual(new Date('2026-02-19T10:00:00Z'));
   });
 });

--- a/apps/web/src/app/api/calendar/events/__tests__/post-agent-trigger.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/post-agent-trigger.test.ts
@@ -113,10 +113,9 @@ vi.mock('@/lib/integrations/google-calendar/push-service', () => ({
   pushEventToGoogle: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/ai/core/timestamp-utils', () => ({
-  isNaiveISODatetime: vi.fn(() => false),
-  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
-}));
+// timestamp-utils is pure and cheap; these cases all pass absolute (Z) datetimes,
+// so the real parser is used rather than a stub that would have to fake the
+// naive-datetime rule.
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 

--- a/apps/web/src/app/api/calendar/events/__tests__/post-driveless-scoped-token.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/post-driveless-scoped-token.test.ts
@@ -127,10 +127,9 @@ vi.mock('@/lib/integrations/google-calendar/push-service', () => ({
   pushEventToGoogle: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/ai/core/timestamp-utils', () => ({
-  isNaiveISODatetime: vi.fn(() => false),
-  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
-}));
+// timestamp-utils is pure and cheap; these cases all pass absolute (Z) datetimes,
+// so the real parser is used rather than a stub that would have to fake the
+// naive-datetime rule.
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 

--- a/apps/web/src/app/api/calendar/events/__tests__/post-timezone-resolution.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/post-timezone-resolution.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Contract test for POST /api/calendar/events timezone resolution (#2404).
+ *
+ * The schema used to declare `timezone: z.string().default('UTC')`, so a client
+ * that omitted the field — which the API contract explicitly permits — had its
+ * naive wall-clock datetime interpreted as UTC and silently booked at the wrong
+ * instant, while the task routes resolved the same omission against the
+ * caller's profile. This pins the three-tier order (body → profile → UTC) and,
+ * just as importantly, that the RESOLVED zone is what lands in the event row —
+ * otherwise the next PATCH inherits the wrong zone.
+ *
+ * `timestamp-utils` and `personalization-utils` are deliberately NOT mocked:
+ * the naive→instant conversion and the profile lookup are the behaviour under
+ * test, so only the database underneath them is stubbed.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+const { selectWhere, capturedEventValues } = vi.hoisted(() => ({
+  selectWhere: vi.fn<() => Promise<Array<{ timezone: string | null }>>>(),
+  capturedEventValues: { current: null as Record<string, unknown> | null },
+}));
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server');
+  return { ...actual, after: vi.fn((fn: () => void) => fn()) };
+});
+
+vi.mock('@pagespace/db/db', () => {
+  const db = {
+    query: {
+      calendarEvents: { findFirst: vi.fn() },
+      eventAttendees: { findFirst: vi.fn() },
+      pages: { findFirst: vi.fn(), findMany: vi.fn() },
+    },
+    // The only db.select() in the POST path is getUserTimezone's profile read.
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: selectWhere })) })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'evt-new' }]) })),
+    })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+    transaction: vi.fn(),
+  };
+  return { db };
+});
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => args),
+  or: vi.fn((...args: unknown[]) => args),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  inArray: vi.fn(),
+  isNull: vi.fn(),
+  isNotNull: vi.fn(),
+  asc: vi.fn(),
+  desc: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/calendar', () => ({
+  calendarEvents: { id: 'id', driveId: 'driveId', createdById: 'createdById' },
+  eventAttendees: { eventId: 'eventId', userId: 'userId' },
+  calendarEventDrives: { eventId: 'eventId', driveId: 'driveId' },
+}));
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: { id: 'id', workflowId: 'workflowId', calendarEventId: 'calendarEventId' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', isTrashed: 'isTrashed', driveId: 'driveId' },
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id', timezone: 'timezone' } }));
+vi.mock('@pagespace/db/schema/workflow-runs', () => ({ workflowRuns: { id: 'id', sourceTable: 'sourceTable', sourceId: 'sourceId' } }));
+// Pulled in by personalization-utils, which stays real here.
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', timezone: 'timezone' } }));
+vi.mock('@pagespace/db/schema/personalization', () => ({ userPersonalization: { userId: 'userId' } }));
+vi.mock('@pagespace/lib/memory/memory-pages', () => ({ readMemoryPages: vi.fn().mockResolvedValue({}) }));
+
+vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
+  upsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'trg-1' }),
+  validateCalendarAgentTrigger: vi.fn().mockResolvedValue({ agentPageId: 'agent-1' }),
+}));
+
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: vi.fn().mockResolvedValue(['user-1']),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => typeof r === 'object' && r !== null && 'error' in r),
+  checkMCPDriveScope: vi.fn(() => null),
+  checkMCPCreateScope: vi.fn(() => null),
+  isPrincipalDriveMember: vi.fn().mockResolvedValue(true),
+  getPrincipalDriveIds: vi.fn().mockResolvedValue(['drive-1']),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+  isScopedMCPAuth: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/websocket/calendar-events', () => ({
+  broadcastCalendarEvent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/integrations/google-calendar/push-service', () => ({
+  pushEventToGoogle: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/workflows/recurrence-utils', () => ({ expandRecurringEvents: vi.fn(() => []) }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: {
+      child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    },
+  },
+}));
+vi.mock('cron-parser', () => ({ CronExpressionParser: { parse: vi.fn() } }));
+
+import { POST } from '../route';
+import { db } from '@pagespace/db/db';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const USER_ID = 'user-1';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: USER_ID,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'session-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost:3000/api/calendar/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** A personal (driveless) 7pm dinner, expressed as a naive wall-clock time. */
+const dinnerAtSeven = {
+  title: 'Dinner',
+  startAt: '2026-02-19T19:00:00',
+  endAt: '2026-02-19T20:00:00',
+};
+
+describe('POST /api/calendar/events — timezone resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedEventValues.current = null;
+    selectWhere.mockResolvedValue([]);
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockAuth());
+
+    (db.transaction as Mock).mockImplementation(async (cb: (tx: unknown) => unknown) => {
+      const tx = {
+        insert: vi.fn(() => ({
+          values: vi.fn((values: Record<string, unknown>) => {
+            // The first insert in the tx is the event itself; attendee inserts follow.
+            if (capturedEventValues.current === null) capturedEventValues.current = values;
+            return { returning: vi.fn().mockResolvedValue([{ id: 'evt-new' }]) };
+          }),
+        })),
+        update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+      };
+      return cb(tx);
+    });
+
+    (db.query.calendarEvents.findFirst as Mock).mockResolvedValue({ id: 'evt-new', attendees: [] });
+  });
+
+  it("interprets a naive datetime in the caller's profile timezone when the body omits one", async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+
+    const res = await POST(makeRequest(dinnerAtSeven));
+
+    expect(res.status).toBe(201);
+    // 7pm Central on a February date = 01:00 UTC the next day. Under the old
+    // `.default('UTC')` this stored 19:00Z — 1pm local, six hours early.
+    expect(capturedEventValues.current?.startAt).toEqual(new Date('2026-02-20T01:00:00Z'));
+    expect(capturedEventValues.current?.endAt).toEqual(new Date('2026-02-20T02:00:00Z'));
+  });
+
+  it('stores the resolved zone on the event, so a later edit inherits it', async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+
+    const res = await POST(makeRequest(dinnerAtSeven));
+
+    expect(res.status).toBe(201);
+    expect(capturedEventValues.current?.timezone).toBe('America/Chicago');
+  });
+
+  it('lets an explicit body timezone win, without reading the profile', async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+
+    const res = await POST(makeRequest({ ...dinnerAtSeven, timezone: 'Asia/Tokyo' }));
+
+    expect(res.status).toBe(201);
+    expect(capturedEventValues.current?.startAt).toEqual(new Date('2026-02-19T10:00:00Z'));
+    expect(capturedEventValues.current?.timezone).toBe('Asia/Tokyo');
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('falls back to UTC when neither the body nor the profile supplies a timezone', async () => {
+    selectWhere.mockResolvedValue([{ timezone: null }]);
+
+    const res = await POST(makeRequest(dinnerAtSeven));
+
+    expect(res.status).toBe(201);
+    expect(capturedEventValues.current?.startAt).toEqual(new Date('2026-02-19T19:00:00Z'));
+    expect(capturedEventValues.current?.timezone).toBe('UTC');
+  });
+
+  it('leaves an absolute datetime alone — the profile zone must not re-offset it', async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+
+    const res = await POST(makeRequest({
+      title: 'Dinner',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T20:00:00Z',
+    }));
+
+    expect(res.status).toBe(201);
+    expect(capturedEventValues.current?.startAt).toEqual(new Date('2026-02-19T19:00:00Z'));
+    // The zone is still recorded — it describes how to DISPLAY the event.
+    expect(capturedEventValues.current?.timezone).toBe('America/Chicago');
+  });
+
+  it('gives the agent trigger the same resolved zone as the event', async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+    const { upsertCalendarTriggerWorkflowInTx } = await import('@/lib/workflows/calendar-trigger-helpers');
+
+    const res = await POST(makeRequest({
+      ...dinnerAtSeven,
+      driveId: 'drive-1',
+      agentTrigger: { agentPageId: 'agent-1', prompt: 'prep dinner' },
+    }));
+
+    expect(res.status).toBe(201);
+    expect(upsertCalendarTriggerWorkflowInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        timezone: 'America/Chicago',
+        triggerAt: new Date('2026-02-20T01:00:00Z'),
+      }),
+    );
+  });
+});

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -14,19 +14,23 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPCreateScope, isPrincipalDriveMember, getPrincipalDriveIds, canPrincipalViewPage, isScopedMCPAuth } from '@/lib/auth';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { pushEventToGoogle } from '@/lib/integrations/google-calendar/push-service';
-import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
+import { parseDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
+import { absoluteInstant } from '@/lib/validation/date-params';
 import { expandRecurringEvents } from '@/lib/workflows/recurrence-utils';
 import { CronExpressionParser } from 'cron-parser';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
-// Query parameters for listing events
+// Query parameters for listing events. The range bounds are absolute instants,
+// not wall-clock times — see `absoluteInstant`; an event's own start/end is the
+// opposite case and gets read in the event's timezone below.
 const listQuerySchema = z.object({
   context: z.enum(['user', 'drive']).default('user'),
   driveId: z.string().optional(),
-  startDate: z.coerce.date(),
-  endDate: z.coerce.date(),
+  startDate: absoluteInstant,
+  endDate: absoluteInstant,
   includePersonal: z.coerce.boolean().default(true),
 });
 
@@ -40,7 +44,11 @@ const createEventSchema = z.object({
   startAt: z.coerce.date(),
   endAt: z.coerce.date(),
   allDay: z.boolean().default(false),
-  timezone: z.string().default('UTC'),
+  // Deliberately optional, NOT `.default('UTC')`: the route resolves an absent
+  // timezone against the caller's profile (resolveTimezone), and a default here
+  // would erase the difference between "omitted" and "explicitly UTC" before the
+  // handler could tell them apart.
+  timezone: z.string().optional(),
   recurrenceRule: z.object({
     frequency: z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY']),
     interval: z.number().int().min(1).default(1),
@@ -524,14 +532,19 @@ export async function POST(request: Request) {
 
     const data = parseResult.data;
 
-    // Apply timezone-aware parsing for naive ISO datetimes.
-    // When a client sends "2026-02-19T19:00:00" with timezone "America/Chicago",
-    // the time should be interpreted as 7pm Central, not 7pm UTC.
-    const startAt = (typeof body.startAt === 'string' && isNaiveISODatetime(body.startAt))
-      ? parseNaiveDatetimeInTimezone(body.startAt, data.timezone)
+    // Explicit body value wins, else the caller's profile timezone, else UTC —
+    // the same resolution the task and trigger routes use, so "tomorrow at 7pm"
+    // means one instant across the API rather than one per endpoint.
+    const timezone = await resolveTimezone(data.timezone, userId);
+
+    // Read the datetimes in the resolved timezone: "2026-02-19T19:00:00" with
+    // "America/Chicago" is 7pm Central, not 7pm UTC. Absolute values are
+    // unaffected — the zod-coerced value already agrees with them.
+    const startAt = typeof body.startAt === 'string'
+      ? parseDatetimeInTimezone(body.startAt, timezone)
       : data.startAt;
-    const endAt = (typeof body.endAt === 'string' && isNaiveISODatetime(body.endAt))
-      ? parseNaiveDatetimeInTimezone(body.endAt, data.timezone)
+    const endAt = typeof body.endAt === 'string'
+      ? parseDatetimeInTimezone(body.endAt, timezone)
       : data.endAt;
 
     // Check MCP create scope (scoped tokens can only create in their allowed drives).
@@ -638,7 +651,11 @@ export async function POST(request: Request) {
           startAt,
           endAt,
           allDay: data.allDay,
-          timezone: data.timezone,
+          // Store the RESOLVED zone, not the raw body field: the column is the
+          // event's own timezone from here on (PATCH and rendering read it back),
+          // so letting it fall to the schema default would re-introduce the bug
+          // on the next edit.
+          timezone,
           recurrenceRule: data.recurrenceRule ?? null,
           visibility: data.visibility,
           color: data.color,
@@ -674,7 +691,7 @@ export async function POST(request: Request) {
           scheduledById: userId,
           calendarEventId: created.id,
           triggerAt: startAt,
-          timezone: data.timezone,
+          timezone,
           agentTrigger: {
             agentPageId,
             prompt: data.agentTrigger.prompt,

--- a/apps/web/src/app/api/drives/[driveId]/backups/schedule/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/schedule/route.ts
@@ -120,6 +120,17 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ dr
       .limit(1);
 
     const frequency = parsed.frequency ?? existing?.frequency ?? 'daily';
+    /**
+     * Deliberately NOT resolved against the caller's profile, unlike calendar
+     * events, task due dates and workflow schedules (#2404).
+     *
+     * A backup window belongs to the DRIVE, not to whoever last touched the
+     * setting. Any owner or admin can save this form, so a profile fallback
+     * would let a colleague in another timezone silently move the whole drive's
+     * backup window by toggling an unrelated field. The zone is an explicit
+     * choice with its own control in the UI; absent means "keep what the drive
+     * already had", and UTC only for a schedule that never had one.
+     */
     const timezone = parsed.timezone ?? existing?.timezone ?? 'UTC';
     const now = new Date();
 

--- a/apps/web/src/app/api/drives/[driveId]/history/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/history/route.ts
@@ -7,14 +7,16 @@ import { isActivityEligibleForRollback } from '@pagespace/lib/permissions/rollba
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 
 const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
-  startDate: z.coerce.date().optional(),
-  endDate: z.coerce.date().optional(),
+  // Absolute instants, not wall-clock times — see optionalAbsoluteInstant.
+  startDate: optionalAbsoluteInstant,
+  endDate: optionalAbsoluteInstant,
   actorId: z.string().optional(),
   operation: z.string().optional(),
   resourceType: z.string().optional(),

--- a/apps/web/src/app/api/pages/[pageId]/history/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/history/route.ts
@@ -6,14 +6,16 @@ import { isActivityEligibleForRollback } from '@pagespace/lib/permissions/rollba
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
 const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
-  startDate: z.coerce.date().optional(),
-  endDate: z.coerce.date().optional(),
+  // Absolute instants, not wall-clock times — see optionalAbsoluteInstant.
+  startDate: optionalAbsoluteInstant,
+  endDate: optionalAbsoluteInstant,
   actorId: z.string().optional(),
   operation: z.string().optional(),
   includeAiOnly: z.coerce.boolean().optional(),

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -44,9 +44,18 @@ vi.mock('@/lib/ai/tools/task-helpers', () => ({
   reorderTaskPeers: vi.fn().mockResolvedValue({ index: 0, position: 0 }),
 }));
 
-vi.mock('@/lib/ai/core/personalization-utils', () => ({
-  getUserTimezone: vi.fn().mockResolvedValue(undefined),
-}));
+// The route resolves its timezone through resolveTimezone. Wiring the mock's
+// resolveTimezone to the mocked getUserTimezone keeps the existing profile /
+// UTC assertions below testing the route end to end; the precedence rule
+// itself is pinned in personalization-utils.test.ts.
+vi.mock('@/lib/ai/core/personalization-utils', () => {
+  const getUserTimezone = vi.fn().mockResolvedValue(undefined);
+  return {
+    getUserTimezone,
+    resolveTimezone: async (explicit: string | null | undefined, userId: string) =>
+      explicit?.trim() || (await getUserTimezone(userId)) || 'UTC',
+  };
+});
 
 vi.mock('@pagespace/lib/utils/enums', () => ({
     PageType: { DOCUMENT: 'DOCUMENT', FOLDER: 'FOLDER', TASK_LIST: 'TASK_LIST' },
@@ -169,7 +178,7 @@ import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import { createTaskAssignedNotification, createMentionNotification } from '@pagespace/lib/notifications/notifications';
 import { checkSubTasksComplete } from '@/lib/tasks/completion-guard';
-import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { createTaskTriggerWorkflow, syncTaskDueDateTrigger } from '@/lib/workflows/task-trigger-helpers';
 import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 
@@ -233,11 +242,19 @@ function setupTaskLookup(taskList = { id: mockTaskListId }, task: Record<string,
   vi.mocked(db.query.taskItems.findFirst).mockResolvedValue(task as never);
 }
 
+// Column values handed to the task update inside the tx, newest last. Lets a
+// test assert what was actually written (e.g. the parsed due date) rather than
+// only what the route echoed back.
+const capturedUpdates: Record<string, unknown>[] = [];
+
 function setupTransaction(returnedTask: Record<string, unknown> = baseTask) {
   vi.mocked(db.transaction).mockImplementation(async (callback) => {
     const txUpdateReturning = vi.fn().mockResolvedValue([returnedTask]);
     const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
-    const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+    const txUpdateSet = vi.fn((values: Record<string, unknown>) => {
+      capturedUpdates.push(values);
+      return { where: txUpdateWhere };
+    });
 
     const tx = {
       update: vi.fn(() => ({ set: txUpdateSet })),
@@ -1213,6 +1230,63 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
       agentTrigger: expect.objectContaining({ agentPageId: 'agent-1', triggerType: 'due_date' }),
       timezone: 'America/New_York',
     }));
+  });
+
+  /**
+   * The stored due date and the trigger scheduled against it have to agree on
+   * the instant. The timezone was already resolved for the trigger, but the due
+   * date itself went through a bare `new Date()`, so a naive value was read in
+   * the server's zone and the two disagreed by the caller's offset (#2404).
+   *
+   * Asserted as the GAP between two callers rather than one absolute instant:
+   * a fixed expectation passes under the old parse on any machine whose zone
+   * matches the profile, which is exactly how this survived locally.
+   */
+  const patchDueDate = async (profileTimezone: string, dueDate: string) => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, baseTask);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    setupTransaction(baseTask);
+    setupRelationsLookup({ ...baseTask, assignee: null, assigneeAgent: null, user: null, assignees: [] });
+    vi.mocked(getUserTimezone).mockResolvedValue(profileTimezone);
+    capturedUpdates.length = 0;
+
+    const response = await PATCH(createPatchRequest({ dueDate }), context);
+    expect(response.status).toBe(200);
+    return capturedUpdates.find(values => 'dueDate' in values)?.dueDate as Date | null;
+  };
+
+  it('reads a naive due date in the caller profile timezone', async () => {
+    const chicago = await patchDueDate('America/Chicago', '2026-02-19T19:00:00');
+    const tokyo = await patchDueDate('Asia/Tokyo', '2026-02-19T19:00:00');
+
+    // UTC-6 vs UTC+9 in February. Read in the server's zone, both would be equal.
+    expect(Number(chicago) - Number(tokyo)).toBe(15 * 60 * 60 * 1000);
+  });
+
+  it('schedules the due-date trigger against the same instant it stored', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, baseTask);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    setupTransaction(baseTask);
+    setupRelationsLookup({ ...baseTask, assignee: null, assigneeAgent: null, user: null, assignees: [] });
+    vi.mocked(getUserTimezone).mockResolvedValue('America/Chicago');
+    capturedUpdates.length = 0;
+
+    const response = await PATCH(createPatchRequest({ dueDate: '2026-02-19T19:00:00' }), context);
+
+    expect(response.status).toBe(200);
+    const stored = capturedUpdates.find(values => 'dueDate' in values)?.dueDate;
+    expect(syncTaskDueDateTrigger).toHaveBeenCalledWith(mockTaskId, stored);
+  });
+
+  it('leaves an absolute due date alone and never reads the profile for it', async () => {
+    const stored = await patchDueDate('America/Chicago', '2026-02-19T19:00:00Z');
+
+    expect(stored).toEqual(new Date('2026-02-19T19:00:00Z'));
+    expect(getUserTimezone).not.toHaveBeenCalled();
   });
 
   it('#1837 finding #10 — echoes the created trigger in the response, not just the generic task block', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -205,7 +205,12 @@ export async function PATCH(
   const resolvedTimezone = (agentTrigger || dueDateNeedsTimezone)
     ? await resolveTimezone(typeof timezone === 'string' ? timezone : null, userId)
     : 'UTC';
-  const parsedDueDate = dueDate ? parseDatetimeInTimezone(String(dueDate), resolvedTimezone) : null;
+  // Only a string can be naive. Anything else — an epoch number, say — keeps the
+  // prior `new Date()` behaviour instead of being stringified into an Invalid
+  // Date; this route parses an unvalidated body, so that input is reachable.
+  const parsedDueDate = dueDate
+    ? (typeof dueDate === 'string' ? parseDatetimeInTimezone(dueDate, resolvedTimezone) : new Date(dueDate))
+    : null;
 
   if (dueDate !== undefined) {
     updates.dueDate = parsedDueDate;

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -15,7 +15,8 @@ import { createTaskAssignedNotification } from '@pagespace/lib/notifications/not
 import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers, createTaskTriggerWorkflow, type TaskTriggerWorkflowResult } from '@/lib/workflows/task-trigger-helpers';
 import { checkSubTasksComplete, SUBTASKS_INCOMPLETE_STATUS } from '@/lib/tasks/completion-guard';
 import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
-import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
+import { isNaiveISODatetime, parseDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
 import { decryptTaskUserRelationsOne } from '@/lib/tasks/decrypt-task-relations';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -194,8 +195,20 @@ export async function PATCH(
     updates.assigneeAgentId = assigneeAgentId || null;
   }
 
+  // Resolve the timezone once, before the due date is read: explicit body value
+  // wins, else the caller's profile timezone, else UTC. A naive
+  // "2026-02-19T19:00:00" is a wall-clock time with no meaning until it has a
+  // zone, and the trigger workflow below must schedule against the very same
+  // instant this write stores (#2404). An absolute due date needs no zone, so
+  // the profile lookup stays skipped in the common case.
+  const dueDateNeedsTimezone = typeof dueDate === 'string' && isNaiveISODatetime(dueDate);
+  const resolvedTimezone = (agentTrigger || dueDateNeedsTimezone)
+    ? await resolveTimezone(typeof timezone === 'string' ? timezone : null, userId)
+    : 'UTC';
+  const parsedDueDate = dueDate ? parseDatetimeInTimezone(String(dueDate), resolvedTimezone) : null;
+
   if (dueDate !== undefined) {
-    updates.dueDate = dueDate ? new Date(dueDate) : null;
+    updates.dueDate = parsedDueDate;
   }
 
   // Validate agentTrigger shape up front (before any writes), mirroring the POST route.
@@ -217,7 +230,7 @@ export async function PATCH(
     if (triggerType !== 'due_date' && triggerType !== 'completion') {
       return NextResponse.json({ error: 'agentTrigger.triggerType must be "due_date" or "completion"' }, { status: 400 });
     }
-    const effectiveDueDate = dueDate !== undefined ? (dueDate ? new Date(dueDate) : null) : existingTask.dueDate;
+    const effectiveDueDate = dueDate !== undefined ? parsedDueDate : existingTask.dueDate;
     if (triggerType === 'due_date' && !effectiveDueDate) {
       return NextResponse.json({ error: 'Due date is required for due_date triggers' }, { status: 400 });
     }
@@ -365,9 +378,6 @@ export async function PATCH(
   // Create the agent trigger workflow after the transaction commits, mirroring update_task.
   let agentTriggerResult: TaskTriggerWorkflowResult | undefined;
   if (normalizedAgentTrigger && taskListPage?.driveId) {
-    const resolvedTimezone = typeof timezone === 'string' && timezone.trim()
-      ? timezone.trim()
-      : (await getUserTimezone(userId)) || 'UTC';
     agentTriggerResult = await createTaskTriggerWorkflow({
       database: db,
       driveId: taskListPage.driveId,
@@ -382,7 +392,7 @@ export async function PATCH(
 
   // Task trigger cascades (after transaction commits)
   if (dueDate !== undefined) {
-    void syncTaskDueDateTrigger(taskId, dueDate ? new Date(dueDate) : null);
+    void syncTaskDueDateTrigger(taskId, parsedDueDate);
   }
   if (statusMovedToDone) {
     void cancelTaskDueDateTrigger(taskId, 'Task completed before due date');

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -59,6 +59,10 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 // Track mock values for transaction
 let transactionPageResult = [{ id: 'mock-page-id', title: 'Mock Page' }];
 let transactionTaskResult = [{ id: 'mock-task-id', title: 'Mock Task' }];
+// Column values handed to tx.insert(...).values(...), newest last. Lets a test
+// assert what was actually written (e.g. the parsed due date) rather than only
+// what the route echoed back.
+const capturedInserts: Record<string, unknown>[] = [];
 
 // REVIEW: Deep ORM chain mocks (db.insert().values().returning(), db.transaction(tx => ...))
 // are used here because the route directly calls Drizzle ORM with no service layer.
@@ -113,13 +117,16 @@ vi.mock('@pagespace/db/db', () => {
         // Create a tx object that mimics the transaction context
         const tx = {
           insert: vi.fn(() => ({
-            values: vi.fn(() => ({
-              returning: vi.fn().mockImplementation(() => {
-                insertCallCount++;
-                // First insert is for pages, second is for taskItems
-                return Promise.resolve(insertCallCount === 1 ? transactionPageResult : transactionTaskResult);
-              }),
-            })),
+            values: vi.fn((values: Record<string, unknown>) => {
+              capturedInserts.push(values);
+              return {
+                returning: vi.fn().mockImplementation(() => {
+                  insertCallCount++;
+                  // First insert is for pages, second is for taskItems
+                  return Promise.resolve(insertCallCount === 1 ? transactionPageResult : transactionTaskResult);
+                }),
+              };
+            }),
           })),
         };
         return callback(tx);
@@ -172,9 +179,18 @@ vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
   createTaskTriggerWorkflow: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/ai/core/personalization-utils', () => ({
-  getUserTimezone: vi.fn().mockResolvedValue(undefined),
-}));
+// The route resolves its timezone through resolveTimezone. Wiring the mock's
+// resolveTimezone to the mocked getUserTimezone keeps the existing profile /
+// UTC assertions below testing the route end to end; the precedence rule
+// itself is pinned in personalization-utils.test.ts.
+vi.mock('@/lib/ai/core/personalization-utils', () => {
+  const getUserTimezone = vi.fn().mockResolvedValue(undefined);
+  return {
+    getUserTimezone,
+    resolveTimezone: async (explicit: string | null | undefined, userId: string) =>
+      explicit?.trim() || (await getUserTimezone(userId)) || 'UTC',
+  };
+});
 
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions'
@@ -262,12 +278,15 @@ describe('Task API Routes', () => {
       let insertCallCount = 0;
       const tx = {
         insert: vi.fn(() => ({
-          values: vi.fn(() => ({
-            returning: vi.fn().mockImplementation(() => {
-              insertCallCount++;
-              return Promise.resolve(insertCallCount === 1 ? transactionPageResult : transactionTaskResult);
-            }),
-          })),
+          values: vi.fn((values: Record<string, unknown>) => {
+            capturedInserts.push(values);
+            return {
+              returning: vi.fn().mockImplementation(() => {
+                insertCallCount++;
+                return Promise.resolve(insertCallCount === 1 ? transactionPageResult : transactionTaskResult);
+              }),
+            };
+          }),
         })),
       };
       return callback(tx);
@@ -1294,6 +1313,62 @@ describe('Task API Routes', () => {
       expect(response.status).toBe(201);
       expect(getUserTimezone).toHaveBeenCalledWith(mockUserId);
       expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'Europe/Berlin' }));
+    });
+
+    /**
+     * A due date is stored as an instant, so a naive wall-clock value has to be
+     * read in the caller's zone — the same rule the trigger timezone already
+     * followed. Parsing it with a bare `new Date()` read it in the server
+     * process's zone instead, which silently disagreed with the trigger the
+     * route scheduled against that very date (#2404).
+     *
+     * The assertion is the GAP between two callers rather than one absolute
+     * instant, deliberately: a fixed expectation would pass under the old
+     * `new Date()` on any machine whose own zone happened to match the profile
+     * (this repo's development machines are US Central, so the buggy parse
+     * looked correct locally and only diverged in deployment).
+     */
+    const createTaskWithDueDate = async (profileTimezone: string, dueDate: string) => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+      capturedInserts.length = 0;
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(getUserTimezone).mockResolvedValue(profileTimezone);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never)
+        .mockResolvedValueOnce(null as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(createRequest({ title: 'Task', dueDate }), { params: mockParams });
+      expect(response.status).toBe(201);
+      return capturedInserts.find(values => 'dueDate' in values)?.dueDate as Date | null;
+    };
+
+    it('reads a naive due date in the caller profile timezone', async () => {
+      const chicago = await createTaskWithDueDate('America/Chicago', '2026-02-19T19:00:00');
+      const tokyo = await createTaskWithDueDate('Asia/Tokyo', '2026-02-19T19:00:00');
+
+      // 7pm Central is 15 hours after 7pm in Tokyo (UTC-6 vs UTC+9 in February).
+      // Read in the server's zone instead, both callers would get one instant.
+      expect(Number(chicago) - Number(tokyo)).toBe(15 * 60 * 60 * 1000);
+    });
+
+    it('leaves an absolute due date alone and never reads the profile for it', async () => {
+      const stored = await createTaskWithDueDate('America/Chicago', '2026-02-19T19:00:00Z');
+
+      expect(stored).toEqual(new Date('2026-02-19T19:00:00Z'));
+      // An absolute value needs no zone, so the write costs no profile query.
+      expect(getUserTimezone).not.toHaveBeenCalled();
     });
 
     it('creates task page as TASK_LIST type with empty content', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -1371,6 +1371,17 @@ describe('Task API Routes', () => {
       expect(getUserTimezone).not.toHaveBeenCalled();
     });
 
+    // The body is not schema-validated here, so a non-string due date is
+    // reachable. It used to go through `new Date(value)` and work; routing it
+    // through the naive-aware parser would have stringified an epoch number into
+    // an Invalid Date.
+    it('still accepts an epoch-number due date', async () => {
+      const epoch = Date.UTC(2026, 1, 19, 19, 0, 0);
+      const stored = await createTaskWithDueDate('America/Chicago', epoch as unknown as string);
+
+      expect(stored).toEqual(new Date(epoch));
+    });
+
     it('creates task page as TASK_LIST type with empty content', async () => {
       const mockTaskList = { id: mockTaskListId };
       const mockNewTask = { id: 'new-task', title: 'New Task', status: 'pending', priority: 'medium', position: 0 };

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -18,7 +18,8 @@ import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
 import { compareByPagePosition, computeTaskMovePosition } from '@/services/api/task-ordering';
 import { reorderTaskListChildPages } from '@/services/api/task-reorder-service';
 import { computeReorderPlan } from '@pagespace/lib/services/reorder';
-import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
+import { isNaiveISODatetime, parseDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
 import { decryptTaskUserRelations, decryptTaskUserRelationsOne } from '@/lib/tasks/decrypt-task-relations';
 import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 import { parseTaskQuerySpec } from './query-spec';
@@ -492,11 +493,19 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   const primaryAssigneeId = assigneeId || assigneeIds?.find((a: { type: string }) => a.type === 'user')?.id || null;
   const primaryAgentId = assigneeAgentId || assigneeIds?.find((a: { type: string }) => a.type === 'agent')?.id || null;
 
-  // Resolve the trigger timezone once, up front: explicit body value wins, else
-  // the caller's profile timezone, else UTC — matching the internal create_task tool.
-  const resolvedTimezone = agentTrigger
-    ? (typeof timezone === 'string' && timezone.trim() ? timezone.trim() : (await getUserTimezone(userId)) || 'UTC')
+  // Resolve the timezone once, up front: explicit body value wins, else the
+  // caller's profile timezone, else UTC — matching the internal create_task tool.
+  //
+  // Needed for the trigger workflow AND for reading the due date: a naive
+  // "2026-02-19T19:00:00" is a wall-clock time that means nothing without a
+  // zone. Resolving only for the trigger would leave the due date itself read
+  // in the server's zone (#2404). An absolute due date needs no zone, so the
+  // profile lookup stays skipped in the common case.
+  const dueDateNeedsTimezone = typeof dueDate === 'string' && isNaiveISODatetime(dueDate);
+  const resolvedTimezone = (agentTrigger || dueDateNeedsTimezone)
+    ? await resolveTimezone(typeof timezone === 'string' ? timezone : null, userId)
     : 'UTC';
+  const parsedDueDate = dueDate ? parseDatetimeInTimezone(String(dueDate), resolvedTimezone) : null;
 
   // Create task and its document page in a transaction
   const result = await db.transaction(async (tx) => {
@@ -520,7 +529,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       priority: priority || 'medium',
       assigneeId: primaryAssigneeId,
       assigneeAgentId: primaryAgentId,
-      dueDate: dueDate ? new Date(dueDate) : null,
+      dueDate: parsedDueDate,
       completedAt: initialCompletedAt,
       metadata: {
         createdAt: new Date().toISOString(),
@@ -564,7 +573,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         taskId: newTask.id,
         taskMetadata: newTask.metadata as Record<string, unknown> | null,
         agentTrigger,
-        dueDate: dueDate ? new Date(dueDate) : null,
+        dueDate: parsedDueDate,
         timezone: resolvedTimezone,
       });
     }

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -505,7 +505,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   const resolvedTimezone = (agentTrigger || dueDateNeedsTimezone)
     ? await resolveTimezone(typeof timezone === 'string' ? timezone : null, userId)
     : 'UTC';
-  const parsedDueDate = dueDate ? parseDatetimeInTimezone(String(dueDate), resolvedTimezone) : null;
+  // Only a string can be naive. Anything else — an epoch number, say — keeps the
+  // prior `new Date()` behaviour instead of being stringified into an Invalid
+  // Date; this route parses an unvalidated body, so that input is reachable.
+  const parsedDueDate = dueDate
+    ? (typeof dueDate === 'string' ? parseDatetimeInTimezone(dueDate, resolvedTimezone) : new Date(dueDate))
+    : null;
 
   // Create task and its document page in a transaction
   const result = await db.transaction(async (tx) => {

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -22,9 +22,18 @@ vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
   recomputeTaskTriggerMetadata: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/ai/core/personalization-utils', () => ({
-  getUserTimezone: vi.fn().mockResolvedValue(undefined),
-}));
+// The route resolves its timezone through resolveTimezone. Wiring the mock's
+// resolveTimezone to the mocked getUserTimezone keeps the existing profile /
+// UTC assertions below testing the route end to end; the precedence rule
+// itself is pinned in personalization-utils.test.ts.
+vi.mock('@/lib/ai/core/personalization-utils', () => {
+  const getUserTimezone = vi.fn().mockResolvedValue(undefined);
+  return {
+    getUserTimezone,
+    resolveTimezone: async (explicit: string | null | undefined, userId: string) =>
+      explicit?.trim() || (await getUserTimezone(userId)) || 'UTC',
+  };
+});
 
 vi.mock('@/lib/websocket', () => ({
   broadcastTaskEvent: vi.fn(),

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
@@ -11,7 +11,7 @@ import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
 
 const logger = loggers.api.child({ module: 'task-triggers-api' });
 
@@ -159,7 +159,7 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
 
   // Explicit body value wins, else the caller's profile timezone, else UTC —
   // matching the internal update_task/create_task tools.
-  const timezone = parsed.data.timezone?.trim() || (await getUserTimezone(userId)) || 'UTC';
+  const timezone = await resolveTimezone(parsed.data.timezone, userId);
 
   try {
     await createTaskTriggerWorkflow({

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -19,6 +19,7 @@ import {
   getPrincipalBatchPagePermissions,
 } from '@/lib/auth';
 import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
+import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -34,8 +35,9 @@ const querySchema = z.object({
   // Filter parameters - status accepts any string for custom statuses
   status: z.string().optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
-  startDate: z.coerce.date().optional(),
-  endDate: z.coerce.date().optional(),
+  // Absolute instants, not wall-clock times — see optionalAbsoluteInstant.
+  startDate: optionalAbsoluteInstant,
+  endDate: optionalAbsoluteInstant,
   // New filter parameters
   search: z.string().optional(),
   assigneeId: z.string().optional(),

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -19,7 +19,7 @@ import {
   getPrincipalBatchPagePermissions,
 } from '@/lib/auth';
 import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
-import { optionalAbsoluteInstant } from '@/lib/validation/date-params';
+import { optionalAbsoluteInstant, exclusiveEndBound } from '@/lib/validation/date-params';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -69,6 +69,8 @@ export async function GET(request: Request) {
 
   const userId = auth.userId;
   const { searchParams } = new URL(request.url);
+  // Kept raw: only exclusiveEndBound can tell a date-only bound from an instant.
+  const rawEndDate = searchParams.get('endDate');
 
   try {
     // Parse and validate query parameters
@@ -249,9 +251,9 @@ export async function GET(request: Request) {
       filterConditions.push(gte(taskItems.createdAt, params.startDate));
     }
     if (params.endDate) {
-      const endOfDay = new Date(params.endDate);
-      endOfDay.setDate(endOfDay.getDate() + 1);
-      filterConditions.push(lt(taskItems.createdAt, endOfDay));
+      // A date-only bound covers the whole day; an explicit instant means that
+      // instant. See exclusiveEndBound.
+      filterConditions.push(lt(taskItems.createdAt, exclusiveEndBound(rawEndDate, params.endDate)));
     }
     // Search filter (case-insensitive title/description). Title lives on pages,
     // so match it via a subquery against pages.title.

--- a/apps/web/src/app/api/workflows/[workflowId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/__tests__/route.test.ts
@@ -381,6 +381,61 @@ describe('PATCH /api/workflows/[workflowId]', () => {
       instructionPageId: 'page_instr',
     }));
   });
+
+  /**
+   * The column is what the cron poller schedules against: it reads the stored
+   * value straight into getNextRunDate on every tick
+   * (api/cron/workflows/route.ts). A value that resolution accepted but the
+   * column did not — a padded zone, or whitespace that resolves back to the
+   * existing one — would throw there, leave nextRunAt stale, and re-fire the
+   * workflow on every poll. So what gets validated and what gets stored have to
+   * be the same string (PR #2405 review, codex P1).
+   */
+  describe('timezone persistence', () => {
+    const patchTimezone = async (timezone: string) => {
+      const request = new Request('https://example.com/api/workflows/wf_1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ timezone }),
+      });
+      const response = await PATCH(request, createContext('wf_1'));
+      expect(response!.status).toBe(200);
+      return mockUpdateSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    };
+
+    it('stores a space-padded timezone trimmed', async () => {
+      const written = await patchTimezone('  America/Chicago  ');
+
+      expect(written.timezone).toBe('America/Chicago');
+    });
+
+    it('stores the existing zone rather than whitespace when the field is blank', async () => {
+      const written = await patchTimezone('   ');
+
+      // Resolution treats blank as absent and falls back to the workflow's own
+      // zone; the column must not end up holding the blank string.
+      expect(written.timezone).toBe('UTC');
+    });
+
+    it('schedules against the same zone it stores', async () => {
+      const written = await patchTimezone('  America/Chicago  ');
+
+      expect(getNextRunDate).toHaveBeenCalledWith('0 9 * * 1-5', written.timezone);
+    });
+
+    it('leaves the stored zone untouched when the request omits it', async () => {
+      const request = new Request('https://example.com/api/workflows/wf_1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'New Name' }),
+      });
+      const response = await PATCH(request, createContext('wf_1'));
+
+      expect(response!.status).toBe(200);
+      const written = mockUpdateSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(written.timezone).toBeUndefined();
+    });
+  });
 });
 
 // ============================================================================

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -168,6 +168,13 @@ export async function PATCH(
     .update(workflows)
     .set({
       ...data,
+      // Persist the CANONICAL zone this request validated, not the raw field —
+      // `...data` would spread a space-padded or whitespace-only string past the
+      // validation above and straight into the column. The cron runner hands
+      // that stored value to getNextRunDate on every tick, so an unschedulable
+      // string there leaves nextRunAt stale and the workflow re-firing forever.
+      // Absent stays undefined, which Drizzle reads as "no change".
+      timezone: data.timezone === undefined ? undefined : effectiveTimezone,
       nextRunAt,
       updatedAt: new Date(),
     })

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -10,6 +10,7 @@ import { eq, and } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
 import { workflowStepsSchema, validateStepsForApi } from '@/lib/workflows/steps-api-validation';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
@@ -132,8 +133,14 @@ export async function PATCH(
     stepWarnings = stepsResult.warnings;
   }
 
-  // Validate timezone
-  const effectiveTimezone = data.timezone ?? workflow.timezone;
+  // Validate timezone. Body value wins, else the workflow's own stored zone,
+  // else the caller's profile, else UTC — the same chain create resolves, so
+  // the rule is one rule (#2404). The stored column is NOT NULL, so the profile
+  // tier is a guard that costs no query in the normal case.
+  const effectiveTimezone = await resolveTimezone(
+    data.timezone?.trim() || workflow.timezone,
+    auth.userId,
+  );
   const tzValidation = validateTimezone(effectiveTimezone);
   if (!tzValidation.valid) {
     return NextResponse.json({ error: tzValidation.error }, { status: 400 });
@@ -155,8 +162,7 @@ export async function PATCH(
 
   // Compute nextRunAt based on updated fields (only for cron workflows)
   const isEnabled = data.isEnabled ?? workflow.isEnabled;
-  const timezone = data.timezone ?? workflow.timezone;
-  const nextRunAt = isEnabled ? getNextRunDate(cronExpr, timezone) : null;
+  const nextRunAt = isEnabled ? getNextRunDate(cronExpr, effectiveTimezone) : null;
 
   const [updated] = await db
     .update(workflows)

--- a/apps/web/src/app/api/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/__tests__/route.test.ts
@@ -471,6 +471,73 @@ describe('POST /api/workflows', () => {
     expect(response.status).toBe(201);
   });
 
+  /**
+   * A cron schedule is wall-clock by nature, so an omitted timezone is the
+   * caller's zone, not UTC. The schema used to declare `.default('UTC')`, which
+   * both made "omitted" indistinguishable from "explicitly UTC" and ran
+   * "0 9 * * *" at 9am UTC — 3am for a US Central scheduler (#2404).
+   *
+   * The profile read is the SECOND db.select in the POST path; the first
+   * validates the agent page.
+   */
+  describe('timezone resolution', () => {
+    const bodyWithoutTimezone = {
+      driveId: mockDriveId,
+      name: 'Daily Report',
+      agentPageId: 'page_1',
+      prompt: 'Generate report',
+      cronExpression: '0 9 * * *',
+      isEnabled: true,
+    };
+
+    const postWorkflow = async (body: Record<string, unknown>, profileTimezone: string | null) => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      vi.mocked(validateCronExpression).mockReturnValue({ valid: true });
+      vi.mocked(getNextRunDate).mockReturnValue(new Date('2025-06-01T09:00:00Z'));
+      mockWhere
+        .mockResolvedValueOnce([{ id: 'page_1', type: 'AI_CHAT', driveId: mockDriveId }])
+        .mockResolvedValueOnce([{ timezone: profileTimezone }]);
+
+      const request = new Request('https://example.com/api/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+    };
+
+    it("schedules an omitted timezone in the caller's profile zone", async () => {
+      await postWorkflow(bodyWithoutTimezone, 'America/Chicago');
+
+      expect(getNextRunDate).toHaveBeenCalledWith('0 9 * * *', 'America/Chicago');
+    });
+
+    it('stores the resolved zone, so later edits and runs inherit it', async () => {
+      await postWorkflow(bodyWithoutTimezone, 'America/Chicago');
+
+      expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'America/Chicago' }));
+    });
+
+    it('lets an explicit body timezone win over the profile', async () => {
+      await postWorkflow({ ...bodyWithoutTimezone, timezone: 'Asia/Tokyo' }, 'America/Chicago');
+
+      expect(getNextRunDate).toHaveBeenCalledWith('0 9 * * *', 'Asia/Tokyo');
+      expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'Asia/Tokyo' }));
+    });
+
+    it('falls back to UTC when the profile has no timezone', async () => {
+      await postWorkflow(bodyWithoutTimezone, null);
+
+      expect(getNextRunDate).toHaveBeenCalledWith('0 9 * * *', 'UTC');
+      expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'UTC' }));
+    });
+  });
+
   // The DB column and internal create_workflow tool both support
   // instructionPageId as an alternative to prompt (agentTriggerBaseSchema).
   // The route's .strict() schema previously rejected it outright and

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -11,6 +11,7 @@ import { pages } from '@pagespace/db/schema/core'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
+import { resolveTimezone } from '@/lib/ai/core/personalization-utils';
 import { workflowStepsSchema, validateStepsForApi } from '@/lib/workflows/steps-api-validation';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
@@ -33,7 +34,10 @@ const createWorkflowSchema = z.object({
   instructionPageId: z.string().nullable().optional(),
   contextPageIds: z.array(z.string()).default([]),
   cronExpression: z.string().min(1),
-  timezone: z.string().default('UTC'),
+  // Optional, NOT `.default('UTC')`: the route resolves an absent timezone
+  // against the caller's profile, and a default here would erase the difference
+  // between "omitted" and "explicitly UTC" before the handler sees it (#2404).
+  timezone: z.string().optional(),
   isEnabled: z.boolean().default(true),
 }).strict().refine(
   // Step-based workflows carry their behavior in `steps`; legacy bodies keep
@@ -195,8 +199,14 @@ export async function POST(request: Request) {
     }
   }
 
+  // Explicit body value wins, else the caller's profile timezone, else UTC —
+  // the same resolution the create_workflow tool applies from its execution
+  // context. A cron schedule is wall-clock by nature: "0 9 * * *" resolved to
+  // UTC instead of the scheduler's own zone runs the workflow at 3am for them.
+  const timezone = await resolveTimezone(data.timezone, userId);
+
   // Validate timezone
-  const tzValidation = validateTimezone(data.timezone);
+  const tzValidation = validateTimezone(timezone);
   if (!tzValidation.valid) {
     return NextResponse.json({ error: tzValidation.error }, { status: 400 });
   }
@@ -207,7 +217,7 @@ export async function POST(request: Request) {
   if (!cronValidation.valid) {
     return NextResponse.json({ error: `Invalid cron expression: ${cronValidation.error}` }, { status: 400 });
   }
-  nextRunAt = data.isEnabled ? getNextRunDate(data.cronExpression, data.timezone) : null;
+  nextRunAt = data.isEnabled ? getNextRunDate(data.cronExpression, timezone) : null;
 
   const [workflow] = await db.insert(workflows).values({
     driveId: data.driveId,
@@ -221,7 +231,9 @@ export async function POST(request: Request) {
     contextPageIds: data.contextPageIds,
     triggerType: MANAGEABLE_TRIGGER_TYPE,
     cronExpression: data.cronExpression,
-    timezone: data.timezone,
+    // Store the RESOLVED zone: it is the workflow's own timezone from here on
+    // (PATCH and every future run read it back).
+    timezone,
     isEnabled: data.isEnabled,
     eventTriggers: null,
     watchedFolderIds: null,

--- a/apps/web/src/components/activity/ActivityDashboard.tsx
+++ b/apps/web/src/components/activity/ActivityDashboard.tsx
@@ -13,7 +13,7 @@ import { ActivityTimeline } from './ActivityTimeline';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 import type { ActivityLog, ActivityFilters, Drive, Pagination } from './types';
-import { dayRangeParams } from './utils';
+import { dayRangeParams, parseDayParam, formatDayParam } from './utils';
 import type { RollbackContext } from './ActivityItem';
 import type { ActivityActionResult } from '@/types/activity-actions';
 
@@ -38,12 +38,10 @@ export function ActivityDashboard({ context, driveId: initialDriveId, driveName 
   // Filter state from URL params
   const [selectedDriveId, setSelectedDriveId] = useState<string | undefined>(initialDriveId);
   const [filters, setFilters] = useState<ActivityFilters>(() => ({
-    startDate: searchParams.get('startDate')
-      ? new Date(searchParams.get('startDate') as string)
-      : undefined,
-    endDate: searchParams.get('endDate')
-      ? new Date(searchParams.get('endDate') as string)
-      : undefined,
+    // Date-only URL values are calendar days and must be read in the viewer's
+    // zone — see parseDayParam.
+    startDate: parseDayParam(searchParams.get('startDate')),
+    endDate: parseDayParam(searchParams.get('endDate')),
     actorId: searchParams.get('actorId') || undefined,
     operation: searchParams.get('operation') || undefined,
     resourceType: searchParams.get('resourceType') || undefined,
@@ -55,10 +53,10 @@ export function ActivityDashboard({ context, driveId: initialDriveId, driveName 
     const params = new URLSearchParams();
 
     if (newFilters.startDate) {
-      params.set('startDate', newFilters.startDate.toISOString().split('T')[0]);
+      params.set('startDate', formatDayParam(newFilters.startDate));
     }
     if (newFilters.endDate) {
-      params.set('endDate', newFilters.endDate.toISOString().split('T')[0]);
+      params.set('endDate', formatDayParam(newFilters.endDate));
     }
     if (newFilters.actorId) {
       params.set('actorId', newFilters.actorId);

--- a/apps/web/src/components/activity/ActivityDashboard.tsx
+++ b/apps/web/src/components/activity/ActivityDashboard.tsx
@@ -13,6 +13,7 @@ import { ActivityTimeline } from './ActivityTimeline';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 import type { ActivityLog, ActivityFilters, Drive, Pagination } from './types';
+import { dayRangeParams } from './utils';
 import type { RollbackContext } from './ActivityItem';
 import type { ActivityActionResult } from '@/types/activity-actions';
 
@@ -121,11 +122,9 @@ export function ActivityDashboard({ context, driveId: initialDriveId, driveName 
         } else if (context === 'user' && filters.driveId) {
           params.set('driveId', filters.driveId);
         }
-        if (filters.startDate) {
-          params.set('startDate', filters.startDate.toISOString());
-        }
-        if (filters.endDate) {
-          params.set('endDate', filters.endDate.toISOString());
+        // The picker selects DAYS; the API takes instants and endDate is exclusive.
+        for (const [key, value] of Object.entries(dayRangeParams(filters.startDate, filters.endDate))) {
+          params.set(key, value);
         }
         if (filters.actorId) {
           params.set('actorId', filters.actorId);

--- a/apps/web/src/components/activity/ExportButton.tsx
+++ b/apps/web/src/components/activity/ExportButton.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
 import type { ActivityFilters } from './types';
+import { dayRangeParams } from './utils';
 
 interface ExportButtonProps {
   context: 'user' | 'drive';
@@ -28,11 +29,9 @@ export function ExportButton({ context, driveId, filters }: ExportButtonProps) {
       if (effectiveDriveId) {
         params.set('driveId', effectiveDriveId);
       }
-      if (filters.startDate) {
-        params.set('startDate', filters.startDate.toISOString());
-      }
-      if (filters.endDate) {
-        params.set('endDate', filters.endDate.toISOString());
+      // The picker selects DAYS; the API takes instants and endDate is exclusive.
+      for (const [key, value] of Object.entries(dayRangeParams(filters.startDate, filters.endDate))) {
+        params.set(key, value);
       }
       if (filters.actorId) {
         params.set('actorId', filters.actorId);

--- a/apps/web/src/components/activity/__tests__/utils.test.ts
+++ b/apps/web/src/components/activity/__tests__/utils.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   isRollbackOperation,
   hasAiConversationId,
   isEditSessionGroupable,
   groupConsecutiveActivities,
+  dayRangeParams,
 } from '../utils';
 import type { ActivityLog } from '../types';
 
@@ -311,5 +312,58 @@ describe('groupConsecutiveActivities', () => {
       expect(result[2].type).toBe('rollback');
       expect(result[3].type).toBe('edit_session');
     });
+  });
+});
+
+/**
+ * The activity filters are a DAY picker over an API that takes instants, and
+ * `endDate` is exclusive — so the day the user picked is only included if the
+ * bound is the start of the following day. The routes used to add that day
+ * themselves in server-local time, which reproduced this window by accident
+ * while stretching any explicit instant a caller sent (#2404).
+ *
+ * TZ is pinned away from UTC because that is the only way these assertions can
+ * tell a LOCAL day window from a UTC one.
+ */
+describe('dayRangeParams', () => {
+  const originalTz = process.env.TZ;
+  beforeAll(() => { process.env.TZ = 'America/Chicago'; });
+  afterAll(() => { process.env.TZ = originalTz; });
+
+  it('includes the whole of the selected end day', () => {
+    // The picker hands back local midnight for each selected day.
+    const start = new Date(2026, 1, 10);
+    const end = new Date(2026, 1, 19);
+
+    const params = dayRangeParams(start, end);
+
+    expect(params.endDate).toBe(new Date(2026, 1, 20).toISOString());
+    // 10 days later, exactly — no DST in that window, and no server involved.
+    const span = Date.parse(params.endDate!) - Date.parse(params.startDate!);
+    expect(span).toBe(10 * 24 * 60 * 60 * 1000);
+  });
+
+  it("describes the viewer's local day, not a UTC one", () => {
+    const day = new Date(2026, 1, 19);
+
+    const params = dayRangeParams(day, day);
+
+    // Local midnight in Chicago is 06:00Z, so a UTC-day window would start at
+    // 00:00Z. The bounds have to carry the offset or the user gets someone
+    // else's day.
+    expect(params.startDate).toBe('2026-02-19T06:00:00.000Z');
+    expect(params.endDate).toBe('2026-02-20T06:00:00.000Z');
+  });
+
+  it('normalises a picked time-of-day down to the start of that day', () => {
+    const middleOfDay = new Date(2026, 1, 19, 14, 37, 12);
+
+    expect(dayRangeParams(middleOfDay).startDate).toBe(new Date(2026, 1, 19).toISOString());
+  });
+
+  it('omits whichever bound was not picked', () => {
+    expect(dayRangeParams(undefined, undefined)).toEqual({});
+    expect(dayRangeParams(new Date(2026, 1, 19))).not.toHaveProperty('endDate');
+    expect(dayRangeParams(undefined, new Date(2026, 1, 19))).not.toHaveProperty('startDate');
   });
 });

--- a/apps/web/src/components/activity/__tests__/utils.test.ts
+++ b/apps/web/src/components/activity/__tests__/utils.test.ts
@@ -5,6 +5,8 @@ import {
   isEditSessionGroupable,
   groupConsecutiveActivities,
   dayRangeParams,
+  parseDayParam,
+  formatDayParam,
 } from '../utils';
 import type { ActivityLog } from '../types';
 
@@ -328,7 +330,11 @@ describe('groupConsecutiveActivities', () => {
 describe('dayRangeParams', () => {
   const originalTz = process.env.TZ;
   beforeAll(() => { process.env.TZ = 'America/Chicago'; });
-  afterAll(() => { process.env.TZ = originalTz; });
+  afterAll(() => {
+    // Assigning undefined would leave TZ set to the STRING "undefined".
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
 
   it('includes the whole of the selected end day', () => {
     // The picker hands back local midnight for each selected day.
@@ -365,5 +371,72 @@ describe('dayRangeParams', () => {
     expect(dayRangeParams(undefined, undefined)).toEqual({});
     expect(dayRangeParams(new Date(2026, 1, 19))).not.toHaveProperty('endDate');
     expect(dayRangeParams(undefined, new Date(2026, 1, 19))).not.toHaveProperty('startDate');
+  });
+});
+
+/**
+ * The filters live in the URL so a view can be reloaded or shared. Both ends of
+ * that round trip have a timezone trap, and they fail in OPPOSITE directions:
+ *
+ * - `new Date("2026-02-19")` is UTC midnight, so it reads back as the 18th
+ *   WEST of Greenwich.
+ * - `toISOString().split('T')[0]` is the UTC day, so it writes the 18th EAST
+ *   of Greenwich (Tokyo midnight is 15:00Z the previous day).
+ *
+ * Each half is therefore pinned in the hemisphere where it actually breaks —
+ * in UTC, and in the other hemisphere, both bugs are invisible.
+ */
+const withTimezone = (timezone: string) => {
+  const originalTz = process.env.TZ;
+  beforeAll(() => { process.env.TZ = timezone; });
+  afterAll(() => {
+    // Assigning undefined would leave TZ set to the STRING "undefined".
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
+};
+
+describe('day URL params, west of Greenwich', () => {
+  withTimezone('America/Chicago');
+
+  it('reads a date-only value as the local day, not UTC midnight', () => {
+    // `new Date("2026-02-19")` would be Feb 18 18:00 here.
+    expect(parseDayParam('2026-02-19')).toEqual(new Date(2026, 1, 19));
+  });
+
+  it('survives the round trip a reload or shared link performs', () => {
+    const picked = new Date(2026, 1, 19);
+
+    const reloaded = parseDayParam(formatDayParam(picked));
+
+    expect(reloaded).toEqual(picked);
+    // And the request built from the reloaded value still covers that same day.
+    expect(dayRangeParams(reloaded, reloaded)).toEqual(dayRangeParams(picked, picked));
+  });
+
+  it('still honours an explicit instant in the URL', () => {
+    expect(parseDayParam('2026-02-19T06:00:00.000Z')).toEqual(new Date('2026-02-19T06:00:00.000Z'));
+  });
+
+  it('returns undefined for an absent or unparseable value', () => {
+    expect(parseDayParam(null)).toBeUndefined();
+    expect(parseDayParam('')).toBeUndefined();
+    expect(parseDayParam('not-a-date')).toBeUndefined();
+  });
+});
+
+describe('day URL params, east of Greenwich', () => {
+  withTimezone('Asia/Tokyo');
+
+  it('writes the day the user picked, not the UTC day', () => {
+    // Tokyo midnight on the 19th is 15:00Z on the 18th, so the UTC day is a day
+    // behind what the picker showed.
+    expect(formatDayParam(new Date(2026, 1, 19))).toBe('2026-02-19');
+  });
+
+  it('survives the round trip here too', () => {
+    const picked = new Date(2026, 1, 19);
+
+    expect(parseDayParam(formatDayParam(picked))).toEqual(picked);
   });
 });

--- a/apps/web/src/components/activity/utils.ts
+++ b/apps/web/src/components/activity/utils.ts
@@ -1,4 +1,4 @@
-import { isToday, isYesterday, isThisWeek, format, addDays, startOfDay } from 'date-fns';
+import { isToday, isYesterday, isThisWeek, format, addDays, startOfDay, parseISO } from 'date-fns';
 import type {
   ActivityLog,
   ActivityGroupSummary,
@@ -303,4 +303,31 @@ export function dayRangeParams(
     ...(startDate ? { startDate: startOfDay(startDate).toISOString() } : {}),
     ...(endDate ? { endDate: addDays(startOfDay(endDate), 1).toISOString() } : {}),
   };
+}
+
+/**
+ * Read a day the user picked back out of a URL parameter.
+ *
+ * The filters live in the URL so a view can be reloaded or shared, and they are
+ * written as `YYYY-MM-DD` — a CALENDAR DAY, which only means anything in the
+ * reader's own timezone. `new Date("2026-02-19")` is the trap: ISO 8601 defines
+ * a bare date as UTC midnight, so west of Greenwich it reads back as the 18th
+ * and the whole range slides a day (#2404). `parseISO` reads a date-only value
+ * as local midnight, and still honours an explicit instant if one is present.
+ */
+export function parseDayParam(value: string | null | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsed = parseISO(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/**
+ * Write a picked day into a URL parameter, as the day the user sees.
+ *
+ * The counterpart trap to {@link parseDayParam}: `toISOString().split('T')[0]`
+ * takes the UTC day, which east of Greenwich is the day BEFORE the one that was
+ * picked (Tokyo midnight is 15:00Z the previous day). `format` is local.
+ */
+export function formatDayParam(date: Date): string {
+  return format(date, 'yyyy-MM-dd');
 }

--- a/apps/web/src/components/activity/utils.ts
+++ b/apps/web/src/components/activity/utils.ts
@@ -1,4 +1,4 @@
-import { isToday, isYesterday, isThisWeek, format } from 'date-fns';
+import { isToday, isYesterday, isThisWeek, format, addDays, startOfDay } from 'date-fns';
 import type {
   ActivityLog,
   ActivityGroupSummary,
@@ -279,4 +279,28 @@ export function groupConsecutiveActivities(
   }
 
   return result;
+}
+
+/**
+ * The instant bounds the activity APIs want for a day-picker range.
+ *
+ * The picker selects DAYS, in the viewer's own timezone; `startDate`/`endDate`
+ * on the API are absolute instants and `endDate` is EXCLUSIVE. So the selected
+ * end day is included by sending the start of the *next* local day — which also
+ * means the window is the user's day wherever they are, with no day arithmetic
+ * on the server, which cannot know their zone.
+ *
+ * The routes used to add a day themselves, in the server's local time. That
+ * happened to reproduce this window (the browser sent local midnight and the
+ * server added 24h) but it stretched any explicit instant a caller sent by a
+ * whole day, and depended on where the server ran (#2404).
+ */
+export function dayRangeParams(
+  startDate?: Date,
+  endDate?: Date,
+): { startDate?: string; endDate?: string } {
+  return {
+    ...(startDate ? { startDate: startOfDay(startDate).toISOString() } : {}),
+    ...(endDate ? { endDate: addDays(startOfDay(endDate), 1).toISOString() } : {}),
+  };
 }

--- a/apps/web/src/lib/ai/core/__tests__/personalization-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/personalization-utils.test.ts
@@ -11,10 +11,12 @@ import { assert } from '@/lib/memory/__tests__/riteway';
  */
 
 const findFirst = vi.fn();
+const selectWhere = vi.fn(() => Promise.resolve([] as Array<{ timezone: string | null }>));
+const select = vi.fn(() => ({ from: () => ({ where: selectWhere }) }));
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: { userPersonalization: { findFirst: (...a: unknown[]) => findFirst(...a) } },
-    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+    select: (...a: unknown[]) => select(...(a as [])),
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
@@ -207,6 +209,105 @@ describe('getUserPersonalization', () => {
       should: 'inject the page, which is what the user can actually edit',
       actual: result?.bio,
       expected: 'current page bio',
+    });
+  });
+});
+
+/**
+ * The one place the body → profile → UTC order is defined.
+ *
+ * Every route that turns a naive wall-clock datetime into an instant resolves
+ * through this function, so a task due "tomorrow at 7pm" and a calendar event
+ * "tomorrow at 7pm" land at the same instant for the same caller. Calendar
+ * create used to re-derive the rule as a bare Zod `.default('UTC')` and booked
+ * events hours off for anyone who omitted the field (#2404).
+ */
+describe('resolveTimezone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectWhere.mockResolvedValue([]);
+  });
+
+  it('prefers an explicit timezone over the stored profile', async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+    const { resolveTimezone } = await import('../personalization-utils');
+
+    assert({
+      given: 'a request that names its own timezone',
+      should: 'use it verbatim',
+      actual: await resolveTimezone('Asia/Tokyo', 'user-1'),
+      expected: 'Asia/Tokyo',
+    });
+  });
+
+  it('does not read the profile when the caller supplied a timezone', async () => {
+    const { resolveTimezone } = await import('../personalization-utils');
+    await resolveTimezone('Asia/Tokyo', 'user-1');
+
+    assert({
+      given: 'an explicit timezone',
+      should: 'skip the profile query entirely',
+      actual: select.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  it('trims an explicit timezone', async () => {
+    const { resolveTimezone } = await import('../personalization-utils');
+
+    assert({
+      given: 'a padded timezone string',
+      should: 'return the trimmed zone',
+      actual: await resolveTimezone('  Europe/Berlin  ', 'user-1'),
+      expected: 'Europe/Berlin',
+    });
+  });
+
+  it("falls back to the caller's profile when the request omits a timezone", async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+    const { resolveTimezone } = await import('../personalization-utils');
+
+    assert({
+      given: 'no explicit timezone but a profile that has one',
+      should: 'use the profile zone rather than UTC',
+      actual: await resolveTimezone(undefined, 'user-1'),
+      expected: 'America/Chicago',
+    });
+  });
+
+  it('treats a blank explicit timezone as absent', async () => {
+    selectWhere.mockResolvedValue([{ timezone: 'America/Chicago' }]);
+    const { resolveTimezone } = await import('../personalization-utils');
+
+    assert({
+      given: 'a whitespace-only timezone field',
+      should: 'fall through to the profile instead of storing an empty zone',
+      actual: await resolveTimezone('   ', 'user-1'),
+      expected: 'America/Chicago',
+    });
+  });
+
+  it('falls back to UTC when the profile has no timezone either', async () => {
+    selectWhere.mockResolvedValue([{ timezone: null }]);
+    const { resolveTimezone } = await import('../personalization-utils');
+
+    assert({
+      given: 'a user who never set a timezone',
+      should: 'end at UTC',
+      actual: await resolveTimezone(null, 'user-1'),
+      expected: 'UTC',
+    });
+  });
+
+  it('falls back to UTC when the profile lookup fails', async () => {
+    selectWhere.mockRejectedValue(new Error('db down'));
+    const { resolveTimezone } = await import('../personalization-utils');
+
+    assert({
+      given: 'a database error during the profile read',
+      should: 'still resolve to UTC rather than failing the write',
+      actual: await resolveTimezone(undefined, 'user-1'),
+      expected: 'UTC',
     });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/timestamp-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/timestamp-utils.test.ts
@@ -9,6 +9,7 @@ import {
   isNaiveISODatetime,
   normalizeTimezone,
   parseNaiveDatetimeInTimezone,
+  parseDatetimeInTimezone,
   parseDateTime,
 } from '../timestamp-utils';
 import { OPENROUTER_CACHE_TTL_SECONDS, TIMESTAMP_BUCKET_MS } from '../ai-providers-config';
@@ -479,6 +480,58 @@ describe('timestamp-utils', () => {
       const result = parseDateTime('tomorrow at 9am', ref, 'UTC');
       expect(result.getUTCDate()).toBe(11);
       expect(result.getUTCHours()).toBe(9);
+    });
+  });
+
+  /**
+   * The single definition of what a client-supplied datetime means. Every write
+   * that stores an instant (calendar events, task due dates, triggers) goes
+   * through here, so the three input shapes must not drift apart (#2404).
+   */
+  describe('parseDatetimeInTimezone', () => {
+    it('reads a naive wall-clock datetime in the given zone', () => {
+      assert({
+        given: 'a naive "7pm" and America/Chicago',
+        should: 'return 7pm Central as an instant, not 7pm UTC',
+        actual: parseDatetimeInTimezone('2026-02-19T19:00:00', 'America/Chicago'),
+        expected: new Date('2026-02-20T01:00:00Z'),
+      });
+    });
+
+    it('leaves a Z-suffixed datetime alone', () => {
+      assert({
+        given: 'a datetime that already states UTC',
+        should: 'ignore the timezone argument entirely',
+        actual: parseDatetimeInTimezone('2026-02-19T19:00:00Z', 'America/Chicago'),
+        expected: new Date('2026-02-19T19:00:00Z'),
+      });
+    });
+
+    it('leaves an offset-bearing datetime alone', () => {
+      assert({
+        given: 'a datetime carrying its own +09:00 offset',
+        should: 'honour the stated offset over the caller zone',
+        actual: parseDatetimeInTimezone('2026-02-19T19:00:00+09:00', 'America/Chicago'),
+        expected: new Date('2026-02-19T10:00:00Z'),
+      });
+    });
+
+    it('leaves a date-only value as UTC midnight', () => {
+      assert({
+        given: 'a date with no time at all',
+        should: 'keep the ISO 8601 meaning (UTC midnight) rather than shifting it into the zone',
+        actual: parseDatetimeInTimezone('2026-02-19', 'America/Chicago'),
+        expected: new Date('2026-02-19T00:00:00Z'),
+      });
+    });
+
+    it('holds across a DST boundary', () => {
+      assert({
+        given: 'a naive time on the far side of a spring-forward transition',
+        should: 'use the offset in effect at the target instant (CDT, -05:00)',
+        actual: parseDatetimeInTimezone('2026-07-04T19:00:00', 'America/Chicago'),
+        expected: new Date('2026-07-05T00:00:00Z'),
+      });
     });
   });
 });

--- a/apps/web/src/lib/ai/core/personalization-utils.ts
+++ b/apps/web/src/lib/ai/core/personalization-utils.ts
@@ -176,3 +176,32 @@ export async function getUserTimezone(
     return undefined;
   }
 }
+
+/**
+ * Resolve the timezone a request should be interpreted in: explicit value
+ * wins, else the caller's profile timezone, else UTC.
+ *
+ * This three-tier order is the API-wide convention for every route that turns
+ * a *naive* wall-clock datetime into an instant (tasks, task triggers,
+ * calendar events) — a task due "tomorrow at 7pm" and an event "tomorrow at
+ * 7pm" must land at the same instant for the same caller. Keep the resolution
+ * here rather than re-deriving it per route: an omitted `timezone` silently
+ * offsetting a stored instant is invisible at the call site, so each
+ * independent copy is a coin flip (#2404).
+ *
+ * A blank or whitespace-only explicit value counts as absent. Routes must
+ * therefore leave `timezone` OPTIONAL in their schema — a Zod
+ * `.default('UTC')` makes "absent" indistinguishable from "explicitly UTC"
+ * before this function ever sees it.
+ *
+ * The profile lookup only runs when there is no explicit value, so callers
+ * that always send one pay no query.
+ */
+export async function resolveTimezone(
+  explicit: string | null | undefined,
+  userId: string
+): Promise<string> {
+  const trimmed = explicit?.trim();
+  if (trimmed) return trimmed;
+  return (await getUserTimezone(userId)) || 'UTC';
+}

--- a/apps/web/src/lib/ai/core/timestamp-utils.ts
+++ b/apps/web/src/lib/ai/core/timestamp-utils.ts
@@ -124,6 +124,29 @@ export function parseNaiveDatetimeInTimezone(naiveDatetime: string, timezone: st
 }
 
 /**
+ * Turn a client-supplied ISO datetime string into an instant.
+ *
+ * Absolute values (carrying `Z` or an explicit offset) and date-only values
+ * already identify an instant and pass straight through `new Date`. Only a
+ * *naive* wall-clock datetime — the one form that means nothing without a zone
+ * — is read in `timezone`.
+ *
+ * This is the single definition of what a naive datetime means for every write
+ * that stores an instant (#2404). The alternative, a bare `new Date(value)`,
+ * reads it in the *server process's* local zone: UTC in deployment but the
+ * developer's zone under `next dev`, so the same request produces different
+ * instants in different environments and neither is the caller's intent.
+ *
+ * Callers resolve `timezone` first — `resolveTimezone` on a request path, the
+ * execution context's timezone on an AI tool path.
+ */
+export function parseDatetimeInTimezone(value: string, timezone: string): Date {
+  return isNaiveISODatetime(value)
+    ? parseNaiveDatetimeInTimezone(value, timezone)
+    : new Date(value);
+}
+
+/**
  * Get user's time-of-day based on their timezone
  * @param timezone - IANA timezone string (e.g., "America/New_York")
  * @param now - Instant (epoch ms) to evaluate; defaults to the current clock.

--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -102,6 +102,7 @@ import { db } from '@pagespace/db/db';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core/types';
 import { checkSubTasksComplete } from '@/lib/tasks/completion-guard';
+import { syncTaskDueDateTrigger } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
 const mockDb = vi.mocked(db);
@@ -367,6 +368,86 @@ describe('task-management-tools', () => {
             tasks: expect.any(Array),
           }),
         );
+      });
+
+      /**
+       * A due date the model writes as a wall-clock time ("2026-02-19T19:00:00")
+       * has to be read in the user's zone, which the execution context already
+       * carries. A bare `new Date()` read it in the server's zone instead, so
+       * the AI path stored a different instant than the same words typed into
+       * the calendar (#2404).
+       *
+       * The assertion is the GAP between two callers, not one absolute instant:
+       * a fixed expectation passes under the old parse on any machine whose
+       * zone matches the context's.
+       */
+      const updateDueDateIn = async (timezone: string, dueDate: string) => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-1',
+          pageId: 'doc-page-1',
+          status: 'pending',
+          priority: 'medium',
+          assigneeId: null,
+          assigneeAgentId: null,
+          dueDate: null,
+          completedAt: null,
+          metadata: null,
+          page: { title: 'My Task', parentId: 'task-list-page-1' },
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'task-list-page-1',
+          userId: 'user-123',
+          title: 'My Tasks',
+          description: null,
+          status: 'pending',
+        });
+        mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+        mockDb.query.taskStatusConfigs.findMany = vi.fn().mockResolvedValue([]);
+        mockCanUserEditPage.mockResolvedValue(true);
+
+        mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+          const tx = {
+            update: vi.fn(() => ({
+              set: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  returning: vi.fn().mockResolvedValue([
+                    { id: 'task-1', pageId: 'doc-page-1', status: 'pending', priority: 'medium', position: 0, dueDate: null, assigneeId: null, assigneeAgentId: null, completedAt: null },
+                  ]),
+                })),
+              })),
+            })),
+            delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+            insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+          };
+          return cb(tx);
+        }) as unknown as typeof mockDb.transaction;
+
+        vi.mocked(syncTaskDueDateTrigger).mockClear();
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123', timezone } as ToolExecutionContext,
+        };
+
+        await taskManagementTools.update_task.execute!({ taskId: 'task-1', dueDate }, context);
+
+        return vi.mocked(syncTaskDueDateTrigger).mock.calls.at(-1)?.[1] as Date | null;
+      };
+
+      it('reads a naive due date in the caller timezone from the execution context', async () => {
+        const chicago = await updateDueDateIn('America/Chicago', '2026-02-19T19:00:00');
+        const tokyo = await updateDueDateIn('Asia/Tokyo', '2026-02-19T19:00:00');
+
+        // UTC-6 vs UTC+9 in February. Read in the server's zone, both would be equal.
+        expect(Number(chicago) - Number(tokyo)).toBe(15 * 60 * 60 * 1000);
+      });
+
+      it('leaves an absolute due date alone whatever the caller timezone', async () => {
+        const stored = await updateDueDateIn('America/Chicago', '2026-02-19T19:00:00Z');
+
+        expect(stored).toEqual(new Date('2026-02-19T19:00:00Z'));
       });
 
       it('broadcasts page:updated when title changes', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/task-verb-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-verb-tools.test.ts
@@ -202,6 +202,77 @@ describe('task verb tools', () => {
       );
     });
 
+    /**
+     * The due date the model supplies is usually a wall-clock time, and the
+     * user's zone lives on the execution context. Parsing it with a bare
+     * `new Date()` read it in the server's zone, so create_task and the REST
+     * task route stored different instants for the same words (#2404).
+     *
+     * Asserted as the GAP between two callers rather than a fixed instant: a
+     * fixed expectation passes under the old parse on any machine whose zone
+     * matches the context's.
+     */
+    const createTaskWithDueDate = async (timezone: string, dueDate: string) => {
+      mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+        id: 'list-1',
+        pageId: 'page-1',
+        userId: 'user-123',
+        title: 'My Tasks',
+        description: null,
+        status: 'pending',
+      });
+      mockDb.query.taskStatusConfigs.findMany = vi.fn().mockResolvedValue([]);
+      mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      let capturedTaskInsert: Record<string, unknown> | null = null;
+      mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+        let insertCallCount = 0;
+        const tx = {
+          insert: vi.fn(() => ({
+            values: vi.fn((vals: Record<string, unknown>) => {
+              insertCallCount++;
+              if (insertCallCount === 2) capturedTaskInsert = vals;
+              return {
+                returning: vi.fn().mockResolvedValue(
+                  insertCallCount === 1
+                    ? [{ id: 'new-page', title: 'New Task', type: 'TASK_LIST' }]
+                    : [{ id: 'new-task', pageId: 'new-page', status: 'pending', priority: 'medium', position: 0, dueDate: null, assigneeId: null, assigneeAgentId: null, metadata: {}, completedAt: null }]
+                ),
+              };
+            }),
+          })),
+        };
+        return cb(tx);
+      }) as unknown as typeof mockDb.transaction;
+
+      mockDb.query.pages.findFirst = vi.fn()
+        .mockResolvedValueOnce({ id: 'page-1', type: 'TASK_LIST', title: 'My Task List', driveId: 'drive-1' })
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ driveId: 'drive-1' });
+
+      await taskManagementTools.create_task.execute!(
+        { pageId: 'page-1', title: 'New Task', dueDate },
+        { ...context, experimental_context: { userId: 'user-123', timezone } as ToolExecutionContext },
+      );
+
+      return (capturedTaskInsert as Record<string, unknown> | null)?.dueDate as Date | null;
+    };
+
+    it('reads a naive due date in the caller timezone from the execution context', async () => {
+      const chicago = await createTaskWithDueDate('America/Chicago', '2026-02-19T19:00:00');
+      const tokyo = await createTaskWithDueDate('Asia/Tokyo', '2026-02-19T19:00:00');
+
+      // UTC-6 vs UTC+9 in February. Read in the server's zone, both would be equal.
+      expect(Number(chicago) - Number(tokyo)).toBe(15 * 60 * 60 * 1000);
+    });
+
+    it('leaves an absolute due date alone whatever the caller timezone', async () => {
+      const stored = await createTaskWithDueDate('America/Chicago', '2026-02-19T19:00:00Z');
+
+      expect(stored).toEqual(new Date('2026-02-19T19:00:00Z'));
+    });
+
     it('rejects a blank/whitespace title', async () => {
       await expect(
         taskManagementTools.create_task.execute!(

--- a/apps/web/src/lib/ai/tools/task-helpers.ts
+++ b/apps/web/src/lib/ai/tools/task-helpers.ts
@@ -15,6 +15,7 @@ import { reorderTaskListChildPages } from '@/services/api/task-reorder-service';
 import { compareByPagePosition, computeTaskMovePosition } from '@/services/api/task-ordering';
 import { computeReorderPlan } from '@pagespace/lib/services/reorder';
 import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
+import { parseDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
 
 /**
  * The Drizzle transaction handle passed to `db.transaction(async (tx) => ...)`.
@@ -363,6 +364,12 @@ export async function createTask(
 ) {
   const { pageId, title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
 
+  // The caller's timezone, resolved upstream onto the execution context. A naive
+  // due date ("2026-02-19T19:00:00") is a wall-clock time and is read in it;
+  // absolute values are untouched (#2404).
+  const taskTimezone = context.timezone || 'UTC';
+  const parsedDueDate = dueDate ? parseDatetimeInTimezone(dueDate, taskTimezone) : null;
+
   // Reject blank/whitespace titles, matching the update path and REST task route.
   const trimmedTitle = title.trim();
   if (!trimmedTitle) {
@@ -495,7 +502,7 @@ export async function createTask(
       priority: priority || 'medium',
       assigneeId: primaryUserId,
       assigneeAgentId: primaryAgentId,
-      dueDate: dueDate ? new Date(dueDate) : null,
+      dueDate: parsedDueDate,
       metadata: {
         createdAt: new Date().toISOString(),
         note,
@@ -529,8 +536,8 @@ export async function createTask(
         taskId: newTask.id,
         taskMetadata: newTask.metadata as Record<string, unknown> | null,
         agentTrigger,
-        dueDate: dueDate ? new Date(dueDate) : null,
-        timezone: context.timezone || 'UTC',
+        dueDate: parsedDueDate,
+        timezone: taskTimezone,
       });
     }
 

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -20,6 +20,7 @@ import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/pag
 import { compareByPagePosition } from '@/services/api/task-ordering';
 import { checkSubTasksComplete, toToolFailure } from '@/lib/tasks/completion-guard';
 import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
+import { parseDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import {
   normalizeTaskAgentTriggerInput,
@@ -97,6 +98,13 @@ Agent Triggers:
       if (!userId) {
         throw new Error('User authentication required');
       }
+
+      // The caller's timezone, resolved upstream onto the execution context. A
+      // naive due date ("2026-02-19T19:00:00") is a wall-clock time and is read
+      // in it; absolute values are untouched (#2404). The stored due date and
+      // the trigger scheduled against it must agree on the instant.
+      const taskTimezone = (context as ToolExecutionContext).timezone || 'UTC';
+      const parsedDueDate = dueDate ? parseDatetimeInTimezone(dueDate, taskTimezone) : null;
 
       if (!taskId) {
         throw new Error('taskId is required to update a task. To create a new task, use create_task.');
@@ -181,7 +189,7 @@ Agent Triggers:
         if (priority !== undefined) updateData.priority = priority;
         if (assigneeId !== undefined) updateData.assigneeId = assigneeId;
         if (assigneeAgentId !== undefined) updateData.assigneeAgentId = assigneeAgentId;
-        if (dueDate !== undefined) updateData.dueDate = dueDate ? new Date(dueDate) : null;
+        if (dueDate !== undefined) updateData.dueDate = parsedDueDate;
 
         // Add note to metadata
         if (note || status !== undefined) {
@@ -314,13 +322,13 @@ Agent Triggers:
             taskMetadata: resultTask.metadata as Record<string, unknown> | null,
             agentTrigger,
             dueDate: resultTask.dueDate,
-            timezone: (context as ToolExecutionContext).timezone || 'UTC',
+            timezone: taskTimezone,
           });
         }
 
         // Task trigger cascades
         if (dueDate !== undefined) {
-          void syncTaskDueDateTrigger(taskId, dueDate ? new Date(dueDate) : null);
+          void syncTaskDueDateTrigger(taskId, parsedDueDate);
         }
         if (status !== undefined) {
           const completedSlugs = validConfigs.length > 0

--- a/apps/web/src/lib/validation/__tests__/date-params.test.ts
+++ b/apps/web/src/lib/validation/__tests__/date-params.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Range-bound parsing for listing filters (#2404).
+ *
+ * Two separate claims are pinned here, because the routes got both wrong in
+ * opposite directions: a bound must not be read in whatever timezone the server
+ * happens to run in, and an `endDate` that names an instant must not be quietly
+ * stretched by a day.
+ *
+ * TZ is pinned away from UTC for the whole file: under the old local-`setDate`
+ * arithmetic these assertions pass on a UTC machine and fail elsewhere, which is
+ * exactly the environment-dependence being removed.
+ */
+process.env.TZ = 'America/Chicago';
+
+import { describe, it, expect } from 'vitest';
+import { absoluteInstant, optionalAbsoluteInstant, exclusiveEndBound } from '../date-params';
+
+const assert = ({ given, should, actual, expected }: {
+  given: string; should: string; actual: unknown; expected: unknown;
+}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+describe('absoluteInstant', () => {
+  it('reads a naive bound as UTC rather than server-local time', () => {
+    assert({
+      given: 'a naive datetime bound and a non-UTC server timezone',
+      should: 'pin it to UTC so the window does not move with the deployment',
+      actual: absoluteInstant.parse('2026-02-19T19:00:00'),
+      expected: new Date('2026-02-19T19:00:00Z'),
+    });
+  });
+
+  it('leaves a bound that states its own offset alone', () => {
+    assert({
+      given: 'a bound carrying +09:00',
+      should: 'honour the stated offset',
+      actual: absoluteInstant.parse('2026-02-19T19:00:00+09:00'),
+      expected: new Date('2026-02-19T10:00:00Z'),
+    });
+  });
+
+  it('reads a date-only bound as UTC midnight', () => {
+    assert({
+      given: 'a date with no time',
+      should: 'keep the ISO 8601 meaning',
+      actual: absoluteInstant.parse('2026-02-19'),
+      expected: new Date('2026-02-19T00:00:00Z'),
+    });
+  });
+
+  it('lets the optional variant pass undefined through', () => {
+    assert({
+      given: 'an omitted bound',
+      should: 'stay undefined rather than becoming the epoch',
+      actual: optionalAbsoluteInstant.parse(undefined),
+      expected: undefined,
+    });
+  });
+});
+
+describe('exclusiveEndBound', () => {
+  it('covers the whole day for a date-only bound', () => {
+    assert({
+      given: '"through the 19th"',
+      should: 'end at the start of the 20th, so the 19th is included',
+      actual: exclusiveEndBound('2026-02-19', new Date('2026-02-19T00:00:00Z')),
+      expected: new Date('2026-02-20T00:00:00Z'),
+    });
+  });
+
+  it('does not stretch a bound that names an instant', () => {
+    assert({
+      given: 'an explicit 19:00Z upper bound',
+      should: 'end exactly there, not 24 hours later',
+      actual: exclusiveEndBound('2026-02-19T19:00:00Z', new Date('2026-02-19T19:00:00Z')),
+      expected: new Date('2026-02-19T19:00:00Z'),
+    });
+  });
+
+  it('does not stretch a naive instant bound either', () => {
+    assert({
+      given: 'a naive datetime bound',
+      should: 'stay the instant it parsed to',
+      actual: exclusiveEndBound('2026-02-19T19:00:00', new Date('2026-02-19T19:00:00Z')),
+      expected: new Date('2026-02-19T19:00:00Z'),
+    });
+  });
+
+  /**
+   * This is the case that actually discriminates UTC arithmetic from local
+   * `setDate`. On an ordinary date the two agree for any whole-hour offset, so
+   * a plain "adds a day" assertion would pass either way and prove nothing;
+   * across a DST transition local arithmetic yields 23 or 25 hours instead of
+   * 24. US DST starts 2026-03-08.
+   */
+  it('adds the day in UTC — a local +1 day across a DST boundary is not 24 hours', () => {
+    assert({
+      given: 'a date-only bound on the day a DST transition falls',
+      should: 'advance exactly one UTC day regardless of the server timezone',
+      actual: exclusiveEndBound('2026-03-08', new Date('2026-03-08T00:00:00Z')),
+      expected: new Date('2026-03-09T00:00:00Z'),
+    });
+  });
+
+  it('treats a padded date-only bound as a day', () => {
+    assert({
+      given: 'a date-only bound with stray whitespace',
+      should: 'still get the inclusive-day treatment',
+      actual: exclusiveEndBound(' 2026-02-19 ', new Date('2026-02-19T00:00:00Z')),
+      expected: new Date('2026-02-20T00:00:00Z'),
+    });
+  });
+
+  it('returns the parsed value when there is no raw string to inspect', () => {
+    assert({
+      given: 'no raw query value',
+      should: 'fall back to the parsed instant untouched',
+      actual: exclusiveEndBound(null, new Date('2026-02-19T19:00:00Z')),
+      expected: new Date('2026-02-19T19:00:00Z'),
+    });
+  });
+});

--- a/apps/web/src/lib/validation/date-params.ts
+++ b/apps/web/src/lib/validation/date-params.ts
@@ -20,16 +20,13 @@ import { isNaiveISODatetime } from '@/lib/ai/core/timestamp-utils';
  * Values that already carry `Z` or an offset are untouched, as are date-only
  * values (`"2026-02-19"`), which ISO 8601 already defines as UTC.
  */
-export const absoluteInstant = z.preprocess(
-  (value) => (typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value),
-  z.coerce.date(),
-);
+const pinNaiveToUtc = (value: unknown) =>
+  typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value;
+
+export const absoluteInstant = z.preprocess(pinNaiveToUtc, z.coerce.date());
 
 /** {@link absoluteInstant} for filters where the bound may be omitted. */
-export const optionalAbsoluteInstant = z.preprocess(
-  (value) => (typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value),
-  z.coerce.date().optional(),
-);
+export const optionalAbsoluteInstant = z.preprocess(pinNaiveToUtc, z.coerce.date().optional());
 
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/apps/web/src/lib/validation/date-params.ts
+++ b/apps/web/src/lib/validation/date-params.ts
@@ -30,3 +30,33 @@ export const optionalAbsoluteInstant = z.preprocess(
   (value) => (typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value),
   z.coerce.date().optional(),
 );
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The exclusive upper bound for an inclusive `endDate` filter.
+ *
+ * The two input shapes mean different things and only one of them wants a day
+ * added:
+ *
+ * - `endDate=2026-02-19` names a DAY. "Through the 19th" includes everything
+ *   that happened during it, so the exclusive bound is the start of the 20th.
+ * - `endDate=2026-02-19T19:00:00Z` names an INSTANT and means exactly that.
+ *   Adding a day here hands back 24 hours the caller never asked for.
+ *
+ * Callers used to add the day unconditionally, and with local `setDate` — so an
+ * explicit instant was stretched by a day, and the stretch itself depended on
+ * the server's own timezone. The day is added in UTC here for the same reason
+ * the bounds are parsed in UTC: a range must not mean different things in
+ * different deployments (#2404).
+ *
+ * Takes the RAW query string because the parsed `Date` cannot answer the
+ * question — a date-only value and an explicit `T00:00:00Z` both land on UTC
+ * midnight, and guessing from the instant would silently mis-handle one of them.
+ */
+export function exclusiveEndBound(raw: string | null | undefined, parsed: Date): Date {
+  if (!raw || !DATE_ONLY.test(raw.trim())) return parsed;
+  const nextDay = new Date(parsed);
+  nextDay.setUTCDate(nextDay.getUTCDate() + 1);
+  return nextDay;
+}

--- a/apps/web/src/lib/validation/date-params.ts
+++ b/apps/web/src/lib/validation/date-params.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { isNaiveISODatetime } from '@/lib/ai/core/timestamp-utils';
+
+/**
+ * A query-parameter date bound: an ABSOLUTE instant.
+ *
+ * Range filters (`startDate`/`endDate` on listings, history, activity exports)
+ * are not wall-clock times. A window spans rows that each carry their own zone,
+ * so there is no single timezone to reinterpret it in — unlike a stored event's
+ * own start/end, which the row's `timezone` owns and which
+ * `parseDatetimeInTimezone` reads.
+ *
+ * The difference from a plain `z.coerce.date()` is a naive value
+ * (`"2026-02-19T19:00:00"`): `new Date()` reads it in the *server process's*
+ * local zone — UTC in deployment but the developer's zone under `next dev` — so
+ * a range query silently meant different windows in different environments and
+ * boundary bugs would not reproduce locally (#2404). Pinning it to UTC keeps
+ * deployed behaviour identical and makes it reproducible everywhere else.
+ *
+ * Values that already carry `Z` or an offset are untouched, as are date-only
+ * values (`"2026-02-19"`), which ISO 8601 already defines as UTC.
+ */
+export const absoluteInstant = z.preprocess(
+  (value) => (typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value),
+  z.coerce.date(),
+);
+
+/** {@link absoluteInstant} for filters where the bound may be omitted. */
+export const optionalAbsoluteInstant = z.preprocess(
+  (value) => (typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value),
+  z.coerce.date().optional(),
+);

--- a/apps/web/src/lib/validation/date-params.ts
+++ b/apps/web/src/lib/validation/date-params.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { isNaiveISODatetime } from '@/lib/ai/core/timestamp-utils';
 
+/** Shared by both bound schemas so they cannot drift on what "naive" means. */
+const pinNaiveToUtc = (value: unknown) =>
+  typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value;
+
 /**
  * A query-parameter date bound: an ABSOLUTE instant.
  *
@@ -20,9 +24,6 @@ import { isNaiveISODatetime } from '@/lib/ai/core/timestamp-utils';
  * Values that already carry `Z` or an offset are untouched, as are date-only
  * values (`"2026-02-19"`), which ISO 8601 already defines as UTC.
  */
-const pinNaiveToUtc = (value: unknown) =>
-  typeof value === 'string' && isNaiveISODatetime(value) ? `${value.trim()}Z` : value;
-
 export const absoluteInstant = z.preprocess(pinNaiveToUtc, z.coerce.date());
 
 /** {@link absoluteInstant} for filters where the bound may be omitted. */

--- a/packages/sdk/src/operations/calendar.ts
+++ b/packages/sdk/src/operations/calendar.ts
@@ -50,10 +50,19 @@
  * strict ISO 8601 date or datetime string. A *naive* datetime (no `Z`/offset,
  * e.g. `"2026-02-19T19:00:00"`) is interpreted server-side in the request's
  * own `timezone` field (`isNaiveISODatetime` + `parseNaiveDatetimeInTimezone`)
- * — NOT UTC. A datetime carrying `Z` or an explicit offset is an absolute
- * instant and `timezone` has no effect on it. `startDate`/`endDate` on
- * `calendar.list` go through plain `z.coerce.date()` server-side (no naive
- * reinterpretation) since listing has no single owning timezone.
+ * — NOT UTC. Omitting `timezone` is not the same as sending `"UTC"`: the
+ * server resolves an absent field against the caller's profile timezone and
+ * only then falls back to UTC (`resolveTimezone`), matching `tasks.create` and
+ * `tasks.setTrigger`. `create` also stores the resolved zone on the event, so
+ * a later `update` that omits `timezone` reinterprets against the event's own
+ * zone rather than the editor's. A datetime carrying `Z` or an explicit offset
+ * is an absolute instant and `timezone` has no effect on it.
+ *
+ * `startDate`/`endDate` on `calendar.list` are absolute instants and are never
+ * reinterpreted against a caller timezone — a listing spans events that each
+ * own a different zone, so there is nothing to reinterpret it in. A naive value
+ * there is read as UTC (server-side, deterministically — it does not depend on
+ * where the server runs).
  */
 import { z } from 'zod';
 import { defineOperation } from '../registry/define.js';

--- a/packages/sdk/src/operations/tasks.ts
+++ b/packages/sdk/src/operations/tasks.ts
@@ -15,6 +15,16 @@
  * D2 fix: `delete_task_trigger`'s route was session-only prior to
  * #1764/66/67/70; it now accepts `['session','mcp']`, so this op declares
  * `requiredScope: 'drive'` like every other op here, not `sessionOnly`.
+ *
+ * Timezone contract for `dueDate` (same rule `calendar` documents): a *naive*
+ * datetime (no `Z`/offset, e.g. `"2026-02-19T19:00:00"`) is a wall-clock time
+ * and is read server-side in this request's `timezone` field, else the caller's
+ * profile timezone, else UTC. A value carrying `Z` or an explicit offset is an
+ * absolute instant and `timezone` has no effect on it, and a date-only value
+ * (`"2026-02-19"`) keeps its ISO 8601 meaning of UTC midnight. Omitting
+ * `timezone` is therefore NOT the same as sending `"UTC"`. The due date and any
+ * `due_date` agentTrigger scheduled against it always resolve to the same
+ * instant.
  */
 import { z } from 'zod';
 import { defineOperation } from '../registry/define.js';

--- a/packages/sdk/src/operations/workflows.ts
+++ b/packages/sdk/src/operations/workflows.ts
@@ -93,7 +93,13 @@ export const createWorkflow = defineOperation({
     instructionPageId: z.string().nullable().optional(),
     contextPageIds: z.array(z.string()).default([]),
     cronExpression: z.string().min(1),
-    timezone: z.string().default('UTC'),
+    /**
+     * IANA zone the cron expression is evaluated in. Omitting it is NOT the
+     * same as sending `"UTC"`: the server resolves an absent value against the
+     * caller's profile timezone and only then falls back to UTC. A default here
+     * would send `"UTC"` on the caller's behalf and take that choice away.
+     */
+    timezone: z.string().optional(),
     isEnabled: z.boolean().default(true),
   })
     .refine((data) => Boolean(data.prompt?.trim()) || Boolean(data.instructionPageId), {


### PR DESCRIPTION
Fixes #2404, plus the rest of the class it belongs to.

## The bug as filed

`POST /api/calendar/events` declared `timezone: z.string().default('UTC')`. A client that omitted the field — which the schema explicitly permits — had a naive `"2026-02-19T19:00:00"` read as 7pm **UTC**, so a US Central user's dinner was stored at 1pm. No error, nothing to notice until the reminder fired at the wrong hour. The task routes already resolved *body → profile → UTC*, so the same words meant two different instants depending on which endpoint you asked.

Nothing in the app hit it: the web UI sends absolute `toISOString()` values, and the AI tools bypass the route and resolve from their execution context. The exposure was SDK/MCP/direct-API clients — `pagespace-voice`, where it was found, being one.

## What the sweep turned up

I grepped the class rather than guessing: every `.default('UTC')`, every `z.coerce.date()` in a route, every `parseDateTime`/`isNaiveISODatetime` caller, every `new Date(<body field>)`.

**Cron workflows had the identical schema bug, with worse consequences.** `api/workflows/route.ts` carried the same `.default('UTC')`, and there the zone drives `getNextRunDate` — `0 9 * * *` created without a timezone ran at 9am UTC, 3am for the person who scheduled it. Same shape as calendar too: the internal `create_workflow` tool already resolved from context, so REST was the outlier.

**Task due dates were never naive-aware at all — on any of the four paths** (REST POST/PATCH, `create_task`, `update_task`). The trigger *timezone* was resolved correctly, which is what made tasks look finished, but the due date itself went through a bare `new Date()`. A task and the reminder scheduled against that very date could disagree by the caller's offset.

That one hid for a specific reason worth recording: `new Date()` reads a naive value in the **server process's** zone, and the development machines here are America/Chicago — the same zone the profile would have supplied. It was correct locally and wrong only in deployment, where the server is UTC.

## One rule, one definition of it

- **`resolveTimezone(explicit, userId)`** — explicit value, else the caller's profile timezone, else UTC. Routes must keep `timezone` optional: a Zod `.default('UTC')` destroys the difference between "omitted" and "explicitly UTC" before the handler can see it. Now used by calendar create/update, workflows create/update, both task routes and both trigger routes.
- **`parseDatetimeInTimezone(value, timezone)`** — only naive values are read in the zone; `Z`/offset values and date-only values pass through untouched. Now the single definition of what a naive datetime means, shared by calendar, both task routes and both task tools.

Create stores the **resolved** zone (events, workflows), so a later edit inherits the hour the author meant instead of re-deriving UTC.

## Two deliberate non-changes, documented in place

- **Drive backup schedules** keep *body → stored → UTC* with no profile tier. The window belongs to the drive, and any admin can save that form, so a profile fallback would let a colleague in another timezone move the whole drive's backups by toggling an unrelated field.
- **Listing range bounds** stay absolute instants — a window spans rows that each own a different zone, so there is nothing to reinterpret it in. They now pin a naive bound to UTC (`absoluteInstant`, shared across calendar list, tasks, activities, activity export, drive history, page history). Identical to deployed behaviour; it only drops the dependence on where the server runs, so a boundary bug reproduces locally.

## Tests

18 new tests here on top of the 21 for the calendar fix itself, plus 5 unit tests for the shared parser (including a DST boundary and the date-only case).

The due-date and timezone tests assert the **gap between two callers in different zones** (a fixed 15h for Chicago vs Tokyo in February) rather than one absolute instant. A fixed expectation passes under the old parse on any machine whose zone matches the profile — which is exactly how this survived. Every fix was mutation-checked: revert it, watch the gap collapse to zero.

I also deleted six partial `timestamp-utils` stubs in the calendar tests that mocked the parser with a subtly different implementation — the thing that lets the rule drift in the first place.

## Verification

- `bun run typecheck` — 17/17
- `bun run lint` — clean
- `bun run knip:check` — at baseline
- `@pagespace/sdk` — 767 passed
- web suite — 17159 passed; the 18 failing files are all Postgres-backed `.integration` suites with no `DATABASE_URL`, the same set as before this branch

SDK docs updated for both `calendar` and `workflows`: omitting `timezone` is documented as *not* the same as sending `"UTC"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tdn8GJTcAgP9zNPoCNDATr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone handling for calendar events, tasks, workflows, and scheduled triggers.
  * Naive timestamps now use the request or profile timezone, with UTC as a fallback.
  * Explicitly zoned timestamps and date-only values remain unchanged.
  * Date-range and activity filters now behave consistently across server timezones, with correct exclusive end dates.
  * Calendar events and workflows retain their resolved timezone for future updates and scheduling.
  * Task due dates and triggers now use the same resolved instant and timezone.

* **Documentation**
  * Clarified timezone behavior for calendar operations and drive backup schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 1 (c9343ca02)

**Persist the zone that was validated** (codex P1 + coderabbit, both PATCH routes). Resolution trimmed and validated, then the update wrote the raw request field: `" America/Chicago "` was validated trimmed and stored padded; `" "` resolved back to the existing zone and stored a blank. On workflows that is not cosmetic — `api/cron/workflows/route.ts:84` hands the stored value to `getNextRunDate` on every tick, so an unschedulable string throws, `nextRunAt` goes stale, and the workflow re-fires on every poll. It was also a regression from this branch: before `.trim()` entered the resolution, `" "` reached `validateTimezone` and got a 400. Both routes now store `effectiveTimezone` when the field was supplied and leave the column untouched when it was not.

**Keep an explicit `endDate` exact** (coderabbit, 3 sites). The listing routes added one calendar day to every `endDate`, so a bound naming an instant quietly returned another 24 hours — and the addition used local `setDate`, making the window depend on the server's timezone, which is the thing this branch exists to remove. `exclusiveEndBound` now separates the two shapes: a date-only bound still covers its whole day (advancing one **UTC** day, so a DST transition cannot make it 23 or 25 hours), and an instant bound means that instant. I did not apply the proposed unconditional diff, which would have silently dropped the final day for every caller sending `endDate=2026-02-19`.

**Not changed — trigger resync on a timezone-only edit** (coderabbit, "heavy lift"). The premise does not hold here: the calendar executor reads `event.timezone` live at fire time (`calendar-trigger-executor.ts:108`), firing is driven by the absolute `calendarTriggers.triggerAt`, and `expandOccurrences` takes no timezone at all — so a timezone edit is already picked up and moves no occurrence. Resyncing would delete and recreate future trigger rows for no behavioural change. Full reasoning is on the thread; left open for human verification.

Added: 11 unit tests for bound parsing (run under `TZ=America/Chicago`), 4 for workflow timezone persistence, 2 for calendar. All mutation-checked. One earlier assertion was **deleted** rather than kept — "adds the day in UTC" passed under local `setDate` on an ordinary date, so its name promised a guarantee it did not test; the DST case is the one that discriminates and is named for it.


## Self-review follow-ups (18cb647fd, f5399169c, d9a688614)

Found by re-reading the diff rather than by a reviewer:

- **A non-string `dueDate` stopped working.** Both task routes parse an unvalidated body, so `dueDate` is not guaranteed to be a string. `parseDatetimeInTimezone(String(dueDate), …)` turned an epoch number into `new Date("1771527600000")` — an Invalid Date — where `new Date(1771527600000)` had worked. Only a string can be naive, so only a string takes the naive-aware path now. Pinned by a test that fails with "expected Invalid Date" against the old line.
- **One preprocess, not two.** The naive→UTC lambda was written out once per bound schema; named once now so the two cannot drift on what "naive" means.
- **The SDK `tasks` module documents the `dueDate` contract**, the way `calendar` already did. This PR changed how `dueDate` is read, and a client author looking at `dueDate: z.string()` had no way to know that omitting `timezone` is not the same as sending `"UTC"`.

## Reviewer notes

- The Codex P1 thread is **left open deliberately**. It is fixed in c9343ca02 with the reasoning on the thread, but the author of a fix should not be the one marking it verified. CodeRabbit's four threads were resolved by CodeRabbit itself after it re-checked them — including the trigger-resync finding, which it re-analysed and **withdrew**.
- One CodeRabbit nitpick (`querySchema` → `QUERY_SCHEMA`) was declined, with counts in the thread: 102 route files use camelCase schema constants and 0 use UPPER_SNAKE_CASE, so applying it to one file would break consistency with its siblings — two of which are in this PR under the same name.


### The catch worth reading (40f20b075)

Making an explicit `endDate` exact was right for API callers and **silently truncated the app's own activity views**, which this branch would otherwise have shipped.

The activity date picker selects *days* and hands back local midnight. The routes' old unconditional `+1 day` reproduced the user's local window by accident — browser sends local midnight, server adds 24h. Remove the day and "Feb 10 – Feb 19" stops at Feb 19 00:00 local, losing almost all of the last day, in both the feed and the CSV export.

Date-only bounds would not have fixed it either: that is a *UTC* day, six hours off a Chicago user's day.

The fix puts the bound on the side that actually knows the timezone. `dayRangeParams` sends the start of the **next local day** as the exclusive end, so the window is the user's own days wherever they are, and the server does no day arithmetic it has no business doing. Both call sites — feed query and export — now share it rather than building params twice. Four tests under a pinned non-UTC `TZ`, since that is the only way to distinguish a local-day window from a UTC one; dropping the `+1` fails two.

This is why the reviewer's original suggestion (apply `lt(...)` to `params.endDate` directly) could not be taken as written.


### Review round 2 (d3eb11ec7)

CodeRabbit had **auto-paused** ("this branch is under active development") partway through, so its green check was covering commits it had never read. Requested a fresh review of the final state, which found two things:

- **A reloaded or shared filter link moved the range back a day.** `new Date("2026-02-19")` is UTC midnight, so west of Greenwich the URL read back as the 18th. Pre-existing, but this branch made it bite harder: normalising with `startOfDay` turned a six-hour skew into a whole day. `parseDayParam` reads date-only values as local midnight via `parseISO`, and still honours an explicit instant.
- **`process.env.TZ = undefined` leaves the variable set to the string `"undefined"`.** The shared `withTimezone` helper deletes the key when it was originally unset. (Blast radius was contained anyway — `pool: 'forks'` isolates each test file.)

And the half neither reviewer reached: `updateUrl` wrote `toISOString().split('T')[0]`, the **UTC** day — the mirror-image bug, one day early *east* of Greenwich. `formatDayParam` uses local `format`.

The tests for this are split by hemisphere, and that is not decoration. Written as a single suite pinned to `America/Chicago`, the write-side assertion **passed against the broken implementation**, because there the UTC day happens to match. Each half is now pinned where its bug is observable, and both are mutation-checked.
