### PR TITLE
fix(api): a non-threaded completion opens the conversation it writes to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 - **Talking to one of your agents from outside PageSpace works again** — the OpenAI-compatible
   endpoint (`/v1/chat/completions`, what the PageSpace CLI and any OpenAI-style client use) answered
   every valid request to a page agent with a generic "Failed to process chat request. Please try
-  again." Trying again never helped: unless the caller named an existing conversation to continue,
-  the reply was being filed against a conversation that had never been opened, and saving the first
-  message failed before the agent said a word. Each call now opens its conversation properly, which
-  also means those exchanges show up in the agent's history like any other, instead of being lost.
-  Asking the same agent through the app was never affected.
+  again," and trying again never helped. A call without a `conversation_id` is documented as
+  stateless — you send the messages, the agent replies, nothing is kept — but the endpoint was
+  trying to file both halves of it away regardless, under a thread that had never been opened. That
+  save failed every time, before the agent said a word. Those calls now keep nothing, as promised,
+  and answer normally. Passing a `conversation_id` is still what makes a thread durable, and that
+  path was never affected — nor was asking the same agent through the app.
 - **Confirming a CLI login by email now actually finishes the login** — running `pagespace login`
   without a passkey sends a confirmation email, and clicking its link used to land on a page saying
   "Confirmed | You can return to the tab where you started this action" while the tab you started in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Talking to one of your agents from outside PageSpace works again** — the OpenAI-compatible
+  endpoint (`/v1/chat/completions`, what the PageSpace CLI and any OpenAI-style client use) answered
+  every valid request to a page agent with a generic "Failed to process chat request. Please try
+  again." Trying again never helped: unless the caller named an existing conversation to continue,
+  the reply was being filed against a conversation that had never been opened, and saving the first
+  message failed before the agent said a word. Each call now opens its conversation properly, which
+  also means those exchanges show up in the agent's history like any other, instead of being lost.
+  Asking the same agent through the app was never affected.
 - **Confirming a CLI login by email now actually finishes the login** — running `pagespace login`
   without a passkey sends a confirmation email, and clicking its link used to land on a page saying
   "Confirmed | You can return to the tab where you started this action" while the tab you started in

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -707,34 +707,62 @@ describe('POST /api/v1/chat/completions', () => {
     });
   });
 
-  test('openai mode: creates the conversations row the minted id will be written against', async () => {
-    // #2414: without this the auto-minted conversationId has no `conversations`
-    // row, and savePageMessage — whose conversationId is NOT NULL with an FK —
-    // fails 23503 before streaming starts, 500ing every non-threaded request.
-    await POST(makeRequest(validBody));
-    const created = vi.mocked(conversationRepository.createConversation).mock.calls[0];
-    const saved = vi.mocked(messageRepository.savePageMessage).mock.calls[0]?.[0];
+  test('openai mode: a request without conversation_id persists nothing and still streams', async () => {
+    // #2414: the route used to save both sides of a stateless call against a
+    // freshly minted conversationId that had no `conversations` row. That
+    // column is NOT NULL with an FK, so the save died 23503 in setup and 500'd
+    // every default-shaped request. The documented contract for this path is
+    // "nothing is kept" (docs/features/agent-api), so the writes go, not the
+    // FK — creating the row would have made the stateless path durable.
+    const response = await POST(makeRequest(validBody));
+    await response.text();
     assert({
-      given: 'a request with no conversation_id, so the route mints one',
-      should: 'create that exact conversation for the caller and agent page before saving the user message',
+      given: 'a request with no conversation_id — the documented stateless path',
+      should: 'return a 200 stream while writing no conversation and no message',
       actual: {
-        createdWith: created?.slice(0, 3),
-        savedAgainst: saved?.conversationId,
+        status: response.status,
+        conversationsCreated: vi.mocked(conversationRepository.createConversation).mock.calls.length,
+        messagesSaved: vi.mocked(messageRepository.savePageMessage).mock.calls.length,
       },
-      expected: {
-        createdWith: ['test-id-123', 'user-1', 'page-123'],
-        savedAgainst: 'test-id-123',
-      },
+      expected: { status: 200, conversationsCreated: 0, messagesSaved: 0 },
     });
   });
 
-  test('thread mode: does not re-create a conversation the ownership check already resolved', async () => {
-    await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
+  test('openai mode: a stateless call is still billed for what it burned', async () => {
+    // Not persisting is not the same as not charging: the provider ran.
+    const response = await POST(makeRequest(validBody));
+    await response.text();
+    const call = vi.mocked(AIMonitoring.trackUsage).mock.calls[0]?.[0];
+    assert({
+      given: 'a stateless call that finished normally',
+      should: 'still track usage once, against the in-request correlation id',
+      actual: {
+        count: vi.mocked(AIMonitoring.trackUsage).mock.calls.length,
+        conversationId: call?.conversationId,
+        success: call?.success,
+      },
+      expected: { count: 1, conversationId: 'test-id-123', success: true },
+    });
+  });
+
+  test('thread mode: a supplied conversation_id is what makes the exchange durable', async () => {
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
+    await response.text();
+    const roles = vi.mocked(messageRepository.savePageMessage).mock.calls.map(c => c[0].role);
+    const convIds = vi.mocked(messageRepository.savePageMessage).mock.calls.map(c => c[0].conversationId);
     assert({
       given: 'a thread-mode request whose conversations row already exists',
-      should: 'leave creation to the 5c ownership check and not create it again',
-      actual: vi.mocked(conversationRepository.createConversation).mock.calls.length,
-      expected: 0,
+      should: 'persist both sides against that conversation, without re-creating it',
+      actual: {
+        roles,
+        convIds: [...new Set(convIds)],
+        conversationsCreated: vi.mocked(conversationRepository.createConversation).mock.calls.length,
+      },
+      expected: {
+        roles: ['user', 'assistant'],
+        convIds: ['conv-abc'],
+        conversationsCreated: 0,
+      },
     });
   });
 
@@ -1089,7 +1117,9 @@ describe('POST /api/v1/chat/completions', () => {
       },
     })) as unknown as typeof streamText);
 
-    const response = await POST(makeRequest(validBody));
+    // conversation_id supplied: persistence is what this test is about, and a
+    // stateless call deliberately writes nothing (#2414).
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
     await response.text();
 
     const saveCalls = vi.mocked(messageRepository.savePageMessage).mock.calls;
@@ -1157,19 +1187,23 @@ describe('POST /api/v1/chat/completions', () => {
       },
     })) as unknown as typeof streamText);
 
-    const response = await POST(makeRequest(validBody));
+    // conversation_id supplied so the assistant row is actually written —
+    // otherwise "saved without toolCalls" would pass on a save that never
+    // happened (#2414).
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
     await response.text();
 
     const saveCalls = vi.mocked(messageRepository.savePageMessage).mock.calls;
     const assistantSave = saveCalls.find((c) => c[0].role === 'assistant');
     assert({
       given: 'a stream with steps but no tool calls',
-      should: 'save the assistant message without toolCalls or toolResults',
+      should: 'save the assistant message, with no toolCalls or toolResults on it',
       actual: {
+        saved: assistantSave !== undefined,
         toolCalls: assistantSave?.[0]?.toolCalls,
         toolResults: assistantSave?.[0]?.toolResults,
       },
-      expected: { toolCalls: undefined, toolResults: undefined },
+      expected: { saved: true, toolCalls: undefined, toolResults: undefined },
     });
   });
 
@@ -1213,7 +1247,9 @@ describe('POST /api/v1/chat/completions', () => {
     // here must NOT strand the gate's hold + in-flight slot until TTL.
     vi.mocked(messageRepository.savePageMessage).mockRejectedValueOnce(new Error('db write failed'));
 
-    const response = await POST(makeRequest(validBody));
+    // Thread mode: only a durable call persists the user message at all, so
+    // that save is the setup step this leak regression can throw from (#2414).
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
 
     assert({
       given: 'a throw during pre-stream setup (user-message persistence) after the hold is placed',
@@ -1364,7 +1400,9 @@ describe('POST /api/v1/chat/completions', () => {
       () => new Promise<void>((resolve) => setTimeout(() => { released = true; resolve(); }, 0)),
     );
 
-    const response = await POST(makeRequest(validBody));
+    // Thread mode for the same reason as the test above: the stateless path
+    // never reaches savePageMessage (#2414).
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
 
     assert({
       given: 'a pre-stream setup failure whose hold release resolves on a later tick',

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -707,6 +707,37 @@ describe('POST /api/v1/chat/completions', () => {
     });
   });
 
+  test('openai mode: creates the conversations row the minted id will be written against', async () => {
+    // #2414: without this the auto-minted conversationId has no `conversations`
+    // row, and savePageMessage — whose conversationId is NOT NULL with an FK —
+    // fails 23503 before streaming starts, 500ing every non-threaded request.
+    await POST(makeRequest(validBody));
+    const created = vi.mocked(conversationRepository.createConversation).mock.calls[0];
+    const saved = vi.mocked(messageRepository.savePageMessage).mock.calls[0]?.[0];
+    assert({
+      given: 'a request with no conversation_id, so the route mints one',
+      should: 'create that exact conversation for the caller and agent page before saving the user message',
+      actual: {
+        createdWith: created?.slice(0, 3),
+        savedAgainst: saved?.conversationId,
+      },
+      expected: {
+        createdWith: ['test-id-123', 'user-1', 'page-123'],
+        savedAgainst: 'test-id-123',
+      },
+    });
+  });
+
+  test('thread mode: does not re-create a conversation the ownership check already resolved', async () => {
+    await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
+    assert({
+      given: 'a thread-mode request whose conversations row already exists',
+      should: 'leave creation to the 5c ownership check and not create it again',
+      actual: vi.mocked(conversationRepository.createConversation).mock.calls.length,
+      expected: 0,
+    });
+  });
+
   test('openai mode: does not call getMessagesForPage when conversation_id is absent', async () => {
     await POST(makeRequest(validBody));
     assert({

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -395,21 +395,26 @@ export async function POST(request: Request): Promise<Response> {
     const isThreadMode = incomingConversationId !== undefined;
     const conversationId = isThreadMode ? incomingConversationId : createId();
 
-    // The minted id needs its `conversations` row BEFORE anything writes a
-    // message against it. `messages.conversationId` is NOT NULL with an FK to
-    // `conversations.id`, so a non-threaded call — the default shape every
-    // plain OpenAI client and pagespace-cli's brain path sends — died on a
-    // 23503 foreign-key violation in savePageMessage before streaming ever
-    // started (#2414). Thread mode already has its row: 5c created it for a
-    // client_manages_history caller, and validateConversationAccess proved it
-    // exists for everyone else.
+    // `conversation_id` IS the persistence switch, and its absence means the
+    // caller opted out. The public contract is explicit — "Each call is
+    // stateless by default: you send the messages, the agent replies, nothing
+    // is kept. Pass a conversation_id and the thread becomes durable"
+    // (apps/marketing/src/app/docs/features/agent-api/page.tsx) — so a default
+    // call must persist NOTHING, and this route was trying to save both sides
+    // of it anyway. `messages.conversationId` is NOT NULL with an FK to
+    // `conversations.id`, and the minted id has no row, so every one of those
+    // saves died 23503 in setup and 500'd the request before streaming (#2414).
     //
-    // Same eager-create as /api/ai/page-agents/consult, and for the second
-    // reason it gives too: the conversation is then listable, instead of
-    // holding messages no listing that joins `conversations` can see.
-    if (!isThreadMode) {
-      await conversationRepository.createConversation(conversationId, authResult.userId, pageId);
-    }
+    // Creating the row instead would have "fixed" the 500 by making the
+    // stateless path durable: prompts a caller deliberately left unthreaded
+    // would land in the agent's history, visible in the app. That is the wrong
+    // half of the contract to change. Skipping the writes honours it and
+    // removes the FK violation at the same time.
+    //
+    // The id itself lives on as an in-request correlation key — tool
+    // attribution (`aiConversationId`) and the usage row both take it, and
+    // neither column carries an FK — so nothing downstream needs a real row.
+    const persistConversation = isThreadMode;
 
     const userMessage = messages[messages.length - 1];
 
@@ -468,7 +473,7 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     const userMessageId = userMessage.id;
-    if (userMessage && userMessage.role === 'user') {
+    if (persistConversation && userMessage && userMessage.role === 'user') {
       await messageRepository.savePageMessage({
         messageId: userMessageId,
         pageId,
@@ -550,7 +555,10 @@ export async function POST(request: Request): Promise<Response> {
       const assistantId = createId();
       const extracted = extractToolCallsFromSteps(steps ?? []);
       const hasContent = text !== undefined || extracted.toolCalls.length > 0;
-      if (hasContent) {
+      // Both halves of the exchange follow the one switch: a stateless call
+      // keeps the reply no more than it keeps the prompt. The billing that
+      // follows is unconditional — an unpersisted turn is still real spend.
+      if (persistConversation && hasContent) {
         await messageRepository.savePageMessage({
           messageId: assistantId,
           pageId,

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -36,6 +36,7 @@ import { buildToolSummaryEvent } from '@/lib/ai/openai-api/build-tool-summary-ev
 import { validateConversationAccess } from '@/lib/ai/openai-api/v1-conversations';
 import { extractToolCallsFromSteps } from '@/lib/ai/openai-api/extract-tool-calls-from-steps';
 import { resolveHoldDisposition } from '@/lib/ai/openai-api/resolve-hold-disposition';
+import { describeErrorCause } from '@/lib/ai/openai-api/describe-error-cause';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
@@ -393,6 +394,23 @@ export async function POST(request: Request): Promise<Response> {
     // 8. Build message context and save new user message
     const isThreadMode = incomingConversationId !== undefined;
     const conversationId = isThreadMode ? incomingConversationId : createId();
+
+    // The minted id needs its `conversations` row BEFORE anything writes a
+    // message against it. `messages.conversationId` is NOT NULL with an FK to
+    // `conversations.id`, so a non-threaded call — the default shape every
+    // plain OpenAI client and pagespace-cli's brain path sends — died on a
+    // 23503 foreign-key violation in savePageMessage before streaming ever
+    // started (#2414). Thread mode already has its row: 5c created it for a
+    // client_manages_history caller, and validateConversationAccess proved it
+    // exists for everyone else.
+    //
+    // Same eager-create as /api/ai/page-agents/consult, and for the second
+    // reason it gives too: the conversation is then listable, instead of
+    // holding messages no listing that joins `conversations` can see.
+    if (!isThreadMode) {
+      await conversationRepository.createConversation(conversationId, authResult.userId, pageId);
+    }
+
     const userMessage = messages[messages.length - 1];
 
     let inferenceMessages = messages;
@@ -550,7 +568,7 @@ export async function POST(request: Request): Promise<Response> {
             },
           }),
         }).catch((err: unknown) => {
-          loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
+          loggers.ai.error('OpenAI API: failed to save assistant message', err as Error, describeErrorCause(err));
         });
       }
 
@@ -750,7 +768,13 @@ export async function POST(request: Request): Promise<Response> {
   } catch (setupError) {
     // Pre-stream failure (capabilities / convertToModelMessages / persistence). No provider
     // tokens were billed; the finally frees the hold. Return 500 like the in-app chat route.
-    loggers.ai.error('OpenAI API: request setup failed before streaming', setupError as Error, { pageId });
+    // ...with the driver's own diagnostics, not just Drizzle's `Failed query:`
+    // wrapper — a constraint violation should name its constraint in the log
+    // rather than requiring the schema to be read by hand (#2414).
+    loggers.ai.error('OpenAI API: request setup failed before streaming', setupError as Error, {
+      pageId,
+      ...describeErrorCause(setupError),
+    });
     return NextResponse.json({ error: 'Failed to process chat request. Please try again.' }, { status: 500 });
   } finally {
     // Setup-phase disposition is always 'release' (resolveHoldDisposition); only act when the

--- a/apps/web/src/lib/ai/openai-api/__tests__/describe-error-cause.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/describe-error-cause.test.ts
@@ -1,0 +1,54 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { describeErrorCause } from '../describe-error-cause';
+
+describe('describeErrorCause', () => {
+  test('lifts the Postgres diagnostics out of a Drizzle-wrapped query error', () => {
+    const cause = Object.assign(new Error('insert or update on table "messages" violates foreign key constraint'), {
+      code: '23503',
+      constraint: 'messages_conversationId_conversations_id_fk',
+      detail: 'Key (conversationId)=(k7otmhzstwtj8v47d9gjw1cq) is not present in table "conversations".',
+      table: 'messages',
+    });
+    const wrapped = new Error('Failed query: insert into "messages" ...', { cause });
+
+    assert({
+      given: 'a Failed query error whose cause carries the FK violation',
+      should: 'return the sqlstate, constraint, detail, table and cause message',
+      actual: describeErrorCause(wrapped),
+      expected: {
+        causeMessage: 'insert or update on table "messages" violates foreign key constraint',
+        causeCode: '23503',
+        causeConstraint: 'messages_conversationId_conversations_id_fk',
+        causeDetail: 'Key (conversationId)=(k7otmhzstwtj8v47d9gjw1cq) is not present in table "conversations".',
+        causeTable: 'messages',
+      },
+    });
+  });
+
+  test('reports only the fields the cause actually carries', () => {
+    const wrapped = new Error('Failed query', { cause: Object.assign(new Error('deadlock detected'), { code: '40P01' }) });
+
+    assert({
+      given: 'a cause with a message and a code but no constraint/detail/table',
+      should: 'omit the absent fields rather than emitting empty ones',
+      actual: describeErrorCause(wrapped),
+      expected: { causeMessage: 'deadlock detected', causeCode: '40P01' },
+    });
+  });
+
+  test('returns undefined when there is no cause worth logging', () => {
+    assert({
+      given: 'errors with no cause, a non-object cause, and a cause with no string fields',
+      should: 'return undefined for each so callers can spread unconditionally',
+      actual: [
+        describeErrorCause(new Error('plain')),
+        describeErrorCause(new Error('wrapped', { cause: 'a string cause' })),
+        describeErrorCause(new Error('wrapped', { cause: { code: 23503 } })),
+        describeErrorCause(undefined),
+        describeErrorCause('not an error'),
+      ],
+      expected: [undefined, undefined, undefined, undefined, undefined],
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/describe-error-cause.ts
+++ b/apps/web/src/lib/ai/openai-api/describe-error-cause.ts
@@ -1,0 +1,47 @@
+/**
+ * Flatten the driver diagnostics a database error hides under `cause`.
+ *
+ * Drizzle wraps a failed statement as `Error: Failed query: insert into
+ * "messages" (...)` and hangs the real driver error off `cause`. The wrapper
+ * names no constraint, so a logged foreign-key violation reads as an anonymous
+ * insert failure — #2414 took a by-hand schema read to identify, when the
+ * `cause` was already carrying `code: '23503'` and
+ * `messages_conversationId_conversations_id_fk` outright. The logger serializes
+ * an Error's name/message/stack and stops there, so the fields have to be
+ * lifted into metadata to survive.
+ *
+ * Returns `undefined` when the error carries nothing worth logging, so callers
+ * can spread it into log metadata unconditionally.
+ */
+export interface ErrorCauseDetail {
+  /** Index signature so the whole shape satisfies the logger's `LogInput`. */
+  [key: string]: string | undefined;
+  causeMessage?: string;
+  /** Postgres SQLSTATE, e.g. '23503' for foreign_key_violation. */
+  causeCode?: string;
+  causeConstraint?: string;
+  causeDetail?: string;
+  causeTable?: string;
+}
+
+const FIELDS = [
+  ['message', 'causeMessage'],
+  ['code', 'causeCode'],
+  ['constraint', 'causeConstraint'],
+  ['detail', 'causeDetail'],
+  ['table', 'causeTable'],
+] as const;
+
+export function describeErrorCause(error: unknown): ErrorCauseDetail | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const cause = (error as { cause?: unknown }).cause;
+  if (typeof cause !== 'object' || cause === null) return undefined;
+
+  const raw = cause as Record<string, unknown>;
+  const detail: ErrorCauseDetail = {};
+  for (const [from, to] of FIELDS) {
+    const value = raw[from];
+    if (typeof value === 'string' && value !== '') detail[to] = value;
+  }
+  return Object.keys(detail).length > 0 ? detail : undefined;
+}


### PR DESCRIPTION
Fixes #2414.

## The bug

`POST /api/v1/chat/completions` returned a 500 for every valid page-agent request, before streaming started. With no caller-supplied `conversation_id`, the route minted a fresh `conversationId` and then tried to save both sides of the exchange against it — but `messages.conversationId` is `NOT NULL` with an FK to `conversations.id`, and no such row was ever created, so the insert died `23503` in setup.

That is the default shape of every plain OpenAI-style client, and `pagespace-cli`'s brain path sends no `conversation_id` at all, so the endpoint was unusable for all of them.

## The fix: remove the writes, not the FK

The obvious repair — create the `conversations` row — resolves the 500 by making the documented stateless path durable. The public contract is explicit:

> Each call is stateless by default: you send the messages, the agent replies, nothing is kept. Pass a `conversation_id` and the thread becomes **durable**.
> — `apps/marketing/src/app/docs/features/agent-api/page.tsx`

Creating the row would file prompts a caller deliberately left unthreaded into the agent's history, visible in the app, with no change to the promise they relied on. So the writes go instead: a call with no `conversation_id` now persists neither the prompt nor the reply. That is both what the docs promise and what removes the FK violation — `savePageMessage` is simply never reached with an id that has no row. `conversation_id` remains the persistence switch, and the durable path is untouched.

The minted id still exists as an in-request correlation key. Tool attribution (`aiConversationId`) and the `ai_usage` row both take it, and neither column carries an FK, so nothing downstream needs a real row. Billing is deliberately outside the guard: an unpersisted turn is still real provider spend.

## On the issue's second bug

The report's "a supplied `conversationId` is ignored" is not a route bug. The wire field is snake_case `conversation_id` (`validate-inference-request.ts:226`), and it has been threaded into `savePageMessage` since #1390 (May 2026); a camelCase key is simply never read. `pagespace-cli`'s `brain.ts` sends no conversation id in any spelling, so it hit the real bug above rather than this one. No change made; it can opt into durability by sending `conversation_id`.

## Debuggability

The issue's other observation was that Drizzle's `Failed query: insert into "messages" ...` wrapper swallowed the underlying Postgres error, so identifying the constraint took a by-hand schema read. New `describe-error-cause.ts` lifts the driver's `cause` fields — sqlstate, constraint, detail, table — into the log metadata for the setup-failure and assistant-save catches, which the logger's `Error` serialization otherwise drops. This class of failure now names itself.

The caller-facing 500 body is deliberately unchanged: altering it is a client-contract change beyond this fix.

## Validation

- `bun run typecheck` (monorepo) — 17/17 pass
- `bun run lint` — 15/15 pass
- Route + `openai-api` suites — 190 pass
- **Mutation-checked in both directions**: forcing `persistConversation` on fails the stateless test; forcing it off fails seven durability tests. So the guard is pinned from both sides, not just asserted.
- `bun run test:security` — 51/51 suites pass
- Rebased onto current `master` (`1a627f64c`); no conflicts, and no churn to the touched files in the intervening 85 commits

Several existing tests asserted persistence while sending no `conversation_id`, so they now send one — including two credit-hold leak regressions (L6) whose throwing `savePageMessage` is the setup step they depend on. Those two were also leaking an unconsumed `mockRejectedValueOnce` into a later test once the stateless path stopped calling it.

Not verified end-to-end against a live server — no prod credential in this environment, so the issue's `curl` repro is still worth running once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hY84rE32KNJTYUEBUjG2j
