### PR TITLE
feat(ai): add GLM-5.3 (admin Z.ai) and Gemini 3.7 Flash (Google/OpenRouter)

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -37,6 +37,7 @@ describe('ai-providers-config', () => {
       // Admin-only direct Z.ai Coder Plan connection: bare glm-* native ids.
       expect(AI_PROVIDERS).toHaveProperty('glm');
       expect(AI_PROVIDERS.glm.name).toBe('Z.ai (Admin)');
+      expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5.3');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5.1');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5-turbo');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-4.7');
@@ -62,6 +63,7 @@ describe('ai-providers-config', () => {
     it('uses full OpenRouter model ids as keys for cloud vendors', () => {
       expect(AI_PROVIDERS.openai.models).toHaveProperty('openai/gpt-5.6-sol');
       expect(AI_PROVIDERS.anthropic.models).toHaveProperty('anthropic/claude-opus-5');
+      expect(AI_PROVIDERS.google.models).toHaveProperty('google/gemini-3.7-flash');
       expect(AI_PROVIDERS.google.models).toHaveProperty('google/gemini-3.6-flash');
       expect(AI_PROVIDERS.xai.models).toHaveProperty('x-ai/grok-4.5');
       expect(AI_PROVIDERS.moonshot.models).toHaveProperty('moonshotai/kimi-k3');
@@ -81,6 +83,7 @@ describe('ai-providers-config', () => {
       expect(FREE_TIER_MODELS.has('openai/gpt-5.4-nano')).toBe(true);
       expect(FREE_TIER_MODELS.has('openai/gpt-5.4-mini')).toBe(true);
       expect(FREE_TIER_MODELS.has('anthropic/claude-haiku-4.5')).toBe(true);
+      expect(FREE_TIER_MODELS.has('google/gemini-3.7-flash')).toBe(true);
       expect(FREE_TIER_MODELS.has('google/gemini-3.5-flash-lite')).toBe(true);
     });
 

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -69,6 +69,7 @@ export const FREE_TIER_MODELS = new Set<string>([
   'openai/gpt-5.4-nano',
   'openai/gpt-5.4-mini',
   'anthropic/claude-haiku-4.5',
+  'google/gemini-3.7-flash',
   'google/gemini-3.5-flash-lite',
   'google/gemini-3.5-flash',
   'google/gemini-3.1-flash-lite',
@@ -156,6 +157,7 @@ export const AI_PROVIDERS = {
   google: {
     name: 'Google',
     models: {
+      'google/gemini-3.7-flash': 'Gemini 3.7 Flash',
       'google/gemini-3.6-flash': 'Gemini 3.6 Flash',
       'google/gemini-3.5-flash-lite': 'Gemini 3.5 Flash Lite',
       'google/gemini-3.5-flash': 'Gemini 3.5 Flash',
@@ -310,6 +312,7 @@ export const AI_PROVIDERS = {
     // NOT billed against the shared credit pool (see METERING_EXEMPT_PROVIDERS).
     // Models officially supported by that endpoint; bare `glm-*` ids (no vendor prefix).
     models: {
+      'glm-5.3':     'GLM-5.3',
       'glm-5.2':     'GLM-5.2',
       'glm-5.1':     'GLM-5.1',
       'glm-5-turbo': 'GLM-5 Turbo',

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -100,6 +100,7 @@ export const AI_PRICING = {
   'openai/gpt-oss-20b': { input: 0.03, output: 0.14 },
 
   // OpenRouter - Google (source: openrouter.ai/api/v1/models)
+  'google/gemini-3.7-flash': { input: 0.375, output: 1.875 },
   'google/gemini-3.6-flash': { input: 1.50, output: 7.50 },
   'google/gemini-3.5-flash-lite': { input: 0.30, output: 2.50 },
   'google/gemini-3.5-flash': { input: 1.50, output: 9.00 },
@@ -140,6 +141,8 @@ export const AI_PRICING = {
   'mistralai/devstral-small': { input: 0.10, output: 0.30 },
 
   // Z.ai GLM direct — GLM Coder Plan supported models only (source: z.ai/guides/overview/pricing)
+  // GLM-5.3 rates unpublished at launch (2026-08-14); GLM-5.2 rates as placeholder.
+  'glm-5.3':     { input: 1.40, output: 4.40 },
   'glm-5.2':     { input: 1.40, output: 4.40 },
   'glm-5.1':     { input: 1.40, output: 4.40 },
   'glm-5-turbo': { input: 1.20, output: 4.00 },
@@ -410,6 +413,7 @@ export const MODEL_CONTEXT_WINDOWS = {
   'openai/gpt-oss-20b': 131072,
 
   // OpenRouter Models - Google
+  'google/gemini-3.7-flash': 1048576,
   'google/gemini-3.6-flash': 1048576,
   'google/gemini-3.5-flash-lite': 1048576,
   'google/gemini-3.5-flash': 1048576,
@@ -451,6 +455,7 @@ export const MODEL_CONTEXT_WINDOWS = {
   'mistralai/devstral-small': 128000,
 
   // Z.ai GLM direct — GLM Coder Plan supported models only
+  'glm-5.3':     1000000,
   'glm-5.2':     1000000,
   'glm-5.1':     202752,
   'glm-5-turbo': 202752,


### PR DESCRIPTION
## Summary
- **GLM-5.3** added to the admin-only `glm` provider (bare `glm-5.3` id — the Z.ai Coding Plan endpoint this provider connects to). Z.ai hasn't published per-token rates yet, so GLM-5.2's rates ($1.40/$4.40 per M) stand in as a placeholder with a comment, following the GLM-5.2 addition (#1646). 1M-token context window per Z.ai docs. No public `z-ai/glm-5.3` entry — OpenRouter doesn't list it yet (gated release), same reasoning as #1646.
- **Gemini 3.7 Flash** added under the Google provider as `google/gemini-3.7-flash` with OpenRouter's listed rates ($0.375 in / $1.875 out per M) and 1,048,576-token context. Also added to `FREE_TIER_MODELS` so free-tier users can select it.
- Test assertions added for all three changes (admin glm model, google catalog id, free-tier membership).

## Verification
- `bun run --filter web test -- ai-providers-config` — 45/45 passed
- `bun run --filter @pagespace/lib test -- ai-monitoring` — 116/116 passed (includes the AI_PRICING ↔ MODEL_CONTEXT_WINDOWS sync guard)
- `bun run typecheck` — 17/17 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5q9HaJWHk9vuJj2kCdDY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini 3.7 Flash to the available model catalog and free-tier options.
  * Added GLM-5.3 as an admin-only model option.
  * Added support for the models’ context limits and usage pricing information.
* **Bug Fixes**
  * Improved model availability and usage tracking for the newly supported AI models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->