### PR TITLE
fix(sidebar): the Channels badge counted mentions, not unread messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,14 @@ jobs:
   # proved by Playwright specs that, until this job, ran only when a human remembered to run
   # them. The specs' own headers said so ("There is no e2e job in CI, so these run locally").
   #
-  # SCOPE: specs 15/16/17 only, not the whole e2e suite. These three are the epic's gate; the
+  # SCOPE: specs 15-19 only, not the whole e2e suite. These are the live-delivery gate; the
   # metering and storage specs (09-14, 08) need Stripe and real S3 credentials and cost far
   # more runner time than their regression risk here justifies. Widening the list means
   # widening `E2E_SPECS` below AND the citations in the evidence manifest.
+  #
+  # 19 joins for the same reason 18 did: the sidebar Channels count is delivered over the
+  # same socket topology, both ends of its seam are unit- and integration-tested, and a typo
+  # in an event name or room fails silently as "no unread" rather than as a red test.
   #
   # The topology is reproduced deliberately and every piece of it is load-bearing — see the
   # comments on each step. Getting it wrong does not fail loudly; it makes the live-delivery
@@ -229,7 +233,7 @@ jobs:
       # NEXT_PUBLIC_REALTIME_URL is deliberately UNSET. See the proxy step.
       E2E_WEB_TARGET: http://127.0.0.1:3100
       E2E_REALTIME_TARGET: http://127.0.0.1:3001
-      E2E_SPECS: tests/15-chat-fixture-smoke.spec.ts tests/16-dispatch-multiplayer.spec.ts tests/17-agent-workspace-grid.spec.ts tests/18-sidebar-directory-live.spec.ts
+      E2E_SPECS: tests/15-chat-fixture-smoke.spec.ts tests/16-dispatch-multiplayer.spec.ts tests/17-agent-workspace-grid.spec.ts tests/18-sidebar-directory-live.spec.ts tests/19-channels-badge-live.spec.ts
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,17 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   you had not read and the number beside **Channels** stayed at zero, disagreeing with the per-channel
   counts on the Channels page. It now counts every message you have not read across the channels you
   can see, in every drive you belong to, and it moves the moment a message arrives rather than
-  waiting for a page reload. Opening the channel clears it, and a channel you do not have access to
-  never contributes to it.
+  waiting for a page reload. A channel you do not have access to never contributes to it.
+
+- **A channel you are sitting in stops counting messages you just watched arrive** — the channel was
+  only ever marked read at the moment you opened it, so messages that landed while you sat reading
+  them still counted as unread and inflated the sidebar count until you navigated away and came
+  back. They now clear as they arrive, and a channel left open in a background tab still counts
+  them, so nothing marks itself read behind your back.
+
+- **Deleted messages no longer count as unread** — a message someone posted and then deleted still
+  counted towards the unread count on the Channels page, leaving a number next to a channel that had
+  nothing new to show you. It only cleared by opening the channel.
 
 - **Talking to one of your agents from outside PageSpace works again** — the OpenAI-compatible
   endpoint (`/v1/chat/completions`, what the PageSpace CLI and any OpenAI-style client use) answered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   for one. And if clearing the old answer fails, the retry does not start at all and tells you so,
   rather than going ahead and handing the model its own previous answer to rewrite.
 
+- **The Channels count in the sidebar now counts unread messages, not just the ones that mention
+  you** — it only ever moved when somebody @-mentioned you, so a channel could fill up with messages
+  you had not read and the number beside **Channels** stayed at zero, disagreeing with the per-channel
+  counts on the Channels page. It now counts every message you have not read across the channels you
+  can see, in every drive you belong to, and it moves the moment a message arrives rather than
+  waiting for a page reload. Opening the channel clears it, and a channel you do not have access to
+  never contributes to it.
+
 - **Talking to one of your agents from outside PageSpace works again** — the OpenAI-compatible
   endpoint (`/v1/chat/completions`, what the PageSpace CLI and any OpenAI-style client use) answered
   every valid request to a page agent with a generic "Failed to process chat request. Please try

--- a/apps/e2e/support/db.ts
+++ b/apps/e2e/support/db.ts
@@ -294,3 +294,27 @@ export async function createMcpToken(userId: string): Promise<string> {
   });
   return raw;
 }
+
+/**
+ * A CHANNEL page in `driveId`, non-private so ordinary drive members can read it
+ * through the default membership rule rather than an explicit grant. That is the
+ * common shape in the product and the one whose fan-out regressed, so it is the
+ * shape the badge spec should exercise.
+ */
+export async function seedChannel(driveId: string, title = 'general'): Promise<string> {
+  const page = await factories.createPage(driveId, {
+    type: 'CHANNEL',
+    title,
+    isPrivate: false,
+  });
+  return page.id;
+}
+
+/**
+ * Add `userId` to `driveId` as an accepted MEMBER — no admin role, no page grant.
+ * Accepted matters: permission resolution joins drive_members on acceptedAt IS NOT
+ * NULL, so a pending invite reads as a non-member.
+ */
+export async function addDriveMember(driveId: string, userId: string): Promise<void> {
+  await factories.createDriveMember(driveId, userId, { role: 'MEMBER' });
+}

--- a/apps/e2e/tests/19-channels-badge-live.spec.ts
+++ b/apps/e2e/tests/19-channels-badge-live.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, seedChannel, addDriveMember } from '../support/db';
+import { sessionPost } from '../support/http';
+import { authedContext } from '../fixtures/chat.fixture';
+
+/**
+ * # The Channels count moves when someone posts, without a reload
+ *
+ * The user story: **a message in a channel you belong to raises the number beside
+ * "Channels" while you are looking at something else.** Before this, the badge
+ * counted unread @mentions only, so an ordinary message left it at zero.
+ *
+ * ## Why this spec exists when the pieces were already tested
+ *
+ * Both ends of the seam are proven, and the middle was not:
+ *
+ *  - the SERVER end — the recipient set really does include an ordinary accepted
+ *    member of a non-private channel, against a real database
+ *    (`page-viewers.integration.test.ts`), and the badge query really does count
+ *    watermark-unread messages (`api/sidebar/badges/__tests__/route.test.ts`);
+ *  - the CLIENT end — the hook really does subscribe to `inbox:channel_updated`
+ *    and revalidate on it (`useSidebarBadges.test.ts`).
+ *
+ * What nothing asserted is that a real post travels the whole way: POST → fan-out
+ * → `notifications:<userId>` room → the socket this browser actually holds → SWR
+ * → the rendered number. Every link in that chain is a string or a room name
+ * matched by convention, and a typo in any of them fails silently — the badge
+ * simply never moves, which looks identical to "no unread". This spec is the one
+ * thing that fails loudly when that happens.
+ *
+ * It is also the regression the fan-out fix was for: the recipient here is a
+ * plain MEMBER with no page_permissions row and no admin role, which is exactly
+ * the user the previous hand-written recipient query dropped.
+ *
+ * ## Ruling out the poll
+ *
+ * "The number appeared" is not by itself evidence of the socket — a refetch on an
+ * interval would look the same. So the first test counts requests to
+ * `/api/sidebar/badges` and asserts a CONTROL: a quiet period, of the same length
+ * as the assertion window, in which the badge endpoint is not hit at all. If
+ * someone later adds a `refreshInterval` to the hook, that control fails and says
+ * so, rather than this spec quietly degrading into a poll test.
+ *
+ * ## Topology
+ *
+ * Same as `16-dispatch-multiplayer.spec.ts` and `18-sidebar-directory-live.spec.ts`,
+ * and required for the same reason: realtime must be reachable SAME-ORIGIN, because
+ * the shipped CSP is `connect-src 'self' ws: wss:` and Socket.IO's opening XHR
+ * handshake to another origin is blocked outright — no socket, no rooms. See the
+ * `e2e` job in `.github/workflows/ci.yml`.
+ */
+
+const BADGE = 'nav-badge-channels';
+const BADGE_ENDPOINT = '/api/sidebar/badges';
+
+/** Long enough for the 250ms debounce plus a refetch, short enough to stay a test. */
+const APPEAR_TIMEOUT = 20_000;
+/** The control window. Same length as the one the assertion gets. */
+const QUIET_MS = APPEAR_TIMEOUT;
+
+/**
+ * Wait until the badge-endpoint request count stops moving, so the control window
+ * measures steady state rather than the tail of mount.
+ */
+async function waitForFetchesToSettle(count: () => number, stableForMs = 2_000): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  let last = count();
+  let stableSince = Date.now();
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 250));
+    const now = count();
+    if (now !== last) {
+      last = now;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= stableForMs) {
+      return;
+    }
+  }
+}
+
+test.describe('Channels badge, live', () => {
+  test('counts a message posted while the reader is on another page, with no reload', async ({
+    browser,
+    request,
+    baseURL,
+  }) => {
+    const poster = await seedUser();
+    const reader = await seedUser();
+    // A plain accepted member: no admin role, no explicit page grant. This is the
+    // exact principal the old fan-out query failed to notify.
+    await addDriveMember(poster.driveId, reader.userId);
+    const channelId = await seedChannel(poster.driveId);
+
+    const context = await authedContext(browser, reader.sessionToken, baseURL!);
+    const page = await context.newPage();
+
+    let badgeFetches = 0;
+    page.on('request', (req) => {
+      if (req.url().includes(BADGE_ENDPOINT)) badgeFetches += 1;
+    });
+
+    // The reader sits in their OWN drive, never opening the channel — the badge is
+    // user-wide, so a message in a drive they merely belong to must still count.
+    await page.goto(`/dashboard/${reader.driveId}`);
+    await expect(page.getByTestId(BADGE)).toHaveCount(0);
+
+    // Let mount settle before measuring. The hook fetches twice on mount — SWR's own
+    // fetch plus the effect watching the notification store's unread count — and both
+    // land together a few hundred ms in. Snapshotting before they arrive would count
+    // startup as a poll, which is what the first draft of this control did.
+    await waitForFetchesToSettle(() => badgeFetches);
+    const fetchesAfterLoad = badgeFetches;
+
+    // CONTROL: nothing arrives, so nothing should refetch. A poll would show up here.
+    // Measured while writing this: over 60s idle the endpoint is hit exactly twice,
+    // both at ~365ms, and never again — there is no interval to accommodate.
+    await page.waitForTimeout(QUIET_MS);
+    expect(
+      badgeFetches,
+      'the badge endpoint was refetched during a quiet period — this spec can no longer tell a socket update from a poll',
+    ).toBe(fetchesAfterLoad);
+    await expect(page.getByTestId(BADGE)).toHaveCount(0);
+
+    const res = await sessionPost(request, `/api/channels/${channelId}/messages`, poster, {
+      content: 'anyone around?',
+    });
+    expect(res.status(), await res.text()).toBe(201);
+
+    await expect(page.getByTestId(BADGE)).toHaveText('1', { timeout: APPEAR_TIMEOUT });
+
+    await context.close();
+  });
+
+  test('clears when the reader opens the channel', async ({ browser, request, baseURL }) => {
+    const poster = await seedUser();
+    const reader = await seedUser();
+    await addDriveMember(poster.driveId, reader.userId);
+    const channelId = await seedChannel(poster.driveId);
+
+    const context = await authedContext(browser, reader.sessionToken, baseURL!);
+    const page = await context.newPage();
+    await page.goto(`/dashboard/${reader.driveId}`);
+
+    await sessionPost(request, `/api/channels/${channelId}/messages`, poster, {
+      content: 'first',
+    });
+    await expect(page.getByTestId(BADGE)).toHaveText('1', { timeout: APPEAR_TIMEOUT });
+
+    // Opening the channel advances the read watermark, which broadcasts
+    // inbox:read_status_changed back to this same reader and clears the count.
+    await page.goto(`/dashboard/${poster.driveId}/${channelId}`);
+    await expect(page.getByTestId(BADGE)).toHaveCount(0, { timeout: APPEAR_TIMEOUT });
+
+    await context.close();
+  });
+
+  test('does not count a channel the reader cannot see', async ({ browser, request, baseURL }) => {
+    const poster = await seedUser();
+    const outsider = await seedUser();
+    // Deliberately NOT a member of the poster's drive.
+    const channelId = await seedChannel(poster.driveId);
+
+    const context = await authedContext(browser, outsider.sessionToken, baseURL!);
+    const page = await context.newPage();
+    await page.goto(`/dashboard/${outsider.driveId}`);
+
+    await sessionPost(request, `/api/channels/${channelId}/messages`, poster, {
+      content: 'private business',
+    });
+
+    // Give it the same window the positive case gets, so this is a real negative
+    // rather than a race that happens to pass.
+    await page.waitForTimeout(APPEAR_TIMEOUT);
+    await expect(page.getByTestId(BADGE)).toHaveCount(0);
+
+    await context.close();
+  });
+});

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -31,6 +31,11 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserViewPage: vi.fn().mockResolvedValue(true),
   canUserEditPage: vi.fn().mockResolvedValue(true),
+  // Inbox fan-out asks the centralized helper which candidates can view the
+  // channel. Default to all of them, matching canUserViewPage's default above.
+  getUsersWhoCanViewPage: vi.fn(
+    async (_pageId: string, candidateUserIds: string[]) => new Set(candidateUserIds)
+  ),
 }));
 
 // --- Channel repository seam --------------------------------------------------

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, isNull, gt, inArray } from '@pagespace/db/operators'
+import { eq } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
-import { driveMembers, pagePermissions } from '@pagespace/db/schema/members'
+import { driveMembers } from '@pagespace/db/schema/members'
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth';
 // canUserViewPage below is only used for mention RECIPIENTS (other users), not
 // the requesting principal — those checks are keyed to arbitrary user ids and
 // must stay user-level.
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { canUserViewPage, getUsersWhoCanViewPage } from '@pagespace/lib/permissions/permissions'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
@@ -58,40 +58,17 @@ async function fanOutChannelInboxUpdate(
   }
   const otherMemberIds = [...memberUserIds].filter((id) => id !== senderUserId);
 
-  const viewableUserIds = new Set<string>();
   if (otherMemberIds.length === 0) {
-    return viewableUserIds;
+    return new Set<string>();
   }
 
-  if (driveOwnerId && otherMemberIds.includes(driveOwnerId)) {
-    viewableUserIds.add(driveOwnerId);
-  }
-
-  const adminMembers = await db.select({ userId: driveMembers.userId })
-    .from(driveMembers)
-    .where(and(
-      eq(driveMembers.driveId, driveId),
-      inArray(driveMembers.userId, otherMemberIds),
-      eq(driveMembers.role, 'ADMIN')
-    ));
-  for (const admin of adminMembers) {
-    viewableUserIds.add(admin.userId);
-  }
-
-  const remainingIds = otherMemberIds.filter((id) => !viewableUserIds.has(id));
-  if (remainingIds.length > 0) {
-    const permittedMembers = await db.select({ userId: pagePermissions.userId })
-      .from(pagePermissions)
-      .where(and(
-        eq(pagePermissions.pageId, pageId),
-        inArray(pagePermissions.userId, remainingIds),
-        eq(pagePermissions.canView, true),
-        or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
-      ));
-    for (const pm of permittedMembers) {
-      viewableUserIds.add(pm.userId);
-    }
-  }
+  // Recipients come from the centralized permission rules, not a local copy of
+  // them. The hand-written version this replaces knew about drive owners,
+  // admins and explicit page_permissions rows, but not about custom roles or
+  // the rule that any accepted member can view a non-private page — so an
+  // ordinary member of a public channel, the most common reader there is, was
+  // never sent an inbox event and their sidebar count stayed stale.
+  const viewableUserIds = await getUsersWhoCanViewPage(pageId, otherMemberIds);
 
   await Promise.all(
     otherMemberIds

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -61,10 +61,20 @@ export async function GET(request: Request) {
           FROM pages p
           INNER JOIN drives d ON d.id = p."driveId"
           LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
+          -- Candidate filter only; getBatchPagePermissions below is the access
+          -- decision. An explicit grant beats membership there, so a channel
+          -- shared with someone outside the drive must survive to be asked
+          -- about. Expiry is deliberately left to that helper.
+          LEFT JOIN page_permissions pp
+            ON pp."pageId" = p.id AND pp."userId" = ${userId} AND pp."canView" = true
           WHERE p.type = 'CHANNEL'
             AND p."isTrashed" = false
             AND p."driveId" = ${driveId}
-            AND (d."ownerId" = ${userId} OR dm."userId" IS NOT NULL)
+            AND (
+              d."ownerId" = ${userId}
+              OR dm."userId" IS NOT NULL
+              OR pp."userId" IS NOT NULL
+            )
         ),
         channel_last_messages AS (
           SELECT DISTINCT ON (cm."pageId")
@@ -236,9 +246,16 @@ export async function GET(request: Request) {
             FROM pages p
             INNER JOIN drives d ON d.id = p."driveId"
             LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
+            -- Candidate filter only; see the drive-scoped query above.
+            LEFT JOIN page_permissions pp
+              ON pp."pageId" = p.id AND pp."userId" = ${userId} AND pp."canView" = true
             WHERE p.type = 'CHANNEL'
               AND p."isTrashed" = false
-              AND (d."ownerId" = ${userId} OR dm."userId" IS NOT NULL)
+              AND (
+                d."ownerId" = ${userId}
+                OR dm."userId" IS NOT NULL
+                OR pp."userId" IS NOT NULL
+              )
           ),
           channel_last_messages AS (
             SELECT DISTINCT ON (cm."pageId")

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -82,7 +82,8 @@ export async function GET(request: Request) {
           FROM channel_messages cm
           LEFT JOIN channel_read_status crs
             ON crs."channelId" = cm."pageId" AND crs."userId" = ${userId}
-          WHERE cm."createdAt" > COALESCE(crs."lastReadAt", '1970-01-01'::timestamp)
+          WHERE cm."isActive" = true
+            AND cm."createdAt" > COALESCE(crs."lastReadAt", '1970-01-01'::timestamp)
             AND (
               cm."userId" != ${userId}
               OR cm."aiMeta"->>'senderType' = 'agent'
@@ -255,7 +256,8 @@ export async function GET(request: Request) {
             FROM channel_messages cm
             LEFT JOIN channel_read_status crs
               ON crs."channelId" = cm."pageId" AND crs."userId" = ${userId}
-            WHERE cm."createdAt" > COALESCE(crs."lastReadAt", '1970-01-01'::timestamp)
+            WHERE cm."isActive" = true
+              AND cm."createdAt" > COALESCE(crs."lastReadAt", '1970-01-01'::timestamp)
               AND (
                 cm."userId" != ${userId}
                 OR cm."aiMeta"->>'senderType' = 'agent'

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -251,7 +251,11 @@ export async function GET(request: Request) {
             FROM pages p
             INNER JOIN drives d ON d.id = p."driveId"
             LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
-            -- Candidate filter only; see the drive-scoped query above.
+            -- Candidate filter only. Same join and predicate as the drive-scoped
+            -- query above and as countChannelUnread in
+            -- apps/web/src/app/api/sidebar/badges/route.ts, which is why the nav
+            -- badge and these pills agree about which channels exist; change one
+            -- and change all three.
             LEFT JOIN page_permissions pp
               ON pp."pageId" = p.id
               AND pp."userId" = ${userId}

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -64,9 +64,14 @@ export async function GET(request: Request) {
           -- Candidate filter only; getBatchPagePermissions below is the access
           -- decision. An explicit grant beats membership there, so a channel
           -- shared with someone outside the drive must survive to be asked
-          -- about. Expiry is deliberately left to that helper.
+          -- about. Expiry uses now() at time zone utc because expiresAt is a
+          -- UTC wall clock stored without a zone: a bare now() would compare it
+          -- against the session zone and be wrong in both directions.
           LEFT JOIN page_permissions pp
-            ON pp."pageId" = p.id AND pp."userId" = ${userId} AND pp."canView" = true
+            ON pp."pageId" = p.id
+            AND pp."userId" = ${userId}
+            AND pp."canView" = true
+            AND (pp."expiresAt" IS NULL OR pp."expiresAt" > (now() at time zone 'utc'))
           WHERE p.type = 'CHANNEL'
             AND p."isTrashed" = false
             AND p."driveId" = ${driveId}
@@ -248,7 +253,10 @@ export async function GET(request: Request) {
             LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
             -- Candidate filter only; see the drive-scoped query above.
             LEFT JOIN page_permissions pp
-              ON pp."pageId" = p.id AND pp."userId" = ${userId} AND pp."canView" = true
+              ON pp."pageId" = p.id
+              AND pp."userId" = ${userId}
+              AND pp."canView" = true
+              AND (pp."expiresAt" IS NULL OR pp."expiresAt" > (now() at time zone 'utc'))
             WHERE p.type = 'CHANNEL'
               AND p."isTrashed" = false
               AND (

--- a/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
+++ b/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
@@ -196,6 +196,30 @@ describe('GET /api/sidebar/badges — channels', () => {
     expect(badges.calendar).toBe(SELECT_COUNTS[3]);
   });
 
+  it('counts viewable channels beyond the permission batch size', async () => {
+    // The bound is on the permission query, not on the candidate set. Capping
+    // candidates would undercount — or report zero — when the denied channels
+    // happen to sort first, while readable unread sat past the cut.
+    const DENIED = 250; // > PERMISSION_BATCH_SIZE, so the readable one lands in a later chunk
+    const rows = [
+      ...Array.from({ length: DENIED }, (_, i) => ({ id: `ch_denied_${i}`, unread_count: '7' })),
+      { id: 'ch_visible', unread_count: '3' },
+    ];
+    withUnreadRows(rows);
+    setPermissions({
+      ...Object.fromEntries(rows.map((r) => [r.id, false])),
+      ch_visible: true,
+    });
+
+    expect(await getChannels()).toBe(3);
+    // and every candidate was actually evaluated, none dropped
+    const evaluated = vi
+      .mocked(getBatchPagePermissions as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls.flatMap((call) => call[1] as string[]);
+    expect(evaluated).toHaveLength(rows.length);
+    expect(evaluated).toContain('ch_visible');
+  });
+
   it('keeps each badge wired to its own query', async () => {
     // Guards the positional destructuring of the Promise.all, which this
     // route's change had to renumber. Each db.select() resolves to a distinct

--- a/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
+++ b/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
@@ -214,8 +214,8 @@ describe('GET /api/sidebar/badges — channels', () => {
     expect(await getChannels()).toBe(3);
     // and every candidate was actually evaluated, none dropped
     const evaluated = vi
-      .mocked(getBatchPagePermissions as unknown as ReturnType<typeof vi.fn>)
-      .mock.calls.flatMap((call) => call[1] as string[]);
+      .mocked(getBatchPagePermissions)
+      .mock.calls.flatMap((call) => call[1]);
     expect(evaluated).toHaveLength(rows.length);
     expect(evaluated).toContain('ch_visible');
   });

--- a/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
+++ b/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the `channels` figure of /api/sidebar/badges.
+ *
+ * The badge used to count unread MENTION notifications only, so an ordinary
+ * message in a channel you belong to left it at zero. It now sums unread
+ * messages past each channel's `channel_read_status` watermark — and, because
+ * drive membership is not page access, only for channels the centralized
+ * permission helper says the user can view.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@pagespace/db/operators', () => {
+  // Capture the literal text chunks so tests can identify which query ran.
+  const sql = (strings: TemplateStringsArray, ..._values: unknown[]) => ({
+    __sqlText: strings.join('?'),
+  });
+  const noop = (...args: unknown[]) => ({ __op: args });
+  return {
+    sql,
+    eq: noop,
+    ne: noop,
+    and: noop,
+    or: noop,
+    isNull: noop,
+    gte: noop,
+    count: () => ({ __op: 'count' }),
+  };
+});
+
+vi.mock('@pagespace/db/schema/social', () => ({ directMessages: {}, dmConversations: {} }));
+vi.mock('@pagespace/db/schema/notifications', () => ({ notifications: {} }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
+vi.mock('@pagespace/db/schema/calendar', () => ({ calendarEvents: {}, eventAttendees: {} }));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getBatchPagePermissions: vi.fn(),
+}));
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
+
+const mockUserId = 'user_123';
+
+const mockAuth = () => {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+    userId: mockUserId,
+    tokenVersion: 0,
+    tokenType: 'session' as const,
+    sessionId: 'test-session',
+    role: 'user' as const,
+    adminRoleVersion: 0,
+  });
+};
+
+/**
+ * The other four badges use the Drizzle query builder, which is a thenable
+ * chain. One self-returning thenable stands in for all of them and always
+ * resolves to a zero count, so `channels` is the only figure under test.
+ */
+const stubQueryBuilder = () => {
+  const chain: Record<string, unknown> = {
+    then: (resolve: (value: unknown) => unknown) => resolve([{ count: 0 }]),
+  };
+  for (const method of ['from', 'innerJoin', 'leftJoin', 'where']) {
+    chain[method] = () => chain;
+  }
+  (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+};
+
+const grantView = (...pageIds: string[]) => {
+  vi.mocked(getBatchPagePermissions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+    new Map(
+      pageIds.map((id) => [id, { canView: true, canEdit: false, canShare: false, canDelete: false }])
+    )
+  );
+};
+
+const withUnreadRows = (rows: Array<{ id: string; unread_count: string }>) => {
+  (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows });
+};
+
+const getChannels = async () => {
+  const res = await GET(new Request('http://localhost/api/sidebar/badges'));
+  expect(res.status).toBe(200);
+  return (await res.json()).channels as number;
+};
+
+describe('GET /api/sidebar/badges — channels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+    stubQueryBuilder();
+  });
+
+  it('sums unread message counts across viewable channels', async () => {
+    withUnreadRows([
+      { id: 'ch_1', unread_count: '3' },
+      { id: 'ch_2', unread_count: '4' },
+    ]);
+    grantView('ch_1', 'ch_2');
+
+    expect(await getChannels()).toBe(7);
+  });
+
+  it('excludes channels the user cannot view', async () => {
+    withUnreadRows([
+      { id: 'ch_visible', unread_count: '2' },
+      { id: 'ch_hidden', unread_count: '99' },
+    ]);
+    // ch_hidden is in one of the user's drives but permissioned away from them.
+    grantView('ch_visible');
+
+    expect(await getChannels()).toBe(2);
+  });
+
+  it('counts unread messages from the watermark query, not MENTION notifications', async () => {
+    withUnreadRows([{ id: 'ch_1', unread_count: '5' }]);
+    grantView('ch_1');
+
+    await getChannels();
+
+    const sqlText = String(
+      (vi.mocked(db.execute).mock.calls[0][0] as unknown as { __sqlText: string }).__sqlText
+    );
+    expect(sqlText).toContain('channel_read_status');
+    expect(sqlText).not.toContain('MENTION');
+  });
+
+  it('returns 0 and skips the permission batch when nothing is unread', async () => {
+    withUnreadRows([]);
+
+    expect(await getChannels()).toBe(0);
+    expect(getBatchPagePermissions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
+++ b/apps/web/src/app/api/sidebar/badges/__tests__/route.test.ts
@@ -71,36 +71,58 @@ const mockAuth = () => {
 
 /**
  * The other four badges use the Drizzle query builder, which is a thenable
- * chain. One self-returning thenable stands in for all of them and always
- * resolves to a zero count, so `channels` is the only figure under test.
+ * chain. Each `db.select()` gets its own self-returning thenable resolving to a
+ * DISTINCT count, handed out in the order the route builds its Promise.all:
+ * dms, files, tasks, calendar (channels is raw SQL and takes no slot).
+ *
+ * Distinct values are the point. With every chain resolving to 0, transposing
+ * two names in the positional destructuring — which this route's change had to
+ * touch — is invisible. See the response-contract test below.
  */
+const SELECT_COUNTS = [11, 22, 33, 44];
+
 const stubQueryBuilder = () => {
-  const chain: Record<string, unknown> = {
-    then: (resolve: (value: unknown) => unknown) => resolve([{ count: 0 }]),
-  };
-  for (const method of ['from', 'innerJoin', 'leftJoin', 'where']) {
-    chain[method] = () => chain;
-  }
-  (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  let nth = 0;
+  (db.select as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+    const value = SELECT_COUNTS[nth++] ?? 0;
+    const chain: Record<string, unknown> = {
+      then: (resolve: (v: unknown) => unknown) => resolve([{ count: value }]),
+    };
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where']) {
+      chain[method] = () => chain;
+    }
+    return chain;
+  });
 };
 
-const grantView = (...pageIds: string[]) => {
+const perm = (canView: boolean) => ({ canView, canEdit: false, canShare: false, canDelete: false });
+
+/**
+ * getBatchPagePermissions pre-seeds every id it was asked about with an explicit
+ * deny, so "denied" arrives as a present entry with canView:false, not as an
+ * absent key. Tests must be able to express both — a filter written as
+ * `permissions.has(id)` passes the absent case while leaking the denied one.
+ */
+const setPermissions = (entries: Record<string, boolean>) => {
   vi.mocked(getBatchPagePermissions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
-    new Map(
-      pageIds.map((id) => [id, { canView: true, canEdit: false, canShare: false, canDelete: false }])
-    )
+    new Map(Object.entries(entries).map(([id, canView]) => [id, perm(canView)]))
   );
 };
+
+const grantView = (...pageIds: string[]) =>
+  setPermissions(Object.fromEntries(pageIds.map((id) => [id, true])));
 
 const withUnreadRows = (rows: Array<{ id: string; unread_count: string }>) => {
   (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows });
 };
 
-const getChannels = async () => {
+const getBadges = async () => {
   const res = await GET(new Request('http://localhost/api/sidebar/badges'));
   expect(res.status).toBe(200);
-  return (await res.json()).channels as number;
+  return (await res.json()) as Record<string, number>;
 };
+
+const getChannels = async () => (await getBadges()).channels;
 
 describe('GET /api/sidebar/badges — channels', () => {
   beforeEach(() => {
@@ -119,12 +141,24 @@ describe('GET /api/sidebar/badges — channels', () => {
     expect(await getChannels()).toBe(7);
   });
 
-  it('excludes channels the user cannot view', async () => {
+  it('excludes a channel present in the permission map but denied', async () => {
     withUnreadRows([
       { id: 'ch_visible', unread_count: '2' },
-      { id: 'ch_hidden', unread_count: '99' },
+      { id: 'ch_denied', unread_count: '99' },
     ]);
-    // ch_hidden is in one of the user's drives but permissioned away from them.
+    // ch_denied is in one of the user's drives but permissioned away from them.
+    // It is PRESENT with canView:false — the shape getBatchPagePermissions
+    // actually returns — so a `permissions.has(id)` filter would leak it.
+    setPermissions({ ch_visible: true, ch_denied: false });
+
+    expect(await getChannels()).toBe(2);
+  });
+
+  it('excludes a channel absent from the permission map', async () => {
+    withUnreadRows([
+      { id: 'ch_visible', unread_count: '2' },
+      { id: 'ch_missing', unread_count: '99' },
+    ]);
     grantView('ch_visible');
 
     expect(await getChannels()).toBe(2);
@@ -148,5 +182,33 @@ describe('GET /api/sidebar/badges — channels', () => {
 
     expect(await getChannels()).toBe(0);
     expect(getBatchPagePermissions).not.toHaveBeenCalled();
+  });
+
+  it('reports 0 unread channels rather than blanking every badge when the query fails', async () => {
+    // The channel slot sits in a Promise.all: an unhandled rejection 500s the
+    // route, and the client renders that as all five badges empty. Only the
+    // channel figure should degrade.
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+
+    const badges = await getBadges();
+    expect(badges.channels).toBe(0);
+    expect(badges.dms).toBe(SELECT_COUNTS[0]);
+    expect(badges.calendar).toBe(SELECT_COUNTS[3]);
+  });
+
+  it('keeps each badge wired to its own query', async () => {
+    // Guards the positional destructuring of the Promise.all, which this
+    // route's change had to renumber. Each db.select() resolves to a distinct
+    // count in build order, so a transposition shows up as swapped values.
+    withUnreadRows([{ id: 'ch_1', unread_count: '5' }]);
+    grantView('ch_1');
+
+    expect(await getBadges()).toEqual({
+      dms: SELECT_COUNTS[0],
+      channels: 5,
+      files: SELECT_COUNTS[1],
+      tasks: SELECT_COUNTS[2],
+      calendar: SELECT_COUNTS[3],
+    });
   });
 });

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -15,13 +15,35 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 type ChannelUnreadRow = { id: string; unread_count: string };
 
 /**
+ * Bound on channels-with-unread carried back from one badge request. The badge
+ * renders "99+" past two digits, so no reachable number of channels changes what
+ * the user sees — this only stops an unbounded id list reaching the `inArray` in
+ * getBatchPagePermissions (the hazard apps/web/eslint.config.mjs guards for
+ * `findMany`, which cannot see a raw `db.execute`).
+ */
+const MAX_UNREAD_CHANNELS = 500;
+
+/**
  * Total unread channel messages across every drive the user owns or belongs to.
  *
- * The CTEs mirror /api/inbox's user-wide channel query (`user_channels` and
- * `channel_unread`) so this nav number equals the sum of the per-channel pills
- * that surface on the /channels route. Keep the two in step when either moves.
+ * Counts the same thing as /api/inbox's per-channel `unreadCount` — same
+ * watermark, same self-vs-agent rule — so this nav number and the per-channel
+ * pills on the /channels route agree. Keep the two in step when either moves.
  *
- * A `mute` filter, when one exists, belongs as another join/predicate on
+ * It does NOT spell it the same way. /api/inbox aggregates `channel_messages`
+ * whole and restricts afterwards, which the planner cannot push down: the
+ * restriction is a join qual, and join quals are not pushed beneath a GROUP BY.
+ * Measured on 400k messages across 500 channels with the user in 10 of them,
+ * that plan seq-scans every row and aggregates every channel — 2952 buffers,
+ * 52ms — to return 10 rows. Adding an INNER JOIN inside the aggregate does not
+ * help; the planner still drives from `channel_messages` (85ms). The LATERAL
+ * below forces the nested loop, so each of the user's channels is an index
+ * lookup: 105 buffers, 1.3ms, and it scales with the user's channel count
+ * rather than the size of the table. That matters here and not on /api/inbox
+ * because this endpoint is hit on every page load, and one message in an
+ * N-member drive schedules N of these.
+ *
+ * A `mute` filter, when one exists, belongs as another predicate on
  * `user_channels` — nothing else here needs to change for it.
  */
 async function countChannelUnread(userId: string): Promise<number> {
@@ -34,23 +56,29 @@ async function countChannelUnread(userId: string): Promise<number> {
       WHERE p.type = 'CHANNEL'
         AND p."isTrashed" = false
         AND (d."ownerId" = ${userId} OR dm."userId" IS NOT NULL)
-    ),
-    channel_unread AS (
-      SELECT cm."pageId", COUNT(*) as unread_count
+    )
+    SELECT uc.id, x.unread_count
+    FROM user_channels uc
+    CROSS JOIN LATERAL (
+      SELECT COUNT(*) as unread_count
       FROM channel_messages cm
-      LEFT JOIN channel_read_status crs
-        ON crs."channelId" = cm."pageId" AND crs."userId" = ${userId}
-      WHERE cm."createdAt" > COALESCE(crs."lastReadAt", '1970-01-01'::timestamp)
+      WHERE cm."pageId" = uc.id
+        AND cm."isActive" = true
+        AND cm."createdAt" > COALESCE(
+          (
+            SELECT crs."lastReadAt"
+            FROM channel_read_status crs
+            WHERE crs."channelId" = uc.id AND crs."userId" = ${userId}
+          ),
+          '1970-01-01'::timestamp
+        )
         AND (
           cm."userId" != ${userId}
           OR cm."aiMeta"->>'senderType' = 'agent'
         )
-      GROUP BY cm."pageId"
-    )
-    SELECT uc.id, cu.unread_count
-    FROM user_channels uc
-    INNER JOIN channel_unread cu ON cu."pageId" = uc.id
-    WHERE cu.unread_count > 0
+    ) x
+    WHERE x.unread_count > 0
+    LIMIT ${MAX_UNREAD_CHANNELS}
   `);
 
   const rows = result.rows;
@@ -99,7 +127,18 @@ export async function GET(req: Request) {
         // Unread channel messages (watermark-based, not @mention-only): any
         // message past the user's channel_read_status watermark counts, which
         // subsumes mentions since an @mention is also an unread message.
-        countChannelUnread(userId),
+        //
+        // Degraded rather than fatal. This slot went from an indexed two-table
+        // count() to raw SQL plus a permission batch, and it sits in a
+        // Promise.all whose rejection 500s the route — which the client renders
+        // as all five badges blank, not one. Reporting no unread channels when
+        // the query fails loses less than blanking the other four, and matches
+        // getBatchPagePermissions, which already swallows its own failures into
+        // an all-deny map (i.e. zero) rather than throwing.
+        countChannelUnread(userId).catch((error) => {
+          loggers.api.error('Failed to count unread channel messages:', error as Error);
+          return 0;
+        }),
 
         // Unread @mention notifications in non-channel pages (docs, files, etc.)
         db

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -45,6 +45,16 @@ const PERMISSION_BATCH_SIZE = 200;
  * because this endpoint is hit on every page load, and one message in an
  * N-member drive schedules N of these.
  *
+ * `user_channels` is a cheap candidate filter, not the access decision — that
+ * stays with getBatchPagePermissions below. It must therefore be no NARROWER
+ * than the real rules or channels vanish before anyone asks about them, which
+ * is why a page_permissions grant qualifies on its own: an explicit grant beats
+ * membership in resolvePagePermissionRow, and sharing a single channel with
+ * someone outside the drive is exactly what that path is for. It deliberately
+ * ignores `expiresAt` and over-includes instead — an expired grant is denied a
+ * few lines later by the helper that owns expiry, and matching the ORM's
+ * timestamp binding by hand in raw SQL is how timezone bugs get written.
+ *
  * A `mute` filter, when one exists, belongs as another predicate on
  * `user_channels` — nothing else here needs to change for it.
  */
@@ -55,9 +65,15 @@ async function countChannelUnread(userId: string): Promise<number> {
       FROM pages p
       INNER JOIN drives d ON d.id = p."driveId"
       LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
+      LEFT JOIN page_permissions pp
+        ON pp."pageId" = p.id AND pp."userId" = ${userId} AND pp."canView" = true
       WHERE p.type = 'CHANNEL'
         AND p."isTrashed" = false
-        AND (d."ownerId" = ${userId} OR dm."userId" IS NOT NULL)
+        AND (
+          d."ownerId" = ${userId}
+          OR dm."userId" IS NOT NULL
+          OR pp."userId" IS NOT NULL
+        )
     )
     SELECT uc.id, x.unread_count
     FROM user_channels uc

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -1,15 +1,74 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db';
-import { eq, ne, and, or, count, isNull, gte } from '@pagespace/db/operators';
+import { eq, ne, and, or, count, isNull, gte, sql } from '@pagespace/db/operators';
 import { directMessages, dmConversations } from '@pagespace/db/schema/social';
 import { notifications } from '@pagespace/db/schema/notifications';
 import { pages } from '@pagespace/db/schema/core';
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+type ChannelUnreadRow = { id: string; unread_count: string };
+
+/**
+ * Total unread channel messages across every drive the user owns or belongs to.
+ *
+ * The CTEs mirror /api/inbox's user-wide channel query (`user_channels` and
+ * `channel_unread`) so this nav number equals the sum of the per-channel pills
+ * that surface on the /channels route. Keep the two in step when either moves.
+ *
+ * A `mute` filter, when one exists, belongs as another join/predicate on
+ * `user_channels` — nothing else here needs to change for it.
+ */
+async function countChannelUnread(userId: string): Promise<number> {
+  const result = await db.execute<ChannelUnreadRow>(sql`
+    WITH user_channels AS (
+      SELECT p.id
+      FROM pages p
+      INNER JOIN drives d ON d.id = p."driveId"
+      LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
+      WHERE p.type = 'CHANNEL'
+        AND p."isTrashed" = false
+        AND (d."ownerId" = ${userId} OR dm."userId" IS NOT NULL)
+    ),
+    channel_unread AS (
+      SELECT cm."pageId", COUNT(*) as unread_count
+      FROM channel_messages cm
+      LEFT JOIN channel_read_status crs
+        ON crs."channelId" = cm."pageId" AND crs."userId" = ${userId}
+      WHERE cm."createdAt" > COALESCE(crs."lastReadAt", '1970-01-01'::timestamp)
+        AND (
+          cm."userId" != ${userId}
+          OR cm."aiMeta"->>'senderType' = 'agent'
+        )
+      GROUP BY cm."pageId"
+    )
+    SELECT uc.id, cu.unread_count
+    FROM user_channels uc
+    INNER JOIN channel_unread cu ON cu."pageId" = uc.id
+    WHERE cu.unread_count > 0
+  `);
+
+  const rows = result.rows;
+  if (rows.length === 0) return 0;
+
+  // Drive membership is not page access: a channel can be permissioned away
+  // from a member. Filter through the centralized helper, never hand-rolled SQL.
+  const permissions = await getBatchPagePermissions(
+    userId,
+    rows.map((row) => row.id)
+  );
+
+  return rows.reduce(
+    (sum, row) =>
+      permissions.get(row.id)?.canView ? sum + (Number(row.unread_count) || 0) : sum,
+    0
+  );
+}
 
 export async function GET(req: Request) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
@@ -17,7 +76,7 @@ export async function GET(req: Request) {
   const { userId } = auth;
 
   try {
-    const [dmResult, channelMentionResult, fileMentionResult, taskResult, calendarResult] =
+    const [dmResult, channelUnreadCount, fileMentionResult, taskResult, calendarResult] =
       await Promise.all([
         // Unread DMs from other participants (top-level messages only)
         db
@@ -37,19 +96,10 @@ export async function GET(req: Request) {
             )
           ),
 
-        // Unread @mention notifications in channel pages
-        db
-          .select({ count: count() })
-          .from(notifications)
-          .innerJoin(pages, eq(notifications.pageId, pages.id))
-          .where(
-            and(
-              eq(notifications.userId, userId),
-              eq(notifications.isRead, false),
-              eq(notifications.type, 'MENTION'),
-              eq(pages.type, 'CHANNEL')
-            )
-          ),
+        // Unread channel messages (watermark-based, not @mention-only): any
+        // message past the user's channel_read_status watermark counts, which
+        // subsumes mentions since an @mention is also an unread message.
+        countChannelUnread(userId),
 
         // Unread @mention notifications in non-channel pages (docs, files, etc.)
         db
@@ -97,7 +147,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({
       dms: Number(dmResult[0]?.count ?? 0),
-      channels: Number(channelMentionResult[0]?.count ?? 0),
+      channels: channelUnreadCount,
       files: Number(fileMentionResult[0]?.count ?? 0),
       tasks: Number(taskResult[0]?.count ?? 0),
       calendar: Number(calendarResult[0]?.count ?? 0),

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -15,13 +15,15 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 type ChannelUnreadRow = { id: string; unread_count: string };
 
 /**
- * Bound on channels-with-unread carried back from one badge request. The badge
- * renders "99+" past two digits, so no reachable number of channels changes what
- * the user sees — this only stops an unbounded id list reaching the `inArray` in
- * getBatchPagePermissions (the hazard apps/web/eslint.config.mjs guards for
- * `findMany`, which cannot see a raw `db.execute`).
+ * Chunk size for the permission batch. What needs bounding is the `inArray`
+ * inside getBatchPagePermissions — the hazard apps/web/eslint.config.mjs guards
+ * for `findMany` but cannot see on a raw `db.execute`. Capping the candidate
+ * rows instead would be wrong: the cap would apply before permission filtering,
+ * so a user whose first N channels were all denied would be undercounted, or
+ * report zero, while unread messages they can plainly see sat past the cut.
+ * Chunking bounds each query without dropping any channel.
  */
-const MAX_UNREAD_CHANNELS = 500;
+const PERMISSION_BATCH_SIZE = 200;
 
 /**
  * Total unread channel messages across every drive the user owns or belongs to.
@@ -78,7 +80,6 @@ async function countChannelUnread(userId: string): Promise<number> {
         )
     ) x
     WHERE x.unread_count > 0
-    LIMIT ${MAX_UNREAD_CHANNELS}
   `);
 
   const rows = result.rows;
@@ -86,16 +87,21 @@ async function countChannelUnread(userId: string): Promise<number> {
 
   // Drive membership is not page access: a channel can be permissioned away
   // from a member. Filter through the centralized helper, never hand-rolled SQL.
-  const permissions = await getBatchPagePermissions(
-    userId,
-    rows.map((row) => row.id)
-  );
+  let total = 0;
+  for (let i = 0; i < rows.length; i += PERMISSION_BATCH_SIZE) {
+    const chunk = rows.slice(i, i + PERMISSION_BATCH_SIZE);
+    const permissions = await getBatchPagePermissions(
+      userId,
+      chunk.map((row) => row.id)
+    );
+    for (const row of chunk) {
+      if (permissions.get(row.id)?.canView) {
+        total += Number(row.unread_count) || 0;
+      }
+    }
+  }
 
-  return rows.reduce(
-    (sum, row) =>
-      permissions.get(row.id)?.canView ? sum + (Number(row.unread_count) || 0) : sum,
-    0
-  );
+  return total;
 }
 
 export async function GET(req: Request) {

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -46,7 +46,10 @@ const PERMISSION_BATCH_SIZE = 200;
  * N-member drive schedules N of these.
  *
  * `user_channels` is a cheap candidate filter, not the access decision — that
- * stays with getBatchPagePermissions below. It must therefore be no NARROWER
+ * stays with getBatchPagePermissions below. Its join and predicate are shared
+ * verbatim with both channel queries in apps/web/src/app/api/inbox/route.ts,
+ * which is what makes this badge and those pills agree about which channels
+ * exist; change one and change all three. It must therefore be no NARROWER
  * than the real rules or channels vanish before anyone asks about them, which
  * is why a page_permissions grant qualifies on its own: an explicit grant beats
  * membership in resolvePagePermissionRow, and sharing a single channel with

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -50,10 +50,15 @@ const PERMISSION_BATCH_SIZE = 200;
  * than the real rules or channels vanish before anyone asks about them, which
  * is why a page_permissions grant qualifies on its own: an explicit grant beats
  * membership in resolvePagePermissionRow, and sharing a single channel with
- * someone outside the drive is exactly what that path is for. It deliberately
- * ignores `expiresAt` and over-includes instead — an expired grant is denied a
- * few lines later by the helper that owns expiry, and matching the ORM's
- * timestamp binding by hand in raw SQL is how timezone bugs get written.
+ * someone outside the drive is exactly what that path is for. Expiry is matched
+ * too, so the candidate set does not carry rows the helper will only deny.
+ *
+ * `now() at time zone 'utc'` rather than `now()`: these columns store UTC wall
+ * clock as `timestamp without time zone`, while bare `now()` is a timestamptz
+ * rendered in the session's zone. Comparing the two is wrong in both directions
+ * — measured, a naive comparison keeps an expired grant alive in
+ * America/Los_Angeles and drops a live one in Asia/Tokyo — and invisible on
+ * UTC CI and production.
  *
  * A `mute` filter, when one exists, belongs as another predicate on
  * `user_channels` — nothing else here needs to change for it.
@@ -66,7 +71,10 @@ async function countChannelUnread(userId: string): Promise<number> {
       INNER JOIN drives d ON d.id = p."driveId"
       LEFT JOIN drive_members dm ON dm."driveId" = d.id AND dm."userId" = ${userId}
       LEFT JOIN page_permissions pp
-        ON pp."pageId" = p.id AND pp."userId" = ${userId} AND pp."canView" = true
+        ON pp."pageId" = p.id
+        AND pp."userId" = ${userId}
+        AND pp."canView" = true
+        AND (pp."expiresAt" IS NULL OR pp."expiresAt" > (now() at time zone 'utc'))
       WHERE p.type = 'CHANNEL'
         AND p."isTrashed" = false
         AND (

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -138,7 +138,10 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
                         <item.icon className="h-4 w-4 shrink-0" />
                         {item.name}
                         {item.badge > 0 && (
-                            <span className="ml-auto inline-flex items-center justify-center h-4 min-w-[16px] px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-medium tabular-nums">
+                            <span
+                                data-testid={`nav-badge-${item.name.toLowerCase().replace(/\s+/g, "-")}`}
+                                className="ml-auto inline-flex items-center justify-center h-4 min-w-[16px] px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-medium tabular-nums"
+                            >
                                 {item.badge > 99 ? "99+" : item.badge}
                             </span>
                         )}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -48,6 +48,9 @@ import { useFindStore } from '@/stores/useFindStore';
 import { useDraft } from '@/hooks/useDraft';
 import { buildDraftKey } from '@/lib/draft/draft';
 
+/** Coalesces the re-mark-as-read POST across a burst of incoming messages. */
+const MARK_READ_DEBOUNCE_MS = 1000;
+
 interface ChannelRef {
   id: string;
   driveId: string;
@@ -180,6 +183,43 @@ function ChannelView({ page }: ChannelViewProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page.id]);
 
+  const markChannelRead = useCallback(() => {
+    post<{ success: boolean; notificationsMarkedRead: number }>(`/api/channels/${page.id}/read`, {})
+      .then((res) => refetchNotificationsIfMarkedRead(res.notificationsMarkedRead))
+      .catch(() => {
+        // Silently ignore errors - marking as read is not critical
+      });
+  }, [page.id]);
+
+  // Advancing the watermark only on open left every message that arrived while
+  // you sat reading the channel counted as unread, inflating the sidebar badge
+  // until you navigated away and back. Re-mark as messages land, debounced so a
+  // busy channel does not POST per message, and only while the tab is actually
+  // visible — a backgrounded tab must not silently clear unread you never saw.
+  const markReadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleMarkChannelRead = useCallback(() => {
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+    if (markReadTimerRef.current) clearTimeout(markReadTimerRef.current);
+    markReadTimerRef.current = setTimeout(() => {
+      markReadTimerRef.current = null;
+      markChannelRead();
+    }, MARK_READ_DEBOUNCE_MS);
+  }, [markChannelRead]);
+
+  useEffect(() => () => {
+    if (markReadTimerRef.current) clearTimeout(markReadTimerRef.current);
+  }, []);
+
+  // Coming back to a tab that was hidden while messages arrived: those are on
+  // screen now, so clear them rather than waiting for the next message.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') markChannelRead();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [markChannelRead]);
+
   useEffect(() => {
     const fetchMessages = async () => {
       const res = await fetchWithAuth(`/api/channels/${page.id}/messages`);
@@ -189,14 +229,10 @@ function ChannelView({ page }: ChannelViewProps) {
       setNextCursor(data.nextCursor ?? null);
 
       // Mark channel as read when viewed
-      post<{ success: boolean; notificationsMarkedRead: number }>(`/api/channels/${page.id}/read`, {})
-        .then((res) => refetchNotificationsIfMarkedRead(res.notificationsMarkedRead))
-        .catch(() => {
-          // Silently ignore errors - marking as read is not critical
-        });
+      markChannelRead();
     };
     fetchMessages();
-  }, [page.id]);
+  }, [page.id, markChannelRead]);
 
   // Connect to socket store when user is available
   useEffect(() => {
@@ -227,6 +263,8 @@ function ChannelView({ page }: ChannelViewProps) {
         }
         return [...prev.filter(m => !m.id.startsWith('temp-')), message];
       });
+      // It is on screen now, so it is not unread.
+      scheduleMarkChannelRead();
     };
 
     const handleThreadCountUpdated = (data: {
@@ -251,7 +289,7 @@ function ChannelView({ page }: ChannelViewProps) {
       socket.off('new_message', handleNewMessage);
       socket.off('thread_reply_count_updated', handleThreadCountUpdated);
     };
-  }, [socket, connectionStatus, page.id]);
+  }, [socket, connectionStatus, page.id, scheduleMarkChannelRead]);
 
   const handleStartQuote = useCallback((m: MessageWithReactions) => {
     if (m.id.startsWith('temp-')) return;

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -206,9 +206,15 @@ function ChannelView({ page }: ChannelViewProps) {
     }, MARK_READ_DEBOUNCE_MS);
   }, [markChannelRead]);
 
+  // Keyed on page.id, not [], because CenterPanel reuses this component across
+  // channels: a timer left pending from the channel you just left would post a
+  // read for it a second after it stopped being on screen.
   useEffect(() => () => {
-    if (markReadTimerRef.current) clearTimeout(markReadTimerRef.current);
-  }, []);
+    if (markReadTimerRef.current) {
+      clearTimeout(markReadTimerRef.current);
+      markReadTimerRef.current = null;
+    }
+  }, [page.id]);
 
   // Coming back to a tab that was hidden while messages arrived: those are on
   // screen now, so clear them rather than waiting for the next message.

--- a/apps/web/src/hooks/__tests__/useSidebarBadges.test.ts
+++ b/apps/web/src/hooks/__tests__/useSidebarBadges.test.ts
@@ -14,8 +14,13 @@ import { createMockSocket } from '@/test/socket-mocks';
 
 const { mockMutate } = vi.hoisted(() => ({ mockMutate: vi.fn() }));
 const mockSocket = createMockSocket();
+// A second Socket instance stands in for the one useSocket mints on auth
+// refresh — it replaces the object rather than mutating it, so every consumer
+// effect re-subscribes.
+const refreshedSocket = createMockSocket();
+let currentSocket = mockSocket;
 
-vi.mock('../useSocket', () => ({ useSocket: () => mockSocket }));
+vi.mock('../useSocket', () => ({ useSocket: () => currentSocket }));
 
 vi.mock('swr', () => ({
   default: () => ({ data: undefined, mutate: mockMutate }),
@@ -37,6 +42,8 @@ describe('useSidebarBadges', () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     mockSocket._handlers.clear();
+    refreshedSocket._handlers.clear();
+    currentSocket = mockSocket;
   });
 
   afterEach(() => {
@@ -74,6 +81,23 @@ describe('useSidebarBadges', () => {
     flushDebounce();
 
     expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('still revalidates when the socket is replaced mid-debounce', () => {
+    // An auth refresh swaps the Socket instance, which re-runs the subscription
+    // effect. A debounce timer scoped to that effect would be cancelled by the
+    // cleanup and the badge would silently stay stale.
+    const { rerender } = renderHook(() => useSidebarBadges());
+    mockMutate.mockClear();
+
+    act(() => { mockSocket._trigger('inbox:channel_updated', { id: 'ch_1' }); });
+    currentSocket = refreshedSocket;
+    rerender();
+    flushDebounce();
+
+    expect(mockMutate).toHaveBeenCalled();
+    // and the new socket is the one now subscribed
+    expect(refreshedSocket._handlers.get('inbox:channel_updated')?.length).toBeGreaterThan(0);
   });
 
   it('removes its handlers and cancels a pending revalidation on unmount', () => {

--- a/apps/web/src/hooks/__tests__/useSidebarBadges.test.ts
+++ b/apps/web/src/hooks/__tests__/useSidebarBadges.test.ts
@@ -1,0 +1,92 @@
+/**
+ * useSidebarBadges live-update coverage.
+ *
+ * The Channels nav badge only ever moved on `notification:new` (an @mention),
+ * so an ordinary channel message left the number stale until a page reload —
+ * even though the server already fans `inbox:channel_updated` out to every
+ * viewable member's personal notifications room on each post. These tests pin
+ * the subscription list and the trailing debounce that keeps a busy channel
+ * from firing one badge refetch per message.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { createMockSocket } from '@/test/socket-mocks';
+
+const { mockMutate } = vi.hoisted(() => ({ mockMutate: vi.fn() }));
+const mockSocket = createMockSocket();
+
+vi.mock('../useSocket', () => ({ useSocket: () => mockSocket }));
+
+vi.mock('swr', () => ({
+  default: () => ({ data: undefined, mutate: mockMutate }),
+}));
+
+vi.mock('@/stores/useNotificationStore', () => ({
+  useNotificationStore: (selector: (state: { unreadCount: number }) => unknown) =>
+    selector({ unreadCount: 0 }),
+}));
+
+import { useSidebarBadges } from '../useSidebarBadges';
+
+const DEBOUNCE_MS = 250;
+
+const flushDebounce = () => act(() => { vi.advanceTimersByTime(DEBOUNCE_MS); });
+
+describe('useSidebarBadges', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockSocket._handlers.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('revalidates when a new channel message arrives', async () => {
+    renderHook(() => useSidebarBadges());
+    mockMutate.mockClear(); // the mount-effect revalidation is not what we assert
+
+    act(() => { mockSocket._trigger('inbox:channel_updated', { id: 'ch_1' }); });
+    flushDebounce();
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it.each([
+    'notification:new',
+    'inbox:dm_updated',
+    'inbox:channel_updated',
+    'inbox:thread_updated',
+    'inbox:read_status_changed',
+  ])('subscribes to %s', (event) => {
+    renderHook(() => useSidebarBadges());
+    expect(mockSocket._handlers.get(event)?.length).toBeGreaterThan(0);
+  });
+
+  it('coalesces a burst of events into a single revalidation', () => {
+    renderHook(() => useSidebarBadges());
+    mockMutate.mockClear();
+
+    act(() => {
+      for (let i = 0; i < 5; i++) mockSocket._trigger('inbox:channel_updated', { id: 'ch_1' });
+    });
+    flushDebounce();
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes its handlers and cancels a pending revalidation on unmount', () => {
+    const { unmount } = renderHook(() => useSidebarBadges());
+    act(() => { mockSocket._trigger('inbox:channel_updated', { id: 'ch_1' }); });
+
+    mockMutate.mockClear();
+    unmount();
+    flushDebounce();
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    for (const handlers of mockSocket._handlers.values()) {
+      expect(handlers).toHaveLength(0);
+    }
+  });
+});

--- a/apps/web/src/hooks/useSidebarBadges.ts
+++ b/apps/web/src/hooks/useSidebarBadges.ts
@@ -22,21 +22,41 @@ const fetcher = async (url: string): Promise<SidebarBadges> => {
 
 const EMPTY: SidebarBadges = { dms: 0, channels: 0, files: 0, tasks: 0, calendar: 0 };
 
+const SOCKET_EVENTS = [
+  'notification:new',
+  'inbox:dm_updated',
+  'inbox:channel_updated',
+  'inbox:thread_updated',
+  'inbox:read_status_changed',
+] as const;
+
+const REVALIDATE_DEBOUNCE_MS = 250;
+
 export function useSidebarBadges(): SidebarBadges {
   const socket = useSocket();
   const { data, mutate } = useSWR<SidebarBadges>('/api/sidebar/badges', fetcher);
 
-  // Revalidate when socket events arrive (new notifications, DM updates)
+  // Revalidate when socket events arrive. `inbox:channel_updated` is the one
+  // that fans out to every viewable member on a new channel message — without
+  // it the Channels badge only moved on mentions and stayed stale until reload.
+  //
+  // Debounced because channel traffic is burstier than DM/notification traffic
+  // and each event triggers a full /api/sidebar/badges refetch; undebounced, a
+  // busy channel fires one request per message.
   useEffect(() => {
     if (!socket) return;
-    const revalidate = () => void mutate();
-    socket.on('notification:new', revalidate);
-    socket.on('inbox:dm_updated', revalidate);
-    socket.on('inbox:read_status_changed', revalidate);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const revalidate = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        void mutate();
+      }, REVALIDATE_DEBOUNCE_MS);
+    };
+    for (const event of SOCKET_EVENTS) socket.on(event, revalidate);
     return () => {
-      socket.off('notification:new', revalidate);
-      socket.off('inbox:dm_updated', revalidate);
-      socket.off('inbox:read_status_changed', revalidate);
+      if (timer) clearTimeout(timer);
+      for (const event of SOCKET_EVENTS) socket.off(event, revalidate);
     };
   }, [socket, mutate]);
 

--- a/apps/web/src/hooks/useSidebarBadges.ts
+++ b/apps/web/src/hooks/useSidebarBadges.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import useSWR from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocket } from './useSocket';
@@ -43,19 +43,28 @@ export function useSidebarBadges(): SidebarBadges {
   // Debounced because channel traffic is burstier than DM/notification traffic
   // and each event triggers a full /api/sidebar/badges refetch; undebounced, a
   // busy channel fires one request per message.
+  // The pending timer is a ref, not effect-local, and the effect's cleanup
+  // deliberately does not clear it. `socket` identity is replaced on every auth
+  // refresh (useSocket mints a new Socket rather than mutating the old one), so
+  // an effect-local timer meant an event landing in the 250ms either side of a
+  // token refresh had its revalidation cancelled by the re-subscribe and never
+  // fired — leaving the badge stale until the next event. Only unmount cancels.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
   useEffect(() => {
     if (!socket) return;
-    let timer: ReturnType<typeof setTimeout> | null = null;
     const revalidate = () => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        timer = null;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
         void mutate();
       }, REVALIDATE_DEBOUNCE_MS);
     };
     for (const event of SOCKET_EVENTS) socket.on(event, revalidate);
     return () => {
-      if (timer) clearTimeout(timer);
       for (const event of SOCKET_EVENTS) socket.off(event, revalidate);
     };
   }, [socket, mutate]);

--- a/packages/lib/src/permissions/__tests__/page-viewers.integration.test.ts
+++ b/packages/lib/src/permissions/__tests__/page-viewers.integration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration tests for `getUsersWhoCanViewPage`.
+ *
+ * Requires a running Postgres database with the latest migrations applied.
+ * Run via:
+ *   ./scripts/test-with-db.sh
+ *   bun run --filter '@pagespace/lib' test -- src/permissions/__tests__/page-viewers.integration.test.ts
+ *
+ * Why this exists as an integration test rather than a unit test: the decision
+ * itself is already pinned without a database (resolve-page-permission-row.test.ts).
+ * What is NOT provable there is the half that actually broke — the query. The
+ * channel inbox fan-out used to resolve recipients with its own joins covering
+ * drive owners, admins and explicit grants, but not the rule that any accepted
+ * member can view a non-private page, so ordinary members of a public channel
+ * silently stopped receiving events for channels they can plainly read.
+ *
+ * A wrong join produces exactly that failure again while every pure-function
+ * test stays green, so the assertion that matters is the round trip: for every
+ * user, `getUsersWhoCanViewPage` must agree with `getBatchPagePermissions`,
+ * which is the function the rest of the app asks. Each case below therefore
+ * checks the membership set AND cross-checks it against the other direction.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { factories } from '@pagespace/db/test/factories';
+import { db } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { drives, pages } from '@pagespace/db/schema/core';
+import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
+import { getUsersWhoCanViewPage, getBatchPagePermissions } from '../permissions';
+
+/**
+ * The invariant: asking "who can see this page" and asking each of them "can
+ * you see this page" must return the same set. Drift between the two is the
+ * bug class this whole helper exists to make impossible.
+ */
+async function expectAgreesWithPerUserCheck(pageId: string, candidateIds: string[]) {
+  const viewers = await getUsersWhoCanViewPage(pageId, candidateIds);
+
+  const perUser = new Set<string>();
+  for (const userId of candidateIds) {
+    const perms = await getBatchPagePermissions(userId, [pageId]);
+    if (perms.get(pageId)?.canView) perUser.add(userId);
+  }
+
+  expect([...viewers].sort()).toEqual([...perUser].sort());
+  return viewers;
+}
+
+describe('getUsersWhoCanViewPage (integration)', () => {
+  beforeEach(async () => {
+    await db.delete(pagePermissions);
+    await db.delete(pages);
+    await db.delete(driveMembers);
+    await db.delete(drives);
+    await db.delete(users);
+  });
+
+  it('includes an accepted member of a non-private channel with no explicit grant', async () => {
+    // The regression case: this user has no page_permissions row and is not an
+    // admin, so the old hand-written fan-out query dropped them entirely.
+    const owner = await factories.createUser();
+    const member = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: false });
+    await factories.createDriveMember(drive.id, member.id);
+
+    const viewers = await expectAgreesWithPerUserCheck(channel.id, [owner.id, member.id]);
+
+    expect(viewers.has(member.id)).toBe(true);
+    expect(viewers.has(owner.id)).toBe(true);
+  });
+
+  it('excludes a member of a PRIVATE page unless explicitly granted', async () => {
+    const owner = await factories.createUser();
+    const plain = await factories.createUser();
+    const granted = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const page = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: true });
+    await factories.createDriveMember(drive.id, plain.id);
+    await factories.createDriveMember(drive.id, granted.id);
+    await factories.createPagePermission(page.id, granted.id, { canView: true });
+
+    const viewers = await expectAgreesWithPerUserCheck(page.id, [plain.id, granted.id]);
+
+    expect(viewers.has(plain.id)).toBe(false);
+    expect(viewers.has(granted.id)).toBe(true);
+  });
+
+  it('honours an explicit deny over member access to a non-private page', async () => {
+    const owner = await factories.createUser();
+    const denied = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: false });
+    await factories.createDriveMember(drive.id, denied.id);
+    await factories.createPagePermission(channel.id, denied.id, { canView: false });
+
+    const viewers = await expectAgreesWithPerUserCheck(channel.id, [denied.id]);
+
+    expect(viewers.has(denied.id)).toBe(false);
+  });
+
+  it('includes a non-member holding an unexpired grant, and excludes an expired one', async () => {
+    const owner = await factories.createUser();
+    const outsider = await factories.createUser();
+    const expired = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: false });
+    // Neither is a drive member — the grant is the only reason they'd qualify.
+    await factories.createPagePermission(channel.id, outsider.id, {
+      canView: true,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    await factories.createPagePermission(channel.id, expired.id, {
+      canView: true,
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const viewers = await expectAgreesWithPerUserCheck(channel.id, [outsider.id, expired.id]);
+
+    expect(viewers.has(outsider.id)).toBe(true);
+    expect(viewers.has(expired.id)).toBe(false);
+  });
+
+  it('excludes an invitee who has not accepted', async () => {
+    const owner = await factories.createUser();
+    const pending = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: false });
+    await factories.createDriveMember(drive.id, pending.id, { acceptedAt: null });
+
+    const viewers = await expectAgreesWithPerUserCheck(channel.id, [pending.id]);
+
+    expect(viewers.has(pending.id)).toBe(false);
+  });
+
+  it('excludes a stranger with no membership and no grant', async () => {
+    const owner = await factories.createUser();
+    const stranger = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: false });
+
+    const viewers = await expectAgreesWithPerUserCheck(channel.id, [stranger.id]);
+
+    expect(viewers.has(stranger.id)).toBe(false);
+  });
+
+  it('grants nobody on a trashed page, member or owner', async () => {
+    const owner = await factories.createUser();
+    const member = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, {
+      type: 'CHANNEL',
+      isPrivate: false,
+      isTrashed: true,
+    });
+    await factories.createDriveMember(drive.id, member.id);
+
+    const viewers = await expectAgreesWithPerUserCheck(channel.id, [owner.id, member.id]);
+
+    expect(viewers.size).toBe(0);
+  });
+
+  it('evaluates every candidate across the chunk boundary', async () => {
+    // The candidate list is chunked at 200; a chunking bug silently drops the
+    // tail, which reads as "those members just do not get notified".
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL', isPrivate: false });
+
+    const members: string[] = [];
+    for (let i = 0; i < 205; i++) {
+      const u = await factories.createUser();
+      await factories.createDriveMember(drive.id, u.id);
+      members.push(u.id);
+    }
+
+    const viewers = await getUsersWhoCanViewPage(channel.id, members);
+
+    expect(viewers.size).toBe(members.length);
+    // Specifically the ones past the first chunk.
+    expect(viewers.has(members[200])).toBe(true);
+    expect(viewers.has(members[204])).toBe(true);
+  });
+
+  it('returns nobody for an empty candidate list without touching the database', async () => {
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const channel = await factories.createPage(drive.id, { type: 'CHANNEL' });
+
+    expect((await getUsersWhoCanViewPage(channel.id, [])).size).toBe(0);
+  });
+});

--- a/packages/lib/src/permissions/__tests__/resolve-page-permission-row.test.ts
+++ b/packages/lib/src/permissions/__tests__/resolve-page-permission-row.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The page-access decision, tested without a database.
+ *
+ * This function exists so the two directions of the same question resolve
+ * identically: getBatchPagePermissions ("which pages can this user see?") and
+ * getUsersWhoCanViewPage ("which users can see this page?"). They previously
+ * had separate implementations and drifted — the channel inbox fan-out knew
+ * about owners, admins and explicit grants but not rule 4 or custom roles, so
+ * ordinary members of a public channel were silently dropped from fan-out.
+ *
+ * These cases pin the precedence order, which is what a second implementation
+ * gets wrong first.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolvePagePermissionRow, type PagePermissionRow } from '../permissions';
+
+const USER = 'user_me';
+const OTHER = 'user_other';
+
+const row = (overrides: Partial<PagePermissionRow> = {}): PagePermissionRow => ({
+  pageId: 'page_1',
+  isTrashed: false,
+  isPrivate: false,
+  pageType: 'CHANNEL',
+  driveOwnerId: OTHER,
+  memberRole: null,
+  explicitCanView: null,
+  explicitCanEdit: null,
+  explicitCanShare: null,
+  explicitCanDelete: null,
+  customRolePerms: null,
+  customRoleDriveWidePerms: null,
+  ...overrides,
+});
+
+describe('resolvePagePermissionRow', () => {
+  it('grants nothing on a trashed page, whoever is asking', () => {
+    expect(resolvePagePermissionRow(row({ isTrashed: true, driveOwnerId: USER }), USER)).toBeNull();
+  });
+
+  it('gives the drive owner everything', () => {
+    expect(resolvePagePermissionRow(row({ driveOwnerId: USER }), USER)).toEqual({
+      canView: true, canEdit: true, canShare: true, canDelete: true,
+    });
+  });
+
+  it('gives a drive admin everything', () => {
+    expect(resolvePagePermissionRow(row({ memberRole: 'ADMIN' }), USER)).toEqual({
+      canView: true, canEdit: true, canShare: true, canDelete: true,
+    });
+  });
+
+  // Rule 4 — the case the fan-out's hand-written copy was missing.
+  it('lets an accepted member view a non-private page with no explicit grant', () => {
+    const resolved = resolvePagePermissionRow(row({ memberRole: 'MEMBER' }), USER);
+    expect(resolved?.canView).toBe(true);
+  });
+
+  it('lets an accepted member post in a channel but not in other page types', () => {
+    expect(resolvePagePermissionRow(row({ memberRole: 'MEMBER' }), USER)?.canEdit).toBe(true);
+    expect(
+      resolvePagePermissionRow(row({ memberRole: 'MEMBER', pageType: 'DOCUMENT' }), USER)?.canEdit
+    ).toBe(false);
+  });
+
+  it('does not let a member view a PRIVATE page without a grant', () => {
+    expect(resolvePagePermissionRow(row({ memberRole: 'MEMBER', isPrivate: true }), USER)).toBeNull();
+  });
+
+  it('grants nothing to a non-member with no grant', () => {
+    expect(resolvePagePermissionRow(row(), USER)).toBeNull();
+  });
+
+  it('grants nothing to an unaccepted invitee (memberRole is null until accepted)', () => {
+    // getBatchPagePermissions joins driveMembers on acceptedAt IS NOT NULL, so a
+    // pending invite arrives here as memberRole: null.
+    expect(resolvePagePermissionRow(row({ memberRole: null }), USER)).toBeNull();
+  });
+
+  describe('precedence', () => {
+    it('an explicit deny overrides rule 4 for a member of a non-private page', () => {
+      const resolved = resolvePagePermissionRow(
+        row({ memberRole: 'MEMBER', explicitCanView: false }),
+        USER
+      );
+      expect(resolved).toEqual({
+        canView: false, canEdit: false, canShare: false, canDelete: false,
+      });
+    });
+
+    it('an explicit grant opens a private page to a member', () => {
+      const resolved = resolvePagePermissionRow(
+        row({ memberRole: 'MEMBER', isPrivate: true, explicitCanView: true }),
+        USER
+      );
+      expect(resolved?.canView).toBe(true);
+    });
+
+    it('owner/admin beats an explicit deny', () => {
+      expect(
+        resolvePagePermissionRow(row({ driveOwnerId: USER, explicitCanView: false }), USER)?.canView
+      ).toBe(true);
+      expect(
+        resolvePagePermissionRow(row({ memberRole: 'ADMIN', explicitCanView: false }), USER)?.canView
+      ).toBe(true);
+    });
+
+    it('a custom role decides before rule 4 falls back', () => {
+      const resolved = resolvePagePermissionRow(
+        row({
+          memberRole: 'MEMBER',
+          isPrivate: true,
+          customRolePerms: { page_1: { canView: true, canEdit: false, canShare: false } },
+        }),
+        USER
+      );
+      expect(resolved?.canView).toBe(true);
+      // Custom roles never confer delete.
+      expect(resolved?.canDelete).toBe(false);
+    });
+  });
+});

--- a/packages/lib/src/permissions/__tests__/resolve-page-permission-row.test.ts
+++ b/packages/lib/src/permissions/__tests__/resolve-page-permission-row.test.ts
@@ -118,5 +118,23 @@ describe('resolvePagePermissionRow', () => {
       // Custom roles never confer delete.
       expect(resolved?.canDelete).toBe(false);
     });
+
+    it('falls back to the custom role drive-wide grant when the page has no entry', () => {
+      // resolveCustomRolePermissions takes two inputs — the per-page entry and
+      // the drive-wide default. Only the former is exercised above, and the
+      // fallback is the half a second implementation is likeliest to drop.
+      const resolved = resolvePagePermissionRow(
+        row({
+          memberRole: 'MEMBER',
+          isPrivate: true,
+          customRolePerms: {},
+          customRoleDriveWidePerms: { canView: true, canEdit: true, canShare: false },
+        }),
+        USER
+      );
+      expect(resolved?.canView).toBe(true);
+      expect(resolved?.canEdit).toBe(true);
+      expect(resolved?.canDelete).toBe(false);
+    });
   });
 });

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -980,8 +980,12 @@ export interface PagePermissionRow {
   explicitCanEdit: boolean | null;
   explicitCanShare: boolean | null;
   explicitCanDelete: boolean | null;
-  customRolePerms: unknown;
-  customRoleDriveWidePerms: unknown;
+  // Typed, not `unknown`: drive_roles.permissions and .driveWidePermissions
+  // carry $type annotations that are structurally CustomRolePerms and PagePerm,
+  // so both selects already yield these — nullable because they arrive through a
+  // leftJoin. Declaring them here keeps the decision function free of casts.
+  customRolePerms: CustomRolePerms | null;
+  customRoleDriveWidePerms: PagePerm | null;
 }
 
 /**
@@ -1021,10 +1025,11 @@ export function resolvePagePermissionRow(
   }
 
   if (row.customRolePerms) {
-    const perms = row.customRolePerms as CustomRolePerms;
-    const driveWide = row.customRoleDriveWidePerms as PagePerm | null;
     const resolved = resolveCustomRolePermissions(
-      { permissions: perms, driveWidePermissions: driveWide },
+      {
+        permissions: row.customRolePerms,
+        driveWidePermissions: row.customRoleDriveWidePerms,
+      },
       row.pageId,
     );
     if (resolved !== null) {
@@ -1227,7 +1232,7 @@ export async function getUsersWhoCanViewPage(
       }
     }
   } catch (error) {
-    loggers.api.error('[BATCH_PERMISSIONS] Error resolving page viewers', {
+    loggers.api.error('[PAGE_VIEWERS] Error resolving page viewers', {
       pageId,
       candidateCount: candidateUserIds.length,
       error: error instanceof Error ? error.message : String(error),

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -2,6 +2,7 @@ import { db } from '@pagespace/db/db';
 import { and, eq, or, isNull, isNotNull, gt, inArray } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { driveMembers, pagePermissions, driveRoles } from '@pagespace/db/schema/members';
+import { users } from '@pagespace/db/schema/auth';
 import { loggers } from '../logging/logger-config';
 import { parseUserId, parsePageId } from '../validators/id-validators';
 import { fetchCustomRolePermissions, resolveCustomRolePermissions, type CustomRolePerms, type PagePerm } from './membership-queries';
@@ -978,6 +979,87 @@ export async function usersShareDrive(
  * `map.get(pageId)?.canView` without conditional-path handling for missing
  * entries.
  */
+/**
+ * One joined row of page + drive + this user's membership/grants, as selected by
+ * both page-permission queries below.
+ */
+export interface PagePermissionRow {
+  pageId: string;
+  isTrashed: boolean | null;
+  isPrivate: boolean | null;
+  pageType: string | null;
+  driveOwnerId: string | null;
+  memberRole: string | null;
+  explicitCanView: boolean | null;
+  explicitCanEdit: boolean | null;
+  explicitCanShare: boolean | null;
+  explicitCanDelete: boolean | null;
+  customRolePerms: unknown;
+  customRoleDriveWidePerms: unknown;
+}
+
+/**
+ * The page-access decision itself, with no database in it.
+ *
+ * Extracted so the two directions of the same question — "which of these pages
+ * can this user see?" (getBatchPagePermissions) and "which of these users can
+ * see this page?" (getUsersWhoCanViewPage) — resolve through one implementation
+ * and cannot drift apart. They had drifted: the channel inbox fan-out grew its
+ * own recipient query that knew about owners, admins and explicit grants but
+ * not about rule 4 or custom roles, so ordinary drive members silently stopped
+ * receiving events for channels they can plainly read.
+ *
+ * Returns null when the row grants nothing (the caller's default deny stands).
+ */
+export function resolvePagePermissionRow(
+  row: PagePermissionRow,
+  userId: string
+): PermissionLevel | null {
+  if (row.isTrashed) return null;
+
+  const isOwner = row.driveOwnerId === userId;
+  const isAdmin = row.memberRole === 'ADMIN';
+  const isMember = row.memberRole !== null;
+
+  if (isOwner || isAdmin) {
+    return { canView: true, canEdit: true, canShare: true, canDelete: true };
+  }
+
+  if (row.explicitCanView !== null) {
+    return {
+      canView: row.explicitCanView ?? false,
+      canEdit: row.explicitCanEdit ?? false,
+      canShare: row.explicitCanShare ?? false,
+      canDelete: row.explicitCanDelete ?? false,
+    };
+  }
+
+  if (row.customRolePerms) {
+    const perms = row.customRolePerms as CustomRolePerms;
+    const driveWide = row.customRoleDriveWidePerms as PagePerm | null;
+    const resolved = resolveCustomRolePermissions(
+      { permissions: perms, driveWidePermissions: driveWide },
+      row.pageId,
+    );
+    if (resolved !== null) {
+      return { ...resolved, canDelete: false };
+    }
+  }
+
+  // Rule 4: any accepted drive member gets access to non-private pages.
+  // Channels grant canEdit so members can post messages (Discord/Slack semantics).
+  if (isMember && !row.isPrivate) {
+    return {
+      canView: true,
+      canEdit: row.pageType === 'CHANNEL',
+      canShare: false,
+      canDelete: false,
+    };
+  }
+
+  return null;
+}
+
 export async function getBatchPagePermissions(
   userId: string,
   pageIds: string[]
@@ -1046,57 +1128,9 @@ export async function getBatchPagePermissions(
       .where(inArray(pages.id, pageIds));
 
     for (const row of rows) {
-      if (row.isTrashed) {
-        continue;
-      }
-
-      const isOwner = row.driveOwnerId === userId;
-      const isAdmin = row.memberRole === 'ADMIN';
-      const isMember = row.memberRole !== null;
-
-      if (isOwner || isAdmin) {
-        results.set(row.pageId, {
-          canView: true,
-          canEdit: true,
-          canShare: true,
-          canDelete: true,
-        });
-        continue;
-      }
-
-      if (row.explicitCanView !== null) {
-        results.set(row.pageId, {
-          canView: row.explicitCanView ?? false,
-          canEdit: row.explicitCanEdit ?? false,
-          canShare: row.explicitCanShare ?? false,
-          canDelete: row.explicitCanDelete ?? false,
-        });
-        continue;
-      }
-
-      if (row.customRolePerms) {
-        const perms = row.customRolePerms as CustomRolePerms;
-        const driveWide = row.customRoleDriveWidePerms as PagePerm | null;
-        const resolved = resolveCustomRolePermissions(
-          { permissions: perms, driveWidePermissions: driveWide },
-          row.pageId,
-        );
-        if (resolved !== null) {
-          results.set(row.pageId, { ...resolved, canDelete: false });
-          continue;
-        }
-      }
-
-      // Rule 4: any accepted drive member gets access to non-private pages.
-      // Channels grant canEdit so members can post messages (Discord/Slack semantics).
-      if (isMember && !row.isPrivate) {
-        const canEdit = row.pageType === 'CHANNEL';
-        results.set(row.pageId, {
-          canView: true,
-          canEdit,
-          canShare: false,
-          canDelete: false,
-        });
+      const resolved = resolvePagePermissionRow(row, userId);
+      if (resolved) {
+        results.set(row.pageId, resolved);
       }
     }
 
@@ -1109,4 +1143,86 @@ export async function getBatchPagePermissions(
     });
     return results;
   }
+}
+
+/**
+ * Which of `candidateUserIds` can view `pageId` — the inverse of
+ * getBatchPagePermissions, for fan-out paths that must decide who to notify.
+ *
+ * Same joins, pivoted over users instead of pages, and the same decision via
+ * resolvePagePermissionRow, so the two can never disagree about who has access.
+ * Fails closed: on error nobody is returned.
+ */
+export async function getUsersWhoCanViewPage(
+  pageId: string,
+  candidateUserIds: string[]
+): Promise<Set<string>> {
+  const viewers = new Set<string>();
+  if (candidateUserIds.length === 0) return viewers;
+
+  try {
+    const rows = await db
+      .select({
+        pageId: pages.id,
+        userId: users.id,
+        isTrashed: pages.isTrashed,
+        isPrivate: pages.isPrivate,
+        pageType: pages.type,
+        driveOwnerId: drives.ownerId,
+        memberRole: driveMembers.role,
+        explicitCanView: pagePermissions.canView,
+        explicitCanEdit: pagePermissions.canEdit,
+        explicitCanShare: pagePermissions.canShare,
+        explicitCanDelete: pagePermissions.canDelete,
+        customRolePerms: driveRoles.permissions,
+        customRoleDriveWidePerms: driveRoles.driveWidePermissions,
+      })
+      .from(pages)
+      // One row per candidate user for this single page, so every candidate is
+      // evaluated even when they have no membership or grant rows at all.
+      .innerJoin(users, inArray(users.id, candidateUserIds))
+      .leftJoin(drives, eq(drives.id, pages.driveId))
+      .leftJoin(
+        driveMembers,
+        and(
+          eq(driveMembers.driveId, pages.driveId),
+          eq(driveMembers.userId, users.id),
+          isNotNull(driveMembers.acceptedAt)
+        )
+      )
+      .leftJoin(
+        pagePermissions,
+        and(
+          eq(pagePermissions.pageId, pages.id),
+          eq(pagePermissions.userId, users.id),
+          or(
+            isNull(pagePermissions.expiresAt),
+            gt(pagePermissions.expiresAt, new Date())
+          )
+        )
+      )
+      .leftJoin(
+        driveRoles,
+        and(
+          eq(driveRoles.id, driveMembers.customRoleId),
+          eq(driveRoles.driveId, pages.driveId)
+        )
+      )
+      .where(eq(pages.id, pageId));
+
+    for (const row of rows) {
+      if (resolvePagePermissionRow(row, row.userId)?.canView) {
+        viewers.add(row.userId);
+      }
+    }
+  } catch (error) {
+    loggers.api.error('[BATCH_PERMISSIONS] Error resolving page viewers', {
+      pageId,
+      candidateCount: candidateUserIds.length,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return new Set<string>();
+  }
+
+  return viewers;
 }

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -1146,6 +1146,14 @@ export async function getBatchPagePermissions(
 }
 
 /**
+ * Chunk size for the candidate list. Callers build it from drive membership,
+ * which is unbounded — the channel fan-out's own findMany carries a lint
+ * exemption saying so — and a whole drive's worth of ids in one `IN` list is
+ * the thing to avoid. Mirrors PERMISSION_BATCH_SIZE in the sidebar badges route.
+ */
+const VIEWER_BATCH_SIZE = 200;
+
+/**
  * Which of `candidateUserIds` can view `pageId` — the inverse of
  * getBatchPagePermissions, for fan-out paths that must decide who to notify.
  *
@@ -1161,58 +1169,61 @@ export async function getUsersWhoCanViewPage(
   if (candidateUserIds.length === 0) return viewers;
 
   try {
-    const rows = await db
-      .select({
-        pageId: pages.id,
-        userId: users.id,
-        isTrashed: pages.isTrashed,
-        isPrivate: pages.isPrivate,
-        pageType: pages.type,
-        driveOwnerId: drives.ownerId,
-        memberRole: driveMembers.role,
-        explicitCanView: pagePermissions.canView,
-        explicitCanEdit: pagePermissions.canEdit,
-        explicitCanShare: pagePermissions.canShare,
-        explicitCanDelete: pagePermissions.canDelete,
-        customRolePerms: driveRoles.permissions,
-        customRoleDriveWidePerms: driveRoles.driveWidePermissions,
-      })
-      .from(pages)
-      // One row per candidate user for this single page, so every candidate is
-      // evaluated even when they have no membership or grant rows at all.
-      .innerJoin(users, inArray(users.id, candidateUserIds))
-      .leftJoin(drives, eq(drives.id, pages.driveId))
-      .leftJoin(
-        driveMembers,
-        and(
-          eq(driveMembers.driveId, pages.driveId),
-          eq(driveMembers.userId, users.id),
-          isNotNull(driveMembers.acceptedAt)
-        )
-      )
-      .leftJoin(
-        pagePermissions,
-        and(
-          eq(pagePermissions.pageId, pages.id),
-          eq(pagePermissions.userId, users.id),
-          or(
-            isNull(pagePermissions.expiresAt),
-            gt(pagePermissions.expiresAt, new Date())
+    for (let i = 0; i < candidateUserIds.length; i += VIEWER_BATCH_SIZE) {
+      const chunk = candidateUserIds.slice(i, i + VIEWER_BATCH_SIZE);
+      const rows = await db
+        .select({
+          pageId: pages.id,
+          userId: users.id,
+          isTrashed: pages.isTrashed,
+          isPrivate: pages.isPrivate,
+          pageType: pages.type,
+          driveOwnerId: drives.ownerId,
+          memberRole: driveMembers.role,
+          explicitCanView: pagePermissions.canView,
+          explicitCanEdit: pagePermissions.canEdit,
+          explicitCanShare: pagePermissions.canShare,
+          explicitCanDelete: pagePermissions.canDelete,
+          customRolePerms: driveRoles.permissions,
+          customRoleDriveWidePerms: driveRoles.driveWidePermissions,
+        })
+        .from(pages)
+        // One row per candidate user for this single page, so every candidate is
+        // evaluated even when they have no membership or grant rows at all.
+        .innerJoin(users, inArray(users.id, chunk))
+        .leftJoin(drives, eq(drives.id, pages.driveId))
+        .leftJoin(
+          driveMembers,
+          and(
+            eq(driveMembers.driveId, pages.driveId),
+            eq(driveMembers.userId, users.id),
+            isNotNull(driveMembers.acceptedAt)
           )
         )
-      )
-      .leftJoin(
-        driveRoles,
-        and(
-          eq(driveRoles.id, driveMembers.customRoleId),
-          eq(driveRoles.driveId, pages.driveId)
+        .leftJoin(
+          pagePermissions,
+          and(
+            eq(pagePermissions.pageId, pages.id),
+            eq(pagePermissions.userId, users.id),
+            or(
+              isNull(pagePermissions.expiresAt),
+              gt(pagePermissions.expiresAt, new Date())
+            )
+          )
         )
-      )
-      .where(eq(pages.id, pageId));
+        .leftJoin(
+          driveRoles,
+          and(
+            eq(driveRoles.id, driveMembers.customRoleId),
+            eq(driveRoles.driveId, pages.driveId)
+          )
+        )
+        .where(eq(pages.id, pageId));
 
-    for (const row of rows) {
-      if (resolvePagePermissionRow(row, row.userId)?.canView) {
-        viewers.add(row.userId);
+      for (const row of rows) {
+        if (resolvePagePermissionRow(row, row.userId)?.canView) {
+          viewers.add(row.userId);
+        }
       }
     }
   } catch (error) {

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -966,20 +966,6 @@ export async function usersShareDrive(
 }
 
 /**
- * Batch permission lookup for multiple pages in a single DB round-trip.
- *
- * One SQL statement joins `pages`, `drives`, `drive_members` (for ADMIN role,
- * accepted members only), and `page_permissions` (with `expires_at` filter)
- * across all requested page IDs. Ordering is irrelevant; the result map keys
- * on pageId.
- *
- * Returns an entry for every `pageId` in input — pages the user cannot access
- * (including non-existent, trashed, or expired-grant pages) are represented
- * with all four flags set to `false`. Callers can therefore read
- * `map.get(pageId)?.canView` without conditional-path handling for missing
- * entries.
- */
-/**
  * One joined row of page + drive + this user's membership/grants, as selected by
  * both page-permission queries below.
  */
@@ -1060,6 +1046,20 @@ export function resolvePagePermissionRow(
   return null;
 }
 
+/**
+ * Batch permission lookup for multiple pages in a single DB round-trip.
+ *
+ * One SQL statement joins `pages`, `drives`, `drive_members` (for ADMIN role,
+ * accepted members only), and `page_permissions` (with `expires_at` filter)
+ * across all requested page IDs. Ordering is irrelevant; the result map keys
+ * on pageId.
+ *
+ * Returns an entry for every `pageId` in input — pages the user cannot access
+ * (including non-existent, trashed, or expired-grant pages) are represented
+ * with all four flags set to `false`. Callers can therefore read
+ * `map.get(pageId)?.canView` without conditional-path handling for missing
+ * entries.
+ */
 export async function getBatchPagePermissions(
   userId: string,
   pageIds: string[]


### PR DESCRIPTION
## What

The number beside **Channels** in the left sidebar's primary nav was unread `MENTION` notifications joined to `pages.type = 'CHANNEL'`. A plain message in a channel you belong to produces no mention notification, so the badge sat at zero while the channel filled up — and disagreed with the per-channel pills on the `/channels` route, which have always been watermark-derived.

It now counts unread **messages**, updates live, reaches the people who can actually read the channel, and stops counting messages you've already watched arrive.

## How

**`api/sidebar/badges/route.ts`** — `channels` comes from `countChannelUnread(userId)`, counting messages past the user's `channel_read_status` watermark across channels in drives they own or belong to. Same watermark and self-vs-agent rule as `/api/inbox`, so the nav number and the per-channel pills agree. Drive membership is not page access, so rows go through `getBatchPagePermissions` — chunked, so the bound sits on the permission query rather than on the candidate set (capping candidates would undercount when denied channels sort first). Mentions are subsumed, not lost.

It deliberately does **not** spell the query the same way as `/api/inbox`. That form aggregates `channel_messages` whole and restricts afterwards, which the planner cannot push down — the restriction is a join qual, and join quals aren't pushed beneath a `GROUP BY`. Measured on 400k messages across 500 channels with the user in 10:

| form | plan | buffers | time |
|---|---|---|---|
| `/api/inbox`'s form | parallel seq scan + aggregate over all 500 channels | 2952 | 52ms |
| `INNER JOIN` inside the aggregate | still drives from `channel_messages` | 2958 | 85ms |
| **`CROSS JOIN LATERAL`** (this PR) | nested loop, one index lookup per user channel | **148** | **1.4ms** |

This endpoint is hit on every page load, and one message in an N-member drive schedules N of them.

**`permissions.ts` + `channels/[pageId]/messages/route.ts`** — the badge counted messages for readers the fan-out never told. `fanOutChannelInboxUpdate` resolved recipients with its own query (owner + `ADMIN` + explicit `page_permissions`), while page access is decided by `getBatchPagePermissions`, whose rule 4 grants any accepted member access to a non-private page, and which honours custom roles. So an ordinary member of a public channel — the most common reader there is — was never sent `inbox:channel_updated`, and their count only moved on an unrelated revalidation. The gap was one-directional (narrower than real access), so a staleness bug, not a leak.

Rather than add a third copy of the rules, the decision is now one pure function, `resolvePagePermissionRow`, shared by both directions: `getBatchPagePermissions` ("which pages can this user see?") and a new `getUsersWhoCanViewPage` ("which users can see this page?"), the same joins pivoted over users. They can't drift apart again by construction.

**`hooks/useSidebarBadges.ts`** — subscribes to `inbox:channel_updated` and `inbox:thread_updated`, debounced 250ms (a busy channel would otherwise fire one full badge refetch per message). The timer is a ref, not effect-local: `socket` identity is replaced on auth refresh, and an effect-local timer had its pending revalidation cancelled by the re-subscribe.

**`ChannelView.tsx`** — the watermark only advanced on open, so messages arriving while you sat reading the channel stayed unread and inflated the badge until you navigated away and back. It now re-marks read as messages land, debounced, only while the tab is visible so a backgrounded tab never clears unread you didn't see, and cancelled on channel switch so a pending post can't land against the channel you just left.

**`api/inbox/route.ts`** — added the missing `isActive = true` to both unread CTEs. Soft-deleted messages counted as unread, leaving a number beside a channel with nothing to show.

No schema change, no migration, no new route. `PrimaryNavigation.tsx` already renders `badges.channels` with the `99+` clamp, so there's no UI diff.

## Validation

- **Tests** — 8 badge-route, 9 hook, 12 permission-precedence, plus the existing inbox (14) and channel-messages suites still green; 448 lib permission tests pass.
- **Everything claimed is mutation-checked.** Each fix was reverted in turn and confirmed to turn exactly the intended test red: the permission filter (pinned against a *present-but-denied* entry — `permissions.has(id)` passed before), the per-badge wiring (a transposed `Promise.all` destructuring), the degrade path, the socket-swap case, the batch boundary, and rule 4 in the shared decision.
- **SQL verified against real Postgres**, not just typecheck: the LATERAL form returns row-for-row identical results to the old form across the watermark, absent read rows, own-vs-agent-vs-webhook senders, soft-deleted messages, trashed pages and non-channel pages.
- `bun run typecheck` (monorepo) 17/17 and `bun run lint` 15/15. Rebased on master tip, no conflicts.

**End-to-end, in a real browser over a real socket** — `tests/19-channels-badge-live.spec.ts`, added to `E2E_SPECS`. All three pass in CI: the count appears for an ordinary accepted MEMBER while they sit in a different drive with no reload; opening the channel clears it; a channel they cannot see never counts. The poll is ruled out by a measured control rather than assumed — the badge endpoint is hit exactly twice at mount (~365ms) and never again across 60s idle, so a future `refreshInterval` fails the control loudly.

## Robustness

The channel count sits in a `Promise.all` whose rejection 500s the route, which the client renders as all five badges blank rather than one. It degrades to zero and logs instead, matching `getBatchPagePermissions`, which already swallows its own failures into an all-deny map. `getUsersWhoCanViewPage` fails closed.

## Out of scope

Mute. No mute concept exists anywhere in the codebase; the query is shaped so a mute filter drops onto `user_channels` as one extra predicate, and the comment in the route says so.

Still inherited from `/api/inbox`: a user newly added to an old busy channel sees its full history as unread until they open it (`COALESCE(lastReadAt, epoch)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtsZBRLSQfwLAruGpwaaWo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel sidebar badges now include all unread messages from accessible channels.
  * Unread counts update in real time and remain accurate across background tabs.
  * Reading messages in an open channel clears its unread badge automatically.
  * Deleted messages and messages from inaccessible channels are excluded.
  * Channel access and inbox visibility now consistently respect page permissions.

* **Bug Fixes**
  * Improved unread-count accuracy and handling when channels or message data are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
