### PR TITLE
feat(drive-envs): environment services, CRUD API, permissions and quota (ships dark)

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/rebuild/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/rebuild/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Rebuild an environment's machine — `POST /api/drives/[driveId]/envs/[envId]/rebuild`.
+ *
+ * Its own sub-route, and a POST, because it is an ACT rather than an edit to the
+ * env's fields: PATCH on the parent means "these are the env's new attributes",
+ * and nothing about a rebuild changes an attribute — same id, same name, same
+ * address, new machine. The drive's other imperative verbs (`restore`,
+ * `publish-home`, `verify`) are shaped the same way.
+ *
+ * **This is the ONLY sprite-replacing verb**, and it is destructive by design:
+ * the environment's filesystem does not survive. That is what the caller is
+ * asking for — a wedged daemon, a full disk, a dependency tree past saving — and
+ * it is why the gate is drive OWNER or ADMIN rather than anyone who may run code
+ * in the env. `rebuildDriveEnv` owns the ordering: the old Sprite must be
+ * CONFIRMED dead before the new one is minted, because the Sprite name is
+ * deterministic in the env id and provisioning first would hand back the same
+ * disk while reporting a rebuild.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  checkMCPDriveScope,
+  isPrincipalDriveOwnerOrAdmin,
+} from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { rebuildEnv, resolveEnvInDrive } from '@/lib/drive-envs/drive-envs-runtime';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+export async function POST(request: Request, context: { params: Promise<{ driveId: string; envId: string }> }) {
+  try {
+    const { driveId, envId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'rebuild', envId },
+      });
+      return NextResponse.json({ error: 'Only drive owners and admins can rebuild environments' }, { status: 403 });
+    }
+
+    if (!(await resolveEnvInDrive(envId, driveId))) {
+      return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+    }
+
+    const result = await rebuildEnv({ envId, requesterId: auth.userId });
+    if (!result.ok) {
+      if (result.reason === 'not_found') return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+      // Both remaining failures leave the env intact and retryable — the
+      // teardown one still on its old machine, the provision one machineless
+      // until the next ensure — so both are 503 rather than a 4xx the client
+      // could read as "stop asking".
+      loggers.api.error(
+        `Drive environment rebuild failed (${result.reason})`,
+        new Error(result.detail),
+        { envId },
+      );
+      return NextResponse.json({ error: 'Could not rebuild the environment', reason: result.reason }, { status: 503 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { route: 'drive-envs', operation: 'rebuild', envId },
+    });
+
+    return NextResponse.json({ rebuilt: true });
+  } catch (error) {
+    loggers.api.error('Failed to rebuild drive environment', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to rebuild environment' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/route.ts
@@ -1,0 +1,183 @@
+/**
+ * One drive environment — `/api/drives/[driveId]/envs/[envId]`.
+ *
+ * GET    → { env }                 — any accepted member of the drive
+ * PATCH  { name } → { env }        — drive OWNER or ADMIN
+ * DELETE ?force=true → { deleted }  — drive OWNER or ADMIN
+ *
+ * **`driveId` is checked against the row, not trusted from the path.** An env's
+ * id is globally unique, so a member of drive A could otherwise reach drive B's
+ * env by nesting its id under a drive they do belong to. The mismatch answers
+ * 404 rather than 403: telling a stranger that an id exists elsewhere is itself
+ * the leak.
+ *
+ * **DELETE is the destructive verb.** It refuses while sessions are live inside
+ * the env (409) unless `?force=true`, because deleting the row CASCADES those
+ * sessions away — see `deleteDriveEnv`, which owns the ordering (guard → kill →
+ * confirm → row) and aborts the delete if the kill could not be confirmed.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  checkMCPDriveScope,
+  isPrincipalDriveMember,
+  isPrincipalDriveOwnerOrAdmin,
+} from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { renameDriveEnvRequestSchema } from '@pagespace/lib/drive-envs/env-contract';
+import {
+  deleteEnv,
+  renameEnv,
+  resolveEnvInDrive,
+  toDriveEnvDTO,
+} from '@/lib/drive-envs/drive-envs-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+export async function GET(request: Request, context: { params: Promise<{ driveId: string; envId: string }> }) {
+  try {
+    const { driveId, envId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveMember(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'read', envId },
+      });
+      return NextResponse.json({ error: 'Not a member of this drive' }, { status: 403 });
+    }
+
+    const env = await resolveEnvInDrive(envId, driveId);
+    if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+
+    return NextResponse.json({ env: toDriveEnvDTO(env) });
+  } catch (error) {
+    loggers.api.error('Failed to read drive environment', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to read environment' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, context: { params: Promise<{ driveId: string; envId: string }> }) {
+  try {
+    const { driveId, envId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'rename', envId },
+      });
+      return NextResponse.json({ error: 'Only drive owners and admins can rename environments' }, { status: 403 });
+    }
+
+    if (!(await resolveEnvInDrive(envId, driveId))) {
+      return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = renameDriveEnvRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'A non-empty environment name is required' }, { status: 400 });
+    }
+
+    const result = await renameEnv({ envId, name: parsed.data.name });
+    if (!result.ok) {
+      if (result.reason === 'not_found') return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+      return NextResponse.json({ error: 'An environment with this name already exists' }, { status: 409 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { route: 'drive-envs', operation: 'rename', envId, name: result.env.name },
+    });
+
+    return NextResponse.json({ env: toDriveEnvDTO(result.env) });
+  } catch (error) {
+    loggers.api.error('Failed to rename drive environment', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to rename environment' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, context: { params: Promise<{ driveId: string; envId: string }> }) {
+  try {
+    const { driveId, envId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'delete', envId },
+      });
+      return NextResponse.json({ error: 'Only drive owners and admins can delete environments' }, { status: 403 });
+    }
+
+    if (!(await resolveEnvInDrive(envId, driveId))) {
+      return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+    }
+
+    // Opt-in by exact value: any other spelling reads as "not forced", so a
+    // stray `?force` or `?force=0` can never destroy a drive's shared work.
+    const force = new URL(request.url).searchParams.get('force') === 'true';
+    const result = await deleteEnv({ envId, force });
+
+    if (!result.ok) {
+      if (result.reason === 'not_found') return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+      if (result.reason === 'live_sessions') {
+        return NextResponse.json(
+          {
+            error: 'Sessions are still running in this environment',
+            reason: 'live_sessions',
+            liveSessionCount: result.liveSessionCount,
+          },
+          { status: 409 },
+        );
+      }
+      // The kill could not be confirmed, so the row was deliberately NOT
+      // deleted: it is the reconciler's only handle on a VM that may still be
+      // running. A retry is the right client behavior, hence 503.
+      loggers.api.error('Drive environment teardown failed', new Error(result.detail), { envId });
+      return NextResponse.json({ error: 'Could not tear down the environment machine', reason: 'teardown_failed' }, { status: 503 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.delete',
+      userId: auth.userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { route: 'drive-envs', operation: 'delete', envId, force, spriteTornDown: result.spriteTornDown },
+    });
+
+    return NextResponse.json({ deleted: true, spriteTornDown: result.spriteTornDown });
+  } catch (error) {
+    loggers.api.error('Failed to delete drive environment', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to delete environment' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/route.ts
@@ -161,8 +161,10 @@ export async function DELETE(request: Request, context: { params: Promise<{ driv
         );
       }
       // The kill could not be confirmed, so the row was deliberately NOT
-      // deleted: it is the reconciler's only handle on a VM that may still be
-      // running. A retry is the right client behavior, hence 503.
+      // deleted: it is the only remaining pointer at a VM that may still be
+      // running, and for a surviving env row the retry is a later delete or
+      // rebuild rather than a cron. A retry is the right client behavior,
+      // hence 503.
       loggers.api.error('Drive environment teardown failed', new Error(result.detail), { envId });
       return NextResponse.json({ error: 'Could not tear down the environment machine', reason: 'teardown_failed' }, { status: 503 });
     }

--- a/apps/web/src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Contract tests for `/api/drives/[driveId]/envs/**`.
+ *
+ * Mocked at the SERVICE SEAM (the drive-envs runtime), not the ORM: what these
+ * assert is the route's own contract — who is let through which verb, how a
+ * service result becomes a status code, and the two guards that live in the
+ * route rather than in the service (the env-belongs-to-this-drive check and the
+ * `?force=` parse).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn(), auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+}));
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(() => false),
+  checkMCPDriveScope: vi.fn().mockReturnValue(null),
+  isPrincipalDriveMember: vi.fn(),
+  isPrincipalDriveOwnerOrAdmin: vi.fn(),
+}));
+vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({
+  createEnvInDrive: vi.fn(),
+  listEnvsInDrive: vi.fn(),
+  renameEnv: vi.fn(),
+  deleteEnv: vi.fn(),
+  rebuildEnv: vi.fn(),
+  resolveEnvInDrive: vi.fn(),
+  toDriveEnvDTO: vi.fn((row: { id: string; driveId: string; name: string }) => ({
+    id: row.id,
+    driveId: row.driveId,
+    name: row.name,
+    status: 'none',
+    createdAt: '2026-08-17T12:00:00.000Z',
+  })),
+}));
+
+import { GET as listEnvs, POST as createEnv } from '../route';
+import { GET as readEnv, PATCH as patchEnv, DELETE as deleteEnvRoute } from '../[envId]/route';
+import { POST as rebuildEnvRoute } from '../[envId]/rebuild/route';
+import { isPrincipalDriveMember, isPrincipalDriveOwnerOrAdmin, authenticateRequestWithOptions } from '@/lib/auth';
+import {
+  createEnvInDrive,
+  deleteEnv,
+  listEnvsInDrive,
+  rebuildEnv,
+  renameEnv,
+  resolveEnvInDrive,
+} from '@/lib/drive-envs/drive-envs-runtime';
+
+const DRIVE_ID = 'drive-1';
+const ENV_ID = 'env-1';
+const USER_ID = 'user-1';
+
+const params = { params: Promise.resolve({ driveId: DRIVE_ID }) };
+const envParams = { params: Promise.resolve({ driveId: DRIVE_ID, envId: ENV_ID }) };
+
+function req(url = `http://localhost/api/drives/${DRIVE_ID}/envs`, init?: RequestInit): Request {
+  return new Request(url, init);
+}
+
+function jsonReq(body: unknown, url = `http://localhost/api/drives/${DRIVE_ID}/envs`): Request {
+  return new Request(url, { method: 'POST', body: JSON.stringify(body), headers: { 'content-type': 'application/json' } });
+}
+
+const envRow = { id: ENV_ID, driveId: DRIVE_ID, name: 'staging' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: USER_ID } as never);
+  vi.mocked(isPrincipalDriveMember).mockResolvedValue(true);
+  vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(true);
+  vi.mocked(resolveEnvInDrive).mockResolvedValue(envRow as never);
+});
+
+describe('GET /envs — who may SEE a drive"s machines', () => {
+  it('given an accepted member, should list', async () => {
+    vi.mocked(listEnvsInDrive).mockResolvedValue([]);
+    const response = await listEnvs(req(), params);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ envs: [] });
+  });
+
+  it('given a non-member, should refuse — membership, not mere authentication', async () => {
+    vi.mocked(isPrincipalDriveMember).mockResolvedValue(false);
+    const response = await listEnvs(req(), params);
+    expect(response.status).toBe(403);
+    expect(listEnvsInDrive).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /envs — who may CREATE one', () => {
+  it('given a plain MEMBER, should refuse — an env is drive infrastructure', async () => {
+    // Deliberately NOT the read gate: seeing a machine and administering one
+    // are different authorities, and a member passes the first.
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+    const response = await createEnv(jsonReq({ name: 'staging' }), params);
+    expect(response.status).toBe(403);
+    expect(createEnvInDrive).not.toHaveBeenCalled();
+  });
+
+  it('given an admin and a valid name, should create and answer 201', async () => {
+    vi.mocked(createEnvInDrive).mockResolvedValue({ ok: true, env: envRow } as never);
+    const response = await createEnv(jsonReq({ name: '  staging  ' }), params);
+    expect(response.status).toBe(201);
+    // Trimmed at the boundary: `(driveId, name)` uniqueness makes the name an
+    // address, so ' staging ' and 'staging' must not become two envs.
+    expect(createEnvInDrive).toHaveBeenCalledWith({ driveId: DRIVE_ID, name: 'staging', createdBy: USER_ID });
+  });
+
+  it('given a blank name, should answer 400 without touching the service', async () => {
+    const response = await createEnv(jsonReq({ name: '   ' }), params);
+    expect(response.status).toBe(400);
+    expect(createEnvInDrive).not.toHaveBeenCalled();
+  });
+
+  it('given a duplicate name, should answer 409', async () => {
+    vi.mocked(createEnvInDrive).mockResolvedValue({ ok: false, reason: 'name_taken' } as never);
+    const response = await createEnv(jsonReq({ name: 'staging' }), params);
+    expect(response.status).toBe(409);
+  });
+
+  it('given the payer is at their ceiling, should answer 402 and name the limit', async () => {
+    vi.mocked(createEnvInDrive).mockResolvedValue({
+      ok: false,
+      reason: 'quota_exceeded',
+      denial: 'env_limit_reached',
+      limit: 2,
+    } as never);
+    const response = await createEnv(jsonReq({ name: 'staging' }), params);
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({ reason: 'env_limit_reached', limit: 2 });
+  });
+
+  it('given an ineligible tier, should answer 403 — a forbidden feature, not a reached ceiling', async () => {
+    vi.mocked(createEnvInDrive).mockResolvedValue({
+      ok: false,
+      reason: 'quota_exceeded',
+      denial: 'tier_ineligible',
+      limit: 0,
+    } as never);
+    const response = await createEnv(jsonReq({ name: 'staging' }), params);
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('the env-belongs-to-this-drive guard', () => {
+  it('given an env id from ANOTHER drive, should answer 404 on read — never 403, which would confirm it exists', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue(null);
+    const response = await readEnv(req(), envParams);
+    expect(response.status).toBe(404);
+  });
+
+  it('given an env id from another drive, should answer 404 on delete WITHOUT deleting', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue(null);
+    const response = await deleteEnvRoute(
+      req(`http://localhost/api/drives/${DRIVE_ID}/envs/${ENV_ID}`, { method: 'DELETE' }),
+      envParams,
+    );
+    expect(response.status).toBe(404);
+    expect(deleteEnv).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /envs/[envId] — rename', () => {
+  it('given a plain member, should refuse', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+    const response = await patchEnv(jsonReq({ name: 'prod' }), envParams);
+    expect(response.status).toBe(403);
+    expect(renameEnv).not.toHaveBeenCalled();
+  });
+
+  it('given a taken name, should answer 409', async () => {
+    vi.mocked(renameEnv).mockResolvedValue({ ok: false, reason: 'name_taken' } as never);
+    const response = await patchEnv(jsonReq({ name: 'prod' }), envParams);
+    expect(response.status).toBe(409);
+  });
+
+  it('given an admin and a free name, should rename', async () => {
+    vi.mocked(renameEnv).mockResolvedValue({ ok: true, env: { ...envRow, name: 'prod' } } as never);
+    const response = await patchEnv(jsonReq({ name: 'prod' }), envParams);
+    expect(response.status).toBe(200);
+    expect(renameEnv).toHaveBeenCalledWith({ envId: ENV_ID, name: 'prod' });
+  });
+});
+
+describe('DELETE /envs/[envId] — the destructive verb', () => {
+  function del(query = ''): Request {
+    return req(`http://localhost/api/drives/${DRIVE_ID}/envs/${ENV_ID}${query}`, { method: 'DELETE' });
+  }
+
+  it('should NOT force by default', async () => {
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: true, spriteTornDown: false } as never);
+    await deleteEnvRoute(del(), envParams);
+    expect(deleteEnv).toHaveBeenCalledWith({ envId: ENV_ID, force: false });
+  });
+
+  it('given ?force=true, should force', async () => {
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: true, spriteTornDown: true } as never);
+    await deleteEnvRoute(del('?force=true'), envParams);
+    expect(deleteEnv).toHaveBeenCalledWith({ envId: ENV_ID, force: true });
+  });
+
+  it('given a bare or non-"true" force flag, should NOT force — a stray query must not destroy shared work', async () => {
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: true, spriteTornDown: false } as never);
+    await deleteEnvRoute(del('?force'), envParams);
+    await deleteEnvRoute(del('?force=1'), envParams);
+    await deleteEnvRoute(del('?force=TRUE'), envParams);
+    for (const call of vi.mocked(deleteEnv).mock.calls) expect(call[0]).toEqual({ envId: ENV_ID, force: false });
+  });
+
+  it('given live sessions, should answer 409 and report the count', async () => {
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: false, reason: 'live_sessions', liveSessionCount: 3 } as never);
+    const response = await deleteEnvRoute(del(), envParams);
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ reason: 'live_sessions', liveSessionCount: 3 });
+  });
+
+  it('given an unconfirmed teardown, should answer 503 — the env survives and a retry is right', async () => {
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: false, reason: 'teardown_failed', detail: 'boom' } as never);
+    const response = await deleteEnvRoute(del(), envParams);
+    expect(response.status).toBe(503);
+  });
+
+  it('given a plain member, should refuse before any delete is attempted', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+    const response = await deleteEnvRoute(del('?force=true'), envParams);
+    expect(response.status).toBe(403);
+    expect(deleteEnv).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /envs/[envId]/rebuild — the only sprite-replacing verb', () => {
+  const rebuildReq = () =>
+    req(`http://localhost/api/drives/${DRIVE_ID}/envs/${ENV_ID}/rebuild`, { method: 'POST' });
+
+  it('given a plain member, should refuse — rebuilding destroys a shared filesystem', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+    const response = await rebuildEnvRoute(rebuildReq(), envParams);
+    expect(response.status).toBe(403);
+    expect(rebuildEnv).not.toHaveBeenCalled();
+  });
+
+  it('given an admin, should rebuild AS that requester', async () => {
+    vi.mocked(rebuildEnv).mockResolvedValue({ ok: true, sandboxId: 'pgs-env-abc' } as never);
+    const response = await rebuildEnvRoute(rebuildReq(), envParams);
+    expect(response.status).toBe(200);
+    expect(rebuildEnv).toHaveBeenCalledWith({ envId: ENV_ID, requesterId: USER_ID });
+  });
+
+  it('given the teardown failed, should answer 503 and say so', async () => {
+    vi.mocked(rebuildEnv).mockResolvedValue({ ok: false, reason: 'teardown_failed', detail: 'boom' } as never);
+    const response = await rebuildEnvRoute(rebuildReq(), envParams);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ reason: 'teardown_failed' });
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/envs/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/route.ts
@@ -1,0 +1,140 @@
+/**
+ * Drive Environments API — `/api/drives/[driveId]/envs`.
+ *
+ * An environment is a PERSISTENT, drive-owned machine: named, shared by the
+ * drive's members, and outliving every session that runs inside it. It is drive
+ * INFRASTRUCTURE, which is why this route family nests under the drive (unlike
+ * `/api/agent-workspaces/**`, which is flat because a session belongs to no
+ * single container) and why its write verbs are owner/admin-only.
+ *
+ * GET    → { envs: DriveEnvDTO[] }   — any accepted member of the drive
+ * POST   { name } → 201 { env }      — drive OWNER or ADMIN
+ *
+ * SHIPS DARK: nothing in the UI links here yet. The routes exist so the
+ * sessions-inside-an-env work has something to build against.
+ *
+ * Two refusals are worth naming, because they are the ones a client will meet:
+ * `409 name_taken` (an env is addressed by name, so `(driveId, name)` is
+ * unique) and `402 env_limit_reached` / `403 tier_ineligible` from the per-plan
+ * environment allowance — an env row is the billed persistence unit, metered
+ * against the DRIVE OWNER, so a free-tier drive gets none at all.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  checkMCPDriveScope,
+  isPrincipalDriveMember,
+  isPrincipalDriveOwnerOrAdmin,
+} from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { createDriveEnvRequestSchema } from '@pagespace/lib/drive-envs/env-contract';
+import { createEnvInDrive, listEnvsInDrive, toDriveEnvDTO } from '@/lib/drive-envs/drive-envs-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+export async function GET(request: Request, context: { params: Promise<{ driveId: string }> }) {
+  try {
+    const { driveId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    // Reading the drive's machines is a MEMBER capability: an env is shared
+    // infrastructure, and a member who may spawn a session inside one has to be
+    // able to see it exists. Administering it is a different question, below.
+    if (!(await isPrincipalDriveMember(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'list' },
+      });
+      return NextResponse.json({ error: 'Not a member of this drive' }, { status: 403 });
+    }
+
+    return NextResponse.json({ envs: await listEnvsInDrive(driveId) });
+  } catch (error) {
+    loggers.api.error('Failed to list drive environments', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to list environments' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request, context: { params: Promise<{ driveId: string }> }) {
+  try {
+    const { driveId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'create' },
+      });
+      return NextResponse.json({ error: 'Only drive owners and admins can create environments' }, { status: 403 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = createDriveEnvRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'A non-empty environment name is required' }, { status: 400 });
+    }
+
+    const result = await createEnvInDrive({ driveId, name: parsed.data.name, createdBy: auth.userId });
+    if (!result.ok) {
+      if (result.reason === 'drive_not_found') {
+        return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+      }
+      if (result.reason === 'name_taken') {
+        return NextResponse.json({ error: 'An environment with this name already exists' }, { status: 409 });
+      }
+      // Quota. The two denials get DIFFERENT statuses because they have
+      // different remedies: an ineligible tier is a forbidden feature (403),
+      // a reached ceiling is a payment-required upgrade or a deletion (402) —
+      // the same split the sandbox quota surfaces elsewhere.
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'create', denial: result.denial, limit: result.limit },
+      });
+      return NextResponse.json(
+        {
+          error:
+            result.denial === 'tier_ineligible'
+              ? 'Environments are not available on this plan'
+              : 'Environment limit reached for this plan',
+          reason: result.denial,
+          limit: result.limit,
+        },
+        { status: result.denial === 'tier_ineligible' ? 403 : 402 },
+      );
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { route: 'drive-envs', operation: 'create', envId: result.env.id, name: result.env.name },
+    });
+
+    return NextResponse.json({ env: toDriveEnvDTO(result.env) }, { status: 201 });
+  } catch (error) {
+    loggers.api.error('Failed to create drive environment', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to create environment' }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/drive-envs/__tests__/drive-envs-runtime.test.ts
+++ b/apps/web/src/lib/drive-envs/__tests__/drive-envs-runtime.test.ts
@@ -1,0 +1,209 @@
+/**
+ * The env provisioning WIRING — the seams `ensureSpriteHolderSandbox` is handed.
+ *
+ * The provisioning core is deliberately holder-agnostic: it derives no Sprite
+ * key, resolves no tenant, and picks no authorization gate of its own. Every one
+ * of those is injected, which means the env's correctness on those axes lives
+ * HERE, in ten lines of wiring, and nowhere else. Two of them are silent if
+ * wrong:
+ *
+ *  - **The keyspace.** Session keys fold `agent-session-sprite:v2`, envs fold
+ *    `drive-env-sprite:v1`. Wiring the session derivation here would put env
+ *    names and session names in ONE keyspace, where an env could derive the name
+ *    of a session Sprite still awaiting reclaim and provision straight onto a VM
+ *    the reclaim outbox is about to kill. Nothing downstream would notice.
+ *  - **The tenant.** The fold's tenant is the DRIVE OWNER. Using the requester
+ *    would give one env two different Sprite identities depending on who
+ *    rebuilt it — the same split `resolveSessionTenantId` fails closed to avoid.
+ *
+ * So this asserts what the wiring passes, not what the core does with it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const ENV_ID = 'env-1';
+const DRIVE_ID = 'drive-1';
+const DRIVE_OWNER_ID = 'owner-1';
+const REQUESTER_ID = 'requester-9';
+const SECRET = 'x'.repeat(40);
+
+const envRow = {
+  id: ENV_ID,
+  driveId: DRIVE_ID,
+  name: 'staging',
+  createdBy: DRIVE_OWNER_ID,
+  spriteKey: null,
+  sandboxId: null,
+  spriteInstanceId: null,
+  egressPolicyToken: null,
+  teardownRequestedAt: null,
+  spriteTornDownAt: null,
+  storageLastBilledAt: new Date(),
+  storageMeasuredBytes: null,
+  storageMeasuredAt: null,
+  lastActiveAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { query: { drives: { findFirst: vi.fn() }, users: { findFirst: vi.fn() } } },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(() => ({})) }));
+vi.mock('@pagespace/db/schema/core', () => ({ drives: {} }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: {} }));
+vi.mock('@pagespace/lib/services/sandbox/machine-session-manager', () => ({
+  getSandboxSessionSecret: () => SECRET,
+}));
+vi.mock('@pagespace/lib/services/sandbox/network-options', () => ({
+  resolveSandboxNetworkOptions: () => ({}),
+}));
+vi.mock('@pagespace/lib/services/sandbox/egress-ip', () => ({ getConfiguredEgressIpTag: () => undefined }));
+vi.mock('@pagespace/lib/services/sandbox/containment', () => ({
+  decideFullEgressEnablement: () => ({ ok: true }),
+  isContainmentVerified: () => true,
+}));
+vi.mock('@pagespace/lib/services/sandbox/can-run-code', () => ({
+  canRunCode: vi.fn(async () => ({ ok: true })),
+  isCodeExecutionEnabled: () => true,
+}));
+vi.mock('@pagespace/lib/services/drive-envs/drive-envs-store', () => ({
+  createDbDriveEnvStore: async () => ({}),
+}));
+vi.mock('@/lib/agent-workspaces/agent-workspaces-runtime', () => ({ getSandboxHost: async () => ({}) }));
+
+/**
+ * `rebuildDriveEnv` is replaced by a probe that does ONE thing: hand the
+ * runtime's own `ensureSandbox` a row, which is exactly the call the real
+ * service makes after a confirmed teardown. The service's ordering is covered
+ * by its own suite; what is under test here is the deps that call builds.
+ */
+vi.mock('@pagespace/lib/services/drive-envs/drive-envs', () => ({
+  rebuildDriveEnv: vi.fn(async ({ deps }: { deps: { ensureSandbox: (row: unknown) => Promise<unknown> } }) => {
+    await deps.ensureSandbox(envRow);
+    return { ok: true, sandboxId: 'pgs-env-probe' };
+  }),
+  createDriveEnv: vi.fn(),
+  listDriveEnvs: vi.fn(),
+  renameDriveEnv: vi.fn(),
+  deleteDriveEnv: vi.fn(),
+  toDriveEnvDTO: vi.fn(),
+}));
+
+const ensureSpriteHolderSandbox = vi.fn(async (_input: unknown) => ({
+  ok: true,
+  sandboxId: 'pgs-env-probe',
+  resumed: false,
+}));
+vi.mock('@pagespace/lib/services/agent-workspaces/agent-workspace-sprite', () => ({
+  ensureSpriteHolderSandbox: (input: unknown) => ensureSpriteHolderSandbox(input),
+}));
+
+import { rebuildEnv } from '../drive-envs-runtime';
+import { deriveDriveEnvSpriteKey } from '@pagespace/lib/drive-envs/env-sprite-key';
+import { deriveAgentSessionSpriteKey } from '@pagespace/lib/agent-workspaces/workspace-sprite-key';
+import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
+import { db } from '@pagespace/db/db';
+
+type ProvisionCall = {
+  row: { holderId: string; endedAt: Date | null };
+  intent: string;
+  deps: {
+    deriveSpriteKey: (holderId: string) => string;
+    authorize: () => Promise<{ ok: boolean; reason?: string }>;
+    checkQuota: (input: { alreadyProvisioned: boolean }) => Promise<{ allowed: boolean; denial?: string; reason?: string }>;
+  };
+};
+
+function lastProvisionCall(): ProvisionCall {
+  const call = ensureSpriteHolderSandbox.mock.calls.at(-1) as unknown[] | undefined;
+  if (!call) throw new Error('ensureSpriteHolderSandbox was never called');
+  return call[0] as ProvisionCall;
+}
+
+function stubPayer(tier: string): void {
+  vi.mocked(db.query.drives.findFirst).mockResolvedValue({ ownerId: DRIVE_OWNER_ID } as never);
+  vi.mocked(db.query.users.findFirst).mockResolvedValue({ subscriptionTier: tier } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stubPayer('pro');
+});
+
+describe('rebuildEnv wiring', () => {
+  it('should fold the Sprite key in the ENV keyspace, tenanted on the DRIVE OWNER', async () => {
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+
+    const derived = lastProvisionCall().deps.deriveSpriteKey(ENV_ID);
+    expect(derived).toBe(
+      deriveDriveEnvSpriteKey({ tenantId: DRIVE_OWNER_ID, envId: ENV_ID, secret: SECRET }),
+    );
+    expect(derived.startsWith('pgs-env-')).toBe(true);
+  });
+
+  it('should NEVER derive a session name for an env — one keyspace would let an env land on a session VM awaiting reclaim', async () => {
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+
+    const derived = lastProvisionCall().deps.deriveSpriteKey(ENV_ID);
+    const sessionName = deriveAgentSessionSpriteKey({
+      tenantId: DRIVE_OWNER_ID,
+      workspaceId: ENV_ID,
+      secret: SECRET,
+    });
+    expect(derived).not.toBe(sessionName);
+  });
+
+  it('should NOT tenant the fold on the requester — one env must not have two Sprite identities', async () => {
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+
+    const derived = lastProvisionCall().deps.deriveSpriteKey(ENV_ID);
+    expect(derived).not.toBe(
+      deriveDriveEnvSpriteKey({ tenantId: REQUESTER_ID, envId: ENV_ID, secret: SECRET }),
+    );
+  });
+
+  it('should authorize the REQUESTER against the env\'s drive, billed to the drive owner', async () => {
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+    await lastProvisionCall().deps.authorize();
+
+    expect(canRunCode).toHaveBeenCalledWith({
+      userId: REQUESTER_ID,
+      driveId: DRIVE_ID,
+      ownerId: DRIVE_OWNER_ID,
+      requestOrigin: 'user',
+    });
+  });
+
+  it('should provision with the ENSURE intent — the same CAS every other provisioner runs', async () => {
+    // `reprovision` would skip the probe and mint against a row the teardown
+    // already cleared; the point of going through the one core is that this
+    // path is not special.
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+    expect(lastProvisionCall().intent).toBe('ensure');
+    expect(lastProvisionCall().row.holderId).toBe(ENV_ID);
+  });
+
+  it('given a payer whose tier lost sandbox access, should refuse at the mint site', async () => {
+    stubPayer('free');
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+
+    const quota = await lastProvisionCall().deps.checkQuota({ alreadyProvisioned: false });
+    expect(quota).toEqual({ allowed: false, denial: 'not_authorized', reason: 'tier_ineligible' });
+  });
+
+  it('given an eligible payer, should let the mint through — the env ALLOWANCE is metered at create, not here', async () => {
+    const quota = await (async () => {
+      await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+      return lastProvisionCall().deps.checkQuota({ alreadyProvisioned: false });
+    })();
+    expect(quota).toEqual({ allowed: true });
+  });
+
+  it('given a vanished drive, should fail closed rather than fold under another tenant', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(undefined as never);
+
+    await rebuildEnv({ envId: ENV_ID, requesterId: REQUESTER_ID });
+
+    expect(ensureSpriteHolderSandbox).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/drive-envs/__tests__/drive-envs-runtime.test.ts
+++ b/apps/web/src/lib/drive-envs/__tests__/drive-envs-runtime.test.ts
@@ -89,38 +89,53 @@ vi.mock('@pagespace/lib/services/drive-envs/drive-envs', () => ({
   toDriveEnvDTO: vi.fn(),
 }));
 
-const ensureSpriteHolderSandbox = vi.fn(async (_input: unknown) => ({
-  ok: true,
-  sandboxId: 'pgs-env-probe',
-  resumed: false,
-}));
+/**
+ * Typed FROM THE REAL EXPORT, not from a hand-written shape.
+ *
+ * This suite exists to catch drift in what the wiring hands the provisioner, so
+ * a locally re-declared deps type would defeat it in the one case that matters:
+ * `SpriteHolderProvisionDeps` gaining or renaming a seam would leave these tests
+ * compiling green against a contract that no longer exists (CodeRabbit's
+ * nitpick, and it is right that a stale-but-compiling assertion is worse here
+ * than elsewhere).
+ */
+const ensureSpriteHolderSandbox =
+  vi.fn<(input: EnsureSpriteHolderInput) => Promise<EnsureSpriteHolderSandboxResult>>(async () => ({
+    ok: true,
+    sandboxId: 'pgs-env-probe',
+    resumed: false,
+  }));
 vi.mock('@pagespace/lib/services/agent-workspaces/agent-workspace-sprite', () => ({
-  ensureSpriteHolderSandbox: (input: unknown) => ensureSpriteHolderSandbox(input),
+  ensureSpriteHolderSandbox: (input: EnsureSpriteHolderInput) => ensureSpriteHolderSandbox(input),
 }));
 
+import type {
+  EnsureSpriteHolderSandboxResult,
+  SpriteHolderProvisionDeps,
+  SpriteHolderProvisionIntent,
+} from '@pagespace/lib/services/agent-workspaces/agent-workspace-sprite';
+import type { SpriteHolderLifecycleRow } from '@pagespace/lib/agent-workspaces/plan-workspace-lifecycle';
+import type { SubscriptionTier } from '@pagespace/lib/billing/subscription-tiers';
 import { rebuildEnv } from '../drive-envs-runtime';
+
+/** The core's own call shape — derived, so a change to it breaks this suite instead of sliding past. */
+type EnsureSpriteHolderInput = {
+  row: SpriteHolderLifecycleRow;
+  intent: SpriteHolderProvisionIntent;
+  deps: SpriteHolderProvisionDeps;
+};
 import { deriveDriveEnvSpriteKey } from '@pagespace/lib/drive-envs/env-sprite-key';
 import { deriveAgentSessionSpriteKey } from '@pagespace/lib/agent-workspaces/workspace-sprite-key';
 import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 import { db } from '@pagespace/db/db';
 
-type ProvisionCall = {
-  row: { holderId: string; endedAt: Date | null };
-  intent: string;
-  deps: {
-    deriveSpriteKey: (holderId: string) => string;
-    authorize: () => Promise<{ ok: boolean; reason?: string }>;
-    checkQuota: (input: { alreadyProvisioned: boolean }) => Promise<{ allowed: boolean; denial?: string; reason?: string }>;
-  };
-};
-
-function lastProvisionCall(): ProvisionCall {
-  const call = ensureSpriteHolderSandbox.mock.calls.at(-1) as unknown[] | undefined;
+function lastProvisionCall(): EnsureSpriteHolderInput {
+  const call = ensureSpriteHolderSandbox.mock.calls.at(-1);
   if (!call) throw new Error('ensureSpriteHolderSandbox was never called');
-  return call[0] as ProvisionCall;
+  return call[0];
 }
 
-function stubPayer(tier: string): void {
+function stubPayer(tier: SubscriptionTier): void {
   vi.mocked(db.query.drives.findFirst).mockResolvedValue({ ownerId: DRIVE_OWNER_ID } as never);
   vi.mocked(db.query.users.findFirst).mockResolvedValue({ subscriptionTier: tier } as never);
 }

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -1,0 +1,226 @@
+/**
+ * Production wiring for the drive-environment services (`@pagespace/lib`
+ * services/drive-envs) — DI of the DB-backed store, the Sprites host, the payer
+ * lookup and the permission checks.
+ *
+ * ZERO decision logic lives here, by the same mandate `agent-workspaces-runtime.ts`
+ * states: every `if` below turns a null into another null. Anything that WEIGHS
+ * facts lives in the pure planners (`drive-envs/plan-env-delete.ts`,
+ * `plan-workspace-lifecycle.ts`) or in the centralized permission helpers, and
+ * is merely executed by the services this module binds.
+ *
+ * The Sprites host is shared with the session runtime rather than re-created:
+ * one process, one driver, and — more to the point — one place where the
+ * Node-24/ESM-only `@fly/sprites` import is guarded.
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { drives } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { toSubscriptionTier, type SubscriptionTier } from '@pagespace/lib/billing/subscription-tiers';
+import { canRunCode, isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { isSandboxAvailable } from '@pagespace/lib/billing/sandbox-eligibility';
+import {
+  decideFullEgressEnablement,
+  isContainmentVerified,
+} from '@pagespace/lib/services/sandbox/containment';
+import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
+import { resolveSandboxNetworkOptions } from '@pagespace/lib/services/sandbox/network-options';
+import { getConfiguredEgressIpTag } from '@pagespace/lib/services/sandbox/egress-ip';
+import { deriveDriveEnvSpriteKey } from '@pagespace/lib/drive-envs/env-sprite-key';
+import { ensureSpriteHolderSandbox } from '@pagespace/lib/services/agent-workspaces/agent-workspace-sprite';
+import {
+  createDbDriveEnvStore,
+  type DriveEnvRecord,
+  type DriveEnvStore,
+} from '@pagespace/lib/services/drive-envs/drive-envs-store';
+import {
+  createDriveEnv,
+  listDriveEnvs,
+  renameDriveEnv,
+  deleteDriveEnv,
+  rebuildDriveEnv,
+  toDriveEnvDTO,
+  type CreateDriveEnvResult,
+  type RenameDriveEnvResult,
+  type DeleteDriveEnvResult,
+  type RebuildDriveEnvResult,
+} from '@pagespace/lib/services/drive-envs/drive-envs';
+import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+import { getSandboxHost } from '@/lib/agent-workspaces/agent-workspaces-runtime';
+
+export { toDriveEnvDTO };
+export type { DriveEnvDTO, DriveEnvRecord };
+
+// ---------------------------------------------------------------------------
+// Lazy singleton — the store reconnects to one DB pool; it is built on first
+// use so importing this module does no DB work.
+// ---------------------------------------------------------------------------
+
+let envStorePromise: Promise<DriveEnvStore> | null = null;
+
+export function getDriveEnvStore(): Promise<DriveEnvStore> {
+  envStorePromise ??= createDbDriveEnvStore();
+  return envStorePromise;
+}
+
+// ---------------------------------------------------------------------------
+// Row-fact lookups (null-plumbing only)
+// ---------------------------------------------------------------------------
+
+export async function findDriveEnvRecord(envId: string): Promise<DriveEnvRecord | null> {
+  return (await getDriveEnvStore()).findById(envId);
+}
+
+/**
+ * The drive's PAYER and their tier — its OWNER, with no fallback.
+ *
+ * No fallback is the whole content of this function. An env is drive-owned,
+ * drive-shared and drive-billed, so a vanished drive has nobody to meter and
+ * nobody to bill; falling back to the acting user would charge a member for a
+ * machine the drive was going to pay for, and would fold this env's Sprite key
+ * under a different tenant than the one it already provisioned under.
+ */
+export async function resolveDriveEnvPayer(
+  driveId: string,
+): Promise<{ payerId: string; tier: SubscriptionTier } | null> {
+  const drive = await db.query.drives.findFirst({ where: eq(drives.id, driveId), columns: { ownerId: true } });
+  if (!drive) return null;
+  const owner = await db.query.users.findFirst({
+    where: eq(users.id, drive.ownerId),
+    columns: { subscriptionTier: true },
+  });
+  return { payerId: drive.ownerId, tier: toSubscriptionTier(owner?.subscriptionTier) };
+}
+
+// ---------------------------------------------------------------------------
+// Entry wrappers — result unions, never throws, for the routes to map
+// ---------------------------------------------------------------------------
+
+/**
+ * The env, IF it exists and genuinely belongs to the drive in the path.
+ *
+ * Returns null for both "no such env" and "wrong drive", deliberately: the
+ * caller answers 404 either way, so the two are indistinguishable from outside.
+ */
+export async function resolveEnvInDrive(envId: string, driveId: string): Promise<DriveEnvRecord | null> {
+  const env = await findDriveEnvRecord(envId);
+  if (!env || env.driveId !== driveId) return null;
+  return env;
+}
+
+export async function createEnvInDrive(input: {
+  driveId: string;
+  name: string;
+  createdBy: string;
+}): Promise<CreateDriveEnvResult> {
+  const store = await getDriveEnvStore();
+  return createDriveEnv({
+    driveId: input.driveId,
+    name: input.name,
+    createdBy: input.createdBy,
+    deps: { store, resolvePayer: resolveDriveEnvPayer, now: () => new Date() },
+  });
+}
+
+export async function listEnvsInDrive(driveId: string): Promise<DriveEnvDTO[]> {
+  const store = await getDriveEnvStore();
+  return listDriveEnvs({ driveId, deps: { store } });
+}
+
+export async function renameEnv(input: { envId: string; name: string }): Promise<RenameDriveEnvResult> {
+  const store = await getDriveEnvStore();
+  return renameDriveEnv({ envId: input.envId, name: input.name, deps: { store, now: () => new Date() } });
+}
+
+export async function deleteEnv(input: { envId: string; force: boolean }): Promise<DeleteDriveEnvResult> {
+  const [store, host] = await Promise.all([getDriveEnvStore(), getSandboxHost()]);
+  return deleteDriveEnv({ envId: input.envId, force: input.force, deps: { store, host, now: () => new Date() } });
+}
+
+/**
+ * Rebuild an env's machine — teardown, then the ONE provisioning core, bound to
+ * the ENV's flavor of each seam.
+ *
+ * `requesterId` is who this provision authorizes as. Every seam below is the
+ * env's answer to a question the core deliberately does not decide for itself:
+ * which keyspace the Sprite name folds in (`drive-env-sprite:v1`, never the
+ * session namespace), who may run code here, and what a refusal is called.
+ */
+export async function rebuildEnv(input: { envId: string; requesterId: string }): Promise<RebuildDriveEnvResult> {
+  const [store, host] = await Promise.all([getDriveEnvStore(), getSandboxHost()]);
+  return rebuildDriveEnv({
+    envId: input.envId,
+    deps: {
+      store,
+      host,
+      now: () => new Date(),
+      ensureSandbox: async (row) => {
+        // The tenant an env's Sprite key folds under is the DRIVE OWNER, with
+        // no fallback — same rule, and same failure mode if broken, as
+        // `resolveSessionTenantId`: a different tenant means a different key
+        // means a second Sprite identity for one env.
+        const payer = await resolveDriveEnvPayer(row.driveId);
+        if (!payer) return { ok: false, reason: 'provision_failed', detail: 'drive_not_found' };
+        return ensureSpriteHolderSandbox({
+          row: { ...row, holderId: row.id, endedAt: null },
+          // `ensure`, not `reprovision`: the teardown already happened and was
+          // confirmed, so the row reads as machineless and the core takes its
+          // `create` arm — through the same CAS every other provisioner runs.
+          intent: 'ensure',
+          deps: {
+            store: {
+              updateSpriteIdentity: ({ holderId, ...identity }) =>
+                store.updateSpriteIdentity({ envId: holderId, ...identity }),
+              applyStamps: ({ holderId, stamps, cas }) => store.applyStamps({ envId: holderId, stamps, cas }),
+              reloadSpritePointer: (holderId) => store.reloadSpritePointer(holderId),
+              enqueueReclaim: (reclaim) => store.enqueueReclaim(reclaim),
+            },
+            host,
+            substrate: { kind: 'sprite' },
+            options: resolveSandboxNetworkOptions({ surface: 'session', egressIpTag: getConfiguredEgressIpTag() }),
+            deriveSpriteKey: (holderId) =>
+              deriveDriveEnvSpriteKey({
+                tenantId: payer.payerId,
+                envId: holderId,
+                secret: getSandboxSessionSecret(),
+              }),
+            // The centralized code-execution gate, resolved against the env's
+            // DRIVE and its payer — which is also where the tier-eligibility
+            // check lives, so a downgraded payer is refused here rather than
+            // deeper in.
+            authorize: async () => {
+              const result = await canRunCode({
+                userId: input.requesterId,
+                driveId: row.driveId,
+                ownerId: payer.payerId,
+                requestOrigin: 'user',
+              });
+              return result.ok ? { ok: true } : { ok: false, reason: result.reason };
+            },
+            checkFullEgressEnablement: async () =>
+              decideFullEgressEnablement({
+                adminGateEnabled: isCodeExecutionEnabled(),
+                containment: isContainmentVerified() ? { contained: true } : null,
+              }),
+            // The env ALLOWANCE is metered where the commitment is made — at
+            // `createDriveEnv`, on the row, which is the billed persistence
+            // unit. Provisioning an env that already exists adds no allocation
+            // to count, so there is no second ceiling to apply here; what this
+            // re-asserts is tier ELIGIBILITY, so a payer downgraded since the
+            // env was created stops getting machines for it. That is the same
+            // fact `authorize` above denies on (`can-run-code`'s tier gate),
+            // re-checked at the mint site as defense in depth and reported
+            // under the same word rather than dressed up as a quota it is not.
+            checkQuota: async () => {
+              if (isSandboxAvailable(payer.tier)) return { allowed: true };
+              return { allowed: false, denial: 'not_authorized', reason: 'tier_ineligible' };
+            },
+            now: () => new Date(),
+          },
+        });
+      },
+    },
+  });
+}

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -51,7 +51,7 @@ import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 import { getSandboxHost } from '@/lib/agent-workspaces/agent-workspaces-runtime';
 
 export { toDriveEnvDTO };
-export type { DriveEnvDTO, DriveEnvRecord };
+export type { DriveEnvDTO };
 
 // ---------------------------------------------------------------------------
 // Lazy singleton — the store reconnects to one DB pool; it is built on first
@@ -69,7 +69,8 @@ export function getDriveEnvStore(): Promise<DriveEnvStore> {
 // Row-fact lookups (null-plumbing only)
 // ---------------------------------------------------------------------------
 
-export async function findDriveEnvRecord(envId: string): Promise<DriveEnvRecord | null> {
+/** The row, or null. Internal: every caller outside this module goes through `resolveEnvInDrive`, which additionally proves the env belongs to the drive in the path. */
+async function findDriveEnvRecord(envId: string): Promise<DriveEnvRecord | null> {
   return (await getDriveEnvStore()).findById(envId);
 }
 

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -29,7 +29,10 @@ import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine
 import { resolveSandboxNetworkOptions } from '@pagespace/lib/services/sandbox/network-options';
 import { getConfiguredEgressIpTag } from '@pagespace/lib/services/sandbox/egress-ip';
 import { deriveDriveEnvSpriteKey } from '@pagespace/lib/drive-envs/env-sprite-key';
-import { ensureSpriteHolderSandbox } from '@pagespace/lib/services/agent-workspaces/agent-workspace-sprite';
+import {
+  ensureSpriteHolderSandbox,
+  type SpriteHolderProvisionDeps,
+} from '@pagespace/lib/services/agent-workspaces/agent-workspace-sprite';
 import {
   createDbDriveEnvStore,
   type DriveEnvRecord,
@@ -48,6 +51,7 @@ import {
   type RebuildDriveEnvResult,
 } from '@pagespace/lib/services/drive-envs/drive-envs';
 import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+import type { SandboxHost } from '@pagespace/lib/services/sandbox/sandbox-host';
 import { getSandboxHost } from '@/lib/agent-workspaces/agent-workspaces-runtime';
 
 export { toDriveEnvDTO };
@@ -149,6 +153,89 @@ export async function deleteEnv(input: { envId: string; force: boolean }): Promi
  * which keyspace the Sprite name folds in (`drive-env-sprite:v1`, never the
  * session namespace), who may run code here, and what a refusal is called.
  */
+/**
+ * The env's flavor of every seam the holder-neutral provisioner asks for.
+ *
+ * Extracted from `rebuildEnv` below because this — not the verb that calls it —
+ * is where an environment's provisioning correctness actually lives. The core
+ * derives no Sprite key, resolves no tenant and picks no authorization gate of
+ * its own, so getting any of these wrong is silent, and burying them four
+ * closures deep inside a lifecycle call made them read like plumbing rather than
+ * the decisions they are. `drive-envs-runtime.test.ts` asserts on exactly this
+ * object.
+ *
+ * `payer` is the DRIVE OWNER, resolved by the caller and passed in — the tenant
+ * an env's Sprite key folds under, with no fallback, for the same reason
+ * `resolveSessionTenantId` fails closed: a different tenant means a different
+ * key means a second Sprite identity for one env.
+ */
+function buildEnvProvisionDeps({
+  row,
+  payer,
+  requesterId,
+  store,
+  host,
+}: {
+  row: DriveEnvRecord;
+  payer: { payerId: string; tier: SubscriptionTier };
+  requesterId: string;
+  store: DriveEnvStore;
+  host: SandboxHost;
+}): SpriteHolderProvisionDeps {
+  return {
+    // The identity/stamp slice, renamed holder → env. This adapter IS what makes
+    // an env a second holder of the ONE provisioning CAS rather than a second
+    // provisioner with its own.
+    store: {
+      updateSpriteIdentity: ({ holderId, ...identity }) =>
+        store.updateSpriteIdentity({ envId: holderId, ...identity }),
+      applyStamps: ({ holderId, stamps, cas }) => store.applyStamps({ envId: holderId, stamps, cas }),
+      reloadSpritePointer: (holderId) => store.reloadSpritePointer(holderId),
+      enqueueReclaim: (reclaim) => store.enqueueReclaim(reclaim),
+    },
+    host,
+    substrate: { kind: 'sprite' },
+    options: resolveSandboxNetworkOptions({ surface: 'session', egressIpTag: getConfiguredEgressIpTag() }),
+    /** The ENV keyspace (`drive-env-sprite:v1`), never the session one — see `env-sprite-key.ts` on why a shared namespace is a reclaim hazard rather than a tidiness question. */
+    deriveSpriteKey: (holderId) =>
+      deriveDriveEnvSpriteKey({ tenantId: payer.payerId, envId: holderId, secret: getSandboxSessionSecret() }),
+    /**
+     * The centralized code-execution gate, resolved against the env's DRIVE and
+     * its payer — which is also where tier eligibility lives, so a downgraded
+     * payer is refused here rather than deeper in.
+     */
+    authorize: async () => {
+      const result = await canRunCode({
+        userId: requesterId,
+        driveId: row.driveId,
+        ownerId: payer.payerId,
+        requestOrigin: 'user',
+      });
+      return result.ok ? { ok: true } : { ok: false, reason: result.reason };
+    },
+    checkFullEgressEnablement: async () =>
+      decideFullEgressEnablement({
+        adminGateEnabled: isCodeExecutionEnabled(),
+        containment: isContainmentVerified() ? { contained: true } : null,
+      }),
+    /**
+     * The env ALLOWANCE is metered where the commitment is made — at
+     * `createDriveEnv`, on the row. Provisioning an env that already exists adds
+     * no allocation to count, so there is no second ceiling here; what this
+     * re-asserts is tier ELIGIBILITY, so a payer downgraded since the env was
+     * created stops getting machines for it. That is the same fact `authorize`
+     * denies on (`can-run-code`'s tier gate), re-checked at the mint site as
+     * defense in depth and reported under the same word rather than dressed up
+     * as a quota it is not.
+     */
+    checkQuota: async () => {
+      if (isSandboxAvailable(payer.tier)) return { allowed: true };
+      return { allowed: false, denial: 'not_authorized', reason: 'tier_ineligible' };
+    },
+    now: () => new Date(),
+  };
+}
+
 export async function rebuildEnv(input: { envId: string; requesterId: string }): Promise<RebuildDriveEnvResult> {
   const [store, host] = await Promise.all([getDriveEnvStore(), getSandboxHost()]);
   return rebuildDriveEnv({
@@ -158,10 +245,9 @@ export async function rebuildEnv(input: { envId: string; requesterId: string }):
       host,
       now: () => new Date(),
       ensureSandbox: async (row) => {
-        // The tenant an env's Sprite key folds under is the DRIVE OWNER, with
-        // no fallback — same rule, and same failure mode if broken, as
-        // `resolveSessionTenantId`: a different tenant means a different key
-        // means a second Sprite identity for one env.
+        // Fails CLOSED on a vanished drive: there is no tenant to fold the
+        // Sprite key under, and inventing one would split this env across two
+        // Sprite identities.
         const payer = await resolveDriveEnvPayer(row.driveId);
         if (!payer) return { ok: false, reason: 'provision_failed', detail: 'drive_not_found' };
         return ensureSpriteHolderSandbox({
@@ -170,56 +256,7 @@ export async function rebuildEnv(input: { envId: string; requesterId: string }):
           // confirmed, so the row reads as machineless and the core takes its
           // `create` arm — through the same CAS every other provisioner runs.
           intent: 'ensure',
-          deps: {
-            store: {
-              updateSpriteIdentity: ({ holderId, ...identity }) =>
-                store.updateSpriteIdentity({ envId: holderId, ...identity }),
-              applyStamps: ({ holderId, stamps, cas }) => store.applyStamps({ envId: holderId, stamps, cas }),
-              reloadSpritePointer: (holderId) => store.reloadSpritePointer(holderId),
-              enqueueReclaim: (reclaim) => store.enqueueReclaim(reclaim),
-            },
-            host,
-            substrate: { kind: 'sprite' },
-            options: resolveSandboxNetworkOptions({ surface: 'session', egressIpTag: getConfiguredEgressIpTag() }),
-            deriveSpriteKey: (holderId) =>
-              deriveDriveEnvSpriteKey({
-                tenantId: payer.payerId,
-                envId: holderId,
-                secret: getSandboxSessionSecret(),
-              }),
-            // The centralized code-execution gate, resolved against the env's
-            // DRIVE and its payer — which is also where the tier-eligibility
-            // check lives, so a downgraded payer is refused here rather than
-            // deeper in.
-            authorize: async () => {
-              const result = await canRunCode({
-                userId: input.requesterId,
-                driveId: row.driveId,
-                ownerId: payer.payerId,
-                requestOrigin: 'user',
-              });
-              return result.ok ? { ok: true } : { ok: false, reason: result.reason };
-            },
-            checkFullEgressEnablement: async () =>
-              decideFullEgressEnablement({
-                adminGateEnabled: isCodeExecutionEnabled(),
-                containment: isContainmentVerified() ? { contained: true } : null,
-              }),
-            // The env ALLOWANCE is metered where the commitment is made — at
-            // `createDriveEnv`, on the row, which is the billed persistence
-            // unit. Provisioning an env that already exists adds no allocation
-            // to count, so there is no second ceiling to apply here; what this
-            // re-asserts is tier ELIGIBILITY, so a payer downgraded since the
-            // env was created stops getting machines for it. That is the same
-            // fact `authorize` above denies on (`can-run-code`'s tier gate),
-            // re-checked at the mint site as defense in depth and reported
-            // under the same word rather than dressed up as a quota it is not.
-            checkQuota: async () => {
-              if (isSandboxAvailable(payer.tier)) return { allowed: true };
-              return { allowed: false, denial: 'not_authorized', reason: 'tier_ineligible' };
-            },
-            now: () => new Date(),
-          },
+          deps: buildEnvProvisionDeps({ row, payer, requesterId: input.requesterId, store, host }),
         });
       },
     },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -97,6 +97,26 @@
       "import": "./dist/agent-workspaces/plan-workspace-lifecycle.js",
       "require": "./dist/agent-workspaces/plan-workspace-lifecycle.js"
     },
+    "./drive-envs/env-contract": {
+      "types": "./dist/drive-envs/env-contract.d.ts",
+      "import": "./dist/drive-envs/env-contract.js",
+      "require": "./dist/drive-envs/env-contract.js"
+    },
+    "./drive-envs/plan-env-delete": {
+      "types": "./dist/drive-envs/plan-env-delete.d.ts",
+      "import": "./dist/drive-envs/plan-env-delete.js",
+      "require": "./dist/drive-envs/plan-env-delete.js"
+    },
+    "./services/drive-envs/drive-envs": {
+      "types": "./dist/services/drive-envs/drive-envs.d.ts",
+      "import": "./dist/services/drive-envs/drive-envs.js",
+      "require": "./dist/services/drive-envs/drive-envs.js"
+    },
+    "./services/drive-envs/drive-envs-store": {
+      "types": "./dist/services/drive-envs/drive-envs-store.d.ts",
+      "import": "./dist/services/drive-envs/drive-envs-store.js",
+      "require": "./dist/services/drive-envs/drive-envs-store.js"
+    },
     "./drive-envs/env-sprite-key": {
       "types": "./dist/drive-envs/env-sprite-key.d.ts",
       "import": "./dist/drive-envs/env-sprite-key.js",

--- a/packages/lib/src/drive-envs/__tests__/plan-env-delete.test.ts
+++ b/packages/lib/src/drive-envs/__tests__/plan-env-delete.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { planEnvDelete, type DriveEnvDeleteRow } from '../plan-env-delete';
+
+const NOW = new Date('2026-08-17T12:00:00.000Z');
+
+function makeRow(over: Partial<DriveEnvDeleteRow> = {}): DriveEnvDeleteRow {
+  return { id: 'env-1', sandboxId: null, spriteInstanceId: null, spriteTornDownAt: null, ...over };
+}
+
+/** A row that believes it holds a live Sprite — the shape a teardown acts on. */
+function liveRow(over: Partial<DriveEnvDeleteRow> = {}): DriveEnvDeleteRow {
+  return makeRow({ sandboxId: 'pgs-env-abc', spriteInstanceId: 'inst-1', ...over });
+}
+
+describe('planEnvDelete — the live-session guard', () => {
+  it('given live sessions and no force, should deny and report the count', () => {
+    const plan = planEnvDelete({ row: liveRow(), liveSessionCount: 3, force: false });
+    expect(plan).toEqual({ action: 'deny_live_sessions', liveSessionCount: 3 });
+  });
+
+  it('given live sessions and force, should proceed to teardown — force is the ONLY thing that passes the guard', () => {
+    const plan = planEnvDelete({ row: liveRow(), liveSessionCount: 3, force: true });
+    expect(plan).toEqual({ action: 'teardown_then_delete', sandboxId: 'pgs-env-abc', expectedInstanceId: 'inst-1' });
+  });
+
+  it('given ZERO live sessions, should proceed without needing force', () => {
+    const plan = planEnvDelete({ row: liveRow(), liveSessionCount: 0, force: false });
+    expect(plan.action).toBe('teardown_then_delete');
+  });
+
+  it('given the guard trips, should decide BEFORE reading any pointer — an env with no Sprite is still refused', () => {
+    // The ordering is the invariant: the row delete cascades to live sessions,
+    // so "nothing to kill" must never be allowed to short-circuit the guard.
+    const plan = planEnvDelete({ row: makeRow(), liveSessionCount: 1, force: false });
+    expect(plan).toEqual({ action: 'deny_live_sessions', liveSessionCount: 1 });
+  });
+});
+
+describe('planEnvDelete — what has to die first', () => {
+  it('given a live Sprite, should teardown_then_delete carrying the CAS instance', () => {
+    const plan = planEnvDelete({ row: liveRow(), liveSessionCount: 0, force: false });
+    expect(plan).toEqual({ action: 'teardown_then_delete', sandboxId: 'pgs-env-abc', expectedInstanceId: 'inst-1' });
+  });
+
+  it('given a live Sprite the platform reported no instance for, should still teardown with a null CAS', () => {
+    const plan = planEnvDelete({ row: liveRow({ spriteInstanceId: null }), liveSessionCount: 0, force: false });
+    expect(plan).toEqual({ action: 'teardown_then_delete', sandboxId: 'pgs-env-abc', expectedInstanceId: null });
+  });
+
+  it('given a never-provisioned env, should delete_only', () => {
+    const plan = planEnvDelete({ row: makeRow(), liveSessionCount: 0, force: false });
+    expect(plan).toEqual({ action: 'delete_only' });
+  });
+
+  it('given an ALREADY torn-down env, should delete_only — the pointer survives a teardown and must not re-kill', () => {
+    // Teardown stamps `spriteTornDownAt` and deliberately LEAVES `sandboxId`
+    // in place (a reclaim needs that pointer), so a name-only test would send
+    // every stopped env back through a kill of a VM that is already gone.
+    const plan = planEnvDelete({
+      row: liveRow({ spriteTornDownAt: NOW }),
+      liveSessionCount: 0,
+      force: false,
+    });
+    expect(plan).toEqual({ action: 'delete_only' });
+  });
+
+  it('given a teardown REQUESTED but never confirmed, should still teardown — intent is not confirmation', () => {
+    const plan = planEnvDelete({
+      row: liveRow({ spriteTornDownAt: null }),
+      liveSessionCount: 0,
+      force: false,
+    });
+    expect(plan.action).toBe('teardown_then_delete');
+  });
+});

--- a/packages/lib/src/drive-envs/env-contract.ts
+++ b/packages/lib/src/drive-envs/env-contract.ts
@@ -1,0 +1,109 @@
+/**
+ * The drive-environment wire contract — the DTO every client is served, and the
+ * one validator each side parses with.
+ *
+ * The rule `session-contract.ts` established governs this module too: a shape
+ * that crosses a process boundary is declared ONCE, here, and never restated at
+ * a route. `Date` never crosses the boundary (ISO-8601 strings only).
+ *
+ * **The name is part of the contract, not a label.** `(driveId, name)` is UNIQUE
+ * on `drive_envs` — the deliberate exception to the repo's "ids address, names
+ * label" rule, because an environment is a target humans and pipelines name out
+ * loud ("promote to staging"). So the name is validated HERE, at the boundary,
+ * rather than left to the database's unique index to reject after the fact: a
+ * blank or whitespace-only name is a 400, not a row.
+ *
+ * There is deliberately NO `kind` field. Environments are untyped and uniformly
+ * Sprite-backed; dev / staging / prod are use cases expressed by NAMING an env
+ * (see the `drive_envs` table docblock, which explains why the enum was deleted
+ * rather than never written).
+ */
+
+import { z } from 'zod';
+
+/** Longest environment name accepted. Long enough for `staging-eu-west` and its kin, short enough to render in a sidebar row. */
+export const MAX_DRIVE_ENV_NAME_LENGTH = 64;
+
+/**
+ * The most environments one listing returns — and, because the store's list
+ * query carries it as a LIMIT, the most a drive's listing can ever show. Set an
+ * order of magnitude above the highest per-tier ceiling
+ * (`DRIVE_ENV_LIMITS.business`) so it is a runaway-query backstop rather than a
+ * cap a real drive can hit: a drive's envs are quota-bounded per PAYER, and a
+ * payer's drives could in principle concentrate them, but a listing that
+ * silently truncated a drive's real set would hide machines the drive is being
+ * billed for.
+ */
+export const MAX_DRIVE_ENVS_LISTED = 100;
+
+/**
+ * An environment name as accepted from a client: trimmed, non-empty, bounded.
+ *
+ * Trimming is part of the schema rather than a call-site habit because the
+ * uniqueness that makes a name an ADDRESS is the database's, and `staging` vs
+ * `staging ` would otherwise be two distinct rows a user cannot tell apart.
+ */
+export const driveEnvNameSchema = z
+  .string()
+  .transform((value) => value.trim())
+  .pipe(z.string().min(1).max(MAX_DRIVE_ENV_NAME_LENGTH));
+
+/**
+ * The Sprite states an environment can be reported in, DERIVED from its pointer
+ * columns and never stored (`deriveDriveEnvStatus`).
+ *
+ * Three, not the session surface's four:
+ *
+ *  - `'none'` — never provisioned. The state a freshly-created env sits in until
+ *    the first session runs inside it (envs provision lazily).
+ *  - `'running'` — a Sprite is linked. INCLUDING a hibernating one: idle Sprites
+ *    hibernate and wake on demand, which is invisible to the user.
+ *  - `'stopped'` — the Sprite was torn down (a rebuild in flight, or a reclaim),
+ *    and the ENV ROW SURVIVES. This is where the session vocabulary stops
+ *    fitting: a session's equivalent state is `'ended'`, a terminal fact about
+ *    the session itself, whereas an env outliving its machine is the entire
+ *    point of an env. Reusing the word would tell a client the environment was
+ *    over when it is merely idle between machines.
+ *
+ * `'starting'` is deliberately absent for the same reason it is absent from
+ * `SandboxStatus`: provisioning happens inside ONE call, so there is no
+ * persisted in-flight state to read.
+ */
+export const DRIVE_ENV_STATUSES = ['none', 'running', 'stopped'] as const;
+
+export const driveEnvStatusSchema = z.enum(DRIVE_ENV_STATUSES);
+export type DriveEnvStatus = z.infer<typeof driveEnvStatusSchema>;
+
+/** Wire timestamps are ISO-8601 strings; `Date` never crosses the boundary. */
+const isoTimestamp = z.string().datetime();
+
+/**
+ * One drive environment as served to any client.
+ *
+ * Deliberately NARROW: identity, ownership, name, derived status, birthday. No
+ * Sprite pointer, no egress token, no storage measurement — those are internal
+ * lifecycle and billing facts, and a client that could read `sandboxId` would be
+ * one step from addressing a VM by something other than its env.
+ */
+export const driveEnvDtoSchema = z.object({
+  /** `drive_envs.id` — the API address and the Sprite-key fold. */
+  id: z.string().min(1),
+  /** The owning drive. An env has no user-scoped form: it is drive-owned, drive-paid, drive-shared. */
+  driveId: z.string().min(1),
+  /** Unique within the drive — an address humans use, not a label. */
+  name: z.string().min(1),
+  status: driveEnvStatusSchema,
+  createdAt: isoTimestamp,
+});
+
+export type DriveEnvDTO = z.infer<typeof driveEnvDtoSchema>;
+
+/** POST body for creating an environment. Just a name — there is no kind to choose. */
+export const createDriveEnvRequestSchema = z.object({
+  name: driveEnvNameSchema,
+});
+
+/** PATCH body for renaming an environment. */
+export const renameDriveEnvRequestSchema = z.object({
+  name: driveEnvNameSchema,
+});

--- a/packages/lib/src/drive-envs/env-contract.ts
+++ b/packages/lib/src/drive-envs/env-contract.ts
@@ -26,13 +26,19 @@ export const MAX_DRIVE_ENV_NAME_LENGTH = 64;
 
 /**
  * The most environments one listing returns — and, because the store's list
- * query carries it as a LIMIT, the most a drive's listing can ever show. Set an
- * order of magnitude above the highest per-tier ceiling
- * (`DRIVE_ENV_LIMITS.business`) so it is a runaway-query backstop rather than a
- * cap a real drive can hit: a drive's envs are quota-bounded per PAYER, and a
- * payer's drives could in principle concentrate them, but a listing that
- * silently truncated a drive's real set would hide machines the drive is being
- * billed for.
+ * query carries it as a LIMIT, the most a drive's listing can ever show.
+ *
+ * It is also the CEILING ON THE CEILING: `quota.ts` clamps every per-tier
+ * `DRIVE_ENV_LIMIT_*` to this number, so no payer can hold more environments
+ * than a listing can display. That coupling is deliberate and load-bearing. An
+ * env row that exists but never appears is billed infrastructure with no
+ * surface that admits it exists — strictly worse than a refused create — and a
+ * per-payer ceiling above a per-drive listing cap is exactly how you get one,
+ * since nothing stops a payer concentrating their envs in a single drive.
+ *
+ * Raising this is therefore the FIRST half of raising any tier ceiling past
+ * 100; paginating the listing is the alternative, and would let the two numbers
+ * come apart safely.
  */
 export const MAX_DRIVE_ENVS_LISTED = 100;
 

--- a/packages/lib/src/drive-envs/env-contract.ts
+++ b/packages/lib/src/drive-envs/env-contract.ts
@@ -31,10 +31,13 @@ export const MAX_DRIVE_ENV_NAME_LENGTH = 64;
  * It is also the CEILING ON THE CEILING: `quota.ts` clamps every per-tier
  * `DRIVE_ENV_LIMIT_*` to this number, so no payer can hold more environments
  * than a listing can display. That coupling is deliberate and load-bearing. An
- * env row that exists but never appears is billed infrastructure with no
- * surface that admits it exists — strictly worse than a refused create — and a
+ * env row that exists but never appears is a machine the drive is paying for
+ * with no surface that admits it exists — strictly worse than a refused create
+ * — and a
  * per-payer ceiling above a per-drive listing cap is exactly how you get one,
- * since nothing stops a payer concentrating their envs in a single drive.
+ * since nothing stops a payer concentrating their envs in a single drive. (The
+ * cost is real from creation even though the app's storage meter does not read
+ * `drive_envs` yet — see `checkDriveEnvAllowance`.)
  *
  * Raising this is therefore the FIRST half of raising any tier ceiling past
  * 100; paginating the listing is the alternative, and would let the two numbers

--- a/packages/lib/src/drive-envs/plan-env-delete.ts
+++ b/packages/lib/src/drive-envs/plan-env-delete.ts
@@ -1,0 +1,93 @@
+/**
+ * Deleting an environment, decided purely.
+ *
+ * An env delete is the one operation in this epic that destroys a SHARED
+ * filesystem, and it has to answer three questions in a fixed order: is anyone
+ * still working in here, is there a VM to kill, and only then may the row go.
+ * All three are decided from facts a caller has already read — the env's pointer
+ * columns, a live-session count, and the caller's `force` — so this module is a
+ * pure function and the ordering it encodes is testable without a database, a
+ * Sprite, or a clock.
+ *
+ * **Why the order is load-bearing.** `drive_envs` cascades to
+ * `agent_workspaces.envId`, so DELETING THE ROW DELETES the sessions bound to
+ * it. That is correct (an env owns its sessions) and it is also why the
+ * live-session guard cannot be an afterthought at the end of the flow: by the
+ * time the row is gone, the sessions someone was working in are gone with it.
+ * The guard runs first, and `force` is the only thing that can pass it.
+ *
+ * **What the cascade CANNOT strand.** An env-bound session holds no Sprite
+ * pointer of its own — `agent_workspaces_env_no_sprite_check` forbids it — so
+ * cascading a session away can never orphan a VM, leave bytes unbilled, or hide
+ * a machine from the reclaim outbox. The ONE Sprite in play is the env's own,
+ * which is exactly what `teardown_then_delete` exists to kill before the row
+ * (and its AFTER DELETE reclaim trigger) disappears.
+ *
+ * The verdicts, and nothing else:
+ *
+ *  - `deny_live_sessions` — sessions are still live in here and the caller did
+ *    not force. Reports the count so the caller can say how many.
+ *  - `teardown_then_delete` — the env believes it holds a live Sprite. Kill it
+ *    (CAS on the instance) BEFORE the row goes, so the kill is confirmed by the
+ *    thing that asked for it rather than left to the crash net.
+ *  - `delete_only` — nothing to kill: never provisioned, or already torn down.
+ *
+ * A missing row is deliberately NOT a verdict here. "There is no such env" is a
+ * lookup fact, not a deletion policy, and folding it in would make a 404 and a
+ * refusal indistinguishable to the caller that has to choose a status code — the
+ * same split `AgentSessionAccessCheck` draws around `session_not_found`.
+ */
+
+/** The env columns a delete decision reads. Pointers only; nothing derived, nothing named after a table. */
+export interface DriveEnvDeleteRow {
+  /** The env's own id — never read by the decision, carried so a verdict names the row it describes. */
+  id: string;
+  /** The Sprite name currently recorded; null = never provisioned. */
+  sandboxId: string | null;
+  /** WHICH VM, as opposed to which name it answers to. The teardown CAS keys on this. */
+  spriteInstanceId: string | null;
+  /** Stamped once a kill was CONFIRMED. Non-null = we do not believe a live Sprite exists. */
+  spriteTornDownAt: Date | null;
+}
+
+export interface PlanEnvDeleteInput {
+  row: DriveEnvDeleteRow;
+  /**
+   * Sessions still LIVE inside this env — not-ended rows carrying this `envId`.
+   * Counted by the caller (`countLiveSessionsInEnv`) rather than derived here,
+   * because it is a second table's fact.
+   */
+  liveSessionCount: number;
+  /** The caller's explicit override of the live-session guard. Nothing else in this decision consults it. */
+  force: boolean;
+}
+
+export type PlanEnvDeletePlan =
+  /** Sessions are live and `force` was not given. The row and its Sprite are untouched. */
+  | { action: 'deny_live_sessions'; liveSessionCount: number }
+  /** Kill the env's Sprite (guarded by the instance the row records), then delete the row. */
+  | { action: 'teardown_then_delete'; sandboxId: string; expectedInstanceId: string | null }
+  /** No live Sprite to kill — delete the row. */
+  | { action: 'delete_only' };
+
+export function planEnvDelete({ row, liveSessionCount, force }: PlanEnvDeleteInput): PlanEnvDeletePlan {
+  // FIRST, and before anything reads a pointer: the cascade that follows a row
+  // delete takes live sessions with it, so this is the only moment the caller
+  // can be told to stop.
+  if (liveSessionCount > 0 && !force) {
+    return { action: 'deny_live_sessions', liveSessionCount };
+  }
+  // "Believed live" is BOTH conditions, matching the partial index and every
+  // other live-Sprite predicate in the epic: a teardown stamps
+  // `spriteTornDownAt` and deliberately LEAVES `sandboxId` in place (the
+  // pointer a reclaim would need), so testing the name alone would send every
+  // already-torn-down env back through a kill of a VM that is already gone.
+  if (row.sandboxId !== null && row.spriteTornDownAt === null) {
+    return {
+      action: 'teardown_then_delete',
+      sandboxId: row.sandboxId,
+      expectedInstanceId: row.spriteInstanceId,
+    };
+  }
+  return { action: 'delete_only' };
+}

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
@@ -246,6 +246,22 @@ describe('deleteIfUnoccupied — the live-session guard, for real', () => {
     expect(rows).toHaveLength(0);
   });
 
+  it('given two CONCURRENT deletes, should let exactly one win and tell the other the truth', async () => {
+    // The row lock serializes them, so this is deterministic rather than racy:
+    // the loser blocks, then re-checks under READ COMMITTED and finds the row
+    // gone. Reporting `not_found` rather than a second success is what keeps
+    // `spriteTornDown` honest — only one call actually killed anything.
+    const envId = await seedEnv();
+
+    const [first, second] = await Promise.all([
+      store.deleteIfUnoccupied({ envId, force: false }),
+      store.deleteIfUnoccupied({ envId, force: false }),
+    ]);
+
+    expect([first, second].filter((r) => r.ok)).toHaveLength(1);
+    expect([first, second].filter((r) => !r.ok)).toEqual([{ ok: false, reason: 'not_found' }]);
+  });
+
   it('given the row is gone, should report not_found rather than a phantom success', async () => {
     expect(await store.deleteIfUnoccupied({ envId: createId(), force: false })).toEqual({
       ok: false,

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
@@ -196,7 +196,14 @@ describe('deleteIfUnoccupied — the live-session guard, for real', () => {
       // A session binds to this env, and HOLDS the transaction open.
       await spawner.query('BEGIN');
       await spawner.query(
-        'INSERT INTO agent_workspaces (id, "driveId", "ownerId", "envId", "updatedAt") VALUES ($1,$2,$3,$4,now())',
+        // `now() at time zone 'utc'`, not bare `now()`: these timestamp columns
+        // store UTC wall-clock, while `now()` is a timestamptz resolved through
+        // the session's TZ — so a non-UTC connection writes local time into a
+        // column everything else reads as UTC. Invisible on UTC CI, wrong
+        // anywhere else, and the repo rule exists because that asymmetry has
+        // bitten claim/expiry predicates before.
+        `INSERT INTO agent_workspaces (id, "driveId", "ownerId", "envId", "updatedAt")
+         VALUES ($1,$2,$3,$4,(now() at time zone 'utc'))`,
         [spawnId, driveId, payerId, envId],
       );
 
@@ -232,7 +239,14 @@ describe('deleteIfUnoccupied — the live-session guard, for real', () => {
     try {
       await spawner.query('BEGIN');
       await spawner.query(
-        'INSERT INTO agent_workspaces (id, "driveId", "ownerId", "envId", "updatedAt") VALUES ($1,$2,$3,$4,now())',
+        // `now() at time zone 'utc'`, not bare `now()`: these timestamp columns
+        // store UTC wall-clock, while `now()` is a timestamptz resolved through
+        // the session's TZ — so a non-UTC connection writes local time into a
+        // column everything else reads as UTC. Invisible on UTC CI, wrong
+        // anywhere else, and the repo rule exists because that asymmetry has
+        // bitten claim/expiry predicates before.
+        `INSERT INTO agent_workspaces (id, "driveId", "ownerId", "envId", "updatedAt")
+         VALUES ($1,$2,$3,$4,(now() at time zone 'utc'))`,
         [spawnId, driveId, payerId, envId],
       );
       const deleting = store.deleteIfUnoccupied({ envId, force: true });

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
@@ -540,6 +540,41 @@ describe('the Sprite-identity CAS, in SQL', () => {
   });
 });
 
+describe('list — the drive-scoped listing, in SQL', () => {
+  it('should return ONLY this drive\'s envs — a listing that crossed drives would be a leak', async () => {
+    // The fake filters by `driveId` because it was written to; this proves the
+    // actual WHERE clause does. Envs are drive-owned and a drive's members see
+    // its machines, so a listing that reached into a sibling drive — even one
+    // owned by the same payer — would show infrastructure the requester was
+    // never authorized for.
+    await seedEnv({ driveId, name: 'mine-a' });
+    await seedEnv({ driveId, name: 'mine-b' });
+    await seedEnv({ driveId: secondDriveId, name: 'same-payer-other-drive' });
+    await seedEnv({ driveId: otherDriveId, name: 'other-payer' });
+
+    const rows = await store.list(driveId);
+
+    expect(rows.map((row) => row.name).sort()).toEqual(['mine-a', 'mine-b']);
+  });
+
+  it('should order OLDEST first — an env name is an address, so the row must not move under the reader', async () => {
+    const older = await seedEnv({ driveId, name: 'first' });
+    const newer = await seedEnv({ driveId, name: 'second' });
+    // Force a definite ordering rather than relying on insert timing.
+    await db.update(driveEnvs).set({ createdAt: new Date('2026-01-01T00:00:00Z') }).where(eq(driveEnvs.id, older));
+    await db.update(driveEnvs).set({ createdAt: new Date('2026-06-01T00:00:00Z') }).where(eq(driveEnvs.id, newer));
+
+    const rows = await store.list(driveId);
+
+    expect(rows.map((row) => row.id)).toEqual([older, newer]);
+  });
+
+  it('given a drive with no envs, should return empty rather than everything', async () => {
+    await seedEnv({ driveId, name: 'somewhere-else' });
+    expect(await store.list(otherDriveId)).toEqual([]);
+  });
+});
+
 describe('countLiveSessionsInEnv / countEnvsOwnedBy', () => {
   it('should count only NOT-ENDED sessions in this env', async () => {
     const envId = await seedEnv();

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
@@ -1,0 +1,532 @@
+/**
+ * `drive_envs` store — REAL Postgres.
+ *
+ * The unit suite drives the env services against an in-memory fake, which is
+ * the right tool for the lifecycle orderings and proves NOTHING about the two
+ * things this PR's correctness actually rests on:
+ *
+ *  1. **The delete guard's row lock.** `deleteIfUnoccupied` claims that taking
+ *     `SELECT ... FOR UPDATE` on the env row makes the live-session count
+ *     atomic with the delete, because binding a session needs `FOR KEY SHARE`
+ *     on that same row for its FK and the two conflict. That is a claim about
+ *     Postgres lock semantics. A fake cannot agree or disagree with it; only
+ *     two real connections racing can.
+ *  2. **The create ceiling's advisory lock.** Same shape: the per-payer
+ *     `pg_advisory_xact_lock` is what stops two differently-named creates from
+ *     both landing past the ceiling, and it either serializes them in Postgres
+ *     or it does not.
+ *
+ * Both are the P1 findings from review, so both are pinned here against a real
+ * database rather than against a model of one.
+ *
+ * Also covers the SQL the fake silently gets right where JS and SQL differ: the
+ * `IS NULL` compare-and-swap semantics, and the AFTER DELETE reclaim trigger's
+ * WHEN clause.
+ *
+ * Runs in CI (the Unit Tests job provides Postgres). Locally:
+ *     DATABASE_URL=... bun run --filter '@pagespace/lib' test -- src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq, inArray } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { drives } from '@pagespace/db/schema/core';
+import { driveEnvs } from '@pagespace/db/schema/drive-envs';
+import { agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
+import { machineSpriteReclaims } from '@pagespace/db/schema/machine-sprite-reclaims';
+import { createDbDriveEnvStore } from '../drive-envs-store';
+
+/**
+ * A SECOND, INDEPENDENT CONNECTION — the only way to observe a lock.
+ *
+ * `db` is one pooled client here, and a test that used it for both sides of a
+ * lock would either deadlock against itself or prove nothing. `pg` is not
+ * hoisted for this package, so it is resolved through `@pagespace/db`'s own
+ * module context — the same physical driver the db package uses.
+ */
+import { createRequire } from 'node:module';
+const requireFromTest = createRequire(import.meta.url);
+const requireFromDb = createRequire(requireFromTest.resolve('@pagespace/db/db'));
+const { Pool } = requireFromDb('pg') as unknown as {
+  Pool: new (config: Record<string, unknown>) => {
+    connect(): Promise<{
+      query(text: string, params?: unknown[]): Promise<{ rows: Array<Record<string, unknown>> }>;
+      release(): void;
+    }>;
+    end(): Promise<void>;
+  };
+};
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 4 });
+
+const payerId = createId();
+const otherPayerId = createId();
+const driveId = createId();
+const secondDriveId = createId();
+const otherDriveId = createId();
+/** Every sandbox name this file lets reach the DB — the reclaim outbox is FK-less, so teardown must sweep it by name. */
+const sandboxIds = new Set<string>();
+
+let store: Awaited<ReturnType<typeof createDbDriveEnvStore>>;
+
+async function seedEnv(
+  over: Partial<{
+    driveId: string;
+    name: string;
+    sandboxId: string;
+    spriteInstanceId: string | null;
+    spriteTornDownAt: Date;
+  }> = {},
+): Promise<string> {
+  const id = createId();
+  if (over.sandboxId) sandboxIds.add(over.sandboxId);
+  await db.insert(driveEnvs).values({
+    id,
+    driveId: over.driveId ?? driveId,
+    name: over.name ?? `env-${id.slice(0, 8)}`,
+    createdBy: payerId,
+    sandboxId: over.sandboxId ?? null,
+    spriteInstanceId: over.spriteInstanceId ?? null,
+    spriteTornDownAt: over.spriteTornDownAt ?? null,
+    updatedAt: new Date(),
+  });
+  return id;
+}
+
+/** A live (not-ended) session bound to an env — what the delete guard counts. */
+async function seedSessionInEnv(envId: string, endedAt: Date | null = null): Promise<string> {
+  const id = createId();
+  await db.insert(agentWorkspaces).values({
+    id,
+    driveId,
+    ownerId: payerId,
+    envId,
+    endedAt,
+    updatedAt: new Date(),
+  });
+  return id;
+}
+
+beforeAll(async () => {
+  store = await createDbDriveEnvStore();
+  await db.insert(users).values([
+    { id: payerId, email: `env-payer-${payerId}@test.local`, name: 'Env Payer', updatedAt: new Date() },
+    { id: otherPayerId, email: `env-other-${otherPayerId}@test.local`, name: 'Other Payer', updatedAt: new Date() },
+  ]).onConflictDoNothing();
+  await db.insert(drives).values([
+    { id: driveId, name: 'Env Drive', slug: `env-drive-${driveId}`, ownerId: payerId, updatedAt: new Date() },
+    { id: secondDriveId, name: 'Env Drive 2', slug: `env-drive2-${secondDriveId}`, ownerId: payerId, updatedAt: new Date() },
+    { id: otherDriveId, name: 'Other Drive', slug: `other-drive-${otherDriveId}`, ownerId: otherPayerId, updatedAt: new Date() },
+  ]).onConflictDoNothing();
+});
+
+beforeEach(async () => {
+  await db.delete(agentWorkspaces).where(eq(agentWorkspaces.ownerId, payerId));
+  for (const drive of [driveId, secondDriveId, otherDriveId]) {
+    await db.delete(driveEnvs).where(eq(driveEnvs.driveId, drive));
+  }
+  if (sandboxIds.size > 0) {
+    await db.delete(machineSpriteReclaims).where(inArray(machineSpriteReclaims.sandboxId, [...sandboxIds]));
+  }
+});
+
+afterAll(async () => {
+  await db.delete(agentWorkspaces).where(eq(agentWorkspaces.ownerId, payerId));
+  for (const drive of [driveId, secondDriveId, otherDriveId]) {
+    await db.delete(driveEnvs).where(eq(driveEnvs.driveId, drive));
+  }
+  if (sandboxIds.size > 0) {
+    await db.delete(machineSpriteReclaims).where(inArray(machineSpriteReclaims.sandboxId, [...sandboxIds]));
+  }
+  await db.delete(drives).where(inArray(drives.id, [driveId, secondDriveId, otherDriveId]));
+  await db.delete(users).where(inArray(users.id, [payerId, otherPayerId]));
+  await pool.end();
+});
+
+describe('deleteIfUnoccupied — the live-session guard, for real', () => {
+  it('given a live session, should refuse and leave the row', async () => {
+    const envId = await seedEnv();
+    await seedSessionInEnv(envId);
+
+    const result = await store.deleteIfUnoccupied({ envId, force: false });
+
+    expect(result).toEqual({ ok: false, reason: 'live_sessions', liveSessionCount: 1 });
+    const [row] = await db.select().from(driveEnvs).where(eq(driveEnvs.id, envId)).limit(1);
+    expect(row).toBeDefined();
+  });
+
+  it('given only ENDED sessions, should delete — and the cascade takes them with it', async () => {
+    const envId = await seedEnv();
+    const endedId = await seedSessionInEnv(envId, new Date());
+
+    const result = await store.deleteIfUnoccupied({ envId, force: false });
+
+    expect(result).toEqual({ ok: true });
+    const sessions = await db.select().from(agentWorkspaces).where(eq(agentWorkspaces.id, endedId));
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('given force, should delete AND cascade the live sessions away', async () => {
+    const envId = await seedEnv();
+    const liveId = await seedSessionInEnv(envId);
+
+    expect(await store.deleteIfUnoccupied({ envId, force: true })).toEqual({ ok: true });
+
+    const sessions = await db.select().from(agentWorkspaces).where(eq(agentWorkspaces.id, liveId));
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('should BLOCK on an in-flight session insert, then SEE it — the store\'s own row lock closing the TOCTOU window', async () => {
+    // THE P1, driven through the store rather than around it. The claim is a
+    // Postgres lock-semantics claim: `deleteIfUnoccupied`'s `FOR UPDATE` on the
+    // env row conflicts with the `FOR KEY SHARE` an `agent_workspaces` insert
+    // must take on that same row for its FK.
+    //
+    // Without that lock the store would not block, would count zero (the
+    // insert is uncommitted and therefore invisible), and would DELETE the row
+    // — cascading away a session that commits a moment later. This test fails
+    // exactly that way if `.for('update')` is dropped, which is what makes it a
+    // test of the fix and not of Postgres.
+    const envId = await seedEnv();
+    const spawnId = createId();
+
+    const spawner = await pool.connect();
+    try {
+      // A session binds to this env, and HOLDS the transaction open.
+      await spawner.query('BEGIN');
+      await spawner.query(
+        'INSERT INTO agent_workspaces (id, "driveId", "ownerId", "envId", "updatedAt") VALUES ($1,$2,$3,$4,now())',
+        [spawnId, driveId, payerId, envId],
+      );
+
+      let settled = false;
+      const deleting = store.deleteIfUnoccupied({ envId, force: false }).then((result) => {
+        settled = true;
+        return result;
+      });
+
+      // The delete must be WAITING on the row lock, not racing past it.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(settled).toBe(false);
+
+      await spawner.query('COMMIT');
+
+      // Released, and the count now sees the session that committed.
+      expect(await deleting).toEqual({ ok: false, reason: 'live_sessions', liveSessionCount: 1 });
+      const [row] = await db.select().from(driveEnvs).where(eq(driveEnvs.id, envId)).limit(1);
+      expect(row).toBeDefined();
+    } finally {
+      spawner.release();
+    }
+  });
+
+  it('given force, should still take the lock and delete through an in-flight bind', async () => {
+    // Forcing skips the COUNT, not the lock — the FK-holding insert is
+    // serialized behind the delete either way, and then fails against a row
+    // that is gone. A spawn racing the deletion of its own env failing is the
+    // correct outcome.
+    const envId = await seedEnv();
+    const spawnId = createId();
+    const spawner = await pool.connect();
+    try {
+      await spawner.query('BEGIN');
+      await spawner.query(
+        'INSERT INTO agent_workspaces (id, "driveId", "ownerId", "envId", "updatedAt") VALUES ($1,$2,$3,$4,now())',
+        [spawnId, driveId, payerId, envId],
+      );
+      const deleting = store.deleteIfUnoccupied({ envId, force: true });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await spawner.query('COMMIT');
+      expect(await deleting).toEqual({ ok: true });
+    } finally {
+      spawner.release();
+    }
+    const rows = await db.select().from(agentWorkspaces).where(eq(agentWorkspaces.id, spawnId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('given the row is gone, should report not_found rather than a phantom success', async () => {
+    expect(await store.deleteIfUnoccupied({ envId: createId(), force: false })).toEqual({
+      ok: false,
+      reason: 'not_found',
+    });
+  });
+});
+
+describe('the AFTER DELETE reclaim trigger', () => {
+  it('given a row that still believes it is live, should enqueue its pointer', async () => {
+    const sandboxId = `pgs-env-live-${createId()}`;
+    const envId = await seedEnv({ sandboxId, spriteInstanceId: 'inst-1' });
+
+    await store.deleteIfUnoccupied({ envId, force: false });
+
+    const [reclaim] = await db
+      .select()
+      .from(machineSpriteReclaims)
+      .where(eq(machineSpriteReclaims.sandboxId, sandboxId))
+      .limit(1);
+    expect(reclaim?.spriteInstanceId).toBe('inst-1');
+  });
+
+  it('given a CONFIRMED torn-down row, should enqueue nothing — no chasing a dead name', async () => {
+    const sandboxId = `pgs-env-dead-${createId()}`;
+    const envId = await seedEnv({ sandboxId, spriteInstanceId: 'inst-1', spriteTornDownAt: new Date() });
+
+    await store.deleteIfUnoccupied({ envId, force: false });
+
+    const reclaims = await db
+      .select()
+      .from(machineSpriteReclaims)
+      .where(eq(machineSpriteReclaims.sandboxId, sandboxId));
+    expect(reclaims).toHaveLength(0);
+  });
+});
+
+describe('createIfUnderLimit — the ceiling, for real', () => {
+  it('given the payer is under the ceiling, should mint', async () => {
+    const result = await store.createIfUnderLimit({
+      driveId,
+      name: 'staging',
+      createdBy: payerId,
+      now: new Date(),
+      payerId,
+      maxEnvs: 2,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('given the payer is AT the ceiling, should refuse — counted across every drive they own', async () => {
+    // The count is per PAYER, not per drive: envs in a second drive of the same
+    // owner consume the same allowance.
+    await seedEnv({ driveId, name: 'a' });
+    await seedEnv({ driveId: secondDriveId, name: 'b' });
+
+    const result = await store.createIfUnderLimit({
+      driveId,
+      name: 'c',
+      createdBy: payerId,
+      now: new Date(),
+      payerId,
+      maxEnvs: 2,
+    });
+    expect(result).toEqual({ ok: false, reason: 'limit_reached' });
+  });
+
+  it('should not count ANOTHER payer\'s environments', async () => {
+    await seedEnv({ driveId: otherDriveId, name: 'theirs' });
+    const result = await store.createIfUnderLimit({
+      driveId,
+      name: 'mine',
+      createdBy: payerId,
+      now: new Date(),
+      payerId,
+      maxEnvs: 1,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('should serialize on the PER-PAYER advisory lock — held from outside, the create waits', async () => {
+    // THE OTHER P1, pinned deterministically rather than by racing. Holding the
+    // exact key `createIfUnderLimit` takes, from an independent connection,
+    // must block it: that proves both that the lock is taken at all and that
+    // its key is the per-PAYER one. A missing lock does not block (the create
+    // returns immediately), and neither does a per-DRIVE key — which is the
+    // subtly wrong version, since one payer's two drives would then race past
+    // a ceiling defined across both.
+    const holder = await pool.connect();
+    try {
+      await holder.query('BEGIN');
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`drive-env-create:${payerId}`]);
+
+      let settled = false;
+      const creating = store
+        .createIfUnderLimit({ driveId, name: 'dev', createdBy: payerId, now: new Date(), payerId, maxEnvs: 5 })
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(settled).toBe(false);
+
+      await holder.query('COMMIT');
+      expect((await creating).ok).toBe(true);
+    } finally {
+      holder.release();
+    }
+  });
+
+  it('should NOT contend with another payer\'s create — the lock is per payer, not global', async () => {
+    // The other half of the key claim: a global lock would serialize unrelated
+    // payers, turning env creation into a deployment-wide bottleneck.
+    const holder = await pool.connect();
+    try {
+      await holder.query('BEGIN');
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`drive-env-create:${otherPayerId}`]);
+
+      const result = await store.createIfUnderLimit({
+        driveId,
+        name: 'dev',
+        createdBy: payerId,
+        now: new Date(),
+        payerId,
+        maxEnvs: 5,
+      });
+
+      expect(result.ok).toBe(true);
+      await holder.query('COMMIT');
+    } finally {
+      holder.release();
+    }
+  });
+
+  it('given MANY concurrent creates at the ceiling, should let exactly the remaining slots through', async () => {
+    // The behavioral form of the same guarantee: `(driveId, name)` uniqueness
+    // cannot serialize `env-0` against `env-1`, so the ceiling has to come from
+    // the lock. Six concurrent creates, two slots left, exactly two winners.
+    await seedEnv({ driveId, name: 'existing-a' });
+    await seedEnv({ driveId, name: 'existing-b' });
+
+    const attempts = await Promise.all(
+      Array.from({ length: 6 }, (_unused, index) =>
+        store.createIfUnderLimit({
+          driveId,
+          name: `race-${index}`,
+          createdBy: payerId,
+          now: new Date(),
+          payerId,
+          maxEnvs: 4,
+        }),
+      ),
+    );
+
+    expect(attempts.filter((attempt) => attempt.ok)).toHaveLength(2);
+    const rows = await db.select().from(driveEnvs).where(eq(driveEnvs.driveId, driveId));
+    expect(rows).toHaveLength(4);
+  });
+
+  it('given a duplicate NAME, should answer name_taken rather than throwing — drizzle wraps the driver error', async () => {
+    // The wrapped-`cause` case: `drizzle-orm@0.45.2` rethrows the driver's
+    // 23505 inside `DrizzleQueryError`, so a top-level `.code` test would let
+    // this escape as a 500 instead of the 409 the route sends.
+    await seedEnv({ driveId, name: 'staging' });
+    const result = await store.createIfUnderLimit({
+      driveId,
+      name: 'staging',
+      createdBy: payerId,
+      now: new Date(),
+      payerId,
+      maxEnvs: 10,
+    });
+    expect(result).toEqual({ ok: false, reason: 'name_taken' });
+  });
+});
+
+describe('rename — the same wrapped-violation path', () => {
+  it('given the new name is taken in the drive, should answer name_taken', async () => {
+    await seedEnv({ driveId, name: 'prod' });
+    const envId = await seedEnv({ driveId, name: 'dev' });
+
+    expect(await store.rename({ envId, name: 'prod', now: new Date() })).toEqual({
+      ok: false,
+      reason: 'name_taken',
+    });
+  });
+
+  it('given the same name in ANOTHER drive, should allow it — uniqueness is per drive', async () => {
+    await seedEnv({ driveId: secondDriveId, name: 'prod' });
+    const envId = await seedEnv({ driveId, name: 'dev' });
+
+    const result = await store.rename({ envId, name: 'prod', now: new Date() });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('the Sprite-identity CAS, in SQL', () => {
+  it('given the row has no sandbox, should record only against a NULL previous pointer', async () => {
+    // `eqOrIsNull`: SQL `=` never matches NULL, so a plain `eq` here would make
+    // every first provision silently lose its own CAS.
+    const sandboxId = `pgs-env-cas-${createId()}`;
+    sandboxIds.add(sandboxId);
+    const envId = await seedEnv();
+
+    const recorded = await store.updateSpriteIdentity({
+      envId,
+      previousSandboxId: null,
+      spriteKey: sandboxId,
+      sandboxId,
+      spriteInstanceId: 'inst-1',
+      egressPolicyToken: null,
+      stamps: { lastActiveAt: new Date(), teardownRequestedAt: null, spriteTornDownAt: null },
+      now: new Date(),
+    });
+
+    expect(recorded).toBe(true);
+    const [row] = await db.select().from(driveEnvs).where(eq(driveEnvs.id, envId)).limit(1);
+    expect(row.sandboxId).toBe(sandboxId);
+  });
+
+  it('given a STALE previous pointer, should refuse — the loser of a concurrent provision', async () => {
+    const sandboxId = `pgs-env-held-${createId()}`;
+    sandboxIds.add(sandboxId);
+    const envId = await seedEnv({ sandboxId, spriteInstanceId: 'inst-1' });
+
+    const recorded = await store.updateSpriteIdentity({
+      envId,
+      previousSandboxId: null,
+      spriteKey: 'other-key',
+      sandboxId: `pgs-env-other-${createId()}`,
+      spriteInstanceId: 'inst-2',
+      egressPolicyToken: null,
+      stamps: {},
+      now: new Date(),
+    });
+
+    expect(recorded).toBe(false);
+  });
+
+  it('should CAS the teardown stamp on the INSTANCE, not merely the name', async () => {
+    const sandboxId = `pgs-env-teardown-${createId()}`;
+    sandboxIds.add(sandboxId);
+    const envId = await seedEnv({ sandboxId, spriteInstanceId: 'inst-2' });
+
+    // Stale expectation — a concurrent re-provision moved the instance.
+    const stale = await store.stampSpriteTornDown({
+      envId,
+      sandboxId,
+      spriteInstanceId: 'inst-1',
+      stamps: { spriteTornDownAt: new Date() },
+    });
+    expect(stale).toBe(false);
+
+    const current = await store.stampSpriteTornDown({
+      envId,
+      sandboxId,
+      spriteInstanceId: 'inst-2',
+      stamps: { spriteTornDownAt: new Date() },
+    });
+    expect(current).toBe(true);
+  });
+});
+
+describe('countLiveSessionsInEnv / countEnvsOwnedBy', () => {
+  it('should count only NOT-ENDED sessions in this env', async () => {
+    const envId = await seedEnv();
+    const otherEnvId = await seedEnv({ name: 'other' });
+    await seedSessionInEnv(envId);
+    await seedSessionInEnv(envId, new Date());
+    await seedSessionInEnv(otherEnvId);
+
+    expect(await store.countLiveSessionsInEnv(envId)).toBe(1);
+  });
+
+  it('should count envs through DRIVE ownership, across every drive the payer owns', async () => {
+    await seedEnv({ driveId, name: 'a' });
+    await seedEnv({ driveId: secondDriveId, name: 'b' });
+    await seedEnv({ driveId: otherDriveId, name: 'theirs' });
+
+    expect(await store.countEnvsOwnedBy(payerId)).toBe(2);
+    expect(await store.countEnvsOwnedBy(otherPayerId)).toBe(1);
+  });
+});

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
@@ -207,7 +207,7 @@ describe('deleteDriveEnv', () => {
 
     expect(result).toEqual({ ok: false, reason: 'live_sessions', liveSessionCount: 2 });
     expect(host.calls.kill).toEqual([]);
-    expect(store.calls.deleteById).toBe(0);
+    expect(store.calls.deleteIfUnoccupied).toBe(0);
     expect(store.rows.has(ENV_ID)).toBe(true);
   });
 
@@ -267,7 +267,7 @@ describe('deleteDriveEnv', () => {
     const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
 
     expect(result).toMatchObject({ ok: false, reason: 'teardown_failed' });
-    expect(store.calls.deleteById).toBe(0);
+    expect(store.calls.deleteIfUnoccupied).toBe(0);
     expect(store.rows.has(ENV_ID)).toBe(true);
     // The intent survives, which is what licenses the orphan reconciler to retry.
     expect(store.rows.get(ENV_ID)?.teardownRequestedAt).toEqual(NOW);

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
@@ -267,13 +267,35 @@ describe('deleteDriveEnv', () => {
     expect(host.calls.kill).toEqual([]);
   });
 
-  it('should leave the deleted row Sprite pointer in the reclaim outbox — the crash net, via the AFTER DELETE trigger', async () => {
+  it('given a CONFIRMED teardown, should enqueue NOTHING — the trigger must not have the cron chase a dead name', async () => {
     const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
     const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
 
     await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
 
-    expect(store.reclaims.get(SANDBOX_ID)).toBe('inst-1');
+    expect(store.reclaims.size).toBe(0);
+  });
+
+  it('given a concurrent re-provision won the confirmation CAS, should still delete AND leave the live replacement to the reclaim outbox', async () => {
+    // The crash net doing its actual job. Our kill destroyed instance 1; while
+    // it ran, another provisioner put a LIVE instance 2 on the row. The
+    // confirmation CAS correctly refuses (stamping that VM dead would hide a
+    // billing machine forever), so the row goes to DELETE still believing it is
+    // live — which is exactly the shape the AFTER DELETE trigger fires on.
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+    const realKill = host.host.kill.bind(host.host);
+    host.host.kill = async (input) => {
+      await realKill(input);
+      const row = store.rows.get(ENV_ID);
+      if (row) store.rows.set(ENV_ID, { ...row, spriteInstanceId: 'inst-2' });
+    };
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, spriteTornDown: false });
+    expect(store.rows.has(ENV_ID)).toBe(false);
+    expect(store.reclaims.get(SANDBOX_ID)).toBe('inst-2');
   });
 
   it('given no such env, should answer not_found', async () => {

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createDriveEnv,
+  listDriveEnvs,
+  renameDriveEnv,
+  deleteDriveEnv,
+  rebuildDriveEnv,
+  deriveDriveEnvStatus,
+  toDriveEnvDTO,
+  type CreateDriveEnvDeps,
+  type DeleteDriveEnvDeps,
+  type RebuildDriveEnvDeps,
+} from '../drive-envs';
+import { driveEnvDtoSchema } from '../../../drive-envs/env-contract';
+import { getDriveEnvLimit } from '../../sandbox/quota';
+import { SandboxSpriteReplacedError } from '../../sandbox/sandbox-host';
+import { DRIVE_ID, ENV_ID, NOW, PAYER_ID, makeDriveEnvStore, makeEnvRecord, makeSpriteHost } from './fakes';
+
+const SANDBOX_ID = 'pgs-env-abc';
+
+function makeCreateDeps(
+  store: ReturnType<typeof makeDriveEnvStore>,
+  over: Partial<CreateDriveEnvDeps> = {},
+): CreateDriveEnvDeps {
+  return {
+    store: store.store,
+    resolvePayer: async () => ({ payerId: PAYER_ID, tier: 'pro' }),
+    now: () => NOW,
+    ...over,
+  };
+}
+
+function makeDeleteDeps(
+  store: ReturnType<typeof makeDriveEnvStore>,
+  host: ReturnType<typeof makeSpriteHost>,
+): DeleteDriveEnvDeps {
+  return { store: store.store, host: host.host, now: () => NOW };
+}
+
+describe('createDriveEnv', () => {
+  it('should mint a row WITHOUT provisioning — envs provision lazily, on the first session inside one', async () => {
+    const store = makeDriveEnvStore();
+    const result = await createDriveEnv({ driveId: DRIVE_ID, name: 'staging', createdBy: 'user-1', deps: makeCreateDeps(store) });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.env.driveId).toBe(DRIVE_ID);
+    expect(result.env.name).toBe('staging');
+    expect(result.env.sandboxId).toBeNull();
+    expect(result.env.spriteKey).toBeNull();
+  });
+
+  it('given a vanished drive, should fail closed rather than meter the request against anybody else', async () => {
+    const store = makeDriveEnvStore();
+    const countEnvsOwnedBy = vi.spyOn(store.store, 'countEnvsOwnedBy');
+    const result = await createDriveEnv({
+      driveId: DRIVE_ID,
+      name: 'staging',
+      createdBy: null,
+      deps: makeCreateDeps(store, { resolvePayer: async () => null }),
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'drive_not_found' });
+    expect(countEnvsOwnedBy).not.toHaveBeenCalled();
+  });
+
+  it('given a duplicate name in the drive, should answer name_taken — the unique index resolves concurrent creates', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ name: 'staging' })]);
+    const result = await createDriveEnv({ driveId: DRIVE_ID, name: 'staging', createdBy: null, deps: makeCreateDeps(store) });
+    expect(result).toEqual({ ok: false, reason: 'name_taken' });
+  });
+
+  it('given the payer is AT their tier ceiling, should refuse before minting a row', async () => {
+    const store = makeDriveEnvStore();
+    store.ownedEnvs.set(PAYER_ID, getDriveEnvLimit('pro'));
+    const result = await createDriveEnv({ driveId: DRIVE_ID, name: 'staging', createdBy: null, deps: makeCreateDeps(store) });
+
+    expect(result).toEqual({ ok: false, reason: 'quota_exceeded', denial: 'env_limit_reached', limit: getDriveEnvLimit('pro') });
+    expect(store.rows.size).toBe(0);
+  });
+
+  it('given a FREE-tier payer, should refuse as tier_ineligible — envs are a paid-tier feature', async () => {
+    const store = makeDriveEnvStore();
+    const result = await createDriveEnv({
+      driveId: DRIVE_ID,
+      name: 'staging',
+      createdBy: null,
+      deps: makeCreateDeps(store, { resolvePayer: async () => ({ payerId: PAYER_ID, tier: 'free' }) }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result).toMatchObject({ reason: 'quota_exceeded', denial: 'tier_ineligible' });
+    expect(store.rows.size).toBe(0);
+  });
+
+  it('should meter the DRIVE OWNER, not the creator — an env is drive-owned and drive-billed', async () => {
+    const store = makeDriveEnvStore();
+    const countEnvsOwnedBy = vi.spyOn(store.store, 'countEnvsOwnedBy');
+    await createDriveEnv({ driveId: DRIVE_ID, name: 'staging', createdBy: 'some-member', deps: makeCreateDeps(store) });
+    expect(countEnvsOwnedBy).toHaveBeenCalledWith(PAYER_ID);
+  });
+});
+
+describe('listDriveEnvs / the DTO', () => {
+  it('should serve contract-valid DTOs carrying no Sprite pointer at all', async () => {
+    const store = makeDriveEnvStore([
+      makeEnvRecord({ id: 'env-a', name: 'dev' }),
+      makeEnvRecord({ id: 'env-b', name: 'staging', sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' }),
+    ]);
+    const dtos = await listDriveEnvs({ driveId: DRIVE_ID, deps: { store: store.store } });
+
+    expect(dtos.map((d) => d.name)).toEqual(['dev', 'staging']);
+    for (const dto of dtos) expect(driveEnvDtoSchema.parse(dto)).toEqual(dto);
+    expect(JSON.stringify(dtos)).not.toContain(SANDBOX_ID);
+  });
+
+  it('should report status from the pointer columns, checking the teardown stamp FIRST', () => {
+    // A torn-down env KEEPS its sandboxId (a reclaim needs that pointer), so
+    // testing the name first would report a destroyed VM as running.
+    expect(deriveDriveEnvStatus({ sandboxId: null, spriteTornDownAt: null })).toBe('none');
+    expect(deriveDriveEnvStatus({ sandboxId: SANDBOX_ID, spriteTornDownAt: null })).toBe('running');
+    expect(deriveDriveEnvStatus({ sandboxId: SANDBOX_ID, spriteTornDownAt: NOW })).toBe('stopped');
+  });
+
+  it('should project a stopped env as stopped, never as ended — an env outlives its machine', () => {
+    const dto = toDriveEnvDTO(makeEnvRecord({ sandboxId: SANDBOX_ID, spriteTornDownAt: NOW }));
+    expect(dto.status).toBe('stopped');
+    expect(dto.createdAt).toBe(NOW.toISOString());
+  });
+});
+
+describe('renameDriveEnv', () => {
+  it('should move the name and nothing else — the id, key and filesystem are untouched', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ spriteKey: 'key-1', sandboxId: SANDBOX_ID })]);
+    const result = await renameDriveEnv({ envId: ENV_ID, name: 'prod', deps: { store: store.store, now: () => NOW } });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.env.name).toBe('prod');
+    expect(result.env.id).toBe(ENV_ID);
+    expect(result.env.spriteKey).toBe('key-1');
+    expect(result.env.sandboxId).toBe(SANDBOX_ID);
+  });
+
+  it('given the new name is taken in the drive, should refuse — a name is an address', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ id: 'env-a', name: 'dev' }), makeEnvRecord({ id: 'env-b', name: 'prod' })]);
+    const result = await renameDriveEnv({ envId: 'env-a', name: 'prod', deps: { store: store.store, now: () => NOW } });
+    expect(result).toEqual({ ok: false, reason: 'name_taken' });
+  });
+
+  it('given no such env, should answer not_found', async () => {
+    const store = makeDriveEnvStore();
+    const result = await renameDriveEnv({ envId: 'nope', name: 'prod', deps: { store: store.store, now: () => NOW } });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('deleteDriveEnv', () => {
+  it('given live sessions and no force, should refuse and touch NOTHING', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: `inst-${SANDBOX_ID}` })]);
+    store.liveSessions.set(ENV_ID, 2);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: `inst-${SANDBOX_ID}` } } });
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: false, reason: 'live_sessions', liveSessionCount: 2 });
+    expect(host.calls.kill).toEqual([]);
+    expect(store.calls.deleteById).toBe(0);
+    expect(store.rows.has(ENV_ID)).toBe(true);
+  });
+
+  it('given live sessions AND force, should tear the Sprite down and delete the row', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: `inst-${SANDBOX_ID}` })]);
+    store.liveSessions.set(ENV_ID, 2);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: `inst-${SANDBOX_ID}` } } });
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: true, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, spriteTornDown: true });
+    expect(host.live.has(SANDBOX_ID)).toBe(false);
+    expect(store.rows.has(ENV_ID)).toBe(false);
+  });
+
+  it('should record the teardown INTENT before the kill — a crash in between must stay reclaimable', async () => {
+    const order: string[] = [];
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: `inst-${SANDBOX_ID}` })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: `inst-${SANDBOX_ID}` } } });
+    const realRequest = store.store.requestTeardown.bind(store.store);
+    store.store.requestTeardown = async (input) => {
+      order.push('requestTeardown');
+      // The stamp must be DURABLE before the kill, not merely called first.
+      expect(store.rows.get(ENV_ID)?.teardownRequestedAt).toBeNull();
+      await realRequest(input);
+      expect(store.rows.get(ENV_ID)?.teardownRequestedAt).toEqual(NOW);
+    };
+    const realKill = host.host.kill.bind(host.host);
+    host.host.kill = async (input) => {
+      order.push('kill');
+      await realKill(input);
+    };
+    store.store.deleteById = (async (envId: string) => {
+      order.push('deleteById');
+      return store.rows.delete(envId);
+    }) as typeof store.store.deleteById;
+
+    await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(order).toEqual(['requestTeardown', 'kill', 'deleteById']);
+  });
+
+  it('should CAS the kill on the INSTANCE the row records, not just the name', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+
+    await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(host.calls.kill).toEqual([{ sandboxId: SANDBOX_ID, expectedInstanceId: 'inst-1' }]);
+  });
+
+  it('given the kill FAILS, should abort the delete and leave the row as the reconciler handle', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } }, killError: new Error('control plane down') });
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toMatchObject({ ok: false, reason: 'teardown_failed' });
+    expect(store.calls.deleteById).toBe(0);
+    expect(store.rows.has(ENV_ID)).toBe(true);
+    // The intent survives, which is what licenses the orphan reconciler to retry.
+    expect(store.rows.get(ENV_ID)?.teardownRequestedAt).toEqual(NOW);
+  });
+
+  it('given a REPLACEMENT VM already holds the name, should treat the target as gone and finish the delete', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({
+      seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } },
+      killError: new SandboxSpriteReplacedError(SANDBOX_ID, 'inst-1', 'inst-2'),
+    });
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result.ok).toBe(true);
+    expect(store.rows.has(ENV_ID)).toBe(false);
+  });
+
+  it('given a never-provisioned env, should delete without killing anything', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord()]);
+    const host = makeSpriteHost();
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, spriteTornDown: false });
+    expect(host.calls.kill).toEqual([]);
+    expect(store.rows.has(ENV_ID)).toBe(false);
+  });
+
+  it('given an ALREADY torn-down env, should delete without re-killing a confirmed-dead Sprite', async () => {
+    const store = makeDriveEnvStore([
+      makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1', spriteTornDownAt: NOW }),
+    ]);
+    const host = makeSpriteHost();
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, spriteTornDown: false });
+    expect(host.calls.kill).toEqual([]);
+  });
+
+  it('should leave the deleted row Sprite pointer in the reclaim outbox — the crash net, via the AFTER DELETE trigger', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+
+    await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(store.reclaims.get(SANDBOX_ID)).toBe('inst-1');
+  });
+
+  it('given no such env, should answer not_found', async () => {
+    const store = makeDriveEnvStore();
+    const result = await deleteDriveEnv({ envId: 'nope', force: false, deps: makeDeleteDeps(store, makeSpriteHost()) });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('rebuildDriveEnv', () => {
+  function makeRebuildDeps(
+    store: ReturnType<typeof makeDriveEnvStore>,
+    host: ReturnType<typeof makeSpriteHost>,
+    over: Partial<RebuildDriveEnvDeps> = {},
+  ): RebuildDriveEnvDeps {
+    return {
+      store: store.store,
+      host: host.host,
+      // Stands in for the app's binding of `ensureSpriteHolderSandbox`: mints a
+      // VM under the env's deterministic name and records it, exactly as the
+      // real `create` arm does.
+      ensureSandbox: async (row) => {
+        const handle = await host.host.provision({ name: SANDBOX_ID, substrate: { kind: 'sprite' }, options: {} });
+        await store.store.updateSpriteIdentity({
+          envId: row.id,
+          previousSandboxId: row.sandboxId,
+          spriteKey: SANDBOX_ID,
+          sandboxId: handle.sandboxId,
+          spriteInstanceId: handle.spriteInstanceId ?? null,
+          egressPolicyToken: null,
+          stamps: { lastActiveAt: NOW, teardownRequestedAt: null, spriteTornDownAt: null },
+          now: NOW,
+        });
+        return { ok: true, sandboxId: handle.sandboxId, resumed: false };
+      },
+      now: () => NOW,
+      ...over,
+    };
+  }
+
+  it('should KILL before it re-provisions — a deterministic name would otherwise hand back the same disk', async () => {
+    const order: string[] = [];
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({
+      seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } },
+      nextInstanceId: () => 'inst-2',
+    });
+    const realKill = host.host.kill.bind(host.host);
+    host.host.kill = async (input) => {
+      order.push('kill');
+      await realKill(input);
+    };
+    const deps = makeRebuildDeps(store, host);
+    const ensure = deps.ensureSandbox;
+    deps.ensureSandbox = async (row) => {
+      order.push('provision');
+      return ensure(row);
+    };
+
+    const result = await rebuildDriveEnv({ envId: ENV_ID, deps });
+
+    expect(result).toEqual({ ok: true, sandboxId: SANDBOX_ID });
+    expect(order).toEqual(['kill', 'provision']);
+    // Same env id, same Sprite name, DIFFERENT VM — that is what a rebuild is.
+    expect(store.rows.get(ENV_ID)?.spriteInstanceId).toBe('inst-2');
+    expect(store.rows.get(ENV_ID)?.spriteTornDownAt).toBeNull();
+  });
+
+  it('given the kill FAILS, should abort and leave the env on the machine it had', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } }, killError: new Error('nope') });
+    const deps = makeRebuildDeps(store, host);
+    const ensureSandbox = vi.fn(deps.ensureSandbox);
+    deps.ensureSandbox = ensureSandbox;
+
+    const result = await rebuildDriveEnv({ envId: ENV_ID, deps });
+
+    expect(result).toMatchObject({ ok: false, reason: 'teardown_failed' });
+    expect(ensureSandbox).not.toHaveBeenCalled();
+    expect(store.rows.get(ENV_ID)?.spriteInstanceId).toBe('inst-1');
+  });
+
+  it('given a never-provisioned env, should just provision — there is nothing to tear down', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord()]);
+    const host = makeSpriteHost();
+    const result = await rebuildDriveEnv({ envId: ENV_ID, deps: makeRebuildDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, sandboxId: SANDBOX_ID });
+    expect(host.calls.kill).toEqual([]);
+  });
+
+  it('should hand the provisioner the POST-teardown row, not the stale pre-teardown snapshot', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } }, nextInstanceId: () => 'inst-2' });
+    const deps = makeRebuildDeps(store, host);
+    const seen: Array<Date | null> = [];
+    const ensure = deps.ensureSandbox;
+    deps.ensureSandbox = async (row) => {
+      seen.push(row.spriteTornDownAt);
+      return ensure(row);
+    };
+
+    await rebuildDriveEnv({ envId: ENV_ID, deps });
+
+    expect(seen).toEqual([NOW]);
+  });
+
+  it('given provisioning fails after the kill, should report it and leave the env machineless but intact', async () => {
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+    const result = await rebuildDriveEnv({
+      envId: ENV_ID,
+      deps: makeRebuildDeps(store, host, {
+        ensureSandbox: async () => ({ ok: false, reason: 'provision_failed', detail: 'no capacity' }),
+      }),
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'provision_failed', detail: 'no capacity' });
+    expect(store.rows.has(ENV_ID)).toBe(true);
+    expect(store.rows.get(ENV_ID)?.spriteTornDownAt).toEqual(NOW);
+  });
+
+  it('given no such env, should answer not_found', async () => {
+    const store = makeDriveEnvStore();
+    const result = await rebuildDriveEnv({ envId: 'nope', deps: makeRebuildDeps(store, makeSpriteHost()) });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
@@ -94,6 +94,46 @@ describe('createDriveEnv', () => {
     expect(store.rows.size).toBe(0);
   });
 
+  it('given the pre-check passed but the payer hit the ceiling first, should still refuse — the STRUCTURAL check is the real one', async () => {
+    // The race Codex named: two admins create differently-NAMED envs for one
+    // payer at the ceiling. `(driveId, name)` uniqueness cannot serialize them,
+    // and both advisory pre-checks read "under". The count-and-insert under the
+    // per-payer advisory lock is what actually holds the line, so a create that
+    // passed the pre-check must still be refused by the store.
+    const store = makeDriveEnvStore();
+    const deps = makeCreateDeps(store);
+    // Under the ceiling when the pre-check reads...
+    store.ownedEnvs.set(PAYER_ID, getDriveEnvLimit('pro') - 1);
+    const countEnvsOwnedBy = vi.spyOn(store.store, 'countEnvsOwnedBy').mockImplementation(async (payerId) => {
+      // ...and AT it by the time the insert serializes behind the other admin.
+      const seen = store.ownedEnvs.get(payerId) ?? 0;
+      store.ownedEnvs.set(payerId, getDriveEnvLimit('pro'));
+      return seen;
+    });
+
+    const result = await createDriveEnv({ driveId: DRIVE_ID, name: 'staging', createdBy: null, deps });
+
+    expect(countEnvsOwnedBy).toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      reason: 'quota_exceeded',
+      denial: 'env_limit_reached',
+      limit: getDriveEnvLimit('pro'),
+    });
+    expect(store.rows.size).toBe(0);
+  });
+
+  it('should hand the store the payer AND the tier ceiling — the lock is per PAYER, not per drive', async () => {
+    // Per-drive serialization would let one payer's two drives race past a
+    // ceiling that is defined across every drive they own.
+    const store = makeDriveEnvStore();
+    const createIfUnderLimit = vi.spyOn(store.store, 'createIfUnderLimit');
+    await createDriveEnv({ driveId: DRIVE_ID, name: 'staging', createdBy: null, deps: makeCreateDeps(store) });
+    expect(createIfUnderLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ payerId: PAYER_ID, maxEnvs: getDriveEnvLimit('pro') }),
+    );
+  });
+
   it('should meter the DRIVE OWNER, not the creator — an env is drive-owned and drive-billed', async () => {
     const store = makeDriveEnvStore();
     const countEnvsOwnedBy = vi.spyOn(store.store, 'countEnvsOwnedBy');
@@ -199,14 +239,15 @@ describe('deleteDriveEnv', () => {
       order.push('kill');
       await realKill(input);
     };
-    store.store.deleteById = (async (envId: string) => {
-      order.push('deleteById');
-      return store.rows.delete(envId);
-    }) as typeof store.store.deleteById;
+    const realDelete = store.store.deleteIfUnoccupied.bind(store.store);
+    store.store.deleteIfUnoccupied = async (deleteInput) => {
+      order.push('deleteIfUnoccupied');
+      return realDelete(deleteInput);
+    };
 
     await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
 
-    expect(order).toEqual(['requestTeardown', 'kill', 'deleteById']);
+    expect(order).toEqual(['requestTeardown', 'kill', 'deleteIfUnoccupied']);
   });
 
   it('should CAS the kill on the INSTANCE the row records, not just the name', async () => {
@@ -296,6 +337,46 @@ describe('deleteDriveEnv', () => {
     expect(result).toEqual({ ok: true, spriteTornDown: false });
     expect(store.rows.has(ENV_ID)).toBe(false);
     expect(store.reclaims.get(SANDBOX_ID)).toBe('inst-2');
+  });
+
+  it('given a session binds DURING the teardown, should refuse the delete rather than cascade it away', async () => {
+    // The window Codex named: the cheap guard read zero, and by the time the
+    // row would be deleted a session is live in the env. `agent_workspaces.envId`
+    // is ON DELETE CASCADE, so an unguarded delete here destroys work nobody
+    // opted into destroying. The atomic re-guard inside the delete refuses.
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+    const realKill = host.host.kill.bind(host.host);
+    host.host.kill = async (killInput) => {
+      await realKill(killInput);
+      store.liveSessions.set(ENV_ID, 1);
+    };
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: false, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: false, reason: 'live_sessions', liveSessionCount: 1 });
+    // The env survives, machineless — an ordinary `stopped` env the racing
+    // session re-provisions on its next ensure. A rebuilt machine is
+    // recoverable; a deleted live session's work is not.
+    expect(store.rows.has(ENV_ID)).toBe(true);
+    expect(store.rows.get(ENV_ID)?.spriteTornDownAt).toEqual(NOW);
+  });
+
+  it('given force, should delete even when a session binds during the teardown', async () => {
+    // Forcing means the caller was told sessions are live and said destroy them
+    // anyway, so the atomic re-guard skips the count — not the lock.
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+    const realKill = host.host.kill.bind(host.host);
+    host.host.kill = async (killInput) => {
+      await realKill(killInput);
+      store.liveSessions.set(ENV_ID, 1);
+    };
+
+    const result = await deleteDriveEnv({ envId: ENV_ID, force: true, deps: makeDeleteDeps(store, host) });
+
+    expect(result).toEqual({ ok: true, spriteTornDown: true });
+    expect(store.rows.has(ENV_ID)).toBe(false);
   });
 
   it('given no such env, should answer not_found', async () => {

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
@@ -11,6 +11,7 @@ import {
   type DeleteDriveEnvDeps,
   type RebuildDriveEnvDeps,
 } from '../drive-envs';
+import { isUniqueViolation } from '../drive-envs-store';
 import { driveEnvDtoSchema } from '../../../drive-envs/env-contract';
 import { getDriveEnvLimit } from '../../sandbox/quota';
 import { SandboxSpriteReplacedError } from '../../sandbox/sandbox-host';
@@ -386,6 +387,37 @@ describe('deleteDriveEnv', () => {
   });
 });
 
+describe('isUniqueViolation', () => {
+  it('given drizzle\'s WRAPPED error, should recognize the unique violation', () => {
+    // `drizzle-orm@0.45.2`'s pg-core rethrows every driver error as
+    // `DrizzleQueryError` with the original on `.cause`, so a top-level `.code`
+    // test matches nothing that comes back from an insert — and a duplicate
+    // environment name escapes as a 500 instead of the 409 the route sends.
+    const driverError = Object.assign(new Error('duplicate key value'), { code: '23505' });
+    const wrapped = Object.assign(new Error('Failed query: insert into "drive_envs"'), { cause: driverError });
+    expect(isUniqueViolation(wrapped)).toBe(true);
+  });
+
+  it('given a BARE driver error, should still recognize it — the shape is a dependency detail', () => {
+    expect(isUniqueViolation(Object.assign(new Error('dup'), { code: '23505' }))).toBe(true);
+  });
+
+  it('given any other failure, should not claim a name collision', () => {
+    const other = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+    expect(isUniqueViolation(Object.assign(new Error('Failed query'), { cause: other }))).toBe(false);
+    expect(isUniqueViolation(new Error('connection refused'))).toBe(false);
+    expect(isUniqueViolation(null)).toBe(false);
+  });
+
+  it('given a CYCLIC cause chain, should terminate', () => {
+    const a = new Error('a') as Error & { cause?: unknown };
+    const b = new Error('b') as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isUniqueViolation(a)).toBe(false);
+  });
+});
+
 describe('rebuildDriveEnv', () => {
   function makeRebuildDeps(
     store: ReturnType<typeof makeDriveEnvStore>,
@@ -457,6 +489,29 @@ describe('rebuildDriveEnv', () => {
     expect(result).toMatchObject({ ok: false, reason: 'teardown_failed' });
     expect(ensureSandbox).not.toHaveBeenCalled();
     expect(store.rows.get(ENV_ID)?.spriteInstanceId).toBe('inst-1');
+  });
+
+  it('given the confirmation CAS refused, should abort WITHOUT provisioning — a live replacement is not a rebuild', async () => {
+    // A concurrent provision put a live instance 2 on the row while our kill
+    // ran. Continuing would resume THAT machine and report a rebuild over a
+    // filesystem this call never destroyed — the exact lie the
+    // kill-before-provision ordering exists to prevent.
+    const store = makeDriveEnvStore([makeEnvRecord({ sandboxId: SANDBOX_ID, spriteInstanceId: 'inst-1' })]);
+    const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+    const realKill = host.host.kill.bind(host.host);
+    host.host.kill = async (killInput) => {
+      await realKill(killInput);
+      const row = store.rows.get(ENV_ID);
+      if (row) store.rows.set(ENV_ID, { ...row, spriteInstanceId: 'inst-2' });
+    };
+    const deps = makeRebuildDeps(store, host);
+    const ensureSandbox = vi.fn(deps.ensureSandbox);
+    deps.ensureSandbox = ensureSandbox;
+
+    const result = await rebuildDriveEnv({ envId: ENV_ID, deps });
+
+    expect(result).toEqual({ ok: false, reason: 'teardown_failed', detail: 'teardown_not_confirmed' });
+    expect(ensureSandbox).not.toHaveBeenCalled();
   });
 
   it('given a never-provisioned env, should just provision — there is nothing to tear down', async () => {

--- a/packages/lib/src/services/drive-envs/__tests__/fakes.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/fakes.ts
@@ -53,7 +53,7 @@ export interface FakeDriveEnvStore {
   liveSessions: Map<string, number>;
   /** payerId → envs owned across their drives, the quota's input. */
   ownedEnvs: Map<string, number>;
-  calls: { deleteById: number; requestTeardown: number; stampSpriteTornDown: number };
+  calls: { deleteIfUnoccupied: number; requestTeardown: number; stampSpriteTornDown: number };
 }
 
 export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date = () => NOW): FakeDriveEnvStore {
@@ -62,7 +62,7 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
   const reclaims = new Map<string, string | null>();
   const liveSessions = new Map<string, number>();
   const ownedEnvs = new Map<string, number>();
-  const calls = { deleteById: 0, requestTeardown: 0, stampSpriteTornDown: 0 };
+  const calls = { deleteIfUnoccupied: 0, requestTeardown: 0, stampSpriteTornDown: 0 };
   let minted = 0;
 
   /** The `(driveId, name)` unique index, modelled — a duplicate is an ANSWER, not a throw. */
@@ -114,7 +114,7 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
     },
 
     async deleteIfUnoccupied({ envId, force }) {
-      calls.deleteById += 1;
+      calls.deleteIfUnoccupied += 1;
       const row = rows.get(envId);
       if (!row) return { ok: false, reason: 'not_found' };
       // The guard re-read INSIDE the atomic step — the fake is single-threaded,

--- a/packages/lib/src/services/drive-envs/__tests__/fakes.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/fakes.ts
@@ -1,0 +1,194 @@
+/**
+ * In-memory fakes for the drive-environment services — same discipline as
+ * `services/agent-workspaces/__tests__/fakes.ts`: every test here runs with NO
+ * database and NO live Sprite.
+ *
+ * The store fake implements the REAL compare-and-swap semantics (identity CAS on
+ * the previous pointer, teardown CAS on the instance) and the REAL unique
+ * `(driveId, name)` constraint, because those are the things the service's
+ * ordering has to survive. The Sprite host is the SESSION suite's fake, imported
+ * rather than re-written: it already models the name-keyed provisioning contract
+ * (two provisions of one name hand back one physical VM) and the
+ * replaced-instance kill refusal, and an env is the same kind of Sprite holder.
+ */
+
+import type { DriveEnvRecord, DriveEnvStore } from '../drive-envs-store';
+import { envStampColumns } from '../drive-envs-store';
+
+export { makeSpriteHost } from '../../agent-workspaces/__tests__/fakes';
+
+export const NOW = new Date('2026-08-17T12:00:00.000Z');
+export const ENV_ID = 'env-1';
+export const DRIVE_ID = 'drive-1';
+export const PAYER_ID = 'owner-1';
+
+export function makeEnvRecord(over: Partial<DriveEnvRecord> = {}): DriveEnvRecord {
+  return {
+    id: ENV_ID,
+    driveId: DRIVE_ID,
+    name: 'staging',
+    createdBy: 'user-1',
+    spriteKey: null,
+    sandboxId: null,
+    spriteInstanceId: null,
+    egressPolicyToken: null,
+    teardownRequestedAt: null,
+    spriteTornDownAt: null,
+    storageLastBilledAt: NOW,
+    storageMeasuredBytes: null,
+    storageMeasuredAt: null,
+    lastActiveAt: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...over,
+  };
+}
+
+export interface FakeDriveEnvStore {
+  store: DriveEnvStore;
+  rows: Map<string, DriveEnvRecord>;
+  /** Models `machine_sprite_reclaims`: sandboxId → spriteInstanceId. */
+  reclaims: Map<string, string | null>;
+  /** envId → live (not-ended) session count, the delete guard's input. */
+  liveSessions: Map<string, number>;
+  /** payerId → envs owned across their drives, the quota's input. */
+  ownedEnvs: Map<string, number>;
+  calls: { deleteById: number; requestTeardown: number; stampSpriteTornDown: number };
+}
+
+export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date = () => NOW): FakeDriveEnvStore {
+  const rows = new Map<string, DriveEnvRecord>();
+  for (const row of seed) rows.set(row.id, row);
+  const reclaims = new Map<string, string | null>();
+  const liveSessions = new Map<string, number>();
+  const ownedEnvs = new Map<string, number>();
+  const calls = { deleteById: 0, requestTeardown: 0, stampSpriteTornDown: 0 };
+  let minted = 0;
+
+  /** The `(driveId, name)` unique index, modelled — a duplicate is an ANSWER, not a throw. */
+  function nameTaken(driveId: string, name: string, exceptId?: string): boolean {
+    for (const row of rows.values()) {
+      if (row.driveId === driveId && row.name === name && row.id !== exceptId) return true;
+    }
+    return false;
+  }
+
+  const store: DriveEnvStore = {
+    async findById(envId) {
+      return rows.get(envId) ?? null;
+    },
+
+    async list(driveId) {
+      return [...rows.values()]
+        .filter((row) => row.driveId === driveId)
+        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    },
+
+    async create({ driveId, name, createdBy, now: at }) {
+      if (nameTaken(driveId, name)) return { ok: false, reason: 'name_taken' };
+      minted += 1;
+      const row = makeEnvRecord({
+        id: `env-${minted}`,
+        driveId,
+        name,
+        createdBy,
+        storageLastBilledAt: at,
+        createdAt: at,
+        updatedAt: at,
+      });
+      rows.set(row.id, row);
+      return { ok: true, env: row };
+    },
+
+    async rename({ envId, name, now: at }) {
+      const row = rows.get(envId);
+      if (!row) return { ok: false, reason: 'not_found' };
+      if (nameTaken(row.driveId, name, envId)) return { ok: false, reason: 'name_taken' };
+      const next = { ...row, name, updatedAt: at };
+      rows.set(envId, next);
+      return { ok: true, env: next };
+    },
+
+    async deleteById(envId) {
+      calls.deleteById += 1;
+      const row = rows.get(envId);
+      if (!row) return false;
+      rows.delete(envId);
+      // The AFTER DELETE trigger: a row carrying a Sprite pointer parks it in
+      // the reclaim outbox on the way out, whatever the caller did or did not
+      // confirm.
+      if (row.sandboxId !== null) reclaims.set(row.sandboxId, row.spriteInstanceId);
+      return true;
+    },
+
+    async countLiveSessionsInEnv(envId) {
+      return liveSessions.get(envId) ?? 0;
+    },
+
+    async countEnvsOwnedBy(payerId) {
+      return ownedEnvs.get(payerId) ?? 0;
+    },
+
+    async updateSpriteIdentity({ envId, previousSandboxId, spriteKey, sandboxId, spriteInstanceId, egressPolicyToken, stamps, now: at }) {
+      const row = rows.get(envId);
+      if (!row) return false;
+      // The identity CAS: only the provisioner whose read matches the row's
+      // CURRENT pointer may record an identity.
+      if ((row.sandboxId ?? null) !== (previousSandboxId ?? null)) return false;
+      rows.set(envId, {
+        ...row,
+        spriteKey,
+        sandboxId,
+        spriteInstanceId,
+        egressPolicyToken,
+        storageLastBilledAt: at,
+        updatedAt: at,
+        ...envStampColumns(stamps),
+      });
+      return true;
+    },
+
+    async applyStamps({ envId, stamps, cas }) {
+      const row = rows.get(envId);
+      const columns = envStampColumns(stamps);
+      if (Object.keys(columns).length === 0) return true;
+      if (!row) return cas?.sandboxId === undefined;
+      if (cas?.sandboxId !== undefined && (row.sandboxId ?? null) !== (cas.sandboxId ?? null)) return false;
+      rows.set(envId, { ...row, ...columns, updatedAt: now() });
+      return true;
+    },
+
+    async requestTeardown({ envId, sandboxId, spriteInstanceId, at }) {
+      calls.requestTeardown += 1;
+      const row = rows.get(envId);
+      if (!row) return;
+      if (row.sandboxId !== sandboxId) return;
+      if ((row.spriteInstanceId ?? null) !== (spriteInstanceId ?? null)) return;
+      rows.set(envId, { ...row, teardownRequestedAt: at, updatedAt: at });
+    },
+
+    async stampSpriteTornDown({ envId, sandboxId, spriteInstanceId, stamps }) {
+      calls.stampSpriteTornDown += 1;
+      const row = rows.get(envId);
+      if (!row) return false;
+      // CAS on the INSTANCE, not just the name — a concurrent re-provision's
+      // live replacement must never be stamped dead.
+      if (row.sandboxId !== sandboxId) return false;
+      if ((row.spriteInstanceId ?? null) !== (spriteInstanceId ?? null)) return false;
+      rows.set(envId, { ...row, ...envStampColumns(stamps), updatedAt: now() });
+      return true;
+    },
+
+    async reloadSpritePointer(envId) {
+      const row = rows.get(envId);
+      if (!row) return null;
+      return { sandboxId: row.sandboxId, spriteInstanceId: row.spriteInstanceId };
+    },
+
+    async enqueueReclaim({ sandboxId, spriteInstanceId }) {
+      reclaims.set(sandboxId, spriteInstanceId ?? reclaims.get(sandboxId) ?? null);
+    },
+  };
+
+  return { store, rows, reclaims, liveSessions, ownedEnvs, calls };
+}

--- a/packages/lib/src/services/drive-envs/__tests__/fakes.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/fakes.ts
@@ -84,8 +84,12 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
         .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
     },
 
-    async create({ driveId, name, createdBy, now: at }) {
+    async createIfUnderLimit({ driveId, name, createdBy, now: at, payerId, maxEnvs }) {
       if (nameTaken(driveId, name)) return { ok: false, reason: 'name_taken' };
+      // The structural ceiling, modelled: the fake's map IS the serialized
+      // count, so a create past the limit loses here exactly as the advisory
+      // -locked count-and-insert makes it lose in Postgres.
+      if ((ownedEnvs.get(payerId) ?? 0) >= maxEnvs) return { ok: false, reason: 'limit_reached' };
       minted += 1;
       const row = makeEnvRecord({
         id: `env-${minted}`,
@@ -109,10 +113,17 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
       return { ok: true, env: next };
     },
 
-    async deleteById(envId) {
+    async deleteIfUnoccupied({ envId, force }) {
       calls.deleteById += 1;
       const row = rows.get(envId);
-      if (!row) return false;
+      if (!row) return { ok: false, reason: 'not_found' };
+      // The guard re-read INSIDE the atomic step — the fake is single-threaded,
+      // so what this models is the ordering: the count is taken here, after the
+      // teardown, not from the caller's earlier snapshot.
+      if (!force) {
+        const liveSessionCount = liveSessions.get(envId) ?? 0;
+        if (liveSessionCount > 0) return { ok: false, reason: 'live_sessions', liveSessionCount };
+      }
       rows.delete(envId);
       // The AFTER DELETE trigger, WHEN clause included: it fires only for a
       // row that still BELIEVES it holds a live Sprite (`sandboxId IS NOT NULL
@@ -122,7 +133,7 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
       if (row.sandboxId !== null && row.spriteTornDownAt === null) {
         reclaims.set(row.sandboxId, row.spriteInstanceId);
       }
-      return true;
+      return { ok: true };
     },
 
     async countLiveSessionsInEnv(envId) {

--- a/packages/lib/src/services/drive-envs/__tests__/fakes.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/fakes.ts
@@ -114,10 +114,14 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
       const row = rows.get(envId);
       if (!row) return false;
       rows.delete(envId);
-      // The AFTER DELETE trigger: a row carrying a Sprite pointer parks it in
-      // the reclaim outbox on the way out, whatever the caller did or did not
-      // confirm.
-      if (row.sandboxId !== null) reclaims.set(row.sandboxId, row.spriteInstanceId);
+      // The AFTER DELETE trigger, WHEN clause included: it fires only for a
+      // row that still BELIEVES it holds a live Sprite (`sandboxId IS NOT NULL
+      // AND spriteTornDownAt IS NULL` — the same predicate as the partial index
+      // and the orphan reconciler). A confirmed-dead Sprite enqueues nothing;
+      // a row for a dead name would have the cron chase it forever.
+      if (row.sandboxId !== null && row.spriteTornDownAt === null) {
+        reclaims.set(row.sandboxId, row.spriteInstanceId);
+      }
       return true;
     },
 

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -238,10 +238,12 @@ export interface DriveEnvStore {
   /**
    * Record the durable teardown INTENT, BEFORE the kill — the one stamp written
    * ahead of its IO, so a crash between "we decided to kill" and "the kill was
-   * confirmed" still leaves the Sprite reclaimable. CAS-guarded on the pointer
-   * about to be killed: a concurrent provision that revived this env onto a NEW
-   * VM must not be left carrying a teardown request, because a teardown request
-   * is exactly what licenses the orphan reconciler to destroy a Sprite.
+   * confirmed" leaves a durable record of the intent rather than a silent
+   * half-teardown. CAS-guarded on the pointer about to be killed: a concurrent
+   * provision that revived this env onto a NEW VM must not be left carrying a
+   * teardown request — for sessions that stamp is exactly what licenses the
+   * orphan reconciler to destroy a Sprite, and `drive_envs` joins that cron's
+   * row sources in the follow-up that folds envs into the crons.
    */
   requestTeardown(input: {
     envId: string;

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -107,6 +107,15 @@ export interface DriveEnvStore {
    * every drive they own, so a per-drive lock would let one payer's two drives
    * race past it — the same hole with more steps.
    *
+   * **`payerId` MUST be `driveId`'s owner.** The lock key, the count and the
+   * inserted row have to describe one ledger; a `payerId` that does not own
+   * this drive would serialize on one payer's key while metering a second
+   * payer's envs and inserting into a third's drive. It is a parameter rather
+   * than a join inside the transaction only because the caller has already
+   * resolved the drive's owner to get their TIER (`resolveDriveEnvPayer`, which
+   * fails closed on a vanished drive), so re-reading it here would be a second
+   * source of truth for the same fact rather than a check on it.
+   *
    * It is also the ONLY way to mint an env row. There is deliberately no
    * unguarded `create` alongside it: a second minting path is a ceiling a
    * future caller can forget, and the whole point of making this structural is

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -170,6 +170,14 @@ export interface DriveEnvStore {
    * There is no third interleaving: a session cannot appear between the count
    * and the delete without the lock this transaction is holding.
    *
+   * **This reasoning assumes READ COMMITTED**, which is Postgres's default and
+   * what this deployment runs (nothing sets an isolation level — verified, not
+   * assumed). The assumption is load-bearing rather than incidental: it is what
+   * makes a blocked statement RE-READ and see the committed session. Under
+   * REPEATABLE READ the same block would end in a serialization failure
+   * instead, which is safe but a different contract — so raising the pool's
+   * isolation level means revisiting this method, not just this comment.
+   *
    * `force` skips the count (not the lock), which is the whole meaning of
    * forcing: the caller has been told sessions are live and has said destroy
    * them anyway.

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -89,15 +89,41 @@ export interface DriveEnvStore {
    */
   list(driveId: string): Promise<DriveEnvRecord[]>;
   /**
-   * Mint an env row. NOT idempotent: creating an env is an explicit act.
+   * Mint an env row IFF this PAYER is under `maxEnvs` owned environments — the
+   * ceiling made STRUCTURAL rather than a pre-check, exactly as
+   * `AgentSessionStore.createIfUnderLimit` makes the session spawn ceiling
+   * structural.
+   *
+   * A count-then-insert at the call site is TOCTOU-racy in a way the unique
+   * index cannot cover: `(driveId, name)` only serializes creates of the SAME
+   * name, so two admins creating `dev` and `staging` for one payer sitting at
+   * the ceiling both read "under" and both insert. This serializes the
+   * count-and-insert under a per-PAYER Postgres advisory lock (the same
+   * primitive the session spawn ceiling and `credit-gate.ts` use), so two
+   * concurrent creates billed to one payer cannot both win, while creates for
+   * different payers never contend.
+   *
+   * Per payer, NOT per drive: the ceiling is on what the payer owns across
+   * every drive they own, so a per-drive lock would let one payer's two drives
+   * race past it — the same hole with more steps.
+   *
+   * It is also the ONLY way to mint an env row. There is deliberately no
+   * unguarded `create` alongside it: a second minting path is a ceiling a
+   * future caller can forget, and the whole point of making this structural is
+   * that it cannot be forgotten.
    *
    * `(driveId, name)` is UNIQUE, so a duplicate name is refused BY THE DATABASE
    * and reported as `name_taken` rather than raised — a name collision is an
    * ordinary answer to an ordinary request (two admins naming a `staging` at
-   * once), not an exception the caller should have to pattern-match a driver
-   * error string to recognize.
+   * once), not an exception the caller should pattern-match a driver error
+   * string to recognize.
    */
-  create(input: NewDriveEnvInput): Promise<{ ok: true; env: DriveEnvRecord } | { ok: false; reason: 'name_taken' }>;
+  createIfUnderLimit(
+    input: NewDriveEnvInput & { payerId: string; maxEnvs: number },
+  ): Promise<
+    | { ok: true; env: DriveEnvRecord }
+    | { ok: false; reason: 'name_taken' | 'limit_reached' }
+  >;
   /**
    * Rename, subject to the same unique constraint — and reporting the same
    * `name_taken` answer for the same reason. `not_found` distinguishes a
@@ -109,15 +135,44 @@ export interface DriveEnvStore {
     now: Date;
   }): Promise<{ ok: true; env: DriveEnvRecord } | { ok: false; reason: 'name_taken' | 'not_found' }>;
   /**
-   * Delete the row. The cascade removes every session bound to it (and, through
-   * those sessions, their panes, rev counters and shells), and the AFTER DELETE
-   * trigger rescues this row's Sprite pointer into `machine_sprite_reclaims` —
-   * the crash net for a teardown that never confirmed.
+   * Delete the row, ATOMICALLY with the live-session guard.
    *
-   * Reports whether a row was actually removed, so a concurrent delete of the
-   * same env is answered honestly rather than reported twice as a success.
+   * The cascade removes every session bound to this env (and, through those
+   * sessions, their panes, rev counters and shells), which is why the guard
+   * cannot be a separate earlier read: between a count that returned zero and
+   * an unguarded delete, a session can bind to this env and be cascaded away
+   * with work the caller never opted into destroying.
+   *
+   * So the count and the delete run in ONE transaction that first takes
+   * `SELECT ... FOR UPDATE` on the env row, and that lock is what makes the
+   * guard sound rather than merely narrower. Inserting an `agent_workspaces`
+   * row with this `envId` must take `FOR KEY SHARE` on this same env row to
+   * satisfy its foreign key, and `FOR KEY SHARE` conflicts with `FOR UPDATE`.
+   * Therefore, once this transaction holds the lock:
+   *
+   *  - a session insert that already COMMITTED is visible to the count below
+   *    (a new statement snapshot under READ COMMITTED), and refuses the delete;
+   *  - a session insert still IN FLIGHT is blocked on the FK lock until this
+   *    transaction ends — and if the delete lands, that insert's FK check then
+   *    fails against a row that no longer exists. A spawn racing the deletion
+   *    of its own environment failing is the correct outcome; a spawn silently
+   *    succeeding into a doomed env is not.
+   *
+   * There is no third interleaving: a session cannot appear between the count
+   * and the delete without the lock this transaction is holding.
+   *
+   * `force` skips the count (not the lock), which is the whole meaning of
+   * forcing: the caller has been told sessions are live and has said destroy
+   * them anyway.
+   *
+   * Reports the live count on refusal, and distinguishes a vanished row, so a
+   * concurrent delete of the same env is answered honestly rather than reported
+   * twice as a success.
    */
-  deleteById(envId: string): Promise<boolean>;
+  deleteIfUnoccupied(input: {
+    envId: string;
+    force: boolean;
+  }): Promise<{ ok: true } | { ok: false; reason: 'not_found' } | { ok: false; reason: 'live_sessions'; liveSessionCount: number }>;
   /**
    * Sessions still LIVE inside this env — rows carrying this `envId` with no
    * `endedAt`. The delete guard's input. A COUNT, never `list(...).length`: the
@@ -315,16 +370,30 @@ export async function createDbDriveEnvStore(now: () => Date = () => new Date()):
       return rows as DriveEnvRecord[];
     },
 
-    async create({ driveId, name, createdBy, now: at }) {
+    async createIfUnderLimit({ driveId, name, createdBy, now: at, payerId, maxEnvs }) {
       try {
-        const [row] = await db
-          .insert(driveEnvs)
-          .values({ driveId, name, createdBy, createdAt: at, updatedAt: at })
-          .returning();
-        return { ok: true as const, env: row as DriveEnvRecord };
+        return await db.transaction(async (tx) => {
+          // Per-payer advisory lock, held for this transaction only — the same
+          // primitive the session spawn ceiling uses. It serializes concurrent
+          // creates for THIS payer (so the count below cannot go stale before
+          // the insert) without contending with any other payer's create.
+          await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${'drive-env-create:' + payerId}))`);
+          const [{ n }] = await tx
+            .select({ n: count() })
+            .from(driveEnvs)
+            .innerJoin(drives, eq(drives.id, driveEnvs.driveId))
+            .where(eq(drives.ownerId, payerId));
+          if (n >= maxEnvs) return { ok: false as const, reason: 'limit_reached' as const };
+          const [row] = await tx
+            .insert(driveEnvs)
+            .values({ driveId, name, createdBy, createdAt: at, updatedAt: at })
+            .returning();
+          return { ok: true as const, env: row as DriveEnvRecord };
+        });
       } catch (error) {
-        // The unique index IS the concurrency control here: two admins naming a
-        // `staging` at once both reach this insert, and exactly one loses.
+        // The `(driveId, name)` unique index still resolves same-name races,
+        // and it aborts the transaction — so it surfaces here rather than at
+        // the insert above.
         if (isUniqueViolation(error)) return { ok: false as const, reason: 'name_taken' as const };
         throw error;
       }
@@ -345,9 +414,32 @@ export async function createDbDriveEnvStore(now: () => Date = () => new Date()):
       }
     },
 
-    async deleteById(envId) {
-      const deleted = await db.delete(driveEnvs).where(eq(driveEnvs.id, envId)).returning({ id: driveEnvs.id });
-      return deleted.length > 0;
+    async deleteIfUnoccupied({ envId, force }) {
+      return db.transaction(async (tx) => {
+        // The row lock FIRST — see the interface doc for why it, and not the
+        // count, is what makes this guard sound.
+        const [locked] = await tx
+          .select({ id: driveEnvs.id })
+          .from(driveEnvs)
+          .where(eq(driveEnvs.id, envId))
+          .limit(1)
+          .for('update');
+        if (!locked) return { ok: false as const, reason: 'not_found' as const };
+
+        if (!force) {
+          const [live] = await tx
+            .select({ n: count() })
+            .from(agentWorkspaces)
+            .where(and(eq(agentWorkspaces.envId, envId), isNull(agentWorkspaces.endedAt)));
+          const liveSessionCount = live?.n ?? 0;
+          if (liveSessionCount > 0) {
+            return { ok: false as const, reason: 'live_sessions' as const, liveSessionCount };
+          }
+        }
+
+        await tx.delete(driveEnvs).where(eq(driveEnvs.id, envId));
+        return { ok: true as const };
+      });
     },
 
     async countLiveSessionsInEnv(envId) {

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -1,0 +1,472 @@
+/**
+ * Drive environments store (IO, dependency-injected).
+ *
+ * DB-backed CRUD for `drive_envs` — one row per persistent, drive-owned
+ * environment — plus the Sprite-identity slice the holder-neutral provisioner
+ * (`ensureSpriteHolderSandbox`) requires of any Sprite holder. Split from the
+ * orchestration in `drive-envs.ts` for the reason `agent-workspaces-store.ts`
+ * gives: orchestration is testable against an in-memory fake with no database
+ * and no live Sprite.
+ *
+ * Two things this module deliberately does NOT do:
+ *
+ *  - **No policy.** Every lifecycle write here is described by a verdict
+ *    computed elsewhere (`planSpriteHolderLifecycle`, `planEnvDelete`),
+ *    including WHICH columns to stamp — they arrive as a
+ *    `SpriteHolderRowStamps` object rather than being re-derived per call site.
+ *  - **No session writes.** An env owns its sessions through a cascading FK, not
+ *    through this store: it COUNTS live sessions (the delete guard's input) and
+ *    never ends, binds, or deletes one. Deleting the env row is what removes
+ *    them, in the database, atomically with the row that owned them.
+ *
+ * **The Sprite slice mirrors `AgentSessionStore`'s method-for-method**, under
+ * `envId` instead of `workspaceId`, because that is what makes an env a second
+ * HOLDER rather than a second provisioner: `drive-envs.ts` adapts the names and
+ * hands this slice to the one provisioning core, so the CAS that serializes
+ * concurrent provisions is the same code for both holder kinds. See
+ * `agent-workspace-sprite.ts` for why a second copy of that CAS would be
+ * correct against itself and race against nothing.
+ *
+ * Every read is BOUNDED (`.limit(...)`, or an aggregate `count()`): an env
+ * listing is small by construction — quota caps them per payer — but the
+ * findMany-limit rule exists because "small by construction" is a claim about
+ * today's constants, not about the query.
+ */
+
+import type { SpriteHolderRowStamps } from '../../agent-workspaces/plan-workspace-lifecycle';
+import { MAX_DRIVE_ENVS_LISTED } from '../../drive-envs/env-contract';
+
+/**
+ * One `drive_envs` row.
+ *
+ * Mirrors the table column-for-column on purpose: `findById` selects the WHOLE
+ * row and casts it to this interface, so a column missing from this mirror is
+ * not absent at runtime — it is present and invisible to the type system, which
+ * is the drift the session store's own record type warns about.
+ */
+export interface DriveEnvRecord {
+  /** The env's own id — the API address and the Sprite-key fold. */
+  id: string;
+  /** The owning drive. NOT NULL: an env has no user-scoped form. */
+  driveId: string;
+  /** Unique within the drive — an address, not a label. */
+  name: string;
+  /** AUDIT ONLY: who asked for this env. Nothing resolves payment, permission or lifecycle through it. */
+  createdBy: string | null;
+
+  spriteKey: string | null;
+  sandboxId: string | null;
+  spriteInstanceId: string | null;
+  egressPolicyToken: string | null;
+  teardownRequestedAt: Date | null;
+  spriteTornDownAt: Date | null;
+
+  storageLastBilledAt: Date;
+  storageMeasuredBytes: number | null;
+  storageMeasuredAt: Date | null;
+
+  lastActiveAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewDriveEnvInput {
+  driveId: string;
+  name: string;
+  /** The creating user, recorded for audit. Null when no user context applies. */
+  createdBy: string | null;
+  now: Date;
+}
+
+export interface DriveEnvStore {
+  findById(envId: string): Promise<DriveEnvRecord | null>;
+  /**
+   * The drive's environments, oldest first, bounded by
+   * {@link MAX_DRIVE_ENVS_LISTED}. Oldest-first rather than
+   * newest-activity-first (the session listing's order): env names are
+   * addresses a user learns the position of, so a listing that reshuffled as
+   * machines woke would move the row someone was reaching for.
+   */
+  list(driveId: string): Promise<DriveEnvRecord[]>;
+  /**
+   * Mint an env row. NOT idempotent: creating an env is an explicit act.
+   *
+   * `(driveId, name)` is UNIQUE, so a duplicate name is refused BY THE DATABASE
+   * and reported as `name_taken` rather than raised — a name collision is an
+   * ordinary answer to an ordinary request (two admins naming a `staging` at
+   * once), not an exception the caller should have to pattern-match a driver
+   * error string to recognize.
+   */
+  create(input: NewDriveEnvInput): Promise<{ ok: true; env: DriveEnvRecord } | { ok: false; reason: 'name_taken' }>;
+  /**
+   * Rename, subject to the same unique constraint — and reporting the same
+   * `name_taken` answer for the same reason. `not_found` distinguishes a
+   * vanished env from a refused one, which the caller needs to choose 404 vs 409.
+   */
+  rename(input: {
+    envId: string;
+    name: string;
+    now: Date;
+  }): Promise<{ ok: true; env: DriveEnvRecord } | { ok: false; reason: 'name_taken' | 'not_found' }>;
+  /**
+   * Delete the row. The cascade removes every session bound to it (and, through
+   * those sessions, their panes, rev counters and shells), and the AFTER DELETE
+   * trigger rescues this row's Sprite pointer into `machine_sprite_reclaims` —
+   * the crash net for a teardown that never confirmed.
+   *
+   * Reports whether a row was actually removed, so a concurrent delete of the
+   * same env is answered honestly rather than reported twice as a success.
+   */
+  deleteById(envId: string): Promise<boolean>;
+  /**
+   * Sessions still LIVE inside this env — rows carrying this `envId` with no
+   * `endedAt`. The delete guard's input. A COUNT, never `list(...).length`: the
+   * question is how many, and a guard should not pull every column of every
+   * session to answer it.
+   */
+  countLiveSessionsInEnv(envId: string): Promise<number>;
+  /**
+   * How many envs this PAYER already owns, across every drive they own — the
+   * quota's input.
+   *
+   * Counted through drive ownership, not through `createdBy`: an env is
+   * DRIVE-owned and drive-billed, `createdBy` is audit only, and metering the
+   * creator would let a payer hold unlimited envs by having members create them
+   * (and would bill a member who has since left for machines they cannot see).
+   */
+  countEnvsOwnedBy(payerId: string): Promise<number>;
+
+  // ---------------------------------------------------------------------------
+  // The Sprite-holder slice. Method-for-method the same contract as
+  // `AgentSessionStore`'s identically-named methods — see that module for the CAS
+  // semantics each one owes. `drive-envs.ts` adapts `envId` → `holderId` and
+  // hands these to `ensureSpriteHolderSandbox`.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Record a freshly-provisioned (or adopted) Sprite identity under a CAS on the
+   * row's CURRENT `sandboxId`, together with the verdict's stamps — ONE atomic
+   * write, so a row can never be seen carrying a new identity with the previous
+   * generation's teardown stamps still on it.
+   */
+  updateSpriteIdentity(input: {
+    envId: string;
+    previousSandboxId: string | null;
+    spriteKey: string;
+    sandboxId: string;
+    spriteInstanceId: string | null;
+    egressPolicyToken: string | null;
+    stamps: SpriteHolderRowStamps;
+    now: Date;
+  }): Promise<boolean>;
+  /**
+   * Write a verdict's stamps, optionally CAS-guarded on the pointer the plan was
+   * computed from. `cas.endedAt` is accepted for signature parity with the
+   * session store — an env row HAS no `endedAt` column (an env is persistent;
+   * it is deleted, never ended), so the guard is ignored rather than silently
+   * matched against something else.
+   */
+  applyStamps(input: {
+    envId: string;
+    stamps: SpriteHolderRowStamps;
+    cas?: { sandboxId?: string | null; endedAt?: Date | null };
+  }): Promise<boolean>;
+  /**
+   * Record the durable teardown INTENT, BEFORE the kill — the one stamp written
+   * ahead of its IO, so a crash between "we decided to kill" and "the kill was
+   * confirmed" still leaves the Sprite reclaimable. CAS-guarded on the pointer
+   * about to be killed: a concurrent provision that revived this env onto a NEW
+   * VM must not be left carrying a teardown request, because a teardown request
+   * is exactly what licenses the orphan reconciler to destroy a Sprite.
+   */
+  requestTeardown(input: {
+    envId: string;
+    sandboxId: string;
+    spriteInstanceId: string | null;
+    at: Date;
+  }): Promise<void>;
+  /**
+   * Stamp the row after its Sprite is CONFIRMED killed, under a CAS on the
+   * INSTANCE. Keeps the row — an env survives its machine — and the CAS is what
+   * stops a concurrent re-provision's LIVE replacement from being marked dead.
+   */
+  stampSpriteTornDown(input: {
+    envId: string;
+    sandboxId: string;
+    spriteInstanceId: string | null;
+    stamps: SpriteHolderRowStamps;
+  }): Promise<boolean>;
+  /** Re-read just the Sprite pointer AND INSTANCE, to reconcile a lost provisioning race BEFORE killing. */
+  reloadSpritePointer(envId: string): Promise<{ sandboxId: string | null; spriteInstanceId: string | null } | null>;
+  /**
+   * Enqueue a Sprite pointer into the reclaim outbox (`machine_sprite_reclaims`)
+   * — for a Sprite that was PROVISIONED but never recorded on any row, which no
+   * trigger and no row-based cross-check could ever find. Idempotent, mirroring
+   * the trigger's own insert.
+   */
+  enqueueReclaim(input: { sandboxId: string; spriteInstanceId: string | null }): Promise<void>;
+}
+
+/**
+ * Translate a lifecycle verdict's stamps into env columns to write (pure).
+ *
+ * The session store's `stampColumns` twin, minus `endedAt`: `drive_envs` has no
+ * such column, and silently dropping a key a caller passed would be worse than
+ * not accepting it — so the ENV type simply cannot express it, and the one
+ * verdict that stamps `endedAt` (a session `end`) is not a verdict any env path
+ * executes.
+ *
+ * The encoding this preserves, exactly as the session twin does: an ABSENT key
+ * means "leave this column alone", an explicit `null` means "clear it". A spread
+ * would collapse that distinction the moment a stamps object carried an explicit
+ * `undefined`.
+ */
+export function envStampColumns(stamps: SpriteHolderRowStamps): Partial<{
+  lastActiveAt: Date;
+  teardownRequestedAt: Date | null;
+  spriteTornDownAt: Date | null;
+  storageMeasuredBytes: null;
+  storageMeasuredAt: null;
+}> {
+  const columns: Record<string, unknown> = {};
+  if (stamps.lastActiveAt !== undefined) columns.lastActiveAt = stamps.lastActiveAt;
+  if (stamps.teardownRequestedAt !== undefined) columns.teardownRequestedAt = stamps.teardownRequestedAt;
+  if (stamps.spriteTornDownAt !== undefined) columns.spriteTornDownAt = stamps.spriteTornDownAt;
+  if (stamps.storageMeasuredBytes !== undefined) columns.storageMeasuredBytes = stamps.storageMeasuredBytes;
+  if (stamps.storageMeasuredAt !== undefined) columns.storageMeasuredAt = stamps.storageMeasuredAt;
+  return columns;
+}
+
+/**
+ * What recording a live (re-)provisioned Sprite writes onto a `drive_envs` row
+ * (pure) — the env twin of `revivedAgentSessionColumns`.
+ *
+ * The identity, the verdict's stamps, and a RESET storage watermark. The reset
+ * is not a stamp because it is not a lifecycle fact: a new Sprite generation is
+ * a fresh, empty filesystem, so billing the elapsed window against the dead
+ * generation's measured size would charge for a disk that no longer exists.
+ */
+export function revivedDriveEnvColumns(input: {
+  spriteKey: string;
+  sandboxId: string;
+  spriteInstanceId: string | null;
+  egressPolicyToken: string | null;
+  stamps: SpriteHolderRowStamps;
+  now: Date;
+}) {
+  return {
+    spriteKey: input.spriteKey,
+    sandboxId: input.sandboxId,
+    spriteInstanceId: input.spriteInstanceId,
+    egressPolicyToken: input.egressPolicyToken,
+    storageLastBilledAt: input.now,
+    updatedAt: input.now,
+    ...envStampColumns(input.stamps),
+  };
+}
+
+/** Postgres unique-violation. A duplicate `(driveId, name)` is an ANSWER (`name_taken`), never a raised error. */
+const UNIQUE_VIOLATION = '23505';
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === UNIQUE_VIOLATION;
+}
+
+/**
+ * Production DB-backed implementation. Lazily resolves the db client, schema
+ * tables and operators so callers that inject a fake (in tests) never load the
+ * DB module graph — the same shape `createDbAgentSessionStore` uses.
+ *
+ * `now` defaults to the wall clock and is injectable for the store's own
+ * bookkeeping touches (an `updatedAt` bump alongside a verdict that names no
+ * timestamp of its own), so a test can pin it rather than assert "some recent
+ * timestamp".
+ */
+export async function createDbDriveEnvStore(now: () => Date = () => new Date()): Promise<DriveEnvStore> {
+  const [
+    { db },
+    { eq, and, eqOrIsNull, isNull, sql, count, asc },
+    { driveEnvs },
+    { agentWorkspaces },
+    { drives },
+    { machineSpriteReclaims },
+  ] = await Promise.all([
+    import('@pagespace/db/db'),
+    import('@pagespace/db/operators'),
+    import('@pagespace/db/schema/drive-envs'),
+    import('@pagespace/db/schema/agent-workspaces'),
+    import('@pagespace/db/schema/core'),
+    import('@pagespace/db/schema/machine-sprite-reclaims'),
+  ]);
+
+  return {
+    async findById(envId) {
+      const [row] = await db.select().from(driveEnvs).where(eq(driveEnvs.id, envId)).limit(1);
+      return (row as DriveEnvRecord) ?? null;
+    },
+
+    async list(driveId) {
+      const rows = await db
+        .select()
+        .from(driveEnvs)
+        .where(eq(driveEnvs.driveId, driveId))
+        .orderBy(asc(driveEnvs.createdAt))
+        .limit(MAX_DRIVE_ENVS_LISTED);
+      return rows as DriveEnvRecord[];
+    },
+
+    async create({ driveId, name, createdBy, now: at }) {
+      try {
+        const [row] = await db
+          .insert(driveEnvs)
+          .values({ driveId, name, createdBy, createdAt: at, updatedAt: at })
+          .returning();
+        return { ok: true as const, env: row as DriveEnvRecord };
+      } catch (error) {
+        // The unique index IS the concurrency control here: two admins naming a
+        // `staging` at once both reach this insert, and exactly one loses.
+        if (isUniqueViolation(error)) return { ok: false as const, reason: 'name_taken' as const };
+        throw error;
+      }
+    },
+
+    async rename({ envId, name, now: at }) {
+      try {
+        const [row] = await db
+          .update(driveEnvs)
+          .set({ name, updatedAt: at })
+          .where(eq(driveEnvs.id, envId))
+          .returning();
+        if (!row) return { ok: false as const, reason: 'not_found' as const };
+        return { ok: true as const, env: row as DriveEnvRecord };
+      } catch (error) {
+        if (isUniqueViolation(error)) return { ok: false as const, reason: 'name_taken' as const };
+        throw error;
+      }
+    },
+
+    async deleteById(envId) {
+      const deleted = await db.delete(driveEnvs).where(eq(driveEnvs.id, envId)).returning({ id: driveEnvs.id });
+      return deleted.length > 0;
+    },
+
+    async countLiveSessionsInEnv(envId) {
+      const [row] = await db
+        .select({ n: count() })
+        .from(agentWorkspaces)
+        .where(and(eq(agentWorkspaces.envId, envId), isNull(agentWorkspaces.endedAt)));
+      return row?.n ?? 0;
+    },
+
+    async countEnvsOwnedBy(payerId) {
+      // Through drive ownership — see the interface doc for why `createdBy`
+      // would be the wrong column to meter.
+      const [row] = await db
+        .select({ n: count() })
+        .from(driveEnvs)
+        .innerJoin(drives, eq(drives.id, driveEnvs.driveId))
+        .where(eq(drives.ownerId, payerId));
+      return row?.n ?? 0;
+    },
+
+    async updateSpriteIdentity({
+      envId,
+      previousSandboxId,
+      spriteKey,
+      sandboxId,
+      spriteInstanceId,
+      egressPolicyToken,
+      stamps,
+      now: at,
+    }) {
+      const updated = await db
+        .update(driveEnvs)
+        .set(revivedDriveEnvColumns({ spriteKey, sandboxId, spriteInstanceId, egressPolicyToken, stamps, now: at }))
+        .where(
+          and(
+            eq(driveEnvs.id, envId),
+            // CAS on the CURRENT sandboxId: null for a first provision, the
+            // vanished/replaced name for a re-provision. `eqOrIsNull` matches
+            // the null case, which plain `eq` never does in SQL.
+            eqOrIsNull(driveEnvs.sandboxId, previousSandboxId),
+          ),
+        )
+        .returning({ id: driveEnvs.id });
+      return updated.length > 0;
+    },
+
+    async applyStamps({ envId, stamps, cas }) {
+      const columns = envStampColumns(stamps);
+      // Nothing to write is a legitimate verdict; an empty `set` is a SQL error.
+      if (Object.keys(columns).length === 0) return true;
+      const conditions = [eq(driveEnvs.id, envId)];
+      // Only `sandboxId` is a real guard here: `drive_envs` has no `endedAt`
+      // column (see the interface doc), so `cas.endedAt` is accepted for
+      // signature parity and deliberately not translated into a condition.
+      if (cas?.sandboxId !== undefined) conditions.push(eqOrIsNull(driveEnvs.sandboxId, cas.sandboxId));
+      const updated = await db
+        .update(driveEnvs)
+        .set({ ...columns, updatedAt: now() })
+        .where(and(...conditions))
+        .returning({ id: driveEnvs.id });
+      // No guard requested: the caller accepted whatever the row currently is,
+      // so a miss (the row was deleted) is not a refusal.
+      if (cas?.sandboxId === undefined) return true;
+      return updated.length > 0;
+    },
+
+    async requestTeardown({ envId, sandboxId, spriteInstanceId, at }) {
+      await db
+        .update(driveEnvs)
+        .set({ teardownRequestedAt: at, updatedAt: at })
+        .where(
+          and(
+            eq(driveEnvs.id, envId),
+            eq(driveEnvs.sandboxId, sandboxId),
+            eqOrIsNull(driveEnvs.spriteInstanceId, spriteInstanceId),
+          ),
+        );
+    },
+
+    async stampSpriteTornDown({ envId, sandboxId, spriteInstanceId, stamps }) {
+      const updated = await db
+        .update(driveEnvs)
+        .set({ ...envStampColumns(stamps), updatedAt: now() })
+        // CAS on the INSTANCE, not just the name: a concurrent re-provision may
+        // have written a LIVE replacement into this row, and stamping that as
+        // torn down would hide a billing VM from the reconciler forever.
+        .where(
+          and(
+            eq(driveEnvs.id, envId),
+            eq(driveEnvs.sandboxId, sandboxId),
+            eqOrIsNull(driveEnvs.spriteInstanceId, spriteInstanceId),
+          ),
+        )
+        .returning({ id: driveEnvs.id });
+      return updated.length > 0;
+    },
+
+    async reloadSpritePointer(envId) {
+      const [row] = await db
+        .select({ sandboxId: driveEnvs.sandboxId, spriteInstanceId: driveEnvs.spriteInstanceId })
+        .from(driveEnvs)
+        .where(eq(driveEnvs.id, envId))
+        .limit(1);
+      return row ?? null;
+    },
+
+    async enqueueReclaim({ sandboxId, spriteInstanceId }) {
+      // Mirrors the AFTER-DELETE trigger's own insert: idempotent on the
+      // sandboxId PK, chasing the NEWEST instance on conflict — a newer
+      // generation took this deterministic name, so the outbox pointer must
+      // follow the VM that is actually alive now.
+      await db
+        .insert(machineSpriteReclaims)
+        .values({ sandboxId, spriteInstanceId })
+        .onConflictDoUpdate({
+          target: machineSpriteReclaims.sandboxId,
+          set: { spriteInstanceId: sql`coalesce(excluded."spriteInstanceId", ${machineSpriteReclaims.spriteInstanceId})` },
+        });
+    },
+  };
+}

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -323,8 +323,34 @@ export function revivedDriveEnvColumns(input: {
 /** Postgres unique-violation. A duplicate `(driveId, name)` is an ANSWER (`name_taken`), never a raised error. */
 const UNIQUE_VIOLATION = '23505';
 
-function isUniqueViolation(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === UNIQUE_VIOLATION;
+/** Bounded so a driver that ever produced a cyclic `cause` chain cannot hang a request here. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Is this a unique-constraint violation — WRAPPED OR NOT?
+ *
+ * The chain walk is the whole point. `drizzle-orm@0.45.2`'s pg-core session
+ * catches every driver error and rethrows it as `DrizzleQueryError` with the
+ * original on `.cause`, so a top-level `error.code === '23505'` test matches
+ * NOTHING that comes back from `db.insert(...)`. A duplicate environment name
+ * would then escape as an unhandled error and surface as a 500 instead of the
+ * 409 the route is written to send — the failure being silent in exactly the
+ * case the code claims to handle.
+ *
+ * Exported so the walk itself is testable against both shapes: the drivers'
+ * bare error and drizzle's wrapper. Which one arrives is a fact about a
+ * dependency, and dependencies change — a test pinning both is what makes the
+ * next drizzle bump visible instead of quietly re-breaking the 409.
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current !== null && current !== undefined; depth += 1) {
+    if (typeof current === 'object' && 'code' in current && (current as { code?: unknown }).code === UNIQUE_VIOLATION) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 /**

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -1,0 +1,496 @@
+/**
+ * Drive environments: create / list / rename / delete / rebuild (IO, dependency-injected).
+ *
+ * The lifecycle orchestration around `drive_envs`, split from the store
+ * (`drive-envs-store.ts`) and from Sprite provisioning
+ * (`agent-workspace-sprite.ts`) because the three answer different questions:
+ * this module is about the ENV — does it exist, may it be created, what does a
+ * client see, what has to die before its row may go — while those are about the
+ * table and the VM.
+ *
+ * **This module owns two decisions and delegates the rest.** Whether a delete
+ * may proceed is `planEnvDelete`'s (pure); whether a Sprite must be created,
+ * resumed or killed is `planSpriteHolderLifecycle`'s (pure, and shared with
+ * sessions — an env is a Sprite HOLDER, not a second kind of provisioner). What
+ * is left here is executing those verdicts in the right order against IO that
+ * can crash between any two steps.
+ *
+ * **`rebuildDriveEnv` is the ONLY verb that replaces an env's Sprite**, and that
+ * exclusivity is the point rather than a convention. A Sprite name is
+ * deterministic in the env's id, and `SandboxHost.provision` auto-resumes "same
+ * name, same filesystem" — which is exactly what makes an env persistent, and
+ * exactly why re-provisioning WITHOUT a confirmed kill first would hand back the
+ * same disk while telling the user it was rebuilt. So rebuild is teardown ⇒
+ * ensure, in that order, under the SAME envId: same address, same name, fresh
+ * filesystem. Nothing else in the system is allowed to swap an env's machine,
+ * because an env's whole contract with its users is that the files stay put.
+ */
+
+import type { SandboxHost } from '../sandbox/sandbox-host';
+import { SandboxSpriteReplacedError } from '../sandbox/sandbox-host';
+import {
+  planSpriteHolderLifecycle,
+  type SpriteHolderLifecycleRow,
+} from '../../agent-workspaces/plan-workspace-lifecycle';
+import { planEnvDelete } from '../../drive-envs/plan-env-delete';
+import type { DriveEnvDTO, DriveEnvStatus } from '../../drive-envs/env-contract';
+import {
+  checkDriveEnvAllowance,
+  type DriveEnvAllowanceDenialReason,
+} from '../sandbox/quota';
+import type { SubscriptionTier } from '../subscription-utils';
+import type { EnsureSpriteHolderSandboxResult } from '../agent-workspaces/agent-workspace-sprite';
+import type { DriveEnvRecord, DriveEnvStore } from './drive-envs-store';
+
+/**
+ * Row → `DriveEnvStatus`, as a pure function (the ONE place the mapping exists)
+ * — the env twin of `deriveSandboxStatus`.
+ *
+ * Two columns, checked in this order:
+ *
+ *  - `spriteTornDownAt` FIRST, because a torn-down env KEEPS the `sandboxId` of
+ *    the Sprite it used to own (that pointer is what a reclaim needs), so
+ *    testing for a sandbox first would report a destroyed VM as running. This is
+ *    the same trap `workspace-status.ts` documents, and it bites identically here.
+ *  - `sandboxId` — a Sprite is linked, INCLUDING a hibernating one. Idle Sprites
+ *    hibernate and wake on demand, which is invisible to the user, so it is not
+ *    a status of its own.
+ *
+ * There is no `endedAt` to consult, and no `'ended'` to return: an env is never
+ * ended, only deleted. A row that still exists is an environment that still
+ * exists, whether or not it currently has a machine.
+ */
+export interface DriveEnvStatusColumns {
+  sandboxId: string | null;
+  spriteTornDownAt: Date | null;
+}
+
+export function deriveDriveEnvStatus(row: DriveEnvStatusColumns): DriveEnvStatus {
+  if (row.spriteTornDownAt !== null) return 'stopped';
+  if (row.sandboxId !== null) return 'running';
+  return 'none';
+}
+
+/**
+ * Project a stored row onto the wire DTO (pure).
+ *
+ * `Date` never crosses the boundary (ISO-8601 strings only), and no Sprite
+ * pointer, egress token or storage measurement is projected at all — see
+ * `env-contract.ts` for why the DTO is deliberately narrow.
+ */
+export function toDriveEnvDTO(row: DriveEnvRecord): DriveEnvDTO {
+  return {
+    id: row.id,
+    driveId: row.driveId,
+    name: row.name,
+    status: deriveDriveEnvStatus(row),
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export interface CreateDriveEnvDeps {
+  store: Pick<DriveEnvStore, 'create' | 'countEnvsOwnedBy'>;
+  /**
+   * The drive's PAYER and their tier — the drive's OWNER, with no fallback.
+   * `null` means the drive is gone, which fails the create closed rather than
+   * metering the request against anybody else.
+   */
+  resolvePayer: (driveId: string) => Promise<{ payerId: string; tier: SubscriptionTier } | null>;
+  now: () => Date;
+}
+
+export type CreateDriveEnvResult =
+  | { ok: true; env: DriveEnvRecord }
+  /** The drive does not exist (so there is no payer to meter, and no drive to own the env). */
+  | { ok: false; reason: 'drive_not_found' }
+  /** `(driveId, name)` is taken — the database refused, which is how concurrent creates are resolved. */
+  | { ok: false; reason: 'name_taken' }
+  /** The payer's tier forbids environments, or they are at their ceiling. `limit` is the ceiling that applied. */
+  | { ok: false; reason: 'quota_exceeded'; denial: DriveEnvAllowanceDenialReason; limit: number };
+
+/**
+ * Create an environment: mint the row.
+ *
+ * Does NOT touch a Sprite — envs provision lazily, on the first session that
+ * runs inside one — so creating an env is instant, and an env that nobody has
+ * opened yet costs storage for nothing.
+ *
+ * **The quota is called HERE, not injected**, and that is deliberate. The row is
+ * the billed persistence unit, so this function is the one moment the commitment
+ * is made; a `checkQuota` dependency would be a gate a future caller could
+ * supply as `async () => ({ allowed: true })` without any reviewer noticing.
+ * What IS injected is the payer lookup, which is genuinely per-deployment IO.
+ */
+export async function createDriveEnv({
+  driveId,
+  name,
+  createdBy,
+  deps,
+}: {
+  driveId: string;
+  /** Already validated and trimmed by `driveEnvNameSchema` at the boundary. */
+  name: string;
+  /** AUDIT ONLY: who asked. Never consulted for permission, payment or lifecycle. */
+  createdBy: string | null;
+  deps: CreateDriveEnvDeps;
+}): Promise<CreateDriveEnvResult> {
+  const payer = await deps.resolvePayer(driveId);
+  if (!payer) return { ok: false, reason: 'drive_not_found' };
+
+  const allowance = await checkDriveEnvAllowance({
+    payerId: payer.payerId,
+    tier: payer.tier,
+    countEnvsOwnedBy: (payerId) => deps.store.countEnvsOwnedBy(payerId),
+  });
+  if (!allowance.allowed) {
+    return { ok: false, reason: 'quota_exceeded', denial: allowance.reason, limit: allowance.limit };
+  }
+
+  const created = await deps.store.create({ driveId, name, createdBy, now: deps.now() });
+  if (!created.ok) return { ok: false, reason: 'name_taken' };
+  return { ok: true, env: created.env };
+}
+
+// ---------------------------------------------------------------------------
+// List / rename
+// ---------------------------------------------------------------------------
+
+export interface ListDriveEnvsDeps {
+  store: Pick<DriveEnvStore, 'list'>;
+}
+
+/**
+ * The drive's environments, as DTOs.
+ *
+ * Access is NOT checked here: the caller has already established that this
+ * requester may enumerate this drive (that is what naming the drive IS), exactly
+ * as `listAgentSessions` treats its filter.
+ */
+export async function listDriveEnvs({
+  driveId,
+  deps,
+}: {
+  driveId: string;
+  deps: ListDriveEnvsDeps;
+}): Promise<DriveEnvDTO[]> {
+  const rows = await deps.store.list(driveId);
+  return rows.map(toDriveEnvDTO);
+}
+
+export interface RenameDriveEnvDeps {
+  store: Pick<DriveEnvStore, 'rename'>;
+  now: () => Date;
+}
+
+export type RenameDriveEnvResult =
+  | { ok: true; env: DriveEnvRecord }
+  | { ok: false; reason: 'not_found' | 'name_taken' };
+
+/**
+ * Rename an environment.
+ *
+ * A rename MOVES AN ADDRESS: `(driveId, name)` is unique because pipelines and
+ * people target an env by name ("promote to staging"), so renaming is a
+ * deliberate admin act and a collision is refused rather than resolved. Nothing
+ * else moves — the id, the Sprite key folded from it, and therefore the
+ * filesystem are all untouched.
+ */
+export async function renameDriveEnv({
+  envId,
+  name,
+  deps,
+}: {
+  envId: string;
+  /** Already validated and trimmed by `driveEnvNameSchema` at the boundary. */
+  name: string;
+  deps: RenameDriveEnvDeps;
+}): Promise<RenameDriveEnvResult> {
+  const renamed = await deps.store.rename({ envId, name, now: deps.now() });
+  if (!renamed.ok) return { ok: false, reason: renamed.reason };
+  return { ok: true, env: renamed.env };
+}
+
+// ---------------------------------------------------------------------------
+// The shared teardown step (delete and rebuild both need it)
+// ---------------------------------------------------------------------------
+
+/** The env row, in the shape the shared lifecycle planner decides on. */
+function toLifecycleRow(row: DriveEnvRecord): SpriteHolderLifecycleRow {
+  return {
+    holderId: row.id,
+    spriteKey: row.spriteKey,
+    sandboxId: row.sandboxId,
+    spriteInstanceId: row.spriteInstanceId,
+    egressPolicyToken: row.egressPolicyToken,
+    teardownRequestedAt: row.teardownRequestedAt,
+    spriteTornDownAt: row.spriteTornDownAt,
+    // An env has no `endedAt` column and no ended state — it is deleted, never
+    // ended. Pinned null so the shared planner reads the row exactly as it is
+    // rather than inferring a session-shaped lifecycle the env does not have.
+    endedAt: null,
+    lastActiveAt: row.lastActiveAt,
+  };
+}
+
+interface TeardownEnvSpriteDeps {
+  store: Pick<DriveEnvStore, 'requestTeardown' | 'stampSpriteTornDown'>;
+  host: SandboxHost;
+  now: () => Date;
+}
+
+type TeardownEnvSpriteResult =
+  /** The Sprite is gone. `stamped` is false when a concurrent provision won the CAS — see below. */
+  | { ok: true; stamped: boolean }
+  | { ok: false; detail: string };
+
+/**
+ * Kill an env's Sprite: intent first, kill second, confirmation third.
+ *
+ * The order is the crash contract, and it is the same one `endAgentSession`
+ * follows for the same reason. `teardownRequestedAt` is written BEFORE the kill
+ * so that a process dying mid-teardown still leaves the VM reclaimable — the
+ * orphan reconciler requires that stamp before it destroys anything. The
+ * confirmation stamp goes on afterwards under a CAS on the INSTANCE, because a
+ * concurrent provision may have put a LIVE replacement into this row, and
+ * marking that one torn down would hide a billing VM from the reconciler forever.
+ */
+async function teardownEnvSprite({
+  envId,
+  sandboxId,
+  expectedInstanceId,
+  row,
+  deps,
+}: {
+  envId: string;
+  sandboxId: string;
+  expectedInstanceId: string | null;
+  row: DriveEnvRecord;
+  deps: TeardownEnvSpriteDeps;
+}): Promise<TeardownEnvSpriteResult> {
+  const now = deps.now();
+  // WHICH columns a confirmed teardown stamps stays the shared planner's
+  // decision, not this module's: an env is a Sprite holder, and "what does
+  // killing a holder's VM record" is precisely the question that planner
+  // answers for both holder kinds. (Its `endedAt` stamp is dropped by
+  // `envStampColumns` — `drive_envs` has no such column.)
+  const plan = planSpriteHolderLifecycle({
+    row: toLifecycleRow(row),
+    intent: 'end',
+    // Ignored for `end`: the planner decides cleanup BEFORE the authorization
+    // gate, because releasing compute must never be blocked by losing access to
+    // it. Passing `true` documents that this path deliberately does not gate.
+    canRun: true,
+    now,
+  });
+  // Not a teardown verdict means the row does not believe it holds a live
+  // Sprite — it was torn down between this caller's read and the planner's
+  // reading of it. Nothing to kill and nothing to stamp: inventing stamps here
+  // would write a confirmation this call never confirmed.
+  if (plan.action !== 'teardown') return { ok: true, stamped: false };
+  const stamps = plan.stamps;
+
+  await deps.store.requestTeardown({ envId, sandboxId, spriteInstanceId: expectedInstanceId, at: now });
+
+  try {
+    await deps.host.kill({ sandboxId, expectedInstanceId });
+  } catch (error) {
+    // A DIFFERENT VM holds this name now, so the one we targeted is already gone
+    // — confirmed enough to stamp (the CAS below still refuses if the row has
+    // moved on to that replacement).
+    if (!(error instanceof SandboxSpriteReplacedError)) {
+      // A real failure: the VM may still be running. The row keeps its teardown
+      // request, so the orphan reconciler retries — which is why this is
+      // reported rather than swallowed, and why the caller must NOT go on to
+      // delete the row: deleting it would hand the reclaim job to the AFTER
+      // DELETE trigger while we still believe the kill is retryable here.
+      return { ok: false, detail: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  const stamped = await deps.store.stampSpriteTornDown({ envId, sandboxId, spriteInstanceId: expectedInstanceId, stamps });
+  return { ok: true, stamped };
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+export interface DeleteDriveEnvDeps {
+  store: Pick<
+    DriveEnvStore,
+    'findById' | 'countLiveSessionsInEnv' | 'requestTeardown' | 'stampSpriteTornDown' | 'deleteById'
+  >;
+  host: SandboxHost;
+  now: () => Date;
+}
+
+export type DeleteDriveEnvResult =
+  | { ok: true; spriteTornDown: boolean }
+  | { ok: false; reason: 'not_found' }
+  /** Sessions are still live in here and `force` was not given. Nothing was touched. */
+  | { ok: false; reason: 'live_sessions'; liveSessionCount: number }
+  | { ok: false; reason: 'teardown_failed'; detail: string };
+
+/**
+ * Delete an environment — the destructive verb, and the only one that takes a
+ * shared filesystem with it.
+ *
+ * The flow, in the order the invariants require:
+ *
+ *  1. **Guard.** Refuse while sessions are live inside the env, unless `force`.
+ *     This has to come first because the row delete CASCADES to those sessions:
+ *     by the time the row is gone, the work someone was doing in it is gone too.
+ *  2. **Teardown.** Kill the env's Sprite while the row still points at it, so
+ *     the kill is confirmed by the caller that asked for it. A failed kill
+ *     ABORTS the delete: the row keeps its teardown request and stays as the
+ *     reconciler's handle on the VM.
+ *  3. **Delete.** The row goes; the cascade removes bound sessions (and their
+ *     panes, rev counters and shells), and the AFTER DELETE trigger parks this
+ *     row's Sprite pointer in `machine_sprite_reclaims` as the crash net for a
+ *     teardown that never confirmed.
+ *
+ * The cascade cannot strand a VM: an env-bound session is CHECK-forbidden from
+ * holding Sprite pointers (`agent_workspaces_env_no_sprite_check`), so the only
+ * machine in play is the env's own, which step 2 has already dealt with. That is
+ * also why `force` does not need to end sessions one by one first — there is
+ * nothing in a session row for an orderly end to release.
+ */
+export async function deleteDriveEnv({
+  envId,
+  force,
+  deps,
+}: {
+  envId: string;
+  /** Override the live-session guard. Nothing else in this flow consults it. */
+  force: boolean;
+  deps: DeleteDriveEnvDeps;
+}): Promise<DeleteDriveEnvResult> {
+  const row = await deps.store.findById(envId);
+  if (!row) return { ok: false, reason: 'not_found' };
+
+  const liveSessionCount = await deps.store.countLiveSessionsInEnv(envId);
+  const plan = planEnvDelete({ row, liveSessionCount, force });
+
+  if (plan.action === 'deny_live_sessions') {
+    return { ok: false, reason: 'live_sessions', liveSessionCount: plan.liveSessionCount };
+  }
+
+  let spriteTornDown = false;
+  if (plan.action === 'teardown_then_delete') {
+    const teardown = await teardownEnvSprite({
+      envId,
+      sandboxId: plan.sandboxId,
+      expectedInstanceId: plan.expectedInstanceId,
+      row,
+      deps,
+    });
+    // A kill we could not confirm must NOT be followed by a row delete: the row
+    // is the reconciler's only handle on a VM it may still have to retry, and
+    // the reclaim outbox is a net for crashes, not a substitute for a teardown
+    // this process knows failed.
+    if (!teardown.ok) return { ok: false, reason: 'teardown_failed', detail: teardown.detail };
+    spriteTornDown = teardown.stamped;
+  }
+
+  const deleted = await deps.store.deleteById(envId);
+  // Losing this race means a concurrent delete removed the row first. The env is
+  // gone either way, which is what the caller asked for — but say so honestly
+  // rather than claim this call is what killed the Sprite.
+  if (!deleted) return { ok: false, reason: 'not_found' };
+  return { ok: true, spriteTornDown };
+}
+
+// ---------------------------------------------------------------------------
+// Rebuild
+// ---------------------------------------------------------------------------
+
+export interface RebuildDriveEnvDeps {
+  store: Pick<DriveEnvStore, 'findById' | 'requestTeardown' | 'stampSpriteTornDown'>;
+  host: SandboxHost;
+  /**
+   * Provision this env's Sprite — the app's binding of the holder-neutral
+   * `ensureSpriteHolderSandbox` with the env's key derivation, authorization,
+   * egress and quota deps.
+   *
+   * Injected rather than composed here for the reason
+   * `agent-workspace-sprite.ts` gives about its own seams: every one of those
+   * deps is deployment IO (a Sprite driver, a secret, a network policy), and a
+   * service module that reached for them could not be tested without them.
+   * Crucially this is `ensure`, not a second provisioning path — the CAS that
+   * serializes concurrent provisions of one holder only works if every
+   * provisioner runs the same one.
+   */
+  ensureSandbox: (row: DriveEnvRecord) => Promise<EnsureSpriteHolderSandboxResult>;
+  now: () => Date;
+}
+
+export type RebuildDriveEnvResult =
+  | { ok: true; sandboxId: string }
+  | { ok: false; reason: 'not_found' }
+  | { ok: false; reason: 'teardown_failed'; detail: string }
+  /** The old Sprite is gone but the new one could not be minted. The env survives, machineless, and the next ensure retries. */
+  | { ok: false; reason: 'provision_failed'; detail: string };
+
+/**
+ * Rebuild an environment: destroy its machine and give it a fresh one, under the
+ * SAME env id.
+ *
+ * The admin escape hatch for an env someone has broken from the inside — a wedged
+ * daemon, a full disk, a dependency tree past saving. It is destructive by
+ * design: the filesystem does not survive, which is precisely what the caller is
+ * asking for, and is why this is an owner/admin verb rather than something a
+ * session can trigger on its own behalf.
+ *
+ * **Teardown must be CONFIRMED before the re-provision**, and this is the one
+ * place that ordering is subtle: Sprite names are deterministic in the env id, so
+ * provisioning again without a confirmed kill resumes the SAME name and hands
+ * back the SAME disk. The user would be told their environment was rebuilt while
+ * looking at the files they asked to be rid of. So a failed kill aborts, and the
+ * env keeps the machine it had.
+ *
+ * The window between the two steps is deliberately left open rather than locked:
+ * an env whose Sprite is torn down and not yet replaced is an ORDINARY state
+ * (`status: 'stopped'`), reachable by a reclaim just as easily as by a rebuild,
+ * and the next ensure — this one or anyone's — provisions from it correctly.
+ */
+export async function rebuildDriveEnv({
+  envId,
+  deps,
+}: {
+  envId: string;
+  deps: RebuildDriveEnvDeps;
+}): Promise<RebuildDriveEnvResult> {
+  const row = await deps.store.findById(envId);
+  if (!row) return { ok: false, reason: 'not_found' };
+
+  if (row.sandboxId !== null && row.spriteTornDownAt === null) {
+    const teardown = await teardownEnvSprite({
+      envId,
+      sandboxId: row.sandboxId,
+      expectedInstanceId: row.spriteInstanceId,
+      row,
+      deps,
+    });
+    if (!teardown.ok) return { ok: false, reason: 'teardown_failed', detail: teardown.detail };
+  }
+
+  // Re-read: the teardown just moved this row's stamps, and the provisioner
+  // plans from the pointer columns. Handing it the pre-teardown snapshot would
+  // ask it to decide against a Sprite that no longer exists.
+  const fresh = await deps.store.findById(envId);
+  if (!fresh) return { ok: false, reason: 'not_found' };
+
+  const provisioned = await deps.ensureSandbox(fresh);
+  if (!provisioned.ok) {
+    return {
+      ok: false,
+      reason: 'provision_failed',
+      detail: provisioned.detail ?? provisioned.denial ?? provisioned.reason,
+    };
+  }
+  return { ok: true, sandboxId: provisioned.sandboxId };
+}

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -36,6 +36,7 @@ import { planEnvDelete } from '../../drive-envs/plan-env-delete';
 import type { DriveEnvDTO, DriveEnvStatus } from '../../drive-envs/env-contract';
 import {
   checkDriveEnvAllowance,
+  getDriveEnvLimit,
   type DriveEnvAllowanceDenialReason,
 } from '../sandbox/quota';
 import type { SubscriptionTier } from '../subscription-utils';
@@ -93,7 +94,7 @@ export function toDriveEnvDTO(row: DriveEnvRecord): DriveEnvDTO {
 // ---------------------------------------------------------------------------
 
 export interface CreateDriveEnvDeps {
-  store: Pick<DriveEnvStore, 'create' | 'countEnvsOwnedBy'>;
+  store: Pick<DriveEnvStore, 'createIfUnderLimit' | 'countEnvsOwnedBy'>;
   /**
    * The drive's PAYER and their tier — the drive's OWNER, with no fallback.
    * `null` means the drive is gone, which fails the create closed rather than
@@ -124,6 +125,18 @@ export type CreateDriveEnvResult =
  * is made; a `checkQuota` dependency would be a gate a future caller could
  * supply as `async () => ({ allowed: true })` without any reviewer noticing.
  * What IS injected is the payer lookup, which is genuinely per-deployment IO.
+ *
+ * **The ceiling is enforced TWICE, and the second one is the real one.** The
+ * allowance check below is an advisory pre-check: it reads a count and produces
+ * the right denial vocabulary (`tier_ineligible` vs `env_limit_reached`) without
+ * a write. It is also racy on its own — two admins creating differently-named
+ * envs for one payer at the ceiling both read "under", and `(driveId, name)`
+ * uniqueness does not serialize different names. So the count-and-insert is
+ * repeated inside `createIfUnderLimit` under a per-payer advisory lock, which is
+ * what actually holds the line. This is the same two-layer shape the session
+ * spawn ceiling uses (an advisory pre-check at the route, a structural
+ * count-and-insert in the store), for the same reason: the pre-check exists to
+ * give a good answer, the structural check exists to be correct.
  */
 export async function createDriveEnv({
   driveId,
@@ -150,8 +163,26 @@ export async function createDriveEnv({
     return { ok: false, reason: 'quota_exceeded', denial: allowance.reason, limit: allowance.limit };
   }
 
-  const created = await deps.store.create({ driveId, name, createdBy, now: deps.now() });
-  if (!created.ok) return { ok: false, reason: 'name_taken' };
+  const created = await deps.store.createIfUnderLimit({
+    driveId,
+    name,
+    createdBy,
+    now: deps.now(),
+    payerId: payer.payerId,
+    maxEnvs: getDriveEnvLimit(payer.tier),
+  });
+  if (!created.ok) {
+    if (created.reason === 'name_taken') return { ok: false, reason: 'name_taken' };
+    // Lost the structural race the pre-check above could not see. Reported as
+    // the SAME refusal the pre-check would have produced, because it is the
+    // same fact — the payer is at their ceiling — learned a moment later.
+    return {
+      ok: false,
+      reason: 'quota_exceeded',
+      denial: 'env_limit_reached',
+      limit: getDriveEnvLimit(payer.tier),
+    };
+  }
   return { ok: true, env: created.env };
 }
 
@@ -322,7 +353,7 @@ async function teardownEnvSprite({
 export interface DeleteDriveEnvDeps {
   store: Pick<
     DriveEnvStore,
-    'findById' | 'countLiveSessionsInEnv' | 'requestTeardown' | 'stampSpriteTornDown' | 'deleteById'
+    'findById' | 'countLiveSessionsInEnv' | 'requestTeardown' | 'stampSpriteTornDown' | 'deleteIfUnoccupied'
   >;
   host: SandboxHost;
   now: () => Date;
@@ -341,15 +372,29 @@ export type DeleteDriveEnvResult =
  *
  * The flow, in the order the invariants require:
  *
- *  1. **Guard.** Refuse while sessions are live inside the env, unless `force`.
- *     This has to come first because the row delete CASCADES to those sessions:
- *     by the time the row is gone, the work someone was doing in it is gone too.
+ *  1. **Guard, cheaply.** Refuse while sessions are live inside the env, unless
+ *     `force`. First, because the row delete CASCADES to those sessions: by the
+ *     time the row is gone, the work someone was doing in it is gone too. This
+ *     read is deliberately NOT the authoritative guard — it is the one that
+ *     refuses before anything is destroyed, which is what makes the common case
+ *     cost nothing.
  *  2. **Teardown.** Kill the env's Sprite while the row still points at it, so
  *     the kill is confirmed by the caller that asked for it. A failed kill
  *     ABORTS the delete: the row keeps its teardown request and stays as the
  *     reconciler's handle on the VM.
- *  3. **Delete.** The row goes, and the cascade removes bound sessions (and
- *     their panes, rev counters and shells).
+ *  3. **Delete, atomically re-guarded.** `deleteIfUnoccupied` repeats the count
+ *     inside one transaction holding `FOR UPDATE` on the env row, which is what
+ *     actually closes the window: a session cannot bind between the count and
+ *     the delete, because binding needs an FK lock on the row this transaction
+ *     holds. The cascade then removes bound sessions (and their panes, rev
+ *     counters and shells).
+ *
+ * A session that binds during step 2 therefore REFUSES the delete rather than
+ * being cascaded away — and leaves the env with a torn-down Sprite. That state
+ * is ordinary (`status: 'stopped'`, indistinguishable from a reclaim) and costs
+ * the racing session a re-provision on its next ensure, which is the right
+ * price: a machine rebuilt is recoverable, a live session's work deleted
+ * without consent is not.
  *
  * The AFTER DELETE trigger is the crash net UNDER step 2, not a second copy of
  * it: it fires only `WHEN sandboxId IS NOT NULL AND spriteTornDownAt IS NULL` —
@@ -408,11 +453,17 @@ export async function deleteDriveEnv({
     spriteTornDown = teardown.stamped;
   }
 
-  const deleted = await deps.store.deleteById(envId);
-  // Losing this race means a concurrent delete removed the row first. The env is
-  // gone either way, which is what the caller asked for — but say so honestly
-  // rather than claim this call is what killed the Sprite.
-  if (!deleted) return { ok: false, reason: 'not_found' };
+  const deleted = await deps.store.deleteIfUnoccupied({ envId, force });
+  if (!deleted.ok) {
+    // `not_found`: a concurrent delete removed the row first. The env is gone
+    // either way, which is what the caller asked for — but say so honestly
+    // rather than claim this call is what killed the Sprite.
+    if (deleted.reason === 'not_found') return { ok: false, reason: 'not_found' };
+    // `live_sessions`: a session bound during the teardown above. Refusing
+    // costs that session a re-provision; cascading it away would cost someone
+    // their work.
+    return { ok: false, reason: 'live_sessions', liveSessionCount: deleted.liveSessionCount };
+  }
   return { ok: true, spriteTornDown };
 }
 

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -283,11 +283,22 @@ type TeardownEnvSpriteResult =
  *
  * The order is the crash contract, and it is the same one `endAgentSession`
  * follows for the same reason. `teardownRequestedAt` is written BEFORE the kill
- * so that a process dying mid-teardown still leaves the VM reclaimable — the
- * orphan reconciler requires that stamp before it destroys anything. The
- * confirmation stamp goes on afterwards under a CAS on the INSTANCE, because a
- * concurrent provision may have put a LIVE replacement into this row, and
- * marking that one torn down would hide a billing VM from the reconciler forever.
+ * so that a process dying mid-teardown leaves a durable record of the INTENT.
+ * The confirmation stamp goes on afterwards under a CAS on the INSTANCE, because
+ * a concurrent provision may have put a LIVE replacement into this row, and
+ * marking that one torn down would hide a billing VM from every pointer there is.
+ *
+ * **What recovers a crash here, precisely.** For a DELETED env row the reclaim
+ * outbox does: the AFTER DELETE trigger parks the pointer and
+ * `reconcileOrphanSprites` drains it (source A). For a SURVIVING row it does
+ * NOT: that cron's second source enumerates `agent_workspaces` only, and
+ * `drive_envs` is not folded into its row sources yet (the schema PR defers that
+ * to when envs join the crons). So an env whose kill failed keeps a live VM its
+ * own row still points at — nothing is leaked or unbilled — and the retry is the
+ * next delete or rebuild, or a plain `ensure`, which resumes the VM and clears
+ * the stale intent. Folding envs into the reconciler is the follow-up that makes
+ * that automatic; it is deliberately not smuggled into this dark-shipped layer,
+ * because it changes the behavior of a cron that is live for sessions today.
  */
 async function teardownEnvSprite({
   envId,
@@ -333,11 +344,12 @@ async function teardownEnvSprite({
     // — confirmed enough to stamp (the CAS below still refuses if the row has
     // moved on to that replacement).
     if (!(error instanceof SandboxSpriteReplacedError)) {
-      // A real failure: the VM may still be running. The row keeps its teardown
-      // request, so the orphan reconciler retries — which is why this is
-      // reported rather than swallowed, and why the caller must NOT go on to
-      // delete the row: deleting it would hand the reclaim job to the AFTER
-      // DELETE trigger while we still believe the kill is retryable here.
+      // A real failure: the VM may still be running. Reported rather than
+      // swallowed, because for a SURVIVING env row nothing retries this on its
+      // own (see the doc above) — the next delete, rebuild or ensure does. And
+      // the caller must NOT go on to delete the row: the row is what still
+      // points at the VM, and deleting it would hand the reclaim job to the
+      // AFTER DELETE trigger while we believe the kill is retryable here.
       return { ok: false, detail: error instanceof Error ? error.message : String(error) };
     }
   }
@@ -381,7 +393,7 @@ export type DeleteDriveEnvResult =
  *  2. **Teardown.** Kill the env's Sprite while the row still points at it, so
  *     the kill is confirmed by the caller that asked for it. A failed kill
  *     ABORTS the delete: the row keeps its teardown request and stays as the
- *     reconciler's handle on the VM.
+ *     only pointer at the VM, so a retry can finish what this call started.
  *  3. **Delete, atomically re-guarded.** `deleteIfUnoccupied` repeats the count
  *     inside one transaction holding `FOR UPDATE` on the env row, which is what
  *     actually closes the window: a session cannot bind between the count and
@@ -441,9 +453,9 @@ export async function deleteDriveEnv({
       deps,
     });
     // A kill we could not confirm must NOT be followed by a row delete: the row
-    // is the reconciler's only handle on a VM it may still have to retry, and
-    // the reclaim outbox is a net for crashes, not a substitute for a teardown
-    // this process knows failed.
+    // is the only remaining pointer at a VM whose kill may still have to be
+    // retried, and the reclaim outbox is a net for crashes, not a substitute
+    // for a teardown this process knows failed.
     if (!teardown.ok) return { ok: false, reason: 'teardown_failed', detail: teardown.detail };
     // `stamped: false` means the confirmation CAS refused — a concurrent
     // provision owns this row's pointer now. The delete still proceeds (the

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -348,10 +348,17 @@ export type DeleteDriveEnvResult =
  *     the kill is confirmed by the caller that asked for it. A failed kill
  *     ABORTS the delete: the row keeps its teardown request and stays as the
  *     reconciler's handle on the VM.
- *  3. **Delete.** The row goes; the cascade removes bound sessions (and their
- *     panes, rev counters and shells), and the AFTER DELETE trigger parks this
- *     row's Sprite pointer in `machine_sprite_reclaims` as the crash net for a
- *     teardown that never confirmed.
+ *  3. **Delete.** The row goes, and the cascade removes bound sessions (and
+ *     their panes, rev counters and shells).
+ *
+ * The AFTER DELETE trigger is the crash net UNDER step 2, not a second copy of
+ * it: it fires only `WHEN sandboxId IS NOT NULL AND spriteTornDownAt IS NULL` —
+ * a row that still believes it holds a live Sprite. After a confirmed teardown
+ * that predicate is false and nothing is enqueued, which is correct: an outbox
+ * row for a dead name would have the reclaim cron chase it forever. What the
+ * trigger DOES catch is the case step 2 cannot close by itself — a concurrent
+ * provision put a live replacement on the row, the confirmation CAS rightly
+ * refused, and the delete carries a machine nothing else would ever find.
  *
  * The cascade cannot strand a VM: an env-bound session is CHECK-forbidden from
  * holding Sprite pointers (`agent_workspaces_env_no_sprite_check`), so the only
@@ -393,6 +400,11 @@ export async function deleteDriveEnv({
     // the reclaim outbox is a net for crashes, not a substitute for a teardown
     // this process knows failed.
     if (!teardown.ok) return { ok: false, reason: 'teardown_failed', detail: teardown.detail };
+    // `stamped: false` means the confirmation CAS refused — a concurrent
+    // provision owns this row's pointer now. The delete still proceeds (the
+    // caller asked for the env to be gone, and it is), and the replacement VM
+    // is handed to the reclaim outbox by the AFTER DELETE trigger, which fires
+    // precisely because the row still reads as live.
     spriteTornDown = teardown.stamped;
   }
 

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -539,6 +539,17 @@ export async function rebuildDriveEnv({
       deps,
     });
     if (!teardown.ok) return { ok: false, reason: 'teardown_failed', detail: teardown.detail };
+    // `stamped: false` means the confirmation CAS refused: a concurrent
+    // provision put a LIVE replacement on this row while we were killing the
+    // old VM. For a DELETE that is survivable (the row goes and the AFTER
+    // DELETE trigger reclaims the replacement) — for a REBUILD it is not.
+    // Continuing would re-read a row pointing at a live machine, resume it, and
+    // report `rebuilt: true` over a filesystem this call never destroyed, which
+    // is precisely the lie the kill-before-provision ordering exists to
+    // prevent. Abort and let the caller retry against the current machine.
+    if (!teardown.stamped) {
+      return { ok: false, reason: 'teardown_failed', detail: 'teardown_not_confirmed' };
+    }
   }
 
   // Re-read: the teardown just moved this row's stamps, and the provisioner

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -17,6 +17,7 @@ import {
   SESSION_ACTIVITY_GRACE_MS,
   type CodeExecutionQuotaDeps,
 } from '../quota';
+import { MAX_DRIVE_ENVS_LISTED } from '../../../drive-envs/env-contract';
 
 function makeDeps(
   overrides: Partial<CodeExecutionQuotaDeps> = {},
@@ -462,6 +463,44 @@ describe('checkDriveEnvAllowance', () => {
       getDriveEnvLimit('founder'),
       getDriveEnvLimit('business'),
     ]).toEqual([0, 2, 5, 10]);
+  });
+
+  it('given an override ABOVE the listing cap, should clamp it — an env a listing cannot show must not be creatable', async () => {
+    // The two numbers are coupled: an env past the listing cap would exist,
+    // hold a Sprite and bill storage while `GET /envs` silently omitted it. A
+    // clamped ceiling refuses the create instead — the visible failure rather
+    // than the invisible one.
+    //
+    // The limits are read at MODULE LOAD, so this stubs the env and re-imports;
+    // asserting on the already-loaded module would pass against an unclamped
+    // implementation, since the defaults are all far below the cap.
+    vi.stubEnv('DRIVE_ENV_LIMIT_BUSINESS', '500');
+    vi.resetModules();
+    try {
+      const quota = await import('../quota');
+      expect(quota.getDriveEnvLimit('business')).toBe(MAX_DRIVE_ENVS_LISTED);
+      const decision = await quota.checkDriveEnvAllowance({
+        payerId: 'payer-1',
+        tier: 'business',
+        countEnvsOwnedBy: async () => MAX_DRIVE_ENVS_LISTED,
+      });
+      expect(decision).toEqual({ allowed: false, reason: 'env_limit_reached', limit: MAX_DRIVE_ENVS_LISTED });
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  it('given an override BELOW the cap, should honor it — the clamp is a ceiling, not a floor', async () => {
+    vi.stubEnv('DRIVE_ENV_LIMIT_PRO', '7');
+    vi.resetModules();
+    try {
+      const quota = await import('../quota');
+      expect(quota.getDriveEnvLimit('pro')).toBe(7);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 
   it('given a tier whose ceiling is above the count, should allow at exactly one below', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -7,6 +7,8 @@ import {
   resetCodeExecutionConcurrency,
   checkCodeExecutionQuota,
   checkAgentSessionConcurrency,
+  checkDriveEnvAllowance,
+  getDriveEnvLimit,
   checkSessionRuntimeGuardrail,
   recordSessionActivity,
   resetSessionRuntimeGuardrail,
@@ -412,5 +414,62 @@ describe('checkAgentSessionConcurrency — tier ineligibility overrides the resu
 
     expect(decision).toEqual({ allowed: false, reason: 'tier_ineligible' });
     expect(countLiveAgentSessions).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkDriveEnvAllowance', () => {
+  it('given an owned count under the tier ceiling, should allow', async () => {
+    const decision = await checkDriveEnvAllowance({
+      payerId: 'payer-1',
+      tier: 'pro',
+      countEnvsOwnedBy: async () => getDriveEnvLimit('pro') - 1,
+    });
+    expect(decision).toEqual({ allowed: true });
+  });
+
+  it('given an owned count AT the tier ceiling, should deny with env_limit_reached and name the limit', async () => {
+    const decision = await checkDriveEnvAllowance({
+      payerId: 'payer-1',
+      tier: 'pro',
+      countEnvsOwnedBy: async () => getDriveEnvLimit('pro'),
+    });
+    expect(decision).toEqual({ allowed: false, reason: 'env_limit_reached', limit: getDriveEnvLimit('pro') });
+  });
+
+  it('given a FREE-tier payer, should deny as tier_ineligible WITHOUT even counting — envs are a paid-tier feature', async () => {
+    // Free's ceiling is 0, so a count-first implementation would also refuse —
+    // but it would refuse with the wrong word (and a needless DB round-trip),
+    // telling a free user they are "at their limit" of a feature they do not have.
+    const countEnvsOwnedBy = vi.fn(async () => 0);
+    const decision = await checkDriveEnvAllowance({ payerId: 'payer-1', tier: 'free', countEnvsOwnedBy });
+
+    expect(decision).toEqual({ allowed: false, reason: 'tier_ineligible', limit: 0 });
+    expect(countEnvsOwnedBy).not.toHaveBeenCalled();
+  });
+
+  it('should meter the PAYER it was handed — the drive owner, never the caller', async () => {
+    const countEnvsOwnedBy = vi.fn(async () => 0);
+    await checkDriveEnvAllowance({ payerId: 'drive-owner', tier: 'business', countEnvsOwnedBy });
+    expect(countEnvsOwnedBy).toHaveBeenCalledWith('drive-owner');
+  });
+
+  it('should carry the documented per-tier ceilings — free 0 / pro 2 / founder 5 / business 10', () => {
+    // The placeholder numbers pending the economics sign-off, pinned so a
+    // silent retune is a test change rather than a billing surprise.
+    expect([
+      getDriveEnvLimit('free'),
+      getDriveEnvLimit('pro'),
+      getDriveEnvLimit('founder'),
+      getDriveEnvLimit('business'),
+    ]).toEqual([0, 2, 5, 10]);
+  });
+
+  it('given a tier whose ceiling is above the count, should allow at exactly one below', async () => {
+    const decision = await checkDriveEnvAllowance({
+      payerId: 'payer-1',
+      tier: 'business',
+      countEnvsOwnedBy: async () => getDriveEnvLimit('business') - 1,
+    });
+    expect(decision).toEqual({ allowed: true });
   });
 });

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -285,3 +285,91 @@ export function resetSessionRuntimeGuardrail(): void {
 export function sessionActivityMapSize(): number {
   return sessionActivityByKey.size;
 }
+
+/**
+ * checkDriveEnvAllowance — the per-payer ceiling on PERSISTENT environments
+ * (`drive_envs`), the third axis this module caps and the only one that meters a
+ * ROW rather than a running thing.
+ *
+ * The other two ceilings above bound compute in flight: `checkCodeExecutionQuota`
+ * caps concurrent RUNS, `checkAgentSessionConcurrency` caps LIVE SANDBOXES. An
+ * environment is neither. It is the billed PERSISTENCE unit: its row exists (and
+ * its filesystem keeps accruing storage cost) whether or not anyone is running
+ * anything inside it, and its whole purpose is to outlive every session that
+ * touches it. So the count that matters is how many envs the payer OWNS, not how
+ * many are awake — an env hibernating for a month still holds a disk someone is
+ * paying for.
+ *
+ * That is also why this gate belongs at `createDriveEnv` rather than at
+ * provisioning time, where the two ceilings above sit: creating the row is the
+ * moment the persistence is committed to, and an env that has never been
+ * provisioned is still an env the payer holds.
+ *
+ * **Ceilings, and the fact that they are placeholders.** The numbers below are a
+ * deliberate first cut pending the economics sign-off — free 0 (an env is a
+ * paid-tier feature; `isSandboxAvailable` already says so, and this table
+ * agrees rather than contradicting it), pro 2, founder 5, business 10. Each is
+ * overridable by env var (`DRIVE_ENV_LIMIT_FREE` and friends) precisely because
+ * they will move: an operator can retune a tier without a deploy, and the
+ * pricing work can land its real numbers as a one-line change.
+ *
+ * `payerId` is the DRIVE OWNER — envs are drive-owned and drive-billed, so a
+ * free-tier member creating an env in a Pro-owned drive is entitled and metered
+ * against the drive's owner, exactly as sandbox eligibility already resolves
+ * (`resolveSandboxPayerTier`). `countEnvsOwnedBy` is injected (the real
+ * implementation is `DriveEnvStore.countEnvsOwnedBy`, wired by the app) so this
+ * stays testable with no database.
+ */
+const DRIVE_ENV_LIMITS: Record<SubscriptionTier, number> = {
+  free: envInt('DRIVE_ENV_LIMIT_FREE', 0),
+  pro: envInt('DRIVE_ENV_LIMIT_PRO', 2),
+  founder: envInt('DRIVE_ENV_LIMIT_FOUNDER', 5),
+  business: envInt('DRIVE_ENV_LIMIT_BUSINESS', 10),
+};
+
+/** The env ceiling for a tier — exported so a caller (or a test) can say WHAT the limit was, not just that it was hit. */
+export function getDriveEnvLimit(tier: SubscriptionTier): number {
+  return DRIVE_ENV_LIMITS[tier];
+}
+
+/**
+ * Deliberately its own denial word rather than reusing `concurrency_limit`:
+ * these are different ceilings with different remedies (end a session vs. delete
+ * an environment), the API maps them to different messages, and the security
+ * audit files them as different events. Conflating them would tell a user to
+ * close sessions when what they have run out of is environments.
+ */
+export type DriveEnvAllowanceDenialReason = 'tier_ineligible' | 'env_limit_reached';
+
+export type DriveEnvAllowanceDecision =
+  | { allowed: true }
+  | { allowed: false; reason: DriveEnvAllowanceDenialReason; limit: number };
+
+export interface CheckDriveEnvAllowanceInput {
+  /** The DRIVE OWNER — envs are drive-owned and drive-billed. */
+  payerId: string;
+  /** The payer's tier, resolved by the caller (drive owner's subscription). */
+  tier: SubscriptionTier;
+  countEnvsOwnedBy: (payerId: string) => Promise<number>;
+}
+
+export async function checkDriveEnvAllowance({
+  payerId,
+  tier,
+  countEnvsOwnedBy,
+}: CheckDriveEnvAllowanceInput): Promise<DriveEnvAllowanceDecision> {
+  const limit = DRIVE_ENV_LIMITS[tier];
+  // Eligibility FIRST, and ahead of any count: a free-tier payer is refused for
+  // being on a tier without cloud machines at all, which is a different thing to
+  // tell them than "you are at your limit" — and it costs no database round-trip
+  // to say. Checked here as defense in depth, in addition to (not instead of)
+  // `can-run-code.ts`'s own tier gate, matching both checks above.
+  if (!isSandboxAvailable(tier)) {
+    return { allowed: false, reason: 'tier_ineligible', limit };
+  }
+  const owned = await countEnvsOwnedBy(payerId);
+  if (owned >= limit) {
+    return { allowed: false, reason: 'env_limit_reached', limit };
+  }
+  return { allowed: true };
+}

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -20,6 +20,7 @@
 
 import type { SubscriptionTier } from '../subscription-utils';
 import { isSandboxAvailable } from '../../billing/sandbox-eligibility';
+import { MAX_DRIVE_ENVS_LISTED } from '../../drive-envs/env-contract';
 
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
@@ -320,14 +321,32 @@ export function sessionActivityMapSize(): number {
  * implementation is `DriveEnvStore.countEnvsOwnedBy`, wired by the app) so this
  * stays testable with no database.
  */
-const DRIVE_ENV_LIMITS: Record<SubscriptionTier, number> = {
-  free: envInt('DRIVE_ENV_LIMIT_FREE', 0),
-  pro: envInt('DRIVE_ENV_LIMIT_PRO', 2),
-  founder: envInt('DRIVE_ENV_LIMIT_FOUNDER', 5),
-  business: envInt('DRIVE_ENV_LIMIT_BUSINESS', 10),
-};
+/**
+ * A tier ceiling, CLAMPED to what a listing can actually show.
+ *
+ * The two numbers are coupled whether or not anyone says so: an env listing is
+ * bounded by `MAX_DRIVE_ENVS_LISTED`, so a ceiling above it would let a payer
+ * legitimately create environments that `GET /envs` then silently omits — rows
+ * that still hold a Sprite and still bill storage, with no surface that admits
+ * they exist. Silently invisible billed infrastructure is a worse failure than
+ * a refused create, so the override is clamped rather than honored, and this is
+ * the one place the coupling has to be remembered.
+ *
+ * Raising the ceiling past 100 is therefore a two-part change on purpose: raise
+ * `MAX_DRIVE_ENVS_LISTED` (or paginate the listing) first, and this follows.
+ */
+function envLimit(name: string, fallback: number): number {
+  return Math.min(envInt(name, fallback), MAX_DRIVE_ENVS_LISTED);
+}
 
 /** The env ceiling for a tier — exported so a caller (or a test) can say WHAT the limit was, not just that it was hit. */
+const DRIVE_ENV_LIMITS: Record<SubscriptionTier, number> = {
+  free: envLimit('DRIVE_ENV_LIMIT_FREE', 0),
+  pro: envLimit('DRIVE_ENV_LIMIT_PRO', 2),
+  founder: envLimit('DRIVE_ENV_LIMIT_FOUNDER', 5),
+  business: envLimit('DRIVE_ENV_LIMIT_BUSINESS', 10),
+};
+
 export function getDriveEnvLimit(tier: SubscriptionTier): number {
   return DRIVE_ENV_LIMITS[tier];
 }

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -294,12 +294,19 @@ export function sessionActivityMapSize(): number {
  *
  * The other two ceilings above bound compute in flight: `checkCodeExecutionQuota`
  * caps concurrent RUNS, `checkAgentSessionConcurrency` caps LIVE SANDBOXES. An
- * environment is neither. It is the billed PERSISTENCE unit: its row exists (and
- * its filesystem keeps accruing storage cost) whether or not anyone is running
+ * environment is neither. It is the PERSISTENCE unit: its row exists — and its
+ * filesystem keeps costing real money — whether or not anyone is running
  * anything inside it, and its whole purpose is to outlive every session that
  * touches it. So the count that matters is how many envs the payer OWNS, not how
- * many are awake — an env hibernating for a month still holds a disk someone is
- * paying for.
+ * many are awake: an env hibernating for a month still holds a disk someone is
+ * paying Fly for.
+ *
+ * Note the tense. The COST is real from the moment an env is provisioned; the
+ * app's own storage METER does not read `drive_envs` yet — `sandbox-storage-
+ * billing.ts` enumerates `agent_workspaces` only, and the env row source lands
+ * with the storage-reconcile follow-up. This ceiling exists because the cost is
+ * real, not because the meter has caught up, which is precisely why it is a
+ * ceiling on ROWS rather than on measured bytes.
  *
  * That is also why this gate belongs at `createDriveEnv` rather than at
  * provisioning time, where the two ceilings above sit: creating the row is the


### PR DESCRIPTION
The service/API layer for persistent per-drive environments, on top of the `drive_envs` schema (#2430) and the holder-neutral provisioner (#2431). **Ships dark** — nothing in the UI links here; this exists so the sessions-inside-an-env work has something to build against.

## What an environment is, restated where it matters

A session is ephemeral: it owns a Sprite keyed to its own id, and closing it takes the filesystem with it. An **environment** is the thing you return to — a named, drive-owned machine that outlives every session run inside it. It is drive infrastructure, not a page: no tree position, no permissions of its own, drive-owned and drive-billed.

## The pure decisions

- **`drive-envs/plan-env-delete.ts`** — env row + live-session count + `force` → `deny_live_sessions | teardown_then_delete | delete_only`. The live-session guard runs FIRST, before any pointer is read, because the row delete cascades to the sessions running inside it. The Sprite predicate tests BOTH columns, since a teardown stamps `spriteTornDownAt` and deliberately leaves `sandboxId` in place.
- **`drive-envs/env-contract.ts`** — the DTO, the name validator (a name is an ADDRESS here: `(driveId, name)` is unique), and three statuses. `stopped`, not `ended` — an env outliving its machine is the entire point, and reusing the session word would tell a client the environment was over when it is merely idle between machines.

## The services

- **`drive-envs-store.ts`** — bounded CRUD plus the Sprite-holder slice, method-for-method the session store's. That parity is what makes an env a second HOLDER rather than a second provisioner: the CAS that serializes concurrent provisions only works if every provisioner runs the same one.
- **`drive-envs.ts`** — create / list / rename / delete / rebuild. Delete is guard → intent → kill → confirm → atomic re-guard → row, and a failed *or unconfirmed* kill aborts. **Rebuild is the only sprite-replacing verb**, and it kills before it re-provisions — the Sprite name is deterministic in the env id, so provisioning first would hand back the same disk while reporting a rebuild.
- **`quota.ts`** — `checkDriveEnvAllowance` meters the ROW (the billed persistence unit, awake or not) against the DRIVE OWNER, with `DRIVE_ENV_LIMIT_*` overrides on placeholder ceilings (free 0 / pro 2 / founder 5 / business 10) pending the economics sign-off.

## The API

`/api/drives/[driveId]/envs/**`. Read = any accepted member; create/rename/delete/rebuild = drive OWNER or ADMIN, through the principal-aware centralized checks (never a hand-rolled membership read). DELETE refuses live sessions with 409 unless `?force=true` — exact value only, so a stray `?force` cannot destroy shared work. Quota denials split by remedy: 403 for an ineligible tier, 402 for a reached ceiling. The env-belongs-to-this-drive check answers 404, since a 403 would confirm the id exists elsewhere.

## What review changed

Five findings landed, all real, all now covered:

| Finding | Fix |
|---|---|
| Delete guard was TOCTOU — a session binding after the count was cascaded away (P1) | Count and delete in one transaction holding `FOR UPDATE` on the env row; binding needs a conflicting `FOR KEY SHARE` for its FK, so the window closes |
| Create ceiling was a read-then-write — two differently-named creates both passed (P1) | `createIfUnderLimit`: per-PAYER advisory-locked count-and-insert, modelled on the session spawn ceiling. The unguarded `create` is gone, so there is one minting path |
| `DRIVE_ENV_LIMIT_*` above the listing cap made billed envs invisible (P2) | Limits clamped to `MAX_DRIVE_ENVS_LISTED`; a refused create beats unlistable infrastructure |
| Unique-violation check never matched — drizzle 0.45.2 wraps driver errors in `DrizzleQueryError` (major) | `isUniqueViolation` walks the `cause` chain, depth-bounded; both shapes pinned by tests |
| Rebuild treated an unconfirmed teardown CAS as a kill, resuming a live replacement (major) | Aborts with `teardown_not_confirmed` before provisioning |

One finding (tenant admin seeded without `subscriptionTier`) is real but pre-existing, outside this diff, and already gates every sandbox feature identically — left open with reasoning, and the reviewer agreed it needs a tenant/billing policy decision this PR should not make.

## Verification

- `bun run typecheck` (monorepo, 17/17), `bun run lint` (15/15), knip within baseline, `bun run test:security` (51/51), evidence manifest (15 guarantees, 15 proven), and `db:generate` reports no schema drift.
- **Against real Postgres 17** the full `@pagespace/lib` suite is **429/433 files, 9448 tests passing**. The only two failures are known env-only ones: `ADMIN_DATABASE_URL` unset, and a reorder clock assertion off by exactly the local CDT offset (CI runs UTC). Neither is touched by this change.
- **111 new tests**: 38 service, 26 integration against a real database, 22 route, 9 planner, 8 provisioning-wiring, 8 quota.
- **35 mutation checks, each caught.** Highlights: dropping the listing's `driveId` predicate (a cross-drive leak), dropping `.for('update')` (the delete stops blocking and deletes through a live bind), removing the advisory lock, re-keying it per drive instead of per payer, deriving the Sprite name in the SESSION keyspace, tenanting the fold on the requester, removing the `cause` walk, dropping the cycle guard (hangs the suite), continuing a rebuild on an unconfirmed teardown, unclamping the limits, and reordering the status derivation.
- Two tests were **rejected by their own mutation checks and rewritten**: a `Promise.all` create race survived removing the advisory lock entirely (nothing forced the transactions to interleave), and a clamp assertion passed against an unclamped implementation because the limits are read at module load.
- One suspected defect was **disproven rather than patched**: I thought the routes could fall through to the wrong branch when a result variant is added, so I added the variant and typechecked — six compile errors across both route files, because every terminal branch dereferences a variant-specific field. The union is already closed for the compiler, so the defensive checks I had started writing were reverted.
- Documented, after verifying rather than assuming: the delete guard's correctness depends on READ COMMITTED (nothing in the pool sets an isolation level), and the crash net covers a deleted env row via the reclaim outbox but not a surviving one — folding `drive_envs` into the orphan reconciler's row-scan source is a follow-up, deliberately not smuggled into a dark-shipped layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcVJKn2JNvf3Qi5cgpCSF3
