### PR TITLE
fix(streams): a join on the wrong machine stops claiming the stream does not exist

### DIFF
--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -31,6 +31,23 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
 
+/**
+ * The session row `stream-join-context` falls back to on a registry miss.
+ *
+ * Defaults to "no row", so every pre-existing case keeps exercising exactly the path it did:
+ * the registry answers, or nothing does. The cross-instance cases opt in.
+ */
+const mockSessionRow = vi.fn<() => Promise<unknown[]>>();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => mockSessionRow() }),
+      }),
+    }),
+  },
+}));
+
 import { GET } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
@@ -109,6 +126,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     // Default: the caller owns the stream (canSubscribeToStream short-circuits on that).
     mockCanSubscribeToStream.mockResolvedValue(true);
     vi.mocked(canUserViewPage).mockResolvedValue(true);
+    mockSessionRow.mockResolvedValue([]);
   });
 
   describe('authentication', () => {
@@ -140,7 +158,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
   describe('stream lookup', () => {
     it('given an unknown messageId, should return 404', async () => {
-      // Registry has no entry for mockMessageId
+      // No registry entry AND no session row — the only honest 404.
       const response = await GET(makeRequest(), makeContext(mockMessageId));
 
       expect(response.status).toBe(404);
@@ -154,6 +172,91 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       const response = await GET(makeRequest(), makeContext(mockMessageId));
 
       expect(response.status).toBe(404);
+    });
+  });
+
+  /**
+   * THE ORDERING THIS LEAF EXISTS TO FIX.
+   *
+   * The registry lookup used to sit AHEAD of the authz block — structurally, because the authz
+   * inputs (pageId, conversationId, the stream's owner) lived in the same in-memory entry as
+   * the frames. At N>1 a registry miss is the ORDINARY case, so an entire class of live streams
+   * 404'd before anyone asked who the caller was. These pin that a DB-sourced context runs the
+   * SAME authz block, verbatim, over the SAME `StreamMeta` shape.
+   */
+  describe('cross-instance authorization (registry miss, session row present)', () => {
+    const remoteRow = (over: Record<string, unknown> = {}) => [{
+      channelId: mockPageId,
+      userId: 'user-other',
+      displayName: 'Someone Else',
+      conversationId: mockConversationId,
+      browserSessionId: 'session-other',
+      status: 'streaming',
+      ...over,
+    }];
+
+    it('runs canUserViewPage against the pageId the ROW carries, not an in-memory entry', async () => {
+      mockSessionRow.mockResolvedValue(remoteRow());
+
+      await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(canUserViewPage).toHaveBeenCalledWith(mockUserId, mockPageId);
+    });
+
+    it('runs canSubscribeToStream with the row\'s OWNER, so a co-member\'s private conversation is still private', async () => {
+      mockSessionRow.mockResolvedValue(remoteRow());
+
+      await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(mockCanSubscribeToStream).toHaveBeenCalledWith({
+        userId: mockUserId,
+        streamOwnerId: 'user-other',
+        conversationId: mockConversationId,
+      });
+    });
+
+    it('given no page access to a remote stream, 403s — the same audited denial a local one gets', async () => {
+      mockSessionRow.mockResolvedValue(remoteRow());
+      vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(403);
+    });
+
+    it('given page access but no conversation access, 404s without an audit denial', async () => {
+      // Deliberately NOT an audited 403: a member asking for a co-member's private stream is
+      // the ordinary consequence of a page-wide broadcast, and auditing it would write a row
+      // per member per assistant message.
+      mockSessionRow.mockResolvedValue(remoteRow());
+      mockCanSubscribeToStream.mockResolvedValue(false);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(404);
+      expect(auditRequest).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ eventType: 'authz.access.denied' }),
+      );
+    });
+
+    it('given a global-assistant channel owned by someone else, 403s on the synthetic channel id', async () => {
+      // `parseGlobalChannelId` short-circuits page access for `user:<id>:global` channels, and
+      // it now runs over a channelId that came from the DB. A row belonging to another user's
+      // global assistant must not be joinable.
+      mockSessionRow.mockResolvedValue(remoteRow({ channelId: 'user:user-other:global' }));
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(403);
+    });
+
+    it('given a locally-owned channel, never reads the session row at all', async () => {
+      testRegistry.open(mockMessageId, mockMeta);
+
+      await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(mockSessionRow).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
-import { streamChannelRegistry } from '@/lib/ai/core/stream-channel-registry';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { canSubscribeToStream } from '@/lib/ai/core/stream-subscription-authz';
+import { resolveStreamJoinContext } from '@/lib/ai/core/stream-join-context';
 
 export const dynamic = 'force-dynamic';
 
@@ -46,10 +46,20 @@ export async function GET(
 
   const { messageId } = await context.params;
 
-  const meta = streamChannelRegistry.getMeta(messageId);
-  if (!meta) {
+  // WHAT THIS INSTANCE CAN SAY ABOUT THE STREAM — the registry if it owns it, otherwise the
+  // one thing every instance shares, its `ai_stream_sessions` row.
+  //
+  // The registry lookup used to be right here, ahead of the authz block, and it had to be: the
+  // authz inputs lived in the same in-memory entry as the frames. At N>1 that made an ordinary
+  // cross-instance join indistinguishable from a nonexistent one — both 404. The context module
+  // maps the row to EXACTLY the `StreamMeta` shape the registry produces, so everything below
+  // this line is unchanged and there is no second authorization path to keep in step with the
+  // first. See stream-join-context.ts.
+  const joinContext = await resolveStreamJoinContext(messageId);
+  if (joinContext.kind === 'missing') {
     return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
   }
+  const meta = joinContext.meta;
 
   const channelOwner = parseGlobalChannelId(meta.pageId);
   // Page access, then conversation access. A page channel carries every conversation on
@@ -120,10 +130,17 @@ export async function GET(
   // arithmetic, where the server replayed its whole buffer and the client was told how many
   // frames to discard — under-skipping duplicated visible text, over-skipping left a silent
   // permanent gap, and neither was detectable from either side.
-  const channel = streamChannelRegistry.get(messageId);
-  if (!channel) {
+  //
+  // A `remote` or `terminal` context has no channel to read from YET — serving one is the next
+  // leaf (the durable log's follower). Until then this is the same 404 the route already gave
+  // for a registry miss, reached AFTER authorization rather than instead of it. The client's
+  // poll fallback (`stream-join-poll-fallback.ts`) handles a 404 exactly as it does today, so
+  // cross-instance delivery is unchanged by this leaf — what changes is that the answer is now
+  // classified, and that a caller who may not subscribe is refused for the right reason.
+  if (joinContext.kind !== 'local') {
     return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
   }
+  const channel = joinContext.channel;
 
   const requestedFromSeq = Number(new URL(request.url).searchParams.get('fromSeq') ?? '0');
   const fromSeq = Number.isFinite(requestedFromSeq) && requestedFromSeq >= 0

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-context.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-context.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, beforeEach, vi } from 'vitest';
+import { assert } from './riteway';
+
+const { mockSessionRow, mockLoggerWarn } = vi.hoisted(() => ({
+  mockSessionRow: vi.fn<() => Promise<unknown[]>>(),
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => mockSessionRow() }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+}));
+
+vi.mock('@pagespace/db/schema/ai-streams', () => ({
+  aiStreamSessions: {
+    messageId: 'ai_stream_sessions.message_id',
+    channelId: 'ai_stream_sessions.channel_id',
+    userId: 'ai_stream_sessions.user_id',
+    displayName: 'ai_stream_sessions.display_name',
+    conversationId: 'ai_stream_sessions.conversation_id',
+    browserSessionId: 'ai_stream_sessions.browser_session_id',
+    status: 'ai_stream_sessions.status',
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { info: vi.fn(), warn: mockLoggerWarn, error: vi.fn(), debug: vi.fn() } },
+}));
+
+import { resolveStreamJoinContext } from '../stream-join-context';
+import { streamChannelRegistry, type StreamMeta } from '../stream-channel-registry';
+
+const META: StreamMeta = {
+  pageId: 'page-abc',
+  userId: 'user-a',
+  displayName: 'Alice',
+  conversationId: 'conv-1',
+  browserSessionId: 'session-1',
+};
+
+const row = (over: Record<string, unknown> = {}) => ({
+  channelId: 'page-abc',
+  userId: 'user-a',
+  displayName: 'Alice',
+  conversationId: 'conv-1',
+  browserSessionId: 'session-1',
+  status: 'streaming',
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  streamChannelRegistry.reset();
+  mockSessionRow.mockResolvedValue([]);
+});
+
+describe('resolveStreamJoinContext', () => {
+  it('given a channel this process owns, answers local with the live channel', async () => {
+    const channel = streamChannelRegistry.open('msg-local', META);
+
+    const context = await resolveStreamJoinContext('msg-local');
+
+    assert({
+      given: 'a generation running on this instance',
+      should: 'answer local, carrying the registry\'s own channel object',
+      actual: { kind: context.kind, sameChannel: context.kind === 'local' && context.channel === channel },
+      expected: { kind: 'local', sameChannel: true },
+    });
+  });
+
+  it('given a locally-owned channel, never reads the DB', async () => {
+    streamChannelRegistry.open('msg-local', META);
+
+    await resolveStreamJoinContext('msg-local');
+
+    assert({
+      given: 'a registry hit',
+      should: 'skip the session-row read — the live object is authoritative and a round trip buys nothing',
+      actual: mockSessionRow.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  it('given a registry miss and a streaming row, answers remote — not missing', async () => {
+    mockSessionRow.mockResolvedValue([row()]);
+
+    const context = await resolveStreamJoinContext('msg-elsewhere');
+
+    // THE BUG THIS LEAF FIXES. At N>1 the channel registry is a process-local Map, so a join
+    // that load-balances anywhere but the generating instance found nothing — and the route
+    // 404'd, saying "no such stream" about a stream that was very much running.
+    assert({
+      given: 'a live generation owned by another web instance',
+      should: 'answer remote',
+      actual: context.kind,
+      expected: 'remote',
+    });
+  });
+
+  it('maps the row to EXACTLY the StreamMeta shape the registry produces', async () => {
+    mockSessionRow.mockResolvedValue([row()]);
+
+    const context = await resolveStreamJoinContext('msg-elsewhere');
+
+    // This is the whole trick: because the shape is identical, the route's authz block runs
+    // VERBATIM over DB-sourced meta. A drift here would silently mean a second, weaker
+    // authorization path for cross-instance joins.
+    assert({
+      given: 'a session row',
+      should: 'produce meta with pageId ← channelId and every other field one-for-one',
+      actual: context.kind === 'remote' ? context.meta : null,
+      expected: META,
+    });
+  });
+
+  it('given a completed row, answers terminal rather than missing', async () => {
+    mockSessionRow.mockResolvedValue([row({ status: 'complete' })]);
+
+    const context = await resolveStreamJoinContext('msg-done');
+
+    assert({
+      given: 'a generation that finished',
+      should: 'say so, so a client can reload the durable message instead of reading "never existed"',
+      actual: context.kind === 'terminal' ? { kind: context.kind, aborted: context.aborted } : { kind: context.kind },
+      expected: { kind: 'terminal', aborted: false },
+    });
+  });
+
+  it('given an aborted row, answers terminal with aborted set', async () => {
+    mockSessionRow.mockResolvedValue([row({ status: 'aborted' })]);
+
+    const context = await resolveStreamJoinContext('msg-stopped');
+
+    assert({
+      given: 'a generation that was stopped',
+      should: 'carry aborted, the same distinction a local end already makes',
+      actual: context.kind === 'terminal' ? context.aborted : null,
+      expected: true,
+    });
+  });
+
+  it('given neither a channel nor a row, answers missing', async () => {
+    assert({
+      given: 'a messageId nothing knows about',
+      should: 'answer missing — the only honest 404',
+      actual: (await resolveStreamJoinContext('msg-nowhere')).kind,
+      expected: 'missing',
+    });
+  });
+
+  it('given a read that fails, degrades to missing rather than guessing', async () => {
+    mockSessionRow.mockRejectedValue(new Error('db down'));
+
+    const context = await resolveStreamJoinContext('msg-unreadable');
+
+    // The same degradation the route had before this module existed (a registry miss 404'd
+    // unconditionally), so a DB blip costs a joiner a retry rather than a wrong answer about
+    // who may see what.
+    assert({
+      given: 'a session-row read that threw',
+      should: 'answer missing and warn',
+      actual: { kind: context.kind, warned: mockLoggerWarn.mock.calls.length > 0 },
+      expected: { kind: 'missing', warned: true },
+    });
+  });
+
+  it('does not treat a half-torn-down registry entry as local', async () => {
+    // `getMeta` and `get` are set and cleared together, so requiring BOTH is defence in depth —
+    // but serving `local` with no channel would hand the route a context it cannot subscribe to.
+    streamChannelRegistry.open('msg-racing', META);
+    vi.spyOn(streamChannelRegistry, 'get').mockReturnValue(undefined);
+    mockSessionRow.mockResolvedValue([row()]);
+
+    const context = await resolveStreamJoinContext('msg-racing');
+
+    assert({
+      given: 'meta present but the channel already gone',
+      should: 'fall through to the row rather than claim a local channel',
+      actual: context.kind,
+      expected: 'remote',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/core/stream-join-context.ts
+++ b/apps/web/src/lib/ai/core/stream-join-context.ts
@@ -1,0 +1,125 @@
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { streamChannelRegistry, type StreamMeta } from '@/lib/ai/core/stream-channel-registry';
+import type { StreamChannel } from '@/lib/ai/core/stream-channel';
+
+/**
+ * What a joiner is actually looking at, once the in-process registry has been asked.
+ *
+ * ── THE PROBLEM THIS SOLVES IS AN AUTHORIZATION-ORDERING ONE ────────────────────────────────
+ *
+ * `stream-join`'s first gate was `streamChannelRegistry.getMeta(messageId)`, and it sat BEFORE
+ * the authz block. Not by oversight — structurally. The authz inputs (pageId, conversationId,
+ * the stream's owner) lived in the same in-memory entry as the frames, so there was nothing to
+ * authorize against until the registry answered. A registry miss therefore had to 404, and at
+ * N>1 a registry miss is the ORDINARY case: the channel is a process-local Map, so a join that
+ * load-balances anywhere but the generating instance finds nothing, whatever the stream's real
+ * state is. The route's 404 said "no such stream" about streams that were very much running.
+ *
+ * `ai_stream_sessions` already holds every one of those authz inputs — `stream-lifecycle.ts`
+ * writes the row and the registry entry from the SAME values in the same function — so on a
+ * miss they can simply be read. This module does that, and maps the row to EXACTLY the
+ * `StreamMeta` shape the registry produces (`pageId ← channelId`, everything else one-for-one).
+ *
+ * THAT IS THE WHOLE TRICK, and it is worth stating because the tempting alternative is much
+ * worse: because the meta shape is identical, the route's authz block is UNCHANGED.
+ * `parseGlobalChannelId` → `canUserViewPage` → `canSubscribeToStream`, and the 5s revocation
+ * recheck, all run verbatim over DB-sourced meta. There is no second authorization path to keep
+ * in sync with the first — which is how a cross-instance feature quietly acquires a weaker
+ * permission model than the local one it mirrors.
+ *
+ * `filterSubscribableStreams` is deliberately not used here: it is the BATCHED form, for the
+ * `active-streams` listing. The single-row primitive is `canSubscribeToStream`, which the route
+ * already calls.
+ */
+
+export type StreamJoinContext =
+  /** The generation is running HERE. Frames come from memory, as they always have. */
+  | { kind: 'local'; meta: StreamMeta; channel: StreamChannel }
+  /**
+   * The row says `streaming`, but not on this instance. A real, live generation this process
+   * cannot see — which until now was indistinguishable from "does not exist".
+   */
+  | { kind: 'remote'; meta: StreamMeta }
+  /**
+   * The generation is over. Distinct from `missing` because the CLIENT must be able to tell
+   * "it finished, reload the durable message" from "there is nothing here" — the same
+   * distinction `aborted` carries on a local end.
+   */
+  | { kind: 'terminal'; meta: StreamMeta; aborted: boolean }
+  /** No channel, no row. The only honest 404. */
+  | { kind: 'missing' };
+
+/**
+ * Resolve what this instance can say about a messageId.
+ *
+ * The registry is asked FIRST and its answer is authoritative — a locally-owned channel is the
+ * live object, and going to the DB for a row it already holds would be a round trip for nothing.
+ * Only a miss pays for the read, and only one row.
+ *
+ * A failed read answers `missing`. That is the same degradation the route had before this
+ * module existed (a registry miss 404'd unconditionally), so a DB blip costs a joiner a retry
+ * rather than a wrong answer about who may see what.
+ */
+export const resolveStreamJoinContext = async (messageId: string): Promise<StreamJoinContext> => {
+  const localMeta = streamChannelRegistry.getMeta(messageId);
+  const localChannel = streamChannelRegistry.get(messageId);
+  // Both, or neither — the registry sets and clears them together. Requiring both rather than
+  // trusting one is what keeps a half-torn-down entry from being served as `local` with no
+  // channel to subscribe to.
+  if (localMeta && localChannel) return { kind: 'local', meta: localMeta, channel: localChannel };
+
+  let row: {
+    channelId: string;
+    userId: string;
+    displayName: string;
+    conversationId: string;
+    browserSessionId: string;
+    status: 'streaming' | 'complete' | 'aborted';
+  } | undefined;
+
+  try {
+    [row] = await db
+      .select({
+        // `pageId` in the registry's vocabulary — a real pageId for page-chat, or a synthetic
+        // `user:<id>:global` id. `stream-lifecycle.ts` writes both columns from the same value.
+        channelId: aiStreamSessions.channelId,
+        userId: aiStreamSessions.userId,
+        displayName: aiStreamSessions.displayName,
+        conversationId: aiStreamSessions.conversationId,
+        browserSessionId: aiStreamSessions.browserSessionId,
+        status: aiStreamSessions.status,
+      })
+      .from(aiStreamSessions)
+      .where(eq(aiStreamSessions.messageId, messageId))
+      .limit(1);
+  } catch (error) {
+    loggers.ai.warn('stream-join-context: could not read the session row', {
+      messageId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return { kind: 'missing' };
+  }
+
+  if (!row) return { kind: 'missing' };
+
+  const meta: StreamMeta = {
+    pageId: row.channelId,
+    userId: row.userId,
+    displayName: row.displayName,
+    conversationId: row.conversationId,
+    browserSessionId: row.browserSessionId,
+  };
+
+  // `status` is NOT liveness — a crashed generation leaves a row claiming 'streaming' forever
+  // (see stream-liveness.ts). That is fine here and deliberately not re-litigated: a `remote`
+  // context only promises "the row has not been settled", and whatever follows it discovers the
+  // truth from the frame log and the row's own terminal write. Applying a heartbeat predicate
+  // here would make a joiner's answer disagree with `/active-streams`, which is already the
+  // authoritative liveness surface.
+  if (row.status === 'streaming') return { kind: 'remote', meta };
+
+  return { kind: 'terminal', meta, aborted: row.status === 'aborted' };
+};


### PR DESCRIPTION
## Stack

This is one of three stacked PRs, to be reviewed and merged bottom-up:

| | PR | What | Base |
|---|---|---|---|
| 1 | #2419 | Reap by atomic claim — stops a second machine deleting a live reply | `master` |
| 2 | #2420 | The join authorizes from the DB when the registry misses | `pu/reap-claim` |
| 3 | #2421 | Follow another instance's frames from the durable log | `pu/stream-join-context` |

Each PR is a strict improvement on its own, but the *user-visible* cross-instance join only works once all three land. Workstream A of "make AI streaming safe at more than one machine" — the goal is raising `pagespace-web` from `min_machines_running = 1` to 2.

---

`stream-join`'s first gate was `streamChannelRegistry.getMeta`, and it sat AHEAD
of the authz block. Not by oversight — structurally: the authz inputs (pageId,
conversationId, the stream's owner) lived in the same in-memory entry as the
frames, so there was nothing to authorize against until the registry answered.
At N>1 a registry miss is the ORDINARY case, because the channel registry is a
process-local Map. Every join that load-balanced anywhere but the generating
instance 404'd, saying "no such stream" about streams that were very much
running.

`ai_stream_sessions` already holds every one of those inputs — `stream-lifecycle`
writes the row and the registry entry from the same values in the same function
— so on a miss they are simply read.

New `stream-join-context.ts` answers `local | remote | terminal | missing`,
mapping the row to EXACTLY the `StreamMeta` shape the registry produces
(`pageId ← channelId`, everything else one-for-one).

THAT IS THE WHOLE TRICK: because the shape is identical, the route's authz block
is UNCHANGED. `parseGlobalChannelId` → `canUserViewPage` → `canSubscribeToStream`,
and the 5s revocation recheck, all run verbatim over DB-sourced meta. There is no
second authorization path to keep in step with the first — which is how a
cross-instance feature quietly acquires a weaker permission model than the local
one it mirrors. `filterSubscribableStreams` stays where it is: it is the batched
form, for the `active-streams` listing.

A registry hit never pays for the read. A failed read answers `missing`, the same
degradation the route already had.

`remote` and `terminal` still 404 in this leaf — there is no channel to read
from until the durable log's follower lands next — so cross-instance delivery is
unchanged and the client's poll fallback handles it exactly as today. What
changes here is that the answer is classified, and that a caller who may not
subscribe is refused for the right reason rather than by accident of topology.

Five seeded mutations verified red, including collapsing `remote` back into
`missing`, sourcing the owner from the wrong column, and failing open on an
unreadable row.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SQwbEoZweBEBgsGq9wnqXj

Stacked on #2419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQwbEoZweBEBgsGq9wnqXj
