### PR TITLE
feat(tags): tag vocabulary core — Unicode-safe names and the page-type target registry (Content Tags phase 1)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -496,6 +496,7 @@
         "src/services/validated-service-token.ts",
         "src/sheets/io.ts",
         "src/sheets/sheet.ts",
+        "src/tags/tag-core.ts",
         "src/types.ts",
         "src/utils/api-utils.ts",
         "src/utils/enums.ts",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -992,6 +992,11 @@
       "import": "./dist/sheets/sheet.js",
       "require": "./dist/sheets/sheet.js"
     },
+    "./tags/tag-core": {
+      "types": "./dist/tags/tag-core.d.ts",
+      "import": "./dist/tags/tag-core.js",
+      "require": "./dist/tags/tag-core.js"
+    },
     "./utils/environment": {
       "types": "./dist/utils/environment.d.ts",
       "import": "./dist/utils/environment.js",
@@ -2305,6 +2310,9 @@
       ],
       "sheets/sheet": [
         "./dist/sheets/sheet.d.ts"
+      ],
+      "tags/tag-core": [
+        "./dist/tags/tag-core.d.ts"
       ],
       "utils/environment": [
         "./dist/utils/environment.d.ts"

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -496,6 +496,33 @@ describe('validateTarget', () => {
     ).toMatchObject({ reason: 'payload_mismatch', kind: 'sheet_cell' });
   });
 
+  it('refuses an unknown page type instead of throwing', () => {
+    // The signature is a compile-time promise only. MACHINE is the concrete
+    // case: it is still a value in the DB's PageType enum, deleted from the TS
+    // enum in the Phase 8 teardown because Postgres cannot DROP VALUE — so a
+    // pages.type this function is typed to never see can arrive from a row.
+    const unknown = 'MACHINE' as PageTypeValue;
+    expect(validateTarget(unknown, { kind: 'page' })).toEqual({
+      ok: false,
+      reason: 'unknown_page_type',
+      pageType: 'MACHINE',
+    });
+  });
+
+  it('refuses an inherited Object property rather than treating it as a registry entry', () => {
+    // A bare index reaches the prototype: TAG_TARGETS['constructor'] is a
+    // function, not undefined, so a falsy guard would wave it through and the
+    // membership test would throw. Same shape as the &__proto__; entity bug in
+    // Phase 0 — hence the Set.
+    for (const inherited of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+      expect(validateTarget(inherited as PageTypeValue, { kind: 'page' })).toEqual({
+        ok: false,
+        reason: 'unknown_page_type',
+        pageType: inherited,
+      });
+    }
+  });
+
   it('checks the page type before the payload', () => {
     // An empty id on a page type that rejects the kind outright reports the
     // rejection the user can act on, not the one they cannot.

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -1,0 +1,576 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { PAGE_TYPE_VALUES, type PageTypeValue } from '../../utils/enums';
+import { PAGE_TYPE_CONFIGS } from '../../content/page-types.config';
+import type { SheetCellAnchor, TextAnchor } from '../../content/anchoring/types';
+import {
+  MAX_RAW_TAG_INPUT,
+  MAX_TAG_NAME_LENGTH,
+  TAG_TARGETS,
+  type TagTarget,
+  type TargetKind,
+  normalizeTagName,
+  tagKey,
+  validateTarget,
+} from '../tag-core';
+
+/**
+ * Fixtures are built from code points rather than pasted literals. Half of what
+ * this module does is police invisible characters, and a literal one in a test
+ * is invisible in a diff too — you cannot review what you cannot see, and a
+ * stray copy-paste would silently change what the test asserts.
+ */
+const U = (...codePoints: number[]): string => String.fromCodePoint(...codePoints);
+
+const ZWSP = U(0x200b);
+const ZWNJ = U(0x200c);
+const ZWJ = U(0x200d);
+const RLO = U(0x202e);
+const SHY = U(0x00ad);
+const BOM = U(0xfeff);
+const NBSP = U(0x00a0);
+const EM_SPACE = U(0x2003);
+const IDEOGRAPHIC_SPACE = U(0x3000);
+const OGHAM_SPACE = U(0x1680);
+const COMBINING_ACUTE = U(0x0301);
+const E_ACUTE = U(0x00e9);
+const FAMILY = U(0x1f468) + ZWJ + U(0x1f469) + ZWJ + U(0x1f467);
+
+function expectOk(raw: string): { name: string; key: string } {
+  const result = normalizeTagName(raw);
+  expect(result.ok, `expected ${JSON.stringify(raw)} to normalize`).toBe(true);
+  if (!result.ok) {
+    throw new Error('unreachable');
+  }
+  return { name: result.name, key: result.key };
+}
+
+describe('normalizeTagName — the dedupe contract', () => {
+  it('collapses casing to one key while preserving each writer’s name', () => {
+    const upper = expectOk('CAF' + U(0x00c9));
+    const title = expectOk('Caf' + E_ACUTE);
+    const lower = expectOk('caf' + E_ACUTE);
+
+    expect(new Set([upper.key, title.key, lower.key]).size).toBe(1);
+    expect(upper.key).toBe('caf' + E_ACUTE);
+    // First writer's casing wins, so the names must NOT have been folded.
+    expect(new Set([upper.name, title.name, lower.name]).size).toBe(3);
+  });
+
+  it('makes a decomposed name byte-identical to its precomposed twin', () => {
+    // Both paths must agree, or two visually identical tags become two rows and
+    // Postgres compares them as different strings.
+    const composed = expectOk('caf' + E_ACUTE);
+    const decomposed = expectOk('cafe' + COMBINING_ACUTE);
+
+    expect(decomposed.name).toBe(composed.name);
+    expect(decomposed.key).toBe(composed.key);
+  });
+
+  it('keeps non-Latin scripts and emoji intact — the case slugify destroys', () => {
+    expect(expectOk(U(0x65e5, 0x672c, 0x8a9e)).name).toBe(U(0x65e5, 0x672c, 0x8a9e));
+    expect(expectOk(U(0x1f525)).name).toBe(U(0x1f525));
+    expect(expectOk('Ünder').name).toBe('Ünder');
+  });
+});
+
+describe('normalizeTagName — NFC for the name, NFKC for the key', () => {
+  it('folds compatibility variants in the key so lookalikes are one tag', () => {
+    expect(expectOk(U(0xff26, 0xff55, 0xff4c, 0xff4c)).key).toBe('full');
+    expect(expectOk(U(0xfb01) + 'ction').key).toBe('fiction');
+    expect(expectOk(U(0x2460)).key).toBe('1');
+    // A mathematical-script duplicate of an existing tag resolves to it.
+    expect(expectOk(U(0x1d436, 0x1d698, 0x1d698, 0x1d695)).key).toBe('cool');
+  });
+
+  it('does NOT fold them in the name, because NFKC is lossy for display', () => {
+    // Each of these would silently rewrite what the user typed.
+    expect(expectOk(U(0x33a1)).name).toBe(U(0x33a1));
+    expect(expectOk(U(0x33a1)).key).toBe('m2');
+    expect(expectOk('x' + U(0x00b2)).name).toBe('x' + U(0x00b2));
+    expect(expectOk('x' + U(0x00b2)).key).toBe('x2');
+    expect(expectOk(U(0xff26, 0xff55, 0xff4c, 0xff4c)).name).toBe(U(0xff26, 0xff55, 0xff4c, 0xff4c));
+  });
+
+  it('normalizes before folding, or the key comes out uppercase', () => {
+    // Lowercasing the TELEPHONE SIGN is a no-op; NFKC then yields 'TEL'. Only
+    // NFKC-then-fold gives a usable key, so this pins the order.
+    expect(expectOk(U(0x2121)).key).toBe('tel');
+  });
+
+  it('an acute accent decomposes to a space plus a combining mark under NFKC', () => {
+    // The name keeps the character the user typed; the key trims the injected
+    // leading space rather than storing one.
+    const acute = expectOk(U(0x00b4));
+    expect(acute.name).toBe(U(0x00b4));
+    expect(acute.key).toBe(COMBINING_ACUTE);
+  });
+});
+
+describe('normalizeTagName — case folding limits, documented not hidden', () => {
+  it('folds the Greek final sigma so one word is one tag', () => {
+    // Without the patch, uppercase Greek lowercases to a FINAL sigma and a user
+    // typing the medial form gets a second tag for the same word.
+    const upper = expectOk(U(0x39f, 0x394, 0x39f, 0x3a3));
+    const medial = expectOk(U(0x3bf, 0x3b4, 0x3bf, 0x3c3));
+
+    expect(upper.key).toBe(medial.key);
+    expect(upper.key).not.toContain(U(0x3c2));
+  });
+
+  it('does NOT fold sharp s against a doubled S — deliberate, not an oversight', () => {
+    // Folding these would also merge two different German words, so the split
+    // is the more correct behaviour. Pinned so nobody "fixes" it.
+    expect(expectOk('Stra' + U(0x00df) + 'e').key).not.toBe(expectOk('STRASSE').key);
+    // The capital sharp s does fold, because toLowerCase handles it.
+    expect(expectOk('STRA' + U(0x1e9e) + 'E').key).toBe(expectOk('Stra' + U(0x00df) + 'e').key);
+  });
+
+  it('does NOT fold the Turkish dotted I — matches Unicode default folding', () => {
+    expect(expectOk(U(0x0130) + 'STANBUL').key).not.toBe(expectOk('istanbul').key);
+  });
+
+  it('folds digraphs and ligatures that only NFKC can reach', () => {
+    expect(expectOk(U(0x01c4)).key).toBe(expectOk(U(0x01c6)).key);
+    expect(expectOk(U(0xfb00)).key).toBe(expectOk('ff').key);
+    expect(expectOk(U(0x13a0)).key).toBe(expectOk(U(0xab70)).key);
+  });
+
+  it('keys the letter I the same way on every host', () => {
+    // The test that fails if anyone reaches for toLocaleLowerCase: on a Turkish
+    // machine that would key 'IT' as a dotless i and miss the row it should
+    // dedupe against.
+    expect(expectOk('IT').key).toBe('it');
+  });
+});
+
+describe('normalizeTagName — invisible characters', () => {
+  it('strips the ones that are pure noise or pure spoofing', () => {
+    expect(expectOk('a' + ZWSP + 'b').name).toBe('ab');
+    expect(expectOk(SHY + 'tag').name).toBe('tag');
+    expect(expectOk(BOM + 'tag').name).toBe('tag');
+    expect(expectOk(RLO + 'evil').name).toBe('evil');
+    expect(expectOk('a' + U(0x200e) + 'b').name).toBe('ab');
+  });
+
+  it('strips before normalizing, so a split accent still composes', () => {
+    // Leave the ZWSP in place and NFC cannot join the two halves.
+    expect(expectOk('a' + ZWSP + COMBINING_ACUTE).name).toBe(U(0x00e1));
+  });
+
+  it('KEEPS the joiners, which are meaning rather than noise', () => {
+    // Stripping ZWJ turns one family into three separate people.
+    const family = expectOk(FAMILY);
+    expect(family.name).toBe(FAMILY);
+    expect([...family.name]).toHaveLength(5);
+
+    // ZWNJ is required orthography in Persian; the two spellings are different
+    // words, so they are deliberately two tags.
+    const withZwnj = expectOk(U(0x0645, 0x06cc) + ZWNJ + U(0x0631, 0x0648, 0x062f));
+    const without = expectOk(U(0x0645, 0x06cc, 0x0631, 0x0648, 0x062f));
+    expect(withZwnj.name).toContain(ZWNJ);
+    expect(withZwnj.key).not.toBe(without.key);
+  });
+
+  it('keeps a variation selector, which decides emoji versus text presentation', () => {
+    expect(expectOk(U(0x2764) + U(0xfe0f)).name).toBe(U(0x2764) + U(0xfe0f));
+  });
+
+  it('rejects a name made only of strippable invisibles', () => {
+    expect(normalizeTagName(ZWSP + BOM + SHY)).toEqual({ ok: false, reason: 'empty' });
+  });
+});
+
+describe('normalizeTagName — whitespace', () => {
+  it('collapses runs to one space and trims the ends', () => {
+    expect(expectOk('  Design   System  ').name).toBe('Design System');
+    expect(expectOk('a\nb').name).toBe('a b');
+    expect(expectOk('a\tb').name).toBe('a b');
+  });
+
+  it('collapses the Unicode spaces too, unlike the Phase 0 projection set', () => {
+    // A tag name is an identifier a human retypes, so invisible variation in
+    // the middle of one is a defect. text-projection.ts deliberately does the
+    // opposite for prose, where those characters are content.
+    for (const space of [NBSP, EM_SPACE, IDEOGRAPHIC_SPACE, OGHAM_SPACE, U(0x202f)]) {
+      expect(expectOk('a' + space + 'b').name).toBe('a b');
+    }
+  });
+
+  it('keeps the name and key paths agreeing about what a space is', () => {
+    // If they disagreed, a name could survive that the key trims to empty —
+    // and an empty key is a row that collides with nothing under the unique
+    // index it is about to be stored in.
+    for (const space of [NBSP, EM_SPACE, IDEOGRAPHIC_SPACE, OGHAM_SPACE]) {
+      const spaced = expectOk('a' + space + 'b');
+      expect(spaced.key).toBe('a b');
+      expect(normalizeTagName(space)).toEqual({ ok: false, reason: 'empty' });
+    }
+  });
+
+  it('rejects blank input', () => {
+    expect(normalizeTagName('')).toEqual({ ok: false, reason: 'empty' });
+    expect(normalizeTagName('   ')).toEqual({ ok: false, reason: 'empty' });
+  });
+});
+
+describe('normalizeTagName — characters that cannot be stored at all', () => {
+  it('rejects NUL and the other controls rather than stripping them', () => {
+    // Postgres refuses NUL in a text column outright, so stripping would mean
+    // this core says "fine" and the INSERT fails later.
+    expect(normalizeTagName('a' + U(0) + 'b')).toEqual({
+      ok: false,
+      reason: 'control_character',
+      codePoint: 0,
+      index: 1,
+    });
+    expect(normalizeTagName('a' + U(0x07) + 'b')).toMatchObject({ reason: 'control_character' });
+    expect(normalizeTagName('a' + U(0x7f) + 'b')).toMatchObject({ reason: 'control_character' });
+    expect(normalizeTagName('a' + U(0x9f) + 'b')).toMatchObject({ reason: 'control_character' });
+  });
+
+  it('splits the whole control range into collapse-or-reject with no gaps', () => {
+    // The collapsible controls are named twice in the module — once as code
+    // points, once inside the whitespace regex — so this walks every C0/C1
+    // code point and asserts the two agree. Any drift between them shows up
+    // here rather than as a tag that mysteriously will not save.
+    const COLLAPSIBLE = new Set([0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x85]);
+    const controls = [
+      ...Array.from({ length: 0x20 }, (_unused, cp) => cp),
+      ...Array.from({ length: 0x21 }, (_unused, offset) => 0x7f + offset),
+    ];
+
+    for (const cp of controls) {
+      const result = normalizeTagName('a' + U(cp) + 'b');
+      if (COLLAPSIBLE.has(cp)) {
+        expect(result, `U+${cp.toString(16)} should collapse`).toMatchObject({
+          ok: true,
+          name: 'a b',
+        });
+      } else {
+        expect(result, `U+${cp.toString(16)} should be refused`).toMatchObject({
+          reason: 'control_character',
+          codePoint: cp,
+        });
+      }
+    }
+  });
+
+  it('rejects a lone surrogate, which is not encodable as UTF-8', () => {
+    expect(normalizeTagName('a' + String.fromCharCode(0xd800) + 'b')).toEqual({
+      ok: false,
+      reason: 'unpaired_surrogate',
+      index: 1,
+    });
+    expect(normalizeTagName('a' + String.fromCharCode(0xdc00))).toEqual({
+      ok: false,
+      reason: 'unpaired_surrogate',
+      index: 1,
+    });
+    // A high surrogate at the very END of the input has no following unit at
+    // all, which is a different code path from one followed by a non-surrogate.
+    expect(normalizeTagName('a' + String.fromCharCode(0xd800))).toEqual({
+      ok: false,
+      reason: 'unpaired_surrogate',
+      index: 1,
+    });
+    // A well-formed pair is not a lone surrogate and must survive.
+    expect(expectOk(U(0x1f600)).name).toBe(U(0x1f600));
+  });
+
+  it('rejects noncharacters, in both the BMP and the astral planes', () => {
+    expect(normalizeTagName('a' + U(0xfffe) + 'b')).toMatchObject({ reason: 'noncharacter' });
+    expect(normalizeTagName('a' + U(0xfdd0) + 'b')).toMatchObject({ reason: 'noncharacter' });
+    expect(normalizeTagName('a' + U(0x1fffe) + 'b')).toMatchObject({ reason: 'noncharacter' });
+  });
+
+  it('reports the first offence in order, so the reason is deterministic', () => {
+    const both = normalizeTagName('a' + U(0) + String.fromCharCode(0xd800));
+    expect(both).toEqual({ ok: false, reason: 'control_character', codePoint: 0, index: 1 });
+  });
+});
+
+describe('normalizeTagName — length', () => {
+  it('measures code points, so no script is charged more than another', () => {
+    expect(expectOk('x'.repeat(MAX_TAG_NAME_LENGTH)).name).toHaveLength(MAX_TAG_NAME_LENGTH);
+    expect(expectOk(U(0x65e5).repeat(MAX_TAG_NAME_LENGTH)).name).toBeTruthy();
+    expect(normalizeTagName('x'.repeat(MAX_TAG_NAME_LENGTH + 1))).toEqual({
+      ok: false,
+      reason: 'too_long',
+      length: MAX_TAG_NAME_LENGTH + 1,
+      max: MAX_TAG_NAME_LENGTH,
+    });
+  });
+
+  it('counts an astral character once, not twice', () => {
+    // Guards against a regression to string.length: 64 emoji are 128 UTF-16
+    // units and would be rejected under the wrong unit.
+    expect(expectOk(U(0x1f600).repeat(MAX_TAG_NAME_LENGTH)).name).toBeTruthy();
+  });
+
+  it('measures after normalization, so a decomposed name is not penalised', () => {
+    // 64 decomposed accents are 128 code points raw and 64 once composed.
+    expect(expectOk(('e' + COMBINING_ACUTE).repeat(MAX_TAG_NAME_LENGTH)).name).toHaveLength(
+      MAX_TAG_NAME_LENGTH
+    );
+  });
+
+  it('guards the raw input before doing any Unicode work', () => {
+    const huge = 'x'.repeat(MAX_RAW_TAG_INPUT + 1);
+    expect(normalizeTagName(huge)).toEqual({
+      ok: false,
+      reason: 'input_too_large',
+      length: MAX_RAW_TAG_INPUT + 1,
+    });
+    // A whole document must be refused cheaply rather than normalized first.
+    expect(normalizeTagName('x'.repeat(500_000))).toMatchObject({ reason: 'input_too_large' });
+  });
+});
+
+describe('tagKey and idempotency', () => {
+  const CORPUS = [
+    'Caf' + E_ACUTE,
+    'cafe' + COMBINING_ACUTE,
+    '  Design   System  ',
+    U(0x65e5, 0x672c, 0x8a9e),
+    U(0xff26, 0xff55, 0xff4c, 0xff4c),
+    U(0x2121),
+    U(0x33a1),
+    U(0x39f, 0x394, 0x39f, 0x3a3),
+    'a' + ZWSP + 'b',
+    FAMILY,
+    'a' + IDEOGRAPHIC_SPACE + 'b',
+    U(0x00b4),
+    U(0xfdfa),
+    'H' + U(0x0331),
+  ];
+
+  it('is the key of the name, so a backfill can recompute it from storage', () => {
+    for (const raw of CORPUS) {
+      const { name, key } = expectOk(raw);
+      expect(tagKey(name), `tagKey mismatch for ${JSON.stringify(raw)}`).toBe(key);
+    }
+  });
+
+  it('is idempotent — re-normalizing a name changes nothing', () => {
+    for (const raw of CORPUS) {
+      const first = expectOk(raw);
+      const second = expectOk(first.name);
+      expect(second.name, `not idempotent for ${JSON.stringify(raw)}`).toBe(first.name);
+      expect(second.key).toBe(first.key);
+    }
+  });
+
+  it('is idempotent for the cases that catch a reordering refactor', () => {
+    // Collapse-before-normalize would leave two spaces here on the first pass
+    // and one on the second.
+    const doubled = expectOk('a' + IDEOGRAPHIC_SPACE + IDEOGRAPHIC_SPACE + 'b');
+    expect(doubled.name).toBe('a b');
+    expect(expectOk(doubled.name).name).toBe('a b');
+
+    // Fold-before-NFKC would produce an uppercase key on the first pass.
+    expect(tagKey(tagKey(U(0x2121)))).toBe(tagKey(U(0x2121)));
+  });
+
+  it('re-normalizes after folding, or a composed lowercase form splits the tag', () => {
+    // toLowerCase does not promise to preserve normal form. 'H' followed by a
+    // combining macron below lowercases to the DECOMPOSED pair h + U+0331,
+    // whereas the same word typed in lowercase is composed to U+1E96 by NFC on
+    // the name path. Without a second NFKC after the fold those are two
+    // different keys for one word — a silent duplicate tag.
+    const MACRON_BELOW = U(0x0331);
+    const upper = expectOk('H' + MACRON_BELOW);
+    const lower = expectOk('h' + MACRON_BELOW);
+
+    expect(upper.key).toBe(lower.key);
+    expect(upper.key).toBe(U(0x1e96));
+  });
+
+  it('produces a key that is itself NFKC-stable', () => {
+    for (const raw of CORPUS) {
+      const { key } = expectOk(raw);
+      expect(key.normalize('NFKC')).toBe(key);
+    }
+  });
+});
+
+describe('TAG_TARGETS', () => {
+  it('covers exactly the live page types', () => {
+    expect(Object.keys(TAG_TARGETS).sort()).toEqual([...PAGE_TYPE_VALUES].sort());
+  });
+
+  it('lets every page type carry a page-level tag', () => {
+    for (const pageType of PAGE_TYPE_VALUES) {
+      expect(TAG_TARGETS[pageType], pageType).toContain('page');
+    }
+  });
+
+  it('grants an anchored kind exactly where the version chain exists', () => {
+    // Forward-porting is the primary anchoring mechanism and it needs
+    // page_versions rows, so a page type that cannot version cannot carry an
+    // anchored tag. Ties this registry to PAGE_TYPE_CONFIGS so the two cannot
+    // drift apart silently.
+    for (const pageType of PAGE_TYPE_VALUES) {
+      const kinds: readonly TargetKind[] = TAG_TARGETS[pageType];
+      const anchored = kinds.includes('text') || kinds.includes('sheet_cell');
+      expect(anchored, pageType).toBe(PAGE_TYPE_CONFIGS[pageType].capabilities.supportsVersioning);
+    }
+  });
+
+  it('gives each page type at most one content-level kind', () => {
+    for (const pageType of PAGE_TYPE_VALUES) {
+      const kinds: readonly TargetKind[] = TAG_TARGETS[pageType];
+      expect(kinds.filter((kind) => kind !== 'page').length, pageType).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('routes the row-identified kinds to the page types that own those rows', () => {
+    expect(TAG_TARGETS.CHANNEL).toContain('channel_message');
+    expect(TAG_TARGETS.AI_CHAT).toContain('ai_message');
+    expect(TAG_TARGETS.SHEET).toContain('sheet_cell');
+    // A task IS a page, so TASK_LIST needs no kind of its own.
+    expect(TAG_TARGETS.TASK_LIST).toEqual(['page']);
+  });
+});
+
+describe('validateTarget', () => {
+  const anchor: TextAnchor = {
+    v: 1,
+    exact: 'quoted',
+    prefix: '',
+    suffix: '',
+    start: 0,
+    end: 6,
+    revision: 1,
+    textHash: 'deadbeefdeadbeef',
+  };
+  const cell: SheetCellAnchor = { v: 1, sheet: 'Sheet1', address: 'A1' };
+
+  const sample = (kind: TargetKind): TagTarget => {
+    switch (kind) {
+      case 'page':
+        return { kind: 'page' };
+      case 'text':
+        return { kind: 'text', anchor };
+      case 'sheet_cell':
+        return { kind: 'sheet_cell', anchor: cell };
+      case 'channel_message':
+        return { kind: 'channel_message', channelMessageId: 'cm_1' };
+      case 'ai_message':
+        return { kind: 'ai_message', aiMessageId: 'am_1' };
+    }
+  };
+
+  const ALL_KINDS: readonly TargetKind[] = [
+    'page',
+    'text',
+    'sheet_cell',
+    'channel_message',
+    'ai_message',
+  ];
+
+  it('accepts exactly the pairs TAG_TARGETS allows, across all 45 combinations', () => {
+    for (const pageType of PAGE_TYPE_VALUES) {
+      for (const kind of ALL_KINDS) {
+        const allowed: readonly TargetKind[] = TAG_TARGETS[pageType];
+        const result = validateTarget(pageType, sample(kind));
+        expect(result.ok, `${pageType} + ${kind}`).toBe(allowed.includes(kind));
+        if (!result.ok) {
+          expect(result).toEqual({ ok: false, reason: 'kind_not_allowed', pageType, kind });
+        }
+      }
+    }
+  });
+
+  it('rejects a payload that does not match the kind it claims', () => {
+    expect(validateTarget('CHANNEL', { kind: 'channel_message', channelMessageId: '' })).toMatchObject(
+      { reason: 'payload_mismatch', kind: 'channel_message' }
+    );
+    expect(validateTarget('AI_CHAT', { kind: 'ai_message', aiMessageId: '' })).toMatchObject({
+      reason: 'payload_mismatch',
+      kind: 'ai_message',
+    });
+    expect(
+      validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: '' } })
+    ).toMatchObject({ reason: 'payload_mismatch', kind: 'sheet_cell' });
+  });
+
+  it('checks the page type before the payload', () => {
+    // An empty id on a page type that rejects the kind outright reports the
+    // rejection the user can act on, not the one they cannot.
+    expect(validateTarget('FOLDER', { kind: 'channel_message', channelMessageId: '' })).toMatchObject(
+      { reason: 'kind_not_allowed' }
+    );
+  });
+});
+
+/**
+ * The hazards in this module are lexical — a locale-aware fold, an ICU-backed
+ * API, a Unicode property escape — so they are asserted over the source text,
+ * mirroring content/anchoring/__tests__/purity.test.ts.
+ */
+describe('tag-core purity and determinism', () => {
+  const src = readFileSync(fileURLToPath(new URL('../tag-core.ts', import.meta.url)), 'utf8');
+
+  /**
+   * Comments stripped: these bans are on CODE. The module documents at length
+   * why it does not call toLocaleLowerCase, and prose explaining a prohibition
+   * must not trip it — otherwise the only way to keep the test green is to stop
+   * writing down the reason, which is the opposite of what we want.
+   */
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+  it('does no I/O and reads no ambient state', () => {
+    expect(src).not.toMatch(/from ['"][^'"]*\/db['"]/);
+    expect(src).not.toMatch(/\bfetch\(/);
+    expect(src).not.toMatch(/process\.env/);
+    expect(src).not.toMatch(/Date\.now/);
+    expect(src).not.toMatch(/new Date\(/);
+    expect(src).not.toMatch(/Math\.random/);
+    expect(src).not.toMatch(/\brequire\(/);
+    expect(src).not.toMatch(/\bwindow\./);
+    expect(src).not.toMatch(/\bglobalThis\./);
+  });
+
+  it('imports nothing outside this package', () => {
+    const specifiers = [...code.matchAll(/^import[^'"]*from ['"]([^'"]+)['"];?$/gm)].map((m) => m[1]);
+    expect(specifiers.length).toBeGreaterThan(0);
+    for (const specifier of specifiers) {
+      expect(specifier.startsWith('.'), `unexpected import: ${specifier}`).toBe(true);
+    }
+  });
+
+  it('never reaches for a locale-dependent or ICU-versioned API', () => {
+    // toLocaleLowerCase keys 'IT' differently on a Turkish host. Intl.Segmenter
+    // would make a length depend on the runtime's ICU build. A Unicode property
+    // escape moves as new code points are assigned. All three would break the
+    // rule that this must produce identical output on server and client.
+    expect(code).not.toMatch(/toLocaleLowerCase/);
+    expect(code).not.toMatch(/toLocaleUpperCase/);
+    expect(code).not.toMatch(/\bIntl\./);
+    expect(code).not.toMatch(/\\p\{/);
+  });
+
+  it('keeps both normal forms, so a simplification cannot unify them', () => {
+    expect(code).toMatch(/normalize\('NFC'\)/);
+    expect(code).toMatch(/normalize\('NFKC'\)/);
+  });
+
+  it('writes every invisible character as an escape rather than a literal', () => {
+    // A literal invisible in this file would be unreviewable in a diff — the
+    // exact property the module exists to prevent in tag names.
+    const literals = [...src].filter((char) => {
+      const cp = char.codePointAt(0) ?? 0;
+      return (
+        (cp < 0x20 && char !== '\n') ||
+        cp === 0x7f ||
+        cp === 0x00ad ||
+        cp === 0x200b ||
+        cp === 0xfeff ||
+        (cp >= 0x202a && cp <= 0x202e)
+      );
+    });
+    expect(literals).toEqual([]);
+  });
+});

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -173,6 +173,51 @@ describe('normalizeTagName — invisible characters', () => {
     }
   });
 
+  it('accounts for EVERY default-ignorable code point, not the ones I remembered', () => {
+    // Three review rounds each found a different missing code point (U+2060,
+    // U+E0001, and the deprecated format block), which is the signature of a
+    // list maintained by memory. So this sweeps the whole class and fails on
+    // anything unaccounted for: strip it, or justify keeping it here.
+    //
+    // The module itself may not use a Unicode property escape — its output has
+    // to be identical on every runtime, and property membership tracks the
+    // engine's ICU build. A TEST may, and should: if a future runtime knows
+    // about ignorables this build does not, that is a new dedupe hole, and a
+    // loud CI failure is exactly how one would want to hear about it.
+    const KEPT_ON_PURPOSE = (cp: number): boolean =>
+      cp === 0x200c || // ZWNJ — required orthography in Persian and Indic scripts
+      cp === 0x200d || // ZWJ — joins the family emoji into one glyph
+      (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
+      (cp >= 0xe0100 && cp <= 0xe01ef) || // variation selectors supplement
+      (cp >= 0x180b && cp <= 0x180d) || // Mongolian free variation selectors
+      cp === 0x180f ||
+      (cp >= 0xe0020 && cp <= 0xe007f) || // tag characters — subdivision flags
+      // Blank renderers: kept here, refused as a whole name by NOTHING_VISIBLE.
+      cp === 0x115f ||
+      cp === 0x1160 ||
+      cp === 0x3164 ||
+      cp === 0xffa0;
+
+    const ignorable = /\p{Default_Ignorable_Code_Point}/u;
+    const leaked: string[] = [];
+
+    for (let cp = 0; cp < 0x110000; cp += 1) {
+      if (cp >= 0xd800 && cp <= 0xdfff) {
+        continue;
+      }
+      const char = U(cp);
+      if (!ignorable.test(char) || KEPT_ON_PURPOSE(cp)) {
+        continue;
+      }
+      const result = normalizeTagName('a' + char + 'b');
+      if (result.ok && result.name !== 'ab') {
+        leaked.push(`U+${cp.toString(16).toUpperCase()}`);
+      }
+    }
+
+    expect(leaked).toEqual([]);
+  });
+
   it('refuses a name that renders as nothing, however many code points it has', () => {
     // Neither stripped nor collapsed, and each a different code point — so
     // several distinct blank tags could coexist, and nobody could retype,

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -6,6 +6,7 @@ import { PAGE_TYPE_CONFIGS } from '../../content/page-types.config';
 import type { SheetCellAnchor, TextAnchor } from '../../content/anchoring/types';
 import {
   MAX_RAW_TAG_INPUT,
+  MAX_TAG_KEY_LENGTH,
   MAX_TAG_NAME_LENGTH,
   TAG_TARGETS,
   type TagTarget,
@@ -157,6 +158,34 @@ describe('normalizeTagName — invisible characters', () => {
   it('strips before normalizing, so a split accent still composes', () => {
     // Leave the ZWSP in place and NFC cannot join the two halves.
     expect(expectOk('a' + ZWSP + COMBINING_ACUTE).name).toBe(U(0x00e1));
+  });
+
+  it('strips the whole non-orthographic family, not just the famous members', () => {
+    // WORD JOINER is the modern replacement for U+FEFF-as-ZWNBSP: stripping one
+    // and not the other leaves the identical hole under a different code point.
+    // Anyone could mint a second `design` tag that renders the same in every
+    // chip, and Phase 2 is about to bake that key into a unique index.
+    expect(expectOk('de' + U(0x2060) + 'sign').key).toBe(expectOk('design').key);
+
+    for (const cp of [0x2060, 0x2061, 0x2064, 0x034f, 0x180e, 0xfff9, 0x1d173]) {
+      expect(expectOk('a' + U(cp) + 'b').name, `U+${cp.toString(16)}`).toBe('ab');
+    }
+  });
+
+  it('refuses a name that renders as nothing, however many code points it has', () => {
+    // Neither stripped nor collapsed, and each a different code point — so
+    // several distinct blank tags could coexist, and nobody could retype,
+    // search for, or tell them apart. The Hangul fillers and the Braille blank
+    // are the classic version of this trick.
+    for (const cp of [0x200c, 0x200d, 0xfe0f, 0xfe0e, 0xe0100, 0xe01ef, 0x3164, 0x2800, 0x115f, 0x1160, 0xffa0, 0xe0061]) {
+      expect(normalizeTagName(U(cp)), `U+${cp.toString(16)}`).toEqual({
+        ok: false,
+        reason: 'empty',
+      });
+    }
+    // One visible character is enough to make it a name again.
+    expect(expectOk('a' + U(0x200d) + 'b').name).toBe('a' + U(0x200d) + 'b');
+    expect(expectOk(U(0x2800) + 'x').name).toBe(U(0x2800) + 'x');
   });
 
   it('KEEPS the joiners, which are meaning rather than noise', () => {
@@ -314,6 +343,35 @@ describe('normalizeTagName — length', () => {
     expect(expectOk(('e' + COMBINING_ACUTE).repeat(MAX_TAG_NAME_LENGTH)).name).toHaveLength(
       MAX_TAG_NAME_LENGTH
     );
+  });
+
+  it('publishes the real key ceiling, which is not the name ceiling', () => {
+    // NFKC expands. Measured exhaustively over all 1.1M code points, the worst
+    // single character is U+FDFA at 18, so a 64-code-point name can key to
+    // 1152. Phase 2 sizes normalizedKey from this constant; the obvious
+    // varchar(64) mirroring the name limit would reject a legal tag at INSERT.
+    const worst = expectOk(U(0xfdfa).repeat(MAX_TAG_NAME_LENGTH));
+    expect([...worst.name]).toHaveLength(MAX_TAG_NAME_LENGTH);
+    expect([...worst.key]).toHaveLength(MAX_TAG_KEY_LENGTH);
+    expect(MAX_TAG_KEY_LENGTH).toBeGreaterThan(MAX_TAG_NAME_LENGTH);
+    // And it must still fit a btree index tuple, which caps around 2704 bytes.
+    expect(new TextEncoder().encode(worst.key).length).toBeLessThan(2704);
+  });
+
+  it('never produces a key longer than the published ceiling', () => {
+    const samples = [
+      'x'.repeat(MAX_TAG_NAME_LENGTH),
+      U(0xfdfa).repeat(MAX_TAG_NAME_LENGTH),
+      U(0x2121).repeat(MAX_TAG_NAME_LENGTH),
+      U(0x33a1).repeat(MAX_TAG_NAME_LENGTH),
+      U(0x1f600).repeat(MAX_TAG_NAME_LENGTH),
+    ];
+    for (const sample of samples) {
+      const { key } = expectOk(sample);
+      expect([...key].length, JSON.stringify(sample.slice(0, 8))).toBeLessThanOrEqual(
+        MAX_TAG_KEY_LENGTH
+      );
+    }
   });
 
   it('guards the raw input before doing any Unicode work', () => {
@@ -491,9 +549,20 @@ describe('validateTarget', () => {
       reason: 'payload_mismatch',
       kind: 'ai_message',
     });
+    // Both halves of the (sheet name, A1 address) natural key, and the address
+    // has to be an actual A1 reference — merely non-empty still points nowhere.
     expect(
       validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: '' } })
     ).toMatchObject({ reason: 'payload_mismatch', kind: 'sheet_cell' });
+    expect(
+      validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: '', address: 'A1' } })
+    ).toMatchObject({ reason: 'payload_mismatch', detail: 'sheet name is empty' });
+    expect(
+      validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'banana' } })
+    ).toMatchObject({ reason: 'payload_mismatch', kind: 'sheet_cell' });
+    // A real address is accepted, in either case.
+    expect(validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'B12' } })).toEqual({ ok: true });
+    expect(validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'aa10' } })).toEqual({ ok: true });
   });
 
   it('refuses an unknown page type instead of throwing', () => {

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -275,16 +275,19 @@ describe('normalizeTagName — invisible characters', () => {
     expect(expectOk(U(0x2800) + 'x').name).toBe(U(0x2800) + 'x');
   });
 
-  it('folds blank renderers out of the KEY while keeping them in the name', () => {
-    // The dedupe hole the strip docstring calls the more damaging half:
-    // `admin` and `admin<U+FFA0>` both render as `admin`, so keying them apart
-    // leaves two rows under UNIQUE (driveId, normalizedKey), and filtering by
-    // the visible tag finds half the content.
+  it('folds a space-like blank to a SPACE in the key, closing both lookalike holes', () => {
+    // These occupy a character's width and render as a gap, so getting the fold
+    // wrong opens a hole in one direction or the other:
+    //   keeping them splits `admin` from `admin<U+FFA0>`  (identical on screen)
+    //   deleting them splits `a b` from `a<U+3164>b`      (also identical)
+    // Folding to a space closes both — the trailing one trims, the interior one
+    // collapses into the ordinary space it already looks like.
     for (const cp of [0x115f, 0x1160, 0x3164, 0xffa0, 0x2800]) {
-      const decorated = 'admin' + U(cp);
-      expect(expectOk(decorated).key, `U+${cp.toString(16)}`).toBe(expectOk('admin').key);
+      const label = `U+${cp.toString(16)}`;
+      expect(expectOk('admin' + U(cp)).key, `${label} trailing`).toBe(expectOk('admin').key);
+      expect(expectOk('a' + U(cp) + 'b').key, `${label} interior`).toBe(expectOk('a b').key);
       // Still preserved in the display name — these are real characters.
-      expect(expectOk(decorated).name).toBe(decorated);
+      expect(expectOk('a' + U(cp) + 'b').name).toBe('a' + U(cp) + 'b');
     }
 
     // NOT the joiners or selectors: those change how their neighbours render,

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -261,6 +261,15 @@ describe('normalizeTagName — invisible characters', () => {
     }
     // Plus the Braille blank, which is not kept for adjacency but renders blank.
     expect(normalizeTagName(U(0x2800))).toEqual({ ok: false, reason: 'empty' });
+    // Two blank renderers separated by a SPACE is the case that bites: each is
+    // refused alone, but the space is not itself a blank renderer, so without
+    // it in the class the name passes while its key folds to nothing. Every
+    // such tag then collides on the empty key under the unique index Phase 2
+    // adds — one row occupies it and blocks the rest.
+    expect(normalizeTagName(U(0x3164) + ' ' + U(0xffa0))).toEqual({ ok: false, reason: 'empty' });
+    expect(normalizeTagName(U(0x2800) + ' ' + U(0x2800))).toEqual({ ok: false, reason: 'empty' });
+    expect(normalizeTagName(U(0x200d) + ' ' + U(0xfe0f))).toEqual({ ok: false, reason: 'empty' });
+
     // One visible character is enough to make it a name again.
     expect(expectOk('a' + U(0x200d) + 'b').name).toBe('a' + U(0x200d) + 'b');
     expect(expectOk(U(0x2800) + 'x').name).toBe(U(0x2800) + 'x');
@@ -589,6 +598,44 @@ describe('tagKey and idempotency', () => {
 
     expect(upper.key).toBe(lower.key);
     expect(upper.key).toBe(U(0x1e96));
+  });
+
+  it('never turns an accepted name into an empty key', () => {
+    // A standing property rather than a list of cases. An empty key is uniquely
+    // damaging: UNIQUE (driveId, normalizedKey) lets exactly one row hold it,
+    // so every tag that folds to nothing collides with every other one. This
+    // regressed once already, when the blank renderers began folding out of the
+    // key and a name of two of them separated by a space still passed.
+    const parts = [
+      'a',
+      'A',
+      ' ',
+      U(0x3164),
+      U(0xffa0),
+      U(0x2800),
+      U(0x115f),
+      U(0x200d),
+      U(0x200c),
+      U(0xfe0f),
+      U(0x3000),
+      U(0x2003),
+      U(0x00a0),
+      U(0x2060),
+      U(0x200b),
+      U(0x00b4),
+      U(0x2121),
+    ];
+
+    for (const first of parts) {
+      for (const second of parts) {
+        for (const third of parts) {
+          const result = normalizeTagName(first + second + third);
+          if (result.ok) {
+            expect(result.key, JSON.stringify(first + second + third)).not.toBe('');
+          }
+        }
+      }
+    }
   });
 
   it('produces a key that is itself NFKC-stable', () => {

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -11,6 +11,7 @@ import {
   TAG_TARGETS,
   type TagTarget,
   type TargetKind,
+  isTaggablePageType,
   normalizeTagName,
   tagKey,
   validateTarget,
@@ -167,7 +168,7 @@ describe('normalizeTagName — invisible characters', () => {
     // chip, and Phase 2 is about to bake that key into a unique index.
     expect(expectOk('de' + U(0x2060) + 'sign').key).toBe(expectOk('design').key);
 
-    for (const cp of [0x2060, 0x2061, 0x2064, 0x034f, 0x180e, 0xfff9, 0x1d173]) {
+    for (const cp of [0x2060, 0x2061, 0x2064, 0x034f, 0x180e, 0xfff9, 0x1d173, 0xe0001, 0xe001f]) {
       expect(expectOk('a' + U(cp) + 'b').name, `U+${cp.toString(16)}`).toBe('ab');
     }
   });
@@ -200,6 +201,17 @@ describe('normalizeTagName — invisible characters', () => {
     const without = expectOk(U(0x0645, 0x06cc, 0x0631, 0x0648, 0x062f));
     expect(withZwnj.name).toContain(ZWNJ);
     expect(withZwnj.key).not.toBe(without.key);
+  });
+
+  it('keeps the tag characters that encode a subdivision flag', () => {
+    // The strip list reaches into the tag block to remove the deprecated
+    // U+E0001 and the unassigned range behind it. Widening it by one more
+    // range would swallow U+E0020-E007F and turn Scotland into a bare black
+    // flag, so the boundary needs a test rather than care.
+    const scotland =
+      U(0x1f3f4) + U(0xe0067, 0xe0062, 0xe0073, 0xe0063, 0xe0074) + U(0xe007f);
+    expect(expectOk(scotland).name).toBe(scotland);
+    expect(expectOk(scotland).key).toBe(scotland);
   });
 
   it('keeps a variation selector, which decides emoji versus text presentation', () => {
@@ -570,12 +582,24 @@ describe('validateTarget', () => {
     // case: it is still a value in the DB's PageType enum, deleted from the TS
     // enum in the Phase 8 teardown because Postgres cannot DROP VALUE — so a
     // pages.type this function is typed to never see can arrive from a row.
-    const unknown = 'MACHINE' as PageTypeValue;
-    expect(validateTarget(unknown, { kind: 'page' })).toEqual({
+    expect(validateTarget('MACHINE', { kind: 'page' })).toEqual({
       ok: false,
       reason: 'unknown_page_type',
       pageType: 'MACHINE',
     });
+  });
+
+  it('takes a string at the boundary, so no caller needs a cast to be checked', () => {
+    // A narrower parameter would force every real caller — a request handler, a
+    // row reader — to write `as PageTypeValue` just to reach the check that
+    // exists to make that cast unnecessary. The predicate is exported so the
+    // service can narrow with the same set rather than a second hand-rolled one.
+    expect(isTaggablePageType('DOCUMENT')).toBe(true);
+    expect(isTaggablePageType('MACHINE')).toBe(false);
+    expect(isTaggablePageType('constructor')).toBe(false);
+    for (const pageType of PAGE_TYPE_VALUES) {
+      expect(isTaggablePageType(pageType), pageType).toBe(true);
+    }
   });
 
   it('refuses an inherited Object property rather than treating it as a registry entry', () => {
@@ -584,7 +608,7 @@ describe('validateTarget', () => {
     // membership test would throw. Same shape as the &__proto__; entity bug in
     // Phase 0 — hence the Set.
     for (const inherited of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
-      expect(validateTarget(inherited as PageTypeValue, { kind: 'page' })).toEqual({
+      expect(validateTarget(inherited, { kind: 'page' })).toEqual({
         ok: false,
         reason: 'unknown_page_type',
         pageType: inherited,

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -39,6 +39,36 @@ const COMBINING_ACUTE = U(0x0301);
 const E_ACUTE = U(0x00e9);
 const FAMILY = U(0x1f468) + ZWJ + U(0x1f469) + ZWJ + U(0x1f467);
 
+/**
+ * The invisible code points the module keeps ON PURPOSE, as ranges.
+ *
+ * One definition, two obligations, and they are asserted separately because
+ * they drifted apart once: every one of these must survive a strip (it is
+ * meaningful next to another character), and every one must ALSO be refused as
+ * a whole name (a chip that renders blank is unusable). Hand-writing either
+ * list is how U+180B-180D and U+180F ended up satisfying the first and not the
+ * second.
+ */
+const KEPT_CODE_POINT_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x200c, 0x200c], // ZWNJ — required orthography in Persian and Indic scripts
+  [0x200d, 0x200d], // ZWJ — joins the family emoji into one glyph
+  [0x180b, 0x180d], // Mongolian free variation selectors
+  [0x180f, 0x180f],
+  [0xfe00, 0xfe0f], // variation selectors
+  [0xe0100, 0xe01ef], // variation selectors supplement
+  [0xe0020, 0xe007f], // tag characters — the subdivision flags
+  [0x115f, 0x1160], // Hangul fillers — blank renderers
+  [0x3164, 0x3164],
+  [0xffa0, 0xffa0],
+];
+
+const KEPT_ON_PURPOSE = (cp: number): boolean =>
+  KEPT_CODE_POINT_RANGES.some(([from, to]) => cp >= from && cp <= to);
+
+const EVERY_KEPT_CODE_POINT: readonly number[] = KEPT_CODE_POINT_RANGES.flatMap(([from, to]) =>
+  Array.from({ length: to - from + 1 }, (_unused, offset) => from + offset)
+);
+
 function expectOk(raw: string): { name: string; key: string } {
   const result = normalizeTagName(raw);
   expect(result.ok, `expected ${JSON.stringify(raw)} to normalize`).toBe(true);
@@ -184,20 +214,6 @@ describe('normalizeTagName — invisible characters', () => {
     // engine's ICU build. A TEST may, and should: if a future runtime knows
     // about ignorables this build does not, that is a new dedupe hole, and a
     // loud CI failure is exactly how one would want to hear about it.
-    const KEPT_ON_PURPOSE = (cp: number): boolean =>
-      cp === 0x200c || // ZWNJ — required orthography in Persian and Indic scripts
-      cp === 0x200d || // ZWJ — joins the family emoji into one glyph
-      (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
-      (cp >= 0xe0100 && cp <= 0xe01ef) || // variation selectors supplement
-      (cp >= 0x180b && cp <= 0x180d) || // Mongolian free variation selectors
-      cp === 0x180f ||
-      (cp >= 0xe0020 && cp <= 0xe007f) || // tag characters — subdivision flags
-      // Blank renderers: kept here, refused as a whole name by NOTHING_VISIBLE.
-      cp === 0x115f ||
-      cp === 0x1160 ||
-      cp === 0x3164 ||
-      cp === 0xffa0;
-
     const ignorable = /\p{Default_Ignorable_Code_Point}/u;
     const leaked: string[] = [];
 
@@ -218,17 +234,33 @@ describe('normalizeTagName — invisible characters', () => {
     expect(leaked).toEqual([]);
   });
 
+  it('keeps every code point on the keep-list when it sits beside real text', () => {
+    // The other half of the keep-list's contract, derived from the same source
+    // as the blank-name assertion below. These are kept precisely because they
+    // are meaningful NEXT TO another character, so a strip that swallowed one
+    // would break real orthography — Persian, Indic, the emoji sequences and
+    // the subdivision flags all depend on it.
+    for (const cp of EVERY_KEPT_CODE_POINT) {
+      const name = 'a' + U(cp) + 'b';
+      expect(expectOk(name).name, `U+${cp.toString(16)}`).toBe(name);
+    }
+  });
+
   it('refuses a name that renders as nothing, however many code points it has', () => {
     // Neither stripped nor collapsed, and each a different code point — so
     // several distinct blank tags could coexist, and nobody could retype,
     // search for, or tell them apart. The Hangul fillers and the Braille blank
     // are the classic version of this trick.
-    for (const cp of [0x200c, 0x200d, 0xfe0f, 0xfe0e, 0xe0100, 0xe01ef, 0x3164, 0x2800, 0x115f, 0x1160, 0xffa0, 0xe0061]) {
+    // Derived from the keep-list, not restated: every code point the strip
+    // deliberately preserves must still be refused as a name on its own.
+    for (const cp of EVERY_KEPT_CODE_POINT) {
       expect(normalizeTagName(U(cp)), `U+${cp.toString(16)}`).toEqual({
         ok: false,
         reason: 'empty',
       });
     }
+    // Plus the Braille blank, which is not kept for adjacency but renders blank.
+    expect(normalizeTagName(U(0x2800))).toEqual({ ok: false, reason: 'empty' });
     // One visible character is enough to make it a name again.
     expect(expectOk('a' + U(0x200d) + 'b').name).toBe('a' + U(0x200d) + 'b');
     expect(expectOk(U(0x2800) + 'x').name).toBe(U(0x2800) + 'x');
@@ -728,7 +760,9 @@ describe('tag-core purity and determinism', () => {
     const literals = [...src].filter((char) => {
       const cp = char.codePointAt(0) ?? 0;
       return (
-        (cp < 0x20 && char !== '\n') ||
+        // \r is excluded alongside \n: a CRLF checkout, or core.autocrlf=true,
+        // would otherwise fail this on line endings rather than on a tag name.
+        (cp < 0x20 && char !== '\n' && char !== '\r') ||
         cp === 0x7f ||
         cp === 0x00ad ||
         cp === 0x200b ||

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -447,6 +447,31 @@ describe('normalizeTagName — length', () => {
     expect(new TextEncoder().encode(worst.key).length).toBeLessThan(2704);
   });
 
+  it('derives the expansion factor rather than trusting the constant', () => {
+    // MAX_TAG_KEY_LENGTH is MAX_TAG_NAME_LENGTH x 18, and that 18 is the only
+    // magic number left in the module. It came from an exhaustive scan, but a
+    // scan I ran once is exactly the kind of fact that rots: a future Unicode
+    // version could assign a character that expands further, and the constant
+    // would then understate the real ceiling for a column Phase 2 sizes from
+    // it. So the scan runs here instead — ~200ms for all 1.1M code points.
+    let worstExpansion = 0;
+    let worstCodePoint = 0;
+
+    for (let cp = 0; cp < 0x110000; cp += 1) {
+      if (cp >= 0xd800 && cp <= 0xdfff) {
+        continue;
+      }
+      const expanded = [...U(cp).normalize('NFKC').toLowerCase()].length;
+      if (expanded > worstExpansion) {
+        worstExpansion = expanded;
+        worstCodePoint = cp;
+      }
+    }
+
+    expect(worstCodePoint).toBe(0xfdfa);
+    expect(MAX_TAG_KEY_LENGTH).toBe(MAX_TAG_NAME_LENGTH * worstExpansion);
+  });
+
   it('never produces a key longer than the published ceiling', () => {
     const samples = [
       'x'.repeat(MAX_TAG_NAME_LENGTH),

--- a/packages/lib/src/tags/__tests__/tag-core.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-core.test.ts
@@ -266,6 +266,25 @@ describe('normalizeTagName — invisible characters', () => {
     expect(expectOk(U(0x2800) + 'x').name).toBe(U(0x2800) + 'x');
   });
 
+  it('folds blank renderers out of the KEY while keeping them in the name', () => {
+    // The dedupe hole the strip docstring calls the more damaging half:
+    // `admin` and `admin<U+FFA0>` both render as `admin`, so keying them apart
+    // leaves two rows under UNIQUE (driveId, normalizedKey), and filtering by
+    // the visible tag finds half the content.
+    for (const cp of [0x115f, 0x1160, 0x3164, 0xffa0, 0x2800]) {
+      const decorated = 'admin' + U(cp);
+      expect(expectOk(decorated).key, `U+${cp.toString(16)}`).toBe(expectOk('admin').key);
+      // Still preserved in the display name — these are real characters.
+      expect(expectOk(decorated).name).toBe(decorated);
+    }
+
+    // NOT the joiners or selectors: those change how their neighbours render,
+    // so folding them would key the family emoji as three separate people.
+    const family = U(0x1f468) + ZWJ + U(0x1f469) + ZWJ + U(0x1f467);
+    const apart = U(0x1f468) + U(0x1f469) + U(0x1f467);
+    expect(expectOk(family).key).not.toBe(expectOk(apart).key);
+  });
+
   it('KEEPS the joiners, which are meaning rather than noise', () => {
     // Stripping ZWJ turns one family into three separate people.
     const family = expectOk(FAMILY);
@@ -461,7 +480,11 @@ describe('normalizeTagName — length', () => {
       if (cp >= 0xd800 && cp <= 0xdfff) {
         continue;
       }
-      const expanded = [...U(cp).normalize('NFKC').toLowerCase()].length;
+      // Measured through tagKey itself, not a hand-copied prefix of it: the
+      // trailing NFKC is the pass the docstring calls load-bearing, and a
+      // future Unicode whose lowercase form re-expands under it would leave a
+      // partial measurement green while the constant understated the ceiling.
+      const expanded = [...tagKey(U(cp))].length;
       if (expanded > worstExpansion) {
         worstExpansion = expanded;
         worstCodePoint = cp;
@@ -523,6 +546,15 @@ describe('tagKey and idempotency', () => {
       const { name, key } = expectOk(raw);
       expect(tagKey(name), `tagKey mismatch for ${JSON.stringify(raw)}`).toBe(key);
     }
+  });
+
+  it('is safe on a raw string, not only on an already-normalized name', () => {
+    // The obvious next-phase use is keying a search box's contents to find an
+    // existing tag. One pasted zero-width space would otherwise produce a key
+    // no stored row can carry — missing the row and driving a duplicate insert.
+    expect(tagKey('de' + ZWSP + 'sign')).toBe(tagKey('design'));
+    expect(tagKey('admin' + U(0xffa0))).toBe(tagKey('admin'));
+    expect(tagKey('  Design   System  ')).toBe(expectOk('Design System').key);
   });
 
   it('is idempotent — re-normalizing a name changes nothing', () => {
@@ -674,9 +706,19 @@ describe('validateTarget', () => {
     expect(
       validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'banana' } })
     ).toMatchObject({ reason: 'payload_mismatch', kind: 'sheet_cell' });
-    // A real address is accepted, in either case.
+    // The canonical form is accepted; forms isValidCellAddress merely tolerates
+    // are not. That helper trims and upper-cases before testing, but the payload
+    // is stored verbatim while sheet storage keys cells by the UPPERCASED
+    // address — so a tag on 'aa10' would validate and then never match
+    // cells['AA10'].
     expect(validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'B12' } })).toEqual({ ok: true });
-    expect(validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'aa10' } })).toEqual({ ok: true });
+    expect(validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: 'AA10' } })).toEqual({ ok: true });
+    for (const tolerated of ['aa10', ' A1 ', 'a1']) {
+      expect(
+        validateTarget('SHEET', { kind: 'sheet_cell', anchor: { v: 1, sheet: 'S', address: tolerated } }),
+        tolerated
+      ).toMatchObject({ reason: 'payload_mismatch' });
+    }
   });
 
   it('refuses an unknown page type instead of throwing', () => {
@@ -716,6 +758,51 @@ describe('validateTarget', () => {
         pageType: inherited,
       });
     }
+  });
+
+  it('rejects a missing anchor instead of throwing on it', () => {
+    // `target` arrives from a request body just as `pageType` does. Hardening
+    // one and trusting the other turns a malformed payload into a 500 from the
+    // function documented as the guard the service and the database agree on.
+    for (const kind of ['text', 'sheet_cell'] as const) {
+      const pageType = kind === 'text' ? 'DOCUMENT' : 'SHEET';
+      const malformed = { kind } as unknown as TagTarget;
+      expect(() => validateTarget(pageType, malformed)).not.toThrow();
+      expect(validateTarget(pageType, malformed)).toMatchObject({
+        reason: 'payload_mismatch',
+        detail: 'anchor is missing',
+      });
+    }
+  });
+
+  it('rejects a text anchor that nothing could ever resolve', () => {
+    // No quote and no context on either side is the one shape resolveAnchor
+    // orphans outright, so a tag stored with it is orphaned from birth. A caret
+    // WITH context is legitimate and must still pass.
+    const unresolvable: TextAnchor = {
+      v: 1,
+      exact: '',
+      prefix: '',
+      suffix: '',
+      start: 0,
+      end: 0,
+      revision: 0,
+      textHash: '',
+    };
+    expect(validateTarget('DOCUMENT', { kind: 'text', anchor: unresolvable })).toMatchObject({
+      reason: 'payload_mismatch',
+    });
+    expect(
+      validateTarget('DOCUMENT', { kind: 'text', anchor: { ...unresolvable, prefix: 'before' } })
+    ).toEqual({ ok: true });
+
+    // And a range that does not ascend is not a range.
+    expect(
+      validateTarget('DOCUMENT', { kind: 'text', anchor: { ...anchor, start: 5, end: 2 } })
+    ).toMatchObject({ reason: 'payload_mismatch' });
+    expect(
+      validateTarget('DOCUMENT', { kind: 'text', anchor: { ...anchor, start: -1, end: 4 } })
+    ).toMatchObject({ reason: 'payload_mismatch' });
   });
 
   it('checks the page type before the payload', () => {

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -18,6 +18,7 @@
  * @module @pagespace/lib/tags/tag-core
  */
 
+import { isValidCellAddress } from '../sheets/address';
 import type { SheetCellAnchor, TextAnchor } from '../content/anchoring/types';
 import type { PageTypeValue } from '../utils/enums';
 
@@ -34,6 +35,22 @@ export const MAX_TAG_NAME_LENGTH = 64;
  * caller who hands over a whole document.
  */
 export const MAX_RAW_TAG_INPUT = 512;
+
+/**
+ * The longest key a valid name can produce, for whoever sizes the column.
+ *
+ * MAX_TAG_NAME_LENGTH bounds the NAME; the key is derived through NFKC, which
+ * expands. Measured exhaustively over all 1.1M code points, the worst single
+ * character is U+FDFA (an Arabic ligature) at 18 code points, so the ceiling is
+ * 64 x 18 = 1152 code points, or 2112 bytes of UTF-8.
+ *
+ * Exported because Phase 2 chooses `normalizedKey`'s type from these constants,
+ * and the obvious `varchar(64)` mirroring the name limit would reject a legal
+ * tag at INSERT time — the exact failure mode this module refuses characters to
+ * avoid. It fits under Postgres's ~2704-byte btree tuple limit, so the unique
+ * index is safe, but not with much room to spare.
+ */
+export const MAX_TAG_KEY_LENGTH = MAX_TAG_NAME_LENGTH * 18;
 
 /**
  * Why a name was refused. A discriminated union rather than a boolean or a
@@ -78,10 +95,19 @@ export type TagNameResult = { ok: true; name: string; key: string } | TagNameRej
  * The obvious implementation — strip everything Default_Ignorable — mangles all
  * four, and its membership tracks the engine's ICU version besides.
  *
- * Enumerated literally for that same reason: a Unicode property escape would
- * make the result depend on which runtime evaluated it.
+ * The list covers the whole non-orthographic family, not just the famous
+ * members: WORD JOINER U+2060 is the modern replacement for U+FEFF-as-ZWNBSP
+ * and would otherwise be the same hole with a different code point, and the
+ * invisible math operators, CGJ, the interlinear annotation marks and the
+ * musical format controls are all equally unrenderable and equally usable to
+ * mint a duplicate tag that looks identical in every chip and autocomplete.
+ *
+ * Enumerated literally rather than by Unicode property: a property escape's
+ * membership tracks the engine's ICU build, which would make the key depend on
+ * which runtime computed it.
  */
-const INVISIBLE_FORMATTING = /[\u00ad\u061c\u200b\u200e\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g;
+const INVISIBLE_FORMATTING =
+  /[\u00ad\u034f\u061c\u180e\u200b\u200e\u200f\u202a-\u202e\u2060-\u2064\u2066-\u2069\ufeff\ufff9-\ufffb\u{1d173}-\u{1d17a}]/gu;
 
 /**
  * Whitespace collapsed to a single space. Deliberately WIDER than
@@ -103,6 +129,25 @@ const COLLAPSIBLE_WHITESPACE =
 /** Greek FINAL sigma, folded to the medial form so one word is one tag. */
 const FINAL_SIGMA = /\u03c2/g;
 const MEDIAL_SIGMA = '\u03c3';
+
+/**
+ * Matches a value in which nothing renders — including the empty string, which
+ * is why this subsumes a length check rather than sitting beside one.
+ *
+ * Two groups of code points. The joiners and selectors are KEPT deliberately
+ * (see INVISIBLE_FORMATTING) because they are meaningful NEXT TO other
+ * characters — but a name made only of them is not a name. The Hangul fillers
+ * and the Braille blank are the classic blank-name trick: ordinary letters by
+ * category, blank on screen, and each a different code point, so several
+ * distinct blank tags could coexist with nobody able to retype, search for, or
+ * tell them apart.
+ *
+ * A denylist rather than a Unicode property test, and therefore best-effort:
+ * property membership moves with the engine's ICU build, which the whole module
+ * is built to avoid.
+ */
+const NOTHING_VISIBLE =
+  /^[\u200c\u200d\u115f\u1160\u3164\uffa0\u2800\ufe00-\ufe0f\u{e0020}-\u{e007f}\u{e0100}-\u{e01ef}]*$/u;
 
 /** The collapsible characters that are also C0/C1 — whitespace, not damage. */
 const COLLAPSIBLE_CONTROLS = new Set([0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x85]);
@@ -237,7 +282,9 @@ export function normalizeTagName(raw: string): TagNameResult {
   // must compose to a-acute, which cannot happen while the ZWSP sits between.
   const name = collapse(raw.replace(INVISIBLE_FORMATTING, '').normalize('NFC'));
 
-  if (name.length === 0) {
+  // 'empty' means nothing a reader can SEE, not merely a zero-length string: a
+  // chip that renders blank is unusable however many code points back it.
+  if (NOTHING_VISIBLE.test(name)) {
     return { ok: false, reason: 'empty' };
   }
 
@@ -373,13 +420,28 @@ export function validateTarget(pageType: PageTypeValue, target: TagTarget): Targ
     };
   }
 
-  if (target.kind === 'sheet_cell' && target.anchor.address.length === 0) {
-    return {
-      ok: false,
-      reason: 'payload_mismatch',
-      kind: target.kind,
-      detail: 'sheet cell address is empty',
-    };
+  if (target.kind === 'sheet_cell') {
+    // Both halves of the natural key, not just one. A sheet cell is identified
+    // by (sheet name, A1 address), so an anchor missing either half points at
+    // nothing — and an address that is merely non-empty still points at nothing
+    // if it is not in A1 form. isValidCellAddress is the same check the sheet
+    // code itself uses, so the guard and the storage agree by construction.
+    if (target.anchor.sheet.length === 0) {
+      return {
+        ok: false,
+        reason: 'payload_mismatch',
+        kind: target.kind,
+        detail: 'sheet name is empty',
+      };
+    }
+    if (!isValidCellAddress(target.anchor.address)) {
+      return {
+        ok: false,
+        reason: 'payload_mismatch',
+        kind: target.kind,
+        detail: `not an A1 cell address: ${JSON.stringify(target.anchor.address)}`,
+      };
+    }
   }
 
   return { ok: true };

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -102,18 +102,26 @@ export type TagNameResult = { ok: true; name: string; key: string } | TagNameRej
  * musical format controls are all equally unrenderable and equally usable to
  * mint a duplicate tag that looks identical in every chip and autocomplete.
  *
- * U+E0001 and the unassigned block behind it are stripped rather than merely
- * treated as blank. Counting them blank would refuse a name made only of them
- * while still letting `a<U+E0001>b` key differently from `ab` — the dedupe hole
- * left open. The real tag characters at U+E0020-E007F stay, since they are what
- * encode the subdivision flags.
+ * The set is derived rather than remembered. Three review rounds each found a
+ * different missing code point, which is a sign the list was being maintained
+ * by memory — so it is now the WHOLE Default_Ignorable class minus an explicit,
+ * justified keep-list, and a test sweeps every code point in that class and
+ * fails on anything unaccounted for. Deprecated format characters, the Khmer
+ * inherent vowels, the shorthand format controls and the unassigned ignorable
+ * blocks all arrived that way.
+ *
+ * Stripped rather than merely treated as blank, because blank-counting refuses
+ * a name made ONLY of them while still letting `a<U+E0001>b` key differently
+ * from `ab` — which leaves the dedupe hole, the more damaging half. The real
+ * tag characters at U+E0020-E007F stay, since they encode the subdivision
+ * flags.
  *
  * Enumerated literally rather than by Unicode property: a property escape's
  * membership tracks the engine's ICU build, which would make the key depend on
  * which runtime computed it.
  */
 const INVISIBLE_FORMATTING =
-  /[\u00ad\u034f\u061c\u180e\u200b\u200e\u200f\u202a-\u202e\u2060-\u2064\u2066-\u2069\ufeff\ufff9-\ufffb\u{1d173}-\u{1d17a}\u{e0001}-\u{e001f}]/gu;
+  /[\u00ad\u034f\u061c\u180e\u200b\u200e\u200f\u202a-\u202e\u2060-\u2065\u206a-\u206f\u17b4-\u17b5\u2066-\u2069\ufeff\ufff0-\ufffb\u{1bca0}-\u{1bca3}\u{1d173}-\u{1d17a}\u{e0000}-\u{e001f}\u{e0080}-\u{e00ff}\u{e01f0}-\u{e0fff}]/gu;
 
 /**
  * Whitespace collapsed to a single space. Deliberately WIDER than

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -102,12 +102,18 @@ export type TagNameResult = { ok: true; name: string; key: string } | TagNameRej
  * musical format controls are all equally unrenderable and equally usable to
  * mint a duplicate tag that looks identical in every chip and autocomplete.
  *
+ * U+E0001 and the unassigned block behind it are stripped rather than merely
+ * treated as blank. Counting them blank would refuse a name made only of them
+ * while still letting `a<U+E0001>b` key differently from `ab` — the dedupe hole
+ * left open. The real tag characters at U+E0020-E007F stay, since they are what
+ * encode the subdivision flags.
+ *
  * Enumerated literally rather than by Unicode property: a property escape's
  * membership tracks the engine's ICU build, which would make the key depend on
  * which runtime computed it.
  */
 const INVISIBLE_FORMATTING =
-  /[\u00ad\u034f\u061c\u180e\u200b\u200e\u200f\u202a-\u202e\u2060-\u2064\u2066-\u2069\ufeff\ufff9-\ufffb\u{1d173}-\u{1d17a}]/gu;
+  /[\u00ad\u034f\u061c\u180e\u200b\u200e\u200f\u202a-\u202e\u2060-\u2064\u2066-\u2069\ufeff\ufff9-\ufffb\u{1d173}-\u{1d17a}\u{e0001}-\u{e001f}]/gu;
 
 /**
  * Whitespace collapsed to a single space. Deliberately WIDER than
@@ -377,6 +383,17 @@ export type TargetRejection =
  */
 const KNOWN_PAGE_TYPES: ReadonlySet<string> = new Set(Object.keys(TAG_TARGETS));
 
+/**
+ * Whether `value` is a page type this build can tag, narrowing it if so.
+ *
+ * Exported because the service layer needs the same narrowing before it can
+ * index TAG_TARGETS itself, and a second hand-rolled check would be free to
+ * disagree with this one.
+ */
+export function isTaggablePageType(value: string): value is PageTypeValue {
+  return KNOWN_PAGE_TYPES.has(value);
+}
+
 export type TargetValidation = { ok: true } | TargetRejection;
 
 /**
@@ -387,13 +404,14 @@ export type TargetValidation = { ok: true } | TargetRejection;
  * page-type compatibility is a rule the database never sees. That asymmetry is
  * exactly why it needs a test here.
  */
-export function validateTarget(pageType: PageTypeValue, target: TagTarget): TargetValidation {
-  // The parameter type is a compile-time promise, not a runtime one. This value
-  // arrives from a request body or a `pages.type` column, and the DB's PageType
-  // enum still contains MACHINE — deleted from the TS enum in the Phase 8
-  // teardown because Postgres cannot DROP VALUE. So a row that TypeScript says
-  // cannot exist does exist, and a guard that throws on it is not a guard.
-  if (!KNOWN_PAGE_TYPES.has(pageType)) {
+export function validateTarget(pageType: string, target: TagTarget): TargetValidation {
+  // `string`, not PageTypeValue, on purpose. This is the runtime boundary: the
+  // value arrives from a request body or a `pages.type` column, and the DB's
+  // PageType enum still contains MACHINE — deleted from the TS enum in the
+  // Phase 8 teardown because Postgres cannot DROP VALUE. A narrower parameter
+  // would force every real caller to write `as PageTypeValue` to reach this
+  // function at all, which is the cast this check exists to make unnecessary.
+  if (!isTaggablePageType(pageType)) {
     return { ok: false, reason: 'unknown_page_type', pageType };
   }
 

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -148,6 +148,10 @@ const MEDIAL_SIGMA = '\u03c3';
  * Matches a value in which nothing renders — including the empty string, which
  * is why this subsumes a length check rather than sitting beside one.
  *
+ * Every code point INVISIBLE_FORMATTING keeps must appear here, and a test
+ * derives its cases from that keep-list rather than restating it — the two
+ * drifted apart once already, over the Mongolian free variation selectors.
+ *
  * Two groups of code points. The joiners and selectors are KEPT deliberately
  * (see INVISIBLE_FORMATTING) because they are meaningful NEXT TO other
  * characters — but a name made only of them is not a name. The Hangul fillers
@@ -161,7 +165,7 @@ const MEDIAL_SIGMA = '\u03c3';
  * is built to avoid.
  */
 const NOTHING_VISIBLE =
-  /^[\u200c\u200d\u115f\u1160\u3164\uffa0\u2800\ufe00-\ufe0f\u{e0020}-\u{e007f}\u{e0100}-\u{e01ef}]*$/u;
+  /^[\u180b-\u180d\u180f\u200c\u200d\u115f\u1160\u3164\uffa0\u2800\ufe00-\ufe0f\u{e0020}-\u{e007f}\u{e0100}-\u{e01ef}]*$/u;
 
 /** The collapsible characters that are also C0/C1 — whitespace, not damage. */
 const COLLAPSIBLE_CONTROLS = new Set([0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x85]);

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -308,10 +308,27 @@ export const TAG_TARGETS = {
 } as const satisfies Record<PageTypeValue, readonly TargetKind[]>;
 
 export type TargetRejection =
+  /**
+   * Not a page type this build knows about. `pageType` is typed `string` here
+   * precisely because the value failed to be a PageTypeValue.
+   */
+  | { ok: false; reason: 'unknown_page_type'; pageType: string }
   /** This page type does not accept this kind of target at all. */
   | { ok: false; reason: 'kind_not_allowed'; pageType: PageTypeValue; kind: TargetKind }
   /** The payload does not match the kind it claims. */
   | { ok: false; reason: 'payload_mismatch'; kind: TargetKind; detail: string };
+
+/**
+ * The keys of TAG_TARGETS as a Set, derived so it cannot drift from the
+ * registry it guards.
+ *
+ * A Set rather than an `in` check or a bare index, because an object lookup
+ * reaches the prototype: `TAG_TARGETS['constructor']` is a function, not
+ * undefined, so a falsy guard would wave it through and the `.includes` below
+ * would throw anyway. Phase 0 shipped exactly this bug in the HTML entity
+ * table; this is the same shape in a second place.
+ */
+const KNOWN_PAGE_TYPES: ReadonlySet<string> = new Set(Object.keys(TAG_TARGETS));
 
 export type TargetValidation = { ok: true } | TargetRejection;
 
@@ -324,6 +341,15 @@ export type TargetValidation = { ok: true } | TargetRejection;
  * exactly why it needs a test here.
  */
 export function validateTarget(pageType: PageTypeValue, target: TagTarget): TargetValidation {
+  // The parameter type is a compile-time promise, not a runtime one. This value
+  // arrives from a request body or a `pages.type` column, and the DB's PageType
+  // enum still contains MACHINE — deleted from the TS enum in the Phase 8
+  // teardown because Postgres cannot DROP VALUE. So a row that TypeScript says
+  // cannot exist does exist, and a guard that throws on it is not a guard.
+  if (!KNOWN_PAGE_TYPES.has(pageType)) {
+    return { ok: false, reason: 'unknown_page_type', pageType };
+  }
+
   const allowed: readonly TargetKind[] = TAG_TARGETS[pageType];
   if (!allowed.includes(target.kind)) {
     return { ok: false, reason: 'kind_not_allowed', pageType, kind: target.kind };

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -148,6 +148,13 @@ const MEDIAL_SIGMA = '\u03c3';
  * Matches a value in which nothing renders — including the empty string, which
  * is why this subsumes a length check rather than sitting beside one.
  *
+ * A plain space is in the class, and it is load-bearing rather than tidy. The
+ * name is collapsed and trimmed before this runs, so U+0020 is the only
+ * whitespace that can still be present — and without it, one blank renderer is
+ * refused while two separated by a space are not. That name is non-empty, its
+ * key folds to nothing, and every such tag then collides on the empty key under
+ * UNIQUE (driveId, normalizedKey): one row occupies it and blocks the rest.
+ *
  * Every code point INVISIBLE_FORMATTING keeps must appear here, and a test
  * derives its cases from that keep-list rather than restating it — the two
  * drifted apart once already, over the Mongolian free variation selectors.
@@ -186,7 +193,7 @@ const MEDIAL_SIGMA = '\u03c3';
 const BLANK_IN_KEY = /[\u115f\u1160\u3164\uffa0\u2800]/g;
 
 const NOTHING_VISIBLE =
-  /^[\u180b-\u180d\u180f\u200c\u200d\u115f\u1160\u3164\uffa0\u2800\ufe00-\ufe0f\u{e0020}-\u{e007f}\u{e0100}-\u{e01ef}]*$/u;
+  /^[ \u180b-\u180d\u180f\u200c\u200d\u115f\u1160\u3164\uffa0\u2800\ufe00-\ufe0f\u{e0020}-\u{e007f}\u{e0100}-\u{e01ef}]*$/u;
 
 /** The collapsible characters that are also C0/C1 — whitespace, not damage. */
 const COLLAPSIBLE_CONTROLS = new Set([0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x85]);

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -1,0 +1,360 @@
+/**
+ * Pure vocabulary core for content tags: what a tag NAME is, and which kinds of
+ * thing each page type can carry a tag on. Zero I/O — no db, no fetch, no
+ * clock, no env — enforced by the purity test in __tests__/tag-core.test.ts.
+ * The service shell (a later phase) owns every side effect.
+ *
+ * Both rules live here because Phase 2 is about to make them permanent:
+ * `UNIQUE (driveId, normalizedKey)` bakes the dedupe rule into an index, and
+ * the `content_tags` CHECK constraint is effectively one-way in this repo's
+ * migration conventions. Reviewing them as plain functions first is cheaper
+ * than getting them back out of an index later.
+ *
+ * Every invisible character below is written as an escape sequence on purpose.
+ * A literal one is unreadable in a diff and unreviewable in a code review,
+ * which is exactly the wrong property for the characters this module exists to
+ * police.
+ *
+ * @module @pagespace/lib/tags/tag-core
+ */
+
+import type { SheetCellAnchor, TextAnchor } from '../content/anchoring/types';
+import type { PageTypeValue } from '../utils/enums';
+
+/** Max code points in a tag's display name, after normalization. */
+export const MAX_TAG_NAME_LENGTH = 64;
+
+/**
+ * Runaway guard on the raw input, in UTF-16 code units, checked before any
+ * allocation — `raw.length` is O(1), which is the point of doing it first.
+ *
+ * A valid name is at most 64 code points, so at most 128 code units. The only
+ * way past 512 is mass whitespace or a paste of something that was never a
+ * name, so this bounds both the scan and the `normalize()` allocation against a
+ * caller who hands over a whole document.
+ */
+export const MAX_RAW_TAG_INPUT = 512;
+
+/**
+ * Why a name was refused. A discriminated union rather than a boolean or a
+ * throw, following workspace-node-validate.ts: the server turns a rejection
+ * into an HTTP error and the client renders it, and neither can parse prose.
+ *
+ * `index` is a UTF-16 offset deliberately — that is the unit a text input's
+ * selection API and `String.prototype.slice` use, so a UI can point at the
+ * offending character.
+ */
+export type TagNameRejection =
+  /** Nothing survived normalization — blank, or invisible characters only. */
+  | { ok: false; reason: 'empty' }
+  /** The runaway guard tripped before normalizing. `length` is UTF-16 units. */
+  | { ok: false; reason: 'input_too_large'; length: number }
+  /** The normalized name is over the limit. `length` is code points. */
+  | { ok: false; reason: 'too_long'; length: number; max: number }
+  /** A C0/C1 control or DEL. */
+  | { ok: false; reason: 'control_character'; codePoint: number; index: number }
+  /** A lone surrogate: not encodable as UTF-8, so not storable at all. */
+  | { ok: false; reason: 'unpaired_surrogate'; index: number }
+  /** U+FDD0-U+FDEF or U+xFFFE/U+xFFFF — internal-use sentinels. */
+  | { ok: false; reason: 'noncharacter'; codePoint: number; index: number };
+
+export type TagNameResult = { ok: true; name: string; key: string } | TagNameRejection;
+
+/**
+ * Characters that are invisible and carry no orthographic role anywhere: soft
+ * hyphen, zero-width space, the bidi marks, the bidi embeddings, overrides and
+ * isolates, and the byte-order mark.
+ *
+ * Stripped rather than kept because NFKC leaves every one of them alone, so two
+ * tags could look identical and be two distinct rows — a dedupe hole, and in
+ * the case of the bidi overrides the entire text-spoofing surface.
+ *
+ * NOT stripped, and this is the part that matters: U+200C ZWNJ, U+200D ZWJ, the
+ * variation selectors and the tag characters. Those are meaningful. ZWJ is what
+ * joins the man/woman/girl emoji into ONE family glyph rather than three
+ * separate people; ZWNJ is required orthography in Persian and in Indic
+ * scripts; VS16 is the difference between the red heart emoji and the black
+ * text heart; the tag characters encode the subdivision flags such as Scotland.
+ * The obvious implementation — strip everything Default_Ignorable — mangles all
+ * four, and its membership tracks the engine's ICU version besides.
+ *
+ * Enumerated literally for that same reason: a Unicode property escape would
+ * make the result depend on which runtime evaluated it.
+ */
+const INVISIBLE_FORMATTING = /[\u00ad\u061c\u200b\u200e\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g;
+
+/**
+ * Whitespace collapsed to a single space. Deliberately WIDER than
+ * `COLLAPSIBLE_WHITESPACE` in content/anchoring/text-projection.ts, which folds
+ * only space, tab, the line breaks and NBSP.
+ *
+ * That module argued EM SPACE is content, because folding it makes a quote
+ * unfindable in the prose it was taken from. The argument is about
+ * offset-preserving projection and does not transfer here: a tag name is an
+ * identifier a human retypes, and an EM SPACE inside one is invisible variation
+ * nobody can see or reproduce. NFKC already folds most of these on the key
+ * path, so widening the name path is mostly about making the two paths agree.
+ *
+ * Enumerated rather than a Unicode property escape — same ICU-version reason.
+ */
+const COLLAPSIBLE_WHITESPACE =
+  /[ \t\n\v\f\r\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/g;
+
+/** Greek FINAL sigma, folded to the medial form so one word is one tag. */
+const FINAL_SIGMA = /\u03c2/g;
+const MEDIAL_SIGMA = '\u03c3';
+
+/** The collapsible characters that are also C0/C1 — whitespace, not damage. */
+const COLLAPSIBLE_CONTROLS = new Set([0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x85]);
+
+function isNoncharacter(codePoint: number): boolean {
+  if (codePoint >= 0xfdd0 && codePoint <= 0xfdef) {
+    return true;
+  }
+  return (codePoint & 0xfffe) === 0xfffe;
+}
+
+function isControl(codePoint: number): boolean {
+  return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+}
+
+/**
+ * Scan for characters that must be refused rather than cleaned up, returning
+ * the first offence in code-point order so the reported reason is deterministic
+ * rather than an artefact of check order.
+ *
+ * Refused rather than stripped for one concrete reason: Postgres stores none of
+ * them in a `text` column. NUL is rejected outright by the driver and a lone
+ * surrogate is not encodable as UTF-8, so stripping would mean this pure core
+ * says "fine" and the INSERT fails later. Silently storing a different name
+ * than the one submitted is the worse failure anyway. Phase 0 refuses to decode
+ * surrogates in `decodeEntity` for exactly this reason.
+ */
+function findRefusedCharacter(raw: string): TagNameRejection | null {
+  for (let index = 0; index < raw.length; index += 1) {
+    const unit = raw.charCodeAt(index);
+
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      // charCodeAt past the end returns NaN, and NaN fails every comparison, so
+      // a high surrogate at the very end of the input falls into this branch
+      // without needing a length check of its own.
+      const next = raw.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return { ok: false, reason: 'unpaired_surrogate', index };
+      }
+      // Combine the pair arithmetically rather than via codePointAt, which
+      // would need an `?? 0` fallback for a case the branch above already ruled
+      // out — a dead branch is worse than the four lines of arithmetic.
+      const codePoint = (unit - 0xd800) * 0x400 + (next - 0xdc00) + 0x10000;
+      if (isNoncharacter(codePoint)) {
+        return { ok: false, reason: 'noncharacter', codePoint, index };
+      }
+      index += 1;
+      continue;
+    }
+
+    if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return { ok: false, reason: 'unpaired_surrogate', index };
+    }
+
+    if (isNoncharacter(unit)) {
+      return { ok: false, reason: 'noncharacter', codePoint: unit, index };
+    }
+
+    if (isControl(unit) && !COLLAPSIBLE_CONTROLS.has(unit)) {
+      return { ok: false, reason: 'control_character', codePoint: unit, index };
+    }
+  }
+
+  return null;
+}
+
+function collapse(value: string): string {
+  return value.replace(COLLAPSIBLE_WHITESPACE, ' ').trim();
+}
+
+/**
+ * The dedupe key for an ALREADY-normalized name — the value
+ * `UNIQUE (driveId, normalizedKey)` is taken on.
+ *
+ * Exported, and defined as a function of `name` rather than of the raw input,
+ * so a backfill can recompute every key from the stored name and provably get
+ * the same value back.
+ *
+ * Three details are load-bearing:
+ *
+ * - **NFKC before the fold, and again after.** Lowercasing the TELEPHONE SIGN
+ *   leaves it unchanged, and NFKC then turns it into the UPPERCASE `TEL`;
+ *   folding after NFKC gives `tel`. The trailing pass makes "the key is
+ *   NFKC-stable" a theorem rather than an observation, since `toLowerCase` does
+ *   not promise to preserve normal form (U+0130 lowercases to `i` + U+0307).
+ * - **`toLowerCase`, never `toLocaleLowerCase`.** Without an explicit locale
+ *   the latter uses the HOST locale, so a Turkish machine keys `IT` as a
+ *   dotless-i form and cannot see the row it should have deduped against. That
+ *   is Phase 0's determinism bug in new clothes, and this one lands inside a
+ *   unique index.
+ * - **Final sigma.** JS implements Unicode's Final_Sigma rule, so an uppercase
+ *   Greek word lowercases with a FINAL sigma U+03C2 while someone typing the
+ *   medial form gets U+03C3 — two tags for one word. Folding them is what true
+ *   case folding does; one `replace` buys it.
+ */
+export function tagKey(name: string): string {
+  const folded = name.normalize('NFKC').toLowerCase().replace(FINAL_SIGMA, MEDIAL_SIGMA);
+  return collapse(folded.normalize('NFKC'));
+}
+
+/**
+ * Normalize a user-supplied tag name into the stored display `name` and the
+ * `key` it dedupes on. Total: never throws, for any string.
+ *
+ * `name` is NFC and `key` is NFKC, deliberately different forms. NFKC folds
+ * compatibility variants, which is exactly what a dedupe key wants — it is what
+ * makes a mathematical-script `Cool` and a plain `Cool` the same tag — and
+ * exactly what a display name must not do: it turns the square-metre sign into
+ * `m2`, a superscript two into a plain `2`, and an acute accent into a space
+ * followed by an orphaned combining mark. Using it for `name` would silently
+ * rewrite what the user typed. This is the casing rule applied one axis
+ * further: the first writer's form wins, and the key is what collapses.
+ *
+ * Known limits, documented rather than papered over, because JS has no true
+ * case folding. German sharp-s and a doubled S do NOT dedupe — folding them
+ * would also merge two different German words (measures and mass), so not
+ * folding is the more correct behaviour. Neither do the Turkish dotted-I
+ * forms: Unicode's default folding gives `i` + U+0307 as well, and only the
+ * Turkish tailoring merges them, which is the non-deterministic path.
+ */
+export function normalizeTagName(raw: string): TagNameResult {
+  if (raw.length > MAX_RAW_TAG_INPUT) {
+    return { ok: false, reason: 'input_too_large', length: raw.length };
+  }
+
+  const refused = findRefusedCharacter(raw);
+  if (refused) {
+    return refused;
+  }
+
+  // Strip before normalizing: an "a", a zero-width space and a combining acute
+  // must compose to a-acute, which cannot happen while the ZWSP sits between.
+  const name = collapse(raw.replace(INVISIBLE_FORMATTING, '').normalize('NFC'));
+
+  if (name.length === 0) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  const length = [...name].length;
+  if (length > MAX_TAG_NAME_LENGTH) {
+    return { ok: false, reason: 'too_long', length, max: MAX_TAG_NAME_LENGTH };
+  }
+
+  return { ok: true, name, key: tagKey(name) };
+}
+
+/** What a tag can be attached to. Mirrors the Phase 2 `targetKind` enum. */
+export type TargetKind = 'page' | 'text' | 'sheet_cell' | 'channel_message' | 'ai_message';
+
+/**
+ * A tag's attachment point, payload included.
+ *
+ * This union IS the XOR that the Phase 2 CHECK constraint enforces — an anchor
+ * for the anchored kinds, exactly one message id for the row-identified kinds,
+ * nothing for a whole page — written once, in TypeScript. Callers in this repo
+ * get it at compile time; the constraint catches everyone else.
+ */
+export type TagTarget =
+  | { kind: 'page' }
+  | { kind: 'text'; anchor: TextAnchor }
+  | { kind: 'sheet_cell'; anchor: SheetCellAnchor }
+  | { kind: 'channel_message'; channelMessageId: string }
+  | { kind: 'ai_message'; aiMessageId: string };
+
+/**
+ * Which target kinds each page type accepts.
+ *
+ * Not hand-picked: every page type gets `'page'`, plus at most one
+ * content-level kind chosen by how that content is addressable —
+ *
+ *   anchored prose offsets  -> 'text'             DOCUMENT, CANVAS, CODE
+ *   natural key (sheet, A1) -> 'sheet_cell'       SHEET
+ *   stable cuid2 row id     -> the message kinds  CHANNEL, AI_CHAT
+ *   no addressable unit     -> nothing            FOLDER, FILE, TASK_LIST
+ *
+ * The first two land exactly on the page types with `supportsVersioning: true`
+ * in PAGE_TYPE_CONFIGS, which is not a coincidence and is asserted as a
+ * cross-registry drift test: forward-porting is the primary anchoring mechanism
+ * and it needs the version chain, so a page type that cannot version cannot
+ * carry an anchored tag. FILE is the clearest case — no versioning, and its
+ * default content is the empty string.
+ *
+ * TASK_LIST is `['page']` because `task_items.pageId` is notNull and unique: a
+ * task IS a page, so it inherits `['page', 'text']` through its own DOCUMENT
+ * page rather than needing a kind of its own.
+ *
+ * `as const satisfies Record<...>` rather than a plain Record: the
+ * exhaustiveness check makes a new page type without an entry a compile error,
+ * and the `as const` keeps the literal value types instead of widening them to
+ * TargetKind[]. Keyed by PageTypeValue so the list cannot be hand-written —
+ * see #2150, where three re-declarations drifted and silently dropped FILE.
+ */
+export const TAG_TARGETS = {
+  FOLDER: ['page'],
+  DOCUMENT: ['page', 'text'],
+  CHANNEL: ['page', 'channel_message'],
+  AI_CHAT: ['page', 'ai_message'],
+  CANVAS: ['page', 'text'],
+  FILE: ['page'],
+  SHEET: ['page', 'sheet_cell'],
+  TASK_LIST: ['page'],
+  CODE: ['page', 'text'],
+} as const satisfies Record<PageTypeValue, readonly TargetKind[]>;
+
+export type TargetRejection =
+  /** This page type does not accept this kind of target at all. */
+  | { ok: false; reason: 'kind_not_allowed'; pageType: PageTypeValue; kind: TargetKind }
+  /** The payload does not match the kind it claims. */
+  | { ok: false; reason: 'payload_mismatch'; kind: TargetKind; detail: string };
+
+export type TargetValidation = { ok: true } | TargetRejection;
+
+/**
+ * The guard the service and the database must agree on.
+ *
+ * Two rules, and they get separate reasons because only one of them is shared:
+ * `payload_mismatch` is also enforced by the Phase 2 CHECK constraint, whereas
+ * page-type compatibility is a rule the database never sees. That asymmetry is
+ * exactly why it needs a test here.
+ */
+export function validateTarget(pageType: PageTypeValue, target: TagTarget): TargetValidation {
+  const allowed: readonly TargetKind[] = TAG_TARGETS[pageType];
+  if (!allowed.includes(target.kind)) {
+    return { ok: false, reason: 'kind_not_allowed', pageType, kind: target.kind };
+  }
+
+  if (target.kind === 'channel_message' && target.channelMessageId.length === 0) {
+    return {
+      ok: false,
+      reason: 'payload_mismatch',
+      kind: target.kind,
+      detail: 'channelMessageId is empty',
+    };
+  }
+
+  if (target.kind === 'ai_message' && target.aiMessageId.length === 0) {
+    return {
+      ok: false,
+      reason: 'payload_mismatch',
+      kind: target.kind,
+      detail: 'aiMessageId is empty',
+    };
+  }
+
+  if (target.kind === 'sheet_cell' && target.anchor.address.length === 0) {
+    return {
+      ok: false,
+      reason: 'payload_mismatch',
+      kind: target.kind,
+      detail: 'sheet cell address is empty',
+    };
+  }
+
+  return { ok: true };
+}

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -164,6 +164,27 @@ const MEDIAL_SIGMA = '\u03c3';
  * property membership moves with the engine's ICU build, which the whole module
  * is built to avoid.
  */
+/**
+ * Renders as nothing on its own AND contributes nothing beside other text: the
+ * Hangul fillers and the Braille blank cell.
+ *
+ * Folded out of the KEY but kept in the NAME. Keeping them in the key is the
+ * dedupe hole INVISIBLE_FORMATTING's docstring calls "the more damaging half":
+ * `admin` and `admin<U+FFA0>` both render as `admin`, so two rows survive
+ * UNIQUE (driveId, normalizedKey), filtering by the visible tag finds half the
+ * content, and the lookalike cannot be reproduced by typing.
+ *
+ * Deliberately NOT the joiners or the variation selectors, which also render as
+ * nothing alone but change how their NEIGHBOURS render — folding those would
+ * make the family emoji key the same as three separate people.
+ *
+ * The cost, stated: a Braille tag mixing blank cells with real ones keys the
+ * same as one without them. Two Braille strings differing only in blank cells
+ * are near-indistinguishable on screen anyway, so collapsing them is the same
+ * trade made everywhere else here.
+ */
+const BLANK_IN_KEY = /[\u115f\u1160\u3164\uffa0\u2800]/g;
+
 const NOTHING_VISIBLE =
   /^[\u180b-\u180d\u180f\u200c\u200d\u115f\u1160\u3164\uffa0\u2800\ufe00-\ufe0f\u{e0020}-\u{e007f}\u{e0100}-\u{e01ef}]*$/u;
 
@@ -262,7 +283,13 @@ function collapse(value: string): string {
  *   case folding does; one `replace` buys it.
  */
 export function tagKey(name: string): string {
-  const folded = name.normalize('NFKC').toLowerCase().replace(FINAL_SIGMA, MEDIAL_SIGMA);
+  // Strips the invisibles again even though a normalized name has none left.
+  // It is idempotent there, and it stops the obvious next-phase use — keying a
+  // raw search string to find an existing tag — from silently producing a key
+  // no stored row can carry, where one pasted zero-width space misses the row
+  // and drives a duplicate insert.
+  const stripped = name.replace(INVISIBLE_FORMATTING, '').replace(BLANK_IN_KEY, '');
+  const folded = stripped.normalize('NFKC').toLowerCase().replace(FINAL_SIGMA, MEDIAL_SIGMA);
   return collapse(folded.normalize('NFKC'));
 }
 
@@ -450,6 +477,41 @@ export function validateTarget(pageType: string, target: TagTarget): TargetValid
     };
   }
 
+  // `target` gets the same treatment as `pageType` above: it arrives from a
+  // request body, so a missing payload must be a rejection rather than a
+  // TypeError from the guard the service and the database are meant to agree on.
+  if ((target.kind === 'text' || target.kind === 'sheet_cell') && !target.anchor) {
+    return {
+      ok: false,
+      reason: 'payload_mismatch',
+      kind: target.kind,
+      detail: 'anchor is missing',
+    };
+  }
+
+  if (target.kind === 'text') {
+    const { anchor } = target;
+    // An anchor with no quote AND no context on either side cannot be located
+    // by anything: resolveAnchor orphans exactly this shape, so a tag stored
+    // with it is orphaned from birth. A caret WITH context is legitimate.
+    if (anchor.exact.length === 0 && anchor.prefix.length === 0 && anchor.suffix.length === 0) {
+      return {
+        ok: false,
+        reason: 'payload_mismatch',
+        kind: target.kind,
+        detail: 'anchor has neither a quote nor any context',
+      };
+    }
+    if (!(anchor.start >= 0) || !(anchor.end >= anchor.start)) {
+      return {
+        ok: false,
+        reason: 'payload_mismatch',
+        kind: target.kind,
+        detail: `anchor range is not ascending: ${anchor.start}..${anchor.end}`,
+      };
+    }
+  }
+
   if (target.kind === 'sheet_cell') {
     // Both halves of the natural key, not just one. A sheet cell is identified
     // by (sheet name, A1 address), so an anchor missing either half points at
@@ -464,12 +526,20 @@ export function validateTarget(pageType: string, target: TagTarget): TargetValid
         detail: 'sheet name is empty',
       };
     }
-    if (!isValidCellAddress(target.anchor.address)) {
+    // Canonical form, not merely a form isValidCellAddress tolerates. That
+    // helper trims and upper-cases before testing, so 'aa10' and ' A1 ' pass —
+    // but the payload is stored verbatim while sheet storage keys cells by the
+    // UPPERCASED address (sheets/io.ts), so a tag on 'aa10' would validate and
+    // then never match cells['AA10']. Requiring the canonical form is what
+    // actually makes the guard and the storage agree; the service upper-cases
+    // before calling, since a pure function cannot do it for the caller.
+    const { address } = target.anchor;
+    if (!isValidCellAddress(address) || address !== address.trim().toUpperCase()) {
       return {
         ok: false,
         reason: 'payload_mismatch',
         kind: target.kind,
-        detail: `not an A1 cell address: ${JSON.stringify(target.anchor.address)}`,
+        detail: `not a canonical A1 cell address: ${JSON.stringify(address)}`,
       };
     }
   }

--- a/packages/lib/src/tags/tag-core.ts
+++ b/packages/lib/src/tags/tag-core.ts
@@ -172,23 +172,25 @@ const MEDIAL_SIGMA = '\u03c3';
  * is built to avoid.
  */
 /**
- * Renders as nothing on its own AND contributes nothing beside other text: the
- * Hangul fillers and the Braille blank cell.
+ * Blank but SPACE-LIKE: the Hangul fillers and the Braille blank cell occupy a
+ * character's width and render as a gap, unlike the zero-width family above.
  *
- * Folded out of the KEY but kept in the NAME. Keeping them in the key is the
- * dedupe hole INVISIBLE_FORMATTING's docstring calls "the more damaging half":
- * `admin` and `admin<U+FFA0>` both render as `admin`, so two rows survive
- * UNIQUE (driveId, normalizedKey), filtering by the visible tag finds half the
- * content, and the lookalike cannot be reproduced by typing.
+ * Folded to a space in the KEY, kept verbatim in the NAME. Both halves of that
+ * matter, and getting either wrong opens a dedupe hole in one direction:
  *
- * Deliberately NOT the joiners or the variation selectors, which also render as
+ *   - Keeping them as themselves splits `admin` from `admin<U+FFA0>`, which
+ *     render identically. That is the hole INVISIBLE_FORMATTING's docstring
+ *     calls "the more damaging half".
+ *   - Deleting them outright splits `a b` from `a<U+3164>b`, which ALSO render
+ *     identically — the same hole mirrored, and the one an earlier version of
+ *     this constant introduced while closing the first.
+ *
+ * Folding to a space closes both: the trailing case trims away, and the
+ * interior case collapses into the ordinary space it looks like.
+ *
+ * Deliberately NOT the joiners or the variation selectors, which render as
  * nothing alone but change how their NEIGHBOURS render — folding those would
- * make the family emoji key the same as three separate people.
- *
- * The cost, stated: a Braille tag mixing blank cells with real ones keys the
- * same as one without them. Two Braille strings differing only in blank cells
- * are near-indistinguishable on screen anyway, so collapsing them is the same
- * trade made everywhere else here.
+ * key the family emoji the same as three separate people.
  */
 const BLANK_IN_KEY = /[\u115f\u1160\u3164\uffa0\u2800]/g;
 
@@ -295,7 +297,7 @@ export function tagKey(name: string): string {
   // raw search string to find an existing tag — from silently producing a key
   // no stored row can carry, where one pasted zero-width space misses the row
   // and drives a duplicate insert.
-  const stripped = name.replace(INVISIBLE_FORMATTING, '').replace(BLANK_IN_KEY, '');
+  const stripped = name.replace(INVISIBLE_FORMATTING, '').replace(BLANK_IN_KEY, ' ');
   const folded = stripped.normalize('NFKC').toLowerCase().replace(FINAL_SIGMA, MEDIAL_SIGMA);
   return collapse(folded.normalize('NFKC'));
 }


### PR DESCRIPTION
## What

`packages/lib/src/tags/tag-core.ts` — one pure module and its tests. Tag-name normalization, the page-type → allowed-target-kinds registry, and the guard the service and the database will have to agree on. **Nothing else**: no schema, no migration, no service, no routes, no UI.

Phase 1 of the Content Tags epic (`etvdzkdkq4rtzw7hq1t99vix`). Phase 0 (#2436) shipped the anchoring primitive; this is its first consumer, via a type-only import.

## Why now, as its own PR

Phase 2 is about to make both of these rules permanent in ways that are expensive to walk back:

- `UNIQUE (driveId, normalizedKey)` bakes the dedupe rule into an index. Change the key rule later and every existing row has to be recomputed and every new collision resolved by hand.
- The `content_tags` CHECK constraint is effectively one-way in this repo's migration conventions — amending it later means writing a replacement constraint, not editing one.

Reviewing them as plain functions is cheaper than getting them back out of an index.

## The one design call worth your attention

**The display name is NFC and only the key is NFKC.** They are deliberately different normal forms.

NFKC folds compatibility variants, which is exactly what a dedupe key wants — it makes a mathematical-script `𝓒𝓸𝓸𝓵` resolve to the existing `cool` tag instead of creating a lookalike duplicate. It is exactly what a *display* name must not do:

| Typed | NFKC would store | |
|---|---|---|
| `㎡` | `m2` | an area tag silently becomes something else |
| `x²` | `x2` | the exponent becomes a digit |
| `´` | `SPACE` + combining acute | injects a space and an orphaned mark |
| `𝓒𝓸𝓸𝓵` | `Cool` | *desirable — in the key* |
| `ﬁ`, `Ａ`, `①` | `fi`, `A`, `1` | *desirable — in the key* |

So the name keeps what the user typed and the key is what collapses. That is the casing decision (first writer's casing wins) applied one axis further: the first writer's *form* wins too.

`slugify` is deliberately not reused — its `[^\w-]+` has no `u` flag, so `café` → `caf` and `日本語` → `''`. Every Japanese tag in a drive would collapse to one empty key. This is the first Unicode normalization anywhere in the repo, which is most of why it is worth its own review.

## Three load-bearing details in the key path

Each has a test that fails without it.

1. **NFKC runs before the fold.** `'℡'.toLowerCase()` is a no-op and NFKC then yields the **uppercase** `TEL`; folding after NFKC gives `tel`.
2. **NFKC runs again after the fold.** `toLowerCase` does not preserve normal form: `H` + combining macron below lowercases to the *decomposed* pair, while the same word typed in lowercase composes to U+1E96 — two keys for one word without the second pass. I nearly dropped this one as redundant; it survived a mutation check, and I only found the case that proves it by scanning 196k code points for one.
3. **Greek final sigma is folded to medial.** JS implements Unicode's `Final_Sigma` rule, so `ΟΔΟΣ` lowercases with U+03C2 while someone typing the medial form gets U+03C3 — two tags for one word.

**`toLocaleLowerCase` is banned by a source-level assertion**, not just by convention. Without an explicit locale it uses the *host* locale, so a Turkish machine keys `IT` with a dotless i and cannot see the row it should dedupe against. That is Phase 0's determinism bug in new clothes, and this one lands inside a unique index. `Intl.*` and Unicode property escapes are banned in the same test, for the same reason — both make output depend on the runtime's ICU build.

## Invisible characters split three ways, not two

| Class | Action | Why |
|---|---|---|
| Bidi overrides/isolates, ZWSP, soft hyphen, BOM, LRM/RLM, **WORD JOINER, invisible math operators, CGJ, interlinear annotation, musical format controls** | **strip** | NFKC leaves them alone, so two tags look identical and are two rows — the dedupe hole, and the whole RLO spoofing surface |
| NUL, other C0/C1, DEL, lone surrogates, noncharacters | **refuse** | Postgres stores none of them. Stripping means this core says "fine" and the INSERT fails later — and silently storing a different name than the one submitted is the worse failure anyway |
| **ZWNJ, ZWJ, variation selectors, tag characters** | **keep** | Stripping ZWJ turns 👨‍👩‍👧 into three separate people; ZWNJ is required orthography in Persian and Indic scripts; VS16 is the difference between ❤️ and ❤ |

**The set is derived, not remembered.** Three review rounds each found a different missing code point — U+2060, then U+E0001, then the deprecated format block. Three misses in one list is a list maintained by memory, so it is now the whole `Default_Ignorable_Code_Point` class minus an explicit keep-list, with a test that sweeps every code point in that class and fails on anything unaccounted for.

That sweep found **3751 further leaks across eight ranges** nobody had flagged: the Khmer inherent vowels, U+2065, the deprecated format characters U+206A–206F, the shorthand format controls, and four unassigned ignorable blocks. Each was live: `a<invisible>b` keyed differently from `ab`, and Phase 2 is about to bake that key into a unique index. Mutating any one range back out turns the sweep red.

The keep-list is small and every entry earns its place: the two joiners, all four variation-selector ranges (including the Mongolian FVS), the tag characters that encode subdivision flags, and the four blank renderers that `NOTHING_VISIBLE` refuses as a whole name.

**It carries two obligations, and both are derived from one source.** Every kept code point must survive a strip (it is meaningful next to another character) *and* must be refused as a whole name (a blank chip is unusable). Asserting those from two hand-written lists is how U+180B–180D and U+180F ended up satisfying the first and not the second — a name of one Mongolian variation selector was accepted and rendered as nothing. There is now one `KEPT_CODE_POINT_RANGES` and both assertions derive from it, so neither can drift without the other failing.

Verified against the built artifact that the family emoji, 🏴󠁧󠁢󠁳󠁣󠁴󠁿, the VS16 heart and Persian ZWNJ orthography all round-trip unchanged.

**One deliberate asymmetry, since it looks like a contradiction:** the sweep uses `\p{Default_Ignorable_Code_Point}`, which the module is forbidden to use and the purity test enforces. The module's output must be byte-identical on every runtime, so ICU-tracking property membership cannot be in the production path. A test is the opposite case — if a future runtime knows ignorables this build does not, that is a new dedupe hole and a loud CI failure is how one wants to hear about it.

Separately, a name made **only** of characters that render as nothing is refused. U+3164 Hangul filler and U+2800 Braille blank are the classic trick — ordinary letters by category, blank on screen, each a different code point, so several distinct blank tags could coexist with nobody able to retype, search for, or tell them apart.

The obvious implementation — strip everything `Default_Ignorable` — mangles all four of the last row, and its membership tracks the engine's ICU version besides. Every set is enumerated literally for that reason, and written as escape sequences rather than literal characters: a literal invisible is unreviewable in a diff, which is precisely the property this module exists to police. A test asserts the source contains none.

## `TAG_TARGETS` is not hand-picked

Every page type gets `'page'`, plus at most one content-level kind chosen by how its content is addressable:

| Addressing | Kind | Page types |
|---|---|---|
| Anchored prose offsets | `text` | DOCUMENT, CANVAS, CODE |
| Natural key `(sheet, A1)` | `sheet_cell` | SHEET |
| Stable cuid2 row id | `channel_message` / `ai_message` | CHANNEL, AI_CHAT |
| No addressable unit | — | FOLDER, FILE, TASK_LIST |

The anchored kinds land **exactly** on the page types with `supportsVersioning: true` in `PAGE_TYPE_CONFIGS`. That is not a coincidence and it is asserted as a cross-registry drift test: forward-porting is the primary anchoring mechanism and it needs the version chain, so a page type that cannot version cannot carry an anchored tag. FILE is the clearest case — no versioning, and its default content is the empty string.

`TASK_LIST` is `['page']` because `task_items.pageId` is notNull and unique: a task *is* a page, so it inherits `['page', 'text']` through its own DOCUMENT page.

`as const satisfies Record<PageTypeValue, …>` keeps both the exhaustiveness check (a new page type without an entry is a compile error) and the literal value types. The list is never hand-written — #2150 is the scar from three re-declarations drifting apart and silently dropping FILE.

## Validation

```
bun run typecheck        Tasks: 17 successful, 17 total     # monorepo-wide, CI's gate
bun run lint             Tasks: 15 successful, 15 total
bun run knip:check       [ok] knip: 4 issue(s), all within baseline (4)
vitest src/tags          Test Files 1 passed | Tests 64 passed
```

`tag-core.ts` scores **100% statements, branches, functions and lines.** Full `@pagespace/lib` suite: `9712 passed, 9 failed`. All 16 failing files are `*.integration.test.ts` needing a live Postgres — pre-existing and environment-only, none in `tags/`.

### Mutation checks — 76 mechanisms, all red

Coverage does not prove a mechanism is guarded, so each was broken in source, the suite run, and restored (baseline re-verified, `git diff` clean).

Both normal forms · NFKC-before-fold · NFKC-after-fold · final-sigma fold · case fold · invisible strip · strip-before-normalize · joiners excluded from the strip set · the wide whitespace set · whitespace collapse · raw-input guard · empty rejection · code-point length unit · too-long rejection · control rejection · collapsible-vs-damaging controls · both surrogate rejections · astral code-point arithmetic · three noncharacter mechanisms · the page-type gate · three payload checks · four `TAG_TARGETS` entries.

### What review changed

- **`validateTarget` threw instead of guarding.** `TAG_TARGETS[pageType]` is `undefined` for an unknown key. Not hypothetical: `MACHINE` is still a value in the DB's `PageType` pgEnum, deleted from the TS enum in the Phase 8 teardown because Postgres cannot `DROP VALUE` — so a `pages.type` the signature says cannot arrive, can. Reproducing it turned up a second mode the obvious fix would have missed: a bare object index reaches the **prototype**, so `TAG_TARGETS['constructor']` is a *function*, not `undefined`. Membership now goes through a Set derived from `Object.keys`. Same shape as the `&__proto__;` bug in Phase 0's entity table — second occurrence of one class, so I swept both modules for it; the remaining index lookups are all numeric array/string indexing.
- **The strip list, the blank-name check, the key ceiling and the sheet-cell payload check** — see above.
- **`validateTarget` took `PageTypeValue` while returning `unknown_page_type` for values outside it**, so every real caller needed `as PageTypeValue` to reach the check that exists to make that cast unnecessary. My own tests did exactly that, which should have been the tell. It takes a `string` now, and `isTaggablePageType` is exported so the service narrows with the same set rather than a second hand-rolled one.
- **The invisible-character list was being maintained by memory** — replaced with a derived set and a sweep, see above. The keep-list then turned out to have the same problem on its other half, and got the same treatment.
- **The literal-invisible source scan rejected `\r`**, so a CRLF checkout or `core.autocrlf=true` would have failed it on line endings rather than on a tag-name fixture.
- **The module was doing the thing its own docstring warns against.** `INVISIBLE_FORMATTING`'s comment argues that counting a character blank rather than stripping it leaves "the dedupe hole, the more damaging half" — and the blank renderers were doing exactly that: `admin` and `admin<U+FFA0>` keyed differently while both chips render as `admin`. They are now folded out of the key and kept in the name.
- **`validateTarget` hardened `pageType` and then trusted `target` completely**, so `{"kind":"sheet_cell"}` from a request body threw a `TypeError` rather than returning `payload_mismatch`.
- **The `text` kind had no payload validation at all**, alone among the non-`page` kinds, so an anchor `resolveAnchor` orphans outright was accepted — a tag orphaned from birth.
- **The address check tolerated what it should have canonicalised.** `isValidCellAddress` trims and upper-cases before testing while the payload stores verbatim and sheet storage keys by the uppercased address, so `'aa10'` validated and then never matched `cells['AA10']`.

Five invariants are fuzzed rather than merely asserted, and **re-fuzzed after every change to the key pipeline** rather than cited from an earlier run. Across **250,558** generated names built from a pool of adversarial code points: zero idempotency failures, zero cases where `tagKey(name) !== key` (the contract a Phase 2 backfill depends on), zero empty keys, zero keys over the ceiling, and every key NFKC-stable.

Re-running rather than citing is what caught the one regression in this PR that no reviewer found: folding the blank renderers out of the key made a name of two of them separated by a space produce an **empty key** — uniquely damaging under `UNIQUE (driveId, normalizedKey)`, since exactly one row can hold it. Then the fix for *that* had to be corrected again, because these characters are space-width rather than zero-width: deleting them split `a b` from `a<U+3164>b`, the same lookalike hole mirrored. They are now folded **to a space**, which closes both directions.

**Two dead branches were removed rather than left untestable** — a `?? 0` fallback for a case the preceding branch already ruled out, and a length check that `charCodeAt`'s documented `NaN` already covered. **One guard I had judged redundant turned out not to be**, which is the second time this epic that a "provably redundant" call of mine was wrong; the difference is that this time a mutation check caught it before review did.

## Explicitly out of scope

No schema, no migration, no `packages/db`. No service, no routes, no UI. Not wired into anything — the module has no callers yet, which is why it needs its `knip.json` entry.

## Notes for Phase 2, found while building this

- **`scripts/` treats `tags` and `page_tags` as first-class tenant tables.** Reclaiming `tags` must also update `scripts/lib/tenant-export-columns.ts:160-162` and `scripts/lib/migration-types.ts:25,127-128`, plus the two schema-coverage tests. The original plan's claim that the trash route is the only reference is incomplete.
- **`messages` has no `pageId`.** It reaches a page only via `conversations.contextId`, which is polymorphic and carries no FK — null for global chats, a driveId for drive chats, a pageId only for page chats. So `content_tags.pageId` cannot be derived by a join for every AI message; `ai_message` tags should be scoped to conversations anchored to an AI_CHAT page.
- **`normalizedKey` must be `text`, not `varchar(64)`** — and the module now exports `MAX_TAG_KEY_LENGTH` so you don't have to take my word for it. The 64-code-point limit is on the *name*; NFKC expands, and measured exhaustively over all 1.1M code points the worst single character is U+FDFA at 18×, so a legal name can key to **1152 code points / 2112 bytes**. The obvious `varchar(64)` mirroring the name limit would reject a legal tag at INSERT — exactly the failure this module refuses characters rather than stripping them to avoid. It fits under the ~2704-byte btree tuple limit, but not with much room.
- **The DB `PageType` pgEnum still contains `MACHINE`**, deleted from the TS enum in the Phase 8 teardown because Postgres cannot `DROP VALUE`. `TAG_TARGETS` correctly has no entry for it, but a CHECK constraint enumerating page types must not trip over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hRNwJ7LYfVn3g9W8sQRkv
