### PR TITLE
fix(canvas): the preview's form-action fix reached only half the policy

### DIFF
--- a/apps/web/src/app/api/canvas/[pageId]/preview/__tests__/route.test.ts
+++ b/apps/web/src/app/api/canvas/[pageId]/preview/__tests__/route.test.ts
@@ -41,6 +41,10 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 const request = () => new Request('http://localhost/api/canvas/page-1/preview');
 const context = (pageId = 'page-1') => ({ params: Promise.resolve({ pageId }) });
 
+/** A CSP as its list of whole directives, so two policies compare exactly. */
+const directivesOf = (policy: string) =>
+  policy.split(';').map((directive) => directive.trim()).filter(Boolean);
+
 const canvasPage = (over: Record<string, unknown> = {}) => ({
   id: 'page-1',
   title: 'Welcome',
@@ -228,8 +232,12 @@ describe('GET /api/canvas/[pageId]/preview', () => {
       expect(meta).not.toBe('');
       // The header adds embedding/sandbox directives a <meta> cannot carry; every
       // directive the meta DOES declare must appear in the header unchanged.
-      for (const directive of meta.split(';').map((d) => d.trim()).filter(Boolean)) {
-        expect(header).toContain(directive);
+      // Compared whole, not as a substring: `connect-src https://app.pagespace.ai`
+      // is a substring of `connect-src https://app.pagespace.ai.evil`, so a
+      // substring check would call a widened header identical.
+      const headerDirectives = directivesOf(header);
+      for (const directive of directivesOf(meta)) {
+        expect(headerDirectives).toContain(directive);
       }
     } finally {
       if (previous === undefined) delete process.env.WEB_APP_URL;

--- a/apps/web/src/app/api/canvas/[pageId]/preview/__tests__/route.test.ts
+++ b/apps/web/src/app/api/canvas/[pageId]/preview/__tests__/route.test.ts
@@ -41,9 +41,20 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 const request = () => new Request('http://localhost/api/canvas/page-1/preview');
 const context = (pageId = 'page-1') => ({ params: Promise.resolve({ pageId }) });
 
-/** A CSP as its list of whole directives, so two policies compare exactly. */
+/**
+ * A CSP as its list of whole directives, so two policies compare exactly rather
+ * than by substring. Depends on the `<meta>` content being emitted unescaped
+ * (`render-document.ts`), which is why no entity decoding happens here.
+ */
 const directivesOf = (policy: string) =>
   policy.split(';').map((directive) => directive.trim()).filter(Boolean);
+
+/**
+ * The only two directives the response header may carry that the document's
+ * `<meta>` does not: a `<meta>` cannot meaningfully deliver either. Everything
+ * else must match on both sides — see the invariant test below.
+ */
+const HEADER_ONLY_DIRECTIVE = /^(frame-ancestors|sandbox)\b/;
 
 const canvasPage = (over: Record<string, unknown> = {}) => ({
   id: 'page-1',
@@ -219,6 +230,10 @@ describe('GET /api/canvas/[pageId]/preview', () => {
    * the same inputs. Browsers intersect them, so any directive one grants and the
    * other withholds is silently withheld. This pins every base directive rather
    * than one parameter, so a third input added later cannot diverge unnoticed.
+   *
+   * The origin only bites in the siteMode=false case — site mode permits any
+   * https origin and takes no origin argument. The siteMode=true case is here to
+   * catch the flag itself failing to reach one of the two calls.
    */
   it.each([false, true])('given siteMode=%s, should deliver the same base policy in meta and header', async (siteMode) => {
     const previous = process.env.WEB_APP_URL;
@@ -230,15 +245,17 @@ describe('GET /api/canvas/[pageId]/preview', () => {
       const meta = /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/.exec(await res.text())?.[1] ?? '';
 
       expect(meta).not.toBe('');
-      // The header adds embedding/sandbox directives a <meta> cannot carry; every
-      // directive the meta DOES declare must appear in the header unchanged.
-      // Compared whole, not as a substring: `connect-src https://app.pagespace.ai`
-      // is a substring of `connect-src https://app.pagespace.ai.evil`, so a
-      // substring check would call a widened header identical.
-      const headerDirectives = directivesOf(header);
-      for (const directive of directivesOf(meta)) {
-        expect(headerDirectives).toContain(directive);
-      }
+      // Equality, not containment. Compared whole rather than by substring,
+      // because `connect-src https://app.pagespace.ai` is a substring of
+      // `connect-src https://app.pagespace.ai.evil` — a substring check would
+      // call a widened header identical. And compared in BOTH directions, minus
+      // the closed list of directives a <meta> cannot carry: under intersection
+      // a directive the header grants and the meta never mentions is just as
+      // dead as one the meta contradicts, so "the meta's are a subset" would
+      // wave through exactly the divergence this test exists to catch.
+      expect(directivesOf(header).filter((d) => !HEADER_ONLY_DIRECTIVE.test(d))).toEqual(
+        directivesOf(meta),
+      );
     } finally {
       if (previous === undefined) delete process.env.WEB_APP_URL;
       else process.env.WEB_APP_URL = previous;
@@ -246,8 +263,20 @@ describe('GET /api/canvas/[pageId]/preview', () => {
   });
 
   it('given a non-siteMode page, should serve the baseline policy', async () => {
-    const csp = (await GET(request(), context())).headers.get('Content-Security-Policy') ?? '';
+    // Cleared, not assumed absent: an ambient app origin in the developer's own
+    // environment scopes `connect-src` to it, and this assertion would then fail
+    // locally while passing in CI, where neither var is set.
+    const prevWeb = process.env.WEB_APP_URL;
+    const prevPublic = process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.WEB_APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    try {
+      const csp = (await GET(request(), context())).headers.get('Content-Security-Policy') ?? '';
 
-    expect(csp).not.toMatch(/connect-src[^;]*\bhttps:/);
+      expect(csp).not.toMatch(/connect-src[^;]*\bhttps:/);
+    } finally {
+      if (prevWeb !== undefined) process.env.WEB_APP_URL = prevWeb;
+      if (prevPublic !== undefined) process.env.NEXT_PUBLIC_APP_URL = prevPublic;
+    }
   });
 });

--- a/apps/web/src/app/api/canvas/[pageId]/preview/__tests__/route.test.ts
+++ b/apps/web/src/app/api/canvas/[pageId]/preview/__tests__/route.test.ts
@@ -190,6 +190,53 @@ describe('GET /api/canvas/[pageId]/preview', () => {
     }
   });
 
+  /**
+   * The rendered document carries its own <meta> CSP, and browsers enforce the
+   * INTERSECTION of every policy delivered. A header that permits form-action
+   * while the meta still says 'none' is therefore inert — the fix has to reach
+   * both, or it only looks applied.
+   */
+  it('given an app origin, should scope the meta policy too, not just the header', async () => {
+    const previous = process.env.WEB_APP_URL;
+    process.env.WEB_APP_URL = 'https://app.pagespace.ai';
+    try {
+      const body = await (await GET(request(), context())).text();
+      expect(body).toContain("form-action 'self' https://app.pagespace.ai");
+      expect(body).not.toContain("form-action 'none'");
+    } finally {
+      if (previous === undefined) delete process.env.WEB_APP_URL;
+      else process.env.WEB_APP_URL = previous;
+    }
+  });
+
+  /**
+   * General invariant behind the two specific cases above: the document's <meta>
+   * policy and the response header are built by separate calls that must be fed
+   * the same inputs. Browsers intersect them, so any directive one grants and the
+   * other withholds is silently withheld. This pins every base directive rather
+   * than one parameter, so a third input added later cannot diverge unnoticed.
+   */
+  it.each([false, true])('given siteMode=%s, should deliver the same base policy in meta and header', async (siteMode) => {
+    const previous = process.env.WEB_APP_URL;
+    process.env.WEB_APP_URL = 'https://app.pagespace.ai';
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(canvasPage({ siteMode }) as never);
+    try {
+      const res = await GET(request(), context());
+      const header = res.headers.get('Content-Security-Policy') ?? '';
+      const meta = /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/.exec(await res.text())?.[1] ?? '';
+
+      expect(meta).not.toBe('');
+      // The header adds embedding/sandbox directives a <meta> cannot carry; every
+      // directive the meta DOES declare must appear in the header unchanged.
+      for (const directive of meta.split(';').map((d) => d.trim()).filter(Boolean)) {
+        expect(header).toContain(directive);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.WEB_APP_URL;
+      else process.env.WEB_APP_URL = previous;
+    }
+  });
+
   it('given a non-siteMode page, should serve the baseline policy', async () => {
     const csp = (await GET(request(), context())).headers.get('Content-Security-Policy') ?? '';
 

--- a/apps/web/src/app/api/canvas/[pageId]/preview/route.ts
+++ b/apps/web/src/app/api/canvas/[pageId]/preview/route.ts
@@ -158,6 +158,13 @@ export async function GET(
     // of every policy delivered, so a header that permits `form-action` while
     // the meta still says `'none'` is inert. Ignored under siteMode, which
     // permits any https origin without needing one.
+    //
+    // Passing the already-built policy as `cspOverride` would make the two
+    // identical by construction, but an override is a whole-contract switch:
+    // it also turns OFF site mode's CSS handling, rewriting the external
+    // `url()`/`@import` values a site-mode page is allowed to keep. Same
+    // inputs, two calls — held together by the meta/header invariant test in
+    // this route's suite.
     formActionOrigin,
   });
 

--- a/apps/web/src/app/api/canvas/[pageId]/preview/route.ts
+++ b/apps/web/src/app/api/canvas/[pageId]/preview/route.ts
@@ -9,7 +9,7 @@ import { isFilePage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
 import { buildPreviewResponseHeaders } from '@pagespace/lib/canvas/preview-headers';
-import { buildSiteCsp, buildBaselineCsp } from '@pagespace/lib/canvas/csp';
+import { buildCanvasCsp } from '@pagespace/lib/canvas/csp';
 import {
   extractDashboardFileViewRefs,
   rewriteDashboardFileViewLinks,
@@ -121,10 +121,13 @@ export async function GET(
   // and then works once published. Resolved exactly as `publishCanvasPage` does.
   // Site mode needs no origin — `buildSiteCsp` already permits `form-action`
   // and `connect-src` to any https host.
+  //
+  // `buildCanvasCsp` is the SAME call `renderCanvasDocument` makes for the
+  // document's own <meta> policy below, not a copy of it: browsers enforce the
+  // intersection of every policy delivered, so a header and a meta chosen by two
+  // hand-copied ternaries withhold whatever the copies disagree about.
   const formActionOrigin = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
-  const headers = buildPreviewResponseHeaders(
-    page.siteMode ? buildSiteCsp() : buildBaselineCsp(formActionOrigin),
-  );
+  const headers = buildPreviewResponseHeaders(buildCanvasCsp(page.siteMode, formActionOrigin));
 
   // FAIL CLOSED. This route runs under middleware `skipCSP`, so the app does not
   // supply a policy of its own — an absent policy here would mean an unpoliced
@@ -153,18 +156,18 @@ export async function GET(
     // not want.
     escapeBridge: true,
     siteMode: page.siteMode,
-    // Must match the origin baked into the response header above. The rendered
-    // document carries its OWN <meta> CSP and browsers enforce the intersection
-    // of every policy delivered, so a header that permits `form-action` while
-    // the meta still says `'none'` is inert. Ignored under siteMode, which
-    // permits any https origin without needing one.
+    // Must match the origin baked into the response header above, for the same
+    // intersection reason: a header that permits `form-action` while the meta
+    // still says `'none'` is inert. Ignored under siteMode, which permits any
+    // https origin without needing one.
     //
-    // Passing the already-built policy as `cspOverride` would make the two
-    // identical by construction, but an override is a whole-contract switch:
-    // it also turns OFF site mode's CSS handling, rewriting the external
-    // `url()`/`@import` values a site-mode page is allowed to keep. Same
-    // inputs, two calls — held together by the meta/header invariant test in
-    // this route's suite.
+    // The inputs are threaded rather than the finished policy handed over as
+    // `cspOverride`, which would make the two identical by construction: an
+    // override is a whole-contract switch, and for a SITE-MODE page it also
+    // turns off the CSS handling site mode grants, rewriting the external
+    // `url()`/`@import` values such a page is allowed to keep. This route serves
+    // both kinds of page from one call, so it cannot take that trade. What holds
+    // the inputs together is the meta/header invariant test in this route's suite.
     formActionOrigin,
   });
 

--- a/apps/web/src/app/api/canvas/[pageId]/preview/route.ts
+++ b/apps/web/src/app/api/canvas/[pageId]/preview/route.ts
@@ -153,6 +153,12 @@ export async function GET(
     // not want.
     escapeBridge: true,
     siteMode: page.siteMode,
+    // Must match the origin baked into the response header above. The rendered
+    // document carries its OWN <meta> CSP and browsers enforce the intersection
+    // of every policy delivered, so a header that permits `form-action` while
+    // the meta still says `'none'` is inert. Ignored under siteMode, which
+    // permits any https origin without needing one.
+    formActionOrigin,
   });
 
   return new NextResponse(html, { status: 200, headers });

--- a/packages/lib/src/canvas/__tests__/csp.test.ts
+++ b/packages/lib/src/canvas/__tests__/csp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildBaselineCsp, buildDocumentCsp, buildSiteCsp } from '../csp';
+import { buildBaselineCsp, buildCanvasCsp, buildDocumentCsp, buildSiteCsp } from '../csp';
 
 describe('buildBaselineCsp', () => {
   it('defaults to form-action \'none\' when no origin is given', () => {
@@ -85,5 +85,28 @@ describe('buildDocumentCsp', () => {
     expect(csp).toContain('font-src https://fonts.gstatic.com');
     expect(csp).toContain("object-src 'none'");
     expect(csp).toContain("base-uri 'none'");
+  });
+});
+
+describe('buildCanvasCsp', () => {
+  it('serves the site policy for a site-mode page', () => {
+    expect(buildCanvasCsp(true)).toBe(buildSiteCsp());
+  });
+
+  it('serves the baseline policy scoped to the origin otherwise', () => {
+    expect(buildCanvasCsp(false, 'https://app.pagespace.ai')).toBe(
+      buildBaselineCsp('https://app.pagespace.ai'),
+    );
+  });
+
+  it('treats a null or undefined flag as not site mode, never as a widened policy', () => {
+    // `pages.siteMode` is nullable, and a null read must not fall through to the
+    // permissive site policy.
+    expect(buildCanvasCsp(null)).toBe(buildBaselineCsp());
+    expect(buildCanvasCsp(undefined)).toBe(buildBaselineCsp());
+  });
+
+  it('ignores the origin under site mode, which needs none', () => {
+    expect(buildCanvasCsp(true, 'https://app.pagespace.ai')).toBe(buildCanvasCsp(true));
   });
 });

--- a/packages/lib/src/canvas/__tests__/csp.test.ts
+++ b/packages/lib/src/canvas/__tests__/csp.test.ts
@@ -99,10 +99,10 @@ describe('buildCanvasCsp', () => {
     );
   });
 
-  it('treats a null or undefined flag as not site mode, never as a widened policy', () => {
-    // `pages.siteMode` is nullable, and a null read must not fall through to the
-    // permissive site policy.
-    expect(buildCanvasCsp(null)).toBe(buildBaselineCsp());
+  it('treats an absent flag as not site mode, never as a widened policy', () => {
+    // `renderCanvasDocument` takes `siteMode` as optional, so a caller that omits
+    // it must land on the restrictive policy, not the permissive one.
+    expect(buildCanvasCsp()).toBe(buildBaselineCsp());
     expect(buildCanvasCsp(undefined)).toBe(buildBaselineCsp());
   });
 

--- a/packages/lib/src/canvas/csp.ts
+++ b/packages/lib/src/canvas/csp.ts
@@ -82,3 +82,17 @@ export function buildSiteCsp(): string {
 export function buildDocumentCsp(): string {
   return `${ASSET_CSP_PREFIX} script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'`;
 }
+
+/**
+ * The policy a canvas page's own document carries, chosen by the page's site-mode
+ * flag — the one place that choice is made.
+ *
+ * Exported because the preview route has to build its RESPONSE HEADER from the
+ * same choice `renderCanvasDocument` makes for the document's `<meta>`. Browsers
+ * enforce the INTERSECTION of every policy delivered, so two hand-copied
+ * ternaries silently withhold whatever the copies disagree about, with no error
+ * anywhere. One expression, two callers.
+ */
+export function buildCanvasCsp(siteMode: boolean | null | undefined, formActionOrigin?: string): string {
+  return siteMode ? buildSiteCsp() : buildBaselineCsp(formActionOrigin);
+}

--- a/packages/lib/src/canvas/csp.ts
+++ b/packages/lib/src/canvas/csp.ts
@@ -92,7 +92,11 @@ export function buildDocumentCsp(): string {
  * enforce the INTERSECTION of every policy delivered, so two hand-copied
  * ternaries silently withhold whatever the copies disagree about, with no error
  * anywhere. One expression, two callers.
+ *
+ * The flag is optional because `renderCanvasDocument` takes it that way — an
+ * absent flag is not site mode, so it can never fall through to the permissive
+ * policy.
  */
-export function buildCanvasCsp(siteMode: boolean | null | undefined, formActionOrigin?: string): string {
+export function buildCanvasCsp(siteMode?: boolean, formActionOrigin?: string): string {
   return siteMode ? buildSiteCsp() : buildBaselineCsp(formActionOrigin);
 }

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -1,5 +1,5 @@
 import { sanitizeCSS } from './sanitize-css';
-import { buildBaselineCsp, buildSiteCsp } from './csp';
+import { buildCanvasCsp } from './csp';
 import { escapeHtml } from '../utils/html';
 
 /**
@@ -468,7 +468,7 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
   // reach arbitrary hosts, the exact tracking/exfiltration channel the
   // document pipeline's sanitizer exists to close.
   const siteModeApplies = Boolean(siteMode) && !cspOverride;
-  const csp = cspOverride ?? (siteMode ? buildSiteCsp() : buildBaselineCsp(formActionOrigin));
+  const csp = cspOverride ?? buildCanvasCsp(siteMode, formActionOrigin);
 
   const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts, nonce, siteModeApplies);
   const rawTitle = title && title.trim() ? title : 'Untitled';


### PR DESCRIPTION
Follow-up to #2417 — fixing a bug in one of that PR's own fixes, found while auditing the merged route.

## What was wrong

#2417 scoped the preview's `form-action`/`connect-src` to the app origin so a canvas `<form>` would behave while being written the way it does once published. It passed the origin to the **response header** only.

The rendered document also carries its own `<meta>` CSP, built by a separate call inside `renderCanvasDocument` that never received the origin. So the meta still said `form-action 'none'` — and browsers enforce the **intersection** of every policy delivered. The header permitted what the meta withheld, so the effective policy was unchanged: forms stayed blocked, while the response header advertised a policy suggesting they worked.

Worth noting the irony: the review thread on #2417 argued that passing the origin *without* also granting `allow-forms` would be an inert fix. It was inert for a second reason nobody spotted, mine included.

## The fix

Thread the same `formActionOrigin` into `renderCanvasDocument`, so the meta and the header are built from identical inputs.

Not collapsed into a single call by handing the finished policy in as `cspOverride`, which would make them identical by construction: an override is a whole-contract switch, and for a **site-mode** page it also turns off the CSS handling site mode grants — rewriting the external `url()`/`@import` values such a page is allowed to keep (#2417's `siteModeApplies`). This route serves both kinds of page from one call, so it cannot take that trade.

What it *can* retire is the duplicated choice of policy. The same `siteMode ? buildSiteCsp() : buildBaselineCsp(origin)` ternary was written out twice — in the route and inside `renderCanvasDocument` — and that duplicated ternary is the divergence surface. It is now one exported `buildCanvasCsp` that both call. The inputs still have to reach both calls; that part is what the test below guards.

## The guard that matters more

Fixing the one parameter leaves the shape of the bug intact — two policies built by separate calls fed the same inputs, where any divergence is silently absorbed by the intersection rather than raising an error.

So this also adds a parameterized invariant test: **the `<meta>` policy and the response header must declare the same directives**, checked for both site mode and baseline mode, so a third input added later cannot diverge unnoticed.

Two things that assertion has to get right, both caught by re-reviewing it rather than by the first draft:

- **Whole directives, not substrings** ([review](https://github.com/2witstudios/PageSpace/pull/2422#discussion_r3790527467)). `connect-src https://app.pagespace.ai` is a prefix of `connect-src https://app.pagespace.ai.evil`, so a substring check reads a widened header as identical to the meta.
- **Both directions.** The first version asserted only that the meta's directives were a subset of the header's, justified by the header carrying `frame-ancestors`/`sandbox` — directives a `<meta>` cannot deliver. But that excuses *any* header-only directive, and under intersection a directive the header grants and the meta never mentions is exactly as dead as one the meta contradicts. The exemption is now a closed list of those two, and everything else must match on both sides.

## Is this bug anywhere else?

Audited every path that serves a `renderCanvasDocument` document alongside a response CSP. It isn't:

- **Published artifacts** (canvas / DOCUMENT / CODE / SHEET) are served by Caddy, which sets `Content-Security-Policy "frame-ancestors 'none'"` and nothing more. That directive cannot appear in a `<meta>`, so the two policies share no directive to disagree about and the meta stays authoritative for every fetch directive. Correct by construction.
- The preview route is the only place a header and a meta were ever built over the same directive space, and middleware adds no third policy there (`skipCSP`).
- The auth handoff bridge, the processor's file-serving route, and `getCSPHeaderForFile` are header-only, with no meta CSP in play.

## Testing

- `bun run typecheck` 17/17, `bun run lint` 15/15, `bun run knip:check` within baseline
- Preview route suite 16/16; canvas surface across web + lib green (346 + 287)
- New `buildCanvasCsp` covered directly, including an omitted `siteMode` landing on the restrictive policy rather than the permissive one
- Mutation-checked three ways: dropping the argument fails the specific case and the invariant; widening only the header's origin fails it, where the substring form passed; adding a header-only `media-src` fails it, where the subset form passed
- Also clears the app-origin env vars in the baseline-policy test, which assumed rather than ensured their absence and failed on a developer machine that has them set
- Rebased onto current `master` (disjoint file sets — the intervening commits are all agent-session work), so CI ran against the real merge result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHqAFKp14UeZ5FZarN5oKP
