### PR TITLE
feat(tasks): expanding a task shows its sub-tasks, not a count of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Changed
 
+- **Expanding a task now lists its sub-tasks instead of just counting them** — the drop-down under
+  a task used to say "3 sub-tasks" as plain text and leave you to go find them: open the task, look
+  at its children, come back out, and do it again for every level of a nested tree. The sub-tasks
+  are now listed there, each one a link straight to it, with completed ones ticked and struck
+  through, and a "Load more" for a task with a long list. Tasks with nothing beneath them are
+  untouched — nothing is fetched for them at all.
 - **Voice mode is now audio-native, and the old hands-free mic in the chat box is gone** — talking
   to an assistant used to mean recording a clip, having it transcribed into text, and having the
   reply read back to you. Everything about how you said it — pace, hesitation, the moment you cut

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -414,11 +414,14 @@ interface SortableTaskRowProps {
   canEdit: boolean;
   isCompleted: boolean;
   isExpanded: boolean;
+  // Sub-task links in the expansion are drive-scoped page URLs, and the row has no
+  // other route to the drive it lives in.
+  driveId: string;
   contextMenu?: React.ReactNode;
   children: React.ReactNode;
 }
 
-function SortableTaskRow({ task, canEdit, isCompleted, isExpanded, contextMenu, children }: SortableTaskRowProps) {
+function SortableTaskRow({ task, canEdit, isCompleted, isExpanded, driveId, contextMenu, children }: SortableTaskRowProps) {
   const {
     attributes,
     listeners,
@@ -462,7 +465,7 @@ function SortableTaskRow({ task, canEdit, isCompleted, isExpanded, contextMenu, 
   const expansionRow = (
     <tr key={`${task.id}-desc`} className={getExpansionRowClass(isExpanded)}>
       <td colSpan={8} className="px-4 py-2 border-b bg-muted/20">
-        {isExpanded && <TaskRowDescription task={task} />}
+        {isExpanded && <TaskRowDescription task={task} driveId={driveId} />}
       </td>
     </tr>
   );
@@ -1252,6 +1255,7 @@ function TaskListView({ page }: TaskListViewProps) {
                         canEdit={canEdit}
                         isCompleted={isCompletedStatus(task.status, statusConfigs)}
                         isExpanded={expandedTaskIds.has(task.id)}
+                        driveId={page.driveId}
                         contextMenu={
                           <ContextMenuContent>
                             {task.pageId && (

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
@@ -21,6 +21,14 @@ export const shouldShowPlaceholder = (pageId: string | null | undefined): boolea
 export const shouldShowSkeleton = (isLoading: boolean, content: string | null): boolean =>
   isLoading && content === null;
 
+/**
+ * `TaskItem.pageId` is nullable, and a task whose linked page is gone has nowhere to navigate
+ * to. Interpolating it anyway yields `/dashboard/{driveId}/null` — a link that looks live and
+ * lands on a dead route. `null` here means "render the row, but not as a link".
+ */
+export const subTaskHref = (driveId: string, pageId: string | null | undefined): string | null =>
+  pageId ? `/dashboard/${driveId}/${pageId}` : null;
+
 export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
   const { content, isLoading } = usePageContent({
     pageId: task.pageId ?? null,
@@ -30,7 +38,7 @@ export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
   // Gated on task.subTaskCount inside the hook: a leaf task issues no request at
   // all, which also keeps the route from lazily creating a task_list + 4 status
   // configs for it. See useTaskSubTasks.
-  const { subTasks, hasMore, isLoading: isLoadingSubTasks, isLoadingMore, loadMore } =
+  const { subTasks, hasMore, isLoading: isLoadingSubTasks, isLoadingMore, loadMore, error } =
     useTaskSubTasks(task);
 
   const subTaskCount = task.subTaskCount ?? 0;
@@ -53,22 +61,44 @@ export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
             <Skeleton className="h-8 w-full" />
           ) : (
             <ul className="space-y-0.5">
-              {subTasks.map((subTask) => (
-                <li key={subTask.id}>
-                  <Link
-                    href={`/dashboard/${driveId}/${subTask.pageId}`}
-                    className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm hover:bg-muted/60 hover:underline"
-                  >
+              {subTasks.map((subTask) => {
+                const href = subTaskHref(driveId, subTask.pageId);
+                const body = (
+                  <>
                     {subTask.completedAt
                       ? <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       : <Circle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
                     <span className={subTask.completedAt ? 'line-through text-muted-foreground' : ''}>
                       {subTask.title}
                     </span>
-                  </Link>
-                </li>
-              ))}
+                  </>
+                );
+                return (
+                  <li key={subTask.id}>
+                    {href ? (
+                      <Link
+                        href={href}
+                        className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm hover:bg-muted/60 hover:underline"
+                      >
+                        {body}
+                      </Link>
+                    ) : (
+                      <span className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm text-muted-foreground">
+                        {body}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
             </ul>
+          )}
+          {/* The header above has already told the user this task has N sub-tasks. Rendering an
+              empty list under that count when the fetch failed reads as "there are none" — say
+              what actually happened instead. */}
+          {error && (
+            <p className="px-1 text-xs text-muted-foreground italic">
+              Could not load sub-tasks.
+            </p>
           )}
           {hasMore && (
             <Button

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { LayoutList } from 'lucide-react';
+import Link from 'next/link';
+import { LayoutList, Circle, CheckCircle2 } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
 import { usePageContent } from '@/hooks/usePageContent';
 import { TaskItem } from './task-list-types';
+import { useTaskSubTasks } from './useTaskSubTasks';
 
 const RichEditor = dynamic(() => import('@/components/editors/RichEditor'), { ssr: false });
 
 interface TaskRowDescriptionProps {
   task: TaskItem;
+  driveId: string;
 }
 
 export const shouldShowPlaceholder = (pageId: string | null | undefined): boolean => !pageId;
@@ -17,11 +21,17 @@ export const shouldShowPlaceholder = (pageId: string | null | undefined): boolea
 export const shouldShowSkeleton = (isLoading: boolean, content: string | null): boolean =>
   isLoading && content === null;
 
-export function TaskRowDescription({ task }: TaskRowDescriptionProps) {
+export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
   const { content, isLoading } = usePageContent({
     pageId: task.pageId ?? null,
     enabled: !!task.pageId,
   });
+
+  // Gated on task.subTaskCount inside the hook: a leaf task issues no request at
+  // all, which also keeps the route from lazily creating a task_list + 4 status
+  // configs for it. See useTaskSubTasks.
+  const { subTasks, hasMore, isLoading: isLoadingSubTasks, isLoadingMore, loadMore } =
+    useTaskSubTasks(task);
 
   const subTaskCount = task.subTaskCount ?? 0;
 
@@ -34,9 +44,43 @@ export function TaskRowDescription({ task }: TaskRowDescriptionProps) {
   return (
     <div className="space-y-1.5">
       {subTaskCount > 0 && (
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground px-1">
-          <LayoutList className="h-3 w-3" />
-          <span>{subTaskCount} sub-task{subTaskCount !== 1 ? 's' : ''}</span>
+        <div className="space-y-1">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground px-1">
+            <LayoutList className="h-3 w-3" />
+            <span>{subTaskCount} sub-task{subTaskCount !== 1 ? 's' : ''}</span>
+          </div>
+          {isLoadingSubTasks ? (
+            <Skeleton className="h-8 w-full" />
+          ) : (
+            <ul className="space-y-0.5">
+              {subTasks.map((subTask) => (
+                <li key={subTask.id}>
+                  <Link
+                    href={`/dashboard/${driveId}/${subTask.pageId}`}
+                    className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm hover:bg-muted/60 hover:underline"
+                  >
+                    {subTask.completedAt
+                      ? <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      : <Circle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                    <span className={subTask.completedAt ? 'line-through text-muted-foreground' : ''}>
+                      {subTask.title}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+          {hasMore && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1 text-xs text-muted-foreground"
+              disabled={isLoadingMore}
+              onClick={loadMore}
+            >
+              {isLoadingMore ? 'Loading…' : 'Load more sub-tasks'}
+            </Button>
+          )}
         </div>
       )}
       {shouldShowSkeleton(isLoading, content) ? (

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
@@ -92,12 +92,13 @@ export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
               })}
             </ul>
           )}
-          {/* The header above has already told the user this task has N sub-tasks. Rendering an
-              empty list under that count when the fetch failed reads as "there are none" — say
-              what actually happened instead. */}
-          {error && (
+          {/* The header above has already told the user this task has N sub-tasks, so an empty
+              list under that count reads as "there are none" — the one thing that is definitely
+              not true. Both ways of getting there say what actually happened: the fetch failed,
+              or the children went away between the parent list loading and this expansion. */}
+          {!isLoadingSubTasks && (error || subTasks.length === 0) && (
             <p className="px-1 text-xs text-muted-foreground italic">
-              Could not load sub-tasks.
+              {error ? 'Could not load sub-tasks.' : 'These sub-tasks are no longer here.'}
             </p>
           )}
           {hasMore && (

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskRowDescription.tsx
@@ -1,13 +1,10 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import Link from 'next/link';
-import { LayoutList, Circle, CheckCircle2 } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Button } from '@/components/ui/button';
 import { usePageContent } from '@/hooks/usePageContent';
 import { TaskItem } from './task-list-types';
-import { useTaskSubTasks } from './useTaskSubTasks';
+import { TaskSubTaskList } from './TaskSubTaskList';
 
 const RichEditor = dynamic(() => import('@/components/editors/RichEditor'), { ssr: false });
 
@@ -21,27 +18,11 @@ export const shouldShowPlaceholder = (pageId: string | null | undefined): boolea
 export const shouldShowSkeleton = (isLoading: boolean, content: string | null): boolean =>
   isLoading && content === null;
 
-/**
- * `TaskItem.pageId` is nullable, and a task whose linked page is gone has nowhere to navigate
- * to. Interpolating it anyway yields `/dashboard/{driveId}/null` — a link that looks live and
- * lands on a dead route. `null` here means "render the row, but not as a link".
- */
-export const subTaskHref = (driveId: string, pageId: string | null | undefined): string | null =>
-  pageId ? `/dashboard/${driveId}/${pageId}` : null;
-
 export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
   const { content, isLoading } = usePageContent({
     pageId: task.pageId ?? null,
     enabled: !!task.pageId,
   });
-
-  // Gated on task.subTaskCount inside the hook: a leaf task issues no request at
-  // all, which also keeps the route from lazily creating a task_list + 4 status
-  // configs for it. See useTaskSubTasks.
-  const { subTasks, hasMore, isLoading: isLoadingSubTasks, isLoadingMore, loadMore, error } =
-    useTaskSubTasks(task);
-
-  const subTaskCount = task.subTaskCount ?? 0;
 
   if (shouldShowPlaceholder(task.pageId)) {
     return (
@@ -51,69 +32,7 @@ export function TaskRowDescription({ task, driveId }: TaskRowDescriptionProps) {
 
   return (
     <div className="space-y-1.5">
-      {subTaskCount > 0 && (
-        <div className="space-y-1">
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground px-1">
-            <LayoutList className="h-3 w-3" />
-            <span>{subTaskCount} sub-task{subTaskCount !== 1 ? 's' : ''}</span>
-          </div>
-          {isLoadingSubTasks ? (
-            <Skeleton className="h-8 w-full" />
-          ) : (
-            <ul className="space-y-0.5">
-              {subTasks.map((subTask) => {
-                const href = subTaskHref(driveId, subTask.pageId);
-                const body = (
-                  <>
-                    {subTask.completedAt
-                      ? <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      : <Circle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
-                    <span className={subTask.completedAt ? 'line-through text-muted-foreground' : ''}>
-                      {subTask.title}
-                    </span>
-                  </>
-                );
-                return (
-                  <li key={subTask.id}>
-                    {href ? (
-                      <Link
-                        href={href}
-                        className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm hover:bg-muted/60 hover:underline"
-                      >
-                        {body}
-                      </Link>
-                    ) : (
-                      <span className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm text-muted-foreground">
-                        {body}
-                      </span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-          {/* The header above has already told the user this task has N sub-tasks, so an empty
-              list under that count reads as "there are none" — the one thing that is definitely
-              not true. Both ways of getting there say what actually happened: the fetch failed,
-              or the children went away between the parent list loading and this expansion. */}
-          {!isLoadingSubTasks && (error || subTasks.length === 0) && (
-            <p className="px-1 text-xs text-muted-foreground italic">
-              {error ? 'Could not load sub-tasks.' : 'These sub-tasks are no longer here.'}
-            </p>
-          )}
-          {hasMore && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 px-1 text-xs text-muted-foreground"
-              disabled={isLoadingMore}
-              onClick={loadMore}
-            >
-              {isLoadingMore ? 'Loading…' : 'Load more sub-tasks'}
-            </Button>
-          )}
-        </div>
-      )}
+      <TaskSubTaskList task={task} driveId={driveId} />
       {shouldShowSkeleton(isLoading, content) ? (
         <Skeleton className="h-16 w-full" />
       ) : (

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
@@ -97,7 +97,10 @@ export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
           loading and this expansion. (In that last case the header above has already corrected
           itself to 0 via shownCount; this explains the 0.) */}
       {!isLoading && (error || subTasks.length === 0) && (
-        <p className="px-1 text-xs text-muted-foreground italic">
+        // Announced, because this appears asynchronously: without a live region a screen
+        // reader user gets no signal that the load failed or that a "Try again" control just
+        // arrived — they are left with a count and silence.
+        <p role="status" aria-live="polite" className="px-1 text-xs text-muted-foreground italic">
           {error
             ? (subTasks.length > 0 ? 'Could not load the rest of the sub-tasks.' : 'Could not load sub-tasks.')
             : 'These sub-tasks are no longer here.'}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
@@ -90,11 +90,12 @@ export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
         </ul>
       )}
 
-      {/* The count above has already told the user this task has N sub-tasks, so an empty list
-          under it reads as "there are none" — the one thing that is definitely not true. Each
-          way of getting there says which one it was: the fetch failed outright, a later page
-          failed after some rows were already shown, or the children went away between the
-          parent list loading and this expansion. */}
+      {/* An expanded row that shows nothing has to say why — it was expandable precisely
+          because a count said there was something here. Each way of arriving at an empty or
+          short list says which one it was: the fetch failed outright, a later page failed after
+          some rows were already shown, or the children went away between the parent list
+          loading and this expansion. (In that last case the header above has already corrected
+          itself to 0 via shownCount; this explains the 0.) */}
       {!isLoading && (error || subTasks.length === 0) && (
         <p className="px-1 text-xs text-muted-foreground italic">
           {error

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
@@ -14,9 +14,11 @@ interface TaskSubTaskListProps {
 }
 
 /**
- * `TaskItem.pageId` is nullable, and a task whose linked page is gone has nowhere to navigate
- * to. Interpolating it anyway yields `/dashboard/{driveId}/null` — a link that looks live and
- * lands on a dead route. `null` here means "render the row, but not as a link".
+ * `TaskItem.pageId` is typed `string | null` — WIDER than the database, where
+ * `task_items.pageId` is genuinely `notNull()`. So this guard is not defending against data the
+ * route can currently return; it is refusing to rely on a constraint the type in front of us
+ * contradicts. Interpolating a null anyway yields `/dashboard/{driveId}/null`: a link that looks
+ * live and lands on a dead route. `null` here means "render the row, but not as a link".
  */
 export const subTaskHref = (driveId: string, pageId: string | null | undefined): string | null =>
   pageId ? `/dashboard/${driveId}/${pageId}` : null;

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import Link from 'next/link';
+import { LayoutList, Circle, CheckCircle2 } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { TaskItem } from './task-list-types';
+import { useTaskSubTasks } from './useTaskSubTasks';
+
+interface TaskSubTaskListProps {
+  task: TaskItem;
+  /** Sub-task links are drive-scoped page URLs, and a task row carries no route to its drive. */
+  driveId: string;
+}
+
+/**
+ * `TaskItem.pageId` is nullable, and a task whose linked page is gone has nowhere to navigate
+ * to. Interpolating it anyway yields `/dashboard/{driveId}/null` — a link that looks live and
+ * lands on a dead route. `null` here means "render the row, but not as a link".
+ */
+export const subTaskHref = (driveId: string, pageId: string | null | undefined): string | null =>
+  pageId ? `/dashboard/${driveId}/${pageId}` : null;
+
+/**
+ * The sub-tasks half of an expanded task row: a count, the children as links, and paging.
+ *
+ * Separate from TaskRowDescription because the two halves of the expansion answer to different
+ * things — this one to the sub-task fetch, the other to the linked page's document — and the
+ * epic's next step branches between them.
+ */
+export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
+  // Gated on task.subTaskCount inside the hook: a leaf task issues no request at all, which
+  // also keeps the route from lazily creating a task_list + 4 status configs for it.
+  const { subTasks, hasMore, isLoading, isLoadingMore, loadMore, error } = useTaskSubTasks(task);
+
+  const subTaskCount = task.subTaskCount ?? 0;
+  if (subTaskCount === 0) return null;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground px-1">
+        <LayoutList className="h-3 w-3" />
+        <span>{subTaskCount} sub-task{subTaskCount !== 1 ? 's' : ''}</span>
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-8 w-full" />
+      ) : (
+        <ul className="space-y-0.5">
+          {subTasks.map((subTask) => {
+            const href = subTaskHref(driveId, subTask.pageId);
+            const body = (
+              <>
+                {subTask.completedAt
+                  ? <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  : <Circle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                <span className={subTask.completedAt ? 'line-through text-muted-foreground' : ''}>
+                  {subTask.title}
+                </span>
+              </>
+            );
+            return (
+              <li key={subTask.id}>
+                {href ? (
+                  <Link
+                    href={href}
+                    className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm hover:bg-muted/60 hover:underline"
+                  >
+                    {body}
+                  </Link>
+                ) : (
+                  <span className="flex items-center gap-1.5 px-1 py-0.5 rounded text-sm text-muted-foreground">
+                    {body}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* The count above has already told the user this task has N sub-tasks, so an empty list
+          under it reads as "there are none" — the one thing that is definitely not true. Both
+          ways of getting there say what actually happened: the fetch failed, or the children
+          went away between the parent list loading and this expansion. */}
+      {!isLoading && (error || subTasks.length === 0) && (
+        <p className="px-1 text-xs text-muted-foreground italic">
+          {error ? 'Could not load sub-tasks.' : 'These sub-tasks are no longer here.'}
+        </p>
+      )}
+
+      {hasMore && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-1 text-xs text-muted-foreground"
+          disabled={isLoadingMore}
+          onClick={loadMore}
+        >
+          {isLoadingMore ? 'Loading…' : 'Load more sub-tasks'}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
@@ -82,12 +82,15 @@ export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
       )}
 
       {/* The count above has already told the user this task has N sub-tasks, so an empty list
-          under it reads as "there are none" — the one thing that is definitely not true. Both
-          ways of getting there say what actually happened: the fetch failed, or the children
-          went away between the parent list loading and this expansion. */}
+          under it reads as "there are none" — the one thing that is definitely not true. Each
+          way of getting there says which one it was: the fetch failed outright, a later page
+          failed after some rows were already shown, or the children went away between the
+          parent list loading and this expansion. */}
       {!isLoading && (error || subTasks.length === 0) && (
         <p className="px-1 text-xs text-muted-foreground italic">
-          {error ? 'Could not load sub-tasks.' : 'These sub-tasks are no longer here.'}
+          {error
+            ? (subTasks.length > 0 ? 'Could not load the rest of the sub-tasks.' : 'Could not load sub-tasks.')
+            : 'These sub-tasks are no longer here.'}
         </p>
       )}
 
@@ -99,7 +102,9 @@ export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
           disabled={isLoadingMore}
           onClick={loadMore}
         >
-          {isLoadingMore ? 'Loading…' : 'Load more sub-tasks'}
+          {/* After a failure this is the retry: nothing retries on its own (see the hook's
+              shouldRetryOnError), so the label has to say that this is the way back. */}
+          {isLoadingMore ? 'Loading…' : error ? 'Try again' : 'Load more sub-tasks'}
         </Button>
       )}
     </div>

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskSubTaskList.tsx
@@ -33,16 +33,25 @@ export const subTaskHref = (driveId: string, pageId: string | null | undefined):
 export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
   // Gated on task.subTaskCount inside the hook: a leaf task issues no request at all, which
   // also keeps the route from lazily creating a task_list + 4 status configs for it.
-  const { subTasks, hasMore, isLoading, isLoadingMore, loadMore, error } = useTaskSubTasks(task);
+  const { subTasks, hasMore, isLoading, isLoadingMore, loadMore, retry, error } = useTaskSubTasks(task);
 
   const subTaskCount = task.subTaskCount ?? 0;
   if (subTaskCount === 0) return null;
+
+  // `task.subTaskCount` rode in on the PARENT list's response, which does revalidate (socket
+  // events, 5-minute interval) while this list does not. So the two can drift — someone adds a
+  // sub-task and the header says 4 over a list of 3, indefinitely and silently. Once this list
+  // is settled and complete, it is the fresher of the two: report what is actually here rather
+  // than a count that outranks the rows under it. While paging, the total is still the honest
+  // number, because the rows are deliberately partial.
+  const listIsComplete = !isLoading && !error && !hasMore;
+  const shownCount = listIsComplete ? subTasks.length : subTaskCount;
 
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground px-1">
         <LayoutList className="h-3 w-3" />
-        <span>{subTaskCount} sub-task{subTaskCount !== 1 ? 's' : ''}</span>
+        <span>{shownCount} sub-task{shownCount !== 1 ? 's' : ''}</span>
       </div>
 
       {isLoading ? (
@@ -94,16 +103,23 @@ export function TaskSubTaskList({ task, driveId }: TaskSubTaskListProps) {
         </p>
       )}
 
-      {hasMore && (
+      {/* Shown on `error` even when there is nothing more to load: a FIRST page that failed
+          leaves hasMore false, and since nothing retries on its own (see the hook's
+          shouldRetryOnError) a missing control there would be a dead end.
+
+          Which recovery to use depends on WHICH page failed, and the difference is requests
+          against a route that writes. `retry` is SWR's revalidate-all, so with pages already
+          loaded it would re-issue every one of them. Paging forward re-requests only the page
+          that is missing. So: retry when nothing loaded (there is nothing else to re-request),
+          page forward when the failure came after some rows arrived. */}
+      {(hasMore || error) && (
         <Button
           variant="ghost"
           size="sm"
           className="h-6 px-1 text-xs text-muted-foreground"
           disabled={isLoadingMore}
-          onClick={loadMore}
+          onClick={error && subTasks.length === 0 ? retry : loadMore}
         >
-          {/* After a failure this is the retry: nothing retries on its own (see the hook's
-              shouldRetryOnError), so the label has to say that this is the way back. */}
           {isLoadingMore ? 'Loading…' : error ? 'Try again' : 'Load more sub-tasks'}
         </Button>
       )}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * What the expansion actually renders for the two cases a user can hit but a pure-function
+ * test cannot see: a sub-task whose linked page is gone, and a fetch that failed.
+ *
+ * Both are honesty bugs rather than crashes — a dead link that looks live, and an empty list
+ * under a header that just claimed there are N sub-tasks — so they have to be asserted against
+ * rendered output.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { TaskItem } from '../task-list-types';
+import type { UseTaskSubTasksResult } from '../useTaskSubTasks';
+
+const { useTaskSubTasks } = vi.hoisted(() => ({ useTaskSubTasks: vi.fn() }));
+vi.mock('../useTaskSubTasks', () => ({ useTaskSubTasks }));
+vi.mock('@/hooks/usePageContent', () => ({
+  usePageContent: () => ({ content: '<p>doc</p>', isLoading: false }),
+}));
+// The expansion's document half is a dynamically imported rich editor; it is not what these
+// cases are about, and rendering it drags in the whole tiptap stack.
+vi.mock('next/dynamic', () => ({ default: () => function RichEditorStub() { return null; } }));
+
+import { TaskRowDescription } from '../TaskRowDescription';
+
+const assert = ({ given, should, actual, expected }: {
+  given: string; should: string; actual: unknown; expected: unknown;
+}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+const subTask = (over: Partial<TaskItem> = {}): TaskItem => ({
+  id: 'st1',
+  userId: 'u1',
+  assigneeId: null,
+  assigneeAgentId: null,
+  pageId: 'child-page',
+  title: 'A sub-task',
+  status: 'pending',
+  priority: 'medium',
+  position: 0,
+  dueDate: null,
+  completedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...over,
+});
+
+const parentTask = (): TaskItem => subTask({ id: 'parent', pageId: 'parent-page', title: 'Parent', subTaskCount: 1 });
+
+const hookResult = (over: Partial<UseTaskSubTasksResult> = {}): UseTaskSubTasksResult => ({
+  subTasks: [],
+  statusConfigs: [],
+  hasMore: false,
+  isLoading: false,
+  isLoadingMore: false,
+  error: undefined,
+  loadMore: vi.fn(),
+  ...over,
+});
+
+beforeEach(() => { useTaskSubTasks.mockReset(); });
+
+describe('TaskRowDescription sub-task rows', () => {
+  it('links a sub-task that has a linked page', () => {
+    useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask()] }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    assert({
+      given: 'a sub-task with a linked page',
+      should: 'render it as a drive-scoped link to that page',
+      actual: screen.getByRole('link', { name: 'A sub-task' }).getAttribute('href'),
+      expected: '/dashboard/drive-1/child-page',
+    });
+  });
+
+  it('does not link a sub-task whose linked page is missing', () => {
+    useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask({ pageId: null })] }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    assert({
+      given: 'a sub-task with a null pageId',
+      should: 'still show its title, but never as a link to /dashboard/drive-1/null',
+      actual: {
+        titleShown: !!screen.getByText('A sub-task'),
+        links: screen.queryAllByRole('link').length,
+      },
+      expected: { titleShown: true, links: 0 },
+    });
+  });
+
+  it('says so when the sub-task fetch failed', () => {
+    useTaskSubTasks.mockReturnValue(hookResult({ error: new Error('boom') }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    assert({
+      given: 'a header claiming 1 sub-task and a failed fetch',
+      should: 'explain the failure rather than render an empty list that reads as "none"',
+      actual: !!screen.getByText('Could not load sub-tasks.'),
+      expected: true,
+    });
+  });
+
+  it('stays quiet when the fetch succeeded', () => {
+    useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask()] }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    assert({
+      given: 'a successful fetch',
+      should: 'show no failure message',
+      actual: screen.queryByText('Could not load sub-tasks.'),
+      expected: null,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
@@ -5,6 +5,11 @@
  * Both are honesty bugs rather than crashes — a dead link that looks live, and an empty list
  * under a header that just claimed there are N sub-tasks — so they have to be asserted against
  * rendered output.
+ *
+ * Rendered through TaskRowDescription rather than TaskSubTaskList directly, even though the
+ * logic lives in the latter: what matters is what the assembled expansion puts on screen, and
+ * this way the test survives the two halves being rearranged (which is what the epic's
+ * sub-tasks-vs-document branch will do next).
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
@@ -115,6 +115,29 @@ describe('TaskRowDescription sub-task rows', () => {
     });
   });
 
+  it('offers a way back when a later page failed', () => {
+    // Rows already on screen, plus a standing error: nothing retries on its own, so the
+    // control has to say that pressing it is the way back — and it must not be disabled.
+    useTaskSubTasks.mockReturnValue(hookResult({
+      subTasks: [subTask()],
+      hasMore: true,
+      error: new Error('network went away'),
+    }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    const button = screen.getByRole('button');
+    assert({
+      given: 'a failed later page with rows already shown',
+      should: 'say only the rest failed, and offer an enabled retry rather than a stuck spinner',
+      actual: {
+        message: !!screen.getByText('Could not load the rest of the sub-tasks.'),
+        label: button.textContent,
+        disabled: (button as HTMLButtonElement).disabled,
+      },
+      expected: { message: true, label: 'Try again', disabled: false },
+    });
+  });
+
   it('stays quiet when the fetch succeeded', () => {
     useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask()] }));
     render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
@@ -12,7 +12,8 @@
  * sub-tasks-vs-document branch will do next).
  */
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, vi, beforeEach } from 'vitest';
+import { assert } from '@/hooks/__tests__/riteway';
 import { render, screen } from '@testing-library/react';
 import type { TaskItem } from '../task-list-types';
 import type { UseTaskSubTasksResult } from '../useTaskSubTasks';
@@ -27,10 +28,6 @@ vi.mock('@/hooks/usePageContent', () => ({
 vi.mock('next/dynamic', () => ({ default: () => function RichEditorStub() { return null; } }));
 
 import { TaskRowDescription } from '../TaskRowDescription';
-
-const assert = ({ given, should, actual, expected }: {
-  given: string; should: string; actual: unknown; expected: unknown;
-}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
 
 const subTask = (over: Partial<TaskItem> = {}): TaskItem => ({
   id: 'st1',

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
@@ -56,6 +56,7 @@ const hookResult = (over: Partial<UseTaskSubTasksResult> = {}): UseTaskSubTasksR
   isLoadingMore: false,
   error: undefined,
   loadMore: vi.fn(),
+  retry: vi.fn(),
   ...over,
 });
 
@@ -135,6 +136,77 @@ describe('TaskRowDescription sub-task rows', () => {
         disabled: (button as HTMLButtonElement).disabled,
       },
       expected: { message: true, label: 'Try again', disabled: false },
+    });
+  });
+
+  it('offers a way back when the FIRST page failed and there is no Load more', () => {
+    const retry = vi.fn();
+    useTaskSubTasks.mockReturnValue(hookResult({
+      subTasks: [],
+      hasMore: false,
+      error: new Error('network went away'),
+      retry,
+    }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    screen.getByRole('button', { name: 'Try again' }).click();
+
+    assert({
+      given: 'a failed first page, where hasMore is false and Load more would never render',
+      should: 'still offer a control, and wire it to retry rather than to paging forward',
+      actual: { retried: retry.mock.calls.length },
+      expected: { retried: 1 },
+    });
+  });
+
+  it('reports what is actually in the list once it is complete', () => {
+    // subTaskCount rode in on the parent list's response, which revalidates; this list does
+    // not. When the list is settled and complete it is the fresher of the two, so the header
+    // must not outrank the rows under it.
+    useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask(), subTask({ id: 'st2' })] }));
+    render(<TaskRowDescription task={{ ...parentTask(), subTaskCount: 5 }} driveId="drive-1" />);
+
+    assert({
+      given: 'a stale parent count of 5 over a complete list of 2',
+      should: 'report 2, not 5',
+      actual: { two: !!screen.getByText('2 sub-tasks'), five: screen.queryByText('5 sub-tasks') },
+      expected: { two: true, five: null },
+    });
+  });
+
+  it('keeps reporting the total while the list is still partial', () => {
+    useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask()], hasMore: true }));
+    render(<TaskRowDescription task={{ ...parentTask(), subTaskCount: 5 }} driveId="drive-1" />);
+
+    assert({
+      given: 'one page loaded of a longer list',
+      should: 'still report the total, because the rows are deliberately partial',
+      actual: !!screen.getByText('5 sub-tasks'),
+      expected: true,
+    });
+  });
+
+  it('re-requests only the missing page when a later page failed', () => {
+    // retry() is SWR revalidate-all: using it here would re-issue every loaded page against a
+    // route that writes. Paging forward asks only for the one that is missing.
+    const retry = vi.fn();
+    const loadMore = vi.fn();
+    useTaskSubTasks.mockReturnValue(hookResult({
+      subTasks: [subTask()],
+      hasMore: true,
+      error: new Error('network went away'),
+      retry,
+      loadMore,
+    }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    screen.getByRole('button', { name: 'Try again' }).click();
+
+    assert({
+      given: 'a failure that arrived after some rows had already loaded',
+      should: 'page forward rather than revalidate every page already fetched',
+      actual: { loadMore: loadMore.mock.calls.length, retry: retry.mock.calls.length },
+      expected: { loadMore: 1, retry: 0 },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskRowDescription.render.test.tsx
@@ -99,6 +99,20 @@ describe('TaskRowDescription sub-task rows', () => {
     });
   });
 
+  it('does not leave a bare count standing when the sub-tasks are gone', () => {
+    // subTaskCount rode in on the parent list's response; the children can be trashed between
+    // that response and this expansion. An empty list under "1 sub-task" reads as a lie.
+    useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [] }));
+    render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);
+
+    assert({
+      given: 'a header claiming 1 sub-task and a successful fetch that returned none',
+      should: 'explain the discrepancy rather than render nothing under the count',
+      actual: !!screen.getByText('These sub-tasks are no longer here.'),
+      expected: true,
+    });
+  });
+
   it('stays quiet when the fetch succeeded', () => {
     useTaskSubTasks.mockReturnValue(hookResult({ subTasks: [subTask()] }));
     render(<TaskRowDescription task={parentTask()} driveId="drive-1" />);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
@@ -132,6 +132,40 @@ describe('useTaskSubTasks against the real route and database', () => {
     });
   });
 
+  it('creates no rows for a task WITH children while it is collapsed', async () => {
+    if (!dbAvailable) return;
+
+    // The other door to the same hazard. `enabled: false` is how a row that stays mounted
+    // while collapsed (what recursive expansion state will need) says "not now" — and a task
+    // with children passes the subTaskCount gate, so `enabled` is the only thing standing
+    // between a collapsed row and the route's lazy writes.
+    const owner = await factories.createUser();
+    currentUserId = owner.id;
+    const drive = await factories.createDrive(owner.id);
+    const listPage = await factories.createPage(drive.id, { type: 'TASK_LIST' });
+    const parentPage = await factories.createPage(drive.id, { parentId: listPage.id, type: 'TASK_LIST' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: parentPage.id });
+    const child = await factories.createPage(drive.id, { parentId: parentPage.id, type: 'TASK_LIST' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: child.id });
+
+    const callsBefore = fetchWithAuth.mock.calls.length;
+    renderHook(
+      () => useTaskSubTasks({ pageId: parentPage.id, subTaskCount: 1 }, { enabled: false }),
+      { wrapper: makeWrapper() },
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    assert({
+      given: 'a task that genuinely has sub-tasks, mounted but not expanded',
+      should: 'leave the database untouched — the gate is not the only thing holding the line',
+      actual: {
+        rows: await lazyRowsFor(parentPage.id),
+        requests: fetchWithAuth.mock.calls.length - callsBefore,
+      },
+      expected: { rows: { taskLists: 0, statusConfigs: 0 }, requests: 0 },
+    });
+  });
+
   it('resolves sub-tasks for a parent task from the existing route', async () => {
     if (!dbAvailable) return;
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * The gate, proven against a real Postgres.
+ *
+ * `GET /api/pages/[pageId]/tasks` is not a read. `getOrCreateTaskListForPage`
+ * (route.ts:33) lazily INSERTs a `task_lists` row plus 4 `task_status_configs`
+ * rows for any pageId it has not seen before. Expanding 50 leaf tasks in the task
+ * list would therefore create 50 task lists and 200 status-config rows.
+ *
+ * A test that mocks fetch and asserts "no request was made" cannot prove this:
+ * the write is server-side, so the only evidence that counts is the absence of
+ * the rows. This suite drives the REAL hook, wires its fetch to the REAL route
+ * handler, and then asks the database what happened.
+ *
+ * The parent-task case is deliberately in the same file: it proves the route
+ * really does write on GET, so the leaf case is a guarantee about a live hazard
+ * rather than an assertion about something that was never going to happen.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). FAILS LOUDLY when no DB is reachable — a
+ * silent skip would be a green, zero-assertion pass. Local runs without Docker
+ * opt out explicitly with ALLOW_SKIP_DB_TESTS=1.
+ */
+import React from 'react';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { db } from '@pagespace/db/db';
+import { eq, inArray } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { taskItems, taskLists, taskStatusConfigs } from '@pagespace/db/schema/tasks';
+import { factories } from '@pagespace/db/test/factories';
+import { requireDb } from '@pagespace/db/test/require-db';
+import { useTaskSubTasks } from '../useTaskSubTasks';
+
+// The hook's only outbound edge. Pointing it at the route handler (rather than at a
+// canned response) is what makes the database assertions below meaningful.
+const { fetchWithAuth } = vi.hoisted(() => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth }));
+
+// The route's auth/permission edge is not what this suite is testing; the DB is.
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(async () => ({ userId: currentUserId })),
+  isAuthError: vi.fn(() => false),
+  checkMCPPageScope: vi.fn(async () => null),
+  canPrincipalViewPage: vi.fn(async () => true),
+  canPrincipalEditPage: vi.fn(async () => true),
+}));
+vi.mock('@/lib/websocket', () => ({
+  broadcastTaskEvent: vi.fn(),
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(() => ({})),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+let currentUserId = '';
+
+const assert = ({ given, should, actual, expected }: {
+  given: string; should: string; actual: unknown; expected: unknown;
+}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+const makeWrapper = () => {
+  const cache = new Map();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>{children}</SWRConfig>;
+  };
+};
+
+/** Every task_lists / task_status_configs row the route could have lazily created for a page. */
+async function lazyRowsFor(pageId: string) {
+  const lists = await db.select({ id: taskLists.id })
+    .from(taskLists).where(eq(taskLists.pageId, pageId)).limit(10);
+  if (lists.length === 0) return { taskLists: 0, statusConfigs: 0 };
+  const configs = await db.select({ id: taskStatusConfigs.id })
+    .from(taskStatusConfigs)
+    .where(inArray(taskStatusConfigs.taskListId, lists.map((l) => l.id)))
+    .limit(100);
+  return { taskLists: lists.length, statusConfigs: configs.length };
+}
+
+let dbAvailable = false;
+
+describe('useTaskSubTasks against the real route and database', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch (error) {
+      requireDb('useTaskSubTasks.integration.test.tsx', error);
+      dbAvailable = false;
+    }
+
+    if (!dbAvailable) return;
+
+    // The real handler, addressed exactly as the hook addresses it.
+    const { GET } = await import('@/app/api/pages/[pageId]/tasks/route');
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      const full = new URL(url, 'http://localhost');
+      const pageId = full.pathname.split('/')[3];
+      return GET(new Request(full.toString()), { params: Promise.resolve({ pageId }) });
+    });
+  });
+
+  it('creates no task_lists or task_status_configs rows for a leaf task', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    currentUserId = owner.id;
+    const drive = await factories.createDrive(owner.id);
+    const listPage = await factories.createPage(drive.id, { type: 'TASK_LIST' });
+    // A task IS a TASK_LIST page — that is the mechanism behind infinite nesting.
+    const leafPage = await factories.createPage(drive.id, { parentId: listPage.id, type: 'TASK_LIST' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: leafPage.id });
+
+    const before = await lazyRowsFor(leafPage.id);
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: leafPage.id, subTaskCount: 0 }),
+      { wrapper: makeWrapper() },
+    );
+    // Let any errant fetch effect fire and its response land before asserting absence.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const after = await lazyRowsFor(leafPage.id);
+
+    assert({
+      given: 'a leaf task expanded in the UI',
+      should: 'leave the database exactly as it found it — no lazily created task list, no status configs',
+      actual: { before, after, requests: fetchWithAuth.mock.calls.length, subTasks: result.current.subTasks.length },
+      expected: {
+        before: { taskLists: 0, statusConfigs: 0 },
+        after: { taskLists: 0, statusConfigs: 0 },
+        requests: 0,
+        subTasks: 0,
+      },
+    });
+  });
+
+  it('resolves sub-tasks for a parent task from the existing route', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    currentUserId = owner.id;
+    const drive = await factories.createDrive(owner.id);
+    const listPage = await factories.createPage(drive.id, { type: 'TASK_LIST' });
+    const parentPage = await factories.createPage(drive.id, { parentId: listPage.id, type: 'TASK_LIST' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: parentPage.id });
+
+    const childA = await factories.createPage(drive.id, { parentId: parentPage.id, type: 'TASK_LIST', title: 'Child A' });
+    const childB = await factories.createPage(drive.id, { parentId: parentPage.id, type: 'TASK_LIST', title: 'Child B' });
+    await db.insert(taskItems).values([
+      { userId: owner.id, pageId: childA.id, status: 'pending' },
+      { userId: owner.id, pageId: childB.id, status: 'pending' },
+    ]);
+    // pages.position is the single ordering rail the route sorts on (#2143).
+    await db.update(pages).set({ position: 1 }).where(eq(pages.id, childA.id));
+    await db.update(pages).set({ position: 2 }).where(eq(pages.id, childB.id));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: parentPage.id, subTaskCount: 2 }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(2));
+
+    assert({
+      given: 'a task with two sub-task pages beneath it',
+      should: 'resolve them from GET /api/pages/{task.pageId}/tasks — no new endpoint',
+      actual: result.current.subTasks.map((t) => t.title),
+      expected: ['Child A', 'Child B'],
+    });
+
+    // The same response carries the sub-task list's own status configs — the 4 defaults the
+    // route just lazily created for this task's list. A renderer one level down needs them to
+    // label a status at all, and only a real route can show they actually arrive.
+    assert({
+      given: "the sub-task list's freshly created status configs",
+      should: 'arrive with the sub-tasks, as the default four slugs',
+      actual: result.current.statusConfigs.map((c) => c.slug).sort(),
+      expected: ['blocked', 'completed', 'in_progress', 'pending'],
+    });
+
+    // The other half of the proof: the route really does write on GET, so the leaf
+    // case above is a guarantee about a hazard that exists.
+    assert({
+      given: 'the same GET the leaf task was spared',
+      should: 'have lazily created one task_lists row and its 4 default status configs',
+      actual: await lazyRowsFor(parentPage.id),
+      expected: { taskLists: 1, statusConfigs: 4 },
+    });
+  });
+
+  it('does not re-issue the GET — and so cannot re-run its writes — on re-expand', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    currentUserId = owner.id;
+    const drive = await factories.createDrive(owner.id);
+    const listPage = await factories.createPage(drive.id, { type: 'TASK_LIST' });
+    const parentPage = await factories.createPage(drive.id, { parentId: listPage.id, type: 'TASK_LIST' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: parentPage.id });
+    const child = await factories.createPage(drive.id, { parentId: parentPage.id, type: 'TASK_LIST', title: 'Only child' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: child.id });
+
+    const wrapper = makeWrapper();
+    const callsBefore = fetchWithAuth.mock.calls.length;
+
+    const first = renderHook(
+      () => useTaskSubTasks({ pageId: parentPage.id, subTaskCount: 1 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(first.result.current.subTasks).toHaveLength(1));
+    const callsAfterFirstExpand = fetchWithAuth.mock.calls.length - callsBefore;
+
+    first.unmount(); // collapse
+
+    const second = renderHook(
+      () => useTaskSubTasks({ pageId: parentPage.id, subTaskCount: 1 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(second.result.current.subTasks).toHaveLength(1));
+    await new Promise((r) => setTimeout(r, 50));
+
+    assert({
+      given: 'a task expanded, collapsed, and expanded again',
+      should: 'serve the second expansion from cache — one GET total',
+      actual: {
+        firstExpand: callsAfterFirstExpand,
+        total: fetchWithAuth.mock.calls.length - callsBefore,
+      },
+      expected: { firstExpand: 1, total: 1 },
+    });
+  });
+
+  it('leaves no lazily created task lists behind after expanding a page of leaf tasks', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    currentUserId = owner.id;
+    const drive = await factories.createDrive(owner.id);
+    const listPage = await factories.createPage(drive.id, { type: 'TASK_LIST' });
+
+    const leafPageIds: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const leaf = await factories.createPage(drive.id, { parentId: listPage.id, type: 'TASK_LIST', title: `Leaf ${i}` });
+      await db.insert(taskItems).values({ userId: owner.id, pageId: leaf.id });
+      leafPageIds.push(leaf.id);
+    }
+
+    const wrapper = makeWrapper();
+    for (const pageId of leafPageIds) {
+      renderHook(() => useTaskSubTasks({ pageId, subTaskCount: 0 }), { wrapper });
+    }
+    await new Promise((r) => setTimeout(r, 50));
+
+    const created = await db
+      .select({ id: taskLists.id })
+      .from(taskLists)
+      .where(inArray(taskLists.pageId, leafPageIds))
+      .limit(50);
+    const strayConfigs = created.length === 0 ? [] : await db
+      .select({ id: taskStatusConfigs.id })
+      .from(taskStatusConfigs)
+      .where(inArray(taskStatusConfigs.taskListId, created.map((c) => c.id)))
+      .limit(200);
+
+    assert({
+      given: '10 leaf tasks all expanded at once — the 50-tasks-200-rows scenario in miniature',
+      should: 'create zero task lists and zero status configs',
+      actual: { taskLists: created.length, statusConfigs: strayConfigs.length },
+      expected: { taskLists: 0, statusConfigs: 0 },
+    });
+  });
+
+  it('backs the sub-task count the row already showed', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    currentUserId = owner.id;
+    const drive = await factories.createDrive(owner.id);
+    const listPage = await factories.createPage(drive.id, { type: 'TASK_LIST' });
+    const parentPage = await factories.createPage(drive.id, { parentId: listPage.id, type: 'TASK_LIST' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: parentPage.id });
+    const child = await factories.createPage(drive.id, { parentId: parentPage.id, type: 'TASK_LIST', title: 'Grandchild holder' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: child.id });
+    const grandchild = await factories.createPage(drive.id, { parentId: child.id, type: 'TASK_LIST', title: 'Grandchild' });
+    await db.insert(taskItems).values({ userId: owner.id, pageId: grandchild.id });
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: parentPage.id, subTaskCount: 1 }),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(1));
+
+    assert({
+      given: 'a sub-task that itself has a sub-task',
+      should: 'carry its own subTaskCount, so the next level can apply the same gate without another request',
+      actual: result.current.subTasks[0].subTaskCount,
+      expected: 1,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
@@ -22,6 +22,7 @@
  */
 import React from 'react';
 import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { assert } from '@/hooks/__tests__/riteway';
 import { renderHook, waitFor } from '@testing-library/react';
 import { SWRConfig } from 'swr';
 import { db } from '@pagespace/db/db';
@@ -53,10 +54,6 @@ vi.mock('@/lib/websocket', () => ({
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 
 let currentUserId = '';
-
-const assert = ({ given, should, actual, expected }: {
-  given: string; should: string; actual: unknown; expected: unknown;
-}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
 
 const makeWrapper = () => {
   const cache = new Map();

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx
@@ -109,6 +109,10 @@ describe('useTaskSubTasks against the real route and database', () => {
     await db.insert(taskItems).values({ userId: owner.id, pageId: leafPage.id });
 
     const before = await lazyRowsFor(leafPage.id);
+    // A delta, not an absolute count: this file never resets the spy, so reading
+    // `mock.calls.length` directly would quietly stop meaning "this test issued none" the
+    // moment a case is added above it.
+    const callsBefore = fetchWithAuth.mock.calls.length;
 
     const { result } = renderHook(
       () => useTaskSubTasks({ pageId: leafPage.id, subTaskCount: 0 }),
@@ -122,7 +126,12 @@ describe('useTaskSubTasks against the real route and database', () => {
     assert({
       given: 'a leaf task expanded in the UI',
       should: 'leave the database exactly as it found it — no lazily created task list, no status configs',
-      actual: { before, after, requests: fetchWithAuth.mock.calls.length, subTasks: result.current.subTasks.length },
+      actual: {
+        before,
+        after,
+        requests: fetchWithAuth.mock.calls.length - callsBefore,
+        subTasks: result.current.subTasks.length,
+      },
       expected: {
         before: { taskLists: 0, statusConfigs: 0 },
         after: { taskLists: 0, statusConfigs: 0 },

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
@@ -12,7 +12,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { assert } from '@/hooks/__tests__/riteway';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { SWRConfig } from 'swr';
-import { useTaskSubTasks, shouldFetchSubTasks, getSubTaskPageKey, getSubTasksHasMore } from '../useTaskSubTasks';
+import { useTaskSubTasks, shouldFetchSubTasks, getSubTaskPageKey, getSubTasksHasMore, SUB_TASKS_CACHE_NAMESPACE } from '../useTaskSubTasks';
 import type { TaskItem, TaskListData } from '../task-list-types';
 
 const { fetchWithAuth } = vi.hoisted(() => ({ fetchWithAuth: vi.fn() }));
@@ -100,7 +100,7 @@ describe('getSubTaskPageKey', () => {
       given: 'a task with sub-tasks, first page',
       should: 'key on GET /api/pages/{task.pageId}/tasks with limit and offset 0',
       actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 2 }, true)(0, null),
-      expected: '/api/pages/task-page/tasks?limit=100&offset=0',
+      expected: [SUB_TASKS_CACHE_NAMESPACE, '/api/pages/task-page/tasks?limit=100&offset=0'],
     });
   });
 
@@ -109,7 +109,7 @@ describe('getSubTaskPageKey', () => {
       given: 'page index 2 after a page that reported hasMore',
       should: 'offset by two full pages',
       actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 300 }, true)(2, makeBody([], true)),
-      expected: '/api/pages/task-page/tasks?limit=100&offset=200',
+      expected: [SUB_TASKS_CACHE_NAMESPACE, '/api/pages/task-page/tasks?limit=100&offset=200'],
     });
   });
 
@@ -119,6 +119,25 @@ describe('getSubTaskPageKey', () => {
       should: 'return a null key so SWR requests nothing further',
       actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 2 }, true)(1, makeBody([], false)),
       expected: null,
+    });
+  });
+
+  it('cannot share a cache entry with the full-page task list for the same page', () => {
+    // TaskListView pages this same route with the same page size, so its page-0 key for a
+    // list page is byte-identical to this hook's page-0 key for a task whose linked page IS
+    // that page. Sharing one swr/infinite entry would hand the expansion the full-page view's
+    // page count and let its refreshInterval refetch a key this hook promises not to refetch.
+    const key = getSubTaskPageKey({ pageId: 'page-1', subTaskCount: 2 }, true)(0, null);
+    const taskListViewKey = '/api/pages/page-1/tasks?limit=100&offset=0';
+
+    assert({
+      given: "a task whose linked page is the page TaskListView itself is showing",
+      should: 'be namespaced away from that view key while requesting the identical URL',
+      actual: {
+        collides: JSON.stringify(key) === JSON.stringify(taskListViewKey),
+        requestsSameUrl: key?.[1] === taskListViewKey,
+      },
+      expected: { collides: false, requestsSameUrl: true },
     });
   });
 
@@ -308,6 +327,52 @@ describe('useTaskSubTasks', () => {
         subTasks: 1,
         hasMore: true,
         message: 'network went away',
+      },
+    });
+  });
+
+  it('recovers from a first page that failed', async () => {
+    // The case that has no "Load more" to press: page 1 of 1 fails, so hasMore is false and
+    // nothing retries on its own. Without `retry` this state is terminal.
+    fetchWithAuth
+      .mockRejectedValueOnce(new Error('network went away'))
+      .mockResolvedValueOnce(respond(makeBody([makeSubTask('a')], false)));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 1 }),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.error).toBeDefined());
+
+    assert({
+      given: 'a first page that rejected',
+      should: 'be a dead end but for retry — no rows, nothing more to load, not loading',
+      actual: {
+        subTasks: result.current.subTasks.length,
+        hasMore: result.current.hasMore,
+        isLoading: result.current.isLoading,
+      },
+      expected: { subTasks: 0, hasMore: false, isLoading: false },
+    });
+
+    await act(async () => { result.current.retry(); });
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(1));
+
+    assert({
+      given: 'retry after a failed first page',
+      should: 'request the same page again and clear the error',
+      actual: {
+        ids: result.current.subTasks.map((t) => t.id),
+        urls: fetchWithAuth.mock.calls.map((c) => c[0]),
+        error: result.current.error,
+      },
+      expected: {
+        ids: ['a'],
+        urls: [
+          '/api/pages/parent-page/tasks?limit=100&offset=0',
+          '/api/pages/parent-page/tasks?limit=100&offset=0',
+        ],
+        error: undefined,
       },
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
@@ -275,6 +275,80 @@ describe('useTaskSubTasks', () => {
     });
   });
 
+  it('does not report loading-more when a later page failed', async () => {
+    // The failure mode this guards: page 2 rejects, SWR keeps page 1, `hasMore` still reads
+    // true from it, and `pages` can never reach the bumped `size` because nothing retries.
+    // Reporting "loading more" there disables the control that retries it — under an error
+    // message saying it failed.
+    fetchWithAuth
+      .mockResolvedValueOnce(respond(makeBody([makeSubTask('a')], true)))
+      .mockRejectedValueOnce(new Error('network went away'));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 2 }),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(1));
+    await act(async () => { result.current.loadMore(); });
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    // Long enough that SWR's own retry would have fired if it were still enabled.
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert({
+      given: 'a second page that rejected',
+      should: 'surface the error, keep the rows it did load, and leave the retry control usable',
+      actual: {
+        isLoadingMore: result.current.isLoadingMore,
+        subTasks: result.current.subTasks.length,
+        hasMore: result.current.hasMore,
+        message: result.current.error?.message,
+      },
+      expected: {
+        isLoadingMore: false,
+        subTasks: 1,
+        hasMore: true,
+        message: 'network went away',
+      },
+    });
+  });
+
+  it('retries the failed page when the control is used again', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(respond(makeBody([makeSubTask('a')], true)))
+      .mockRejectedValueOnce(new Error('network went away'))
+      .mockResolvedValueOnce(respond(makeBody([makeSubTask('b')], false)));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 2 }),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(1));
+    await act(async () => { result.current.loadMore(); });
+    await waitFor(() => expect(result.current.error).toBeDefined());
+
+    await act(async () => { result.current.loadMore(); });
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(2));
+
+    assert({
+      given: 'a retry after a failed second page',
+      should: 'fetch the page that failed rather than skipping past it, and clear the error',
+      actual: {
+        ids: result.current.subTasks.map((t) => t.id),
+        urls: fetchWithAuth.mock.calls.map((c) => c[0]),
+        error: result.current.error,
+      },
+      expected: {
+        ids: ['a', 'b'],
+        urls: [
+          '/api/pages/parent-page/tasks?limit=100&offset=0',
+          '/api/pages/parent-page/tasks?limit=100&offset=100',
+          '/api/pages/parent-page/tasks?limit=100&offset=100',
+        ],
+        error: undefined,
+      },
+    });
+  });
+
   it('pages through a long sub-task list on demand', async () => {
     fetchWithAuth
       .mockResolvedValueOnce(respond(makeBody([makeSubTask('a')], true)))

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
@@ -256,6 +256,28 @@ describe('useTaskSubTasks', () => {
     });
   });
 
+  it('does not report loading-more forever once the list is exhausted', async () => {
+    // Only one page exists. A caller that calls loadMore anyway (the hook is public API and
+    // does not police it) bumps `size` to 2, but the key function returns null for index 1,
+    // so `pages` can never reach that size. Without the hasMore term this latched on forever.
+    fetchWithAuth.mockResolvedValue(respond(makeBody([makeSubTask('a')], false)));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 1 }),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(1));
+    await act(async () => { result.current.loadMore(); });
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert({
+      given: 'loadMore called after a page that reported hasMore false',
+      should: 'not be stuck reporting isLoadingMore',
+      actual: { isLoadingMore: result.current.isLoadingMore, requests: fetchWithAuth.mock.calls.length },
+      expected: { isLoadingMore: false, requests: 1 },
+    });
+  });
+
   it('pages through a long sub-task list on demand', async () => {
     fetchWithAuth
       .mockResolvedValueOnce(respond(makeBody([makeSubTask('a')], true)))

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * The sub-task fetch hook: what it asks for, what it refuses to ask for, and what
+ * it serves from cache.
+ *
+ * The refusal is the load-bearing part. `GET /api/pages/[pageId]/tasks` writes on
+ * read (see useTaskSubTasks' gate comment), so "a leaf task issues no request" is a
+ * data-integrity guarantee, not a performance nicety. Proven against the real
+ * database in useTaskSubTasks.integration.test.tsx; proven at the hook boundary here.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { useTaskSubTasks, shouldFetchSubTasks, getSubTaskPageKey, getSubTasksHasMore } from '../useTaskSubTasks';
+import type { TaskItem, TaskListData } from '../task-list-types';
+
+const { fetchWithAuth } = vi.hoisted(() => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth }));
+
+const assert = ({ given, should, actual, expected }: {
+  given: string; should: string; actual: unknown; expected: unknown;
+}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+const makeSubTask = (id: string): TaskItem => ({
+  id,
+  userId: 'u1',
+  assigneeId: null,
+  assigneeAgentId: null,
+  pageId: `page-${id}`,
+  title: `Sub-task ${id}`,
+  status: 'pending',
+  priority: 'medium',
+  position: 0,
+  dueDate: null,
+  completedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const respond = (body: TaskListData) => ({ ok: true, json: async () => body });
+
+const makeBody = (tasks: TaskItem[], hasMore = false): TaskListData => ({
+  taskList: { id: 'tl', title: 'Task List', description: null, status: 'pending', updatedAt: '2026-01-01T00:00:00.000Z' },
+  tasks,
+  statusConfigs: [],
+  hasMore,
+});
+
+// A fresh SWR cache per wrapper factory; a shared one across a mount/unmount/remount
+// is exactly what proves the re-expand cache hit.
+const makeWrapper = () => {
+  const cache = new Map();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>{children}</SWRConfig>;
+  };
+};
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('shouldFetchSubTasks (the gate)', () => {
+  it('refuses a leaf task', () => {
+    assert({
+      given: 'a task with subTaskCount 0',
+      should: 'not fetch — the route would lazily write a task_list for it',
+      actual: shouldFetchSubTasks({ pageId: 'p1', subTaskCount: 0 }),
+      expected: false,
+    });
+  });
+
+  it('refuses a task whose subTaskCount is unknown', () => {
+    assert({
+      given: 'a task with no subTaskCount field',
+      should: 'not fetch',
+      actual: shouldFetchSubTasks({ pageId: 'p1' }),
+      expected: false,
+    });
+  });
+
+  it('refuses a task with no linked page', () => {
+    assert({
+      given: 'a task with a null pageId but a positive subTaskCount',
+      should: 'not fetch — there is no pageId to address the route with',
+      actual: shouldFetchSubTasks({ pageId: null, subTaskCount: 3 }),
+      expected: false,
+    });
+  });
+
+  it('allows a task with sub-tasks', () => {
+    assert({
+      given: 'a task with subTaskCount 3',
+      should: 'fetch',
+      actual: shouldFetchSubTasks({ pageId: 'p1', subTaskCount: 3 }),
+      expected: true,
+    });
+  });
+});
+
+describe('getSubTaskPageKey', () => {
+  it('addresses the existing route with the task own pageId', () => {
+    assert({
+      given: 'a task with sub-tasks, first page',
+      should: 'key on GET /api/pages/{task.pageId}/tasks with limit and offset 0',
+      actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 2 }, true)(0, null),
+      expected: '/api/pages/task-page/tasks?limit=100&offset=0',
+    });
+  });
+
+  it('pages by offset', () => {
+    assert({
+      given: 'page index 2 after a page that reported hasMore',
+      should: 'offset by two full pages',
+      actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 300 }, true)(2, makeBody([], true)),
+      expected: '/api/pages/task-page/tasks?limit=100&offset=200',
+    });
+  });
+
+  it('stops at the end of the list', () => {
+    assert({
+      given: 'a previous page that reported hasMore false',
+      should: 'return a null key so SWR requests nothing further',
+      actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 2 }, true)(1, makeBody([], false)),
+      expected: null,
+    });
+  });
+
+  it('stays null while disabled', () => {
+    assert({
+      given: 'a task with sub-tasks but enabled false (row collapsed)',
+      should: 'return a null key',
+      actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 2 }, false)(0, null),
+      expected: null,
+    });
+  });
+
+  it('stays null for a leaf task', () => {
+    assert({
+      given: 'an enabled leaf task',
+      should: 'return a null key',
+      actual: getSubTaskPageKey({ pageId: 'task-page', subTaskCount: 0 }, true)(0, null),
+      expected: null,
+    });
+  });
+});
+
+describe('getSubTasksHasMore', () => {
+  it('reads the most recent page only', () => {
+    assert({
+      given: 'a first page saying hasMore and a second saying not',
+      should: 'report the second — earlier bounds are stale',
+      actual: getSubTasksHasMore([makeBody([], true), makeBody([], false)]),
+      expected: false,
+    });
+  });
+
+  it('handles no pages', () => {
+    assert({
+      given: 'undefined pages',
+      should: 'report no more',
+      actual: getSubTasksHasMore(undefined),
+      expected: false,
+    });
+  });
+});
+
+describe('useTaskSubTasks', () => {
+  it('issues no request for a leaf task', async () => {
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'leaf-page', subTaskCount: 0 }),
+      { wrapper: makeWrapper() },
+    );
+
+    // Give any errant effect a full macrotask to fire before concluding it didn't.
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert({
+      given: 'an expanded leaf task',
+      should: 'never call the route',
+      actual: fetchWithAuth.mock.calls.length,
+      expected: 0,
+    });
+    assert({
+      given: 'an expanded leaf task',
+      should: 'report no sub-tasks and not be loading',
+      actual: { subTasks: result.current.subTasks, isLoading: result.current.isLoading },
+      expected: { subTasks: [], isLoading: false },
+    });
+  });
+
+  it('issues no request while collapsed', async () => {
+    renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 4 }, { enabled: false }),
+      { wrapper: makeWrapper() },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert({
+      given: 'a task with sub-tasks that is not expanded',
+      should: 'never call the route',
+      actual: fetchWithAuth.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  it('loads sub-tasks for a task that has them', async () => {
+    fetchWithAuth.mockResolvedValue(respond(makeBody([makeSubTask('a'), makeSubTask('b')])));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 2 }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(2));
+
+    assert({
+      given: 'a task with two sub-tasks',
+      should: 'call the existing route with the task own pageId',
+      actual: fetchWithAuth.mock.calls[0][0],
+      expected: '/api/pages/parent-page/tasks?limit=100&offset=0',
+    });
+    assert({
+      given: 'a task with two sub-tasks',
+      should: 'surface them in order',
+      actual: result.current.subTasks.map((t) => t.id),
+      expected: ['a', 'b'],
+    });
+  });
+
+  it('does not refetch on collapse then re-expand', async () => {
+    fetchWithAuth.mockResolvedValue(respond(makeBody([makeSubTask('a')])));
+    const wrapper = makeWrapper();
+
+    const first = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 1 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(first.result.current.subTasks).toHaveLength(1));
+    const callsAfterFirstExpand = fetchWithAuth.mock.calls.length;
+
+    // Collapse: TaskListView unmounts the expansion entirely.
+    first.unmount();
+
+    const second = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 1 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(second.result.current.subTasks).toHaveLength(1));
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert({
+      given: 'the same task expanded, collapsed, and expanded again',
+      should: 'serve the second expansion from cache without a second request',
+      actual: fetchWithAuth.mock.calls.length,
+      expected: callsAfterFirstExpand,
+    });
+  });
+
+  it('pages through a long sub-task list on demand', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(respond(makeBody([makeSubTask('a')], true)))
+      .mockResolvedValueOnce(respond(makeBody([makeSubTask('b')], false)));
+
+    const { result } = renderHook(
+      () => useTaskSubTasks({ pageId: 'parent-page', subTaskCount: 2 }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.hasMore).toBe(true));
+    await act(async () => { result.current.loadMore(); });
+
+    await waitFor(() => expect(result.current.subTasks).toHaveLength(2));
+
+    assert({
+      given: 'a first page reporting hasMore and a Load more click',
+      should: 'request the next offset and append its sub-tasks',
+      actual: {
+        secondUrl: fetchWithAuth.mock.calls[1][0],
+        ids: result.current.subTasks.map((t) => t.id),
+        hasMore: result.current.hasMore,
+      },
+      expected: {
+        secondUrl: '/api/pages/parent-page/tasks?limit=100&offset=100',
+        ids: ['a', 'b'],
+        hasMore: false,
+      },
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskSubTasks.test.tsx
@@ -9,6 +9,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assert } from '@/hooks/__tests__/riteway';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { SWRConfig } from 'swr';
 import { useTaskSubTasks, shouldFetchSubTasks, getSubTaskPageKey, getSubTasksHasMore } from '../useTaskSubTasks';
@@ -16,10 +17,6 @@ import type { TaskItem, TaskListData } from '../task-list-types';
 
 const { fetchWithAuth } = vi.hoisted(() => ({ fetchWithAuth: vi.fn() }));
 vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth }));
-
-const assert = ({ given, should, actual, expected }: {
-  given: string; should: string; actual: unknown; expected: unknown;
-}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
 
 const makeSubTask = (id: string): TaskItem => ({
   id,

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -76,7 +76,17 @@ export interface UseTaskSubTasksOptions {
 
 export interface UseTaskSubTasksResult {
   subTasks: TaskItem[];
-  /** The sub-task list's own status configs — a sub-task's statuses come from its parent task's list. */
+  /**
+   * The SUB-LIST's own status configs — status configs are per-task-list, so these come from
+   * this task's list, not the root one.
+   *
+   * WARNING for whoever renders nested rows: do NOT feed these to a sub-task's status dropdown
+   * by default. On a list whose statuses were customized, the sub-list has quietly received the
+   * 4 defaults instead, so rendering these puts a different status vocabulary one level down
+   * from its parent — visibly wrong with both on screen at once. The epic's decision is to
+   * inherit the ROOT list's configs and diverge only on explicit customization. These are here
+   * because that comparison needs both sides.
+   */
   statusConfigs: TaskStatusConfig[];
   hasMore: boolean;
   isLoading: boolean;
@@ -110,6 +120,12 @@ export function useTaskSubTasks(
   const statusConfigs = pages?.[0]?.statusConfigs ?? [];
 
   const hasMore = getSubTasksHasMore(pages);
+  // SWR types its error as `any`, so asserting `as Error` here would be a claim this code
+  // cannot make — a fetcher can reject with anything. Normalize instead, so a caller reading
+  // `.message` always gets a string rather than `undefined` from a thrown non-Error.
+  const normalizedError = error === undefined || error === null
+    ? undefined
+    : error instanceof Error ? error : new Error(String(error));
 
   return {
     subTasks,
@@ -126,7 +142,7 @@ export function useTaskSubTasks(
     // "loading more" forever. While a page really is in flight, the last LOADED page still
     // says hasMore, so this stays true exactly as long as it should.
     isLoadingMore: gateOpen && size > 1 && hasMore && (pages === undefined || pages.length < size),
-    error: error as Error | undefined,
+    error: normalizedError,
     // Functional form: two clicks in the same tick both read the same stale `size` otherwise,
     // and the second overwrites the first with the same value instead of advancing a page.
     loadMore: () => setSize((currentSize) => currentSize + 1),

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -28,9 +28,14 @@ import type { TaskItem, TaskListData, TaskStatusConfig } from './task-list-types
 /**
  * Must stay <= the GET route's MAX_LIMIT (query-spec.ts, 200) or the server silently clamps
  * the page down while `offset` keeps advancing by this number — which skips rows rather than
- * failing. It happens to equal TaskListView's own TASKS_PAGE_SIZE, but nothing requires that:
- * they are page sizes for two different lists, and coupling them would be a coupling this
- * code does not actually have.
+ * failing.
+ *
+ * It equals TaskListView's own TASKS_PAGE_SIZE, and nothing requires it to: these are page
+ * sizes for two different lists and either can change alone. But do not read "independent" as
+ * "unrelated" — while the two are equal, the two hooks build the SAME request URL for the same
+ * page, which is what made their SWR keys collide before SUB_TASKS_CACHE_NAMESPACE existed.
+ * The namespace holds either way; this is only here so the next reader does not conclude from
+ * "independent" that the URLs can never coincide.
  */
 export const SUB_TASKS_PAGE_SIZE = 100;
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -115,6 +115,13 @@ export function useTaskSubTasks(
       revalidateOnReconnect: false,
       revalidateIfStale: false,
       revalidateFirstPage: false,
+      // SWR retries failed fetches on its own by default (5 attempts, exponential backoff).
+      // That fights the rest of this config: every other automatic request is off precisely
+      // because a request here can lazily write, and a silent background retry also makes
+      // `error` a value that appears and disappears on a timer — impossible for a caller to
+      // render honestly, and impossible for a test to observe without racing it. Failure is
+      // therefore terminal and visible, and the "Load more" control becomes the retry.
+      shouldRetryOnError: false,
     },
   );
 
@@ -145,12 +152,19 @@ export function useTaskSubTasks(
     isLoading: gateOpen && isLoading,
     // A "Load more" click bumps `size` past 1 before the new page resolves into
     // `pages`. `size > 1` keeps the initial load out of this — that one is `isLoading`.
-    // The `hasMore` term is what stops this latching on: once the loaded pages end in
-    // hasMore: false, the key function returns null for every further index, so `pages`
-    // can never catch up to an inflated `size` and a bare length comparison would report
-    // "loading more" forever. While a page really is in flight, the last LOADED page still
-    // says hasMore, so this stays true exactly as long as it should.
-    isLoadingMore: gateOpen && size > 1 && hasMore && (pages === undefined || pages.length < size),
+    //
+    // The other two terms both exist to stop this latching on, because `pages` catching up
+    // to `size` is not the only way a load ends:
+    //   - `hasMore`: once the loaded pages end in hasMore: false, the key function returns
+    //     null for every further index, so `pages` can never reach an inflated `size`.
+    //   - `!normalizedError`: a later page that REJECTS also leaves `pages` short forever —
+    //     retries are off, so nothing is in flight — while `hasMore` still reads true from
+    //     the last page that did load. Reporting "loading more" there would disable the very
+    //     control that retries it, under an error message saying it failed.
+    // While a page genuinely is in flight, neither term fires: the last LOADED page still
+    // says hasMore and no error is standing.
+    isLoadingMore: gateOpen && size > 1 && hasMore && !normalizedError
+      && (pages === undefined || pages.length < size),
     error: normalizedError,
     loadMore,
   };

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -1,0 +1,125 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWRInfinite from 'swr/infinite';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { TaskItem, TaskListData, TaskStatusConfig } from './task-list-types';
+
+/**
+ * Sub-tasks come from the SAME route the top-level list uses — called with the
+ * task's own pageId instead of the list page's. Tasks are TASK_LIST pages (the
+ * route selects children by `eq(pages.type, 'TASK_LIST')`), so a task's children
+ * are its sub-tasks, already enriched with status/priority/assignees/dueDate,
+ * `activeTriggerCount`, `hasContent` and their own `subTaskCount`. No new endpoint.
+ *
+ * The schema comment on `taskItems` in packages/db/src/schema/tasks.ts calling the
+ * linked page a DOCUMENT is stale; do not trust it over the route's own filter.
+ */
+
+/**
+ * Matches TASKS_PAGE_SIZE in TaskListView and DEFAULT_LIMIT in the GET route's
+ * query-spec.ts. Must stay <= that route's MAX_LIMIT (200) or every page beyond
+ * the first would be silently clamped down server-side and `offset` would skip rows.
+ */
+export const SUB_TASKS_PAGE_SIZE = 100;
+
+/** The minimum a caller must know about a task to decide whether to fetch its children. */
+export interface SubTaskGateInput {
+  pageId: string | null;
+  subTaskCount?: number;
+}
+
+/**
+ * THE GATE. `GET /api/pages/[pageId]/tasks` has a write side effect:
+ * `getOrCreateTaskListForPage` (route.ts:33) lazily inserts a `task_lists` row plus
+ * 4 `task_status_configs` rows for any pageId it has not seen. Expanding 50 leaf
+ * tasks would therefore create 50 task lists and 200 status-config rows for tasks
+ * that have no children at all.
+ *
+ * `subTaskCount` is already on the row before expanding (it ships with the parent
+ * list's own response), so refusing to fetch when it is 0 costs nothing and confines
+ * those lazy writes to tasks that genuinely have sub-tasks.
+ */
+export const shouldFetchSubTasks = (task: SubTaskGateInput): boolean =>
+  !!task.pageId && (task.subTaskCount ?? 0) > 0;
+
+/**
+ * Built outside the hook so the gate is testable on its own and so the key is a
+ * pure function of (task, enabled, pageIndex) — SWR caches per key, which is what
+ * makes collapse → re-expand of the same task a cache hit rather than a refetch.
+ */
+export const getSubTaskPageKey = (task: SubTaskGateInput, enabled: boolean) =>
+  (pageIndex: number, previousPageData: TaskListData | null): string | null => {
+    if (!enabled || !shouldFetchSubTasks(task)) return null;
+    if (previousPageData && !previousPageData.hasMore) return null;
+    return `/api/pages/${task.pageId}/tasks?limit=${SUB_TASKS_PAGE_SIZE}&offset=${pageIndex * SUB_TASKS_PAGE_SIZE}`;
+  };
+
+/** Only the most recently loaded page's `hasMore` is current; earlier ones are stale bounds. */
+export const getSubTasksHasMore = (pages: TaskListData[] | undefined): boolean =>
+  !!pages && pages.length > 0 && pages[pages.length - 1].hasMore;
+
+const fetcher = async (url: string): Promise<TaskListData> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to fetch sub-tasks');
+  return res.json();
+};
+
+export interface UseTaskSubTasksOptions {
+  /**
+   * Callers mount this hook inside an expansion, so `enabled` normally just mirrors
+   * "is this row expanded". Passing false keeps the key null — no request, and no
+   * lazy task_list write on the server.
+   */
+  enabled?: boolean;
+}
+
+export interface UseTaskSubTasksResult {
+  subTasks: TaskItem[];
+  /** The sub-task list's own status configs — a sub-task's statuses come from its parent task's list. */
+  statusConfigs: TaskStatusConfig[];
+  hasMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  error: Error | undefined;
+  loadMore: () => void;
+}
+
+export function useTaskSubTasks(
+  task: SubTaskGateInput,
+  { enabled = true }: UseTaskSubTasksOptions = {},
+): UseTaskSubTasksResult {
+  const gateOpen = enabled && shouldFetchSubTasks(task);
+
+  const { data: pages, error, isLoading, size, setSize } = useSWRInfinite<TaskListData>(
+    getSubTaskPageKey(task, enabled),
+    fetcher,
+    {
+      // Expansion is disclosure of data the parent list already summarised — it does
+      // not need to be live. Every revalidation trigger is off so that collapsing and
+      // re-expanding a task is served entirely from SWR's cache: a refetch there would
+      // not just cost a request, it would re-run the route's lazy task_list write path.
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+      revalidateFirstPage: false,
+    },
+  );
+
+  const subTasks = useMemo(() => (pages ?? []).flatMap((p) => p.tasks), [pages]);
+  const statusConfigs = pages?.[0]?.statusConfigs ?? [];
+
+  return {
+    subTasks,
+    statusConfigs,
+    hasMore: getSubTasksHasMore(pages),
+    // With the gate shut there is no key, so SWR reports neither loading nor data —
+    // report "not loading" rather than leaving a caller spinning forever.
+    isLoading: gateOpen && isLoading,
+    // A "Load more" click bumps `size` past 1 before the new page resolves into
+    // `pages`. `size > 1` keeps the initial load out of this — that one is `isLoading`.
+    isLoadingMore: gateOpen && size > 1 && (pages === undefined || pages.length < size),
+    error: error as Error | undefined,
+    loadMore: () => setSize(size + 1),
+  };
+}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -109,17 +109,26 @@ export function useTaskSubTasks(
   const subTasks = useMemo(() => (pages ?? []).flatMap((p) => p.tasks), [pages]);
   const statusConfigs = pages?.[0]?.statusConfigs ?? [];
 
+  const hasMore = getSubTasksHasMore(pages);
+
   return {
     subTasks,
     statusConfigs,
-    hasMore: getSubTasksHasMore(pages),
+    hasMore,
     // With the gate shut there is no key, so SWR reports neither loading nor data —
     // report "not loading" rather than leaving a caller spinning forever.
     isLoading: gateOpen && isLoading,
     // A "Load more" click bumps `size` past 1 before the new page resolves into
     // `pages`. `size > 1` keeps the initial load out of this — that one is `isLoading`.
-    isLoadingMore: gateOpen && size > 1 && (pages === undefined || pages.length < size),
+    // The `hasMore` term is what stops this latching on: once the loaded pages end in
+    // hasMore: false, the key function returns null for every further index, so `pages`
+    // can never catch up to an inflated `size` and a bare length comparison would report
+    // "loading more" forever. While a page really is in flight, the last LOADED page still
+    // says hasMore, so this stays true exactly as long as it should.
+    isLoadingMore: gateOpen && size > 1 && hasMore && (pages === undefined || pages.length < size),
     error: error as Error | undefined,
-    loadMore: () => setSize(size + 1),
+    // Functional form: two clicks in the same tick both read the same stale `size` otherwise,
+    // and the second overwrites the first with the same value instead of advancing a page.
+    loadMore: () => setSize((currentSize) => currentSize + 1),
   };
 }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import type { TaskItem, TaskListData, TaskStatusConfig } from './task-list-types';
@@ -17,9 +17,11 @@ import type { TaskItem, TaskListData, TaskStatusConfig } from './task-list-types
  */
 
 /**
- * Matches TASKS_PAGE_SIZE in TaskListView and DEFAULT_LIMIT in the GET route's
- * query-spec.ts. Must stay <= that route's MAX_LIMIT (200) or every page beyond
- * the first would be silently clamped down server-side and `offset` would skip rows.
+ * Must stay <= the GET route's MAX_LIMIT (query-spec.ts, 200) or the server silently clamps
+ * the page down while `offset` keeps advancing by this number — which skips rows rather than
+ * failing. It happens to equal TaskListView's own TASKS_PAGE_SIZE, but nothing requires that:
+ * they are page sizes for two different lists, and coupling them would be a coupling this
+ * code does not actually have.
  */
 export const SUB_TASKS_PAGE_SIZE = 100;
 
@@ -117,9 +119,16 @@ export function useTaskSubTasks(
   );
 
   const subTasks = useMemo(() => (pages ?? []).flatMap((p) => p.tasks), [pages]);
-  const statusConfigs = pages?.[0]?.statusConfigs ?? [];
+  // Memoized for the same reason as subTasks: `?? []` mints a new array every render, and a
+  // caller that puts this in a dependency array (a nested renderer resolving status labels is
+  // the obvious one) would re-run on every parent render forever.
+  const statusConfigs = useMemo(() => pages?.[0]?.statusConfigs ?? [], [pages]);
 
   const hasMore = getSubTasksHasMore(pages);
+  // Stable identity, so a memoized row that takes this as a prop is not re-rendered by every
+  // parent render. Functional `setSize` because two clicks in the same tick both read the same
+  // stale `size` otherwise, and the second writes the value the first already wrote.
+  const loadMore = useCallback(() => setSize((currentSize) => currentSize + 1), [setSize]);
   // SWR types its error as `any`, so asserting `as Error` here would be a claim this code
   // cannot make — a fetcher can reject with anything. Normalize instead, so a caller reading
   // `.message` always gets a string rather than `undefined` from a thrown non-Error.
@@ -143,8 +152,6 @@ export function useTaskSubTasks(
     // says hasMore, so this stays true exactly as long as it should.
     isLoadingMore: gateOpen && size > 1 && hasMore && (pages === undefined || pages.length < size),
     error: normalizedError,
-    // Functional form: two clicks in the same tick both read the same stale `size` otherwise,
-    // and the second overwrites the first with the same value instead of advancing a page.
-    loadMore: () => setSize((currentSize) => currentSize + 1),
+    loadMore,
   };
 }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskSubTasks.ts
@@ -12,8 +12,17 @@ import type { TaskItem, TaskListData, TaskStatusConfig } from './task-list-types
  * are its sub-tasks, already enriched with status/priority/assignees/dueDate,
  * `activeTriggerCount`, `hasContent` and their own `subTaskCount`. No new endpoint.
  *
- * The schema comment on `taskItems` in packages/db/src/schema/tasks.ts calling the
- * linked page a DOCUMENT is stale; do not trust it over the route's own filter.
+ * The comment on `taskItems` in packages/db/src/schema/tasks.ts used to call that linked page a
+ * DOCUMENT; this branch corrected it. If you find it saying DOCUMENT again, the route's own
+ * filter is the authority.
+ *
+ * KNOWN COST OF THE GATE BELOW: `subTaskCount` is computed by joining task_items to child
+ * pages, so a TASK_LIST child that has no task_items row yet counts as zero. A task whose
+ * children are ALL in that state reads as a leaf here and will not expand, where an unguarded
+ * fetch would have hit the route's own backfillMissingTaskItems and healed them. That is
+ * accepted rather than overlooked: the alternative is fetching for every leaf, which is the
+ * write amplification this gate exists to stop. Opening the task's own page still runs the
+ * backfill, after which the count is right and the row expands.
  */
 
 /**
@@ -46,22 +55,42 @@ export const shouldFetchSubTasks = (task: SubTaskGateInput): boolean =>
   !!task.pageId && (task.subTaskCount ?? 0) > 0;
 
 /**
+ * The cache namespace. Not decoration: TaskListView pages the SAME route with the SAME page
+ * size, so its page-0 key for a list page is byte-identical to this hook's page-0 key for a
+ * task whose linked page IS that page — which happens as soon as someone opens a task's own
+ * page and later expands that task from its parent list. Sharing a plain URL key would hand
+ * both hooks one swr/infinite cache entry, including its page-count: the expansion would mount
+ * at whatever size the full-page view had grown to and render hundreds of rows inside one
+ * table cell, and TaskListView's 5-minute refreshInterval would refetch the very key this hook
+ * promises never to refetch — re-running the route's lazy writes on a timer.
+ *
+ * SWR keys on the serialized key, so prefixing scopes the cache while leaving the request URL
+ * exactly as it was.
+ */
+export const SUB_TASKS_CACHE_NAMESPACE = 'task-sub-tasks';
+
+export type SubTaskPageKey = readonly [namespace: string, url: string];
+
+/**
  * Built outside the hook so the gate is testable on its own and so the key is a
  * pure function of (task, enabled, pageIndex) — SWR caches per key, which is what
  * makes collapse → re-expand of the same task a cache hit rather than a refetch.
  */
 export const getSubTaskPageKey = (task: SubTaskGateInput, enabled: boolean) =>
-  (pageIndex: number, previousPageData: TaskListData | null): string | null => {
+  (pageIndex: number, previousPageData: TaskListData | null): SubTaskPageKey | null => {
     if (!enabled || !shouldFetchSubTasks(task)) return null;
     if (previousPageData && !previousPageData.hasMore) return null;
-    return `/api/pages/${task.pageId}/tasks?limit=${SUB_TASKS_PAGE_SIZE}&offset=${pageIndex * SUB_TASKS_PAGE_SIZE}`;
+    return [
+      SUB_TASKS_CACHE_NAMESPACE,
+      `/api/pages/${task.pageId}/tasks?limit=${SUB_TASKS_PAGE_SIZE}&offset=${pageIndex * SUB_TASKS_PAGE_SIZE}`,
+    ] as const;
   };
 
 /** Only the most recently loaded page's `hasMore` is current; earlier ones are stale bounds. */
 export const getSubTasksHasMore = (pages: TaskListData[] | undefined): boolean =>
   !!pages && pages.length > 0 && pages[pages.length - 1].hasMore;
 
-const fetcher = async (url: string): Promise<TaskListData> => {
+const fetcher = async ([, url]: SubTaskPageKey): Promise<TaskListData> => {
   const res = await fetchWithAuth(url);
   if (!res.ok) throw new Error('Failed to fetch sub-tasks');
   return res.json();
@@ -95,6 +124,19 @@ export interface UseTaskSubTasksResult {
   isLoadingMore: boolean;
   error: Error | undefined;
   loadMore: () => void;
+  /**
+   * Re-request the pages already asked for, clearing `error`. This is the ONLY revalidation
+   * path the hook offers, and it exists because nothing retries on its own (see
+   * shouldRetryOnError below) — without it a first page that fails is a dead end, since
+   * `hasMore` is false at that point and "Load more" is not even on screen.
+   *
+   * Deliberately not a general refresh: it is meant to be wired to a user pressing "try
+   * again" after a visible failure, which is the same class of explicit action as Load more.
+   * Sub-task rows going stale when something changes elsewhere is a different problem with a
+   * different answer (subscribing to the sub-list's own events, which belongs with recursive
+   * expansion state) — do not solve that by calling this on a timer or a socket event.
+   */
+  retry: () => void;
 }
 
 export function useTaskSubTasks(
@@ -103,7 +145,7 @@ export function useTaskSubTasks(
 ): UseTaskSubTasksResult {
   const gateOpen = enabled && shouldFetchSubTasks(task);
 
-  const { data: pages, error, isLoading, size, setSize } = useSWRInfinite<TaskListData>(
+  const { data: pages, error, isLoading, size, setSize, mutate } = useSWRInfinite<TaskListData>(
     getSubTaskPageKey(task, enabled),
     fetcher,
     {
@@ -136,6 +178,7 @@ export function useTaskSubTasks(
   // parent render. Functional `setSize` because two clicks in the same tick both read the same
   // stale `size` otherwise, and the second writes the value the first already wrote.
   const loadMore = useCallback(() => setSize((currentSize) => currentSize + 1), [setSize]);
+  const retry = useCallback(() => { void mutate(); }, [mutate]);
   // SWR types its error as `any`, so asserting `as Error` here would be a claim this code
   // cannot make — a fetcher can reject with anything. Normalize instead, so a caller reading
   // `.message` always gets a string rather than `undefined` from a thrown non-Error.
@@ -167,5 +210,6 @@ export function useTaskSubTasks(
       && (pages === undefined || pages.length < size),
     error: normalizedError,
     loadMore,
+    retry,
   };
 }

--- a/packages/db/src/schema/tasks.ts
+++ b/packages/db/src/schema/tasks.ts
@@ -59,7 +59,12 @@ export const taskStatusConfigs = pgTable('task_status_configs', {
 
 /**
  * Task Items - Individual tasks within a task list
- * Each task has a linked DOCUMENT page (pageId, NOT NULL) which owns the title.
+ * Each task has a linked TASK_LIST page (pageId, NOT NULL) which owns the title. TASK_LIST, not
+ * DOCUMENT as this said until 2026-08: a task's linked page is itself a task list, which is the
+ * mechanism behind nesting — GET /api/pages/[pageId]/tasks selects children by
+ * `eq(pages.type, 'TASK_LIST')`, so calling it with a TASK's pageId returns that task's
+ * sub-tasks. Proven against a real database in
+ * apps/web/src/components/.../task-list/__tests__/useTaskSubTasks.integration.test.tsx.
  * Read titles from the linked page; do not store them on task_items.
  *
  * Assignment (legacy single-assignee fields kept for backward compatibility):

--- a/packages/db/src/schema/tasks.ts
+++ b/packages/db/src/schema/tasks.ts
@@ -63,8 +63,8 @@ export const taskStatusConfigs = pgTable('task_status_configs', {
  * DOCUMENT as this said until 2026-08: a task's linked page is itself a task list, which is the
  * mechanism behind nesting — GET /api/pages/[pageId]/tasks selects children by
  * `eq(pages.type, 'TASK_LIST')`, so calling it with a TASK's pageId returns that task's
- * sub-tasks. Proven against a real database in
- * apps/web/src/components/.../task-list/__tests__/useTaskSubTasks.integration.test.tsx.
+ * sub-tasks. Proven against a real database in apps/web/src/components/layout/middle-content/
+ * page-views/task-list/__tests__/useTaskSubTasks.integration.test.tsx.
  * Read titles from the linked page; do not store them on task_items.
  *
  * Assignment (legacy single-assignee fields kept for backward compatibility):

--- a/packages/lib/src/permissions/__tests__/page-viewers.integration.test.ts
+++ b/packages/lib/src/permissions/__tests__/page-viewers.integration.test.ts
@@ -20,12 +20,8 @@
  * which is the function the rest of the app asks. Each case below therefore
  * checks the membership set AND cross-checks it against the other direction.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { factories } from '@pagespace/db/test/factories';
-import { db } from '@pagespace/db/db';
-import { users } from '@pagespace/db/schema/auth';
-import { drives, pages } from '@pagespace/db/schema/core';
-import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
 import { getUsersWhoCanViewPage, getBatchPagePermissions } from '../permissions';
 
 /**
@@ -46,14 +42,23 @@ async function expectAgreesWithPerUserCheck(pageId: string, candidateIds: string
   return viewers;
 }
 
+/**
+ * No table-wide cleanup here, deliberately. This suite used to open every test with
+ * `db.delete(users)` and friends — unscoped deletes of pages, drives, drive_members and users.
+ *
+ * CI runs `turbo run test:coverage` without --concurrency=1, so @pagespace/lib and web execute
+ * against the SAME Postgres service at the same time. Those deletes therefore reach into other
+ * packages' suites and remove rows they are mid-test on: a web suite that had just seeded a user
+ * and was writing its activity log failed with
+ * `activity_logs_userId_users_id_fk`, and another lost its seeded messages
+ * ("expected [] to deeply equal ['keep me']"). The repo already learned this once — a TRUNCATE
+ * of `users` was scoped down for taking ACCESS EXCLUSIVE on shared tables and deleting other
+ * packages' fixtures; this reintroduced the same hazard with DELETE.
+ *
+ * Nothing here needs it: every test seeds its own users, drive and page, and every call passes
+ * an explicit candidate list, so leftover rows from any other suite cannot enter these results.
+ */
 describe('getUsersWhoCanViewPage (integration)', () => {
-  beforeEach(async () => {
-    await db.delete(pagePermissions);
-    await db.delete(pages);
-    await db.delete(driveMembers);
-    await db.delete(drives);
-    await db.delete(users);
-  });
 
   it('includes an accepted member of a non-private channel with no explicit grant', async () => {
     // The regression case: this user has no page_permissions row and is not an


### PR DESCRIPTION
## What

Expanding a task row listed `{n} sub-task(s)` as dead text above a 120px-clamped slice of the task's document. The count confirmed children existed and gave you no way to reach them — opening one meant navigating into the parent task and back out, on every level of a tree that nests arbitrarily deep.

The expansion now lists the sub-tasks, each a link straight to it, completed ones ticked and struck through, with paging for a long list.

This is the data layer for the Task Row Expansion epic (`oqgdjtbuc8mrs8bczxokj7f0`). Nested `<tr>` rendering, recursive expansion state, and the sub-tasks-vs-document branch are tasks 3/4/5 and are deliberately **not** here — the link list is the minimum honest consumer that makes the hook real rather than knip-dead.

**On epic constraint 1** ("render nested rows as sibling `<tr>`s, not inside the expansion cell"): this PR renders a `<ul>` *inside* the expansion cell, which is the shape that constraint rules out — for **task rows**. These are not task rows. They are links with a tick, carrying no columns to misalign, and they exist so the hook has a real consumer rather than a knip suppression. Task 3 replaces this list with sibling `<tr>`s in the same `<tbody>`; the column-alignment argument is exactly why it should own that, and why building half of it here would be the wrong kind of head start.

## No new endpoint — none was needed

Tasks **are** `TASK_LIST` pages. The tasks route selects children by `eq(pages.type, 'TASK_LIST')`, so calling that same route with a *task's* own pageId returns its sub-tasks already enriched: status, priority, assignees, dueDate, `activeTriggerCount`, `hasContent`, and each child's own `subTaskCount` — plus `statusConfigs` and `limit`/`offset`/`hasMore` paging.

The schema comment on `task_items` had said "linked DOCUMENT page" since before tasks could nest, which is why this read as a discovery rather than a fact. This PR proves it against a real database, so it also corrects that comment.

## The gate is the point

`GET /api/pages/[pageId]/tasks` is not a read. `getOrCreateTaskListForPage` lazily **INSERTs** a `task_lists` row plus 4 `task_status_configs` rows for any pageId it has not seen. Expanding 50 leaf tasks would create 50 task lists and 200 status-config rows — writes caused purely by looking.

`subTaskCount` is already on the row before the expansion opens, so refusing to fetch when it is 0 costs nothing and confines those writes to tasks that genuinely have children. Every revalidation trigger is off for the same reason: a refetch here is another run of that write path, not just another request.

**Known cost, accepted deliberately:** `subTaskCount` is computed by joining `task_items` to child pages, so a `TASK_LIST` child with no `task_items` row yet counts as zero — its parent reads as a leaf and will not expand, where an unguarded fetch would have healed it through the route's own `backfillMissingTaskItems`. The alternative is fetching for every leaf, which is exactly what this gate exists to prevent. Opening the task's own page still runs the backfill. Documented at the gate.

## Evidence

A test that mocks fetch and asserts "no request was made" cannot prove any of this — the write is server-side, so that assertion is the client's account of itself and cannot tell a working gate from a route that never wrote anything.

`useTaskSubTasks.integration.test.tsx` drives the real hook through the **real route handler** against **real Postgres** and counts rows:

- leaf task expanded → `task_lists: 0, status_configs: 0`, before and after
- ten leaf tasks at once (the 50-tasks/200-rows scenario in miniature) → zero rows
- a task that genuinely *has* children, mounted but collapsed via `enabled: false` → zero rows (the other door to the same hazard, and the one recursive expansion state will use)
- parent task → sub-tasks resolve from the existing route, **and** that GET lazily created `1` task list + `4` status configs — the positive control that makes every zero above mean something
- the sub-list's `statusConfigs` arrive as the default four slugs
- expand → collapse → expand → exactly one GET

It fails loudly (`requireDb`) rather than silently skipping when no database is reachable.

**Every behavioural claim is mutation-checked** — 13 mutations across the branch, each turning its own test red and green again on restore: the `subTaskCount` gate, the `enabled` flag, the `hasMore` term, the error term, the null-`pageId` guard, the empty-list explanation, the partial-failure wording, the retry label, the retry-vs-page-forward routing, the header count source, and the cache namespace.

## Review rounds

**CodeRabbit, round 1** — 3 fixed, 1 declined:
- Null `pageId` produced a dead `/dashboard/{driveId}/null` link. Fixed. (The route cannot currently return one — `task_items.pageId` is `notNull()` — but `TaskItem.pageId` is `string | null`, *wider than the column*, and the guard declines to rely on a constraint the type contradicts.)
- A failed fetch rendered an empty list under a header claiming "N sub-tasks", which reads as "there are none". Fixed, then generalised: the same lie was reachable when children are trashed between the parent response and the expansion.
- `isLoadingMore` latched on permanently once pages ended in `hasMore: false`. Fixed.
- **Declined:** exposing `mutate` and wiring it into `TaskListView`'s socket handlers. A sub-task's events fire against the *sub-list's* page, which nothing on this screen subscribes to — that needs task 4's expand/collapse lifecycle. Recorded on the task page so task 4 inherits it.

**CodeRabbit, round 2** — a failed *later* page left `hasMore` true and `pages` short, so `isLoadingMore` stayed true and disabled the retry control, under a message saying it had failed. Fixed. SWR's own 5-attempt background retry is now off: it fought every other setting here and made `error` a value that flickers on a timer, unrenderable honestly and untestable without racing it. Failure is terminal and visible, and the control relabels itself "Try again".

**Independent review pass** — three more, one serious:
- **Cache collision.** `TaskListView` pages the same route with the same page size, so its page-0 key for a list page is byte-identical to this hook's page-0 key for a task whose linked page *is* that page. Reachable by opening a task's own page, paging, then expanding that task from its parent list: both hooks share one `swr/infinite` entry, page count included, so the expansion mounts at the full-page view's size and that view's `refreshInterval` refetches a key this hook promises never to refetch. Keys are now namespaced; the URL is unchanged.
- `retry` is SWR's revalidate-all, so with pages loaded it re-issues all of them against a write-on-GET route. It is now used only when nothing loaded; a later failure pages forward, asking for the one missing page.
- "Never contradicts the count above it" was an overclaim — the header count revalidates and this list does not, so a sub-task added elsewhere left "4" over a list of 3, silently. The settled, complete list is now the header's source; while paging, the total still is.

## Gates

- `bun run typecheck` 17/17 · `bun run lint` 15/15 · knip 4 issues, all within baseline (no baseline entry added)
- task-list suites: **87 tests across 10 files**, including 6 real-Postgres integration cases
- `bun run test` (full monorepo): every failure diagnosed rather than assumed — 4 need `ADMIN_DATABASE_URL` (CI supplies it), 1 was a stale local schema (fixed by `db:migrate`, then passes), 3 are the local non-UTC Postgres session (**proven**: all pass with `?options=-c timezone=UTC`), 1 is a socket-hangup flake that passes in isolation. None touch this diff.

Changelog updated under `[Unreleased] → Changed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanding a task now displays its linked sub-tasks with completion indicators.
  * Added pagination with a “Load more” option for tasks with many sub-tasks.
  * Sub-tasks link to their task-list pages when available.
  * Added retry and clear loading, empty, and error states.

* **Bug Fixes**
  * Tasks without sub-tasks no longer trigger unnecessary loading.
  * Sub-task counts update after all results are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->