### PR TITLE
chore(agents): the review notes #2413 merged without

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/conversation-create-fail-closed.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/conversation-create-fail-closed.test.ts
@@ -29,8 +29,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn(() => false),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/__tests__/conversation-page-binding.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/conversation-page-binding.test.ts
@@ -51,8 +51,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn(() => false),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -19,8 +19,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn(() => false),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -22,8 +22,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -21,8 +21,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn(() => false),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({

--- a/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
@@ -27,8 +27,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn(() => false),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -72,8 +72,19 @@ vi.mock('@/lib/auth', () => ({
   isScopedMCPAuth: vi.fn(() => false),
   // Same boolean as isScopedMCPAuth for these fixtures; the real helper reads
   // through getAllowedDriveIds so it also covers dispatched service auth.
-  isDriveScopedPrincipal: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
-  isServiceAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'service'),
+  //
+  // Typed from the REAL exports, so a signature change here fails typecheck
+  // rather than leaving a silently stale stub. The bodies reimplement rather
+  // than delegate to the sibling `getAllowedDriveIds` mock: that mock is a
+  // fixed `() => []` in these fixtures, so delegating would make every
+  // credential read as unscoped and the scope assertions vacuous.
+  isDriveScopedPrincipal: vi.fn<typeof import('@/lib/auth').isDriveScopedPrincipal>(
+    (auth) => (('allowedDriveIds' in auth ? auth.allowedDriveIds : []) ?? []).length > 0,
+  ),
+  isServiceAuthResult: vi.fn<typeof import('@/lib/auth').isServiceAuthResult>(
+    (result): result is import('@/lib/auth').ServiceAuthResult =>
+      !('error' in result) && 'tokenType' in result && result.tokenType === 'service',
+  ),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -90,12 +90,13 @@ vi.mock('../shell-io', () => ({
   createShellIo: vi.fn(),
   realtimeShellIoTransport: {},
 }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn() }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { ai: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
 }));
 
 import { resolveCallerSessionForWorker, buildSessionToolsDeps } from '../session-tools-runtime';
-import { loggers } from '@pagespace/lib/logging/logger-config';
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 const sessionRow = { id: 'ses-1', ownerId: 'user-1', endedAt: null };
 const globalConversation = { id: 'conv-g', type: 'global', userId: 'user-1', isActive: true, contextId: null };
@@ -481,12 +482,16 @@ describe('killWorker — kill_session never tears the sandbox down', () => {
       actingUserId: 'drive-admin',
     });
 
-    expect(loggers.ai.warn).toHaveBeenCalledWith(
-      expect.stringContaining('stopped by someone other than its owner'),
+    // Through the AUDIT pipeline, not the ordinary logger: this is the record
+    // a dispute or incident review queries, so it has to reach the
+    // tamper-evident log rather than only the console.
+    expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
-        conversationId: 'conv-worker',
-        workerOwnerId: 'worker-owner',
-        actingUserId: 'drive-admin',
+        eventType: 'admin.session.terminated',
+        userId: 'drive-admin',
+        resourceType: 'agent_worker',
+        resourceId: 'conv-worker',
+        details: expect.objectContaining({ workerOwnerId: 'worker-owner' }),
       }),
     );
   });
@@ -501,7 +506,7 @@ describe('killWorker — kill_session never tears the sandbox down', () => {
       actingUserId: 'user-1',
     });
 
-    expect(loggers.ai.warn).not.toHaveBeenCalled();
+    expect(audit).not.toHaveBeenCalled();
   });
 
   test('a failed stream abort still reports success — the conversation and transcript survive regardless, and there is no sandbox to have failed on', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -95,6 +95,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 }));
 
 import { resolveCallerSessionForWorker, buildSessionToolsDeps } from '../session-tools-runtime';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const sessionRow = { id: 'ses-1', ownerId: 'user-1', endedAt: null };
 const globalConversation = { id: 'conv-g', type: 'global', userId: 'user-1', isActive: true, contextId: null };
@@ -465,6 +466,42 @@ describe('killWorker — kill_session never tears the sandbox down', () => {
       conversationId: 'conv-worker',
       userId: 'worker-owner',
     });
+  });
+
+  test('a cross-member kill leaves an audit record naming BOTH parties — the abort row alone cannot say who did it', async () => {
+    // The abort is recorded under the WORKER'S OWNER (the test above), and the
+    // owner sees only a stream that stopped. This is the one place both
+    // identities are in hand, so it is the only place the record can be made.
+    mockAbortConversationStreams.mockResolvedValue(undefined);
+
+    const deps = buildSessionToolsDeps();
+    await deps.killWorker({
+      conversationId: 'conv-worker',
+      streamOwnerId: 'worker-owner',
+      actingUserId: 'drive-admin',
+    });
+
+    expect(loggers.ai.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stopped by someone other than its owner'),
+      expect.objectContaining({
+        conversationId: 'conv-worker',
+        workerOwnerId: 'worker-owner',
+        actingUserId: 'drive-admin',
+      }),
+    );
+  });
+
+  test('an owner stopping their OWN worker records nothing — every kill would otherwise warn, and a log that always fires says nothing', async () => {
+    mockAbortConversationStreams.mockResolvedValue(undefined);
+
+    const deps = buildSessionToolsDeps();
+    await deps.killWorker({
+      conversationId: 'conv-worker',
+      streamOwnerId: 'user-1',
+      actingUserId: 'user-1',
+    });
+
+    expect(loggers.ai.warn).not.toHaveBeenCalled();
   });
 
   test('a failed stream abort still reports success — the conversation and transcript survive regardless, and there is no sandbox to have failed on', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools-runtime.test.ts
@@ -487,7 +487,7 @@ describe('killWorker — kill_session never tears the sandbox down', () => {
     // tamper-evident log rather than only the console.
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventType: 'admin.session.terminated',
+        eventType: 'admin.session.terminate.success',
         userId: 'drive-admin',
         resourceType: 'agent_worker',
         resourceId: 'conv-worker',
@@ -507,6 +507,30 @@ describe('killWorker — kill_session never tears the sandbox down', () => {
     });
 
     expect(audit).not.toHaveBeenCalled();
+  });
+
+  test('a cross-member kill whose abort REJECTS records the failure, not a termination — the tamper-evident log may not claim a stop that did not land', async () => {
+    // `killWorker` returns ok: true either way (the transcript survives
+    // regardless), so nothing downstream can tell these apart. If the record
+    // were written before the abort, the one log built to be trustworthy would
+    // be the one asserting a worker stopped while it kept running.
+    mockAbortConversationStreams.mockRejectedValue(new Error('realtime unreachable'));
+
+    const deps = buildSessionToolsDeps();
+    await deps.killWorker({
+      conversationId: 'conv-worker',
+      streamOwnerId: 'worker-owner',
+      actingUserId: 'drive-admin',
+    });
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'admin.session.terminate.failure',
+        userId: 'drive-admin',
+        resourceId: 'conv-worker',
+        details: expect.objectContaining({ workerOwnerId: 'worker-owner' }),
+      }),
+    );
   });
 
   test('a failed stream abort still reports success — the conversation and transcript survive regardless, and there is no sandbox to have failed on', async () => {

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -65,6 +65,22 @@ async function getConfiguredModel(userId: string, agentConfig: { aiProvider?: st
 }
 
 /**
+ * The session family, built ONCE and reused.
+ *
+ * Every other entry in `availableTools` is a module-level constant; this one is
+ * a factory call, so without the cache each mention-triggered turn rebuilt the
+ * whole family just to look one name up. The tools hold no per-request state —
+ * they read the caller off `experimental_context` at execute time — so a single
+ * instance is the same instance a fresh call would have produced. Lazy rather
+ * than module-level to keep the import cycle this construction exists to avoid.
+ */
+let sessionToolsCache: ReturnType<typeof buildSessionTools> | null = null;
+function getSessionTools(): ReturnType<typeof buildSessionTools> {
+  sessionToolsCache ??= buildSessionTools();
+  return sessionToolsCache;
+}
+
+/**
  * Filter tools for agent configuration
  */
 function filterToolsForAgent(enabledTools: string[] | null): Record<string, unknown> {
@@ -87,7 +103,7 @@ function filterToolsForAgent(enabledTools: string[] | null): Record<string, unkn
     // spawn_session/send_session could only ever have refused here. Dispatch
     // signs its own hop now. Still gated per agent by `enabledTools` below, so
     // adding it here widens nothing on its own.
-    ...buildSessionTools(),
+    ...getSessionTools(),
     // Note: Not including agentCommunicationTools to prevent infinite recursion
   };
   

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -44,6 +44,7 @@ import { isDriveWithinCredentialScope } from '@pagespace/lib/agent-workspaces/cr
 import { decideAgentSessionAccess } from '@pagespace/lib/agent-workspaces/decide-workspace-access';
 import { redactConversationTitleForViewer } from '@pagespace/lib/agent-workspaces/redact-conversation-listing';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import {
   AGENT_DISPATCH_SIGNATURE_HEADER,
   signAgentDispatch,
@@ -1118,11 +1119,26 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       // owner sees only an aborted stream, and the abort itself is recorded under
       // THEIR id (above), so the row cannot say who did it. Record the acting
       // user here — it is the only place both identities are in hand (PR review).
+      //
+      // Through `audit()` rather than the ordinary logger, because this is a
+      // cross-user ADMINISTRATIVE action: the audit pipeline dual-writes to the
+      // tamper-evident `security_audit_log`, which is what makes the event
+      // survive log rotation and show up in audit queries and exports. A plain
+      // `loggers.ai.warn` reaches neither, and on the default console
+      // destination may not be retained at all (PR review, #2423).
       if (actingUserId !== streamOwnerId) {
-        loggers.ai.warn('kill_session: a worker was stopped by someone other than its owner', {
-          conversationId,
-          workerOwnerId: streamOwnerId,
-          actingUserId,
+        audit({
+          eventType: 'admin.session.terminated',
+          // The ACTOR is the subject of an audit row, always — the owner rides
+          // in details, so "what did this admin do" is one indexed query.
+          userId: actingUserId,
+          resourceType: 'agent_worker',
+          resourceId: conversationId,
+          details: { workerOwnerId: streamOwnerId },
+          // Authorized (`checkWorkspaceEndAccess` cleared it upstream) but
+          // cross-user, so it warns rather than informs: worth a look, not an
+          // alarm. `audit()` picks the level off this threshold.
+          riskScore: 0.5,
         });
       }
       await abortConversationStreams({ conversationId, userId: streamOwnerId }).catch(() => {});

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -1113,7 +1113,18 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       // authorized a drive admin to stop another member's worker, aborting as the
       // ADMIN would match zero rows and report success while the worker kept
       // running. Authorization happened before this call; this names the rows.
-      void actingUserId;
+      //
+      // A CROSS-MEMBER stop is the one outcome nobody is told about: the worker's
+      // owner sees only an aborted stream, and the abort itself is recorded under
+      // THEIR id (above), so the row cannot say who did it. Record the acting
+      // user here — it is the only place both identities are in hand (PR review).
+      if (actingUserId !== streamOwnerId) {
+        loggers.ai.warn('kill_session: a worker was stopped by someone other than its owner', {
+          conversationId,
+          workerOwnerId: streamOwnerId,
+          actingUserId,
+        });
+      }
       await abortConversationStreams({ conversationId, userId: streamOwnerId }).catch(() => {});
       // Deliberately NO sandbox teardown: a worker works in its SPAWNER's
       // workspace, so tearing "its" sandbox down would destroy a working context

--- a/apps/web/src/lib/ai/tools/session-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/session-tools-runtime.ts
@@ -1126,9 +1126,22 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
       // survive log rotation and show up in audit queries and exports. A plain
       // `loggers.ai.warn` reaches neither, and on the default console
       // destination may not be retained at all (PR review, #2423).
+      //
+      // AFTER the abort, and carrying its OUTCOME. Recording first would write
+      // "terminated" into a tamper-evident log whose whole value is that it does
+      // not say things that did not happen — and the abort's failure is
+      // swallowed here (the return below is `ok: true` either way, deliberately:
+      // the conversation and transcript survive regardless). A failed
+      // cross-member stop is not a non-event, though — an admin reaching into
+      // another member's worker is worth a row whichever way it lands — so the
+      // two outcomes get two event types rather than one type and one silence
+      // (PR review, #2423).
+      const aborted = await abortConversationStreams({ conversationId, userId: streamOwnerId })
+        .then(() => true)
+        .catch(() => false);
       if (actingUserId !== streamOwnerId) {
         audit({
-          eventType: 'admin.session.terminated',
+          eventType: aborted ? 'admin.session.terminate.success' : 'admin.session.terminate.failure',
           // The ACTOR is the subject of an audit row, always — the owner rides
           // in details, so "what did this admin do" is one indexed query.
           userId: actingUserId,
@@ -1141,7 +1154,6 @@ export function buildSessionToolsDeps(): SessionToolsDeps {
           riskScore: 0.5,
         });
       }
-      await abortConversationStreams({ conversationId, userId: streamOwnerId }).catch(() => {});
       // Deliberately NO sandbox teardown: a worker works in its SPAWNER's
       // workspace, so tearing "its" sandbox down would destroy a working context
       // that is not this worker's to release.

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -954,7 +954,11 @@ export function createSessionTools(deps: SessionToolsDeps): {
     context: ToolExecutionContext | undefined,
     conversationId: string,
   ): Promise<
-    | { ok: true; actor: { userId: string }; row: WorkerRow }
+    // The ok row's `workspaceId` is narrowed to a string on purpose: the
+    // workspace-less refusal below is what makes it non-null, and callers that
+    // need the workspace (kill's END check) should read that from the TYPE
+    // rather than re-asserting an invariant that could be reordered away.
+    | { ok: true; actor: { userId: string }; row: WorkerRow & { workspaceId: string } }
     | { ok: false; error: { success: false; error: string } }
   > => {
     const actor = readActor(context);
@@ -1002,7 +1006,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
     if (row.isClosed) {
       return { ok: false, error: workerListingClosed(conversationId) };
     }
-    return { ok: true, actor, row };
+    return { ok: true, actor, row: { ...row, workspaceId: row.workspaceId } };
   };
 
   /**
@@ -1466,9 +1470,7 @@ export function createSessionTools(deps: SessionToolsDeps): {
         if (opened.row.ownerId !== opened.actor.userId) {
           const canEnd = await deps.checkWorkspaceEndAccess(
             opened.actor.userId,
-            // Non-null by construction: `openAddressableSession` refuses a
-            // workspace-less row before returning ok.
-            opened.row.workspaceId as string,
+            opened.row.workspaceId,
           );
           if (!canEnd.allowed) return cannotStopOthersWorker(sessionId);
         }

--- a/packages/db/src/schema/security-audit.ts
+++ b/packages/db/src/schema/security-audit.ts
@@ -72,8 +72,12 @@ export type SecurityEventType =
   // the stream's owner so the `ai_stream_sessions` rows match — so this is the
   // only record that can name who actually acted. Its own type rather than
   // data.delete: nothing is deleted, and a cross-user administrative stop is
-  // what a dispute or incident review needs to query for.
-  | 'admin.session.terminated'
+  // what a dispute or incident review needs to query for. Split by outcome like
+  // the auth family, because the caller reports success either way: recording
+  // one type for both would let this log assert a termination that never
+  // happened, and recording nothing on failure would hide the attempt.
+  | 'admin.session.terminate.success'
+  | 'admin.session.terminate.failure'
   | 'security.anomaly.detected'
   | 'security.rate.limited'
   | 'security.brute.force.detected'

--- a/packages/db/src/schema/security-audit.ts
+++ b/packages/db/src/schema/security-audit.ts
@@ -67,6 +67,13 @@ export type SecurityEventType =
   // Privileged operator read of another subject's personal data (#954, Art 32(1)(b)).
   // Distinct from data.read so DSAR/admin reads are separable in forensic queries.
   | 'admin.data.read'
+  // A drive owner/admin stopped ANOTHER member's running agent worker (#2413).
+  // The abort itself is filed under the worker's OWNER — `killWorker` aborts as
+  // the stream's owner so the `ai_stream_sessions` rows match — so this is the
+  // only record that can name who actually acted. Its own type rather than
+  // data.delete: nothing is deleted, and a cross-user administrative stop is
+  // what a dispute or incident review needs to query for.
+  | 'admin.session.terminated'
   | 'security.anomaly.detected'
   | 'security.rate.limited'
   | 'security.brute.force.detected'


### PR DESCRIPTION
Follow-up to #2413, which merged while its last review round was still being worked through. These are the CodeRabbit findings that were never inline threads — one flagged outside the diff, six nitpicks — so nothing here answers a thread; four are taken, two are declined with reasons.

## Taken

**1. The workspace a reached worker has is a fact of its type.** `openAddressableSession` refuses a workspace-less row before returning ok, so the ok row's `workspaceId` is non-null by construction — but the type still said `string | null` and `kill_session`'s END check re-asserted it with `as string`. An unchecked cast is a comment the compiler cannot read: reorder the refusals and `checkWorkspaceEndAccess` silently receives `null` while typecheck stays green. The ok shape is narrowed instead, and the cast has nothing left to do.

**2. A cross-member kill leaves a record naming who did it.** #2413 let drive owners and admins stop another member's running worker. The worker's owner learns nothing beyond a stream that stopped, and the abort is deliberately recorded under *their* user id — `killWorker` aborts as the stream's owner so the rows match — so nothing on the way through can say who acted. `killWorker` is the one place both identities are in hand. Logged only when they differ: a warn on every kill fires for every ordinary self-stop and means nothing.

**3. The mention responder builds the session tool family once.** Every other entry in `filterToolsForAgent`'s `availableTools` is a module-level constant; the session family was a factory call, rebuilt per mention-triggered turn and discarded after one name lookup. The tools hold no per-request state — they read the caller off `experimental_context` at execute time — so one instance is the same instance a fresh call would have produced. Lazy rather than module-level, to keep the import cycle that construction exists to avoid.

**4. The scope-predicate mocks are typed from the real exports.** Seven chat fixtures stubbed `isDriveScopedPrincipal` and `isServiceAuthResult` with inline shapes narrower than the `AuthResult` both really take. These are the two predicates that decide whether a dispatched worker's credential counts as confined, so a stale stub is a suite that keeps passing on scope semantics production no longer has. Typing them from the real exports makes a signature change fail typecheck — and it immediately did: `isServiceAuthResult` is a type predicate, which a plain boolean implementation cannot satisfy.

The bodies still reimplement rather than delegate to the sibling `getAllowedDriveIds` mock, as the finding proposed. That mock is a fixed `() => []` in these fixtures, so delegating would make every credential read as unscoped and every scope assertion vacuous. The comment says so, so the next reader does not re-derive it.

## Declined, with reasons

**Remove `actingUserId` from `SessionToolsDeps.killWorker`** (suggested as unused). It was unused by exactly one commit. Item 2 above is what the field is for — it is the only value that lets the audit record name the actor, since the abort itself is filed under the owner.

**Type the seven `filterTools*` identity passthroughs from their real exports.** Declined: the finding named only `filterToolsForEphemeralWorkspace`, one of seven identically-shaped passthroughs in the same factory, so acting on it alone leaves the fixture less consistent than it started. The benefit does not materialise either — the real export is generic (`<T>(tools: Record<string, T>, …)`), `vi.fn<typeof fn>` collapses the type parameter, and an identity mock encodes no production semantics for a signature change to invalidate. Unlike the scope predicates in item 4, there is no behaviour here to go stale.

## Verification

`bun run typecheck` 17/17 and `bun run lint` 15/15 green from the repo root. The touched web suites — `lib/ai/tools/__tests__`, `api/ai/chat/__tests__`, `api/v1/chat/completions/__tests__` — pass at 1355/1355 (54 files; `activity-tools.test.ts` errors on the pre-existing local-env test-DB guard, and touches none of this).

The audit record is mutation-checked: disabling the guard turns the cross-member test red while the same-owner test pins that an ordinary kill stays silent.

**Not run locally:** `test:security` — Docker was down on this machine, so the dockerized test Postgres could not start. CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjkJKcjMnAXCUkiqS182MT

## Review round — the audit record was the weakest thing here

Both reviewers went after item 2, from opposite ends, and both were right.

**Codex (P2): a `loggers.ai.warn` is not an audit trail.** It reaches neither `security_audit_log` nor audit queries and exports, and on the default console destination may not be retained at all. A record nobody can query is barely a record. It now goes through `audit()`, which dual-writes the structured log and the hash-chained table, as `admin.session.terminate.*` — its own event type because nothing is deleted (so `data.delete` misreads it) and "who stopped whose worker" is the query a dispute actually runs. The actor is the row's `userId`, which matters here precisely because the *abort* is filed under the owner; the owner rides in `details`.

**CodeRabbit (Major): the row was written before the abort, whose rejection is swallowed.** `killWorker` returns `ok: true` either way on purpose — the conversation and transcript survive regardless — so a failed abort left the tamper-evident log asserting a termination that never happened. That is the one thing that log exists not to do. The record now runs after the abort settles and carries the outcome.

Two event types rather than one type and one silence: an admin reaching into another member's worker is worth a row whichever way it lands, and recording nothing on failure hides the attempt. Split by outcome the way the auth family already splits `.success` / `.failure`. Both are new `SecurityEventType` members over a text column — writer-side typing only, so no migration, and nothing switches exhaustively on it.

Three tests now, all mutation-checked: disabling the guard reddens the cross-member case, the same-owner case pins that an ordinary self-stop records nothing, and forcing the abort to read as always-successful reddens the rejected-abort case on its event type.

Re-validated after both rounds: `typecheck` 17/17, `lint` 15/15, `@pagespace/lib` audit suites 336/336, and the touched web suites green. CI carries `test:security`.
