### PR TITLE
fix(voice): stop working through a keyhole, and show the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   you what it did. Work that would take minutes gets handed to an agent or a task rather than
   leaving you listening to silence, and it will say where it went. "This page" and "here" mean what
   you are looking at, so it never asks you to read out an id.
+- **The assistant on a call can see whole answers, and you can see it working** — it was being handed
+  only the first 700 characters of everything it looked up, which is why it lost track of documents,
+  misread pages and fumbled edits: it was reading through a keyhole. It now gets what you get when
+  you type. And the work is no longer invisible — the call bar names what it is doing while it does
+  it ("Read Page: Roadmap") instead of going silent, and each tool call appears in the conversation
+  as it happens, spinner and all, exactly the way it does when you type. It is still there when you
+  come back to the thread later.
 - **A call you cannot have does not start** — running out of credit, or already having as many calls
   open as your plan allows, now says so and stops, instead of connecting anyway and leaving you
   talking to something nobody was counting.

--- a/apps/realtime/src/voice/__tests__/voice-call-runtime.test.ts
+++ b/apps/realtime/src/voice/__tests__/voice-call-runtime.test.ts
@@ -77,7 +77,7 @@ const defaultRespond = (
 ): Awaited<ReturnType<VoiceBridgeClient['send']>> =>
   request.kind === 'tool_started' || request.kind === 'tool_finished'
     ? { ok: true, kind: 'tool_activity', saved: true, messageId: 'm1', rev: 1 }
-    : { ok: true, kind: 'tool', output: 'Two pages.' };
+    : { ok: true, kind: 'tool', output: 'Two pages.', failed: false };
 
 function fakeBridge(
   respond: (request: VoiceBridgeRequest) => Awaited<ReturnType<VoiceBridgeClient['send']>> = defaultRespond,
@@ -222,7 +222,7 @@ describe('startVoiceCallRuntime — showing the work in the thread', () => {
     releaseRecord();
   });
 
-  it('given a tool that could not be dispatched, should record it as an error', async () => {
+  it('given the hop itself failed, should record the call as an error', async () => {
     const session = fakeSession();
     const bridge = fakeBridge((request) =>
       request.kind === 'tool'
@@ -240,9 +240,58 @@ describe('startVoiceCallRuntime — showing the work in the thread', () => {
     session.emit(responseDone({ output: [toolCall()] }));
     await flush();
 
-    expect(bridge.ofKind('tool_finished')[0]).toMatchObject({
-      errorText: 'The tool could not be reached.',
+    const [finished] = bridge.ofKind('tool_finished') as { errorText?: string }[];
+    expect(finished.errorText).toContain("couldn't run that");
+  });
+
+  it('given a tool that RAN and failed, should record an error rather than a result', async () => {
+    // The sharp case. A tool that threw, was refused, or was called with bad
+    // parameters still comes back over a perfectly healthy hop carrying a
+    // speakable sentence — the model is blocked until it gets one. Reading
+    // `ok` alone would file a permission error in the thread as a completed
+    // call, rendered green.
+    const session = fakeSession();
+    const bridge = fakeBridge((request) =>
+      request.kind === 'tool'
+        ? { ok: true, kind: 'tool', output: "That didn't work: permission denied", failed: true }
+        : { ok: true, kind: 'tool_activity', saved: true, messageId: 'm1', rev: 1 },
+    );
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
     });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(bridge.ofKind('tool_finished')[0]).toMatchObject({
+      errorText: "That didn't work: permission denied",
+    });
+    // The model still gets its answer — it is blocked until it does.
+    expect(session.sent[0]).toMatchObject({
+      item: { output: "That didn't work: permission denied" },
+    });
+  });
+
+  it('given a tool that succeeded, should record a result and no error', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    const [finished] = bridge.ofKind('tool_finished') as { errorText?: string }[];
+    expect(finished.errorText).toBeUndefined();
   });
 
   it('given an UNBOUND call, should run the tool and record nothing', async () => {
@@ -272,7 +321,7 @@ describe('startVoiceCallRuntime — showing the work in the thread', () => {
         ? { ok: false, error: 'nope' }
         : request.kind === 'tool_finished'
           ? { ok: true, kind: 'tool_activity', saved: true, messageId: 'm1', rev: 1 }
-          : { ok: true, kind: 'tool', output: 'Two pages.' },
+          : { ok: true, kind: 'tool', output: 'Two pages.', failed: false },
     );
     startVoiceCallRuntime({
       session,
@@ -466,7 +515,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     const bridge = fakeBridge(() => {
       // The call ends mid-dispatch — the caller hung up while a tool was running.
       (session as { ended: boolean }).ended = true;
-      return { ok: true, kind: 'tool', output: 'Two pages.' };
+      return { ok: true, kind: 'tool', output: 'Two pages.', failed: false };
     });
     startVoiceCallRuntime({
       session,
@@ -487,7 +536,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     const bridge = fakeBridge((request) =>
       request.kind === 'transcript'
         ? { ok: false, error: 'Voice bridge is unreachable' }
-        : { ok: true, kind: 'tool', output: 'ok' },
+        : { ok: true, kind: 'tool', output: 'ok', failed: false },
     );
     startVoiceCallRuntime({
       session,
@@ -515,7 +564,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     const session = fakeSession();
     const bridge = fakeBridge((request) => {
       if (request.kind === 'transcript') throw 'bridge string blip';
-      return { ok: true, kind: 'tool', output: 'ok' };
+      return { ok: true, kind: 'tool', output: 'ok', failed: false };
     });
     startVoiceCallRuntime({
       session,
@@ -544,7 +593,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     const session = fakeSession();
     const bridge = fakeBridge((request) => {
       if (request.kind === 'transcript') throw new Error('bridge exploded');
-      return { ok: true, kind: 'tool', output: 'ok' };
+      return { ok: true, kind: 'tool', output: 'ok', failed: false };
     });
     startVoiceCallRuntime({
       session,

--- a/apps/realtime/src/voice/__tests__/voice-call-runtime.test.ts
+++ b/apps/realtime/src/voice/__tests__/voice-call-runtime.test.ts
@@ -71,16 +71,23 @@ function fakeMeter() {
   } satisfies CallMeter;
 }
 
+/** Answers each hop as the web tier would: a tool result, or a recorded row. */
+const defaultRespond = (
+  request: VoiceBridgeRequest,
+): Awaited<ReturnType<VoiceBridgeClient['send']>> =>
+  request.kind === 'tool_started' || request.kind === 'tool_finished'
+    ? { ok: true, kind: 'tool_activity', saved: true, messageId: 'm1', rev: 1 }
+    : { ok: true, kind: 'tool', output: 'Two pages.' };
+
 function fakeBridge(
-  respond: (request: VoiceBridgeRequest) => Awaited<ReturnType<VoiceBridgeClient['send']>> = () => ({
-    ok: true,
-    kind: 'tool',
-    output: 'Two pages.',
-  }),
+  respond: (request: VoiceBridgeRequest) => Awaited<ReturnType<VoiceBridgeClient['send']>> = defaultRespond,
 ) {
   const requests: VoiceBridgeRequest[] = [];
   return {
     requests,
+    /** The dispatch hop, found by kind — the thread record also uses this bridge. */
+    dispatch: () => requests.find((r) => r.kind === 'tool'),
+    ofKind: (kind: VoiceBridgeRequest['kind']) => requests.filter((r) => r.kind === kind),
     client: {
       send: vi.fn(async (request: VoiceBridgeRequest) => {
         requests.push(request);
@@ -136,6 +143,154 @@ describe('startVoiceCallRuntime — seeding', () => {
   });
 });
 
+describe('startVoiceCallRuntime — showing the work in the thread', () => {
+  it('should record the call as running BEFORE the tool answers, then as done', async () => {
+    // The order is the feature: a row that only appears once the tool has
+    // finished is a result, not a spinner, and the whole point is filling the
+    // wait.
+    const session = fakeSession();
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    const kinds = bridge.requests.map((r) => r.kind);
+    expect(kinds.indexOf('tool_started')).toBeLessThan(kinds.indexOf('tool'));
+    expect(kinds.indexOf('tool')).toBeLessThan(kinds.indexOf('tool_finished'));
+  });
+
+  it('should name the SAME row in both phases, so it converges instead of doubling', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    const [finished] = bridge.ofKind('tool_finished');
+    expect(finished).toMatchObject({
+      messageId: 'm1',
+      toolCallId: 'call_1',
+      output: 'Two pages.',
+    });
+  });
+
+  it('should not delay the model behind the thread record', async () => {
+    // The caller is already sitting through the tool. A row nobody is waiting
+    // for must not be added to that wait.
+    const session = fakeSession();
+    let releaseRecord: () => void = () => {};
+    const bridge = fakeBridge();
+    const slow = new Promise<void>((resolve) => {
+      releaseRecord = resolve;
+    });
+    const original = bridge.client.send;
+    bridge.client.send = (async (request: VoiceBridgeRequest) => {
+      if (request.kind === 'tool_started') await slow;
+      return original(request);
+    }) as VoiceBridgeClient['send'];
+
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    // The model already has its answer while the record is still blocked.
+    expect(session.sent[0]).toMatchObject({
+      item: { type: 'function_call_output', output: 'Two pages.' },
+    });
+    expect(session.sent[1]).toEqual({ type: 'response.create' });
+    releaseRecord();
+  });
+
+  it('given a tool that could not be dispatched, should record it as an error', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge((request) =>
+      request.kind === 'tool'
+        ? { ok: false, error: 'Voice bridge is unreachable' }
+        : { ok: true, kind: 'tool_activity', saved: true, messageId: 'm1', rev: 1 },
+    );
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(bridge.ofKind('tool_finished')[0]).toMatchObject({
+      errorText: 'The tool could not be reached.',
+    });
+  });
+
+  it('given an UNBOUND call, should run the tool and record nothing', async () => {
+    // No conversation means no thread to write into — a real, supported state.
+    const session = fakeSession({ conversationId: undefined });
+    const bridge = fakeBridge();
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(bridge.ofKind('tool_started')).toEqual([]);
+    expect(bridge.ofKind('tool_finished')).toEqual([]);
+    expect(bridge.dispatch()).toBeDefined();
+  });
+
+  it('given the row could not be created, should not try to update one', async () => {
+    const session = fakeSession();
+    const bridge = fakeBridge((request) =>
+      request.kind === 'tool_started'
+        ? { ok: false, error: 'nope' }
+        : request.kind === 'tool_finished'
+          ? { ok: true, kind: 'tool_activity', saved: true, messageId: 'm1', rev: 1 }
+          : { ok: true, kind: 'tool', output: 'Two pages.' },
+    );
+    startVoiceCallRuntime({
+      session,
+      bridge: bridge.client,
+      meter: fakeMeter(),
+      secret: 'ek_1',
+      seed: [],
+    });
+
+    session.emit(responseDone({ output: [toolCall()] }));
+    await flush();
+
+    expect(bridge.ofKind('tool_finished')).toEqual([]);
+    // And the turn is unharmed.
+    expect(session.sent[1]).toEqual({ type: 'response.create' });
+  });
+});
+
 describe('startVoiceCallRuntime — tool dispatch', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -153,7 +308,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     session.emit(responseDone({ output: [toolCall()] }));
     await flush();
 
-    expect(bridge.requests[0]).toMatchObject({
+    expect(bridge.dispatch()).toMatchObject({
       kind: 'tool',
       name: 'list_pages',
       argumentsJson: '{\n  "driveId": "d1"\n}',
@@ -185,7 +340,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     session.emit(responseDone({ output: [toolCall()] }));
     await flush();
 
-    expect(bridge.requests[0]).toMatchObject({
+    expect(bridge.dispatch()).toMatchObject({
       timezone: 'America/New_York',
       locationContext: { currentPage: { id: 'p1' } },
     });
@@ -279,7 +434,7 @@ describe('startVoiceCallRuntime — tool dispatch', () => {
     session.emit(responseDone({ output: [toolCall()] }));
     await flush();
 
-    expect(bridge.requests[0]).not.toHaveProperty('conversationId');
+    expect(bridge.dispatch()).not.toHaveProperty('conversationId');
     expect(session.sent[1]).toEqual({ type: 'response.create' });
   });
 

--- a/apps/realtime/src/voice/voice-call-runtime.ts
+++ b/apps/realtime/src/voice/voice-call-runtime.ts
@@ -210,6 +210,13 @@ export const startVoiceCallRuntime = (
       ? response.output
       : "I couldn't run that just now. Ask me again in a moment.";
 
+    // TWO DIFFERENT FAILURES, and the thread has to tell them apart from a
+    // result. The hop can fail (no response at all), or the hop can succeed
+    // carrying a tool that refused, threw or was called with bad parameters —
+    // which still returns a speakable sentence, because the model is blocked
+    // until it gets one. Neither is a completed tool call.
+    const failed = !dispatched || (response.ok && response.kind === 'tool' && response.failed);
+
     if (!response.ok) {
       loggers.realtime.warn('Realtime voice tool call could not be dispatched', {
         callId,
@@ -227,12 +234,7 @@ export const startVoiceCallRuntime = (
       .then((messageId) =>
         messageId === undefined
           ? undefined
-          : reportToolFinished(
-              call,
-              messageId,
-              output,
-              dispatched ? undefined : 'The tool could not be reached.',
-            ),
+          : reportToolFinished(call, messageId, output, failed ? output : undefined),
       )
       .catch((error: unknown) => {
         loggers.realtime.error(

--- a/apps/realtime/src/voice/voice-call-runtime.ts
+++ b/apps/realtime/src/voice/voice-call-runtime.ts
@@ -119,7 +119,80 @@ export const startVoiceCallRuntime = (
    * sentence about that rather than silence, because the one unrecoverable
    * outcome is a tool call the model never gets an answer to.
    */
+  /**
+   * Record the tool call in the thread, so a spoken turn shows its work.
+   *
+   * NEVER ON THE MODEL'S PATH. The row is written alongside the dispatch, not
+   * before it: the caller is sitting through the tool's latency already, and a
+   * database write added to it would be latency spent on something nobody is
+   * waiting for. A failure here costs the row and nothing else — hence the same
+   * `void`-and-catch shape `persistTranscript` uses below.
+   *
+   * The started write's promise is returned rather than awaited so the finish
+   * can chain on it. That ordering is the one thing that matters: both writes
+   * name the same row, and a finish that landed first would create the row as a
+   * result and then be overwritten back into a spinner.
+   */
+  const reportToolStarted = (call: FunctionCall): Promise<string | undefined> => {
+    if (!conversationId) return Promise.resolve(undefined);
+    return bridge
+      .send({
+        kind: 'tool_started',
+        callId,
+        userId,
+        conversationId,
+        toolCallId: call.callId,
+        name: call.name,
+        argumentsJson: call.argumentsJson,
+        ...(assistant === undefined ? {} : { assistant }),
+      })
+      .then((response) => {
+        if (response.ok && response.kind === 'tool_activity') {
+          return response.messageId ?? undefined;
+        }
+        loggers.realtime.warn('Realtime voice tool call was not recorded in the thread', {
+          callId,
+          tool: call.name,
+          error: response.ok ? undefined : response.error,
+        });
+        return undefined;
+      });
+  };
+
+  const reportToolFinished = async (
+    call: FunctionCall,
+    messageId: string,
+    output: string,
+    errorText?: string,
+  ): Promise<void> => {
+    if (!conversationId) return;
+    const response = await bridge.send({
+      kind: 'tool_finished',
+      callId,
+      userId,
+      conversationId,
+      messageId,
+      toolCallId: call.callId,
+      name: call.name,
+      argumentsJson: call.argumentsJson,
+      output,
+      ...(errorText === undefined ? {} : { errorText }),
+      ...(assistant === undefined ? {} : { assistant }),
+    });
+    if (!response.ok) {
+      loggers.realtime.warn('Realtime voice tool result was not recorded in the thread', {
+        callId,
+        tool: call.name,
+        error: response.error,
+      });
+    }
+  };
+
   const answerToolCall = async (call: FunctionCall): Promise<void> => {
+    // Started FIRST and unawaited, so the row appears while the tool runs
+    // rather than after it — the spinner is the point.
+    const started = reportToolStarted(call);
+
     const response = await bridge.send({
       kind: 'tool',
       callId,
@@ -132,10 +205,10 @@ export const startVoiceCallRuntime = (
       ...(assistant === undefined ? {} : { assistant }),
     });
 
-    const output =
-      response.ok && response.kind === 'tool'
-        ? response.output
-        : "I couldn't run that just now. Ask me again in a moment.";
+    const dispatched = response.ok && response.kind === 'tool';
+    const output = dispatched
+      ? response.output
+      : "I couldn't run that just now. Ask me again in a moment.";
 
     if (!response.ok) {
       loggers.realtime.warn('Realtime voice tool call could not be dispatched', {
@@ -146,7 +219,28 @@ export const startVoiceCallRuntime = (
       });
     }
 
+    // The model's answer goes out now, before the thread record settles. The
+    // record is chained onto the started write purely for ordering.
     session.send(buildFunctionOutput(call.callId, output));
+
+    void started
+      .then((messageId) =>
+        messageId === undefined
+          ? undefined
+          : reportToolFinished(
+              call,
+              messageId,
+              output,
+              dispatched ? undefined : 'The tool could not be reached.',
+            ),
+      )
+      .catch((error: unknown) => {
+        loggers.realtime.error(
+          'Realtime voice tool activity record threw',
+          error instanceof Error ? error : new Error(String(error)),
+          { callId, tool: call.name },
+        );
+      });
   };
 
   const handleToolCalls = async (calls: readonly FunctionCall[]): Promise<void> => {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -12,6 +12,12 @@ import { GeneratedImageRenderer } from './GeneratedImageRenderer';
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
 import { renderToolContent } from './registry';
 import { dispatchToolCall, resolveIntegrationToolLabel } from './tool-call-dispatch';
+import { TOOL_NAME_MAP, describeToolCall, formatToolName } from '@/lib/ai/tools/tool-labels';
+
+// Re-exported from its new home so existing importers keep working. The table
+// moved to `lib/` because the voice reducer needs the same words and cannot
+// import from `components/`.
+export { TOOL_NAME_MAP };
 
 export interface ToolPart {
   type: string;
@@ -42,84 +48,6 @@ const safeJsonParse = (value: unknown): Record<string, unknown> | null => {
     return value as Record<string, unknown>;
   }
   return null;
-};
-
-// Tool name mapping (display labels for the collapsible header)
-export const TOOL_NAME_MAP: Record<string, string> = {
-  // Drive tools
-  'list_drives': 'Workspaces',
-  'create_drive': 'Create Workspace',
-  'rename_drive': 'Rename Workspace',
-  'update_drive_context': 'Update Context',
-  'set_home_page': 'Set Home Page',
-  // Member tools
-  'list_drive_members': 'Members',
-  'list_collaborators': 'Collaborators',
-  // Role management tools
-  'list_drive_roles': 'Roles',
-  'get_drive_role': 'Role',
-  'create_drive_role': 'Create Role',
-  'update_drive_role': 'Update Role',
-  'delete_drive_role': 'Delete Role',
-  'set_role_page_permissions': 'Set Role Page Access',
-  'set_role_drive_wide_permissions': 'Set Role Drive Access',
-  'remove_role_page_permissions': 'Remove Role Page Access',
-  // Page read tools
-  'list_pages': 'Pages',
-  'read_page': 'Read Page',
-  'list_trash': 'Trash',
-  'list_conversations': 'Conversations',
-  'read_conversation': 'Conversation',
-  'send_channel_message': 'Send Message',
-  'delete_channel_message': 'Delete Message',
-  // Page write tools
-  'replace_lines': 'Edit Document',
-  'insert_content': 'Insert Content',
-  'create_page': 'Create Page',
-  'rename_page': 'Rename Page',
-  'trash_page': 'Move to Trash',
-  'trash_drive': 'Move Drive to Trash',
-  'restore_page': 'Restore',
-  'restore_drive': 'Restore Drive',
-  'move_page': 'Move Page',
-  'edit_sheet_cells': 'Edit Sheet',
-  // Search tools
-  'regex_search': 'Search',
-  'glob_search': 'Find Pages',
-  'multi_drive_search': 'Search All',
-  // Task tools
-  'update_task': 'Update Task',
-  'create_task': 'Create Task',
-  'delete_task': 'Delete Task',
-  'reorder_task': 'Reorder Task',
-  'get_assigned_tasks': 'Assigned Tasks',
-  'create_task_status': 'Create Status',
-  // Agent tools
-  'update_agent_config': 'Configure Agent',
-  'list_agents': 'Agents',
-  'multi_drive_list_agents': 'All Agents',
-  'ask_agent': 'Ask Agent',
-  'ask_user': 'Question',
-  // Web
-  'web_search': 'Web Search',
-  'web_fetch': 'Fetch Page',
-  // Activity
-  'get_activity': 'Activity',
-  // Calendar tools
-  'list_calendar_events': 'Calendar',
-  'get_calendar_event': 'Event',
-  'check_calendar_availability': 'Availability',
-  'create_calendar_event': 'Create Event',
-  'update_calendar_event': 'Update Event',
-  'delete_calendar_event': 'Delete Event',
-  'rsvp_calendar_event': 'RSVP',
-  'invite_calendar_attendees': 'Invite Attendees',
-  'remove_calendar_attendee': 'Remove Attendee',
-  // Workflow tools
-  'create_workflow': 'Create Workflow',
-  'list_workflows': 'Workflows',
-  'update_workflow': 'Update Workflow',
-  'delete_workflow': 'Delete Workflow',
 };
 
 /**
@@ -174,50 +102,19 @@ export function useToolCallDisplay(part: ToolPart, toolName: string) {
     return safeJsonParse(output);
   }, [output]);
 
-  // Memoize formatted tool name
-  const formattedToolName = useMemo(() => {
-    return (
-      resolveIntegrationToolLabel(toolName) ||
-      TOOL_NAME_MAP[toolName] ||
-      toolName.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
-    );
-  }, [toolName]);
+  // Memoize formatted tool name. The integration override stays here: it is the
+  // one part that depends on the integrations registry, which `lib/ai/tools/
+  // tool-labels.ts` deliberately does not.
+  const formattedToolName = useMemo(
+    () => resolveIntegrationToolLabel(toolName) || formatToolName(toolName),
+    [toolName],
+  );
 
   // Memoize descriptive title
-  const descriptiveTitle = useMemo(() => {
-    if (!parsedInput) return formattedToolName;
-    const params = parsedInput as Record<string, unknown>;
-
-    // Add context to title based on tool type
-    if (params.title && typeof params.title === 'string') {
-      return `${formattedToolName}: ${params.title}`;
-    }
-    if (params.name && typeof params.name === 'string') {
-      return `${formattedToolName}: ${params.name}`;
-    }
-    if (params.query && typeof params.query === 'string') {
-      const truncated = params.query.length > 30 ? params.query.slice(0, 30) + '...' : params.query;
-      return `${formattedToolName}: ${truncated}`;
-    }
-    if (params.pattern && typeof params.pattern === 'string') {
-      return `${formattedToolName}: ${params.pattern}`;
-    }
-    if (params.driveSlug && typeof params.driveSlug === 'string') {
-      return `${formattedToolName}: ${params.driveSlug}`;
-    }
-    if (params.owner && params.repo && typeof params.owner === 'string' && typeof params.repo === 'string') {
-      const suffix = params.path && typeof params.path === 'string' ? `/${params.path}` : '';
-      return `${formattedToolName}: ${params.owner}/${params.repo}${suffix}`;
-    }
-    if (params.channel && typeof params.channel === 'string') {
-      return `${formattedToolName}: ${params.channel}`;
-    }
-    if (params.repo && typeof params.repo === 'string') {
-      return `${formattedToolName}: ${params.repo}`;
-    }
-
-    return formattedToolName;
-  }, [parsedInput, formattedToolName]);
+  const descriptiveTitle = useMemo(
+    () => describeToolCall(toolName, parsedInput, formattedToolName),
+    [toolName, parsedInput, formattedToolName],
+  );
 
   // Build rich content via the tool renderer registry
   const richContent = useMemo(

--- a/apps/web/src/components/ai/voice/realtime/VoiceCallBar.tsx
+++ b/apps/web/src/components/ai/voice/realtime/VoiceCallBar.tsx
@@ -104,12 +104,20 @@ export function VoiceCallBar({ assistantName, className }: VoiceCallBarProps) {
         </div>
 
         <div className="min-w-0 flex-1">
-          {latest ? (
+          {/*
+            The status line WINS over the last thing said while a tool is
+            running. Quoting the previous utterance there is the one moment it
+            is actively wrong: the model has stopped talking to go and do
+            something, and the whole point of naming the work is that the
+            silence is explained. Without this the tool status was unreachable
+            after the first spoken turn.
+          */}
+          {runningTool || !latest ? (
+            <p className="truncate text-xs text-muted-foreground">{statusLine}</p>
+          ) : (
             <p className="truncate text-xs italic text-muted-foreground">
               &ldquo;{latest.text}&rdquo;
             </p>
-          ) : (
-            <p className="truncate text-xs text-muted-foreground">{statusLine}</p>
           )}
         </div>
 

--- a/apps/web/src/components/ai/voice/realtime/VoiceCallBar.tsx
+++ b/apps/web/src/components/ai/voice/realtime/VoiceCallBar.tsx
@@ -44,7 +44,7 @@ const METER_BARS = 5;
  * nowhere else.
  */
 export function VoiceCallBar({ assistantName, className }: VoiceCallBarProps) {
-  const { status, error, failure, attached, target, userSpeaking, transcript, tools, localStream, muted } =
+  const { status, error, failure, attached, target, userSpeaking, transcript, activeTools, localStream, muted } =
     useVoiceSession();
   const { stop, setMuted } = useVoiceSessionControls();
 
@@ -58,12 +58,15 @@ export function VoiceCallBar({ assistantName, className }: VoiceCallBarProps) {
   const level = useAudioLevel(localStream, live && !muted);
 
   const latest = transcript.length > 0 ? transcript[transcript.length - 1] : undefined;
-  const latestTool = tools.length > 0 ? tools[tools.length - 1] : undefined;
+  const runningTool = activeTools.length > 0 ? activeTools[activeTools.length - 1] : undefined;
 
   const statusLine = (() => {
     if (chrome.state === 'connecting') return 'Connecting…';
     if (muted) return 'Muted';
-    if (latestTool) return latestTool.speech;
+    // Ahead of "Listening…" on purpose: while a tool runs the model is silent,
+    // and naming the work is the difference between a pause and a dropped call.
+    // Safe to prefer only because `activeTools` empties when it speaks again.
+    if (runningTool) return runningTool.speech;
     if (userSpeaking) return 'Listening…';
     return `Talking to ${assistantName}`;
   })();

--- a/apps/web/src/components/ai/voice/realtime/__tests__/VoiceCallBar.test.tsx
+++ b/apps/web/src/components/ai/voice/realtime/__tests__/VoiceCallBar.test.tsx
@@ -155,6 +155,73 @@ describe('VoiceCallBar — the current utterance, and nothing more', () => {
     expect(screen.getByTestId('voice-call-bar').textContent).toContain('what is on this page');
   });
 
+  it('should name the running tool INSTEAD of the last thing said', async () => {
+    // The bug this exists for: the bar rendered the last transcript whenever
+    // one existed, so the tool status was unreachable after the first spoken
+    // turn — which is every real call. The silence the status explains always
+    // follows something being said.
+    const h = harness();
+    renderBar(h.deps);
+    await startCall();
+
+    await act(async () => {
+      h.peers[0].events.deliver(
+        JSON.stringify({
+          type: 'response.output_audio_transcript.done',
+          transcript: 'Let me check that.',
+        }),
+      );
+      h.peers[0].events.deliver(
+        JSON.stringify({
+          type: 'response.done',
+          response: {
+            output: [
+              {
+                type: 'function_call',
+                call_id: 'call_1',
+                name: 'read_page',
+                arguments: JSON.stringify({ title: 'Roadmap' }),
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    const bar = screen.getByTestId('voice-call-bar').textContent ?? '';
+    expect(bar).toContain('Read Page: Roadmap');
+    expect(bar).not.toContain('Let me check that.');
+  });
+
+  it('should go back to the last thing said once the model speaks again', async () => {
+    const h = harness();
+    renderBar(h.deps);
+    await startCall();
+
+    await act(async () => {
+      h.peers[0].events.deliver(
+        JSON.stringify({
+          type: 'response.done',
+          response: {
+            output: [
+              { type: 'function_call', call_id: 'call_1', name: 'read_page', arguments: '{}' },
+            ],
+          },
+        }),
+      );
+      h.peers[0].events.deliver(
+        JSON.stringify({
+          type: 'response.output_audio_transcript.done',
+          transcript: 'It is in your Inbox.',
+        }),
+      );
+    });
+
+    const bar = screen.getByTestId('voice-call-bar').textContent ?? '';
+    expect(bar).toContain('It is in your Inbox.');
+    expect(bar).not.toContain('Read Page');
+  });
+
   it('should render NO transcript history — that is the message list\'s job', async () => {
     // Spoken turns are written into the conversation and arrive on the ordinary
     // `conversation:*` events. A second copy here would be a second history,

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.read-message-text.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.read-message-text.test.ts
@@ -75,6 +75,18 @@ describe('readMessageText', () => {
     expect(readMessageText('{"hello":"world"}')).toBe('{"hello":"world"}');
   });
 
+  it('given JSON that only LOOKS like an envelope, should not decode it', () => {
+    // Someone can type this. Without the `partsOrder` discriminator — which
+    // `StructuredContentData` requires and every real write includes — the body
+    // `{"textParts":["value"]}` would be served back as `value`, and a message
+    // would be reported as saying something its author never wrote.
+    const lookalike = '{"textParts":["value"]}';
+    expect(readMessageText(lookalike)).toBe(lookalike);
+
+    const withOriginal = '{"originalContent":"value"}';
+    expect(readMessageText(withOriginal)).toBe(withOriginal);
+  });
+
   it('given nothing, should return nothing rather than throw', () => {
     expect(readMessageText(null)).toBe('');
     expect(readMessageText(undefined)).toBe('');

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.readMessageText.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.readMessageText.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { readMessageText } from '../message-utils';
+import { serializeMessageRowToMessages } from '../../openai-api/v1-conversations';
 
 const structured = (over: Record<string, unknown>) =>
   JSON.stringify({ textParts: [], partsOrder: [], originalContent: '', ...over });
@@ -36,10 +37,32 @@ describe('readMessageText', () => {
     expect(readMessageText(content)).toBe('');
   });
 
-  it('given several text parts, should join them', () => {
-    expect(
-      readMessageText(structured({ textParts: ['One. ', 'Two.'], originalContent: 'One. Two.' })),
-    ).toBe('One. Two.');
+  it('given several text parts and no original body, should join them', () => {
+    expect(readMessageText(JSON.stringify({ textParts: ['One. ', 'Two.'], partsOrder: [] }))).toBe(
+      'One. Two.',
+    );
+  });
+
+  it('should be the ONLY reader — the v1 conversations API decodes through it too', () => {
+    // It had a private copy of this. Two functions decoding the same envelope
+    // are two that can disagree about what a message says, on a surface whose
+    // whole job is reporting what a message says.
+    const envelope = structured({
+      textParts: ['Here they are.'],
+      originalContent: 'Here they are.',
+    });
+
+    const [message] = serializeMessageRowToMessages({
+      id: 'm1',
+      role: 'assistant',
+      content: envelope,
+      toolCalls: null,
+      toolResults: null,
+      createdAt: new Date(0),
+      isActive: true,
+    });
+
+    expect((message as { content: string | null }).content).toBe('Here they are.');
   });
 
   it('given a plain legacy row, should pass it through untouched', () => {

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.readMessageText.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.readMessageText.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Reading a stored message's words back out.
+ *
+ * `messages.content` is not prose. Any row saved with parts — every typed
+ * assistant turn — stores a JSON envelope there, and a plain `select` returns
+ * the envelope. Anything that wants the words and reads the column directly
+ * gets `{"textParts":["Here they are."],…}` and treats it as something someone
+ * said. The voice seed did exactly that.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readMessageText } from '../message-utils';
+
+const structured = (over: Record<string, unknown>) =>
+  JSON.stringify({ textParts: [], partsOrder: [], originalContent: '', ...over });
+
+describe('readMessageText', () => {
+  it('given a structured row, should return the words rather than the envelope', () => {
+    const content = structured({
+      textParts: ['Here they are.'],
+      partsOrder: [{ index: 0, type: 'text' }],
+      originalContent: 'Here they are.',
+    });
+
+    expect(readMessageText(content)).toBe('Here they are.');
+  });
+
+  it('given a TOOL row, should return nothing — no words were said', () => {
+    // A voice tool call is persisted as its own row and renders from its parts.
+    // Returning the envelope here is what would seed the next call with JSON in
+    // the assistant's voice.
+    const content = structured({
+      partsOrder: [{ index: 0, type: 'tool-read_page', toolCallId: 'call_1' }],
+    });
+
+    expect(readMessageText(content)).toBe('');
+  });
+
+  it('given several text parts, should join them', () => {
+    expect(
+      readMessageText(structured({ textParts: ['One. ', 'Two.'], originalContent: 'One. Two.' })),
+    ).toBe('One. Two.');
+  });
+
+  it('given a plain legacy row, should pass it through untouched', () => {
+    // Rows written before structured content, and every user turn.
+    expect(readMessageText('just text')).toBe('just text');
+  });
+
+  it('given JSON that is not our envelope, should treat it as text', () => {
+    // A message whose body happens to be JSON is still a message body.
+    expect(readMessageText('{"hello":"world"}')).toBe('{"hello":"world"}');
+  });
+
+  it('given nothing, should return nothing rather than throw', () => {
+    expect(readMessageText(null)).toBe('');
+    expect(readMessageText(undefined)).toBe('');
+    expect(readMessageText('')).toBe('');
+  });
+
+  it('given an envelope with no text parts but an original body, should fall back to it', () => {
+    expect(readMessageText(structured({ originalContent: 'said this' }))).toBe('said this');
+  });
+});

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -369,19 +369,16 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
  */
 export function readMessageText(content: string | null | undefined): string {
   if (!content) return '';
-  try {
-    const parsed: unknown = JSON.parse(content);
-    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      const envelope = parsed as { originalContent?: unknown; textParts?: unknown };
-      if (typeof envelope.originalContent === 'string') return envelope.originalContent;
-      if (Array.isArray(envelope.textParts)) {
-        return envelope.textParts.filter((t): t is string => typeof t === 'string').join('');
-      }
-    }
-  } catch {
-    // Not JSON, so it is what it looks like: the message.
-  }
-  return content;
+  // `parseStructuredContent` is the existing definition of "this is one of our
+  // envelopes" — it requires BOTH `textParts` and `partsOrder`. Reusing it
+  // rather than sniffing for a field means a message whose body happens to be
+  // `{"textParts":["value"]}`, which someone can simply type, is treated as the
+  // text it is instead of being decoded into `value`.
+  const envelope = parseStructuredContent(content);
+  if (!envelope) return content;
+
+  if (typeof envelope.originalContent === 'string') return envelope.originalContent;
+  return envelope.textParts.filter((part): part is string => typeof part === 'string').join('');
 }
 
 function parseStructuredContent(content: string | null | undefined): StructuredContentData | null {

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -350,6 +350,24 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
 }
 
 /** Parse persisted structured content, returning null for plain-text (legacy) content. */
+/**
+ * The plain text of a stored message, whatever shape the column is in.
+ *
+ * `messages.content` holds STRUCTURED JSON for any row saved with parts — the
+ * text, the file/data parts and a `partsOrder` — and the raw column is what a
+ * plain `select` returns. Anything wanting the words has to come through here,
+ * or it gets `{"textParts":["Here they are."],…}` and treats it as prose.
+ *
+ * A row with no text parts (a tool call, which renders from its parts) yields
+ * an empty string, which is the honest answer: nothing was said.
+ */
+export function readMessageText(content: string | null | undefined): string {
+  const structured = parseStructuredContent(content);
+  if (!structured) return content ?? '';
+  const text = structured.textParts.join('').trim();
+  return text.length > 0 ? text : (structured.originalContent ?? '').trim();
+}
+
 function parseStructuredContent(content: string | null | undefined): StructuredContentData | null {
   if (!content) return null;
   try {

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -353,19 +353,35 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
 /**
  * The plain text of a stored message, whatever shape the column is in.
  *
- * `messages.content` holds STRUCTURED JSON for any row saved with parts — the
- * text, the file/data parts and a `partsOrder` — and the raw column is what a
- * plain `select` returns. Anything wanting the words has to come through here,
- * or it gets `{"textParts":["Here they are."],…}` and treats it as prose.
+ * `messages.content` does not hold prose. Any row saved with parts — which is
+ * every typed assistant turn — stores a JSON envelope there
+ * (`extractStructuredContentFromParts`), and a plain `select` returns the
+ * envelope. Anything that wants the words and reads the column directly gets
+ * `{"textParts":["Here they are."],…}` and treats it as something someone said.
+ * The voice seed did exactly that, and replayed it at the model.
  *
- * A row with no text parts (a tool call, which renders from its parts) yields
- * an empty string, which is the honest answer: nothing was said.
+ * A row with no text — a tool call, which renders from its parts — yields an
+ * empty string, which is the honest answer: nothing was said.
+ *
+ * This is the ONE reader. `v1-conversations.ts` had a private copy of it, and
+ * two functions that decode the same envelope are two that can disagree about
+ * what a message says.
  */
 export function readMessageText(content: string | null | undefined): string {
-  const structured = parseStructuredContent(content);
-  if (!structured) return content ?? '';
-  const text = structured.textParts.join('').trim();
-  return text.length > 0 ? text : (structured.originalContent ?? '').trim();
+  if (!content) return '';
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const envelope = parsed as { originalContent?: unknown; textParts?: unknown };
+      if (typeof envelope.originalContent === 'string') return envelope.originalContent;
+      if (Array.isArray(envelope.textParts)) {
+        return envelope.textParts.filter((t): t is string => typeof t === 'string').join('');
+      }
+    }
+  } catch {
+    // Not JSON, so it is what it looks like: the message.
+  }
+  return content;
 }
 
 function parseStructuredContent(content: string | null | undefined): StructuredContentData | null {

--- a/apps/web/src/lib/ai/openai-api/v1-conversations.ts
+++ b/apps/web/src/lib/ai/openai-api/v1-conversations.ts
@@ -1,3 +1,5 @@
+import { readMessageText } from '@/lib/ai/core/message-utils';
+
 // Types
 
 export interface OpenAIToolCall {
@@ -133,21 +135,6 @@ export function validateConversationAccess(
   return { ok: true };
 }
 
-function extractPlainText(content: string): string {
-  try {
-    const parsed = JSON.parse(content);
-    if (typeof parsed === 'object' && !Array.isArray(parsed) && parsed !== null) {
-      if (typeof parsed.originalContent === 'string') return parsed.originalContent;
-      if (Array.isArray(parsed.textParts) && parsed.textParts.length > 0) {
-        return (parsed.textParts as string[]).filter((t): t is string => typeof t === 'string').join('');
-      }
-    }
-  } catch {
-    // plain text
-  }
-  return content;
-}
-
 function parseRawToolCalls(
   raw: unknown,
 ): Array<{ toolCallId: string; toolName: string; input: unknown }> {
@@ -197,7 +184,7 @@ export function serializeMessageRowToMessages(
   row: MessageRow,
 ): Array<OpenAIMessage | OpenAIToolResultMessage> {
   const role = row.role as 'user' | 'assistant' | 'system';
-  const text = extractPlainText(row.content);
+  const text = readMessageText(row.content);
 
   const rawCalls = parseRawToolCalls(row.toolCalls);
   const toolCalls: OpenAIToolCall[] = rawCalls.map((tc) => ({

--- a/apps/web/src/lib/ai/realtime/__tests__/bridge-handler.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/bridge-handler.test.ts
@@ -99,7 +99,12 @@ describe('handleVoiceBridgeRequest — tool dispatch', () => {
     const result = await handleVoiceBridgeRequest(deps(), toolBody());
 
     expect(result.status).toBe(200);
-    expect(result.body).toEqual({ ok: true, kind: 'tool', output: '{"title":"Notes"}' });
+    expect(result.body).toEqual({
+      ok: true,
+      kind: 'tool',
+      output: '{"title":"Notes"}',
+      failed: false,
+    });
   });
 
   it('given a tool that fails, should still answer 200 — the model is blocked until it does', async () => {
@@ -108,7 +113,9 @@ describe('handleVoiceBridgeRequest — tool dispatch', () => {
     const result = await handleVoiceBridgeRequest(deps(), toolBody({ name: 'nonexistent' }));
 
     expect(result.status).toBe(200);
-    expect(result.body).toMatchObject({ ok: true, kind: 'tool' });
+    // 200 with `failed: true`: the hop worked, the tool did not. Anything
+    // recording the call for a human needs to tell those apart.
+    expect(result.body).toMatchObject({ ok: true, kind: 'tool', failed: true });
     expect((result.body as { output: string }).output).toContain('no tool called');
   });
 

--- a/apps/web/src/lib/ai/realtime/__tests__/instructions.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/instructions.test.ts
@@ -74,6 +74,12 @@ describe('buildVoiceInstructions', () => {
     expect(instructions).toMatch(/interrupt/i);
   });
 
+  it('should ask it to speak before EVERY tool call, not just the first', () => {
+    // The dead air people actually hear is the second hop: a tool result sends
+    // the model looking again, and it goes quiet for the whole round trip.
+    expect(build()).toContain('BEFORE EVERY TOOL CALL, not just the first');
+  });
+
   it('should tell it to ACT rather than ask permission', () => {
     // The model's default posture is to confirm before calling a tool, which on
     // a call reads as an assistant that will not do anything.

--- a/apps/web/src/lib/ai/realtime/__tests__/seed.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/seed.test.ts
@@ -303,3 +303,23 @@ describe('buildRealtimeSeed', () => {
     });
   });
 });
+
+describe('buildRealtimeSeed — what a call is NOT reminded of', () => {
+  it('should not replay a tool row as something the assistant said', () => {
+    // A voice tool call is persisted as its own row with no text: it renders
+    // from its parts, and nothing was spoken. Replaying it would put
+    // "Read Page: Roadmap" in the next call's history as an utterance, and
+    // spend the seed's budget on turns nobody took.
+    const seed = buildRealtimeSeed([
+      { role: 'user', content: 'where are my notes?', createdAt: new Date(1) },
+      { role: 'assistant', content: '', createdAt: new Date(2) },
+      { role: 'assistant', content: 'In your Inbox.', createdAt: new Date(3) },
+    ]);
+
+    expect(seed).toHaveLength(2);
+    expect(seed.map((event) => event.item.content[0].text)).toEqual([
+      'where are my notes?',
+      'In your Inbox.',
+    ]);
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/session-state.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/session-state.test.ts
@@ -92,11 +92,19 @@ describe('connection lifecycle', () => {
     ]);
   });
 
-  it('given a failure while a tool was running, should keep showing what it was', () => {
-    // The call dropped mid-tool; erasing what it was doing would leave the bar
-    // claiming nothing was happening when something was.
-    const state = after([toolCall('read_page', { title: 'Notes' }), { type: 'failed', message: 'dropped' }]);
-    expect(state.activeTools).toHaveLength(1);
+  it('given a call that ends or restarts, should stop claiming a tool is running', () => {
+    // A dropped call is not still reading a page. Left alone, the next call
+    // would open showing the previous call's tool as live for its whole first
+    // silent turn.
+    for (const ending of [
+      { type: 'failed', message: 'dropped' },
+      { type: 'disconnected' },
+      { type: 'connecting' },
+      { type: 'connected' },
+    ] as SessionAction[]) {
+      const state = after([toolCall('read_page', { title: 'Notes' }), ending]);
+      expect(state.activeTools, `${ending.type} left a stale tool`).toEqual([]);
+    }
   });
 
   it('given a disconnect, should return to idle and stop listening', () => {
@@ -210,6 +218,25 @@ describe('tool activity — what fills the silence', () => {
     ]);
 
     expect(state.activeTools).toEqual([]);
+    expect(state.transcript).toHaveLength(1);
+  });
+
+  it('should KEEP showing the tool while the caller talks over it', () => {
+    // `extractTranscript` returns the caller's transcripts too. Someone
+    // speaking during a slow tool is the person waiting on it — clearing then
+    // would drop the explanation for the silence exactly when it is needed.
+    const state = after([
+      toolCall('read_page', { title: 'Roadmap' }),
+      {
+        type: 'event',
+        event: {
+          type: 'conversation.item.input_audio_transcription.completed',
+          transcript: 'are you still there?',
+        },
+      },
+    ]);
+
+    expect(state.activeTools).toHaveLength(1);
     expect(state.transcript).toHaveLength(1);
   });
 

--- a/apps/web/src/lib/ai/realtime/__tests__/session-state.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/session-state.test.ts
@@ -11,6 +11,19 @@ const after = (
   from: SessionState = initialSessionState,
 ): SessionState => actions.reduce(sessionReducer, from);
 
+/** A `response.done` announcing one tool call, as OpenAI shapes it. */
+const toolCall = (name: string, args: Record<string, unknown>): SessionAction => ({
+  type: 'event',
+  event: {
+    type: 'response.done',
+    response: {
+      output: [
+        { type: 'function_call', call_id: 'c1', name, arguments: JSON.stringify(args) },
+      ],
+    },
+  },
+});
+
 const said = (type: string, transcript: string): SessionAction => ({
   type: 'event',
   event: { type, transcript },
@@ -32,7 +45,7 @@ describe('initialSessionState', () => {
       error: undefined,
       userSpeaking: false,
       transcript: [],
-      tools: [],
+      activeTools: [],
     });
   });
 });
@@ -79,12 +92,11 @@ describe('connection lifecycle', () => {
     ]);
   });
 
-  it('given a failure after a tool ran, should keep the tool record too', () => {
-    const state = after([
-      { type: 'tool', name: 'read_page', speech: 'Notes: hi' },
-      { type: 'failed', message: 'dropped' },
-    ]);
-    expect(state.tools).toHaveLength(1);
+  it('given a failure while a tool was running, should keep showing what it was', () => {
+    // The call dropped mid-tool; erasing what it was doing would leave the bar
+    // claiming nothing was happening when something was.
+    const state = after([toolCall('read_page', { title: 'Notes' }), { type: 'failed', message: 'dropped' }]);
+    expect(state.activeTools).toHaveLength(1);
   });
 
   it('given a disconnect, should return to idle and stop listening', () => {
@@ -157,15 +169,87 @@ describe('transcript', () => {
   });
 });
 
-describe('tool activity', () => {
-  it('given tools ran, should record what they were and what they said, in order', () => {
+describe('tool activity — what fills the silence', () => {
+  it('given a response announcing a tool call, should say what is running', () => {
+    // This is the whole point: between "let me check that" and the answer, the
+    // model is silent and the bar used to show nothing.
+    const state = after([toolCall('read_page', { title: 'Roadmap' })]);
+
+    expect(state.activeTools).toEqual([{ name: 'read_page', speech: 'Read Page: Roadmap' }]);
+  });
+
+  it('given several calls in one response, should show them all', () => {
     const state = after([
-      { type: 'tool', name: 'read_page', speech: 'Notes: hi' },
-      { type: 'tool', name: 'list_pages', speech: 'You have 1 page' },
+      {
+        type: 'event',
+        event: {
+          type: 'response.done',
+          response: {
+            output: [
+              { type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{}' },
+              { type: 'function_call', call_id: 'c2', name: 'list_pages', arguments: '{}' },
+            ],
+          },
+        },
+      },
     ]);
-    expect(state.tools).toEqual([
-      { name: 'read_page', speech: 'Notes: hi' },
-      { name: 'list_pages', speech: 'You have 1 page' },
+
+    expect(state.activeTools.map((t) => t.name)).toEqual(['read_page', 'list_pages']);
+  });
+
+  it('should clear when the model speaks again — the silence is over', () => {
+    const state = after([
+      toolCall('read_page', { title: 'Roadmap' }),
+      {
+        type: 'event',
+        event: {
+          type: 'response.output_audio_transcript.done',
+          transcript: "It's in your Inbox.",
+        },
+      },
     ]);
+
+    expect(state.activeTools).toEqual([]);
+    expect(state.transcript).toHaveLength(1);
+  });
+
+  it('should clear when a response finishes without calling anything', () => {
+    const state = after([
+      toolCall('read_page', { title: 'Roadmap' }),
+      { type: 'event', event: { type: 'response.done', response: { output: [] } } },
+    ]);
+
+    expect(state.activeTools).toEqual([]);
+  });
+
+  it('given unparseable arguments, should still name the tool', () => {
+    // Arguments are assembled from streamed deltas. A label is never worth
+    // throwing over inside a reducer.
+    const state = after([
+      {
+        type: 'event',
+        event: {
+          type: 'response.done',
+          response: {
+            output: [
+              { type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{"title":' },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(state.activeTools).toEqual([{ name: 'read_page', speech: 'Read Page' }]);
+  });
+
+  it('should not churn identity on an unrelated event', () => {
+    // A re-render per housekeeping frame is a waveform that stutters.
+    const base = after([{ type: 'connected' }]);
+    const next = sessionReducer(base, {
+      type: 'event',
+      event: { type: 'rate_limits.updated' },
+    });
+
+    expect(next).toBe(base);
   });
 });

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-activity-persistence.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-activity-persistence.test.ts
@@ -84,17 +84,30 @@ describe('persistVoiceToolActivity — the running row', () => {
     expect(result).toMatchObject({ saved: true, messageId: 'minted1', rev: 7 });
   });
 
-  it('should carry a readable body, not the raw output', async () => {
-    // The body is what a surface that cannot render parts shows, and what a
-    // notification would quote.
+  it('should write NO text, because nothing was said', async () => {
+    // Load-bearing, not an omission. `buildRealtimeSeed` replays a message's
+    // `content` as an utterance, so a label here would seed the next call with
+    // "Read Page: Roadmap" as though the assistant had said it — and spend the
+    // seed's turn budget on things nobody said. The renderer builds its text
+    // from parts, so the row still shows as a tool card.
     const { deps: d, global } = deps();
 
     await persistVoiceToolActivity(d, running);
 
-    expect(global[0]).toMatchObject({
-      content: 'Read Page: Roadmap',
-      role: 'assistant',
-    });
+    expect(global[0]).toMatchObject({ content: '', role: 'assistant' });
+  });
+
+  it('should be written even though it has no text', async () => {
+    // The transcript writer refuses a blank body — a spoken turn that said
+    // nothing is worse than no row. That reasoning does not reach a row which
+    // renders from its parts, and applying it here would drop the record of a
+    // tool call that actually ran.
+    const { deps: d, global } = deps();
+
+    const result = await persistVoiceToolActivity(d, running);
+
+    expect(result.saved).toBe(true);
+    expect(global).toHaveLength(1);
   });
 
   it('should mark the row as spoken, so the thread shows the mic glyph', async () => {

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-activity-persistence.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-activity-persistence.test.ts
@@ -10,6 +10,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { persistVoiceToolActivity } from '../tool-activity-persistence';
 import type { TranscriptPersistenceDeps } from '../transcript-persistence';
+import type { UIMessage } from 'ai';
+import {
+  convertGlobalAssistantMessageToUIMessage,
+  extractStructuredContentFromParts,
+  readMessageText,
+} from '../../core/message-utils';
 
 const conversation = (over: Record<string, unknown> = {}) => ({
   id: 'conv1',
@@ -24,6 +30,23 @@ const conversation = (over: Record<string, unknown> = {}) => ({
 /** Whatever reached the repository, in the order it got there. */
 type SavedRow = Record<string, unknown>;
 
+/**
+ * The repository does NOT store what it is handed: when a save carries parts it
+ * rewrites `content` into the structured envelope
+ * (`message-repository.ts` → `extractStructuredContentFromParts`). A fake that
+ * records the arguments verbatim therefore tests a row shape that never reaches
+ * the database — and every assertion about what is stored would be about
+ * something imaginary. This mirrors that rewrite.
+ */
+const asStored = async (args: Record<string, unknown>): Promise<SavedRow> => {
+  const uiMessage = args.uiMessage as { parts?: UIMessage['parts'] } | undefined;
+  if (!uiMessage?.parts?.length) return args as SavedRow;
+  return {
+    ...args,
+    content: await extractStructuredContentFromParts(uiMessage.parts, args.content as string),
+  };
+};
+
 function deps(over: Partial<TranscriptPersistenceDeps> = {}) {
   const global: SavedRow[] = [];
   const page: SavedRow[] = [];
@@ -32,11 +55,11 @@ function deps(over: Partial<TranscriptPersistenceDeps> = {}) {
     createConversation: vi.fn(async () => conversation()),
     canAccess: vi.fn(async () => true),
     saveGlobalMessage: async (args) => {
-      global.push(args as SavedRow);
+      global.push(await asStored(args as Record<string, unknown>));
       return { saved: true, rev: 7 };
     },
     savePageMessage: async (args) => {
-      page.push(args as SavedRow);
+      page.push(await asStored(args as Record<string, unknown>));
       return { saved: true, rev: 7 };
     },
     newMessageId: vi.fn(() => 'minted1'),
@@ -84,17 +107,18 @@ describe('persistVoiceToolActivity — the running row', () => {
     expect(result).toMatchObject({ saved: true, messageId: 'minted1', rev: 7 });
   });
 
-  it('should write NO text, because nothing was said', async () => {
-    // Load-bearing, not an omission. `buildRealtimeSeed` replays a message's
-    // `content` as an utterance, so a label here would seed the next call with
+  it('should store NO text, because nothing was said', async () => {
+    // Load-bearing, not an omission. The seed replays a message's words as an
+    // utterance, so a label here would seed the next call with
     // "Read Page: Roadmap" as though the assistant had said it — and spend the
-    // seed's turn budget on things nobody said. The renderer builds its text
-    // from parts, so the row still shows as a tool card.
+    // seed's turn budget on things nobody said. Asserted through the reader the
+    // seed actually uses, because the stored column is an envelope, not text.
     const { deps: d, global } = deps();
 
     await persistVoiceToolActivity(d, running);
 
-    expect(global[0]).toMatchObject({ content: '', role: 'assistant' });
+    expect(global[0].role).toBe('assistant');
+    expect(readMessageText(global[0].content as string)).toBe('');
   });
 
   it('should be written even though it has no text', async () => {
@@ -232,5 +256,76 @@ describe('persistVoiceToolActivity — it takes the same guarded path a transcri
 
     expect(global).toEqual([]);
     expect(result.skipped).toBe('history_deleted');
+  });
+});
+
+/**
+ * The claim being tested is "it is still there when you come back to the
+ * thread". Live delivery rides `uiMessage` on the socket event; a RELOAD
+ * rebuilds the parts from the stored columns instead, so the two can disagree
+ * — and a row that renders once and then vanishes on refresh is worse than one
+ * that never rendered.
+ *
+ * This drives the real reconstruction the thread uses, over exactly what the
+ * writer produced, with no database in between.
+ */
+describe('persistVoiceToolActivity — what comes back after a reload', () => {
+  const reload = async (row: SavedRow) =>
+    convertGlobalAssistantMessageToUIMessage({
+      id: row.messageId as string,
+      conversationId: 'conv1',
+      userId: null,
+      role: 'assistant',
+      content: row.content as string,
+      toolCalls: row.toolCalls ?? null,
+      toolResults: row.toolResults ?? null,
+      createdAt: new Date(0),
+    } as Parameters<typeof convertGlobalAssistantMessageToUIMessage>[0]);
+
+  it('should come back as the same tool part it was written as', async () => {
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, {
+      ...running,
+      messageId: 'm1',
+      output: 'Line 1\nLine 2',
+    });
+    const message = await reload(global[0]);
+
+    expect(message.parts).toHaveLength(1);
+    expect(message.parts[0]).toMatchObject({
+      type: 'tool-read_page',
+      toolCallId: 'call_1',
+      state: 'output-available',
+      output: 'Line 1\nLine 2',
+    });
+  });
+
+  it('given a failed tool, should still come back as an error', async () => {
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, {
+      ...running,
+      messageId: 'm1',
+      output: 'ignored',
+      errorText: "That didn't work: permission denied",
+    });
+    const message = await reload(global[0]);
+
+    expect(message.parts[0]).toMatchObject({
+      state: 'output-error',
+      errorText: "That didn't work: permission denied",
+    });
+  });
+
+  it('should not reappear as a spoken turn — it never said anything', async () => {
+    // The row carries no text, so a reload must not invent an empty utterance
+    // above the tool card.
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, { ...running, messageId: 'm1', output: 'ok' });
+    const message = await reload(global[0]);
+
+    expect(message.parts.filter((part) => part.type === 'text')).toEqual([]);
   });
 });

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-activity-persistence.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-activity-persistence.test.ts
@@ -1,0 +1,223 @@
+/**
+ * A voice tool call, as a row in the thread.
+ *
+ * The cases that matter are the ones about SHAPE: this row is only useful
+ * because it is byte-for-byte the shape the typed surface already produces, so
+ * the renderer, the socket payload and the reload path all accept it without
+ * knowing voice exists. A part that is nearly right renders as nothing.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { persistVoiceToolActivity } from '../tool-activity-persistence';
+import type { TranscriptPersistenceDeps } from '../transcript-persistence';
+
+const conversation = (over: Record<string, unknown> = {}) => ({
+  id: 'conv1',
+  userId: 'u1',
+  isShared: false,
+  type: 'global',
+  contextId: null,
+  isActive: true,
+  ...over,
+});
+
+/** Whatever reached the repository, in the order it got there. */
+type SavedRow = Record<string, unknown>;
+
+function deps(over: Partial<TranscriptPersistenceDeps> = {}) {
+  const global: SavedRow[] = [];
+  const page: SavedRow[] = [];
+  const base: TranscriptPersistenceDeps = {
+    loadConversation: vi.fn(async () => conversation()),
+    createConversation: vi.fn(async () => conversation()),
+    canAccess: vi.fn(async () => true),
+    saveGlobalMessage: async (args) => {
+      global.push(args as SavedRow);
+      return { saved: true, rev: 7 };
+    },
+    savePageMessage: async (args) => {
+      page.push(args as SavedRow);
+      return { saved: true, rev: 7 };
+    },
+    newMessageId: vi.fn(() => 'minted1'),
+    logger: { warn: vi.fn() },
+    ...over,
+  };
+  return { deps: base, global, page };
+}
+
+const running = {
+  callId: 'rtc_1',
+  userId: 'u1',
+  conversationId: 'conv1',
+  toolCallId: 'call_1',
+  name: 'read_page',
+  argumentsJson: '{"title":"Roadmap"}',
+};
+
+/** The tool part the row was written with. */
+const partOf = (rows: SavedRow[]): Record<string, unknown> =>
+  (rows[0]?.uiMessage as { parts: Record<string, unknown>[] }).parts[0];
+
+describe('persistVoiceToolActivity — the running row', () => {
+  it('should write a tool part in the shape the typed surface produces', async () => {
+    // `chunkToPart` emits exactly this. Every renderer and the reload path key
+    // off it, so matching it is what buys all of them.
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, running);
+
+    expect(partOf(global)).toEqual({
+      type: 'tool-read_page',
+      toolCallId: 'call_1',
+      toolName: 'read_page',
+      input: { title: 'Roadmap' },
+      state: 'input-available',
+    });
+  });
+
+  it('should answer with the row id, which is the only way the result finds it', async () => {
+    const { deps: d } = deps();
+
+    const result = await persistVoiceToolActivity(d, running);
+
+    expect(result).toMatchObject({ saved: true, messageId: 'minted1', rev: 7 });
+  });
+
+  it('should carry a readable body, not the raw output', async () => {
+    // The body is what a surface that cannot render parts shows, and what a
+    // notification would quote.
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, running);
+
+    expect(global[0]).toMatchObject({
+      content: 'Read Page: Roadmap',
+      role: 'assistant',
+    });
+  });
+
+  it('should mark the row as spoken, so the thread shows the mic glyph', async () => {
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, running);
+
+    expect(global[0].source).toBe('voice');
+  });
+});
+
+describe('persistVoiceToolActivity — the finished row', () => {
+  it('should reuse the id it was given rather than minting a second row', async () => {
+    // Same id ⇒ the repository updates in place and emits messageUpdated. A new
+    // id would leave a spinner stranded above its own result.
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, {
+      ...running,
+      messageId: 'm1',
+      output: 'Line 1\nLine 2',
+    });
+
+    expect(global[0].messageId).toBe('m1');
+    expect(d.newMessageId).not.toHaveBeenCalled();
+  });
+
+  it('should move the part to output-available and carry what the model saw', async () => {
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, { ...running, messageId: 'm1', output: 'Line 1' });
+
+    expect(partOf(global)).toMatchObject({
+      state: 'output-available',
+      output: 'Line 1',
+    });
+  });
+
+  it('given a failed tool, should render as an error rather than an empty result', async () => {
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, {
+      ...running,
+      messageId: 'm1',
+      output: 'ignored',
+      errorText: 'The tool could not be reached.',
+    });
+
+    expect(partOf(global)).toMatchObject({
+      state: 'output-error',
+      errorText: 'The tool could not be reached.',
+    });
+  });
+
+  it('should populate the columns a reload rebuilds the parts from', async () => {
+    // Live delivery rides `uiMessage`; a refresh rebuilds from these. Without
+    // both, the call renders once and then disappears.
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, { ...running, messageId: 'm1', output: 'Line 1' });
+
+    expect(global[0].toolCalls).toHaveLength(1);
+    expect(global[0].toolResults).toHaveLength(1);
+  });
+});
+
+describe('persistVoiceToolActivity — arguments as they actually arrive', () => {
+  it('given arguments that will not parse, should still record the call', async () => {
+    // Assembled from streamed deltas. The copy that must be right is parsed in
+    // `tool-dispatch.ts`; losing the row over it would hide a call that ran.
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, { ...running, argumentsJson: '{"title":' });
+
+    expect(partOf(global)).toMatchObject({
+      toolName: 'read_page',
+      input: { raw: '{"title":' },
+    });
+  });
+
+  it('given no arguments, should record an empty object rather than nothing', async () => {
+    const { deps: d, global } = deps();
+
+    await persistVoiceToolActivity(d, { ...running, name: 'list_drives', argumentsJson: '' });
+
+    expect(partOf(global)).toMatchObject({ input: {} });
+  });
+});
+
+describe('persistVoiceToolActivity — it takes the same guarded path a transcript does', () => {
+  it('given a caller who cannot read the conversation, should write nothing', async () => {
+    const { deps: d, global } = deps({ canAccess: vi.fn(async () => false) });
+
+    const result = await persistVoiceToolActivity(d, running);
+
+    expect(global).toEqual([]);
+    expect(result.saved).toBe(false);
+  });
+
+  it('given a page conversation, should attribute the row to the agent', async () => {
+    // `userId: null` with `sourceAgentId` is the attribution rule for an
+    // agent-authored row, and a tool call is agent-authored.
+    const { deps: d, page } = deps({
+      loadConversation: vi.fn(async () => conversation({ type: 'page', contextId: 'agent1' })),
+    });
+
+    await persistVoiceToolActivity(d, running);
+
+    expect(page[0]).toMatchObject({
+      pageId: 'agent1',
+      userId: null,
+      sourceAgentId: 'agent1',
+    });
+  });
+
+  it('given a deleted conversation, should refuse rather than write somewhere unreachable', async () => {
+    const { deps: d, global } = deps({
+      loadConversation: vi.fn(async () => conversation({ isActive: false })),
+    });
+
+    const result = await persistVoiceToolActivity(d, running);
+
+    expect(global).toEqual([]);
+    expect(result.skipped).toBe('history_deleted');
+  });
+});

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   buildVoiceToolContext,
   dispatchRealtimeToolCall,
   formatToolResult,
+  MAX_RESULT_CHARS,
   parseToolArguments,
   type RealtimeToolDispatchDeps,
   type RealtimeToolDispatchRequest,
@@ -119,8 +120,8 @@ describe('formatToolResult', () => {
   it('given a LONG result, should hand the model all of it', () => {
     // This used to be cut at 700 characters on the reasoning that a spoken
     // answer cannot be skimmed — which is a rule about what the model says, not
-    // about what it is allowed to know. The typed surface caps nothing, and
-    // this is the same agent.
+    // about what it is allowed to know. 5,500 characters is far past the old
+    // ceiling and nowhere near the session's.
     const long = 'alpha beta '.repeat(500);
 
     expect(formatToolResult(long)).toBe(long.trim());
@@ -128,7 +129,27 @@ describe('formatToolResult', () => {
 
   it('should never invent a continuation hint about content it did not drop', () => {
     expect(formatToolResult('x'.repeat(5000))).toBe('x'.repeat(5000));
-    expect(formatToolResult('alpha beta '.repeat(500))).not.toContain('were not read out');
+    expect(formatToolResult('alpha beta '.repeat(500))).not.toContain('were not returned');
+  });
+
+  it('given a result that would not FIT in the session, should cut it and say how to ask again', () => {
+    // A realtime session is 32k tokens shared with the audio, and a
+    // `function_call_output` stays in it — so one result can end a call. Not a
+    // speech rule: the model summarises for the listener either way.
+    const huge = 'word '.repeat(6000);
+
+    const spoken = formatToolResult(huge);
+
+    expect(spoken.length).toBeLessThan(MAX_RESULT_CHARS + 400);
+    expect(spoken).toContain('characters were not returned');
+    // Named because they are the two shapes that actually get cut.
+    expect(spoken).toContain('tool_search("select:exact_name")');
+    expect(spoken).toContain('lineStart/lineEnd');
+  });
+
+  it('should cut at a word boundary rather than mid-token', () => {
+    const spoken = formatToolResult('alpha beta '.repeat(3000));
+    expect(spoken.split('…')[0].endsWith('alpha') || spoken.split('…')[0].endsWith('beta')).toBe(true);
   });
 
   it('given a circular structure, should not throw', () => {
@@ -141,29 +162,49 @@ describe('formatToolResult', () => {
     expect(formatToolResult(() => 1)).not.toBe('');
   });
 
-  it('should hand back a tool_search result the model can actually parse', async () => {
+  it('should hand back a schema lookup the model can actually parse', async () => {
     // THE FAILURE THIS EXISTS FOR. `tool_search` answers with JSON Schemas, and
-    // a keyword like "calendar" matches enough tools to run to several thousand
-    // characters. Cut to 700 it arrived sliced mid-object, so the model could
-    // not build the `execute_tool` call it went looking for — it guessed
-    // parameters, failed validation, and tried again. That loop is what "it
-    // doesn't navigate tool calls" looked like from the outside.
+    // at 700 characters they arrived sliced mid-object — so the model could not
+    // build the `execute_tool` call it went looking for. It guessed parameters,
+    // failed validation, and tried again. That loop is what "it doesn't
+    // navigate tool calls" looked like from the outside.
+    //
+    // `select:` is the lookup `TOOL_DISCOVERY_PROMPT` actually instructs before
+    // calling a tool, so it is the path that has to survive whole. Measured at
+    // ~7k characters for two tools, comfortably inside the ceiling.
     const search = buildRealtimeToolExposure(buildPageSpaceTools()).tools.tool_search;
     const raw = await (search.execute as (a: unknown, o: unknown) => unknown)(
-      { query: 'calendar' },
+      { query: 'select:create_task,update_task' },
       { experimental_context: {}, toolCallId: 't1', messages: [] },
     );
 
     const spoken = formatToolResult(raw);
 
-    expect(spoken.length).toBeGreaterThan(2000);
+    expect(spoken).not.toContain('were not returned');
     const parsed = JSON.parse(spoken) as { tools: { name: string; inputSchema: unknown }[] };
-    expect(parsed.tools.length).toBeGreaterThan(1);
+    expect(parsed.tools).toHaveLength(2);
     // A schema is only useful whole: every matched tool has to arrive with the
     // parameters the model is about to fill in.
     for (const tool of parsed.tools) {
       expect(tool.inputSchema, `${tool.name} arrived without its schema`).toBeTruthy();
     }
+  });
+
+  it('given a BROAD search, should cut it rather than let it end the call', async () => {
+    // Measured: a one-letter query returns ~89k characters, which is ~22k
+    // tokens — most of the session, spent on a dump the model did not need in
+    // full. It is told to ask again by name.
+    const search = buildRealtimeToolExposure(buildPageSpaceTools()).tools.tool_search;
+    const raw = await (search.execute as (a: unknown, o: unknown) => unknown)(
+      { query: 'a' },
+      { experimental_context: {}, toolCallId: 't1', messages: [] },
+    );
+
+    const spoken = formatToolResult(raw);
+
+    expect(JSON.stringify(raw).length).toBeGreaterThan(50_000);
+    expect(spoken.length).toBeLessThan(MAX_RESULT_CHARS + 400);
+    expect(spoken).toContain('tool_search("select:exact_name")');
   });
 });
 
@@ -259,7 +300,7 @@ describe('buildVoiceToolContext', () => {
 describe('dispatchRealtimeToolCall', () => {
   it('given a real tool, should run it and return its formatted result', async () => {
     const execute = vi.fn(async () => ({ title: 'Notes' }));
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({ read_page: spyTool(execute) }),
       request(),
       'gpt-realtime-2.1',
@@ -306,7 +347,7 @@ describe('dispatchRealtimeToolCall', () => {
   });
 
   it('given a tool name that was never advertised, should tell the model how to recover', async () => {
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({ read_page: spyTool(() => 'ok') }),
       request({ name: 'delete_everything' }),
       'gpt-realtime-2.1',
@@ -317,7 +358,7 @@ describe('dispatchRealtimeToolCall', () => {
   });
 
   it('given a tool with no implementation, should say so rather than hang', async () => {
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({
         read_page: { description: 'x', inputSchema: z.object({}) } as unknown as Tool,
       }),
@@ -330,7 +371,7 @@ describe('dispatchRealtimeToolCall', () => {
 
   it('given unreadable arguments, should answer with a sentence rather than run the tool', async () => {
     const execute = vi.fn();
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({ read_page: spyTool(execute) }),
       request({ argumentsJson: '{"pageId": ' }),
       'gpt-realtime-2.1',
@@ -342,7 +383,7 @@ describe('dispatchRealtimeToolCall', () => {
 
   it('given arguments the tool schema rejects, should report the schema, not run the tool', async () => {
     const execute = vi.fn();
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({ read_page: spyTool(execute) }),
       request({ argumentsJson: '{"pageId": 42}' }),
       'gpt-realtime-2.1',
@@ -370,7 +411,7 @@ describe('dispatchRealtimeToolCall', () => {
   });
 
   it('given a throwing tool (a permission refusal), should turn it into something speakable', async () => {
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({
         read_page: spyTool(() => {
           throw new Error("You don't have access to that page");
@@ -384,7 +425,7 @@ describe('dispatchRealtimeToolCall', () => {
   });
 
   it('given a tool that throws a non-Error, should still answer', async () => {
-    const output = await dispatchRealtimeToolCall(
+    const { output } = await dispatchRealtimeToolCall(
       deps({
         read_page: spyTool(() => {
           throw 'nope';
@@ -395,20 +436,6 @@ describe('dispatchRealtimeToolCall', () => {
     );
 
     expect(output).toContain('nope');
-  });
-
-  it('given a huge tool result, should return the whole thing', async () => {
-    // A page read is the case that matters: 700 characters of a document is
-    // neither a summary the model can give nor enough to edit from, because
-    // `replace_lines` works off line numbers in a full read.
-    const page = 'word '.repeat(5000);
-    const output = await dispatchRealtimeToolCall(
-      deps({ read_page: spyTool(() => page) }),
-      request(),
-      'gpt-realtime-2.1',
-    );
-
-    expect(output).toBe(page.trim());
   });
 
   it('should ALWAYS return a string — function_call_output cannot carry anything else', async () => {
@@ -426,8 +453,60 @@ describe('dispatchRealtimeToolCall', () => {
       ),
     ];
 
-    for (const output of await Promise.all(cases)) {
+    for (const { output } of await Promise.all(cases)) {
       expect(typeof output).toBe('string');
     }
+  });
+
+  it('should say whether the TOOL failed, not just whether the hop did', async () => {
+    // Every failure below still returns a speakable sentence, because the model
+    // is blocked on `function_call_output` until it gets one. That is exactly
+    // why a second answer is needed: without it, a permission error is written
+    // into the thread as a completed tool call, rendered green.
+    const failing = [
+      // Unadvertised tool.
+      dispatchRealtimeToolCall(deps({}), request(), 'gpt-realtime-2.1'),
+      // No implementation.
+      dispatchRealtimeToolCall(
+        deps({ read_page: { description: 'x', inputSchema: z.object({}) } as Tool }),
+        request(),
+        'gpt-realtime-2.1',
+      ),
+      // Unreadable arguments.
+      dispatchRealtimeToolCall(
+        deps({ read_page: spyTool(() => 'ok') }),
+        request({ argumentsJson: 'not json' }),
+        'gpt-realtime-2.1',
+      ),
+      // Arguments the schema refuses.
+      dispatchRealtimeToolCall(
+        deps({ read_page: spyTool(() => 'ok') }),
+        request({ argumentsJson: '{"pageId":42}' }),
+        'gpt-realtime-2.1',
+      ),
+      // A tool that threw.
+      dispatchRealtimeToolCall(
+        deps({
+          read_page: spyTool(() => {
+            throw new Error('permission denied');
+          }),
+        }),
+        request(),
+        'gpt-realtime-2.1',
+      ),
+    ];
+
+    for (const outcome of await Promise.all(failing)) {
+      expect(outcome.failed, outcome.output).toBe(true);
+      // Still speakable: the model must never be left waiting.
+      expect(outcome.output.length).toBeGreaterThan(0);
+    }
+
+    const worked = await dispatchRealtimeToolCall(
+      deps({ read_page: spyTool(() => 'Two pages.') }),
+      request(),
+      'gpt-realtime-2.1',
+    );
+    expect(worked).toEqual({ output: 'Two pages.', failed: false });
   });
 });

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
@@ -142,8 +142,10 @@ describe('formatToolResult', () => {
 
     expect(spoken.length).toBeLessThan(MAX_RESULT_CHARS + 400);
     expect(spoken).toContain('characters were not returned');
-    // Named because they are the two shapes that actually get cut.
-    expect(spoken).toContain('tool_search("select:exact_name")');
+    // Leads with the general instruction, because a truncated listing or
+    // search is the common case and neither specific escape fits it.
+    expect(spoken).toContain('Ask again for less');
+    expect(spoken).toContain('tool_search("select:name")');
     expect(spoken).toContain('lineStart/lineEnd');
   });
 
@@ -204,7 +206,7 @@ describe('formatToolResult', () => {
 
     expect(JSON.stringify(raw).length).toBeGreaterThan(50_000);
     expect(spoken.length).toBeLessThan(MAX_RESULT_CHARS + 400);
-    expect(spoken).toContain('tool_search("select:exact_name")');
+    expect(spoken).toContain('Ask again for less');
   });
 });
 

--- a/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/tool-dispatch.test.ts
@@ -5,12 +5,13 @@ import {
   buildVoiceToolContext,
   dispatchRealtimeToolCall,
   formatToolResult,
-  MAX_SPOKEN_RESULT_CHARS,
   parseToolArguments,
   type RealtimeToolDispatchDeps,
   type RealtimeToolDispatchRequest,
 } from '../tool-dispatch';
 import type { ToolExecutionContext } from '../../core/types';
+import { buildRealtimeToolExposure } from '../tools';
+import { buildPageSpaceTools } from '../../core/ai-tools';
 
 const logger = () => ({ warn: vi.fn(), error: vi.fn() });
 
@@ -115,24 +116,19 @@ describe('formatToolResult', () => {
     expect(formatToolResult(null)).toBe('Done.');
   });
 
-  it('given a long result, should cut at a word boundary and say how much was left', () => {
+  it('given a LONG result, should hand the model all of it', () => {
+    // This used to be cut at 700 characters on the reasoning that a spoken
+    // answer cannot be skimmed — which is a rule about what the model says, not
+    // about what it is allowed to know. The typed surface caps nothing, and
+    // this is the same agent.
     const long = 'alpha beta '.repeat(500);
-    const spoken = formatToolResult(long);
 
-    expect(spoken.length).toBeLessThan(long.length);
-    expect(spoken).toContain('more characters were not read out');
-    // Never a severed word.
-    expect(spoken.split('…')[0].endsWith('beta') || spoken.split('…')[0].endsWith('alpha')).toBe(true);
+    expect(formatToolResult(long)).toBe(long.trim());
   });
 
-  it('given a long result with no spaces, should still cut it', () => {
-    const spoken = formatToolResult('x'.repeat(5000));
-    expect(spoken.length).toBeLessThan(5000);
-  });
-
-  it('given a result exactly at the cap, should not truncate', () => {
-    const exact = 'y'.repeat(MAX_SPOKEN_RESULT_CHARS);
-    expect(formatToolResult(exact)).toBe(exact);
+  it('should never invent a continuation hint about content it did not drop', () => {
+    expect(formatToolResult('x'.repeat(5000))).toBe('x'.repeat(5000));
+    expect(formatToolResult('alpha beta '.repeat(500))).not.toContain('were not read out');
   });
 
   it('given a circular structure, should not throw', () => {
@@ -143,6 +139,31 @@ describe('formatToolResult', () => {
 
   it('given a value JSON.stringify drops, should fall back to a string', () => {
     expect(formatToolResult(() => 1)).not.toBe('');
+  });
+
+  it('should hand back a tool_search result the model can actually parse', async () => {
+    // THE FAILURE THIS EXISTS FOR. `tool_search` answers with JSON Schemas, and
+    // a keyword like "calendar" matches enough tools to run to several thousand
+    // characters. Cut to 700 it arrived sliced mid-object, so the model could
+    // not build the `execute_tool` call it went looking for — it guessed
+    // parameters, failed validation, and tried again. That loop is what "it
+    // doesn't navigate tool calls" looked like from the outside.
+    const search = buildRealtimeToolExposure(buildPageSpaceTools()).tools.tool_search;
+    const raw = await (search.execute as (a: unknown, o: unknown) => unknown)(
+      { query: 'calendar' },
+      { experimental_context: {}, toolCallId: 't1', messages: [] },
+    );
+
+    const spoken = formatToolResult(raw);
+
+    expect(spoken.length).toBeGreaterThan(2000);
+    const parsed = JSON.parse(spoken) as { tools: { name: string; inputSchema: unknown }[] };
+    expect(parsed.tools.length).toBeGreaterThan(1);
+    // A schema is only useful whole: every matched tool has to arrive with the
+    // parameters the model is about to fill in.
+    for (const tool of parsed.tools) {
+      expect(tool.inputSchema, `${tool.name} arrived without its schema`).toBeTruthy();
+    }
   });
 });
 
@@ -376,15 +397,18 @@ describe('dispatchRealtimeToolCall', () => {
     expect(output).toContain('nope');
   });
 
-  it('given a huge tool result, should truncate before returning it', async () => {
+  it('given a huge tool result, should return the whole thing', async () => {
+    // A page read is the case that matters: 700 characters of a document is
+    // neither a summary the model can give nor enough to edit from, because
+    // `replace_lines` works off line numbers in a full read.
+    const page = 'word '.repeat(5000);
     const output = await dispatchRealtimeToolCall(
-      deps({ read_page: spyTool(() => 'word '.repeat(5000)) }),
+      deps({ read_page: spyTool(() => page) }),
       request(),
       'gpt-realtime-2.1',
     );
 
-    expect(output.length).toBeLessThan(1000);
-    expect(output).toContain('were not read out');
+    expect(output).toBe(page.trim());
   });
 
   it('should ALWAYS return a string — function_call_output cannot carry anything else', async () => {

--- a/apps/web/src/lib/ai/realtime/__tests__/voice-bridge-contract-drift.test.ts
+++ b/apps/web/src/lib/ai/realtime/__tests__/voice-bridge-contract-drift.test.ts
@@ -12,14 +12,16 @@
  * a 400 from the attach endpoint, for a reason nobody can see from here).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  voiceBridgeRequestSchema,
   realtimeToolSchema,
   realtimeAttachPayloadSchema,
   realtimeSeedEventSchema,
   type RealtimeSeedEventWire,
 } from '@pagespace/lib/realtime/voice-bridge-contract';
 import { buildRealtimeToolExposure, toRealtimeTools } from '../tools';
+import { handleVoiceBridgeRequest } from '../bridge-handler';
 import { buildRealtimeSeed, type SeedEvent } from '../seed';
 import { buildPageSpaceTools } from '../../core/ai-tools';
 import type { RealtimeTool } from '../session';
@@ -143,5 +145,86 @@ describe('realtime seed wire shape', () => {
         item: { type: 'message', role: 'user', content: [] },
       }).success,
     ).toBe(false);
+  });
+});
+
+/**
+ * The request union and the handler that narrows it.
+ *
+ * `handleVoiceBridgeRequest` used to narrow `kind === 'tool'` and then FALL
+ * THROUGH to the transcript write, so a kind added to the schema would have
+ * been persisted as a spoken turn — a wrong row, written confidently, with
+ * nothing raised anywhere. The handler is exhaustive now; this is what keeps it
+ * that way, because the next member will be added by someone who has not read
+ * that story.
+ */
+describe('every request kind is handled', () => {
+  const kinds = voiceBridgeRequestSchema.options.map(
+    (option) => (option.shape.kind as { value: string }).value,
+  );
+
+  it('should know exactly which kinds exist', () => {
+    // Fails when a member is added, which is the prompt to handle it below.
+    expect(kinds.sort()).toEqual(['tool', 'tool_finished', 'tool_started', 'transcript']);
+  });
+
+  it('should route every one of them without falling through to the transcript write', async () => {
+    const transcriptDeps = {
+      loadConversation: vi.fn(async () => ({
+        id: 'conv1',
+        userId: 'u1',
+        isShared: false,
+        type: 'global',
+        contextId: null,
+        isActive: true,
+      })),
+      createConversation: vi.fn(),
+      canAccess: vi.fn(async () => true),
+      saveGlobalMessage: vi.fn(async () => ({ saved: true, rev: 1 })),
+      savePageMessage: vi.fn(async () => ({ saved: true, rev: 1 })),
+      newMessageId: vi.fn(() => 'm1'),
+      logger: { warn: vi.fn() },
+    };
+    const deps = {
+      toolDeps: () => ({ tools: {}, logger: { warn: vi.fn(), error: vi.fn() } }),
+      transcriptDeps,
+      model: 'gpt-realtime-2.1',
+    } as unknown as Parameters<typeof handleVoiceBridgeRequest>[0];
+
+    const base = { callId: 'rtc_1', userId: 'u1', conversationId: 'conv1' };
+    const bodies: Record<string, unknown> = {
+      tool: { ...base, kind: 'tool', name: 'read_page', argumentsJson: '{}' },
+      transcript: { ...base, kind: 'transcript', role: 'assistant', text: 'hello' },
+      tool_started: {
+        ...base,
+        kind: 'tool_started',
+        toolCallId: 'call_1',
+        name: 'read_page',
+        argumentsJson: '{}',
+      },
+      tool_finished: {
+        ...base,
+        kind: 'tool_finished',
+        toolCallId: 'call_1',
+        name: 'read_page',
+        argumentsJson: '{}',
+        messageId: 'm1',
+        output: 'ok',
+      },
+    };
+
+    for (const kind of kinds) {
+      const response = await handleVoiceBridgeRequest(deps, JSON.stringify(bodies[kind]));
+
+      expect(response.status, `${kind} was refused`).toBe(200);
+      expect(response.body.ok, `${kind} failed`).toBe(true);
+      // The tell for a fallthrough: a kind answered as though it were a transcript.
+      if (kind !== 'transcript') {
+        expect(
+          response.body.ok && response.body.kind,
+          `${kind} was answered as a ${response.body.ok ? response.body.kind : ''}`,
+        ).not.toBe('transcript');
+      }
+    }
   });
 });

--- a/apps/web/src/lib/ai/realtime/bridge-handler.ts
+++ b/apps/web/src/lib/ai/realtime/bridge-handler.ts
@@ -80,7 +80,7 @@ export const handleVoiceBridgeRequest = async (
     // resolve a name in, and the `enabledTools` that `execute_tool` re-checks
     // off the execution context. An agent with no allowlist configured is
     // `null` — unrestricted — and the Global Assistant has no agent at all.
-    const output = await dispatchRealtimeToolCall(
+    const outcome = await dispatchRealtimeToolCall(
       deps.toolDeps(request.assistant?.enabledTools ?? null),
       {
         name: request.name,
@@ -98,7 +98,10 @@ export const handleVoiceBridgeRequest = async (
       },
       deps.model,
     );
-    return { status: 200, body: { ok: true, kind: 'tool', output } };
+    return {
+      status: 200,
+      body: { ok: true, kind: 'tool', output: outcome.output, failed: outcome.failed },
+    };
   }
 
   if (request.kind === 'tool_started' || request.kind === 'tool_finished') {

--- a/apps/web/src/lib/ai/realtime/bridge-handler.ts
+++ b/apps/web/src/lib/ai/realtime/bridge-handler.ts
@@ -21,6 +21,7 @@ import {
   persistVoiceTranscript,
   type TranscriptPersistenceDeps,
 } from './transcript-persistence';
+import { persistVoiceToolActivity } from './tool-activity-persistence';
 
 export type VoiceBridgeDeps = {
   /**
@@ -98,6 +99,46 @@ export const handleVoiceBridgeRequest = async (
       deps.model,
     );
     return { status: 200, body: { ok: true, kind: 'tool', output } };
+  }
+
+  if (request.kind === 'tool_started' || request.kind === 'tool_finished') {
+    // A record, not a dispatch: nothing is waiting on it, and it answers with
+    // the row's id so the second phase can update that same row.
+    const activity = await persistVoiceToolActivity(deps.transcriptDeps, {
+      callId: request.callId,
+      userId: request.userId,
+      conversationId: request.conversationId,
+      toolCallId: request.toolCallId,
+      name: request.name,
+      argumentsJson: request.argumentsJson,
+      ...(request.kind === 'tool_finished'
+        ? {
+            messageId: request.messageId,
+            output: request.output,
+            ...(request.errorText === undefined ? {} : { errorText: request.errorText }),
+          }
+        : {}),
+    });
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        kind: 'tool_activity',
+        saved: activity.saved,
+        messageId: activity.messageId,
+        rev: activity.rev,
+      },
+    };
+  }
+
+  if (request.kind !== 'transcript') {
+    // Exhaustiveness, and it is load-bearing. This used to fall through to the
+    // transcript write, so a kind added to the schema would have been silently
+    // persisted as a spoken turn — a wrong row, written confidently, with no
+    // error anywhere.
+    const unreachable: never = request;
+    throw new Error(`Unhandled voice bridge request kind: ${JSON.stringify(unreachable)}`);
   }
 
   const result = await persistVoiceTranscript(deps.transcriptDeps, {

--- a/apps/web/src/lib/ai/realtime/instructions.ts
+++ b/apps/web/src/lib/ai/realtime/instructions.ts
@@ -136,6 +136,7 @@ ${identity} Everything above still applies EXCEPT where this section overrides i
 
 ## Acting — these OVERRIDE the guidance above
 - "Skip preambles" does NOT apply here. Say one short line AS you call a tool, then call it immediately, so the pause is not silence. Vary these: "One moment." "Let me check." "Pulling that up." "Adding that now."
+- BEFORE EVERY TOOL CALL, not just the first. Two calls in a row is two short lines, not one line and a long silence. If a result sends you looking again, say what you found before you go: "Found the drive — now finding the page."
 - A filler must NOT imply success or failure. Never say you found or changed something before the tool has returned.
 - DO NOT ASK PERMISSION TO USE A TOOL. When you know what the caller wants, do it, then say what you did.
 - Chain tools. A request that needs four calls gets four calls, not a question after the first.

--- a/apps/web/src/lib/ai/realtime/session-state.ts
+++ b/apps/web/src/lib/ai/realtime/session-state.ts
@@ -1,4 +1,9 @@
-import { extractTranscript, type TranscriptEntry } from '@pagespace/lib/realtime/voice-events';
+import {
+  extractFunctionCalls,
+  extractTranscript,
+  type TranscriptEntry,
+} from '@pagespace/lib/realtime/voice-events';
+import { describeToolCall } from '../tools/tool-labels';
 // Type-only, so no runtime edge is created from this pure module to the
 // browser-side connector: the union is DEFINED there because that is where the
 // failures are classified, and restating it here would be a second copy free to
@@ -13,6 +18,7 @@ import type { VoiceConnectFailure } from './connect';
  * Pure: no I/O, no clock, no randomness, no module-level mutable state.
  */
 
+/** One tool the model is off running right now, as the call bar says it. */
 export type ToolActivity = {
   readonly name: string;
   readonly speech: string;
@@ -37,7 +43,16 @@ export type SessionState = {
   /** Whether the user is mid-utterance — distinct from being connected. */
   readonly userSpeaking: boolean;
   readonly transcript: readonly TranscriptEntry[];
-  readonly tools: readonly ToolActivity[];
+  /**
+   * What the model is doing WHILE IT IS NOT TALKING — the dead air after "let
+   * me check that", which was previously shown as nothing at all.
+   *
+   * Deliberately the tools running NOW rather than a log of every tool the call
+   * has used. A growing list would pin the call bar's status line on the first
+   * tool that ever ran, because that line prefers a tool over everything else;
+   * and the history of the call belongs in the thread, which records it.
+   */
+  readonly activeTools: readonly ToolActivity[];
 };
 
 export const initialSessionState: SessionState = {
@@ -46,7 +61,7 @@ export const initialSessionState: SessionState = {
   failure: undefined,
   userSpeaking: false,
   transcript: [],
-  tools: [],
+  activeTools: [],
 };
 
 export type SessionAction =
@@ -59,11 +74,27 @@ export type SessionAction =
       readonly failure?: VoiceConnectFailure;
     }
   | { readonly type: 'disconnected' }
-  | { readonly type: 'event'; readonly event: unknown }
-  | { readonly type: 'tool'; readonly name: string; readonly speech: string };
+  | { readonly type: 'event'; readonly event: unknown };
 
 const SPEECH_STARTED = 'input_audio_buffer.speech_started';
 const SPEECH_STOPPED = 'input_audio_buffer.speech_stopped';
+const RESPONSE_DONE = 'response.done';
+
+/**
+ * A tool call's arguments, for labelling only.
+ *
+ * The string is assembled from streamed deltas and is not guaranteed to parse.
+ * A label is never worth throwing over inside a reducer, so a bad payload
+ * simply costs the subject, not the label — `tool-dispatch.ts` owns the
+ * recovery that matters, on the copy the tool actually runs against.
+ */
+const parseArguments = (argumentsJson: string): unknown => {
+  try {
+    return JSON.parse(argumentsJson);
+  } catch {
+    return undefined;
+  }
+};
 
 const eventType = (event: unknown): string | undefined => {
   if (typeof event !== 'object' || event === null) {
@@ -97,12 +128,6 @@ export const sessionReducer = (
     case 'disconnected':
       return { ...state, status: 'idle', userSpeaking: false, failure: undefined };
 
-    case 'tool':
-      return {
-        ...state,
-        tools: [...state.tools, { name: action.name, speech: action.speech }],
-      };
-
     case 'event': {
       const type = eventType(action.event);
       if (type === SPEECH_STARTED) {
@@ -111,12 +136,33 @@ export const sessionReducer = (
       if (type === SPEECH_STOPPED) {
         return { ...state, userSpeaking: false };
       }
+
+      // A completed response is where a tool call is announced, and it is also
+      // the moment the model stops talking — so it both starts the activity and
+      // is the only place that can report there is none.
+      if (type === RESPONSE_DONE) {
+        const calls = extractFunctionCalls(action.event);
+        const activeTools = calls.map((call) => ({
+          name: call.name,
+          speech: describeToolCall(call.name, parseArguments(call.argumentsJson)),
+        }));
+        // Cleared, not left alone, when a response carried no calls: that is the
+        // model having finished a turn on its own.
+        if (activeTools.length === 0 && state.activeTools.length === 0) return state;
+        return { ...state, activeTools };
+      }
+
       const entry = extractTranscript(action.event);
       // Same object back when nothing changed — an unrelated event must not
       // churn identity and re-render the UI.
-      return entry
-        ? { ...state, transcript: [...state.transcript, entry] }
-        : state;
+      if (!entry) return state;
+      return {
+        ...state,
+        transcript: [...state.transcript, entry],
+        // The model is speaking again, so whatever it went away to do is done.
+        // This is what bounds the status line to exactly the silent window.
+        activeTools: state.activeTools.length === 0 ? state.activeTools : [],
+      };
     }
   }
 };

--- a/apps/web/src/lib/ai/realtime/session-state.ts
+++ b/apps/web/src/lib/ai/realtime/session-state.ts
@@ -109,11 +109,27 @@ export const sessionReducer = (
   action: SessionAction,
 ): SessionState => {
   switch (action.type) {
+    // `activeTools` is cleared on every lifecycle edge below: a call that is
+    // starting, has just started, has failed or has ended is not running a
+    // tool. Left alone, the bar would show the PREVIOUS call's tool as live
+    // for the whole first silent turn of the next one.
     case 'connecting':
-      return { ...state, status: 'connecting', error: undefined, failure: undefined };
+      return {
+        ...state,
+        status: 'connecting',
+        error: undefined,
+        failure: undefined,
+        activeTools: [],
+      };
 
     case 'connected':
-      return { ...state, status: 'connected', error: undefined, failure: undefined };
+      return {
+        ...state,
+        status: 'connected',
+        error: undefined,
+        failure: undefined,
+        activeTools: [],
+      };
 
     case 'failed':
       // Keep the transcript: a drop mid-conversation must not erase the record.
@@ -123,10 +139,17 @@ export const sessionReducer = (
         error: action.message,
         failure: action.failure,
         userSpeaking: false,
+        activeTools: [],
       };
 
     case 'disconnected':
-      return { ...state, status: 'idle', userSpeaking: false, failure: undefined };
+      return {
+        ...state,
+        status: 'idle',
+        userSpeaking: false,
+        failure: undefined,
+        activeTools: [],
+      };
 
     case 'event': {
       const type = eventType(action.event);
@@ -159,9 +182,12 @@ export const sessionReducer = (
       return {
         ...state,
         transcript: [...state.transcript, entry],
-        // The model is speaking again, so whatever it went away to do is done.
-        // This is what bounds the status line to exactly the silent window.
-        activeTools: state.activeTools.length === 0 ? state.activeTools : [],
+        // ONLY the assistant speaking ends the tool window. `extractTranscript`
+        // also returns the CALLER's transcripts, and someone talking over a
+        // running tool must not make the bar claim the work has finished — they
+        // are the one waiting on it.
+        activeTools:
+          entry.role === 'assistant' && state.activeTools.length > 0 ? [] : state.activeTools,
       };
     }
   }

--- a/apps/web/src/lib/ai/realtime/tool-activity-persistence.ts
+++ b/apps/web/src/lib/ai/realtime/tool-activity-persistence.ts
@@ -1,0 +1,134 @@
+/**
+ * A tool call a voice turn made, written into the thread the way a typed one is.
+ *
+ * WHY THIS EXISTS. A call used to leave no trace of its work: only what was
+ * SAID was persisted, so the thread showed an assistant announcing an answer
+ * with nothing between the question and it, and a reload showed the same. The
+ * typed surface has recorded tool calls all along — same columns, same parts,
+ * same renderer — and voice simply never sent them.
+ *
+ * Nothing here is new machinery. The part shape is the one `chunkToPart`
+ * produces, the payload is built by the same `buildAssistantPersistencePayload`
+ * the typed path uses, and delivery is the socket event a voice write already
+ * triggers. This module only decides what a tool call looks like as a message.
+ *
+ * TWO WRITES, ONE ROW. `started` creates it in `input-available` — a spinner —
+ * and `finished` names the same `messageId` so the repository UPDATES it into
+ * `output-available` (or `output-error`). That is why the row converges instead
+ * of the thread filling with pairs: `appendPart` replaces a tool part by its
+ * `toolCallId`, and `emitAfterSave` emits `messageUpdated` for a row that
+ * existed.
+ *
+ * IT IS NEVER ON THE MODEL'S PATH. The tool's answer goes back over the socket
+ * from `voice-call-runtime.ts`; this is a record written alongside. A failure
+ * here costs the row, never the turn.
+ */
+
+import type { UIMessage } from 'ai';
+import { buildAssistantPersistencePayload } from '../core/persistAssistantParts';
+import type { UIMessagePart } from '../core/stream-multicast-registry';
+import { describeToolCall } from '../tools/tool-labels';
+import {
+  persistVoiceTranscript,
+  type TranscriptPersistenceDeps,
+  type TranscriptWriteResult,
+} from './transcript-persistence';
+
+export type ToolActivityRequest = {
+  readonly callId: string;
+  readonly userId: string;
+  readonly conversationId: string;
+  /** OpenAI's `function_call.call_id`, which both phases agree on. */
+  readonly toolCallId: string;
+  readonly name: string;
+  readonly argumentsJson: string;
+  /** Absent while running; present to update that row into its result. */
+  readonly messageId?: string;
+  readonly output?: string;
+  readonly errorText?: string;
+};
+
+/**
+ * Arguments as the thread should show them.
+ *
+ * Parsed rather than passed through as a string so the renderer receives the
+ * same `input` shape a typed tool call has — its cards read fields off an
+ * object. A payload that will not parse still shows the call: the raw string is
+ * more useful on screen than an empty card, and this is a record, not a
+ * dispatch. The copy that has to be right is parsed in `tool-dispatch.ts`.
+ */
+const inputFor = (argumentsJson: string): unknown => {
+  const trimmed = argumentsJson.trim();
+  if (trimmed.length === 0) return {};
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return { raw: trimmed };
+  }
+};
+
+/**
+ * The tool part, in the exact shape `chunkToPart` emits for the typed surface.
+ *
+ * Matching it is the whole trick: every renderer, every merge rule and the
+ * reload path are all keyed to this shape, so a voice tool call gets all of
+ * them for free.
+ */
+const toolPart = (request: ToolActivityRequest, input: unknown): UIMessagePart => {
+  const base = {
+    type: `tool-${request.name}`,
+    toolCallId: request.toolCallId,
+    toolName: request.name,
+    input,
+  };
+
+  if (request.errorText !== undefined) {
+    return { ...base, state: 'output-error', errorText: request.errorText } as UIMessagePart;
+  }
+  if (request.output !== undefined) {
+    return { ...base, state: 'output-available', output: request.output } as UIMessagePart;
+  }
+  return { ...base, state: 'input-available' } as UIMessagePart;
+};
+
+/**
+ * Write (or update) the row for one tool call.
+ *
+ * The conversation resolution, the access check and the global-versus-page
+ * attribution are `persistVoiceTranscript`'s, deliberately: those decisions are
+ * security-relevant and there must not be a second copy of them that a spoken
+ * tool call takes instead.
+ *
+ * `content` is the human label rather than the tool's output. It is what a
+ * surface that cannot render parts falls back to, and what a notification would
+ * quote — "Read Page: Roadmap" is a description of the turn; four kilobytes of
+ * JSON is not.
+ */
+export const persistVoiceToolActivity = async (
+  deps: TranscriptPersistenceDeps,
+  request: ToolActivityRequest,
+): Promise<TranscriptWriteResult> => {
+  const messageId = request.messageId ?? deps.newMessageId();
+  const input = inputFor(request.argumentsJson);
+  const part = toolPart(request, input);
+  const payload = buildAssistantPersistencePayload(messageId, [part]);
+
+  return persistVoiceTranscript(
+    deps,
+    {
+      callId: request.callId,
+      userId: request.userId,
+      conversationId: request.conversationId,
+      role: 'assistant',
+      // Never blank: a blank body is the one thing the transcript writer
+      // refuses, and a tool row must not be silently dropped by that guard.
+      text: describeToolCall(request.name, input),
+    },
+    {
+      messageId,
+      uiMessage: payload.uiMessage as UIMessage,
+      ...(payload.toolCalls === undefined ? {} : { toolCalls: payload.toolCalls }),
+      ...(payload.toolResults === undefined ? {} : { toolResults: payload.toolResults }),
+    },
+  );
+};

--- a/apps/web/src/lib/ai/realtime/tool-activity-persistence.ts
+++ b/apps/web/src/lib/ai/realtime/tool-activity-persistence.ts
@@ -27,7 +27,6 @@
 import type { UIMessage } from 'ai';
 import { buildAssistantPersistencePayload } from '../core/persistAssistantParts';
 import type { UIMessagePart } from '../core/stream-multicast-registry';
-import { describeToolCall } from '../tools/tool-labels';
 import {
   persistVoiceTranscript,
   type TranscriptPersistenceDeps,
@@ -99,10 +98,17 @@ const toolPart = (request: ToolActivityRequest, input: unknown): UIMessagePart =
  * security-relevant and there must not be a second copy of them that a spoken
  * tool call takes instead.
  *
- * `content` is the human label rather than the tool's output. It is what a
- * surface that cannot render parts falls back to, and what a notification would
- * quote — "Read Page: Roadmap" is a description of the turn; four kilobytes of
- * JSON is not.
+ * THE ROW HAS NO TEXT, and that is load-bearing rather than an omission.
+ * Nothing was SAID here — the model spoke separately, and that turn is its own
+ * transcript row. Two things depend on this being empty:
+ *   - `buildRealtimeSeed` replays a message's `content` as an utterance, so a
+ *     label here would seed the NEXT call with "Read Page: Roadmap" as though
+ *     the assistant had said it, and spend the seed's turn budget on things
+ *     nobody said;
+ *   - `MessageRenderer` builds its text from PARTS, so a tool row already
+ *     renders correctly with none — it is the tool card, not a sentence.
+ * It is also simply what `buildAssistantPersistencePayload` computes for a
+ * parts array holding one tool part.
  */
 export const persistVoiceToolActivity = async (
   deps: TranscriptPersistenceDeps,
@@ -120,9 +126,7 @@ export const persistVoiceToolActivity = async (
       userId: request.userId,
       conversationId: request.conversationId,
       role: 'assistant',
-      // Never blank: a blank body is the one thing the transcript writer
-      // refuses, and a tool row must not be silently dropped by that guard.
-      text: describeToolCall(request.name, input),
+      text: payload.content,
     },
     {
       messageId,

--- a/apps/web/src/lib/ai/realtime/tool-activity-persistence.ts
+++ b/apps/web/src/lib/ai/realtime/tool-activity-persistence.ts
@@ -55,15 +55,27 @@ export type ToolActivityRequest = {
  * object. A payload that will not parse still shows the call: the raw string is
  * more useful on screen than an empty card, and this is a record, not a
  * dispatch. The copy that has to be right is parsed in `tool-dispatch.ts`.
+ *
+ * ALWAYS A RECORD. `JSON.parse` happily returns `null`, an array or a bare
+ * number, none of which is an argument bag — and each would reach the renderer
+ * and the persisted `toolCalls` column as a tool input that the typed surface
+ * can never produce. They are kept, under `raw`, rather than discarded: a call
+ * did happen, and the arguments it was made with are what a reader needs.
  */
-const inputFor = (argumentsJson: string): unknown => {
+const inputFor = (argumentsJson: string): Record<string, unknown> => {
   const trimmed = argumentsJson.trim();
   if (trimmed.length === 0) return {};
+
+  let parsed: unknown;
   try {
-    return JSON.parse(trimmed);
+    parsed = JSON.parse(trimmed);
   } catch {
     return { raw: trimmed };
   }
+
+  return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : { raw: parsed };
 };
 
 /**
@@ -73,7 +85,10 @@ const inputFor = (argumentsJson: string): unknown => {
  * reload path are all keyed to this shape, so a voice tool call gets all of
  * them for free.
  */
-const toolPart = (request: ToolActivityRequest, input: unknown): UIMessagePart => {
+const toolPart = (
+  request: ToolActivityRequest,
+  input: Record<string, unknown>,
+): UIMessagePart => {
   const base = {
     type: `tool-${request.name}`,
     toolCallId: request.toolCallId,

--- a/apps/web/src/lib/ai/realtime/tool-dispatch.ts
+++ b/apps/web/src/lib/ai/realtime/tool-dispatch.ts
@@ -28,41 +28,37 @@
  *   - `function_call_output.output` must be a STRING — so everything below
  *     returns one, including every failure.
  *
- * RESULTS ARE NOT TRUNCATED, AND THE CAP THAT USED TO DO IT WAS A BUG. Every
- * result was cut to 700 characters here on the reasoning that a spoken answer
- * cannot be skimmed — which is true, and is a fact about what the model SAYS.
- * This is what the model KNOWS, and starving that is what made a call unable to
- * do its job:
- *   - `tool_search` returns JSON Schemas. Sliced at 700 characters it hands back
- *     one schema cut mid-object, so the model cannot build the `execute_tool`
- *     call it went looking for — it guesses parameters, fails, and tries again.
+ * THE OLD 700-CHARACTER CAP WAS MEASURING THE WRONG THING. Every result was cut
+ * to 700 characters here on the reasoning that a spoken answer cannot be
+ * skimmed — which is true, and is a fact about what the model SAYS. This is
+ * what the model KNOWS, and starving that is what made a call unable to do its
+ * job:
+ *   - `tool_search` returns JSON Schemas. Sliced at 700 characters it handed
+ *     back one schema cut mid-object, so the model could not build the
+ *     `execute_tool` call it went looking for — it guessed parameters, failed,
+ *     and tried again.
  *   - `read_page` returned the first 700 characters of a document, which is
  *     neither a summary nor enough to edit from: `replace_lines` needs line
  *     numbers off a full read.
  *   - `list_pages` was cut off, so "find my document" failed whenever the
  *     document sorted late.
- * The typed surface caps tool results nowhere, and this is the same agent. Where
- * a result really is too large to want whole, the TOOL says so — `read_page`
- * takes `lineStart`/`lineEnd` — which is a decision the model can make with the
- * page in front of it, and a blanket cap here never could.
  *
- * Brevity is still required; it is just enforced where it belongs. The spoken
+ * Brevity is still required; it is enforced where it belongs. The spoken
  * override in `instructions.ts` asks for two or three sentences a turn, and the
  * model summarises the result rather than reciting it.
  *
- * THERE IS STILL A CEILING, AND IT IS ABOUT THE SESSION, NOT ABOUT SPEECH. A
- * realtime session has 32k tokens, shared with the seed, the instructions and
- * the audio for the whole call, and a `function_call_output` stays in it. One
- * result can therefore end a call outright — measured, not theorised:
- * `tool_search` for a broad keyword returns 21k characters, and for a
- * single-letter query 89k, which is ~22k tokens on its own.
+ * THERE IS STILL A CEILING, AND IT IS ABOUT THE SESSION. A realtime session has
+ * 32k tokens, shared with the seed, the instructions and the audio for the whole
+ * call, and a `function_call_output` stays in it — so one result can end a call
+ * outright. Measured, not theorised: `tool_search` returns 21k characters for a
+ * broad keyword and 89k for a single letter, which is ~22k tokens on its own.
  *
- * The ceiling is set so the path the model is actually TOLD to take survives
- * whole. `TOOL_DISCOVERY_PROMPT` instructs `tool_search("select:name")` to get
- * a schema before calling a tool; two tools that way is ~7k characters, and an
- * ordinary page read is far less. What gets cut is the pathological case — a
- * broad keyword dump the model did not need in full — and it is told how to ask
- * again more narrowly.
+ * `MAX_RESULT_CHARS` is therefore set so the path the model is actually TOLD to
+ * take survives whole. `TOOL_DISCOVERY_PROMPT` instructs
+ * `tool_search("select:name")` to get a schema before calling a tool; two tools
+ * that way is ~7k characters, and an ordinary page read is far less. What gets
+ * cut is the case nobody wanted whole — a broad dump — and the model is told how
+ * to ask again for less.
  */
 
 import type { Tool, ToolSet } from 'ai';

--- a/apps/web/src/lib/ai/realtime/tool-dispatch.ts
+++ b/apps/web/src/lib/ai/realtime/tool-dispatch.ts
@@ -49,6 +49,20 @@
  * Brevity is still required; it is just enforced where it belongs. The spoken
  * override in `instructions.ts` asks for two or three sentences a turn, and the
  * model summarises the result rather than reciting it.
+ *
+ * THERE IS STILL A CEILING, AND IT IS ABOUT THE SESSION, NOT ABOUT SPEECH. A
+ * realtime session has 32k tokens, shared with the seed, the instructions and
+ * the audio for the whole call, and a `function_call_output` stays in it. One
+ * result can therefore end a call outright — measured, not theorised:
+ * `tool_search` for a broad keyword returns 21k characters, and for a
+ * single-letter query 89k, which is ~22k tokens on its own.
+ *
+ * The ceiling is set so the path the model is actually TOLD to take survives
+ * whole. `TOOL_DISCOVERY_PROMPT` instructs `tool_search("select:name")` to get
+ * a schema before calling a tool; two tools that way is ~7k characters, and an
+ * ordinary page read is far less. What gets cut is the pathological case — a
+ * broad keyword dump the model did not need in full — and it is told how to ask
+ * again more narrowly.
  */
 
 import type { Tool, ToolSet } from 'ai';
@@ -58,6 +72,18 @@ import type {
   VoiceAssistant,
   VoiceLocationContext,
 } from '@pagespace/lib/realtime/voice-bridge-contract';
+
+/**
+ * How much of one tool result a call can afford to keep.
+ *
+ * ~3k tokens. Sized against the 32k session rather than against a listener's
+ * patience — the model summarises for the listener, and the prompt is what
+ * makes it brief. Above `tool_search("select:…")` (~7k characters for two
+ * tools, the schema lookup the discovery prompt instructs) and above an
+ * ordinary page read; below the point where a single result crowds out the
+ * conversation it belongs to.
+ */
+export const MAX_RESULT_CHARS = 12_000;
 
 /** Parsed arguments, or the sentence to say instead. */
 type ParsedArguments =
@@ -162,10 +188,23 @@ const firstBalancedObject = (text: string): string | undefined => {
  * still succeeded, and an empty `output` reads to the model as a call that
  * produced no answer.
  */
-export const formatToolResult = (value: unknown): string => {
+export const formatToolResult = (
+  value: unknown,
+  maxChars: number = MAX_RESULT_CHARS,
+): string => {
   const text = typeof value === 'string' ? value : safeStringify(value);
   const trimmed = text.trim();
-  return trimmed.length === 0 ? 'Done.' : trimmed;
+  if (trimmed.length === 0) return 'Done.';
+  if (trimmed.length <= maxChars) return trimmed;
+
+  const window = trimmed.slice(0, maxChars);
+  const lastSpace = window.lastIndexOf(' ');
+  const head = (lastSpace > 0 ? window.slice(0, lastSpace) : window).trimEnd();
+  // The hint is for the MODEL. Without it a cut result reads as a complete one,
+  // and the model reports the content ended where the ceiling did. It names the
+  // two ways to ask again because they are the two shapes that get cut: a
+  // search that matched too much, and a page too long to read at once.
+  return `${head}…\n\n[${trimmed.length - head.length} characters were not returned. Ask again more narrowly — tool_search("select:exact_name") for one tool's schema, or read_page with lineStart/lineEnd for the rest of a page.]`;
 };
 
 /**
@@ -196,6 +235,23 @@ export type RealtimeToolDispatchRequest = {
    * and for an unbound call, which act as the user.
    */
   readonly assistant?: VoiceAssistant;
+};
+
+/**
+ * What a dispatch produced: the sentence the model gets, and whether the tool
+ * actually WORKED.
+ *
+ * The two are deliberately different questions. Every failure below still
+ * yields a speakable `output` — the model is blocked on `function_call_output`
+ * and must be unblocked whatever happened — so "the call returned" is not
+ * evidence the tool succeeded. Anything recording the call for a human needs
+ * the other answer: without it, a permission error is written into the thread
+ * as a completed tool call with a sentence about failure inside it, rendered
+ * green.
+ */
+export type RealtimeToolOutcome = {
+  readonly output: string;
+  readonly failed: boolean;
 };
 
 export type RealtimeToolDispatchDeps = {
@@ -269,7 +325,9 @@ export const dispatchRealtimeToolCall = async (
   deps: RealtimeToolDispatchDeps,
   request: RealtimeToolDispatchRequest,
   model: string,
-): Promise<string> => {
+): Promise<RealtimeToolOutcome> => {
+  const failure = (output: string): RealtimeToolOutcome => ({ output, failed: true });
+
   const tool: Tool | undefined = deps.tools[request.name];
   if (!tool) {
     deps.logger.warn('Realtime voice tool call named an unadvertised tool', {
@@ -277,10 +335,12 @@ export const dispatchRealtimeToolCall = async (
       userId: request.userId,
       tool: request.name,
     });
-    return `There is no tool called "${request.name}". Use tool_search to find the right one.`;
+    return failure(
+      `There is no tool called "${request.name}". Use tool_search to find the right one.`,
+    );
   }
   if (!tool.execute) {
-    return `The tool "${request.name}" cannot be run.`;
+    return failure(`The tool "${request.name}" cannot be run.`);
   }
 
   const parsed = parseToolArguments(request.argumentsJson);
@@ -290,12 +350,14 @@ export const dispatchRealtimeToolCall = async (
       userId: request.userId,
       tool: request.name,
     });
-    return parsed.message;
+    return failure(parsed.message);
   }
 
   const validated = (tool.inputSchema as z.ZodType).safeParse(parsed.args);
   if (!validated.success) {
-    return `Invalid parameters for "${request.name}": ${validated.error.message}. Call tool_search("select:${request.name}") for the correct schema.`;
+    return failure(
+      `Invalid parameters for "${request.name}": ${validated.error.message}. Call tool_search("select:${request.name}") for the correct schema.`,
+    );
   }
 
   const context = buildVoiceToolContext(request, model);
@@ -309,7 +371,7 @@ export const dispatchRealtimeToolCall = async (
       // that grows a use for them should not break on voice.
       { experimental_context: context, toolCallId: request.callId, messages: [] },
     );
-    return formatToolResult(result);
+    return { output: formatToolResult(result), failed: false };
   } catch (error) {
     // A throwing tool is a normal outcome (permission denied, missing page),
     // and the model has to be able to say something about it. The message is
@@ -320,6 +382,6 @@ export const dispatchRealtimeToolCall = async (
       { callId: request.callId, userId: request.userId, tool: request.name },
     );
     const message = error instanceof Error ? error.message : String(error);
-    return formatToolResult(`That didn't work: ${message}`);
+    return failure(formatToolResult(`That didn't work: ${message}`));
   }
 };

--- a/apps/web/src/lib/ai/realtime/tool-dispatch.ts
+++ b/apps/web/src/lib/ai/realtime/tool-dispatch.ts
@@ -188,16 +188,13 @@ const firstBalancedObject = (text: string): string | undefined => {
  * still succeeded, and an empty `output` reads to the model as a call that
  * produced no answer.
  */
-export const formatToolResult = (
-  value: unknown,
-  maxChars: number = MAX_RESULT_CHARS,
-): string => {
+export const formatToolResult = (value: unknown): string => {
   const text = typeof value === 'string' ? value : safeStringify(value);
   const trimmed = text.trim();
   if (trimmed.length === 0) return 'Done.';
-  if (trimmed.length <= maxChars) return trimmed;
+  if (trimmed.length <= MAX_RESULT_CHARS) return trimmed;
 
-  const window = trimmed.slice(0, maxChars);
+  const window = trimmed.slice(0, MAX_RESULT_CHARS);
   const lastSpace = window.lastIndexOf(' ');
   const head = (lastSpace > 0 ? window.slice(0, lastSpace) : window).trimEnd();
   // The hint is for the MODEL. Without it a cut result reads as a complete one,

--- a/apps/web/src/lib/ai/realtime/tool-dispatch.ts
+++ b/apps/web/src/lib/ai/realtime/tool-dispatch.ts
@@ -28,16 +28,27 @@
  *   - `function_call_output.output` must be a STRING — so everything below
  *     returns one, including every failure.
  *
- * WHY RESULTS ARE TRUNCATED. A spoken answer cannot be skimmed. A full page
- * read is a two-minute monologue that the user cannot scan, interrupt usefully,
- * or remember — and in a live turn latency wins, with completeness happening in
- * the thread afterwards. The reference prototype
- * (`~/production/pagespace-voice/src/core/present.ts`) solves this with a
- * hand-written presenter per tool; that does not scale to PageSpace's registry
- * of dozens, and a curated presenter list would be a second tool surface that
- * drifts every time a tool is added. So the cap is generic and structural: cut
- * at a word boundary, say how much was left out, and tell the model how to get
- * the rest — the same contract `truncateForSpeech` offers, applied uniformly.
+ * RESULTS ARE NOT TRUNCATED, AND THE CAP THAT USED TO DO IT WAS A BUG. Every
+ * result was cut to 700 characters here on the reasoning that a spoken answer
+ * cannot be skimmed — which is true, and is a fact about what the model SAYS.
+ * This is what the model KNOWS, and starving that is what made a call unable to
+ * do its job:
+ *   - `tool_search` returns JSON Schemas. Sliced at 700 characters it hands back
+ *     one schema cut mid-object, so the model cannot build the `execute_tool`
+ *     call it went looking for — it guesses parameters, fails, and tries again.
+ *   - `read_page` returned the first 700 characters of a document, which is
+ *     neither a summary nor enough to edit from: `replace_lines` needs line
+ *     numbers off a full read.
+ *   - `list_pages` was cut off, so "find my document" failed whenever the
+ *     document sorted late.
+ * The typed surface caps tool results nowhere, and this is the same agent. Where
+ * a result really is too large to want whole, the TOOL says so — `read_page`
+ * takes `lineStart`/`lineEnd` — which is a decision the model can make with the
+ * page in front of it, and a blanket cap here never could.
+ *
+ * Brevity is still required; it is just enforced where it belongs. The spoken
+ * override in `instructions.ts` asks for two or three sentences a turn, and the
+ * model summarises the result rather than reciting it.
  */
 
 import type { Tool, ToolSet } from 'ai';
@@ -47,13 +58,6 @@ import type {
   VoiceAssistant,
   VoiceLocationContext,
 } from '@pagespace/lib/realtime/voice-bridge-contract';
-
-/**
- * How much of a tool result is worth reading aloud. 700 characters is roughly
- * 45 seconds of speech — already long for a spoken answer, and past the point
- * where a listener retains the beginning.
- */
-export const MAX_SPOKEN_RESULT_CHARS = 700;
 
 /** Parsed arguments, or the sentence to say instead. */
 type ParsedArguments =
@@ -148,29 +152,20 @@ const firstBalancedObject = (text: string): string | undefined => {
 };
 
 /**
- * A tool's return value as one speakable string, capped.
+ * A tool's return value as the one string `function_call_output.output` accepts.
  *
- * A string result is spoken as-is; anything else is serialized, because the
- * model reads JSON perfectly well and inventing prose for an arbitrary shape
+ * A string result passes through untouched; anything else is serialized, because
+ * the model reads JSON perfectly well and inventing prose for an arbitrary shape
  * would mean guessing at a schema this module does not know.
+ *
+ * `'Done.'` for an empty result is not cosmetic: a tool that returns nothing has
+ * still succeeded, and an empty `output` reads to the model as a call that
+ * produced no answer.
  */
-export const formatToolResult = (
-  value: unknown,
-  maxChars: number = MAX_SPOKEN_RESULT_CHARS,
-): string => {
+export const formatToolResult = (value: unknown): string => {
   const text = typeof value === 'string' ? value : safeStringify(value);
   const trimmed = text.trim();
-  if (trimmed.length === 0) return 'Done.';
-  if (trimmed.length <= maxChars) return trimmed;
-
-  const window = trimmed.slice(0, maxChars);
-  const lastSpace = window.lastIndexOf(' ');
-  const head = (lastSpace > 0 ? window.slice(0, lastSpace) : window).trimEnd();
-  const omitted = trimmed.length - head.length;
-  // The continuation hint is for the MODEL, not the user: it is what turns a
-  // cut-off result into "I can read you the rest if you want" instead of the
-  // model asserting the content ended there.
-  return `${head}… (${omitted} more characters were not read out; call the tool again for a specific part if the user asks for more.)`;
+  return trimmed.length === 0 ? 'Done.' : trimmed;
 };
 
 /**
@@ -210,7 +205,6 @@ export type RealtimeToolDispatchDeps = {
     readonly warn: (message: string, meta?: Record<string, unknown>) => void;
     readonly error: (message: string, error: Error, meta?: Record<string, unknown>) => void;
   };
-  readonly maxChars?: number;
 };
 
 /**
@@ -315,7 +309,7 @@ export const dispatchRealtimeToolCall = async (
       // that grows a use for them should not break on voice.
       { experimental_context: context, toolCallId: request.callId, messages: [] },
     );
-    return formatToolResult(result, deps.maxChars);
+    return formatToolResult(result);
   } catch (error) {
     // A throwing tool is a normal outcome (permission denied, missing page),
     // and the model has to be able to say something about it. The message is
@@ -326,6 +320,6 @@ export const dispatchRealtimeToolCall = async (
       { callId: request.callId, userId: request.userId, tool: request.name },
     );
     const message = error instanceof Error ? error.message : String(error);
-    return formatToolResult(`That didn't work: ${message}`, deps.maxChars);
+    return formatToolResult(`That didn't work: ${message}`);
   }
 };

--- a/apps/web/src/lib/ai/realtime/tool-dispatch.ts
+++ b/apps/web/src/lib/ai/realtime/tool-dispatch.ts
@@ -198,10 +198,13 @@ export const formatToolResult = (value: unknown): string => {
   const lastSpace = window.lastIndexOf(' ');
   const head = (lastSpace > 0 ? window.slice(0, lastSpace) : window).trimEnd();
   // The hint is for the MODEL. Without it a cut result reads as a complete one,
-  // and the model reports the content ended where the ceiling did. It names the
-  // two ways to ask again because they are the two shapes that get cut: a
-  // search that matched too much, and a page too long to read at once.
-  return `${head}…\n\n[${trimmed.length - head.length} characters were not returned. Ask again more narrowly — tool_search("select:exact_name") for one tool's schema, or read_page with lineStart/lineEnd for the rest of a page.]`;
+  // and the model reports that the content ended where the ceiling did.
+  //
+  // It leads with the general instruction because the general case is what
+  // usually gets cut — a listing or a search that matched too much — and then
+  // names the two specific escapes, which only help if the cut result was one
+  // of those. Advice that assumes the wrong tool is worse than none.
+  return `${head}…\n\n[${trimmed.length - head.length} characters were not returned. Ask again for less: a narrower query or filter, an exact name via tool_search("select:name"), or a line range via read_page's lineStart/lineEnd.]`;
 };
 
 /**

--- a/apps/web/src/lib/ai/realtime/transcript-persistence.ts
+++ b/apps/web/src/lib/ai/realtime/transcript-persistence.ts
@@ -27,6 +27,8 @@
  * exercisable without a database.
  */
 
+import type { UIMessage } from 'ai';
+import type { ToolCall, ToolResult } from '../core/message-utils';
 import { MESSAGE_SOURCE_VOICE } from '@pagespace/db/schema/conversations';
 
 /** The conversation facts this module needs. A `conversations` row satisfies it. */
@@ -45,6 +47,23 @@ export type TranscriptRequest = {
   readonly conversationId: string;
   readonly role: 'user' | 'assistant';
   readonly text: string;
+};
+
+/**
+ * The structured half of a row, when there is one.
+ *
+ * A spoken turn is only text, so it passes none of this. A tool row passes all
+ * of it: `uiMessage` is what `buildEventMessage` puts on the socket event
+ * verbatim, and `toolCalls`/`toolResults` are the columns a reload rebuilds the
+ * parts from. Without both, a tool call would render live and then vanish on
+ * refresh — or the reverse.
+ */
+export type StructuredPayload = {
+  /** Reused across both phases so the second write UPDATES the row, not adds one. */
+  readonly messageId: string;
+  readonly uiMessage: UIMessage;
+  readonly toolCalls?: ToolCall[];
+  readonly toolResults?: ToolResult[];
 };
 
 export type TranscriptWriteResult = {
@@ -66,6 +85,13 @@ type SaveArgs = {
   readonly role: 'user' | 'assistant';
   readonly content: string;
   readonly source: string;
+  /**
+   * The repository has accepted these all along; only this module never sent
+   * them, which is why a voice turn could never be anything but one text part.
+   */
+  readonly uiMessage?: UIMessage;
+  readonly toolCalls?: ToolCall[];
+  readonly toolResults?: ToolResult[];
 };
 
 export type TranscriptPersistenceDeps = {
@@ -122,6 +148,7 @@ const NOTHING: TranscriptWriteResult = { saved: false, messageId: null, rev: 0 }
 export const persistVoiceTranscript = async (
   deps: TranscriptPersistenceDeps,
   request: TranscriptRequest,
+  structured?: StructuredPayload,
 ): Promise<TranscriptWriteResult> => {
   const content = request.text.trim();
   if (content.length === 0) {
@@ -143,7 +170,7 @@ export const persistVoiceTranscript = async (
       });
       return { ...NOTHING, skipped: 'create_failed' };
     }
-    return writeGlobal(deps, request, created, content);
+    return writeGlobal(deps, request, created, content, structured);
   }
 
   if (!existing.isActive) {
@@ -167,17 +194,18 @@ export const persistVoiceTranscript = async (
   }
 
   if (existing.type === 'global') {
-    return writeGlobal(deps, request, existing, content);
+    return writeGlobal(deps, request, existing, content, structured);
   }
 
   if (existing.type === 'page' && existing.contextId) {
-    const messageId = deps.newMessageId();
+    const messageId = structured?.messageId ?? deps.newMessageId();
     const result = await deps.savePageMessage({
       messageId,
       conversationId: request.conversationId,
       role: request.role,
       content,
       source: MESSAGE_SOURCE_VOICE,
+      ...structuredColumns(structured),
       pageId: existing.contextId,
       // The attribution rule: a human author, or NULL for an agent-authored row.
       userId: request.role === 'user' ? request.userId : null,
@@ -194,19 +222,38 @@ export const persistVoiceTranscript = async (
   return { ...NOTHING, skipped: 'unsupported_conversation_type' };
 };
 
+/**
+ * The structured columns, present only for a row that has them.
+ *
+ * Spread rather than passed as `undefined`: the repository distinguishes an
+ * absent `uiMessage` (broadcast a plain text part) from one that is present,
+ * and handing it an explicit undefined would be the same thing said less
+ * clearly.
+ */
+const structuredColumns = (structured: StructuredPayload | undefined) =>
+  structured === undefined
+    ? {}
+    : {
+        uiMessage: structured.uiMessage,
+        ...(structured.toolCalls === undefined ? {} : { toolCalls: structured.toolCalls }),
+        ...(structured.toolResults === undefined ? {} : { toolResults: structured.toolResults }),
+      };
+
 const writeGlobal = async (
   deps: TranscriptPersistenceDeps,
   request: TranscriptRequest,
   conversation: TranscriptConversation,
   content: string,
+  structured?: StructuredPayload,
 ): Promise<TranscriptWriteResult> => {
-  const messageId = deps.newMessageId();
+  const messageId = structured?.messageId ?? deps.newMessageId();
   const result = await deps.saveGlobalMessage({
     messageId,
     conversationId: request.conversationId,
     role: request.role,
     content,
     source: MESSAGE_SOURCE_VOICE,
+    ...structuredColumns(structured),
     // The conversation's OWNER, not the speaker: they are the same person on
     // every path that reaches here (a global thread is owner-only), and taking
     // it off the row keeps this consistent with every other global write.

--- a/apps/web/src/lib/ai/realtime/transcript-persistence.ts
+++ b/apps/web/src/lib/ai/realtime/transcript-persistence.ts
@@ -151,10 +151,14 @@ export const persistVoiceTranscript = async (
   structured?: StructuredPayload,
 ): Promise<TranscriptWriteResult> => {
   const content = request.text.trim();
-  if (content.length === 0) {
+  if (content.length === 0 && structured === undefined) {
     // A blank transcript is a real event — the model heard breath, or the
     // transcriber returned nothing — and an empty message row is worse than
     // no row: it renders as a turn that said nothing.
+    //
+    // A STRUCTURED row is exempt, because that reasoning does not reach it: a
+    // tool row renders from its parts and has no text by design (nothing was
+    // said). Refusing it here would drop the record of a tool call that ran.
     return { ...NOTHING, skipped: 'blank' };
   }
 

--- a/apps/web/src/lib/ai/realtime/voice-runtime-deps.ts
+++ b/apps/web/src/lib/ai/realtime/voice-runtime-deps.ts
@@ -31,6 +31,7 @@ import { buildPageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { getAgentMemoryContext, buildAgentMemorySection } from '@/lib/ai/core/agent-memory';
 import { buildActivePlanPrompt, getActivePlan } from '@/lib/ai/core/plan-binding';
 import { getUserPersonalization } from '@/lib/ai/core/personalization-utils';
+import { readMessageText } from '@/lib/ai/core/message-utils';
 import { canPrincipalViewPage, type AuthResult } from '@/lib/auth';
 import { buildRealtimeToolSet, type ToolAllowlist } from './tools';
 import { buildVoiceCallContext, type VoiceSystemContextDeps } from './system-context';
@@ -154,8 +155,20 @@ export const voiceBindingDeps = (auth: AuthResult): BindingLoaderDeps => ({
   canAccess: (userId, conversation) => canAccessConversation(userId, conversation),
   // Streaming placeholders stay excluded (the default): an empty mid-flight row
   // is not a turn, and `buildRealtimeSeed` would drop it anyway.
-  loadMessages: (conversationId) =>
-    messageRepository.getMessagesByConversationId(conversationId),
+  //
+  // THE TEXT IS READ OUT OF THE COLUMN, NOT TAKEN FROM IT. `messages.content`
+  // holds structured JSON for any row saved with parts — which is every typed
+  // assistant turn — so handing the raw column to the seed replays
+  // `{"textParts":["Here they are."],…}` at the model as though someone had
+  // said it, and spends a 4k-token seed budget doing so. `readMessageText`
+  // returns the words. A row with no text parts (a voice tool call, which
+  // renders from its parts) yields '', and the seed drops it — correctly, since
+  // nothing was said.
+  loadMessages: async (conversationId) =>
+    (await messageRepository.getMessagesByConversationId(conversationId)).map((row) => ({
+      ...row,
+      content: readMessageText(row.content),
+    })),
   loadAgentPage,
   buildCallContext: (request) =>
     buildVoiceCallContext(voiceSystemContextDeps(auth), request),

--- a/apps/web/src/lib/ai/tools/__tests__/tool-labels.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-labels.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The label vocabulary, shared by the thread renderer and the voice call bar.
+ *
+ * These cases exist because this table was extracted out of a component, and an
+ * extraction that changes behaviour while looking tidier is the failure mode
+ * worth guarding. The field ORDER and the fact that only `query` is trimmed are
+ * both faithful ports, not preferences.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TOOL_NAME_MAP, describeToolCall, formatToolName } from '../tool-labels';
+import { buildPageSpaceTools } from '../../core/ai-tools';
+
+describe('formatToolName', () => {
+  it('should use the curated label when there is one', () => {
+    expect(formatToolName('list_drives')).toBe('Workspaces');
+    expect(formatToolName('read_page')).toBe('Read Page');
+  });
+
+  it('given an uncurated tool, should title-case its name rather than show a snake_case id', () => {
+    expect(formatToolName('some_new_tool')).toBe('Some New Tool');
+  });
+
+  it('should not invent a label for the empty string', () => {
+    expect(formatToolName('')).toBe('');
+  });
+});
+
+describe('describeToolCall', () => {
+  it('should name what the call is acting on', () => {
+    expect(describeToolCall('read_page', { title: 'Roadmap' })).toBe('Read Page: Roadmap');
+  });
+
+  it('given no usable arguments, should fall back to the plain label', () => {
+    expect(describeToolCall('list_drives', {})).toBe('Workspaces');
+    expect(describeToolCall('list_drives', undefined)).toBe('Workspaces');
+    expect(describeToolCall('list_drives', 'not an object')).toBe('Workspaces');
+    expect(describeToolCall('list_drives', null)).toBe('Workspaces');
+  });
+
+  it('should prefer title over every other subject, as the renderer always did', () => {
+    // Order is behaviour: a call carrying both is labelled by its title.
+    expect(describeToolCall('x_tool', { title: 'T', name: 'N', query: 'Q' })).toBe('X Tool: T');
+    expect(describeToolCall('x_tool', { name: 'N', query: 'Q' })).toBe('X Tool: N');
+  });
+
+  it('should trim a long query and ONLY a long query', () => {
+    // A query is arbitrary user text; a page title is the page's name, and
+    // clipping it would make the label wrong rather than tidy.
+    const long = 'a'.repeat(60);
+
+    expect(describeToolCall('regex_search', { query: long })).toBe(
+      `${formatToolName('regex_search')}: ${'a'.repeat(30)}...`,
+    );
+    expect(describeToolCall('read_page', { title: long })).toBe(
+      `${formatToolName('read_page')}: ${long}`,
+    );
+  });
+
+  it('should compose owner/repo, and place it where the renderer placed it', () => {
+    expect(describeToolCall('gh_pr_list', { owner: 'o', repo: 'r' })).toContain('o/r');
+    expect(describeToolCall('gh_pr_view', { owner: 'o', repo: 'r', path: 'src' })).toContain(
+      'o/r/src',
+    );
+    // driveSlug is tried BEFORE owner/repo; repo alone is tried after.
+    expect(describeToolCall('x_tool', { driveSlug: 'd', owner: 'o', repo: 'r' })).toBe('X Tool: d');
+    expect(describeToolCall('x_tool', { repo: 'r' })).toBe('X Tool: r');
+  });
+
+  it('given a caller-resolved label, should keep it instead of re-deriving one', () => {
+    // The thread renderer overrides integration tools from the integrations
+    // registry; re-deriving here would silently throw that away.
+    expect(describeToolCall('github_create_issue', { title: 'Bug' }, 'GitHub: Create Issue')).toBe(
+      'GitHub: Create Issue: Bug',
+    );
+  });
+
+  it('should survive arguments of the wrong type without throwing', () => {
+    // These arrive as whatever the model sent. A label is never worth an
+    // exception, least of all one thrown inside a reducer.
+    expect(() => describeToolCall('x_tool', { title: 42, name: null, query: [] })).not.toThrow();
+    expect(describeToolCall('x_tool', { title: 42, name: null, query: [] })).toBe('X Tool');
+  });
+});
+
+describe('the label table against the real registry', () => {
+  it('should give every registered tool a label that is not its raw name', () => {
+    // Not a demand that every tool be curated — the title-case fallback is a
+    // real answer. This asserts the fallback actually fires, so a tool never
+    // reaches a user as `set_task_trigger`.
+    for (const name of Object.keys(buildPageSpaceTools({ codeExecutionEnabled: true }))) {
+      const label = formatToolName(name);
+      expect(label, `${name} has no readable label`).not.toBe(name);
+      expect(label).not.toContain('_');
+    }
+  });
+
+  it('may label names the base registry does not contain, and that is not staleness', () => {
+    // Worth pinning as a fact rather than asserting the opposite of. The
+    // registry is NOT the complete set of names a label can be asked for:
+    // `ask_user` is merged in per-route (`page-chat-turn.ts:1477`), and
+    // `ask_agent` is a name the renderers still handle for messages already in
+    // people's threads. A test demanding the table match the registry would
+    // fail on both and teach the next person to delete a label that is doing
+    // its job.
+    const registry = new Set(Object.keys(buildPageSpaceTools({ codeExecutionEnabled: true })));
+    const outsideRegistry = Object.keys(TOOL_NAME_MAP).filter((name) => !registry.has(name));
+
+    expect(outsideRegistry.sort()).toEqual(['ask_agent', 'ask_user']);
+  });
+});

--- a/apps/web/src/lib/ai/tools/tool-labels.ts
+++ b/apps/web/src/lib/ai/tools/tool-labels.ts
@@ -1,0 +1,176 @@
+/**
+ * What a tool call is CALLED, in words a person reads.
+ *
+ * One vocabulary, two surfaces. The thread renders a tool call in a collapsible
+ * card; a voice call has no card and shows the same thing as the status line
+ * under the waveform while the model is off doing it. A second copy of these
+ * strings for the spoken surface would drift the first time a tool was added,
+ * and the drift would be invisible — nobody diffs a label table.
+ *
+ * This lives in `lib/` rather than beside the renderer because a reducer needs
+ * it: `realtime/session-state.ts` is a pure module with no business importing
+ * from `components/`. The renderer keeps its own integration-label override on
+ * top, which is the one part that depends on the integrations registry.
+ *
+ * Pure: no I/O, no clock, no randomness, no module-level mutable state.
+ */
+
+export const TOOL_NAME_MAP: Record<string, string> = {
+  // Drive tools
+  'list_drives': 'Workspaces',
+  'create_drive': 'Create Workspace',
+  'rename_drive': 'Rename Workspace',
+  'update_drive_context': 'Update Context',
+  'set_home_page': 'Set Home Page',
+  // Member tools
+  'list_drive_members': 'Members',
+  'list_collaborators': 'Collaborators',
+  // Role management tools
+  'list_drive_roles': 'Roles',
+  'get_drive_role': 'Role',
+  'create_drive_role': 'Create Role',
+  'update_drive_role': 'Update Role',
+  'delete_drive_role': 'Delete Role',
+  'set_role_page_permissions': 'Set Role Page Access',
+  'set_role_drive_wide_permissions': 'Set Role Drive Access',
+  'remove_role_page_permissions': 'Remove Role Page Access',
+  // Page read tools
+  'list_pages': 'Pages',
+  'read_page': 'Read Page',
+  'list_trash': 'Trash',
+  'list_conversations': 'Conversations',
+  'read_conversation': 'Conversation',
+  'send_channel_message': 'Send Message',
+  'delete_channel_message': 'Delete Message',
+  // Page write tools
+  'replace_lines': 'Edit Document',
+  'insert_content': 'Insert Content',
+  'create_page': 'Create Page',
+  'rename_page': 'Rename Page',
+  'trash_page': 'Move to Trash',
+  'trash_drive': 'Move Drive to Trash',
+  'restore_page': 'Restore',
+  'restore_drive': 'Restore Drive',
+  'move_page': 'Move Page',
+  'edit_sheet_cells': 'Edit Sheet',
+  // Search tools
+  'regex_search': 'Search',
+  'glob_search': 'Find Pages',
+  'multi_drive_search': 'Search All',
+  // Task tools
+  'update_task': 'Update Task',
+  'create_task': 'Create Task',
+  'delete_task': 'Delete Task',
+  'reorder_task': 'Reorder Task',
+  'get_assigned_tasks': 'Assigned Tasks',
+  'create_task_status': 'Create Status',
+  // Agent tools
+  'update_agent_config': 'Configure Agent',
+  'list_agents': 'Agents',
+  'multi_drive_list_agents': 'All Agents',
+  'ask_agent': 'Ask Agent',
+  'ask_user': 'Question',
+  // Web
+  'web_search': 'Web Search',
+  'web_fetch': 'Fetch Page',
+  // Activity
+  'get_activity': 'Activity',
+  // Calendar tools
+  'list_calendar_events': 'Calendar',
+  'get_calendar_event': 'Event',
+  'check_calendar_availability': 'Availability',
+  'create_calendar_event': 'Create Event',
+  'update_calendar_event': 'Update Event',
+  'delete_calendar_event': 'Delete Event',
+  'rsvp_calendar_event': 'RSVP',
+  'invite_calendar_attendees': 'Invite Attendees',
+  'remove_calendar_attendee': 'Remove Attendee',
+  // Workflow tools
+  'create_workflow': 'Create Workflow',
+  'list_workflows': 'Workflows',
+  'update_workflow': 'Update Workflow',
+  'delete_workflow': 'Delete Workflow',
+};
+
+/**
+ * A tool's display name: the curated label when there is one, otherwise the
+ * name title-cased, which reads acceptably for everything not worth curating
+ * (`rename_page` → "Rename Page").
+ */
+export const formatToolName = (toolName: string): string =>
+  TOOL_NAME_MAP[toolName] ??
+  toolName
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+/**
+ * The subject fields, in the order they are tried, and whether the value is
+ * free text that needs trimming.
+ *
+ * ORDER IS BEHAVIOUR, not taste: a call carrying both `name` and `repo` is
+ * labelled by its `name`, and this list is a faithful port of the sequence the
+ * thread renderer already used. Only `query` is trimmed, because only `query`
+ * is arbitrary user text — a long page title is still the page's title, and
+ * clipping it would make the label wrong rather than tidy.
+ */
+const SUBJECT_FIELDS: readonly { readonly field: string; readonly trim?: true }[] = [
+  { field: 'title' },
+  { field: 'name' },
+  { field: 'query', trim: true },
+  { field: 'pattern' },
+  { field: 'driveSlug' },
+  { field: 'channel' },
+  { field: 'repo' },
+];
+
+/** Where `owner`/`repo` is tried, matching the renderer's original sequence. */
+const OWNER_REPO_AFTER = 'driveSlug';
+
+const MAX_QUERY_CHARS = 30;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+/**
+ * The tool's name plus what it is acting on, from its arguments.
+ *
+ * `label` is passed in rather than derived so a caller that has already
+ * resolved a better name — the thread renderer overrides integration tools from
+ * the integrations registry — does not lose it here.
+ *
+ * Arguments arrive as whatever the model sent, so every read is defensive: a
+ * label is never worth throwing over.
+ */
+export const describeToolCall = (
+  toolName: string,
+  input: unknown,
+  label: string = formatToolName(toolName),
+): string => {
+  if (typeof input !== 'object' || input === null) return label;
+  const params = input as Record<string, unknown>;
+
+  const ownerRepo = (): string | undefined => {
+    const owner = asString(params.owner);
+    const repo = asString(params.repo);
+    if (!owner || !repo) return undefined;
+    const path = asString(params.path);
+    return `${owner}/${repo}${path ? `/${path}` : ''}`;
+  };
+
+  for (const { field, trim } of SUBJECT_FIELDS) {
+    const value = asString(params[field]);
+    if (value) {
+      const subject = trim && value.length > MAX_QUERY_CHARS
+        ? `${value.slice(0, MAX_QUERY_CHARS)}...`
+        : value;
+      return `${label}: ${subject}`;
+    }
+    if (field === OWNER_REPO_AFTER) {
+      const composed = ownerRepo();
+      if (composed) return `${label}: ${composed}`;
+    }
+  }
+
+  return label;
+};

--- a/packages/lib/src/realtime/voice-bridge-contract.ts
+++ b/packages/lib/src/realtime/voice-bridge-contract.ts
@@ -380,7 +380,19 @@ export type VoiceBridgeRequest = z.infer<typeof voiceBridgeRequestSchema>;
  * socket something the model rejects.
  */
 export type VoiceBridgeResponse =
-  | { readonly ok: true; readonly kind: 'tool'; readonly output: string }
+  | {
+      readonly ok: true;
+      readonly kind: 'tool';
+      readonly output: string;
+      /**
+       * Whether the TOOL failed, as distinct from `ok`, which says the hop
+       * worked. Every tool failure still returns a speakable `output` because
+       * the model is blocked until one arrives — so without this flag a
+       * permission error is indistinguishable from a result, and gets recorded
+       * in the thread as a completed call.
+       */
+      readonly failed: boolean;
+    }
   | {
       readonly ok: true;
       readonly kind: 'transcript';

--- a/packages/lib/src/realtime/voice-bridge-contract.ts
+++ b/packages/lib/src/realtime/voice-bridge-contract.ts
@@ -310,9 +310,58 @@ export const voiceTranscriptSchema = z.object({
   text: z.string().min(1),
 });
 
+/**
+ * Record a tool call in the bound conversation, so a spoken turn shows its work
+ * the way a typed one does.
+ *
+ * SEPARATE FROM THE `tool` HOP, which runs the tool and answers the model. This
+ * one writes a row and answers nobody: the model is never waiting on it, and it
+ * must never be able to delay a spoken turn. Folding the two together would put
+ * a database write inside the latency the caller is sitting through.
+ *
+ * TWO PHASES, ONE ROW. `running` creates it and answers with the `messageId`;
+ * `done` carries that id back and updates the same row, which is what turns a
+ * spinner into a result rather than adding a second entry. The id is minted on
+ * the web side because that is where message ids are minted — `apps/realtime`
+ * has no id generator and should not grow one to serve this.
+ *
+ * `output` is the string the model was given, so the thread shows what the
+ * model actually saw. `errorText` marks a tool that failed, which the renderer
+ * already distinguishes.
+ */
+const toolActivityCore = {
+  callId: realtimeCallIdSchema,
+  userId: z.string().min(1),
+  conversationId: z.string().min(1),
+  /** OpenAI's `function_call.call_id` — what the two phases agree on. */
+  toolCallId: z.string().min(1),
+  name: z.string().min(1),
+  argumentsJson: z.string(),
+  assistant: voiceAssistantSchema.optional(),
+};
+
+/** Phase one: the row appears, spinning. Answers with the id phase two needs. */
+export const voiceToolStartedSchema = z.object({
+  kind: z.literal('tool_started'),
+  ...toolActivityCore,
+});
+
+/** Phase two: the same row becomes a result, or an error. */
+export const voiceToolFinishedSchema = z.object({
+  kind: z.literal('tool_finished'),
+  ...toolActivityCore,
+  messageId: z.string().min(1),
+  /** The string the model was given, so the thread shows what the model saw. */
+  output: z.string(),
+  /** Present when the tool failed; the row renders as an error, not a result. */
+  errorText: z.string().optional(),
+});
+
 export const voiceBridgeRequestSchema = z.discriminatedUnion('kind', [
   voiceToolDispatchSchema,
   voiceTranscriptSchema,
+  voiceToolStartedSchema,
+  voiceToolFinishedSchema,
 ]);
 
 /**
@@ -336,6 +385,18 @@ export type VoiceBridgeResponse =
       readonly ok: true;
       readonly kind: 'transcript';
       readonly saved: boolean;
+      readonly messageId: string | null;
+      readonly rev: number;
+    }
+  | {
+      readonly ok: true;
+      readonly kind: 'tool_activity';
+      readonly saved: boolean;
+      /**
+       * The row's id. The `tool_started` answer carries it so `tool_finished`
+       * can name the same row; without it the second write would add a second
+       * entry instead of turning the spinner into a result.
+       */
       readonly messageId: string | null;
       readonly rev: number;
     }


### PR DESCRIPTION
Follow-on to #2406. That PR gave a call the real system prompt, so the model finally knew which tools it had. It still could not use them: it lost track of documents, fumbled edits, and said "let me check that" and then went quiet.

None of that was the prompt.

## The truncation

`formatToolResult` cut **every** tool result to 700 characters before the model saw it (`tool-dispatch.ts:56`). This was voice-only — the typed surface caps tool results nowhere. The same agent, on the same tools, got the whole answer when you typed and a 700-character keyhole when you talked.

The docblock justified it on the grounds that a spoken answer cannot be skimmed. True, and it is a rule about what the model **says** — which the spoken override already enforces ("two or three sentences per turn"). It was being applied to what the model **knows**:

- **`tool_search` answers with JSON Schemas.** A keyword like "calendar" matches enough tools to run to 21k characters (measured below). Sliced at 700 it arrived cut mid-object, so the model could not build the `execute_tool` call it had just gone looking for. It guessed parameters, failed validation, and tried again. *That loop is what "it doesn't navigate tool calls" looked like from outside.*
- **`read_page`** returned the first 700 characters of a document — neither a summary nor enough to edit from, since `replace_lines` works off line numbers in a full read.
- **`list_pages`** was cut off, so "find my document" failed whenever the document sorted late.

The 700-character bound is gone. A **12,000-character** one replaces it, sized against the session rather than against a listener's patience — see "The ceiling" below.

## The ceiling

A `function_call_output` stays in a 32k session that also holds the seed, the instructions and the audio for the whole call, so one result can end a call outright. Measured against the real registry:

| `tool_search` query | chars |
|---|---|
| `select:create_task,update_task` | 7,084 |
| `"calendar"` | 21,618 |
| `"page"` | 42,428 |
| `"a"` | 89,296 |

A one-letter query is ~22k tokens on its own. So `tool_search`, not `read_page`, is the worst offender — and the codebase's existing `MAX_CONTENT_CHARS_PER_PAGE = 8000` would have re-broken the original bug, since a "calendar" lookup is 21k.

The ceiling is therefore set where the path the model is actually *instructed* to take survives whole: `TOOL_DISCOVERY_PROMPT` says to call `tool_search("select:name")` for a schema before calling a tool, which is ~7k for two tools. 12k keeps that and an ordinary page read intact, and cuts only the broad dump the model never needed in full. The continuation hint leads with the general instruction — a truncated listing or search is the common case, and neither specific escape fits it — then names them:

> `[N characters were not returned. Ask again for less: a narrower query or filter, an exact name via tool_search("select:name"), or a line range via read_page's lineStart/lineEnd.]`

Follow-up worth doing separately: `tool_search` caps skill matches (`MAX_SKILL_MATCHES = 10`) but not tool matches, which is why a broad query reaches 89k at source. Capping there would give bounded *well-formed* results instead of truncated JSON, and would help the typed surface too.

## The silence

Two surfaces, because they answer different questions.

**Live, in the call bar.** Client-side and free: the browser already holds its own data channel to OpenAI and already forwards every frame into the reducer, so the reducer now reads the function calls out of `response.done` itself. No server hop, no contract.

The display seam was already built and never connected — `ToolActivity`, the action, the reducer case and `VoiceCallBar` rendering it all existed, and nothing in production ever dispatched it, so `state.tools` was permanently `[]`. I reshaped it rather than adopting it: it only ever appended, and the status line prefers a tool over everything else, so the first tool of a call would have pinned the bar for the rest of it. `activeTools` is what is running **now**, cleared when the model speaks — which bounds it to exactly the silent window.

**Durable, in the thread.** A new bridge kind in two phases: `tool_started` creates the row as a spinner and answers with its id; `tool_finished` names that same id so the repository updates it in place. That convergence is not new code — `appendPart` already replaces a tool part by `toolCallId` and `emitAfterSave` already emits `messageUpdated` for a row that existed. The part is the exact shape `chunkToPart` emits, so the renderer, the socket payload and the reload path all accept it without knowing voice exists.

Neither write is on the model's path. You are already sitting through the tool; a row nobody is waiting for must not be added to that wait. The started write goes out unawaited, the answer is sent the moment the tool returns, and only the finish chains — on the started write's promise, never on the tool.

The conversation resolution, the access check and the global-versus-page attribution are `persistVoiceTranscript`'s, deliberately: those decisions are security-relevant and there must not be a second copy of them that a spoken tool call takes instead.

## A landmine fixed on the way

`bridge-handler.ts` narrowed `kind === 'tool'` and then **fell through** to the transcript write — so any new kind would have been silently persisted as a spoken turn. Wrong row, written confidently, nothing raised. It is exhaustive now, with a drift guard that drives every member of the request schema through the handler.

## Also

`TOOL_NAME_MAP` and the descriptive-title logic moved out of `ToolCallRenderer.tsx` into `lib/ai/tools/tool-labels.ts`, because a pure reducer needs the same words and cannot import from `components/`. The port is faithful on purpose — including the field order and trimming only `query` — and is pinned by tests, since an extraction that changes behaviour while looking tidier is the failure mode worth guarding.

## Verification

- Monorepo `typecheck` (incl. build + lint), `lint`, `knip` clean.
- 1,987 web tests across the touched areas and 1,136 realtime tests pass; the one failing file requires Postgres and fails on the connection.
- Mutation-checked the load-bearing claims: restoring the 700-char cap turns the schema test red; removing the clear-on-speak pins the call bar; reordering the started write breaks the ordering test; restoring the handler fallthrough trips the drift guard; dropping `toolResults` breaks the reload round-trip; restoring the field-sniffing decoder breaks the envelope-lookalike case.
- A tool row is driven through the **real reconstruction the thread uses** and comes back as its tool part — the "still there when you come back" claim, tested rather than asserted. Writing it revealed the persistence fakes had been recording a row shape the repository never stores (it rewrites `content` into the structured envelope); the fakes now mirror that, which makes every assertion in that file about something real.

## Review round 1 (b240c98db)

Six findings from `chatgpt-codex-connector` and `coderabbitai`, all valid; two changed a decision I had made.

- **Unbounded tool output vs the 32k session (P1)** — the ceiling above.
- **A failed tool rendered as a success (P2)** — every failure path deliberately returns `ok: true` with a speakable sentence, because the model is blocked until it gets one. So "the hop worked" was read as "the tool worked", and a permission error was filed in the thread as a completed call. The dispatcher now answers `{ output, failed }`.
- **Stale tool state across calls (P2)** — `activeTools` survived every lifecycle edge, so a new call opened showing the previous call's tool as live through its first silent turn.
- **The status line was unreachable** — the bar rendered the last transcript whenever one existed, so the tool status could only show before the first spoken turn. The feature was invisible in practice; I had tested the reducer and never what the component renders.
- **Clearing on the wrong speaker** — `extractTranscript` returns the caller's transcripts too, so someone talking over a slow tool removed the explanation for the silence exactly when it was needed.
- **Arguments that are not an object** — `JSON.parse` accepts `null`, arrays and primitives; each reached the persisted `toolCalls` column as an input the typed surface can never produce.

## A pre-existing bug found on the way

Checking whether "tool rows carry no text" survived contact with the database, it did not — and the reason turned out to predate this PR.

`messages.content` does not hold prose. Any row saved with parts — which is **every typed assistant turn** — stores a JSON envelope there (`extractStructuredContentFromParts`), and `getMessagesByConversationId` returns the raw column. The voice seed reads that column straight into `conversation.item.create`.

So starting a call on a thread that had been *typed* in has been seeding the model with

```json
{"textParts":["Here they are."],"partsOrder":[…],"originalContent":"…"}
```

as an assistant utterance, spending a budget capped at twenty turns and 4k tokens on envelopes. That has been true since the seed existed; my tool rows would have added one per tool call on top.

`readMessageText` is now the one way to get a message's words. A row with no text parts yields `''` and the seed drops it — which is the behaviour my earlier commit claimed and did not actually have. Consolidating also removed a private duplicate of the same decoder in `v1-conversations.ts`, keeping that function's semantics exactly so the API's output is unchanged.

My earlier test could not have caught this: it asserted what the persistence layer *passes* to the repository, and the rewrite happens inside the repository.

**Not verified: a real call.** This is all unit-level. The check that decides it is *"What's on my calendar tomorrow?"* — it should now complete rather than loop, with the bar naming each step and the thread filling in as it goes. Worth also confirming a tool row survives a reload, and that context usage on a long call stays sane now that results are uncapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEofnKqGYY8Gs8CjwkGPXd
