### PR TITLE
fix(chat): Stop and Retry answer the moment you press them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,26 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Stop and Retry now react the moment you press them** — both were doing their work at roughly
+  the speed they always had, and both spent that time showing you nothing at all, which reads as a
+  hang.
+
+  Pressing Stop changed no pixel until the server confirmed the abort and the result came back over
+  the realtime connection — a wait that is deliberately allowed to run to several seconds when the
+  generation is running on another machine. The button now says **Stopping…** from the moment you
+  press it. It does not say *stopped*: the reply keeps streaming underneath until the generation
+  actually ends, because a Stop that has been requested and a Stop that has taken effect are
+  different things, and claiming the second one while an agent is still running tools and still
+  costing you money is worse than saying nothing. Pressing Stop a moment after the reply had already
+  finished used to produce no response whatsoever; now it acknowledges the press and settles.
+
+  Retry had no feedback at all. It quietly deleted the old answer, waited on the server, and only
+  then started regenerating — so the one visible change in the whole window was the previous reply
+  vanishing, which looks like a failure rather than like work in progress. Retry now behaves exactly
+  like sending a message: the composer locks and offers Stop from the click onward. Retry is also
+  disabled while it is running, so a double-click can no longer start (and bill for) two
+  regenerations.
+
 - **Talking to one of your agents from outside PageSpace works again** — the OpenAI-compatible
   endpoint (`/v1/chat/completions`, what the PageSpace CLI and any OpenAI-style client use) answered
   every valid request to a page agent with a generic "Failed to process chat request. Please try

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   vanishing, which looks like a failure rather than like work in progress. Retry now behaves exactly
   like sending a message: the composer locks and offers Stop from the click onward. Retry is also
   disabled while it is running, so a double-click can no longer start (and bill for) two
-  regenerations.
+  regenerations — and that holds across surfaces, so the dashboard and the sidebar can no longer
+  each start one for the same conversation.
+
+  Because Retry now offers you a Stop, that Stop does what it says. Pressing it while the retry is
+  still clearing the old answer cancels the retry: no new reply is generated and you are not billed
+  for one. And if clearing the old answer fails, the retry does not start at all and tells you so,
+  rather than going ahead and handing the model its own previous answer to rewrite.
 
 - **Talking to one of your agents from outside PageSpace works again** — the OpenAI-compatible
   endpoint (`/v1/chat/completions`, what the PageSpace CLI and any OpenAI-style client use) answered

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -210,6 +210,7 @@ export function SessionChatView({
           onSend={() => void handleSendClick()}
           onStop={() => void chat.handleStop()}
           isStreaming={chat.displayIsStreaming}
+          isStopping={chat.isStopping}
           disabled={isReadOnly}
           placeholder={isReadOnly ? 'View only' : `Message ${name}...`}
           hideModelSelector

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -75,6 +75,8 @@ export interface UseAgentSessionChatReturn {
   /** Resolves false when nothing was dispatched (empty text, refused handoff) — the composer restores its draft. */
   handleSend: (text: string) => Promise<boolean>;
   handleStop: () => Promise<void>;
+  /** A Stop was requested and has not resolved — render "stopping", never "stopped". */
+  isStopping: boolean;
   handleEdit: (messageId: string, newContent: string) => Promise<void>;
   handleDelete: (messageId: string) => Promise<void>;
   handleRetry: () => Promise<void>;
@@ -238,7 +240,7 @@ export function useAgentSessionChat({
     [conversationId, wrapSend, sendMessage, buildBody],
   );
 
-  const handleStop = useStopStream({
+  const { handleStop, isStopping } = useStopStream({
     activeStream,
     pendingSendConversationId,
   });
@@ -255,6 +257,8 @@ export function useAgentSessionChat({
     regenerate: (opts?: { body?: Record<string, unknown> }) => {
       void regenerate(conversationId, opts);
     },
+    // Retry inherits send's optimistic path — see useCacheMessageActions.
+    wrapSend,
   });
 
   const lastAssistantMessageId = useMemo(
@@ -291,6 +295,7 @@ export function useAgentSessionChat({
     reloadConversation,
     handleSend,
     handleStop,
+    isStopping,
     handleEdit,
     handleDelete,
     handleRetry,

--- a/apps/web/src/components/agents/chat/useAgentSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAgentSessionChat.ts
@@ -259,6 +259,9 @@ export function useAgentSessionChat({
     },
     // Retry inherits send's optimistic path — see useCacheMessageActions.
     wrapSend,
+    // …and its release: a retry stopped mid-DELETE dispatches nothing, and nothing else
+    // would clear the pendingSend it registered.
+    releasePendingSend,
   });
 
   const lastAssistantMessageId = useMemo(

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -260,6 +260,9 @@ export function useAssistantSessionChat({
     },
     // Retry inherits send's optimistic path — see useCacheMessageActions.
     wrapSend,
+    // …and its release: a retry stopped mid-DELETE dispatches nothing, and nothing else
+    // would clear the pendingSend it registered.
+    releasePendingSend,
   });
 
   const lastAssistantMessageId = useMemo(

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -240,7 +240,7 @@ export function useAssistantSessionChat({
     [conversationId, wrapSend, sendMessage, buildBody],
   );
 
-  const handleStop = useStopStream({
+  const { handleStop, isStopping } = useStopStream({
     activeStream,
     pendingSendConversationId,
   });
@@ -258,6 +258,8 @@ export function useAssistantSessionChat({
     regenerate: (opts?: { body?: Record<string, unknown> }) => {
       void regenerate(conversationId, opts);
     },
+    // Retry inherits send's optimistic path — see useCacheMessageActions.
+    wrapSend,
   });
 
   const lastAssistantMessageId = useMemo(
@@ -294,6 +296,7 @@ export function useAssistantSessionChat({
     reloadConversation,
     handleSend,
     handleStop,
+    isStopping,
     handleEdit,
     handleDelete,
     handleRetry,

--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -25,6 +25,8 @@ export interface ChatInputProps {
   onStop: () => void;
   /** Whether AI is currently streaming */
   isStreaming: boolean;
+  /** A Stop has been requested and has not resolved yet — see InputActions. */
+  isStopping?: boolean;
   /** Whether the input is disabled */
   disabled?: boolean;
   /** Placeholder text */
@@ -103,6 +105,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       onSend,
       onStop,
       isStreaming,
+      isStopping = false,
       disabled = false,
       placeholder = 'Type your message...',
       driveId,
@@ -267,6 +270,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
           <InputActions
             isStreaming={isStreaming}
+            isStopping={isStopping}
             onSend={handleSend}
             onStop={onStop}
             disabled={!canSend}

--- a/apps/web/src/components/ai/chat/input/InputActions.tsx
+++ b/apps/web/src/components/ai/chat/input/InputActions.tsx
@@ -49,18 +49,23 @@ export function InputActions({
   const buttonContent = isStreaming ? (
     <Button
       data-testid="chat-stop"
-      onClick={onStop}
-      // Disabled while the first Stop is in flight: a second one names the same stream and
-      // changes nothing, and an unlatched button reads as "that click did nothing".
-      disabled={isStopping}
+      // Inert while the first Stop is in flight: a second one names the same stream and changes
+      // nothing, and an unlatched button reads as "that click did nothing". The guard is here
+      // rather than on `disabled` deliberately — see below.
+      onClick={isStopping ? undefined : onStop}
+      // `aria-disabled`, NOT `disabled`, and the difference is the entire point of this state.
+      // A natively disabled button is removed from the focus path, so a keyboard user who
+      // pressed Stop loses focus to the body and never hears the relabel — the feedback this
+      // exists to give is precisely what `disabled` would swallow (CodeRabbit). Focusable and
+      // announced, with the click guarded above, is the same protection without the silence.
+      aria-disabled={isStopping || undefined}
       data-stopping={isStopping ? 'true' : undefined}
-      // The whole point of this state is feedback, so it has to be announceable — a disabled
-      // button with a reworded label is not reliably read out. `aria-busy` is the standard
-      // signal for "this control is working on the thing you asked for".
+      // `aria-busy` is the standard signal for "this control is working on the thing you asked
+      // for", and pairs with the relabel: what it is doing, and that it is still doing it.
       aria-busy={isStopping}
       variant="destructive"
       size="icon"
-      className="h-9 w-9 shrink-0 disabled:opacity-100"
+      className="h-9 w-9 shrink-0 aria-disabled:cursor-not-allowed"
       title={isStopping ? 'Stopping…' : 'Stop generating'}
       aria-label={isStopping ? 'Stopping' : 'Stop generating'}
     >

--- a/apps/web/src/components/ai/chat/input/InputActions.tsx
+++ b/apps/web/src/components/ai/chat/input/InputActions.tsx
@@ -3,12 +3,20 @@
 import React from 'react';
 import { motion, useReducedMotion } from 'motion/react';
 import { Button } from '@/components/ui/button';
-import { ArrowRight, StopCircle } from 'lucide-react';
+import { ArrowRight, Loader2, StopCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface InputActionsProps {
   /** Whether AI is currently streaming */
   isStreaming: boolean;
+  /**
+   * A Stop has been requested and has not resolved yet (`useStopStream.isStopping`).
+   *
+   * Renders as STOPPING, not stopped: the button stays the destructive Stop button and the
+   * reply keeps streaming behind it. The stream's teardown is the socket's call, never this
+   * flag's — see useStopStream's docblock for why claiming otherwise is dishonest.
+   */
+  isStopping?: boolean;
   /** Send message handler */
   onSend: () => void;
   /** Stop streaming handler */
@@ -30,6 +38,7 @@ export interface InputActionsProps {
  */
 export function InputActions({
   isStreaming,
+  isStopping = false,
   onSend,
   onStop,
   disabled = false,
@@ -41,13 +50,21 @@ export function InputActions({
     <Button
       data-testid="chat-stop"
       onClick={onStop}
+      // Disabled while the first Stop is in flight: a second one names the same stream and
+      // changes nothing, and an unlatched button reads as "that click did nothing".
+      disabled={isStopping}
+      data-stopping={isStopping ? 'true' : undefined}
       variant="destructive"
       size="icon"
-      className="h-9 w-9 shrink-0"
-      title="Stop generating"
-      aria-label="Stop generating"
+      className="h-9 w-9 shrink-0 disabled:opacity-100"
+      title={isStopping ? 'Stopping…' : 'Stop generating'}
+      aria-label={isStopping ? 'Stopping' : 'Stop generating'}
     >
-      <StopCircle className="h-4 w-4" />
+      {isStopping ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <StopCircle className="h-4 w-4" />
+      )}
     </Button>
   ) : (
     <button

--- a/apps/web/src/components/ai/chat/input/InputActions.tsx
+++ b/apps/web/src/components/ai/chat/input/InputActions.tsx
@@ -54,6 +54,10 @@ export function InputActions({
       // changes nothing, and an unlatched button reads as "that click did nothing".
       disabled={isStopping}
       data-stopping={isStopping ? 'true' : undefined}
+      // The whole point of this state is feedback, so it has to be announceable — a disabled
+      // button with a reworded label is not reliably read out. `aria-busy` is the standard
+      // signal for "this control is working on the thing you asked for".
+      aria-busy={isStopping}
       variant="destructive"
       size="icon"
       className="h-9 w-9 shrink-0 disabled:opacity-100"

--- a/apps/web/src/components/ai/chat/input/__tests__/InputActions.stopping.test.tsx
+++ b/apps/web/src/components/ai/chat/input/__tests__/InputActions.stopping.test.tsx
@@ -30,6 +30,8 @@ describe('InputActions — stopping affordance', () => {
     expect(screen.queryByTestId('chat-send')).not.toBeInTheDocument();
     expect(stop).toHaveAttribute('aria-label', 'Stopping');
     expect(stop).toHaveAttribute('data-stopping', 'true');
+    // Feedback that only exists visually is not feedback for everyone.
+    expect(stop).toHaveAttribute('aria-busy', 'true');
   });
 
   it('given a stop in flight, should not accept a second Stop click', () => {

--- a/apps/web/src/components/ai/chat/input/__tests__/InputActions.stopping.test.tsx
+++ b/apps/web/src/components/ai/chat/input/__tests__/InputActions.stopping.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InputActions } from '../InputActions';
+
+/**
+ * B1, at the pixel that actually changes.
+ *
+ * The requirement that makes this worth a test is the NEGATIVE one: pressing Stop must not
+ * render anything that says the generation ended. The reply keeps streaming until
+ * `chat:stream_complete` says otherwise, so the button stays the Stop button and only its
+ * label/affordance moves to "stopping".
+ */
+describe('InputActions — stopping affordance', () => {
+  it('given a stream and no stop requested, should render the plain Stop button', () => {
+    render(<InputActions isStreaming onSend={() => {}} onStop={() => {}} />);
+
+    const stop = screen.getByTestId('chat-stop');
+    expect(stop).toBeEnabled();
+    expect(stop).toHaveAttribute('aria-label', 'Stop generating');
+  });
+
+  it('given a stop in flight, should show it as STOPPING and never flip back to Send', () => {
+    render(<InputActions isStreaming isStopping onSend={() => {}} onStop={() => {}} />);
+
+    const stop = screen.getByTestId('chat-stop');
+    // Still the Stop button — a Send button here would mean "it ended", which is a lie while
+    // the generation is very much still running.
+    expect(stop).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-send')).not.toBeInTheDocument();
+    expect(stop).toHaveAttribute('aria-label', 'Stopping');
+    expect(stop).toHaveAttribute('data-stopping', 'true');
+  });
+
+  it('given a stop in flight, should not accept a second Stop click', () => {
+    const onStop = vi.fn();
+    render(<InputActions isStreaming isStopping onSend={() => {}} onStop={onStop} />);
+
+    fireEvent.click(screen.getByTestId('chat-stop'));
+
+    expect(onStop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ai/chat/input/__tests__/InputActions.stopping.test.tsx
+++ b/apps/web/src/components/ai/chat/input/__tests__/InputActions.stopping.test.tsx
@@ -32,6 +32,21 @@ describe('InputActions — stopping affordance', () => {
     expect(stop).toHaveAttribute('data-stopping', 'true');
     // Feedback that only exists visually is not feedback for everyone.
     expect(stop).toHaveAttribute('aria-busy', 'true');
+    expect(stop).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  // The a11y half of the same requirement. A natively disabled button is removed from the focus
+  // path, so a keyboard user who pressed Stop would lose focus to the body and never hear the
+  // relabel — the announcement this state exists to make is exactly what `disabled` would
+  // swallow. It stays focusable and the click is guarded instead.
+  it('given a stop in flight, should stay focusable so the relabel is announced', () => {
+    render(<InputActions isStreaming isStopping onSend={() => {}} onStop={() => {}} />);
+
+    const stop = screen.getByTestId('chat-stop');
+    expect(stop).not.toBeDisabled();
+
+    stop.focus();
+    expect(stop).toHaveFocus();
   });
 
   it('given a stop in flight, should not accept a second Stop click', () => {
@@ -39,6 +54,9 @@ describe('InputActions — stopping affordance', () => {
     render(<InputActions isStreaming isStopping onSend={() => {}} onStop={onStop} />);
 
     fireEvent.click(screen.getByTestId('chat-stop'));
+    // Keyboard activation lands as a click too, and would bypass anything that only styled the
+    // button as unavailable.
+    fireEvent.keyDown(screen.getByTestId('chat-stop'), { key: 'Enter' });
 
     expect(onStop).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
+++ b/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
@@ -30,6 +30,8 @@ export interface ChatLayoutProps {
   onStop: () => void;
   /** Whether AI is currently streaming */
   isStreaming: boolean;
+  /** A Stop has been requested and has not resolved yet — see useStopStream/InputActions. */
+  isStopping?: boolean;
   /** Whether the chat is loading/initializing */
   isLoading: boolean;
   /** Whether the input is disabled */
@@ -80,6 +82,7 @@ export interface ChatLayoutProps {
     onSend: () => void;
     onStop: () => void;
     isStreaming: boolean;
+    isStopping?: boolean;
     disabled?: boolean;
     placeholder?: string;
     driveId?: string;
@@ -139,6 +142,7 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
       onSend,
       onStop,
       isStreaming,
+      isStopping = false,
       isLoading,
       disabled = false,
       placeholder = 'Type your message...',
@@ -245,6 +249,7 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
           onSend,
           onStop,
           isStreaming,
+          isStopping,
           disabled: disabled || isLoading,
           placeholder,
           driveId,

--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -187,6 +187,11 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
         onEdit={!isReadOnly ? onEdit : undefined}
         onDelete={!isReadOnly ? onDelete : undefined}
         onRetry={!isReadOnly ? onRetry : undefined}
+        // A retry is a send: the moment one is issued this surface's streaming flag goes true
+        // (wrapSend registers the pendingSend synchronously), so this both disables the button
+        // in flight and keeps it disabled for the whole generation. Without it a second click
+        // fired a second, double-billed regeneration.
+        retryDisabled={isStreaming}
         onUndoFromHere={!isReadOnly ? handleUndoFromHere : undefined}
         isLastAssistantMessage={message.id === lastAssistantMessageId}
         isLastUserMessage={message.id === lastUserMessageId}

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -25,6 +25,8 @@ interface CompactTextBlockProps {
   onEdit?: () => void;
   onDelete?: () => void;
   onRetry?: () => void;
+  /** A retry is already in flight — see MessageActionButtons.retryDisabled. */
+  retryDisabled?: boolean;
   onUndoFromHere?: () => void;
   isEditing?: boolean;
   onSaveEdit?: (newContent: string) => Promise<void>;
@@ -48,6 +50,7 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
   onEdit,
   onDelete,
   onRetry,
+  retryDisabled = false,
   onUndoFromHere,
   isEditing,
   onSaveEdit,
@@ -108,6 +111,7 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
                 onEdit={onEdit}
                 onDelete={onDelete}
                 onRetry={onRetry}
+                retryDisabled={retryDisabled}
                 onUndoFromHere={onUndoFromHere}
                 compact
               />
@@ -126,6 +130,11 @@ interface CompactMessageRendererProps {
   onEdit?: (messageId: string, newContent: string) => Promise<void>;
   onDelete?: (messageId: string) => Promise<void>;
   onRetry?: (messageId: string) => void;
+  /**
+   * A retry is already in flight for this conversation. Passed down to the retry affordances
+   * only — a second retry regenerates a second time and bills for it.
+   */
+  retryDisabled?: boolean;
   onUndoFromHere?: (messageId: string) => void;
   onTaskUpdate?: (taskId: string, newStatus: 'pending' | 'in_progress' | 'completed' | 'blocked') => void;
   isLastAssistantMessage?: boolean;
@@ -147,6 +156,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
   onEdit,
   onDelete,
   onRetry,
+  retryDisabled = false,
   onUndoFromHere,
   onTaskUpdate,
   isLastAssistantMessage = false,
@@ -262,6 +272,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
                 onEdit={onEdit ? () => setIsEditing(true) : undefined}
                 onDelete={onDelete ? () => setShowDeleteDialog(true) : undefined}
                 onRetry={canRetry ? handleRetry : undefined}
+                retryDisabled={retryDisabled}
                 onUndoFromHere={hasToolCalls && onUndoFromHere ? () => onUndoFromHere(message.id) : undefined}
                 isEditing={isEditing}
                 onSaveEdit={handleSaveEdit}
@@ -332,6 +343,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
                 variant="ghost"
                 size="sm"
                 onClick={handleRetry}
+                disabled={retryDisabled}
                 className="h-4 px-0.5"
                 title="Retry this message"
                 aria-label="Retry this message"

--- a/apps/web/src/components/ai/shared/chat/MessageActionButtons.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageActionButtons.tsx
@@ -8,6 +8,13 @@ interface MessageActionButtonsProps {
   onRetry?: () => void; // Only available for last assistant message
   onUndoFromHere?: () => void; // Undo from this message forward (AI messages with tool calls)
   disabled?: boolean;
+  /**
+   * Retry only. A retry is a send, and once one is in flight the composer is already locked and
+   * showing Stop — but this button stayed live and enabled, so a second click fired a SECOND
+   * retry (a second regeneration, double-billed). Edit and delete stay usable, hence a prop of
+   * its own rather than widening `disabled`.
+   */
+  retryDisabled?: boolean;
   compact?: boolean; // For sidebar compact view
 }
 
@@ -17,6 +24,7 @@ export const MessageActionButtons: React.FC<MessageActionButtonsProps> = ({
   onRetry,
   onUndoFromHere,
   disabled = false,
+  retryDisabled = false,
   compact = false,
 }) => {
   const buttonSize = 'sm' as const;
@@ -29,7 +37,8 @@ export const MessageActionButtons: React.FC<MessageActionButtonsProps> = ({
           variant="ghost"
           size={buttonSize}
           onClick={onRetry}
-          disabled={disabled}
+          disabled={disabled || retryDisabled}
+          data-testid="message-retry"
           className="h-5 px-1"
           title="Retry this message"
         >

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -26,6 +26,8 @@ interface TextBlockProps {
   onEdit?: () => void;
   onDelete?: () => void;
   onRetry?: () => void;
+  /** A retry is already in flight — see MessageActionButtons.retryDisabled. */
+  retryDisabled?: boolean;
   onUndoFromHere?: () => void;
   isEditing?: boolean;
   onSaveEdit?: (newContent: string) => Promise<void>;
@@ -48,6 +50,7 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
   onEdit,
   onDelete,
   onRetry,
+  retryDisabled = false,
   onUndoFromHere,
   isEditing,
   onSaveEdit,
@@ -107,6 +110,7 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
                 onEdit={onEdit}
                 onDelete={onDelete}
                 onRetry={onRetry}
+                retryDisabled={retryDisabled}
                 onUndoFromHere={onUndoFromHere}
               />
             )}
@@ -124,6 +128,11 @@ interface MessageRendererProps {
   onEdit?: (messageId: string, newContent: string) => Promise<void>;
   onDelete?: (messageId: string) => Promise<void>;
   onRetry?: (messageId: string) => void;
+  /**
+   * A retry is already in flight for this conversation. Passed down to the retry affordances
+   * only — a second retry regenerates a second time and bills for it.
+   */
+  retryDisabled?: boolean;
   onUndoFromHere?: (messageId: string) => void;
   onTaskUpdate?: (taskId: string, newStatus: 'pending' | 'in_progress' | 'completed' | 'blocked') => void;
   isLastAssistantMessage?: boolean;
@@ -149,6 +158,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   onEdit,
   onDelete,
   onRetry,
+  retryDisabled = false,
   onUndoFromHere,
   onTaskUpdate,
   isLastAssistantMessage = false,
@@ -267,6 +277,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 onEdit={onEdit ? () => setIsEditing(true) : undefined}
                 onDelete={onDelete ? () => setShowDeleteDialog(true) : undefined}
                 onRetry={canRetry ? handleRetry : undefined}
+                retryDisabled={retryDisabled}
                 onUndoFromHere={hasToolCalls && onUndoFromHere ? () => onUndoFromHere(message.id) : undefined}
                 isEditing={isEditing}
                 onSaveEdit={handleSaveEdit}
@@ -336,6 +347,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 variant="ghost"
                 size="sm"
                 onClick={handleRetry}
+                disabled={retryDisabled}
                 className="h-5 px-1"
                 title="Retry this message"
                 aria-label="Retry this message"

--- a/apps/web/src/components/ai/shared/chat/__tests__/MessageActionButtons.retryDisabled.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/MessageActionButtons.retryDisabled.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MessageActionButtons } from '../MessageActionButtons';
+
+/**
+ * B2. A retry is a send, and a second one is a second regeneration — billed again. The button
+ * took no in-flight state at all, so a double-click fired two.
+ *
+ * Edit and delete are deliberately NOT swept up: they are still legitimate while a regeneration
+ * runs, which is why this is its own prop rather than a widening of `disabled`.
+ */
+describe('MessageActionButtons — retryDisabled', () => {
+  const props = { onEdit: () => {}, onDelete: () => {} };
+
+  it('given no retry in flight, should let Retry fire', () => {
+    const onRetry = vi.fn();
+    render(<MessageActionButtons {...props} onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByTestId('message-retry'));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('given a retry already in flight, should not fire a second one', () => {
+    const onRetry = vi.fn();
+    render(<MessageActionButtons {...props} onRetry={onRetry} retryDisabled />);
+
+    fireEvent.click(screen.getByTestId('message-retry'));
+
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(screen.getByTestId('message-retry')).toBeDisabled();
+  });
+
+  it('given a retry in flight, should leave edit and delete usable', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <MessageActionButtons onEdit={onEdit} onDelete={onDelete} onRetry={() => {}} retryDisabled />,
+    );
+
+    fireEvent.click(screen.getByTitle('Edit message'));
+    fireEvent.click(screen.getByTitle('Delete message'));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -526,6 +526,9 @@ const GlobalAssistantView: React.FC = () => {
     },
     // Retry inherits send's optimistic path — see useCacheMessageActions.
     wrapSend,
+    // …and its release: a retry stopped mid-DELETE dispatches nothing, and nothing else
+    // would clear the pendingSend it registered.
+    releasePendingSend,
   });
 
   // Display ids come from the RENDERED list (affordance placement + streaming

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -452,7 +452,7 @@ const GlobalAssistantView: React.FC = () => {
   // NO PRE-SEND HANDOFFS either. Both shells can have sends in flight at once, so a send into
   // conversation B while A generates needs no `stop()`, no settle wait, and cannot be refused.
 
-  const stop = useStopStream({
+  const { handleStop: stop, isStopping } = useStopStream({
     activeStream,
     pendingSendConversationId,
   });
@@ -524,6 +524,8 @@ const GlobalAssistantView: React.FC = () => {
       if (!currentConversationId) return;
       void regenerate(currentConversationId, opts);
     },
+    // Retry inherits send's optimistic path — see useCacheMessageActions.
+    wrapSend,
   });
 
   // Display ids come from the RENDERED list (affordance placement + streaming
@@ -922,6 +924,7 @@ const GlobalAssistantView: React.FC = () => {
         onSend={handleSendMessage}
         onStop={stop}
         isStreaming={effectiveIsStreaming}
+        isStopping={isStopping}
         isLoading={isLoading}
         disabled={!isAnyProviderConfigured || !isInitialized}
         placeholder={selectedAgent ? `Ask ${selectedAgent.title}...` : 'Ask about your workspace...'}
@@ -974,6 +977,7 @@ const GlobalAssistantView: React.FC = () => {
               onSend={props.onSend}
               onStop={props.onStop}
               isStreaming={props.isStreaming}
+              isStopping={props.isStopping}
               disabled={props.disabled}
               placeholder={props.placeholder}
               driveId={props.driveId}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -449,6 +449,9 @@ const SidebarChatTab: React.FC = () => {
     // Retry inherits send's optimistic path — the SAME wrapSend a send uses, so the composer
     // locks and offers Stop from the click instead of after the deletes.
     wrapSend,
+    // …and its release: a retry stopped mid-DELETE dispatches nothing, and nothing else
+    // would clear the pendingSend it registered.
+    releasePendingSend,
   });
 
   // Display ids come from the RENDERED list (affordance placement + streaming

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -127,6 +127,10 @@ export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
       onEdit={handleEdit}
       onDelete={handleDelete}
       onRetry={handleRetry}
+      // A retry is a send: wrapSend flips displayIsStreaming synchronously, so this disables
+      // the button in flight and for the whole generation (a second click = a second,
+      // double-billed regeneration).
+      retryDisabled={displayIsStreaming}
       onUndoFromHere={handleUndoFromHere}
       isLastAssistantMessage={message.id === lastAssistantMessageId}
       isLastUserMessage={message.id === lastUserMessageId}
@@ -442,8 +446,9 @@ const SidebarChatTab: React.FC = () => {
       if (!currentConversationId) return;
       void regenerate(currentConversationId, opts);
     },
-    // Retry is a send: the handoff runs INSIDE handleRetry, before its destructive steps, and
-    // the hydrate decision re-reads liveness after the handoff settles (dual-stream fix).
+    // Retry inherits send's optimistic path — the SAME wrapSend a send uses, so the composer
+    // locks and offers Stop from the click instead of after the deletes.
+    wrapSend,
   });
 
   // Display ids come from the RENDERED list (affordance placement + streaming
@@ -794,7 +799,7 @@ const SidebarChatTab: React.FC = () => {
   //
   // There is no whose. `activeStream` is a read of the one place a live stream is recorded, and
   // the abort names it by messageId — which no surface owns, and which needs no map.
-  const handleStop = useStopStream({
+  const { handleStop, isStopping } = useStopStream({
     activeStream,
     pendingSendConversationId,
   });
@@ -978,6 +983,7 @@ const SidebarChatTab: React.FC = () => {
           onSend={handleSendMessage}
           onStop={handleStop}
           isStreaming={displayIsStreaming}
+          isStopping={isStopping}
           placeholder={`Ask about ${contextLabel ?? 'your workspace'}...`}
           driveId={locationContext?.currentDrive?.id}
           crossDrive={true}

--- a/apps/web/src/hooks/__tests__/useStopStream.test.tsx
+++ b/apps/web/src/hooks/__tests__/useStopStream.test.tsx
@@ -221,9 +221,7 @@ describe('useStopStream — isStopping', () => {
     act(() => { void result.current.handleStop(); });
     expect(result.current.isStopping).toBe(true);
 
-    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
-
-    expect(result.current.isStopping).toBe(false);
+    await waitFor(() => expect(result.current.isStopping).toBe(false));
     expect(reportAbortOutcome).toHaveBeenCalledWith(
       expect.objectContaining({ code: 'not_found' }),
     );
@@ -240,9 +238,7 @@ describe('useStopStream — isStopping', () => {
     act(() => { void result.current.handleStop(); });
     expect(result.current.isStopping).toBe(true);
 
-    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
-
-    expect(result.current.isStopping).toBe(false);
+    await waitFor(() => expect(result.current.isStopping).toBe(false));
   });
 
   // THE P1. These surfaces keep ONE hook instance across a conversation switch. Stopping A and
@@ -311,6 +307,8 @@ describe('useStopStream — isStopping', () => {
     // A's abort finally answers. It must not touch B's affordance.
     await act(async () => { releaseA?.(); await Promise.resolve(); await Promise.resolve(); });
 
+    // Asserted after the queue has drained rather than via waitFor: this is a "stays true"
+    // claim, and waitFor would pass on the first tick without ever proving it survived.
     expect(result.current.isStopping).toBe(true);
   });
 });

--- a/apps/web/src/hooks/__tests__/useStopStream.test.tsx
+++ b/apps/web/src/hooks/__tests__/useStopStream.test.tsx
@@ -284,4 +284,33 @@ describe('useStopStream — isStopping', () => {
 
     expect(result.current.isStopping).toBe(false);
   });
+
+  // Found while re-reading the P1 fix, same failure family: every release runs AFTER an await,
+  // so by then the user may have switched conversation and pressed Stop again. An unscoped
+  // clearStopping() there wipes the SECOND Stop's feedback on the FIRST one's late reply.
+  it('given a late reply from a superseded Stop, should not wipe the current conversation\'s stopping state', async () => {
+    let releaseA: (() => void) | undefined;
+    abortByMessageId.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        // A's abort comes back 'unconfirmed' — the outcome that releases — but LATE.
+        releaseA = () => resolve({ aborted: false, code: 'unconfirmed', reason: 'no response' });
+      }),
+    );
+
+    const { result, rerender } = renderStop({ activeStream: OWN_STREAM });
+
+    act(() => { void result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+
+    // Switch to B and stop it too. B's abort resolves normally ('aborted' → hold).
+    const streamB = { messageId: 'msg-b', conversationId: 'conv-2', isOwn: true } as ActiveStream;
+    rerender({ activeStream: streamB, pendingSendConversationId: null });
+    await act(async () => { await result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+
+    // A's abort finally answers. It must not touch B's affordance.
+    await act(async () => { releaseA?.(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(result.current.isStopping).toBe(true);
+  });
 });

--- a/apps/web/src/hooks/__tests__/useStopStream.test.tsx
+++ b/apps/web/src/hooks/__tests__/useStopStream.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useStopStream, STOPPING_FEEDBACK_TIMEOUT_MS } from '../useStopStream';
+import { readStopEpoch } from '@/lib/ai/streams/stopRequests';
 import type { ActiveStream } from '@/lib/ai/streams/selectActiveStream';
 
 const abortByMessageId = vi.fn();
@@ -310,5 +311,57 @@ describe('useStopStream — isStopping', () => {
     // Asserted after the queue has drained rather than via waitFor: this is a "stays true"
     // claim, and waitFor would pass on the first tick without ever proving it survived.
     expect(result.current.isStopping).toBe(true);
+  });
+});
+
+/**
+ * The half of Stop the SERVER cannot perform.
+ *
+ * `markAbortRequested` only marks rows that already exist as 'streaming', so a Stop pressed
+ * before the POST is out matches nothing and answers `not_found` — which the UI is deliberately
+ * silent about. A retry spends a whole DELETE round trip in that window with Stop on screen, so
+ * the press has to be recorded somewhere the retry can see it before it dispatches.
+ */
+describe('useStopStream — recording the request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    abortByMessageId.mockResolvedValue(OK);
+    abortByConversation.mockResolvedValue(OK);
+  });
+
+  it('given a Stop in the TTFB window, should record it against the conversation it named', async () => {
+    const before = readStopEpoch('conv-record-1');
+    const { result } = renderHook(() =>
+      useStopStream({ activeStream: undefined, pendingSendConversationId: 'conv-record-1' }),
+    );
+
+    await act(async () => { await result.current.handleStop(); });
+
+    expect(readStopEpoch('conv-record-1')).toBe(before + 1);
+  });
+
+  it('given a live own stream, should record against its conversation, not its messageId', async () => {
+    const before = readStopEpoch('conv-record-2');
+    const stream = { messageId: 'msg-r2', conversationId: 'conv-record-2', isOwn: true } as ActiveStream;
+    const { result } = renderHook(() =>
+      useStopStream({ activeStream: stream, pendingSendConversationId: null }),
+    );
+
+    await act(async () => { await result.current.handleStop(); });
+
+    expect(readStopEpoch('conv-record-2')).toBe(before + 1);
+  });
+
+  // Nothing live and nothing sent: there is no conversation to name, so there is nothing to
+  // record either — and recording under some placeholder would cancel an unrelated retry.
+  it('given nothing to stop, should record nothing', async () => {
+    const before = readStopEpoch('conv-record-3');
+    const { result } = renderHook(() =>
+      useStopStream({ activeStream: undefined, pendingSendConversationId: null }),
+    );
+
+    await act(async () => { await result.current.handleStop(); });
+
+    expect(readStopEpoch('conv-record-3')).toBe(before);
   });
 });

--- a/apps/web/src/hooks/__tests__/useStopStream.test.tsx
+++ b/apps/web/src/hooks/__tests__/useStopStream.test.tsx
@@ -211,18 +211,57 @@ describe('useStopStream — isStopping', () => {
 
   // 'not_found' is deliberately silent (a benign race, and a toast would train users to ignore
   // the real one), so a Stop pressed a beat after the reply finished produced NO feedback at
-  // all. That press only reaches the user while the composer still shows Stop — i.e. the entry
-  // is still live locally — and there the stopping state IS the acknowledgement.
-  it('given the server reports not_found, should still acknowledge the click', async () => {
+  // all. The affordance appearing and then releasing IS the acknowledgement — and it must
+  // RELEASE, not hold: the server has just said nothing is running, so there is nothing to be
+  // stopping, and holding would disable the button for the whole backstop over a no-op.
+  it('given the server reports not_found, should acknowledge the click and then release', async () => {
     abortByMessageId.mockResolvedValue({ aborted: false, code: 'not_found', reason: 'no stream' });
     const { result } = renderStop({ activeStream: OWN_STREAM });
 
-    await act(async () => { await result.current.handleStop(); });
-
+    act(() => { void result.current.handleStop(); });
     expect(result.current.isStopping).toBe(true);
+
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(result.current.isStopping).toBe(false);
     expect(reportAbortOutcome).toHaveBeenCalledWith(
       expect.objectContaining({ code: 'not_found' }),
     );
+  });
+
+  // The helpers never throw on network failure — they resolve 'unconfirmed' (NETWORK_FAILURE),
+  // which made the catch path unreachable for the case that most needs releasing: the user has
+  // just been told the generation may still be running and billing, and the only control that
+  // could stop it was disabled for the whole backstop.
+  it('given an unconfirmed abort, should release so the user can immediately try again', async () => {
+    abortByMessageId.mockResolvedValue({ aborted: false, code: 'unconfirmed', reason: 'no response' });
+    const { result } = renderStop({ activeStream: OWN_STREAM });
+
+    act(() => { void result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(result.current.isStopping).toBe(false);
+  });
+
+  // THE P1. These surfaces keep ONE hook instance across a conversation switch. Stopping A and
+  // then switching to B — which has its own stream running — must not disable B's Stop button
+  // for a Stop nobody asked for.
+  it('given a switch to another conversation with its own live stream, should not claim to be stopping it', async () => {
+    const { result, rerender } = renderStop({ activeStream: OWN_STREAM });
+
+    await act(async () => { await result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+
+    // Same surface, same hook instance, different conversation — and B is streaming, so the
+    // boolean "is anything stoppable?" this replaced stayed true here.
+    rerender({
+      activeStream: { messageId: 'msg-b', conversationId: 'conv-2', isOwn: true } as ActiveStream,
+      pendingSendConversationId: null,
+    });
+
+    expect(result.current.isStopping).toBe(false);
   });
 
   // Nothing live and nothing sent: the composer is showing SEND, so this is unreachable by

--- a/apps/web/src/hooks/__tests__/useStopStream.test.tsx
+++ b/apps/web/src/hooks/__tests__/useStopStream.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { useStopStream } from '../useStopStream';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useStopStream, STOPPING_FEEDBACK_TIMEOUT_MS } from '../useStopStream';
 import type { ActiveStream } from '@/lib/ai/streams/selectActiveStream';
 
 const abortByMessageId = vi.fn();
@@ -41,7 +41,7 @@ describe('useStopStream', () => {
     );
 
     await act(async () => {
-      await result.current();
+      await result.current.handleStop();
     });
 
     expect(abortByMessageId).toHaveBeenCalledWith({ messageId: 'msg-1' });
@@ -58,7 +58,7 @@ describe('useStopStream', () => {
     );
 
     await act(async () => {
-      await result.current();
+      await result.current.handleStop();
     });
 
     expect(abortByConversation).toHaveBeenCalledWith({ conversationId: 'conv-9' });
@@ -72,7 +72,7 @@ describe('useStopStream', () => {
     );
 
     await act(async () => {
-      await result.current();
+      await result.current.handleStop();
     });
 
     expect(abortByMessageId).not.toHaveBeenCalled();
@@ -90,9 +90,159 @@ describe('useStopStream', () => {
     );
 
     await act(async () => {
-      await result.current();
+      await result.current.handleStop();
     });
 
     expect(reportAbortOutcome).toHaveBeenCalledWith(unconfirmed);
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// `isStopping` — the feedback that replaces the deleted local stop, without its lie.
+//
+// Deleting `rawStop` was right (see the hook's docblock and only-a-deliberate-stop.test.ts), but
+// it left the click with nothing to show for itself: reportAbortOutcome is silent on every
+// outcome but 'unconfirmed', so the abort POST's resolved value paints zero pixels, and what
+// actually clears the bubble and flips the composer is the chat:stream_complete SOCKET event.
+// The screen sat unchanged for a full round trip — up to ABORT_SETTLE_TIMEOUT_MS of deliberate
+// server-side settle on a cross-instance owner — plus socket delivery.
+// ---------------------------------------------------------------------------------------------
+describe('useStopStream — isStopping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    abortByMessageId.mockResolvedValue(OK);
+    abortByConversation.mockResolvedValue(OK);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const OWN_STREAM = { messageId: 'msg-1', conversationId: 'conv-1', isOwn: true } as ActiveStream;
+
+  const renderStop = (props: {
+    activeStream?: ActiveStream;
+    pendingSendConversationId?: string | null;
+  }) =>
+    renderHook(
+      (p: { activeStream?: ActiveStream; pendingSendConversationId: string | null }) =>
+        useStopStream({
+          activeStream: p.activeStream,
+          pendingSendConversationId: p.pendingSendConversationId,
+        }),
+      {
+        initialProps: {
+          activeStream: props.activeStream,
+          pendingSendConversationId: props.pendingSendConversationId ?? null,
+        },
+      },
+    );
+
+  it('given Stop is pressed, should set isStopping BEFORE the abort resolves, not after', async () => {
+    // Never resolves: if the flag were set after the await, nothing would ever paint.
+    let release: (() => void) | undefined;
+    abortByMessageId.mockImplementation(
+      () => new Promise((resolve) => { release = () => resolve(OK); }),
+    );
+
+    const { result } = renderStop({ activeStream: OWN_STREAM });
+    expect(result.current.isStopping).toBe(false);
+
+    act(() => { void result.current.handleStop(); });
+
+    expect(result.current.isStopping).toBe(true);
+    expect(abortByMessageId).toHaveBeenCalledTimes(1);
+
+    await act(async () => { release?.(); });
+  });
+
+  // The reply keeps rendering underneath. This hook must not treat its own flag as teardown —
+  // chat:stream_complete is the sole authority, and the stream is still here until it says so.
+  it('given the abort has resolved but the stream entry is still live, should stay stopping (never "stopped")', async () => {
+    const { result } = renderStop({ activeStream: OWN_STREAM });
+
+    await act(async () => { await result.current.handleStop(); });
+
+    expect(result.current.isStopping).toBe(true);
+  });
+
+  // THE clear: chat:stream_complete removes the store entry, so `activeStream` goes away.
+  it('given the socket landing removes the live stream, should clear isStopping', async () => {
+    const { result, rerender } = renderStop({ activeStream: OWN_STREAM });
+
+    await act(async () => { await result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+
+    rerender({ activeStream: undefined, pendingSendConversationId: null });
+
+    expect(result.current.isStopping).toBe(false);
+  });
+
+  // Stop pressed in the TTFB window names the pendingSend conversation; that name resolving is
+  // the same landing.
+  it('given a Stop in the TTFB window, should clear isStopping when the pendingSend resolves', async () => {
+    const { result, rerender } = renderStop({ pendingSendConversationId: 'conv-1' });
+
+    await act(async () => { await result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+    expect(abortByConversation).toHaveBeenCalledWith({ conversationId: 'conv-1' });
+
+    rerender({ activeStream: undefined, pendingSendConversationId: null });
+
+    expect(result.current.isStopping).toBe(false);
+  });
+
+  // A socket that never arrives (dropped connection, dead owning instance) must not wedge the
+  // button spinning until unmount.
+  it('given no socket ever lands, should release isStopping on the bounded timeout', async () => {
+    vi.useFakeTimers();
+    const { result } = renderStop({ activeStream: OWN_STREAM });
+
+    await act(async () => { await result.current.handleStop(); });
+    expect(result.current.isStopping).toBe(true);
+
+    // Still stopping just short of the horizon — the wait has to outlast an honest slow abort.
+    act(() => { vi.advanceTimersByTime(STOPPING_FEEDBACK_TIMEOUT_MS - 1); });
+    expect(result.current.isStopping).toBe(true);
+
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(result.current.isStopping).toBe(false);
+  });
+
+  // 'not_found' is deliberately silent (a benign race, and a toast would train users to ignore
+  // the real one), so a Stop pressed a beat after the reply finished produced NO feedback at
+  // all. That press only reaches the user while the composer still shows Stop — i.e. the entry
+  // is still live locally — and there the stopping state IS the acknowledgement.
+  it('given the server reports not_found, should still acknowledge the click', async () => {
+    abortByMessageId.mockResolvedValue({ aborted: false, code: 'not_found', reason: 'no stream' });
+    const { result } = renderStop({ activeStream: OWN_STREAM });
+
+    await act(async () => { await result.current.handleStop(); });
+
+    expect(result.current.isStopping).toBe(true);
+    expect(reportAbortOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'not_found' }),
+    );
+  });
+
+  // Nothing live and nothing sent: the composer is showing SEND, so this is unreachable by
+  // click — but it must not be able to strand the affordance either.
+  it('given nothing to stop at all, should not leave the affordance raised', async () => {
+    const { result } = renderStop({ activeStream: undefined, pendingSendConversationId: null });
+
+    await act(async () => { await result.current.handleStop(); });
+
+    await waitFor(() => expect(result.current.isStopping).toBe(false));
+  });
+
+  it('given the abort throws, should clear isStopping rather than wait out the backstop', async () => {
+    abortByMessageId.mockRejectedValue(new Error('boom'));
+    const { result } = renderStop({ activeStream: OWN_STREAM });
+
+    await act(async () => {
+      await expect(result.current.handleStop()).rejects.toThrow('boom');
+    });
+
+    expect(result.current.isStopping).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useStopStream.ts
+++ b/apps/web/src/hooks/useStopStream.ts
@@ -125,14 +125,37 @@ export const useStopStream = ({
 
   const [stoppingConversationId, setStoppingConversationId] = useState<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Mirrors the state for reads that happen AFTER an await, where the render-captured value is
+  // a stale snapshot of a Stop that may since have been superseded.
+  const stoppingConversationIdRef = useRef<string | null>(null);
+
+  const raiseStopping = useCallback((conversationId: string) => {
+    stoppingConversationIdRef.current = conversationId;
+    setStoppingConversationId(conversationId);
+  }, []);
 
   const clearStopping = useCallback(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
+    stoppingConversationIdRef.current = null;
     setStoppingConversationId(null);
   }, []);
+
+  /**
+   * Release the affordance ONLY if it is still the one this Stop raised.
+   *
+   * Every release below happens after an await, and by then the user may have switched
+   * conversation and pressed Stop again — at which point an unscoped `clearStopping()` would
+   * wipe the SECOND Stop's feedback on the first one's late reply. Same failure family as the
+   * conversation-keying above: anything this hook does after an await has to name what it is
+   * acting on, because the hook outlives the conversation it was looking at.
+   */
+  const releaseStoppingFor = useCallback((conversationId: string | null) => {
+    if (conversationId === null || stoppingConversationIdRef.current !== conversationId) return;
+    clearStopping();
+  }, [clearStopping]);
 
   // DERIVED, never stored: the affordance belongs to the conversation whose Stop was pressed, so
   // it can only show while that conversation is still the one on screen AND still has something
@@ -166,9 +189,12 @@ export const useStopStream = ({
    * nothing to be stopping. Only `aborted` means teardown is genuinely inbound, and only it
    * keeps waiting on `chat:stream_complete`.
    */
-  const releaseUnlessAbortConfirmed = useCallback((result: AbortResult) => {
-    if (result.code !== 'aborted') clearStopping();
-  }, [clearStopping]);
+  const releaseUnlessAbortConfirmed = useCallback(
+    (result: AbortResult, conversationId: string | null) => {
+      if (result.code !== 'aborted') releaseStoppingFor(conversationId);
+    },
+    [releaseStoppingFor],
+  );
 
   const handleStop = useCallback(async () => {
     // FIRST, synchronously, before any await: the click has to change the screen within a frame.
@@ -177,11 +203,13 @@ export const useStopStream = ({
     //
     // Nothing to name means nothing to claim: with no target there is no conversation to key the
     // affordance to, so it is never raised rather than raised and instantly withdrawn.
-    if (stopTargetConversationId !== null) {
-      setStoppingConversationId(stopTargetConversationId);
+    const stoppedConversationId = stopTargetConversationId;
+    if (stoppedConversationId !== null) {
+      raiseStopping(stoppedConversationId);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       timeoutRef.current = setTimeout(() => {
         timeoutRef.current = null;
+        stoppingConversationIdRef.current = null;
         setStoppingConversationId(null);
       }, STOPPING_FEEDBACK_TIMEOUT_MS);
     }
@@ -192,7 +220,7 @@ export const useStopStream = ({
       if (action.type === 'abortByMessageId') {
         const result = await abortActiveStreamByMessageId({ messageId: action.messageId });
         reportAbortOutcome(result);
-        releaseUnlessAbortConfirmed(result);
+        releaseUnlessAbortConfirmed(result, stoppedConversationId);
         return;
       }
       if (action.type === 'abortByConversation') {
@@ -200,7 +228,7 @@ export const useStopStream = ({
           conversationId: action.conversationId,
         });
         reportAbortOutcome(result);
-        releaseUnlessAbortConfirmed(result);
+        releaseUnlessAbortConfirmed(result, stoppedConversationId);
         return;
       }
       // 'none' — nothing live and nothing sent. Deliberately silent: there is nothing to report
@@ -208,16 +236,18 @@ export const useStopStream = ({
     } catch (error) {
       // Kept for a genuinely unexpected throw (the helpers swallow network failure into
       // 'unconfirmed', which `releaseUnlessAbortConfirmed` handles). No socket is coming for it:
-      // release now rather than making the user wait out the backstop.
-      clearStopping();
+      // release now rather than making the user wait out the backstop — but only if this Stop's
+      // affordance is still the one showing.
+      releaseStoppingFor(stoppedConversationId);
       throw error;
     }
   }, [
     activeStream,
     pendingSendConversationId,
     stopTargetConversationId,
+    raiseStopping,
     releaseUnlessAbortConfirmed,
-    clearStopping,
+    releaseStoppingFor,
   ]);
 
   return { handleStop, isStopping };

--- a/apps/web/src/hooks/useStopStream.ts
+++ b/apps/web/src/hooks/useStopStream.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/ai/core/client';
 import { ABORT_SETTLE_TIMEOUT_MS } from '@/lib/ai/core/stream-horizons';
 import { decideStopAction } from '@/lib/ai/streams/decideStopAction';
+import { recordStopRequest } from '@/lib/ai/streams/stopRequests';
 import type { ActiveStream } from '@/lib/ai/streams/selectActiveStream';
 
 /**
@@ -195,7 +196,15 @@ export const useStopStream = ({
     // Captured, not re-read: everything after the await must act on the conversation this Stop
     // was pressed for, which by then may no longer be the one on screen.
     const stoppedConversationId = stopTargetConversationId;
-    if (stoppedConversationId !== null) raiseStopping(stoppedConversationId);
+    if (stoppedConversationId !== null) {
+      raiseStopping(stoppedConversationId);
+      // Recorded for the abort the SERVER cannot perform. `markAbortRequested` only marks rows
+      // that already exist as 'streaming', so a Stop pressed before the POST is out matches
+      // nothing and answers `not_found` — while a retry, which spends a whole DELETE round trip
+      // in that window with Stop on screen, would then go on and start the generation anyway.
+      // This is what it checks before dispatching. See stopRequests.
+      recordStopRequest(stoppedConversationId);
+    }
 
     const action = decideStopAction({ activeStream, pendingSendConversationId });
 

--- a/apps/web/src/hooks/useStopStream.ts
+++ b/apps/web/src/hooks/useStopStream.ts
@@ -3,7 +3,6 @@ import {
   abortActiveStreamByConversation,
   abortActiveStreamByMessageId,
   reportAbortOutcome,
-  type AbortResult,
 } from '@/lib/ai/core/client';
 import { ABORT_SETTLE_TIMEOUT_MS } from '@/lib/ai/core/stream-horizons';
 import { decideStopAction } from '@/lib/ai/streams/decideStopAction';
@@ -91,7 +90,7 @@ export interface UseStopStreamResult {
  *     duplicated.
  *   - the conversation being switched away from. These surfaces keep one hook instance across a
  *     switch, so a Stop on A must not disable B's Stop button.
- *   - any abort outcome that is not a confirmed `aborted` — see `releaseUnlessAbortConfirmed`.
+ *   - any abort outcome that is not a confirmed `aborted` — see handleStop's release below.
  *   - `STOPPING_FEEDBACK_TIMEOUT_MS`, so a socket that never arrives cannot wedge the button.
  *
  * Between them they also cover the outcome that is silent BY DESIGN and had no feedback
@@ -186,24 +185,6 @@ export const useStopStream = ({
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
   }, []);
 
-  /**
-   * Hold the affordance ONLY on a positive confirmation that a stop is on its way.
-   *
-   * The abort helpers do not throw on failure — they resolve `{ code: 'unconfirmed' }` (see
-   * NETWORK_FAILURE in stream-abort-client), which made the catch below unreachable for exactly
-   * the case that most needs releasing: the user has just been TOLD the generation may still be
-   * running and still billing, and the one control that could stop it was disabled for the whole
-   * backstop. `not_found` is the mirror image — the server says nothing is running, so there is
-   * nothing to be stopping. Only `aborted` means teardown is genuinely inbound, and only it
-   * keeps waiting on `chat:stream_complete`.
-   */
-  const releaseUnlessAbortConfirmed = useCallback(
-    (result: AbortResult, conversationId: string | null) => {
-      if (result.code !== 'aborted') releaseStoppingFor(conversationId);
-    },
-    [releaseStoppingFor],
-  );
-
   const handleStop = useCallback(async () => {
     // FIRST, synchronously, before any await: the click has to change the screen within a frame.
     // Says "stopping", never "stopped" — see the docblock. Nothing else here touches the
@@ -228,12 +209,22 @@ export const useStopStream = ({
         : await abortActiveStreamByConversation({ conversationId: action.conversationId });
 
       reportAbortOutcome(result);
-      releaseUnlessAbortConfirmed(result, stoppedConversationId);
+
+      // HOLD THE AFFORDANCE ONLY ON POSITIVE CONFIRMATION THAT A STOP IS ON ITS WAY.
+      //
+      // The abort helpers do not throw on failure — they resolve `{ code: 'unconfirmed' }` (see
+      // NETWORK_FAILURE in stream-abort-client), which made the catch below unreachable for
+      // exactly the case that most needs releasing: the user has just been TOLD the generation
+      // may still be running and still billing, and the one control that could stop it was
+      // disabled for the whole backstop. `not_found` is the mirror image — the server says
+      // nothing is running, so there is nothing to be stopping. Only `aborted` means teardown is
+      // genuinely inbound, and only it keeps waiting on `chat:stream_complete`.
+      if (result.code !== 'aborted') releaseStoppingFor(stoppedConversationId);
     } catch (error) {
       // Kept for a genuinely unexpected throw (the helpers swallow network failure into
-      // 'unconfirmed', which `releaseUnlessAbortConfirmed` handles). No socket is coming for it:
-      // release now rather than making the user wait out the backstop — but only if this Stop's
-      // affordance is still the one showing.
+      // 'unconfirmed', released just above). No socket is coming for it: release now rather than
+      // making the user wait out the backstop — but only if this Stop's affordance is still the
+      // one showing.
       releaseStoppingFor(stoppedConversationId);
       throw error;
     }
@@ -242,7 +233,6 @@ export const useStopStream = ({
     pendingSendConversationId,
     stopTargetConversationId,
     raiseStopping,
-    releaseUnlessAbortConfirmed,
     releaseStoppingFor,
   ]);
 

--- a/apps/web/src/hooks/useStopStream.ts
+++ b/apps/web/src/hooks/useStopStream.ts
@@ -3,6 +3,7 @@ import {
   abortActiveStreamByConversation,
   abortActiveStreamByMessageId,
   reportAbortOutcome,
+  type AbortResult,
 } from '@/lib/ai/core/client';
 import { ABORT_SETTLE_TIMEOUT_MS } from '@/lib/ai/core/stream-horizons';
 import { decideStopAction } from '@/lib/ai/streams/decideStopAction';
@@ -84,15 +85,19 @@ export interface UseStopStreamResult {
  * while an agent is still calling write tools and still billing is the dishonesty that got
  * `rawStop` deleted.
  *
- * It clears on three paths, and only these:
- *   - the socket landing — observed as the stop TARGET disappearing (the store entry removed,
- *     the pendingSend resolved). That is the authority, read rather than duplicated.
- *   - an error reaching the abort endpoint.
+ * It is keyed to the CONVERSATION it was pressed for, and clears on four paths:
+ *   - the socket landing — observed as that conversation's stop target disappearing (the store
+ *     entry removed, the pendingSend resolved). That is the authority, read rather than
+ *     duplicated.
+ *   - the conversation being switched away from. These surfaces keep one hook instance across a
+ *     switch, so a Stop on A must not disable B's Stop button.
+ *   - any abort outcome that is not a confirmed `aborted` — see `releaseUnlessAbortConfirmed`.
  *   - `STOPPING_FEEDBACK_TIMEOUT_MS`, so a socket that never arrives cannot wedge the button.
  *
- * It also covers the outcome that is silent BY DESIGN and had no feedback whatsoever:
- * 'not_found' — Stop pressed a beat after the reply ended — where the "Stopping…" state
- * resolving is the acknowledgement the deliberately-quiet outcome code cannot give.
+ * Between them they also cover the outcome that is silent BY DESIGN and had no feedback
+ * whatsoever: 'not_found' — Stop pressed a beat after the reply ended — where the "Stopping…"
+ * state appearing and then resolving is the acknowledgement the deliberately-quiet outcome code
+ * cannot give.
  */
 export const useStopStream = ({
   activeStream,
@@ -103,7 +108,22 @@ export const useStopStream = ({
   /** `useSendHandoff`'s in-flight pendingSend key — the conversation captured AT SEND. */
   pendingSendConversationId: string | null;
 }): UseStopStreamResult => {
-  const [isStopping, setIsStopping] = useState(false);
+  // WHICH CONVERSATION a Stop names — not merely WHETHER one is nameable.
+  //
+  // This was a boolean (`hasStopTarget`) and that was a bug: these surfaces keep ONE hook
+  // instance across a conversation switch, so stopping A and then switching to B — which has
+  // its own stream running — left the boolean true, the effect never fired, and B rendered a
+  // disabled "Stopping…" button for a Stop nobody asked for, until the backstop expired. The
+  // identity is what distinguishes the two, so the identity is what is tracked.
+  //
+  // Keyed by CONVERSATION rather than by messageId, because a Stop pressed in the TTFB window
+  // names a conversation and only later acquires a messageId: keying on the message would make
+  // the target "change" mid-abort and drop the affordance the moment the stream entry appeared.
+  // Both branches of `decideStopAction` resolve to this same conversation, in the same order.
+  const stopTargetConversationId =
+    activeStream?.isOwn === true ? activeStream.conversationId : pendingSendConversationId;
+
+  const [stoppingConversationId, setStoppingConversationId] = useState<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearStopping = useCallback(() => {
@@ -111,66 +131,94 @@ export const useStopStream = ({
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-    setIsStopping(false);
+    setStoppingConversationId(null);
   }, []);
 
-  // Is there still anything for this Stop to be stopping? Exactly the two things
-  // `decideStopAction` can name — our own live store entry, and the in-flight send's captured
-  // conversation. When BOTH are gone the stream has been torn down, which on the abort path
-  // happens because `chat:stream_complete` landed and removed the entry. So this IS the socket
-  // landing, observed through the one place a live stream is recorded rather than by
-  // second-guessing it with a socket subscription of our own.
-  const hasStopTarget = activeStream?.isOwn === true || pendingSendConversationId !== null;
+  // DERIVED, never stored: the affordance belongs to the conversation whose Stop was pressed, so
+  // it can only show while that conversation is still the one on screen AND still has something
+  // to stop. A mismatch is either the socket landing (the entry is gone) or a conversation
+  // switch (the target is somebody else) — neither is a state this button may survive.
+  const isStopping =
+    stoppingConversationId !== null && stoppingConversationId === stopTargetConversationId;
 
-  // `isStopping` is in the deps, not just `hasStopTarget`, and that is load-bearing: on an
-  // already-finished stream there is no target at the moment of the click, so a
-  // `[hasStopTarget]`-only effect never re-runs and the affordance hangs until the backstop.
-  // Depending on the flag itself means the very act of raising it schedules its own resolution.
+  // Deriving above already makes the render honest a frame earlier than any effect could; this
+  // is the cleanup half — it releases the backstop timer and the stored identity once they can
+  // no longer describe anything.
   useEffect(() => {
-    if (isStopping && !hasStopTarget) clearStopping();
-  }, [isStopping, hasStopTarget, clearStopping]);
+    if (stoppingConversationId !== null && stoppingConversationId !== stopTargetConversationId) {
+      clearStopping();
+    }
+  }, [stoppingConversationId, stopTargetConversationId, clearStopping]);
 
-  // Unmount (and conversation switch, which unmounts the surface's chat) must not leave a timer
-  // holding a setState on a dead hook.
+  // Unmount must not leave a timer holding a setState on a dead hook.
   useEffect(() => () => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
   }, []);
+
+  /**
+   * Hold the affordance ONLY on a positive confirmation that a stop is on its way.
+   *
+   * The abort helpers do not throw on failure — they resolve `{ code: 'unconfirmed' }` (see
+   * NETWORK_FAILURE in stream-abort-client), which made the catch below unreachable for exactly
+   * the case that most needs releasing: the user has just been TOLD the generation may still be
+   * running and still billing, and the one control that could stop it was disabled for the whole
+   * backstop. `not_found` is the mirror image — the server says nothing is running, so there is
+   * nothing to be stopping. Only `aborted` means teardown is genuinely inbound, and only it
+   * keeps waiting on `chat:stream_complete`.
+   */
+  const releaseUnlessAbortConfirmed = useCallback((result: AbortResult) => {
+    if (result.code !== 'aborted') clearStopping();
+  }, [clearStopping]);
 
   const handleStop = useCallback(async () => {
     // FIRST, synchronously, before any await: the click has to change the screen within a frame.
     // Says "stopping", never "stopped" — see the docblock. Nothing else here touches the
     // rendered stream.
-    setIsStopping(true);
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => {
-      timeoutRef.current = null;
-      setIsStopping(false);
-    }, STOPPING_FEEDBACK_TIMEOUT_MS);
+    //
+    // Nothing to name means nothing to claim: with no target there is no conversation to key the
+    // affordance to, so it is never raised rather than raised and instantly withdrawn.
+    if (stopTargetConversationId !== null) {
+      setStoppingConversationId(stopTargetConversationId);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        setStoppingConversationId(null);
+      }, STOPPING_FEEDBACK_TIMEOUT_MS);
+    }
 
     const action = decideStopAction({ activeStream, pendingSendConversationId });
 
     try {
       if (action.type === 'abortByMessageId') {
-        reportAbortOutcome(await abortActiveStreamByMessageId({ messageId: action.messageId }));
+        const result = await abortActiveStreamByMessageId({ messageId: action.messageId });
+        reportAbortOutcome(result);
+        releaseUnlessAbortConfirmed(result);
         return;
       }
       if (action.type === 'abortByConversation') {
-        reportAbortOutcome(
-          await abortActiveStreamByConversation({ conversationId: action.conversationId }),
-        );
+        const result = await abortActiveStreamByConversation({
+          conversationId: action.conversationId,
+        });
+        reportAbortOutcome(result);
+        releaseUnlessAbortConfirmed(result);
         return;
       }
       // 'none' — nothing live and nothing sent. Deliberately silent: there is nothing to report
-      // and nothing to name. The stopping state releases itself on the next render, because
-      // 'none' is returned for exactly the state in which `hasStopTarget` is already false.
+      // and nothing to name, and nothing was raised above either.
     } catch (error) {
-      // The abort helpers swallow network failure into an 'unconfirmed' AbortResult, so this is
-      // the unexpected-throw path. Whatever it was, no socket is coming for it: release the
-      // affordance now rather than making the user wait out the backstop.
+      // Kept for a genuinely unexpected throw (the helpers swallow network failure into
+      // 'unconfirmed', which `releaseUnlessAbortConfirmed` handles). No socket is coming for it:
+      // release now rather than making the user wait out the backstop.
       clearStopping();
       throw error;
     }
-  }, [activeStream, pendingSendConversationId, clearStopping]);
+  }, [
+    activeStream,
+    pendingSendConversationId,
+    stopTargetConversationId,
+    releaseUnlessAbortConfirmed,
+    clearStopping,
+  ]);
 
   return { handleStop, isStopping };
 };

--- a/apps/web/src/hooks/useStopStream.ts
+++ b/apps/web/src/hooks/useStopStream.ts
@@ -1,11 +1,37 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   abortActiveStreamByConversation,
   abortActiveStreamByMessageId,
   reportAbortOutcome,
 } from '@/lib/ai/core/client';
+import { ABORT_SETTLE_TIMEOUT_MS } from '@/lib/ai/core/stream-horizons';
 import { decideStopAction } from '@/lib/ai/streams/decideStopAction';
 import type { ActiveStream } from '@/lib/ai/streams/selectActiveStream';
+
+/**
+ * How long the "Stopping…" affordance may stay up with no resolution before it releases itself.
+ *
+ * It has to outlast the slowest HONEST Stop: a cross-instance abort waits up to
+ * `ABORT_SETTLE_TIMEOUT_MS` (one watcher tick of phase error, the marked-row read, the parts
+ * persist and the terminal write) and only THEN does `chat:stream_complete` get broadcast and
+ * delivered. Doubling that buys the socket hop without inventing a second number.
+ *
+ * This is a backstop, not the mechanism. Every Stop that actually resolves clears on the socket
+ * landing below, long before this fires; what it exists for is a socket that never arrives (a
+ * dropped connection, an owning instance that died), where the alternative is a button stuck
+ * spinning until unmount.
+ */
+export const STOPPING_FEEDBACK_TIMEOUT_MS = 2 * ABORT_SETTLE_TIMEOUT_MS;
+
+export interface UseStopStreamResult {
+  /** THE Stop action. */
+  handleStop: () => Promise<void>;
+  /**
+   * A Stop has been requested and has not resolved yet. Render it as "stopping", NEVER as
+   * "stopped": the reply is still streaming underneath and may keep streaming.
+   */
+  isStopping: boolean;
+}
 
 /**
  * THE Stop action, for every surface — and now the ONLY thing anywhere in the client that
@@ -39,6 +65,34 @@ import type { ActiveStream } from '@/lib/ai/streams/selectActiveStream';
  * `only-a-deliberate-stop.test.ts` is the source-level tripwire that keeps a local stop from
  * being reintroduced, and it asserts that this path REACHES `/api/ai/abort` — because a Stop
  * that only cancels locally is indistinguishable, from the user's side, from one that works.
+ *
+ * ── `isStopping` — THE FEEDBACK THAT REPLACES IT, WITHOUT THE LIE ─────────────────────────
+ *
+ * Deleting `rawStop` was right, but it left the click with NOTHING to show for itself.
+ * `reportAbortOutcome` is silent on every outcome but 'unconfirmed', so the resolved value of
+ * the abort POST paints zero pixels; what actually clears the bubble and flips the composer is
+ * the `chat:stream_complete` SOCKET event. So the screen sat unchanged for a full round trip —
+ * up to `ABORT_SETTLE_TIMEOUT_MS` of deliberate server-side settle on a cross-instance owner —
+ * plus socket delivery, with no acknowledgement that the press had registered at all. Users
+ * read that as a hang, and press again.
+ *
+ * The distinction the old local stop got wrong is the whole design of this flag: it says
+ * STOPPING, never STOPPED. It is set synchronously BEFORE the await so the button changes
+ * within a frame, and it deliberately touches nothing else — the reply keeps streaming
+ * underneath, the store entry stands, and `chat:stream_complete` remains the SOLE authority for
+ * teardown. A requested Stop and an effective Stop are different facts, and claiming the second
+ * while an agent is still calling write tools and still billing is the dishonesty that got
+ * `rawStop` deleted.
+ *
+ * It clears on three paths, and only these:
+ *   - the socket landing — observed as the stop TARGET disappearing (the store entry removed,
+ *     the pendingSend resolved). That is the authority, read rather than duplicated.
+ *   - an error reaching the abort endpoint.
+ *   - `STOPPING_FEEDBACK_TIMEOUT_MS`, so a socket that never arrives cannot wedge the button.
+ *
+ * It also covers the outcome that is silent BY DESIGN and had no feedback whatsoever:
+ * 'not_found' — Stop pressed a beat after the reply ended — where the "Stopping…" state
+ * resolving is the acknowledgement the deliberately-quiet outcome code cannot give.
  */
 export const useStopStream = ({
   activeStream,
@@ -48,20 +102,75 @@ export const useStopStream = ({
   activeStream: ActiveStream | undefined;
   /** `useSendHandoff`'s in-flight pendingSend key — the conversation captured AT SEND. */
   pendingSendConversationId: string | null;
-}): (() => Promise<void>) =>
-  useCallback(async () => {
+}): UseStopStreamResult => {
+  const [isStopping, setIsStopping] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearStopping = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setIsStopping(false);
+  }, []);
+
+  // Is there still anything for this Stop to be stopping? Exactly the two things
+  // `decideStopAction` can name — our own live store entry, and the in-flight send's captured
+  // conversation. When BOTH are gone the stream has been torn down, which on the abort path
+  // happens because `chat:stream_complete` landed and removed the entry. So this IS the socket
+  // landing, observed through the one place a live stream is recorded rather than by
+  // second-guessing it with a socket subscription of our own.
+  const hasStopTarget = activeStream?.isOwn === true || pendingSendConversationId !== null;
+
+  // `isStopping` is in the deps, not just `hasStopTarget`, and that is load-bearing: on an
+  // already-finished stream there is no target at the moment of the click, so a
+  // `[hasStopTarget]`-only effect never re-runs and the affordance hangs until the backstop.
+  // Depending on the flag itself means the very act of raising it schedules its own resolution.
+  useEffect(() => {
+    if (isStopping && !hasStopTarget) clearStopping();
+  }, [isStopping, hasStopTarget, clearStopping]);
+
+  // Unmount (and conversation switch, which unmounts the surface's chat) must not leave a timer
+  // holding a setState on a dead hook.
+  useEffect(() => () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  const handleStop = useCallback(async () => {
+    // FIRST, synchronously, before any await: the click has to change the screen within a frame.
+    // Says "stopping", never "stopped" — see the docblock. Nothing else here touches the
+    // rendered stream.
+    setIsStopping(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      setIsStopping(false);
+    }, STOPPING_FEEDBACK_TIMEOUT_MS);
+
     const action = decideStopAction({ activeStream, pendingSendConversationId });
 
-    if (action.type === 'abortByMessageId') {
-      reportAbortOutcome(await abortActiveStreamByMessageId({ messageId: action.messageId }));
-      return;
+    try {
+      if (action.type === 'abortByMessageId') {
+        reportAbortOutcome(await abortActiveStreamByMessageId({ messageId: action.messageId }));
+        return;
+      }
+      if (action.type === 'abortByConversation') {
+        reportAbortOutcome(
+          await abortActiveStreamByConversation({ conversationId: action.conversationId }),
+        );
+        return;
+      }
+      // 'none' — nothing live and nothing sent. Deliberately silent: there is nothing to report
+      // and nothing to name. The stopping state releases itself on the next render, because
+      // 'none' is returned for exactly the state in which `hasStopTarget` is already false.
+    } catch (error) {
+      // The abort helpers swallow network failure into an 'unconfirmed' AbortResult, so this is
+      // the unexpected-throw path. Whatever it was, no socket is coming for it: release the
+      // affordance now rather than making the user wait out the backstop.
+      clearStopping();
+      throw error;
     }
-    if (action.type === 'abortByConversation') {
-      reportAbortOutcome(
-        await abortActiveStreamByConversation({ conversationId: action.conversationId }),
-      );
-      return;
-    }
-    // 'none' — nothing live and nothing sent. Deliberately silent: there is nothing to report
-    // and nothing to name.
-  }, [activeStream, pendingSendConversationId]);
+  }, [activeStream, pendingSendConversationId, clearStopping]);
+
+  return { handleStop, isStopping };
+};

--- a/apps/web/src/hooks/useStopStream.ts
+++ b/apps/web/src/hooks/useStopStream.ts
@@ -129,9 +129,17 @@ export const useStopStream = ({
   // a stale snapshot of a Stop that may since have been superseded.
   const stoppingConversationIdRef = useRef<string | null>(null);
 
+  // Raising is ref + state + backstop, always together — one call site so the mirror and the
+  // timer cannot drift out of step with the state they describe.
   const raiseStopping = useCallback((conversationId: string) => {
     stoppingConversationIdRef.current = conversationId;
     setStoppingConversationId(conversationId);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      stoppingConversationIdRef.current = null;
+      setStoppingConversationId(null);
+    }, STOPPING_FEEDBACK_TIMEOUT_MS);
   }, []);
 
   const clearStopping = useCallback(() => {
@@ -203,36 +211,24 @@ export const useStopStream = ({
     //
     // Nothing to name means nothing to claim: with no target there is no conversation to key the
     // affordance to, so it is never raised rather than raised and instantly withdrawn.
+    // Captured, not re-read: everything after the await must act on the conversation this Stop
+    // was pressed for, which by then may no longer be the one on screen.
     const stoppedConversationId = stopTargetConversationId;
-    if (stoppedConversationId !== null) {
-      raiseStopping(stoppedConversationId);
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(() => {
-        timeoutRef.current = null;
-        stoppingConversationIdRef.current = null;
-        setStoppingConversationId(null);
-      }, STOPPING_FEEDBACK_TIMEOUT_MS);
-    }
+    if (stoppedConversationId !== null) raiseStopping(stoppedConversationId);
 
     const action = decideStopAction({ activeStream, pendingSendConversationId });
 
+    // 'none' — nothing live and nothing sent. Deliberately silent: there is nothing to report
+    // and nothing to name, and nothing was raised above either.
+    if (action.type === 'none') return;
+
     try {
-      if (action.type === 'abortByMessageId') {
-        const result = await abortActiveStreamByMessageId({ messageId: action.messageId });
-        reportAbortOutcome(result);
-        releaseUnlessAbortConfirmed(result, stoppedConversationId);
-        return;
-      }
-      if (action.type === 'abortByConversation') {
-        const result = await abortActiveStreamByConversation({
-          conversationId: action.conversationId,
-        });
-        reportAbortOutcome(result);
-        releaseUnlessAbortConfirmed(result, stoppedConversationId);
-        return;
-      }
-      // 'none' — nothing live and nothing sent. Deliberately silent: there is nothing to report
-      // and nothing to name, and nothing was raised above either.
+      const result = action.type === 'abortByMessageId'
+        ? await abortActiveStreamByMessageId({ messageId: action.messageId })
+        : await abortActiveStreamByConversation({ conversationId: action.conversationId });
+
+      reportAbortOutcome(result);
+      releaseUnlessAbortConfirmed(result, stoppedConversationId);
     } catch (error) {
       // Kept for a genuinely unexpected throw (the helpers swallow network failure into
       // 'unconfirmed', which `releaseUnlessAbortConfirmed` handles). No socket is coming for it:

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -36,20 +36,6 @@ vi.mock('../useMessageActions', () => ({
 const userMsg = (id: string): UIMessage => ({ id, role: 'user', parts: [{ type: 'text', text: 'hi' }] });
 const assistantMsg = (id: string): UIMessage => ({ id, role: 'assistant', parts: [{ type: 'text', text: 'reply' }] });
 
-const baseOptions = (
-  overrides: Partial<UseCacheMessageActionsOptions> = {},
-): UseCacheMessageActionsOptions => ({
-  agentId: 'agent-1',
-  conversationId: 'conv-1',
-  renderedMessages: [
-    { mode: 'confirmed', message: userMsg('u1') },
-    { mode: 'confirmed', message: assistantMsg('a1') },
-  ],
-  regenerate: vi.fn(),
-  wrapSend: makeWrapSend(overrides.conversationId === undefined ? 'conv-1' : overrides.conversationId),
-  ...overrides,
-});
-
 /**
  * Faithful to `useSendHandoff.wrapSend`, because the retry latch now IS its pendingSend
  * registration: it registers synchronously, keyed by conversation, before invoking the send.
@@ -59,6 +45,26 @@ const makeWrapSend = (conversationId: string | null) => <T,>(sendFn: () => T): T
   if (!conversationId) return undefined;
   useEditingStore.getState().startPendingSend(conversationId);
   return sendFn();
+};
+
+const baseOptions = (
+  overrides: Partial<UseCacheMessageActionsOptions> = {},
+): UseCacheMessageActionsOptions => {
+  // Resolved once so the default `wrapSend` is keyed to whatever conversation these options
+  // actually describe — an override has to move both together or the stub registers under a
+  // conversation the hook is not looking at.
+  const conversationId = overrides.conversationId === undefined ? 'conv-1' : overrides.conversationId;
+  return {
+    agentId: 'agent-1',
+    conversationId,
+    renderedMessages: [
+      { mode: 'confirmed', message: userMsg('u1') },
+      { mode: 'confirmed', message: assistantMsg('a1') },
+    ],
+    regenerate: vi.fn(),
+    wrapSend: makeWrapSend(conversationId),
+    ...overrides,
+  };
 };
 
 describe('useCacheMessageActions handleRetry', () => {
@@ -199,9 +205,7 @@ describe('useCacheMessageActions handleRetry', () => {
 
     const { result, rerender } = renderHook(
       ({ conversationId }: { conversationId: string }) =>
-        useCacheMessageActions(
-          baseOptions({ conversationId, wrapSend: makeWrapSend(conversationId) }),
-        ),
+        useCacheMessageActions(baseOptions({ conversationId })),
       { initialProps: { conversationId: 'conv-1' } },
     );
     mockState.handleRetryBase?.mockClear();

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -286,6 +286,31 @@ describe('useCacheMessageActions handleRetry', () => {
     applyDeleteSpy.mockRestore();
   });
 
+  // Same failure family as the P1 and P2 above, one level further out: this release runs AFTER
+  // an await, and `releasePendingSend` guards on a ref shared across renders — so the stale copy
+  // this closure holds would release whatever send is registered NOW, which after a switch
+  // belongs to the other conversation. `useSendHandoff`'s own conversation-change cleanup has
+  // already released ours by then, so there is nothing here to do but stay out of the way.
+  it('given the surface switched conversations before the retry declined, should not release the other conversation\'s send', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    mockState.handleRetryBase?.mockResolvedValueOnce(false);
+    const releasePendingSend = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ conversationId }: { conversationId: string }) =>
+        useCacheMessageActions(baseOptions({ conversationId, releasePendingSend })),
+      { initialProps: { conversationId: 'conv-1' } },
+    );
+
+    // A's retry starts, then the user moves to B while it is still awaiting.
+    act(() => { void result.current.handleRetry(); });
+    rerender({ conversationId: 'conv-2' });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(releasePendingSend).not.toHaveBeenCalled();
+    applyDeleteSpy.mockRestore();
+  });
+
   // Why the check is `=== false` and not falsy. With no conversation `wrapSend` never calls its
   // argument and returns `undefined` — it registered nothing, so there is nothing to release,
   // and releasing anyway would clear a pendingSend belonging to something else.

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -281,13 +281,40 @@ describe('useCacheMessageActions handleRetry', () => {
   it('given the deletes failed, should put the rows it removed back in the cache', async () => {
     const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
     const restoreSpy = vi.spyOn(conversationMessagesActions, 'applyConfirmedMessage').mockImplementation(() => {});
-    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'delete-failed' });
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'delete-failed', undeletedIds: ['a1'] });
 
     const { result } = renderHook(() => useCacheMessageActions(baseOptions()));
 
     await act(async () => { await result.current.handleRetry(); });
 
     expect(restoreSpy).toHaveBeenCalledWith('conv-1', expect.objectContaining({ id: 'a1' }));
+    applyDeleteSpy.mockRestore();
+    restoreSpy.mockRestore();
+  });
+
+  // A PARTIAL failure is where naming the rows earns its keep: restoring one the server did
+  // manage to delete would leave the cache claiming a message that exists nowhere.
+  it('given only some deletes failed, should restore only the rows the server still holds', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    const restoreSpy = vi.spyOn(conversationMessagesActions, 'applyConfirmedMessage').mockImplementation(() => {});
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'delete-failed', undeletedIds: ['a2'] });
+
+    const { result } = renderHook(() =>
+      useCacheMessageActions(
+        baseOptions({
+          renderedMessages: [
+            { mode: 'confirmed', message: userMsg('u1') },
+            { mode: 'confirmed', message: assistantMsg('a1') },
+            { mode: 'confirmed', message: assistantMsg('a2') },
+          ],
+        }),
+      ),
+    );
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(restoreSpy).toHaveBeenCalledTimes(1);
+    expect(restoreSpy).toHaveBeenCalledWith('conv-1', expect.objectContaining({ id: 'a2' }));
     applyDeleteSpy.mockRestore();
     restoreSpy.mockRestore();
   });

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -63,6 +63,7 @@ const baseOptions = (
     ],
     regenerate: vi.fn(),
     wrapSend: makeWrapSend(conversationId),
+    releasePendingSend: vi.fn(),
     ...overrides,
   };
 };
@@ -250,6 +251,55 @@ describe('useCacheMessageActions handleRetry', () => {
     expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
 
     mockState.handleRetryBaseResolve?.();
+    applyDeleteSpy.mockRestore();
+  });
+
+  // The wiring for the one retry that registers and then declines to dispatch: a Stop landed
+  // while `useMessageActions.handleRetry` was deleting the superseded rows, so it returns false
+  // rather than starting a generation the user just asked not to start. Nothing else clears the
+  // pendingSend on that path — the handoff effect is keyed on state it never moved — and the
+  // composer renders only Stop while one stands, so the conversation would sit locked until
+  // unmount.
+  it('given the retry declined to dispatch, should release the pending send it registered', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    mockState.handleRetryBase?.mockResolvedValueOnce(false);
+    const releasePendingSend = vi.fn();
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions({ releasePendingSend })));
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(releasePendingSend).toHaveBeenCalledTimes(1);
+    applyDeleteSpy.mockRestore();
+  });
+
+  it('given the retry dispatched, should not release the pending send', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    mockState.handleRetryBase?.mockResolvedValueOnce(true);
+    const releasePendingSend = vi.fn();
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions({ releasePendingSend })));
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(releasePendingSend).not.toHaveBeenCalled();
+    applyDeleteSpy.mockRestore();
+  });
+
+  // Why the check is `=== false` and not falsy. With no conversation `wrapSend` never calls its
+  // argument and returns `undefined` — it registered nothing, so there is nothing to release,
+  // and releasing anyway would clear a pendingSend belonging to something else.
+  it('given no conversation, should not release anything', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    const releasePendingSend = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCacheMessageActions(baseOptions({ conversationId: null, releasePendingSend })),
+    );
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(releasePendingSend).not.toHaveBeenCalled();
     applyDeleteSpy.mockRestore();
   });
 

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -248,4 +248,32 @@ describe('useCacheMessageActions handleRetry', () => {
     mockState.handleRetryBaseResolve?.();
     applyDeleteSpy.mockRestore();
   });
+
+  // The other half of the guard, and the obvious objection to it: a latch that suppresses is
+  // only correct if it also RELEASES. It has no release path of its own by design — it is the
+  // pendingSend, so `useSendHandoff` releases it (stream handoff, error, unmount, or the 15s
+  // safety timeout). This asserts the consequence: once the send is no longer pending, Retry
+  // works again rather than staying wedged for the life of the mount.
+  it('given the pending send has resolved, should allow a retry again', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions()));
+    mockState.handleRetryBase?.mockClear();
+
+    act(() => { void result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
+
+    // What useSendHandoff does when the stream takes over (or the request errors, or the safety
+    // timeout fires): the conversation is no longer pending.
+    act(() => { useEditingStore.getState().endPendingSend('conv-1'); });
+
+    act(() => { void result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(2);
+
+    mockState.handleRetryBaseResolve?.();
+    applyDeleteSpy.mockRestore();
+  });
 });

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -249,6 +249,28 @@ describe('useCacheMessageActions handleRetry', () => {
     applyDeleteSpy.mockRestore();
   });
 
+  // A deliberate WIDENING over the ref this replaced, worth pinning because it is easy to read
+  // as an accident. The latch is "a send is in flight for this conversation", and an ordinary
+  // send counts. It has to: during the submitted window no stream exists yet, so `planRetry`
+  // sees nothing live, takes the just-sent user turn as the one to retry, and fires a
+  // regeneration alongside the send that has not even landed — two generations, billed twice.
+  it('given an ordinary send in flight for this conversation, should not start a retry', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions()));
+    mockState.handleRetryBase?.mockClear();
+
+    // What the composer's Send does — the same `wrapSend`, no retry involved.
+    act(() => { useEditingStore.getState().startPendingSend('conv-1'); });
+
+    act(() => { void result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(mockState.handleRetryBase).not.toHaveBeenCalled();
+
+    applyDeleteSpy.mockRestore();
+  });
+
   // The other half of the guard, and the obvious objection to it: a latch that suppresses is
   // only correct if it also RELEASES. It has no release path of its own by design — it is the
   // pendingSend, so `useSendHandoff` releases it (stream handoff, error, unmount, or the 15s

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -10,7 +10,14 @@ import { useEditingStore } from '@/stores/useEditingStore';
 const mockState = vi.hoisted(() => {
   const state = {
     handleRetryBaseResolve: undefined as (() => void) | undefined,
-    handleRetryBase: undefined as ReturnType<typeof vi.fn> | undefined,
+    // TYPED FROM THE REAL SIGNATURE, not `ReturnType<typeof vi.fn>` (CodeRabbit). Untyped, the
+    // `mockResolvedValueOnce` calls below accept any shape, so a change to `RetryOutcome` leaves
+    // these stubs describing a contract that no longer exists and typecheck says nothing. That
+    // is not hypothetical: this file's stubs returned bare booleans until `handleRetry` grew a
+    // named outcome, and only running the suite caught it.
+    handleRetryBase: undefined as
+      | ReturnType<typeof vi.fn<() => Promise<import('../useMessageActions').RetryOutcome>>>
+      | undefined,
   };
   // ONE spy for the life of the file, not a fresh one per render. The hook re-renders (and
   // re-invokes this factory) on every prop change, so a spy created inside it silently reset
@@ -20,7 +27,12 @@ const mockState = vi.hoisted(() => {
   // (ai SDK makeRequest reads the response to completion) — held open here so the test
   // can assert applyDelete already ran BEFORE this resolves (PR 6 review, CodeRabbit).
   state.handleRetryBase = vi.fn(
-    () => new Promise<void>((resolve) => { state.handleRetryBaseResolve = resolve; }),
+    () => new Promise<import('../useMessageActions').RetryOutcome>((resolve) => {
+      // Held open, and resolved with a DISPATCHED outcome: the cases that hold this promise are
+      // asserting what happens while a retry is in flight, and a retry that got as far as
+      // `regenerate` is what they are describing.
+      state.handleRetryBaseResolve = () => resolve({ dispatched: true });
+    }),
   );
   return state;
 });

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -262,7 +262,7 @@ describe('useCacheMessageActions handleRetry', () => {
   // unmount.
   it('given the retry declined to dispatch, should release the pending send it registered', async () => {
     const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
-    mockState.handleRetryBase?.mockResolvedValueOnce(false);
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'stopped' });
     const releasePendingSend = vi.fn();
 
     const { result } = renderHook(() => useCacheMessageActions(baseOptions({ releasePendingSend })));
@@ -273,9 +273,44 @@ describe('useCacheMessageActions handleRetry', () => {
     applyDeleteSpy.mockRestore();
   });
 
+  // The cache write was a claim about the server, and a failed delete means the server does not
+  // agree. It has to be taken back — not for tidiness, but because the NEXT retry plans its
+  // deletes from this same cache: leave it lying and that retry finds nothing to delete,
+  // dispatches, and hands the model its own previous answer. The same corruption the refusal
+  // just prevented, one click later.
+  it('given the deletes failed, should put the rows it removed back in the cache', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    const restoreSpy = vi.spyOn(conversationMessagesActions, 'applyConfirmedMessage').mockImplementation(() => {});
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'delete-failed' });
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions()));
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(restoreSpy).toHaveBeenCalledWith('conv-1', expect.objectContaining({ id: 'a1' }));
+    applyDeleteSpy.mockRestore();
+    restoreSpy.mockRestore();
+  });
+
+  // A stopped retry deleted the rows for real, so putting them back would be the lie in the
+  // other direction — the user asked for that answer to go, and it went.
+  it('given a stopped retry, should leave the cache deleted', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    const restoreSpy = vi.spyOn(conversationMessagesActions, 'applyConfirmedMessage').mockImplementation(() => {});
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'stopped' });
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions()));
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(restoreSpy).not.toHaveBeenCalled();
+    applyDeleteSpy.mockRestore();
+    restoreSpy.mockRestore();
+  });
+
   it('given the retry dispatched, should not release the pending send', async () => {
     const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
-    mockState.handleRetryBase?.mockResolvedValueOnce(true);
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: true });
     const releasePendingSend = vi.fn();
 
     const { result } = renderHook(() => useCacheMessageActions(baseOptions({ releasePendingSend })));
@@ -293,7 +328,7 @@ describe('useCacheMessageActions handleRetry', () => {
   // already released ours by then, so there is nothing here to do but stay out of the way.
   it('given the surface switched conversations before the retry declined, should not release the other conversation\'s send', async () => {
     const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
-    mockState.handleRetryBase?.mockResolvedValueOnce(false);
+    mockState.handleRetryBase?.mockResolvedValueOnce({ dispatched: false, reason: 'stopped' });
     const releasePendingSend = vi.fn();
 
     const { result, rerender } = renderHook(

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -37,6 +37,7 @@ const baseOptions = (
     { mode: 'confirmed', message: assistantMsg('a1') },
   ],
   regenerate: vi.fn(),
+  wrapSend: <T,>(sendFn: () => T) => sendFn(),
   ...overrides,
 });
 
@@ -104,4 +105,66 @@ describe('useCacheMessageActions handleRetry', () => {
   // `regenerate` composes its request from the store's settled view at call time, which is
   // what that hydration was manually arranging. The cross-conversation content leak it
   // guarded against needed a shared `Chat` to be possible at all.
+
+  // Retry never went through the surface's optimistic path: `regenerate` was called bare, so
+  // pendingSendConversationId stayed null, every surface's displayIsStreaming stayed FALSE for
+  // the whole window, and the composer sat there with an enabled textarea and a Send button
+  // while a regeneration was already under way.
+  it('given a retry, should issue it through wrapSend so the composer locks like a send', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    // Counted around the wrapped call: proves the retry runs INSIDE the registration rather
+    // than merely after it, which is the whole point — the composer has to be locked while the
+    // network work happens, not once it is done.
+    let retriesBeforeInner = -1;
+    let retriesAfterInner = -1;
+    let wrapSendCalls = 0;
+    // Not vi.fn: wrapping erases the generic, and `wrapSend` has to stay generic to satisfy
+    // the option's signature.
+    const wrapSend = <T,>(sendFn: () => T): T => {
+      wrapSendCalls += 1;
+      retriesBeforeInner = mockState.handleRetryBase?.mock.calls.length ?? -1;
+      const returned = sendFn();
+      retriesAfterInner = mockState.handleRetryBase?.mock.calls.length ?? -1;
+      return returned;
+    };
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions({ wrapSend })));
+    mockState.handleRetryBase?.mockClear();
+
+    act(() => { void result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(wrapSendCalls).toBe(1);
+    expect(retriesBeforeInner).toBe(0);
+    expect(retriesAfterInner).toBe(1);
+
+    mockState.handleRetryBaseResolve?.();
+    applyDeleteSpy.mockRestore();
+  });
+
+  // Double-click. Every other guard is state-derived and only closes after a render, so both
+  // clicks land inside the same await window — two regenerations, billed twice.
+  it('given a second retry while the first is still in flight, should fire only one regenerate', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    let wrapSendCalls = 0;
+    const wrapSend = <T,>(sendFn: () => T): T => {
+      wrapSendCalls += 1;
+      return sendFn();
+    };
+
+    const { result } = renderHook(() => useCacheMessageActions(baseOptions({ wrapSend })));
+    mockState.handleRetryBase?.mockClear();
+
+    act(() => {
+      void result.current.handleRetry();
+      void result.current.handleRetry();
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(wrapSendCalls).toBe(1);
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
+
+    mockState.handleRetryBaseResolve?.();
+    applyDeleteSpy.mockRestore();
+  });
 });

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -6,21 +6,29 @@ import { conversationMessagesActions } from '@/hooks/conversationMessagesActions
 
 // vi.mock factories are hoisted above module-scope declarations — a plain `let` here would
 // throw a TDZ ReferenceError at transform time. vi.hoisted lifts this state alongside the mock.
-const mockState = vi.hoisted(() => ({
-  handleRetryBaseResolve: undefined as (() => void) | undefined,
-  handleRetryBase: undefined as ReturnType<typeof vi.fn> | undefined,
-}));
+const mockState = vi.hoisted(() => {
+  const state = {
+    handleRetryBaseResolve: undefined as (() => void) | undefined,
+    handleRetryBase: undefined as ReturnType<typeof vi.fn> | undefined,
+  };
+  // ONE spy for the life of the file, not a fresh one per render. The hook re-renders (and
+  // re-invokes this factory) on every prop change, so a spy created inside it silently reset
+  // its own call count mid-test — which is invisible until a test spans a re-render.
+  //
+  // A real regenerate's underlying Promise resolves only once the new stream finishes
+  // (ai SDK makeRequest reads the response to completion) — held open here so the test
+  // can assert applyDelete already ran BEFORE this resolves (PR 6 review, CodeRabbit).
+  state.handleRetryBase = vi.fn(
+    () => new Promise<void>((resolve) => { state.handleRetryBaseResolve = resolve; }),
+  );
+  return state;
+});
 
 vi.mock('../useMessageActions', () => ({
   useMessageActions: () => ({
     handleEdit: vi.fn(),
     handleDelete: vi.fn(),
-    // A real regenerate's underlying Promise resolves only once the new stream finishes
-    // (ai SDK makeRequest reads the response to completion) — held open here so the test
-    // can assert applyDelete already ran BEFORE this resolves (PR 6 review, CodeRabbit).
-    handleRetry: (mockState.handleRetryBase = vi.fn(
-      () => new Promise<void>((resolve) => { mockState.handleRetryBaseResolve = resolve; }),
-    )),
+    handleRetry: mockState.handleRetryBase,
   }),
 }));
 
@@ -163,6 +171,36 @@ describe('useCacheMessageActions handleRetry', () => {
 
     expect(wrapSendCalls).toBe(1);
     expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
+
+    mockState.handleRetryBaseResolve?.();
+    applyDeleteSpy.mockRestore();
+  });
+
+  // The dashboard and sidebar keep ONE instance of this hook across a conversation switch, and
+  // concurrent sends in different conversations are supported by design. A single boolean latch
+  // let a retry still awaiting A's DELETEs silently swallow a Retry click in B.
+  it('given a retry in flight for one conversation, should not block a retry in another', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+    const wrapSend = <T,>(sendFn: () => T): T => sendFn();
+
+    const { result, rerender } = renderHook(
+      ({ conversationId }: { conversationId: string }) =>
+        useCacheMessageActions(baseOptions({ wrapSend, conversationId })),
+      { initialProps: { conversationId: 'conv-1' } },
+    );
+    mockState.handleRetryBase?.mockClear();
+
+    // A's retry is in flight — handleRetryBase's promise is held open, so the latch is still set.
+    act(() => { void result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
+
+    // Same hook instance, conversation B now on screen.
+    rerender({ conversationId: 'conv-2' });
+    act(() => { void result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(2);
 
     mockState.handleRetryBaseResolve?.();
     applyDeleteSpy.mockRestore();

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useCacheMessageActions.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import type { UIMessage } from 'ai';
 import { useCacheMessageActions, type UseCacheMessageActionsOptions } from '../useCacheMessageActions';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { useEditingStore } from '@/stores/useEditingStore';
 
 // vi.mock factories are hoisted above module-scope declarations — a plain `let` here would
 // throw a TDZ ReferenceError at transform time. vi.hoisted lifts this state alongside the mock.
@@ -45,13 +46,25 @@ const baseOptions = (
     { mode: 'confirmed', message: assistantMsg('a1') },
   ],
   regenerate: vi.fn(),
-  wrapSend: <T,>(sendFn: () => T) => sendFn(),
+  wrapSend: makeWrapSend(overrides.conversationId === undefined ? 'conv-1' : overrides.conversationId),
   ...overrides,
 });
+
+/**
+ * Faithful to `useSendHandoff.wrapSend`, because the retry latch now IS its pendingSend
+ * registration: it registers synchronously, keyed by conversation, before invoking the send.
+ * A bare passthrough here would silently disable the very guard these cases exercise.
+ */
+const makeWrapSend = (conversationId: string | null) => <T,>(sendFn: () => T): T | undefined => {
+  if (!conversationId) return undefined;
+  useEditingStore.getState().startPendingSend(conversationId);
+  return sendFn();
+};
 
 describe('useCacheMessageActions handleRetry', () => {
   beforeEach(() => {
     mockState.handleRetryBaseResolve = undefined;
+    useEditingStore.setState({ pendingSends: new Set() });
   });
 
   it('given a retry, should apply the cache deletes BEFORE handleRetryBase (regenerate) settles, not after', async () => {
@@ -128,10 +141,11 @@ describe('useCacheMessageActions handleRetry', () => {
     let wrapSendCalls = 0;
     // Not vi.fn: wrapping erases the generic, and `wrapSend` has to stay generic to satisfy
     // the option's signature.
-    const wrapSend = <T,>(sendFn: () => T): T => {
+    const inner = makeWrapSend('conv-1');
+    const wrapSend = <T,>(sendFn: () => T): T | undefined => {
       wrapSendCalls += 1;
       retriesBeforeInner = mockState.handleRetryBase?.mock.calls.length ?? -1;
-      const returned = sendFn();
+      const returned = inner(sendFn);
       retriesAfterInner = mockState.handleRetryBase?.mock.calls.length ?? -1;
       return returned;
     };
@@ -155,9 +169,10 @@ describe('useCacheMessageActions handleRetry', () => {
   it('given a second retry while the first is still in flight, should fire only one regenerate', async () => {
     const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
     let wrapSendCalls = 0;
-    const wrapSend = <T,>(sendFn: () => T): T => {
+    const inner = makeWrapSend('conv-1');
+    const wrapSend = <T,>(sendFn: () => T): T | undefined => {
       wrapSendCalls += 1;
-      return sendFn();
+      return inner(sendFn);
     };
 
     const { result } = renderHook(() => useCacheMessageActions(baseOptions({ wrapSend })));
@@ -181,11 +196,12 @@ describe('useCacheMessageActions handleRetry', () => {
   // let a retry still awaiting A's DELETEs silently swallow a Retry click in B.
   it('given a retry in flight for one conversation, should not block a retry in another', async () => {
     const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
-    const wrapSend = <T,>(sendFn: () => T): T => sendFn();
 
     const { result, rerender } = renderHook(
       ({ conversationId }: { conversationId: string }) =>
-        useCacheMessageActions(baseOptions({ wrapSend, conversationId })),
+        useCacheMessageActions(
+          baseOptions({ conversationId, wrapSend: makeWrapSend(conversationId) }),
+        ),
       { initialProps: { conversationId: 'conv-1' } },
     );
     mockState.handleRetryBase?.mockClear();
@@ -201,6 +217,33 @@ describe('useCacheMessageActions handleRetry', () => {
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
     expect(mockState.handleRetryBase).toHaveBeenCalledTimes(2);
+
+    mockState.handleRetryBaseResolve?.();
+    applyDeleteSpy.mockRestore();
+  });
+
+  // The cross-SURFACE case (CodeRabbit). GlobalAssistantView and SidebarChatTab each mount
+  // their own instance of this hook for the same conversation, so a per-instance ref left two
+  // Retry buttons unaware of each other. The server cannot save us there: its per-conversation
+  // takeover is a check-then-act and says so — "two near-simultaneous sends can BOTH find zero
+  // in-flight rows and BOTH proceed: two generations, two sets of tool calls, two bills".
+  it('given two hook instances on the same conversation, should run only one retry', async () => {
+    const applyDeleteSpy = vi.spyOn(conversationMessagesActions, 'applyDelete').mockImplementation(() => {});
+
+    // Two independent mounts, exactly as the dashboard and the sidebar produce.
+    const dashboard = renderHook(() => useCacheMessageActions(baseOptions()));
+    const sidebar = renderHook(() => useCacheMessageActions(baseOptions()));
+    mockState.handleRetryBase?.mockClear();
+
+    act(() => { void dashboard.result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
+
+    // The other surface's Retry, while the first is still in flight.
+    act(() => { void sidebar.result.current.handleRetry(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(mockState.handleRetryBase).toHaveBeenCalledTimes(1);
 
     mockState.handleRetryBaseResolve?.();
     applyDeleteSpy.mockRestore();

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
@@ -181,7 +181,7 @@ describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
     await act(async () => { outcome = await result.current.handleRetry(); });
 
     expect(regenerate).not.toHaveBeenCalled();
-    expect(outcome).toEqual({ dispatched: false, reason: 'delete-failed' });
+    expect(outcome).toEqual({ dispatched: false, reason: 'delete-failed', undeletedIds: ['a1'] });
     // Not silent: the cache row is already gone, so the user would otherwise watch their answer
     // vanish with nothing replacing it and no idea why.
     expect(toast.error).toHaveBeenCalled();

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import { del } from '@/lib/auth/auth-fetch';
+import { recordStopRequest } from '@/lib/ai/streams/stopRequests';
 import { useMessageActions } from '../useMessageActions';
 
 vi.mock('@/lib/auth/auth-fetch', () => ({
@@ -79,6 +82,105 @@ describe('useMessageActions — handleRetry regenerate body', () => {
     expect(regenerate).toHaveBeenCalledWith({
       body: { chatId: 'agent-1', conversationId: 'agent-conv-1' },
     });
+  });
+});
+
+/**
+ * THE STOP THE SERVER CANNOT HONOUR.
+ *
+ * Retry now runs inside `wrapSend`, so the composer offers Stop for the whole DELETE round trip
+ * below — but no stream row exists yet, so `markAbortRequested` matches nothing and the abort
+ * answers `not_found`, which the UI is deliberately silent about. Dispatching the regenerate
+ * anyway would mean the press did nothing visible and a generation started regardless.
+ */
+describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const assistantAfterUser = (): UIMessage[] => [
+    { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+    { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'reply' }] },
+  ];
+
+  it('given a Stop while the superseded rows are being deleted, should not regenerate', async () => {
+    const regenerate = vi.fn();
+    let releaseDeletes: (() => void) | undefined;
+    vi.mocked(del).mockImplementation(
+      () => new Promise((resolve) => { releaseDeletes = () => resolve(undefined); }),
+    );
+
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'conv-1',
+        messages: assistantAfterUser(),
+        regenerate,
+      }),
+    );
+
+    let retry: Promise<boolean> | undefined;
+    act(() => { retry = result.current.handleRetry(); });
+
+    // The press, landing while the DELETEs are still in flight — exactly the window the
+    // composer has been showing Stop for.
+    act(() => { recordStopRequest('conv-1'); });
+
+    await act(async () => { releaseDeletes?.(); await retry; });
+
+    expect(regenerate).not.toHaveBeenCalled();
+    // FALSE, so the caller releases the pendingSend it is holding — nothing else will, and the
+    // composer renders only Stop while it stands.
+    await expect(retry).resolves.toBe(false);
+  });
+
+  // The mirror image, and the reason this is a counter compared against a snapshot rather than a
+  // flag anyone has to clear: stopping a stream and THEN retrying it is the ordinary path.
+  it('given a Stop that happened BEFORE the retry, should still regenerate', async () => {
+    const regenerate = vi.fn();
+    vi.mocked(del).mockResolvedValue(undefined);
+
+    recordStopRequest('conv-2');
+
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'conv-2',
+        messages: assistantAfterUser(),
+        regenerate,
+      }),
+    );
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'conv-2' } });
+  });
+
+  // Keyed by conversation for the same reason everything else in this path is: concurrent sends
+  // in different conversations are supported by design.
+  it('given a Stop in another conversation, should still regenerate this one', async () => {
+    const regenerate = vi.fn();
+    let releaseDeletes: (() => void) | undefined;
+    vi.mocked(del).mockImplementation(
+      () => new Promise((resolve) => { releaseDeletes = () => resolve(undefined); }),
+    );
+
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'conv-3',
+        messages: assistantAfterUser(),
+        regenerate,
+      }),
+    );
+
+    let retry: Promise<boolean> | undefined;
+    act(() => { retry = result.current.handleRetry(); });
+    act(() => { recordStopRequest('conv-elsewhere'); });
+
+    await act(async () => { releaseDeletes?.(); await retry; });
+
+    expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'conv-3' } });
   });
 });
 

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { UIMessage } from 'ai';
-import { del } from '@/lib/auth/auth-fetch';
+import { del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
 import { recordStopRequest } from '@/lib/ai/streams/stopRequests';
-import { useMessageActions } from '../useMessageActions';
+import { useMessageActions, type RetryOutcome } from '../useMessageActions';
 
-vi.mock('@/lib/auth/auth-fetch', () => ({
+// Partial: `ApiRequestError` is a real class the hook does an `instanceof` against, so a stub
+// would make every rejection look like a plain Error and collapse the 404 distinction under test.
+vi.mock('@/lib/auth/auth-fetch', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/auth/auth-fetch')>()),
   fetchWithAuth: vi.fn(),
   patch: vi.fn(),
   del: vi.fn().mockResolvedValue(undefined),
@@ -120,7 +123,7 @@ describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
       }),
     );
 
-    let retry: Promise<boolean> | undefined;
+    let retry: Promise<RetryOutcome> | undefined;
     act(() => { retry = result.current.handleRetry(); });
 
     // The press, landing while the DELETEs are still in flight — exactly the window the
@@ -130,9 +133,9 @@ describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
     await act(async () => { releaseDeletes?.(); await retry; });
 
     expect(regenerate).not.toHaveBeenCalled();
-    // FALSE, so the caller releases the pendingSend it is holding — nothing else will, and the
-    // composer renders only Stop while it stands.
-    await expect(retry).resolves.toBe(false);
+    // Named, not merely false: the caller releases the pendingSend on every non-dispatch, but
+    // only a delete failure additionally means the cache is lying about what the server holds.
+    await expect(retry).resolves.toEqual({ dispatched: false, reason: 'stopped' });
   });
 
   // The mirror image, and the reason this is a counter compared against a snapshot rather than a
@@ -174,14 +177,36 @@ describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
       }),
     );
 
-    let dispatched: boolean | undefined;
-    await act(async () => { dispatched = await result.current.handleRetry(); });
+    let outcome: RetryOutcome | undefined;
+    await act(async () => { outcome = await result.current.handleRetry(); });
 
     expect(regenerate).not.toHaveBeenCalled();
-    expect(dispatched).toBe(false);
+    expect(outcome).toEqual({ dispatched: false, reason: 'delete-failed' });
     // Not silent: the cache row is already gone, so the user would otherwise watch their answer
     // vanish with nothing replacing it and no idea why.
     expect(toast.error).toHaveBeenCalled();
+  });
+
+  // 404 is not a failure here, and conflating them would be its own bug: the route answers
+  // 'Message not found' for a row that is already gone, and gone is the state the delete was
+  // asking for. A collaborator or a second tab getting there first must not block the retry.
+  it('given a delete that 404s because the row is already gone, should still regenerate', async () => {
+    const regenerate = vi.fn();
+    vi.mocked(del).mockRejectedValue(new ApiRequestError('Message not found', 404));
+
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'conv-6',
+        messages: assistantAfterUser(),
+        regenerate,
+      }),
+    );
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'conv-6' } });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('given every delete succeeds, should regenerate and say nothing', async () => {
@@ -221,7 +246,7 @@ describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
       }),
     );
 
-    let retry: Promise<boolean> | undefined;
+    let retry: Promise<RetryOutcome> | undefined;
     act(() => { retry = result.current.handleRetry(); });
     act(() => { recordStopRequest('conv-elsewhere'); });
 

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { UIMessage } from 'ai';
 import { del } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
 import { recordStopRequest } from '@/lib/ai/streams/stopRequests';
 import { useMessageActions } from '../useMessageActions';
 
@@ -154,6 +155,52 @@ describe('useMessageActions — handleRetry and a Stop mid-DELETE', () => {
     await act(async () => { await result.current.handleRetry(); });
 
     expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'conv-2' } });
+  });
+
+  // A FAILED delete breaks the same invariant as a raced one: the row is still in the database,
+  // the server rebuilds history FROM the database, and the model gets its own previous answer as
+  // the newest turn. Awaiting something and then ignoring what it said is not an ordering
+  // guarantee (CodeRabbit).
+  it('given a delete that fails, should not regenerate', async () => {
+    const regenerate = vi.fn();
+    vi.mocked(del).mockRejectedValue(new Error('500'));
+
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'conv-4',
+        messages: assistantAfterUser(),
+        regenerate,
+      }),
+    );
+
+    let dispatched: boolean | undefined;
+    await act(async () => { dispatched = await result.current.handleRetry(); });
+
+    expect(regenerate).not.toHaveBeenCalled();
+    expect(dispatched).toBe(false);
+    // Not silent: the cache row is already gone, so the user would otherwise watch their answer
+    // vanish with nothing replacing it and no idea why.
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('given every delete succeeds, should regenerate and say nothing', async () => {
+    const regenerate = vi.fn();
+    vi.mocked(del).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'conv-5',
+        messages: assistantAfterUser(),
+        regenerate,
+      }),
+    );
+
+    await act(async () => { await result.current.handleRetry(); });
+
+    expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'conv-5' } });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   // Keyed by conversation for the same reason everything else in this path is: concurrent sends

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -205,11 +205,12 @@ export function useCacheMessageActions({
     // nothing to delete, dispatches, and hands the model its own previous answer: the exact
     // corruption the refusal above just prevented, one click later.
     //
-    // Restoring rows that a PARTIALLY failed delete did remove server-side is the safe
-    // direction: an over-reporting cache costs one redundant DELETE on the next retry, which
-    // answers 404, which that path already treats as the row being in the state it wanted.
+    // Only the rows the server STILL HOLDS, which is why the outcome names them. A partial
+    // failure is the case that makes the distinction earn its keep: restoring the ones that did
+    // delete would leave the cache claiming messages that no longer exist anywhere.
     if (outcome.reason === 'delete-failed' && conversationId) {
       for (const message of deletedRows) {
+        if (!outcome.undeletedIds.includes(message.id)) continue;
         conversationMessagesActions.applyConfirmedMessage(conversationId, message);
       }
     }

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -126,11 +126,20 @@ export function useCacheMessageActions({
   // state-derived — planRetry's live-stream check, the button's `retryDisabled` — and state only
   // settles after a render, so a double-click lands both handlers inside the same await window
   // and fires TWO regenerations, billed twice.
-  const retryInFlightRef = useRef(false);
+  //
+  // A SET KEYED BY CONVERSATION, not a boolean. The dashboard and sidebar keep one instance of
+  // this hook across a conversation switch, and concurrent sends in different conversations are
+  // supported by design — so a single flag let a retry still awaiting A's DELETEs silently
+  // swallow a Retry click in B, for as long as A's requests took to settle. What must be
+  // suppressed is a duplicate retry of the SAME conversation, which is what the key names.
+  const retryInFlightConversationsRef = useRef<Set<string>>(new Set());
 
   const handleRetry = useCallback(async () => {
-    if (retryInFlightRef.current) return;
-    retryInFlightRef.current = true;
+    // `conversationId` is null only before identity resolves, where handleRetryBase no-ops
+    // anyway; one shared sentinel for that case cannot collide with a real cuid.
+    const retryKey = conversationId ?? '\u0000no-conversation';
+    if (retryInFlightConversationsRef.current.has(retryKey)) return;
+    retryInFlightConversationsRef.current.add(retryKey);
     try {
       // planRetry is the guard: it plans nothing (no ids, no lastUserMessage) while a
       // stream is live anywhere in the rendered list, so an in-flight run can never be
@@ -156,7 +165,7 @@ export function useCacheMessageActions({
       // offers Stop within a frame, same as a send.
       await wrapSend(() => handleRetryBase());
     } finally {
-      retryInFlightRef.current = false;
+      retryInFlightConversationsRef.current.delete(retryKey);
     }
   }, [renderedMessages, handleRetryBase, conversationId, wrapSend]);
 

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -53,6 +53,16 @@ export interface UseCacheMessageActionsOptions {
    * handleRetry.
    */
   wrapSend: <T>(sendFn: () => T) => T | undefined;
+  /**
+   * The surface's `useSendHandoff.releasePendingSend` — the SAME one its send uses.
+   *
+   * Required because a retry can now decline to dispatch: a Stop pressed while the superseded
+   * assistant rows are being deleted server-side has nothing for the server to abort (no stream
+   * row exists yet), so `handleRetry` refuses to start the generation. That return path moves
+   * none of the handoff effect's dependencies, and the composer renders only Stop while a
+   * pendingSend stands — so without this the conversation would sit locked until unmount.
+   */
+  releasePendingSend: () => void;
 }
 
 /**
@@ -88,6 +98,7 @@ export function useCacheMessageActions({
   renderedMessages,
   regenerate,
   wrapSend,
+  releasePendingSend,
 }: UseCacheMessageActionsOptions): UseCacheMessageActionsResult {
   const stableMessages = useMemo(
     () => renderedMessages.filter((r) => r.mode !== 'streaming').map((r) => r.message),
@@ -170,8 +181,15 @@ export function useCacheMessageActions({
     // leave that whole round trip unfeedbacked — the exact dead window this is here to close.
     // From this call the surface's `displayIsStreaming` is true, so the composer locks and
     // offers Stop within a frame, same as a send.
-    await wrapSend(() => handleRetryBase());
-  }, [renderedMessages, handleRetryBase, conversationId, wrapSend]);
+    const dispatched = await wrapSend(() => handleRetryBase());
+
+    // `false` — not `undefined`, which only means `wrapSend` had no conversation to register
+    // under and therefore never registered anything to release. An explicit false is a retry
+    // that registered and then declined to dispatch (a Stop landed during its DELETEs), and
+    // nothing else will clear the pendingSend for it: the handoff effect is keyed on state this
+    // path never moved, so the composer would show Stop until unmount.
+    if (dispatched === false) releasePendingSend();
+  }, [renderedMessages, handleRetryBase, conversationId, wrapSend, releasePendingSend]);
 
   return { handleEdit, handleDelete, handleRetry, stableMessages };
 }

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -176,6 +176,10 @@ export function useCacheMessageActions({
     // reads the response to completion), so awaiting it first would leave the old assistant
     // rows visible in the cache/UI alongside the new streaming reply for the whole
     // regeneration (PR 6 review, CodeRabbit).
+    // Kept so the cache can be put back if the server deletes turn out not to have happened —
+    // see the restore below. The rows themselves, not just their ids: an id cannot be un-deleted.
+    const deletedRows = stableMessages.filter((m) => assistantIdsToDelete.includes(m.id));
+
     if (conversationId) {
       for (const id of assistantIdsToDelete) conversationMessagesActions.applyDelete(conversationId, id);
     }
@@ -187,13 +191,31 @@ export function useCacheMessageActions({
     // leave that whole round trip unfeedbacked — the exact dead window this is here to close.
     // From this call the surface's `displayIsStreaming` is true, so the composer locks and
     // offers Stop within a frame, same as a send.
-    const dispatched = await wrapSend(() => handleRetryBase());
+    const outcome = await wrapSend(() => handleRetryBase());
 
-    // `false` — not `undefined`, which only means `wrapSend` had no conversation to register
-    // under and therefore never registered anything to release. An explicit false is a retry
-    // that registered and then declined to dispatch (a Stop landed during its DELETEs), and
-    // nothing else will clear the pendingSend for it: the handoff effect is keyed on state this
-    // path never moved, so the composer would show Stop until unmount.
+    // `undefined` means `wrapSend` had no conversation to register under, so it never called its
+    // argument and there is nothing here to undo. Everything below is about a retry that DID
+    // register and then declined.
+    if (!outcome || outcome.dispatched) return;
+
+    // THE CACHE HAS TO BE PUT BACK when the server deletes did not happen. It was written
+    // synchronously above so the superseded answer would disappear at the click, and that write
+    // is now a claim the server does not agree with — which matters beyond cosmetics, because
+    // the NEXT retry plans its deletes from this same cache. Leave it lying and that retry finds
+    // nothing to delete, dispatches, and hands the model its own previous answer: the exact
+    // corruption the refusal above just prevented, one click later.
+    //
+    // Restoring rows that a PARTIALLY failed delete did remove server-side is the safe
+    // direction: an over-reporting cache costs one redundant DELETE on the next retry, which
+    // answers 404, which that path already treats as the row being in the state it wanted.
+    if (outcome.reason === 'delete-failed' && conversationId) {
+      for (const message of deletedRows) {
+        conversationMessagesActions.applyConfirmedMessage(conversationId, message);
+      }
+    }
+
+    // Nothing else will clear the pendingSend on these paths: the handoff effect is keyed on
+    // state they never moved, so the composer would show Stop until unmount.
     //
     // Scoped to the conversation this retry was for, like every other post-await step in this
     // epic. `releasePendingSend` names whatever conversation it was BUILT for but guards on a
@@ -201,8 +223,8 @@ export function useCacheMessageActions({
     // send belonging to the conversation the user has since switched to. If the surface has
     // moved on, `useSendHandoff`'s own conversation-change cleanup already released ours and
     // there is nothing here to do.
-    if (dispatched === false && conversationIdRef.current === conversationId) releasePendingSend();
-  }, [renderedMessages, handleRetryBase, conversationId, wrapSend, releasePendingSend]);
+    if (conversationIdRef.current === conversationId) releasePendingSend();
+  }, [renderedMessages, stableMessages, handleRetryBase, conversationId, wrapSend, releasePendingSend]);
 
   return { handleEdit, handleDelete, handleRetry, stableMessages };
 }

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -20,10 +20,11 @@
  * explicit cache write the action would render no change. A base-call failure
  * rolls back inside useMessageActions and leaves the cache untouched.
  */
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { UIMessage } from 'ai';
 import { useMessageActions } from './useMessageActions';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { planRetry } from '@/lib/ai/streams/planRetry';
 import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
 import type { RenderedMessage } from '@/lib/ai/streams/selectRenderedMessages';
@@ -122,51 +123,54 @@ export function useCacheMessageActions({
     conversationMessagesActions.applyDelete(conversationId, messageId);
   }, [handleDeleteBase, conversationId]);
 
-  // Latched for the whole retry, synchronously, before any await. Every other guard is
-  // state-derived — planRetry's live-stream check, the button's `retryDisabled` — and state only
-  // settles after a render, so a double-click lands both handlers inside the same await window
-  // and fires TWO regenerations, billed twice.
-  //
-  // A SET KEYED BY CONVERSATION, not a boolean. The dashboard and sidebar keep one instance of
-  // this hook across a conversation switch, and concurrent sends in different conversations are
-  // supported by design — so a single flag let a retry still awaiting A's DELETEs silently
-  // swallow a Retry click in B, for as long as A's requests took to settle. What must be
-  // suppressed is a duplicate retry of the SAME conversation, which is what the key names.
-  const retryInFlightConversationsRef = useRef<Set<string>>(new Set());
-
   const handleRetry = useCallback(async () => {
-    // `conversationId` is null only before identity resolves, where handleRetryBase no-ops
-    // anyway; one shared sentinel for that case cannot collide with a real cuid.
-    const retryKey = conversationId ?? '\u0000no-conversation';
-    if (retryInFlightConversationsRef.current.has(retryKey)) return;
-    retryInFlightConversationsRef.current.add(retryKey);
-    try {
-      // planRetry is the guard: it plans nothing (no ids, no lastUserMessage) while a
-      // stream is live anywhere in the rendered list, so an in-flight run can never be
-      // deleted out from under itself. No user turn to retry from is the same no-op.
-      const { assistantIdsToDelete, lastUserMessage } = planRetry(renderedMessages);
-      if (!lastUserMessage) return;
+    // THE DUPLICATE-RETRY GUARD, and it is deliberately not local state.
+    //
+    // Every other guard is too late or too narrow. `planRetry`'s live-stream check and the
+    // button's `retryDisabled` are both state-derived, and state only settles after a render —
+    // so a double-click lands both handlers inside the same await window. A ref would close
+    // that, but only per hook INSTANCE, and the dashboard and the sidebar each mount their own
+    // for the same conversation: two Retry buttons, two refs, neither aware of the other.
+    //
+    // That is not a theoretical gap. The server's per-conversation takeover explicitly does not
+    // close it — "two near-simultaneous sends can BOTH find zero in-flight rows and BOTH
+    // proceed: two generations, two sets of tool calls, two bills" (stream-takeover.ts) — so
+    // the client is the only place it can be closed.
+    //
+    // `useEditingStore.pendingSends` is already exactly this latch: app-wide, keyed by
+    // conversation, and written by the very `wrapSend` below (synchronously, before it returns).
+    // Reusing it rather than adding a second registry means there is one answer to "is a send in
+    // flight for this conversation", and it inherits that store's release paths — including
+    // wrapSend's safety timeout, so a hung DELETE cannot wedge Retry the way a bespoke latch of
+    // our own would.
+    //
+    // A null `conversationId` needs no guard: `wrapSend` returns without calling its argument in
+    // that case, so no retry can have started and none can be duplicated.
+    if (conversationId && useEditingStore.getState().hasPendingSend(conversationId)) return;
 
-      // Delete BEFORE awaiting handleRetryBase, not after: its underlying `regenerate` is a
-      // real Promise that resolves once the new stream finishes (the ai SDK's makeRequest
-      // reads the response to completion), so awaiting it first would leave the old assistant
-      // rows visible in the cache/UI alongside the new streaming reply for the whole
-      // regeneration (PR 6 review, CodeRabbit).
-      if (conversationId) {
-        for (const id of assistantIdsToDelete) conversationMessagesActions.applyDelete(conversationId, id);
-      }
+    // planRetry is the guard: it plans nothing (no ids, no lastUserMessage) while a
+    // stream is live anywhere in the rendered list, so an in-flight run can never be
+    // deleted out from under itself. No user turn to retry from is the same no-op.
+    const { assistantIdsToDelete, lastUserMessage } = planRetry(renderedMessages);
+    if (!lastUserMessage) return;
 
-      // THE OPTIMISTIC PATH, and it starts HERE — not around `regenerate` alone. handleRetryBase
-      // has real network work to do before it can even issue the regenerate POST (it must delete
-      // the superseded assistant rows server-side first; see its own comment for why that
-      // ordering is load-bearing rather than incidental). Wrapping only the regenerate would
-      // leave that whole round trip unfeedbacked — the exact dead window this is here to close.
-      // From this call the surface's `displayIsStreaming` is true, so the composer locks and
-      // offers Stop within a frame, same as a send.
-      await wrapSend(() => handleRetryBase());
-    } finally {
-      retryInFlightConversationsRef.current.delete(retryKey);
+    // Delete BEFORE awaiting handleRetryBase, not after: its underlying `regenerate` is a
+    // real Promise that resolves once the new stream finishes (the ai SDK's makeRequest
+    // reads the response to completion), so awaiting it first would leave the old assistant
+    // rows visible in the cache/UI alongside the new streaming reply for the whole
+    // regeneration (PR 6 review, CodeRabbit).
+    if (conversationId) {
+      for (const id of assistantIdsToDelete) conversationMessagesActions.applyDelete(conversationId, id);
     }
+
+    // THE OPTIMISTIC PATH, and it starts HERE — not around `regenerate` alone. handleRetryBase
+    // has real network work to do before it can even issue the regenerate POST (it must delete
+    // the superseded assistant rows server-side first; see its own comment for why that
+    // ordering is load-bearing rather than incidental). Wrapping only the regenerate would
+    // leave that whole round trip unfeedbacked — the exact dead window this is here to close.
+    // From this call the surface's `displayIsStreaming` is true, so the composer locks and
+    // offers Stop within a frame, same as a send.
+    await wrapSend(() => handleRetryBase());
   }, [renderedMessages, handleRetryBase, conversationId, wrapSend]);
 
   return { handleEdit, handleDelete, handleRetry, stableMessages };

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -20,7 +20,7 @@
  * explicit cache write the action would render no change. A base-call failure
  * rolls back inside useMessageActions and leaves the cache untouched.
  */
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import type { UIMessage } from 'ai';
 import { useMessageActions } from './useMessageActions';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
@@ -105,6 +105,12 @@ export function useCacheMessageActions({
     [renderedMessages],
   );
 
+  // The LIVE conversation, for reads that happen after an await — where the closure's captured
+  // `conversationId` is a snapshot of the retry, not of what is on screen now. See handleRetry's
+  // release.
+  const conversationIdRef = useRef(conversationId);
+  conversationIdRef.current = conversationId;
+
   const {
     handleEdit: handleEditBase,
     handleDelete: handleDeleteBase,
@@ -188,7 +194,14 @@ export function useCacheMessageActions({
     // that registered and then declined to dispatch (a Stop landed during its DELETEs), and
     // nothing else will clear the pendingSend for it: the handoff effect is keyed on state this
     // path never moved, so the composer would show Stop until unmount.
-    if (dispatched === false) releasePendingSend();
+    //
+    // Scoped to the conversation this retry was for, like every other post-await step in this
+    // epic. `releasePendingSend` names whatever conversation it was BUILT for but guards on a
+    // ref shared across renders, so the stale copy this closure holds would happily release a
+    // send belonging to the conversation the user has since switched to. If the surface has
+    // moved on, `useSendHandoff`'s own conversation-change cleanup already released ours and
+    // there is nothing here to do.
+    if (dispatched === false && conversationIdRef.current === conversationId) releasePendingSend();
   }, [renderedMessages, handleRetryBase, conversationId, wrapSend, releasePendingSend]);
 
   return { handleEdit, handleDelete, handleRetry, stableMessages };

--- a/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useCacheMessageActions.ts
@@ -20,7 +20,7 @@
  * explicit cache write the action would render no change. A base-call failure
  * rolls back inside useMessageActions and leaves the cache untouched.
  */
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import type { UIMessage } from 'ai';
 import { useMessageActions } from './useMessageActions';
 import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
@@ -35,6 +35,23 @@ export interface UseCacheMessageActionsOptions {
   /** The full rendered list (selectRenderedMessages output, mode included). */
   renderedMessages: RenderedMessage[];
   regenerate: (options?: { body?: Record<string, unknown> }) => void;
+  /**
+   * The surface's `useSendHandoff.wrapSend` — the SAME one its send uses.
+   *
+   * RETRY IS A SEND AND NOW GOES THROUGH SEND'S OPTIMISTIC PATH. It never did: `regenerate` was
+   * called bare, so `pendingSendConversationId` stayed null, every surface's
+   * `displayIsStreaming` stayed FALSE for the whole window, and the composer sat there with an
+   * enabled textarea and a Send button while a regeneration was already under way. The one
+   * visible change was the old assistant bubble vanishing — which reads as "something broke",
+   * not "working on it". Send had complete optimistic UI the entire time; the two were never
+   * meaningfully different in server work, only in feedback.
+   *
+   * Wrapped HERE rather than at each surface's regenerate adapter: this hook is the one shared
+   * wrapper every surface already funnels retry through, so there is a single place to get it
+   * right and nothing to drift. It also covers more than `regenerate` alone would — see
+   * handleRetry.
+   */
+  wrapSend: <T>(sendFn: () => T) => T | undefined;
 }
 
 /**
@@ -69,6 +86,7 @@ export function useCacheMessageActions({
   conversationId,
   renderedMessages,
   regenerate,
+  wrapSend,
 }: UseCacheMessageActionsOptions): UseCacheMessageActionsResult {
   const stableMessages = useMemo(
     () => renderedMessages.filter((r) => r.mode !== 'streaming').map((r) => r.message),
@@ -104,23 +122,43 @@ export function useCacheMessageActions({
     conversationMessagesActions.applyDelete(conversationId, messageId);
   }, [handleDeleteBase, conversationId]);
 
-  const handleRetry = useCallback(async () => {
-    // planRetry is the guard: it plans nothing (no ids, no lastUserMessage) while a
-    // stream is live anywhere in the rendered list, so an in-flight run can never be
-    // deleted out from under itself. No user turn to retry from is the same no-op.
-    const { assistantIdsToDelete, lastUserMessage } = planRetry(renderedMessages);
-    if (!lastUserMessage) return;
+  // Latched for the whole retry, synchronously, before any await. Every other guard is
+  // state-derived — planRetry's live-stream check, the button's `retryDisabled` — and state only
+  // settles after a render, so a double-click lands both handlers inside the same await window
+  // and fires TWO regenerations, billed twice.
+  const retryInFlightRef = useRef(false);
 
-    // Delete BEFORE awaiting handleRetryBase, not after: its underlying `regenerate` is a
-    // real Promise that resolves once the new stream finishes (the ai SDK's makeRequest
-    // reads the response to completion), so awaiting it first would leave the old assistant
-    // rows visible in the cache/UI alongside the new streaming reply for the whole
-    // regeneration (PR 6 review, CodeRabbit).
-    if (conversationId) {
-      for (const id of assistantIdsToDelete) conversationMessagesActions.applyDelete(conversationId, id);
+  const handleRetry = useCallback(async () => {
+    if (retryInFlightRef.current) return;
+    retryInFlightRef.current = true;
+    try {
+      // planRetry is the guard: it plans nothing (no ids, no lastUserMessage) while a
+      // stream is live anywhere in the rendered list, so an in-flight run can never be
+      // deleted out from under itself. No user turn to retry from is the same no-op.
+      const { assistantIdsToDelete, lastUserMessage } = planRetry(renderedMessages);
+      if (!lastUserMessage) return;
+
+      // Delete BEFORE awaiting handleRetryBase, not after: its underlying `regenerate` is a
+      // real Promise that resolves once the new stream finishes (the ai SDK's makeRequest
+      // reads the response to completion), so awaiting it first would leave the old assistant
+      // rows visible in the cache/UI alongside the new streaming reply for the whole
+      // regeneration (PR 6 review, CodeRabbit).
+      if (conversationId) {
+        for (const id of assistantIdsToDelete) conversationMessagesActions.applyDelete(conversationId, id);
+      }
+
+      // THE OPTIMISTIC PATH, and it starts HERE — not around `regenerate` alone. handleRetryBase
+      // has real network work to do before it can even issue the regenerate POST (it must delete
+      // the superseded assistant rows server-side first; see its own comment for why that
+      // ordering is load-bearing rather than incidental). Wrapping only the regenerate would
+      // leave that whole round trip unfeedbacked — the exact dead window this is here to close.
+      // From this call the surface's `displayIsStreaming` is true, so the composer locks and
+      // offers Stop within a frame, same as a send.
+      await wrapSend(() => handleRetryBase());
+    } finally {
+      retryInFlightRef.current = false;
     }
-    await handleRetryBase();
-  }, [renderedMessages, handleRetryBase, conversationId]);
+  }, [renderedMessages, handleRetryBase, conversationId, wrapSend]);
 
   return { handleEdit, handleDelete, handleRetry, stableMessages };
 }

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -51,7 +51,9 @@ interface UseMessageActionsOptions {
  */
 export type RetryOutcome =
   | { dispatched: true }
-  | { dispatched: false; reason: 'no-conversation' | 'stopped' | 'delete-failed' };
+  | { dispatched: false; reason: 'no-conversation' | 'stopped' }
+  /** `undeletedIds` are the rows the server still holds — exactly what the cache must show. */
+  | { dispatched: false; reason: 'delete-failed'; undeletedIds: string[] };
 
 interface UseMessageActionsResult {
   /** Edit a message's content */
@@ -250,17 +252,26 @@ export function useMessageActions({
       // happen". This route answers 404 'Message not found' for a row that is already gone, and
       // gone is precisely the state we were asking for: a collaborator or a second tab having
       // deleted it first must not block the retry or raise an error over it.
-      const stillPresent = outcomes.filter(
-        (outcome) =>
+      //
+      // Reported per ROW, not as one flag, so the caller can put back exactly what the server
+      // still holds. A partial failure is the interesting case: some rows really are gone, and
+      // restoring those too would leave the cache claiming messages that no longer exist.
+      const undeletedIds = assistantMessagesToDelete
+        .map((msg, i) => ({ id: msg.id, outcome: outcomes[i] }))
+        .filter(({ outcome }) =>
           outcome.status === 'rejected' &&
-          !(outcome.reason instanceof ApiRequestError && outcome.reason.status === 404),
-      );
-      if (stillPresent.length > 0) {
-        for (const outcome of stillPresent) {
-          console.error('Failed to delete old assistant message:', (outcome as PromiseRejectedResult).reason);
+          !(outcome.reason instanceof ApiRequestError && outcome.reason.status === 404));
+
+      if (undeletedIds.length > 0) {
+        for (const { id, outcome } of undeletedIds) {
+          console.error('Failed to delete old assistant message:', id, (outcome as PromiseRejectedResult).reason);
         }
         toast.error('Could not clear the previous reply, so the retry was not started.');
-        return { dispatched: false, reason: 'delete-failed' };
+        return {
+          dispatched: false,
+          reason: 'delete-failed',
+          undeletedIds: undeletedIds.map(({ id }) => id),
+        };
       }
 
       // No local array to prune — `useCacheMessageActions` deletes the same rows from the

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -173,7 +173,29 @@ export function useMessageActions({
     const assistantMessagesToDelete = getAssistantMessagesAfterLastUser(currentMessages);
 
     if (assistantMessagesToDelete.length > 0) {
-      // Delete them from the database in parallel — calls are independent
+      // AWAITED, AND IT HAS TO BE — this is a hard ordering dependency, not caution.
+      //
+      // The obvious latency win here is to fire these DELETEs alongside the regenerate POST
+      // instead of before it: the local cache row is already gone (useCacheMessageActions ran
+      // applyDelete synchronously), so from the client's side the deletes look like a pure
+      // prefix, and dropping the await would take a whole round trip off the retry.
+      //
+      // It would also silently corrupt the retry. The regenerate POST does NOT regenerate from
+      // the messages the client sends: `handleChatTurn` loads the conversation from the DATABASE
+      // and says so ("We use database-loaded messages, NOT requestMessages from client",
+      // global-chat-turn.ts / page-chat-turn.ts), and nothing server-side supersedes the trailing
+      // assistant rows on a regenerate. Race the DELETEs against the POST and the model is handed
+      // its own previous answer as the newest turn — it rewrites or continues that answer instead
+      // of re-answering the user, and does it nondeterministically, depending on which request
+      // reached the DB first.
+      //
+      // The round trip is real and it is paid. What it is NOT any more is INVISIBLE: the whole
+      // retry now runs inside the surface's `wrapSend`, so the composer locks and offers Stop
+      // from the click (see useCacheMessageActions.handleRetry).
+      //
+      // The deletes are already concurrent WITH EACH OTHER — one Promise.allSettled over N
+      // independent requests, not N sequential awaits — so the cost here is one round trip, not
+      // one per superseded message.
       await Promise.allSettled(
         assistantMessagesToDelete.map((msg) => {
           const url = isAgentMode

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -212,10 +212,9 @@ export function useMessageActions({
       // requestMessages from client" (global-chat-turn.ts), "Used ONLY to extract new user
       // message, NOT for conversation history" (page-chat-turn.ts). Nothing server-side
       // supersedes the trailing assistant rows on a regenerate, either. Race the DELETEs against
-      // the POST and the model is handed
-      // its own previous answer as the newest turn — it rewrites or continues that answer instead
-      // of re-answering the user, and does it nondeterministically, depending on which request
-      // reached the DB first.
+      // the POST and the model is handed its own previous answer as the newest turn — it rewrites
+      // or continues that answer instead of re-answering the user, and does it
+      // nondeterministically, depending on which request reached the DB first.
       //
       // The round trip is real and it is paid. What it is NOT any more is INVISIBLE: the whole
       // retry now runs inside the surface's `wrapSend`, so the composer locks and offers Stop
@@ -256,21 +255,21 @@ export function useMessageActions({
       // Reported per ROW, not as one flag, so the caller can put back exactly what the server
       // still holds. A partial failure is the interesting case: some rows really are gone, and
       // restoring those too would leave the cache claiming messages that no longer exist.
-      const undeletedIds = assistantMessagesToDelete
+      const stillPresent = assistantMessagesToDelete
         .map((msg, i) => ({ id: msg.id, outcome: outcomes[i] }))
         .filter(({ outcome }) =>
           outcome.status === 'rejected' &&
           !(outcome.reason instanceof ApiRequestError && outcome.reason.status === 404));
 
-      if (undeletedIds.length > 0) {
-        for (const { id, outcome } of undeletedIds) {
+      if (stillPresent.length > 0) {
+        for (const { id, outcome } of stillPresent) {
           console.error('Failed to delete old assistant message:', id, (outcome as PromiseRejectedResult).reason);
         }
         toast.error('Could not clear the previous reply, so the retry was not started.');
         return {
           dispatched: false,
           reason: 'delete-failed',
-          undeletedIds: undeletedIds.map(({ id }) => id),
+          undeletedIds: stillPresent.map(({ id }) => id),
         };
       }
 

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -181,10 +181,12 @@ export function useMessageActions({
       // prefix, and dropping the await would take a whole round trip off the retry.
       //
       // It would also silently corrupt the retry. The regenerate POST does NOT regenerate from
-      // the messages the client sends: `handleChatTurn` loads the conversation from the DATABASE
-      // and says so ("We use database-loaded messages, NOT requestMessages from client",
-      // global-chat-turn.ts / page-chat-turn.ts), and nothing server-side supersedes the trailing
-      // assistant rows on a regenerate. Race the DELETEs against the POST and the model is handed
+      // the messages the client sends: `handleChatTurn` loads the conversation from the DATABASE,
+      // and both surfaces say so at their history load — "We use database-loaded messages, NOT
+      // requestMessages from client" (global-chat-turn.ts), "Used ONLY to extract new user
+      // message, NOT for conversation history" (page-chat-turn.ts). Nothing server-side
+      // supersedes the trailing assistant rows on a regenerate, either. Race the DELETEs against
+      // the POST and the model is handed
       // its own previous answer as the newest turn — it rewrites or continues that answer instead
       // of re-answering the user, and does it nondeterministically, depending on which request
       // reached the DB first.

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import type { UIMessage } from 'ai';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { getAssistantMessagesAfterLastUser } from '@/lib/ai/streams/getAssistantMessagesAfterLastUser';
+import { readStopEpoch } from '@/lib/ai/streams/stopRequests';
 
 const browserSessionHeaders = (): Record<string, string> => ({
   'X-Browser-Session-Id': getBrowserSessionId(),
@@ -43,8 +44,12 @@ interface UseMessageActionsResult {
   handleEdit: (messageId: string, newContent: string) => Promise<void>;
   /** Delete a message */
   handleDelete: (messageId: string) => Promise<void>;
-  /** Retry/regenerate the last response */
-  handleRetry: () => Promise<void>;
+  /**
+   * Retry/regenerate the last response. Resolves FALSE when nothing was dispatched — no
+   * conversation, or a Stop landed while the superseded rows were being deleted — so a caller
+   * holding a pendingSend can release it (see `useSendHandoff.releasePendingSend`).
+   */
+  handleRetry: () => Promise<boolean>;
   /** Get the last assistant message ID */
   lastAssistantMessageId: string | undefined;
   /** Get the last user message ID */
@@ -163,9 +168,18 @@ export function useMessageActions({
     [isAgentMode, agentId, conversationId]
   );
 
-  // Retry/regenerate the last response
-  const handleRetry = useCallback(async () => {
-    if (!conversationId) return;
+  // Retry/regenerate the last response.
+  //
+  // Reports whether it DISPATCHED, like `handleSend`: a caller holding a pendingSend has to know,
+  // because a wrapped callback that returns without dispatching moves none of the handoff
+  // effect's dependencies and would leave the composer showing Stop until unmount. See
+  // `useSendHandoff.releasePendingSend`.
+  const handleRetry = useCallback(async (): Promise<boolean> => {
+    if (!conversationId) return false;
+
+    // Snapshot BEFORE the DELETE round trip below, checked after it — see stopRequests, and the
+    // dispatch guard at the bottom of this function.
+    const stopEpochAtStart = readStopEpoch(conversationId);
 
     const currentMessages = messagesRef.current;
 
@@ -213,6 +227,17 @@ export function useMessageActions({
       // cache, which is both what renders and what `regenerate` composes its request from.
     }
 
+    // THE STOP THE SERVER COULD NOT HONOUR. Retry now runs inside `wrapSend`, so the composer
+    // has been offering Stop for the whole DELETE round trip above — but no stream row exists
+    // yet, so `markAbortRequested` matches nothing, the abort answers `not_found`, and
+    // `reportAbortOutcome` is deliberately silent about that. Dispatching here anyway would make
+    // that Stop a lie of exactly the kind this epic deleted `rawStop` over: the press appeared to
+    // do nothing and a generation started regardless.
+    //
+    // The deletes have already committed and cannot be taken back, so a stopped retry leaves the
+    // superseded answer gone and nothing regenerating — which is what the user asked for.
+    if (readStopEpoch(conversationId) !== stopEpochAtStart) return false;
+
     // Now regenerate with a clean slate. conversationId is included for both
     // modes — global mode's useChat transport is frozen at first construction
     // (see global-chat-request-body.ts), so the body is what actually
@@ -228,6 +253,7 @@ export function useMessageActions({
             conversationId,
           },
     });
+    return true;
   }, [isAgentMode, agentId, conversationId, regenerate]);
 
   // Compute last message IDs for UI

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -4,7 +4,7 @@
  */
 
 import { useCallback, useRef } from 'react';
-import { patch, del } from '@/lib/auth/auth-fetch';
+import { patch, del, ApiRequestError } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
 import type { UIMessage } from 'ai';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
@@ -39,17 +39,27 @@ interface UseMessageActionsOptions {
   onEditVersionChange?: () => void;
 }
 
+/**
+ * What a retry did, because it can now decline — and the CALLER has to act differently per
+ * reason, so a bare boolean would not carry enough.
+ *
+ * Every non-dispatch leaves a pendingSend registered that nothing else will clear (the handoff
+ * effect is keyed on state these paths never move), so all of them need releasing. Only
+ * `delete-failed` additionally leaves the CACHE lying: the superseded rows were removed from it
+ * synchronously, and if the server still holds them the next retry would plan no deletes at all
+ * and regenerate straight over them — the same corruption, one click later.
+ */
+export type RetryOutcome =
+  | { dispatched: true }
+  | { dispatched: false; reason: 'no-conversation' | 'stopped' | 'delete-failed' };
+
 interface UseMessageActionsResult {
   /** Edit a message's content */
   handleEdit: (messageId: string, newContent: string) => Promise<void>;
   /** Delete a message */
   handleDelete: (messageId: string) => Promise<void>;
-  /**
-   * Retry/regenerate the last response. Resolves FALSE when nothing was dispatched — no
-   * conversation, or a Stop landed while the superseded rows were being deleted — so a caller
-   * holding a pendingSend can release it (see `useSendHandoff.releasePendingSend`).
-   */
-  handleRetry: () => Promise<boolean>;
+  /** Retry/regenerate the last response. */
+  handleRetry: () => Promise<RetryOutcome>;
   /** Get the last assistant message ID */
   lastAssistantMessageId: string | undefined;
   /** Get the last user message ID */
@@ -174,8 +184,8 @@ export function useMessageActions({
   // because a wrapped callback that returns without dispatching moves none of the handoff
   // effect's dependencies and would leave the composer showing Stop until unmount. See
   // `useSendHandoff.releasePendingSend`.
-  const handleRetry = useCallback(async (): Promise<boolean> => {
-    if (!conversationId) return false;
+  const handleRetry = useCallback(async (): Promise<RetryOutcome> => {
+    if (!conversationId) return { dispatched: false, reason: 'no-conversation' };
 
     // Snapshot BEFORE the DELETE round trip below, checked after it — see stopRequests, and the
     // dispatch guard at the bottom of this function.
@@ -234,13 +244,23 @@ export function useMessageActions({
       // old console line: the cache row is already gone (`useCacheMessageActions` applied it
       // synchronously), so the user would see their answer vanish and nothing replace it, with
       // no idea why or that a reload will bring it back.
-      const failed = outcomes.filter((outcome) => outcome.status === 'rejected');
-      if (failed.length > 0) {
-        for (const outcome of failed) {
-          console.error('Failed to delete old assistant message:', outcome.reason);
+      //
+      // 404 IS NOT A FAILURE HERE, and conflating the two would be its own bug — the same
+      // distinction `markAbortRequested` draws between "nothing matched" and "the write did not
+      // happen". This route answers 404 'Message not found' for a row that is already gone, and
+      // gone is precisely the state we were asking for: a collaborator or a second tab having
+      // deleted it first must not block the retry or raise an error over it.
+      const stillPresent = outcomes.filter(
+        (outcome) =>
+          outcome.status === 'rejected' &&
+          !(outcome.reason instanceof ApiRequestError && outcome.reason.status === 404),
+      );
+      if (stillPresent.length > 0) {
+        for (const outcome of stillPresent) {
+          console.error('Failed to delete old assistant message:', (outcome as PromiseRejectedResult).reason);
         }
         toast.error('Could not clear the previous reply, so the retry was not started.');
-        return false;
+        return { dispatched: false, reason: 'delete-failed' };
       }
 
       // No local array to prune — `useCacheMessageActions` deletes the same rows from the
@@ -256,7 +276,9 @@ export function useMessageActions({
     //
     // The deletes have already committed and cannot be taken back, so a stopped retry leaves the
     // superseded answer gone and nothing regenerating — which is what the user asked for.
-    if (readStopEpoch(conversationId) !== stopEpochAtStart) return false;
+    if (readStopEpoch(conversationId) !== stopEpochAtStart) {
+      return { dispatched: false, reason: 'stopped' };
+    }
 
     // Now regenerate with a clean slate. conversationId is included for both
     // modes — global mode's useChat transport is frozen at first construction
@@ -273,7 +295,7 @@ export function useMessageActions({
             conversationId,
           },
     });
-    return true;
+    return { dispatched: true };
   }, [isAgentMode, agentId, conversationId, regenerate]);
 
   // Compute last message IDs for UI

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -212,16 +212,36 @@ export function useMessageActions({
       // The deletes are already concurrent WITH EACH OTHER — one Promise.allSettled over N
       // independent requests, not N sequential awaits — so the cost here is one round trip, not
       // one per superseded message.
-      await Promise.allSettled(
+      const outcomes = await Promise.allSettled(
         assistantMessagesToDelete.map((msg) => {
           const url = isAgentMode
             ? `/api/ai/page-agents/${agentId}/conversations/${conversationId}/messages/${msg.id}`
             : `/api/ai/global/${conversationId}/messages/${msg.id}`;
-          return del(url, undefined, { headers: browserSessionHeaders() }).catch((error) => {
-            console.error('Failed to delete old assistant message:', error);
-          });
+          return del(url, undefined, { headers: browserSessionHeaders() });
         })
       );
+
+      // A FAILED DELETE BREAKS THE SAME INVARIANT AS A RACED ONE (CodeRabbit).
+      //
+      // The rejections used to be swallowed into a console line, which made the ordering above
+      // load-bearing only when the network cooperated: a row that failed to delete is still in
+      // the database, the server rebuilds history FROM the database, and the model is handed its
+      // own previous answer as the newest turn — the exact corruption the await is here to
+      // prevent, arrived by a different route. Awaiting something and then ignoring what it said
+      // is not an ordering guarantee.
+      //
+      // So a failed delete refuses the dispatch, and says so. Silence would be worse than the
+      // old console line: the cache row is already gone (`useCacheMessageActions` applied it
+      // synchronously), so the user would see their answer vanish and nothing replace it, with
+      // no idea why or that a reload will bring it back.
+      const failed = outcomes.filter((outcome) => outcome.status === 'rejected');
+      if (failed.length > 0) {
+        for (const outcome of failed) {
+          console.error('Failed to delete old assistant message:', outcome.reason);
+        }
+        toast.error('Could not clear the previous reply, so the retry was not started.');
+        return false;
+      }
 
       // No local array to prune — `useCacheMessageActions` deletes the same rows from the
       // cache, which is both what renders and what `regenerate` composes its request from.

--- a/apps/web/src/lib/ai/streams/__tests__/stopRequests.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/stopRequests.test.ts
@@ -12,8 +12,11 @@ import { recordStopRequest, readStopEpoch } from '../stopRequests';
  * than assuming zero, which is exactly how a caller must use it.
  */
 describe('stopRequests', () => {
-  it('given no Stop, should read the same epoch twice', () => {
-    expect(readStopEpoch('quiet')).toBe(readStopEpoch('quiet'));
+  // Zero, specifically. A caller snapshots before the first Stop a conversation has ever seen,
+  // so an unknown conversation has to read as a usable baseline rather than as absent.
+  it('given no Stop, should read zero and not move on read', () => {
+    expect(readStopEpoch('quiet')).toBe(0);
+    expect(readStopEpoch('quiet')).toBe(0);
   });
 
   it('given a Stop, should move that conversation on', () => {

--- a/apps/web/src/lib/ai/streams/__tests__/stopRequests.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/stopRequests.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { recordStopRequest, readStopEpoch } from '../stopRequests';
+
+/**
+ * The contract the retry dispatch guard leans on, stated here rather than inferred from the
+ * hooks that use it: a snapshot taken before an await, compared after it, answers "did a Stop
+ * land in between" — for THIS conversation and no other, and without anything having to decide
+ * when a stop request expires.
+ *
+ * Deliberately no reset between cases: there is no reset to test, and its absence is the design
+ * (see the module docblock). Each case uses its own conversation ids and reads a `before` rather
+ * than assuming zero, which is exactly how a caller must use it.
+ */
+describe('stopRequests', () => {
+  it('given no Stop, should read the same epoch twice', () => {
+    expect(readStopEpoch('quiet')).toBe(readStopEpoch('quiet'));
+  });
+
+  it('given a Stop, should move that conversation on', () => {
+    const before = readStopEpoch('moved');
+
+    recordStopRequest('moved');
+
+    expect(readStopEpoch('moved')).toBe(before + 1);
+  });
+
+  it('given a Stop in one conversation, should leave another where it was', () => {
+    const before = readStopEpoch('untouched');
+
+    recordStopRequest('elsewhere');
+
+    expect(readStopEpoch('untouched')).toBe(before);
+  });
+
+  // Monotonic, not a flag: two presses inside one await window must not look like one, or a
+  // caller that snapshotted between them would think nothing had happened.
+  it('given repeated Stops, should keep moving rather than latch', () => {
+    const before = readStopEpoch('repeated');
+
+    recordStopRequest('repeated');
+    recordStopRequest('repeated');
+    recordStopRequest('repeated');
+
+    expect(readStopEpoch('repeated')).toBe(before + 3);
+  });
+});

--- a/apps/web/src/lib/ai/streams/stopRequests.ts
+++ b/apps/web/src/lib/ai/streams/stopRequests.ts
@@ -20,8 +20,12 @@
  * Keyed by conversation for the same reason everything else in this path is: concurrent sends in
  * different conversations are supported by design, and a Stop in A must not cancel a retry in B.
  *
- * Module state rather than a store: nothing renders off this, so a subscription would only add
- * re-renders. It is read at dispatch time, like `useEditingStore.getState()` next to it.
+ * Module state rather than a store — the one stateful thing in this directory, and deliberately
+ * so. Nothing renders off it, so a store subscription would buy nothing but re-renders; it is
+ * read at dispatch time, exactly like the `useEditingStore.getState()` call next to it. Nothing
+ * is ever removed because nothing can be: an entry is one integer, gained only when the user
+ * actually presses Stop in a conversation, in a map that dies with the page. Any eviction rule
+ * would be a second thing that has to be right for Stop to stay honest.
  */
 const stopEpochs = new Map<string, number>();
 

--- a/apps/web/src/lib/ai/streams/stopRequests.ts
+++ b/apps/web/src/lib/ai/streams/stopRequests.ts
@@ -1,0 +1,37 @@
+/**
+ * A per-conversation count of Stop presses — the one signal that makes Stop honest during the
+ * window where the SERVER has nothing to stop.
+ *
+ * `markAbortRequested` can only mark rows that already exist with `status = 'streaming'`. It has
+ * no way to record an abort for a generation that has not started, so a Stop pressed before the
+ * POST is out matches zero rows, answers `not_found`, and `reportAbortOutcome` is deliberately
+ * silent about that. For a send that window is server-side TTFB only. For a RETRY it is bigger
+ * and it is ours: `useMessageActions.handleRetry` awaits a full DELETE round trip before it
+ * issues the regenerate, and the composer has been showing Stop for all of it (the retry now
+ * runs inside `wrapSend`). Press Stop there and the old behaviour was the worst one available —
+ * the abort found nothing, said nothing, and the client then started the generation anyway.
+ *
+ * So the client records the press and the retry checks for it before dispatching. A COUNTER
+ * rather than a flag, compared against a snapshot taken before the await, because that is
+ * race-free without any clearing: nothing has to decide when a stop request has "expired", and a
+ * Stop pressed BEFORE a retry (the ordinary case — stop a stream, then retry it) moves the
+ * counter before the snapshot is taken and therefore cannot cancel it.
+ *
+ * Keyed by conversation for the same reason everything else in this path is: concurrent sends in
+ * different conversations are supported by design, and a Stop in A must not cancel a retry in B.
+ *
+ * Module state rather than a store: nothing renders off this, so a subscription would only add
+ * re-renders. It is read at dispatch time, like `useEditingStore.getState()` next to it.
+ */
+const stopEpochs = new Map<string, number>();
+
+/** Record that Stop was pressed for this conversation. Call synchronously, at the click. */
+export const recordStopRequest = (conversationId: string): void => {
+  stopEpochs.set(conversationId, (stopEpochs.get(conversationId) ?? 0) + 1);
+};
+
+/**
+ * The conversation's Stop count. Snapshot it before an await; if it has moved by the time the
+ * await resolves, a Stop landed in between and whatever the await was leading up to must not run.
+ */
+export const readStopEpoch = (conversationId: string): number => stopEpochs.get(conversationId) ?? 0;


### PR DESCRIPTION
## Why

> "stop and retry also seem to take a really long time before showing any UI change is happening."

They're right, and it isn't backend latency. Neither action is slow — both spend their whole window painting nothing, which reads as a hang.

## Stop

Deleting the local `rawStop()` was right: cancelling a read stops nothing server-side, and a button that flips back to Send over a generation still calling write tools and still billing is a lie. But it left the click with **nothing at all** to show for itself.

`reportAbortOutcome` is silent on every outcome but `'unconfirmed'`, so the abort POST's resolved value paints zero pixels. What actually clears the bubble and flips the composer is the `chat:stream_complete` **socket** event. So the screen sat unchanged for a full round trip — up to `ABORT_SETTLE_TIMEOUT_MS` (4s) of *deliberate* server-side settle on a cross-instance owner — plus socket delivery.

`useStopStream` now returns `{ handleStop, isStopping }`. The flag is raised **synchronously before the await**, so the button changes within a frame: spinner, "Stopping…", still the destructive Stop button.

It keeps the exact distinction `rawStop` got wrong — **stopping, never stopped**. The reply keeps streaming underneath, the store entry stands, and `chat:stream_complete` remains the sole authority for teardown. It clears on three paths only:

- **the socket landing**, read as the stop target disappearing — no second socket subscription, just the one place a live stream is recorded
- an error reaching the abort endpoint
- a bounded backstop (`2 × ABORT_SETTLE_TIMEOUT_MS`), so a socket that never arrives can't wedge the button

Free consequence: `'not_found'` is deliberately silent, so Stop pressed a beat after the reply ended produced *no* feedback. The stopping state resolving is the acknowledgement that silence can't give.

## Retry

Retry never went through the optimistic path at all — `regenerate` was called bare. So `pendingSendConversationId` stayed null, `displayIsStreaming` stayed **false** for the whole window, and the composer kept an enabled textarea and a Send button while a regeneration was already running. The one visible change was the old assistant bubble vanishing, which reads as "something broke", not "working on it".

Retry now runs inside the **same `wrapSend` a send uses**. Wrapped in `useCacheMessageActions` rather than at each surface's regenerate adapter — that hook is the one shared path every surface funnels retry through, so there's a single place to get it right and nothing to drift, and it covers the server deletes as well as the POST (wrapping only `regenerate` would leave that round trip unfeedbacked, which is the bigger half of the dead window).

Double-click: the guard is `useEditingStore.pendingSends`, which `wrapSend` writes synchronously before it invokes the send — so the whole path from click to registration stays inside one tick and a second click cannot slip between them. (It started as a `retryInFlightRef`; review rounds 1 and 2 walked it from a boolean to a conversation-keyed `Set` to the app-wide store, because the dashboard and the sidebar each mount their own instance of this hook for the same conversation. See rounds 1–2 below.) Plus a new `retryDisabled` prop on the button — separate from `disabled` so edit and delete stay usable.

## The deletes stay awaited — deliberately

The brief asked for these to fire in parallel with the regenerate POST. **That would silently corrupt the retry**, so I kept the await and documented why at the site:

`handleChatTurn` rebuilds history from the **database**, not from the client's messages (`"We use database-loaded messages, NOT requestMessages from client"`), and nothing server-side supersedes the trailing assistant rows on a regenerate. Race the DELETEs against the POST and the model is handed its own previous answer as the newest turn — nondeterministically, depending on which request hit the DB first.

Also worth noting: the deletes are already concurrent *with each other* — one `Promise.allSettled` over N independent requests, not N sequential awaits. The cost is one round trip, and it's no longer invisible.

## Verification

Re-run after every review round; the numbers below are from the current tip.

- `bun run typecheck` from the repo root — **17/17 tasks green**, including `web#build`
- `bun run --filter web lint` — clean
- `bun run --filter web test -- src/hooks src/lib/ai src/components` — **6391 passed**, 22 skipped. One failure: `activity-tools.test.ts`, which needs `DATABASE_URL` and fails on any branch.
- **Every mechanism in this PR is mutation-checked**, each confirmed red then restored — the original six (flag set after the await; clear-effect removed; backstop removed; error-path clear removed; `regenerate` called bare again; double-click guard dropped) and everything added since: the shared latch and its conversation keying, the stop-request recording and its absence when there is no target, the stop-epoch bail and its snapshot semantics, the pendingSend release and its `=== false` versus falsy distinction, the release's conversation scoping, the failed-delete gate, its 404 exemption, and the per-row cache restore.
- Rebased onto current master; no conflicts.

### Not verified

The perceptual test needs a browser. Verified in code: the flag is set before any await, the button re-renders off it, the streaming bubble is untouched. **Not** verified: actual paint timing, that the spinner reads as "stopping" rather than "stopped" to a real user, and that the composer lock on retry feels like the send lock. Worth one manual pass.

## Review round 1 — Codex (all three addressed in `0c36574ad`)

All three were real, and two shared a root cause I had missed: **`useStopStream` and `useCacheMessageActions` outlive the conversation they are looking at.** On the dashboard and sidebar these hooks are never remounted on a conversation switch, so any state keyed to "is *something* happening" leaks across conversations.

**P1 — stopping state leaked to the next conversation.** `hasStopTarget` was a boolean, so Stop A → switch to B (streaming) left it true, the clear effect never fired, and B rendered a disabled "Stopping…" button for a Stop nobody asked for until the 8s backstop expired. Now the state stores *which conversation* was stopped and `isStopping` is derived from that identity matching the on-screen target — the switch drops it a frame earlier than an effect could.

Keyed by conversation rather than `messageId` (deviating slightly from the suggestion): a Stop in the TTFB window names a conversation and only later acquires a `messageId`, so a message-keyed latch would see its target "change" mid-abort and drop the affordance the instant the stream entry appeared.

**P2 — unconfirmed aborts held the button hostage.** The helpers `return NETWORK_FAILURE` rather than throwing, so the catch path was unreachable exactly when release matters most: the user has just been told the generation may still be running and billing, and the only control that could stop it was disabled for 8s. The affordance is now held only on a confirmed `aborted`; `unconfirmed` and `not_found` release it. That also sharpens the `not_found` acknowledgement — appear-then-settle instead of hanging over a generation the server says already finished.

**P2 — retry latch blocked other conversations.** One boolean meant a retry awaiting A's DELETEs silently swallowed a Retry click in B — something this architecture explicitly supports ("Both shells can have sends in flight at once"). Now a `Set` keyed by `conversationId`: same-conversation duplicates still suppressed synchronously, cross-conversation retries unblocked.

Three tests added, one rewritten, each mutation-checked. Also fixed a latent harness bug the cross-conversation test exposed: the `useMessageActions` mock built a fresh `vi.fn` per render, silently resetting its own call count across a re-render.

Re-validated after the fixes: `bun run typecheck` 17/17 green; **6354** tests passing (same one pre-existing `DATABASE_URL` failure).

## Review round 2 — CodeRabbit (addressed in `7187325e8`)

**Major — the retry latch was still per-instance.** Round 1 keyed it by conversation, which fixed the cross-conversation block, but it was still a `useRef` — and `GlobalAssistantView` and `SidebarChatTab` each mount their own `useCacheMessageActions` for the same conversation. Two Retry buttons, two refs, neither aware of the other. The server does not cover the gap; `stream-takeover.ts` says so itself: "two near-simultaneous sends can BOTH find zero in-flight rows and BOTH proceed: two generations, two sets of tool calls, two bills".

The latch is now `useEditingStore.pendingSends` rather than new shared state, because that store already **is** this latch — app-wide, keyed by conversation, and written by the very `wrapSend` this handler calls (synchronously, before it returns, so the click→guard→register path stays inside one tick and a double-click cannot slip between them). Reusing it means one answer to "is a send in flight for this conversation", and it inherits that store's release paths — including `wrapSend`'s 15s safety timeout, so a hung DELETE cannot wedge Retry the way the ref could. It also correctly blocks a retry issued while an ordinary *send* is in flight, which the ref did not.

The suite's `wrapSend` stub was a bare passthrough; since the latch now *is* the pendingSend registration, that silently disabled the guard under test, so the stub is now faithful to `useSendHandoff.wrapSend`.

Test added — `given two hook instances on the same conversation, should run only one retry`. Mutation-checked both mechanisms: dropping the guard turns the two-instance **and** double-click cases red; widening it to any pending send turns the cross-conversation case red.

Re-validated: `bun run typecheck` 17/17 green including `web#build`; `bun run --filter web lint` clean; **6356** web tests passing (same one pre-existing `DATABASE_URL` failure).

**Nitpicks — two applied, one declined.** `waitFor` replaces the fixed microtask drains at the `not_found` and `unconfirmed` cases (not at the cross-conversation case, which is a *stays true* claim `waitFor` would pass on the first tick without proving; the site now says so). The stopping Stop button moved from `disabled` to `aria-disabled` with a guarded click: `disabled` removes the button from the focus path, so a keyboard user who pressed Stop never heard the relabel — it was swallowing the exact feedback the state exists to give. Declined the kebab-case test-file rename: every component test in both touched `__tests__` directories is `ComponentName.aspect.test.tsx`, so renaming one makes it the only inconsistent name there.

Also folded `releaseUnlessAbortConfirmed` — a `useCallback` whose whole body was one conditional, called once, immediately after the await it guards — back into that call site.

## Review round 3 — adversarial self-review (`4c64c27b7`)

A pass over the diff looking for what a reviewer would find next turned up a bug this PR had itself introduced.

**A Stop pressed during a retry did nothing, and the generation started anyway.** Retry now runs inside `wrapSend`, so the composer offers Stop for the whole DELETE round trip that precedes the regenerate POST. No stream row exists in that window, and `markAbortRequested` can only mark rows that are already `'streaming'` — so the abort matched nothing, answered `not_found` (which the UI is deliberately silent about), and the client then dispatched the regeneration regardless. The press appeared to do nothing and cost a generation: exactly the lie this epic deleted `rawStop` over, reintroduced by the affordance meant to fix it.

`handleRetry` now snapshots a per-conversation Stop counter before the deletes and refuses to dispatch if it moved. A counter compared against a snapshot rather than a flag, because that needs no clearing and has no race — a Stop pressed *before* a retry (stop a stream, then retry it: the ordinary path) moves the counter before the snapshot is taken and cannot cancel it. Keyed by conversation, so a Stop in A leaves a retry in B alone.

That makes `handleRetry` a call that can decline, so it reports whether it dispatched — the contract `handleSend` already has — and `useCacheMessageActions` releases the pendingSend when it did not. Without that the composer would render only Stop until unmount, which is the wedge `useSendHandoff.releasePendingSend` exists for.

Nine tests, every mechanism mutation-checked: the bail, the snapshot semantics, the conversation keying, the recording (present, and absent when there is no target), the release, and `=== false` versus falsy.

Also rebased onto current master (`e342d5a66`), and corrected one comment that quoted a line as if it appeared in two files when only one has it verbatim.

Re-validated: `bun run typecheck` 17/17 green including `web#build`; `bun run --filter web lint` clean; **6391** web tests passing (same one pre-existing `DATABASE_URL` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1dAhJVqeeASBm5KJQw7zX


## Review round 4 — CodeRabbit

**A failed DELETE still let the regeneration dispatch.** Flagged as outside-diff and pre-existing, with an offer to file it as a follow-up; fixed here instead, because round 3 had just given `handleRetry` the ability to decline, so the failure path is `return` plus the release that already exists. The point is sharp: the rejections were swallowed into a `console.error`, which made the awaited ordering load-bearing only when the network cooperated. A row that fails to delete is still in the database, the server rebuilds history *from* the database, and the model is handed its own previous answer — the corruption the await exists to prevent, reached by another route. It reports rather than staying silent: the cache row is already gone by then, so without a word the user watches their answer vanish with no idea why.

**A tautological assertion** in round 3's own new test (`readStopEpoch('quiet')` compared to itself) — it now pins the zero default a caller's first snapshot depends on.

**Declined:** renaming `mockState` to `MOCK_STATE`. It is a `vi.hoisted` registry whose contents are reassigned every test (`const` binds the reference, not the value), and every `vi.hoisted` binding in `apps/web` is camelCase without exception — `middleware.test.ts`, `form-target-service.test.ts`, `useToastPreferences.test.ts`, `ConnectedAppsList.test.tsx`, `DriveMembers.test.tsx`. Reviewer accepted; thread resolved.

## Review round 5 — adversarial self-review

**The declined-retry release could clobber another conversation's send.** Same failure family as round 1's P1 and P2, one level out. `releasePendingSend` closes over the conversation it was built for but guards on a `hasPendingSendRef` shared across renders, so the stale copy an in-flight retry closure holds releases whatever send is registered *now*. Switch conversations and send while a stopped retry is still settling, and that send's pendingSend is cleared out from under it — composer unlocked, Stop gone, generation still running. Now compared against a ref of the live conversation, matching the pattern `useStopStream` already uses.

## Review round 6 — adversarial self-review

Two holes in round 4's gate, both found by asking what a *second* click does.

**404 was being treated as a failure.** The route answers `Message not found` for a row that is already gone — which is precisely the state the delete was asking for. A collaborator or a second tab getting there first would have blocked the retry and raised an error over a no-op. Same distinction `markAbortRequested` already draws between "nothing matched" and "the write did not happen".

**The cache stayed lying.** The cache delete is written synchronously so the superseded answer vanishes at the click; on a genuine failure that is a claim the server disagrees with — and the *next* retry plans its deletes from that same cache, so it finds nothing to delete, dispatches, and hands the model its own previous answer. The same corruption, one click later. The rows now go back, and only the rows the server still holds: `handleRetry` reports a named outcome carrying the ids whose DELETE failed, so a partial failure does not resurrect rows that really are gone.

That is what made the return value a small union rather than a boolean — every non-dispatch needs the pendingSend released, but only a delete failure also needs the cache restored, and the caller cannot tell those apart from `false`.

## Review round 7 — rebase onto #2419, and CodeRabbit

**Rebased onto the merged sibling.** CI had gone green, but while it ran master gained 17 commits including **#2419** (`fix(streams): a second machine can no longer delete a live reply`) — which rewrites `stream-abort-mark.ts` and `stream-takeover.ts`, the two files this PR's client-side reasoning depends on, plus a migration and an `ai-streams` schema change. Green checks on a base that no longer exists are not evidence, so I re-verified the premises before rebasing:

- `markAbortRequested` still guards on `status = 'streaming'` with no pre-registration of abort intent — so the pre-POST window still has nothing the server can abort, and the stop-epoch is still the only mechanism covering it rather than dead weight.
- The `stream-takeover.ts` line quoted in `useCacheMessageActions` still exists.
- `stream-abort-decisions.ts` and `stream-liveness.ts` are **unchanged** by the merge, so the outcome codes `useStopStream` keys on (`aborted` / `not_found` / `unconfirmed`) are exactly as before — which matters, because the release rule is literally `code !== 'aborted'`.

Rebased clean, re-ran everything against the real base, and CI is green on the rebased tip.

**Typed the retry mock from the real signature** (CodeRabbit). `handleRetryBase` was `ReturnType<typeof vi.fn>`, so `mockResolvedValueOnce` accepted any shape and a change to `RetryOutcome` left the stubs describing a contract that no longer existed, silently. Not hypothetical — that drift already happened in this PR when `handleRetry` gained a named outcome, and only running the suite caught it. Verified the fix: renaming a `RetryOutcome` member now fails typecheck **in the test file**, at three call sites.

## A note for the reviewer

Rounds 3, 5 and 6 were self-review, and each one found a real defect in the previous round's fix — uncancellable generation, then a clobbered send, then a corrupt second retry, then an over-restored cache. They shrink each time and they are all in the same area: the error and cancellation paths around retry, which the happy path never touches. Every one is now covered by a mutation-checked test, but the pattern is worth knowing before reading the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stop now provides immediate “Stopping” feedback and prevents repeated presses while processing.
  - Retry actions lock the composer, offer Stop, and prevent duplicate regenerations.
  - Retry controls remain available for separate conversations when appropriate.

- **Bug Fixes**
  - Improved handling of stop confirmations, timeouts, stream completion, and interrupted responses.

- **Tests**
  - Added coverage for stopping states, retry locking, duplicate prevention, and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




