### PR TITLE
fix(documents): stop discarding local edits on a 409 save conflict

### DIFF
--- a/.pu-reports/pu-mp-conflict-409.md
+++ b/.pu-reports/pu-mp-conflict-409.md
@@ -4,6 +4,42 @@ Board: Multiplayer Documents (Yjs CRDT), Phase A, task `jc5su9gmeohiyo3ulzu7o143
 Client-side only. No server code touched; the 409 contract in
 `apps/web/src/app/api/pages/[pageId]/route.ts` is unchanged.
 
+## Why this PR touches four files outside the document view
+
+A reviewer opening this diff sees `CanvasPageView`, `CodePageView`, `SheetView` and
+`TaskListDescription` changed in a PR titled "409 conflict fix". That is not scope creep — it is a
+dependency, and omitting it would ship a worse bug than the one being fixed.
+
+`useDocument` has **five** production consumers, and every one of them writes through the same
+`saveWithDebounce` / `forceSave` this PR now guards:
+
+| Consumer | File |
+|---|---|
+| Document | `page-views/document/DocumentView.tsx:58` |
+| Code | `page-views/code/CodePageView.tsx:95` |
+| Canvas | `page-views/canvas/CanvasPageView.tsx:88` |
+| Task list | `page-views/task-list/TaskListDescription.tsx:33` |
+| Sheet | `page-views/sheet/hooks/useSheetPersistence.ts:32` (rendered by `SheetView.tsx`) |
+
+The conflict guard lives in the **hook**, so all five stop autosaving the moment a conflict is
+parked. The resolution UI originally lived only in `DocumentView`. That asymmetry means a 409 on a
+Canvas or Sheet page would park a conflict, silently block every subsequent save, flash one toast,
+and leave the user editing a document that never saves again — with nothing on screen to explain it
+and no way to clear it. Edits would survive in memory until reload, then vanish. Strictly worse than
+the original bug, which at least lost the buffer once and visibly.
+
+So the guard and its release valve have to sit at the same altitude. `DocumentConflictGate`
+(`page-views/document/DocumentConflictGate.tsx`) renders `null` until a conflict exists for its
+`pageId`, which lets a view mount it unconditionally in one line. Each of the four extra files
+gains exactly one line plus an import. Extracting the gate rather than copying the banner four
+times keeps the four views free of conflict logic, and a CRDT deletes all five call sites equally.
+
+**Mutation-checked (M13):** deleting the `if (!conflict) return null;` early return from the gate
+turns both `DocumentConflictGate` tests red — the "renders nothing so views can mount it
+unconditionally" case and the "surfaces the resolve UI" case. That is the assertion holding the
+whole arrangement up: without it, mounting the gate in four unrelated views would render a banner
+on every page.
+
 ## The bug
 
 `useDocument.ts`'s 409 handler refetched the server's copy and wrote it straight over

--- a/.pu-reports/pu-mp-conflict-409.md
+++ b/.pu-reports/pu-mp-conflict-409.md
@@ -1,0 +1,126 @@
+# PR 1 — Stop discarding local edits on 409
+
+Board: Multiplayer Documents (Yjs CRDT), Phase A, task `jc5su9gmeohiyo3ulzu7o143`.
+Client-side only. No server code touched; the 409 contract in
+`apps/web/src/app/api/pages/[pageId]/route.ts` is unchanged.
+
+## The bug
+
+`useDocument.ts`'s 409 handler refetched the server's copy and wrote it straight over
+`documents.get(pageId).content`, cleared `isDirty`, cleared `useDirtyStore`, and logged the
+user's lost text to `console.warn`. The toast said "your local copy has been updated", which
+described a data loss as a sync. An existing test asserted that behaviour, so it was pinned.
+
+## What changed
+
+**New pure module — `apps/web/src/lib/documents/conflict-resolution.ts`.** No zustand, no
+sonner, no fetch; `detectedAt` is injected rather than read from the clock. Three functions:
+
+- `decideConflictOutcome({ conflictBody, remotePage, detectedAt })` → `conflict` or `error`. A
+  conflict is only offered when we have both the server's content (to show) and a revision (so
+  the retry can't 409 on the same collision). The revision falls back from the refetched page to
+  `currentRevision` in the 409 body. If neither is available, or the refetch failed, it returns
+  an error — and the local buffer is still left alone.
+- `planConflictResolution(choice, { localContent, conflict })` → `keep-mine` gives
+  `{ action: 'save-local', contentToSave, expectedRevision: remoteRevision }`; `use-theirs`
+  gives `{ action: 'adopt-remote', contentToAdopt, revision }`.
+- `canScheduleSave({ hasPendingConflict })` — the autosave predicate.
+
+**Store — `useDocumentManagerStore`** gains `conflicts: Map<pageId, DocumentConflict>` with
+`setConflict` / `clearConflict`. It is a separate slot: nothing about a conflict touches
+`documents`. `clearDocument` and `clearAllDocuments` clear it too.
+
+**Hook — `useDocument.ts`.** On 409 the handler now parses the 409 body, refetches the server
+page, and hands both to `decideConflictOutcome`. `content`, `isDirty` and `useDirtyStore` are
+never written on this path. It also cancels any debounce that was queued *before* the conflict
+was detected — otherwise that one timer fires, 409s again, and loops.
+
+`saveWithDebounce` consults `canScheduleSave` twice: at schedule time and again inside the
+timeout, because a conflict can be detected during the 1000 ms window. `forceSave` consults it
+and returns `false`. So neither typing nor Cmd-S can re-fire a PATCH while a conflict is parked.
+
+`saveDocument` takes an optional `{ expectedRevision }` override, so the keep-mine retry can
+compare-and-swap against the revision we observed instead of the stale stored one.
+
+`resolveConflict(choice)` applies the plan: `use-theirs` adopts locally and sends no PATCH (the
+server already holds that content); `keep-mine` clears the conflict first — so the save isn't
+blocked by its own guard — and re-saves. **If a third party saved between detection and the
+click, that retry 409s again and re-parks a fresh conflict with the newer remote content.** The
+user's text is still not replaced, and they get a new, accurate choice rather than a generic
+error. That path has its own test.
+
+**UI — `DocumentConflictBanner.tsx`**, rendered by `DocumentView` above the editor whenever a
+conflict is parked. Persistent: no timeout, no dismiss. It has "Keep mine" and "Use theirs", and
+a "View their version" disclosure that renders the parked `remoteContent` read-only —
+DOMPurify-sanitized for `html` mode, plain `<pre>` for `markdown`. The existing `useEditingStore`
+registration at `DocumentView.tsx` is untouched.
+
+## The page-history reassurance: it does NOT hold
+
+The original brief asked me to tell the user the discarded version stays recoverable from page
+history, after verifying it. The data-layer half is true and I confirmed it:
+`applyPageMutation` calls `createPageVersion` unconditionally inside the mutation transaction
+(`page-mutation-service.ts`), with the post-mutation content at the new revision, and there is
+no early return that skips it on a successful mutation. So the other person's revision genuinely
+is persisted.
+
+The user-facing half is false, and the orchestrator independently confirmed it mid-task:
+`apps/web/src/app/api/pages/[pageId]/history/route.ts` is GET-only, there is no restore endpoint,
+no UI reads page history, and the rows expire after 30 days. A user cannot get that content back.
+
+So the copy is not in the product. The banner says plainly that Keep mine replaces their version
+and Use theirs discards your unsaved changes, and the "View their version" panel exists precisely
+so the choice is informed instead of resting on a promise we can't keep. There is a test
+asserting the banner contains neither "recoverable" nor "history".
+
+## Mutation-check evidence
+
+Every mutation below was applied to the source, the relevant suite was run, and the source was
+restored. All ten went red. None touch `packages/*`, so the `dist` rebuild caveat does not apply
+here — every mutated file is compiled from source by the web test run.
+
+| # | Mutation | Test that went red |
+|---|---|---|
+| M1 | 409 handler overwrites the local buffer with remote content again (restores the original bug) | `should preserve the local buffer and park the server copy` + the re-409 test |
+| M2 | `saveWithDebounce` stops consulting the guard | `given a pending conflict, saveWithDebounce should not fire a PATCH` |
+| M3 | `forceSave` stops consulting the guard | `given a pending conflict, forceSave should not fire a PATCH` |
+| M4 | keep-mine plans `expectedRevision: 0` instead of `remoteRevision` | pure `planConflictResolution` test + `keep-mine … against the remote revision` |
+| M5 | use-theirs plans `save-local` instead of `adopt-remote` | pure test + `use-theirs … send no PATCH` |
+| M6 | failed refetch parks a bogus conflict instead of erroring | `given the refetch failed, should return an error` |
+| M7 | 409 no longer cancels the queued debounce | `should cancel the pending debounce so the autosave loop cannot re-fire` |
+| M8 | keep-mine clears the conflict after the save regardless of a repeat 409 | `keep-mine that 409s again … re-park the fresh conflict` |
+| M9 | banner renders remote content unsanitized | `given remote content carrying a script, should render it sanitized` |
+| M10 | banner re-adds the false history reassurance | `should not promise the discarded version is recoverable` |
+
+Note on M2/M3: `canScheduleSave` is a one-line predicate, and its own unit test (`!x`) is a
+tautology that no mutation could meaningfully break. The risk it exists to cover is whether the
+two call sites actually consult it, so that is where the mutation-check is aimed.
+
+## Gates
+
+- `bun run typecheck` (monorepo root) — 17/17 tasks successful.
+- `bun run lint` — 15/15 tasks successful; the remaining warnings are pre-existing and in
+  unrelated files.
+- `bun run --filter web test -- src/lib/documents src/hooks/__tests__/useDocument.test.ts
+  src/components/layout/middle-content/page-views/document` — 35 tests, 3 files, all passing.
+
+Worktree setup done before gates meant anything: `bun install`, then `@pagespace/db` and
+`@pagespace/lib` dist builds (`apps/web` imports lib from dist).
+
+## Deliberately not done
+
+- **No Yjs, CRDT, or collab code.** `RichEditor.tsx`'s extension list is untouched. Phases B+.
+- **No server changes.** The 409 response already returns `currentRevision` / `expectedRevision`
+  and is correct as-is.
+- **No page-history UI or restore endpoint.** Out of scope, and explicitly ruled out by the
+  orchestrator. It is the obvious follow-on to the finding above, but it is not this PR's call.
+- **No three-way merge.** Keep mine / Use theirs is a whole-document choice. Character-level
+  merge is the point of the CRDT phases; building a bespoke merge here would be work thrown away.
+- **No conflict handling for the remote-update path** (`DocumentView.tsx`'s socket handler drops
+  remote changes while you are dirty). That is a real adjacent gap, but it is a different
+  code path from the 409 write path this task scopes, and silently widening scope into it would
+  make the diff harder to review. Flagging it, not fixing it.
+- **No coverage-threshold glob** added for `src/lib/documents/*.ts`. The house pattern gates new
+  pure modules at 100% branch; I did not add the entry because I could not verify the exact
+  figure under the full `turbo run test:coverage` invocation without a whole-suite run, and a
+  wrong entry breaks CI for everyone. Cheap to add later with that number in hand.

--- a/.pu-reports/pu-mp-conflict-409.md
+++ b/.pu-reports/pu-mp-conflict-409.md
@@ -107,6 +107,100 @@ two call sites actually consult it, so that is where the mutation-check is aimed
 Worktree setup done before gates meant anything: `bun install`, then `@pagespace/db` and
 `@pagespace/lib` dist builds (`apps/web` imports lib from dist).
 
+## Round 2 — review response (CodeRabbit + a 4-angle cleanup pass)
+
+### Absent vs empty content — fixed at the root, both directions
+
+CodeRabbit caught `remotePage.content ?? ''`: an ABSENT content field became an empty remote
+document, so "Use theirs" would replace the user's text with nothing — data loss through the exact
+door this PR closes. A sweep for the same question asked elsewhere found the mirror image in
+`resolveConflict`: `state.documents.get(pageId)?.content ?? ''` would let "Keep mine" save an
+EMPTY document over the other person's work if the local record were missing.
+
+`?? ''` cannot express the distinction, and it was now being asked twice, so the fix is a single
+narrowing primitive rather than two remembered guards:
+
+```ts
+export type ContentRead = { present: true; content: string } | { present: false };
+export function readContent(content: string | null | undefined): ContentRead
+```
+
+`undefined` → absent, `null` → an empty document (unchanged, still offerable). The remote side
+returns an `error` outcome; the local side refuses to resolve, leaves the conflict parked, and
+says so. Mutation M11 (delete the `undefined` branch) turns all three levels red at once.
+
+### The regression I introduced, and fixed
+
+The altitude review found it and it is the most important item in this round. `useDocument` has
+**five** production consumers — `DocumentView`, `CodePageView`, `CanvasPageView`,
+`TaskListDescription`, `useSheetPersistence`/`SheetView` — and all five route writes through the
+guarded `saveWithDebounce`/`forceSave`. But the banner was rendered only by `DocumentView`. On the
+other four surfaces a 409 would park a conflict, pause autosave, and offer **no way to resolve
+it** — saving silently dead for the rest of the session, with edits surviving in memory only until
+reload. That is worse than the bug this PR fixes.
+
+Fix: `DocumentConflictGate` — renders nothing until a conflict exists for its `pageId`, so a view
+mounts it unconditionally in one line. All five views now do. `isResolvingConflict` moved into
+`useDocument` so the gate is self-contained (previously local state in `DocumentView`).
+
+### Other review findings applied
+
+- `DOMPurify.sanitize` with default config replaced by the app's shared `sanitizeHtmlAllowlist`
+  — the banner was the only `dangerouslySetInnerHTML` site in `apps/web` not using it, and the
+  default profile keeps `style`/`form`/arbitrary attributes the allowlist strips. Caveat: the
+  allowlist has no `img`, so images in the other version show as absent in the preview pane. An
+  acceptable trade for one consistent sanitization policy.
+- Hand-rolled disclosure replaced with the repo's Radix `Collapsible` (correct trigger/content
+  ARIA association, which the hand-rolled `aria-expanded` lacked).
+- Sanitization is now deferred until the disclosure is actually opened — it was running eagerly on
+  the frame the 409 landed, mid-typing, for a pane most users never open.
+- `contentMode` prop became `previewMode: 'rich' | 'plain'`, so code/canvas/sheet can show their
+  JSON verbatim rather than through an HTML renderer.
+- Dropped a dead `export type { DocumentConflict }` re-export from the store; made `resolveConflict`
+  use one `state` handle consistently.
+
+### Review findings deliberately NOT applied
+
+- **Inline `canScheduleSave` / `planConflictResolution` away** (raised by three of four angles).
+  Both are named in the task spec as required exports of the pure module. `canScheduleSave` is
+  genuinely a tautology in isolation — which is why its mutation-checks are aimed at the two call
+  sites, not at the predicate. Left as specified rather than quietly redesigning the brief.
+- **Move `conflicts` onto `DocumentState`** so it resets with `upsertDocument`. Rejected on
+  inspection: clearing a conflict on remount would silently resume autosave against the freshly
+  fetched revision, overwriting the other person's text with no prompt — "Keep mine" by default.
+  Keeping the conflict parked is the protective behaviour. (`clearDocument` clears both maps and
+  has no production callers today; that is harmless defensive code.)
+- **Park a conflict from the socket handler** (`DocumentView`'s `handleContentUpdate` drops remote
+  changes while dirty). Correct that the machinery generalizes, but it is a behaviour change beyond
+  the 409 write path this task scopes.
+- **Route the conflict refetch through SWR** (CodeRabbit). Rejected and answered on the PR thread.
+  `CLAUDE.md` requires editors to register with `useEditingStore` specifically to prevent SWR
+  clobbering. Also the premise is factually wrong: `PagePaneView.tsx:66` keys on
+  `encodeURIComponent(pageId)` while `WorkflowForm.tsx:68` keys on the raw id — different cache
+  entries, so there is no single "shared key". And `PagePaneView` already holds a live
+  `useSWR<TreePage>` on that key while rendering `DocumentView` beneath it, passing down only
+  `id`/`driveId`; no content crosses today, which is exactly why nothing clobbers.
+
+### Round 2 mutation checks
+
+| # | Mutation | Test that went red |
+|---|---|---|
+| M11 | `readContent` conflates absent with empty (the bug, at its root) | primitive + remote-decision + local-guard tests, all three |
+| M12 | local side falls back to `''` again | `given no local document record, should refuse to resolve` |
+| M13 | gate renders the banner with no conflict parked | both `DocumentConflictGate` tests |
+| M14 | banner renders remote content unsanitized | `should render it sanitized` |
+
+### Round 2 gates
+
+`bunx tsc --noEmit` in `apps/web` exits 0; `bun run typecheck` 17/17; `bun run lint` 15/15.
+Tests across `src/lib/documents`, the hook, and all of `page-views`: **424 passed, 1 file failed** —
+`useTaskSubTasks.integration.test.tsx`, which needs a migrated Postgres this worktree does not have
+and prints its own opt-out instructions. Unrelated to this change.
+
+Twice during this work `bun run typecheck` exited non-zero with a flood of TS6053 `.next/types not
+found` and **no diagnostics**, then passed on an immediate rerun. It looks like `web#typecheck`
+racing `web#build` in the same turbo graph. Worth knowing before someone bisects a phantom CI flake.
+
 ## Deliberately not done
 
 - **No Yjs, CRDT, or collab code.** `RichEditor.tsx`'s extension list is untouched. Phases B+.

--- a/.pu-reports/pu-mp-conflict-409.md
+++ b/.pu-reports/pu-mp-conflict-409.md
@@ -237,6 +237,70 @@ Twice during this work `bun run typecheck` exited non-zero with a flood of TS605
 found` and **no diagnostics**, then passed on an immediate rerun. It looks like `web#typecheck`
 racing `web#build` in the same turbo graph. Worth knowing before someone bisects a phantom CI flake.
 
+## Round 3 — the resolution-save race, and the Gate's shape
+
+### The race (CodeRabbit, accepted — real)
+
+`resolveConflict` used to call `clearConflict` **before** awaiting the retry PATCH, with the
+comment "Clear first so the save is not blocked by its own conflict guard". Working around my own
+safety mechanism was the tell. For the entire duration of that request `hasPendingConflict()` was
+false, so the guards in `saveWithDebounce` and `forceSave` were open. A keystroke in that window
+fired a second PATCH carrying the **stale** stored revision, which 409'd and parked a phantom
+conflict — a conflict banner for a save that actually succeeded, intermittently. `isResolvingConflict`
+does not close those guards; it is spinner state.
+
+Fixed without dodging the guard:
+
+- The conflict stays **parked** for the whole retry, so the autosave guards stay closed.
+- `saveDocument` gained the guard itself — the deepest layer — with an explicit per-call
+  `resolvingConflict: true` opt-in for the resolution path. An option on the call, not a mutation
+  of shared state. This also covers the one direct caller outside the hook
+  (`PageSetupButton.tsx:79`), which already handles a `false` return by telling the user to save
+  first — so a content-mode conversion can no longer be attempted on top of an unresolved conflict.
+- The conflict is cleared **only after the retry succeeds**. A repeat 409 leaves the fresher
+  snapshot `saveDocument` just parked; any other failure leaves the banner up to retry. This also
+  closes a flaw I had raised against myself in review (a failed keep-mine used to drop the conflict
+  and let autosave resume against a stale revision).
+
+### The Gate no longer opens a second `useDocument`
+
+Verified both consequences the design note predicted, then removed the cause rather than patching it.
+
+`changeGroupId` is real: `useDocumentSaving` mints `sessionId` per hook instance and sends it as
+`changeGroupId`; `applyPageMutation` resolves it at `page-mutation-service.ts:100` and threads it
+into **both** `createPageVersion` (`:241`) and `logActivityWithTx`. A Gate-owned instance would put
+the resolution save in its own change group — splitting version and activity grouping at exactly
+the moment a user resolved a conflict. `isResolvingConflict` would likewise have been two
+independent booleans for one operation.
+
+`DocumentConflictGate` now takes `conflict` / `onResolve` / `isResolving` as **props** from the
+view's existing `useDocument` instance. There is one hook instance per page again, the change group
+is the editing session's, and the "render nothing until a conflict exists" guarantee still lives in
+one place. `useSheetPersistence` re-exports the three fields so `SheetView` can pass them through.
+The reasoning is recorded in the component's own docblock so the second instance is not
+reintroduced later.
+
+### Round 3 mutation checks
+
+| # | Mutation | Test that went red |
+|---|---|---|
+| M15 | restore the race — clear the conflict *before* the awaited retry | `given a resolution save in flight, should let neither typing nor forceSave issue a PATCH` (+ the failed-resolution test) |
+| M16 | remove `saveDocument`'s parked-conflict guard | `a direct saveDocument without the resolution opt-in should not PATCH` |
+| M17 | clear the conflict regardless of whether the retry succeeded | the repeat-409 re-park test + the failed-resolution test |
+| M13′ | delete the Gate's `if (!conflict) return null` (re-run after the props rewrite) | `should render nothing so views can mount it unconditionally` |
+
+### Round 3 gates
+
+`bunx tsc --noEmit` exits 0; `bun run lint` 15/15; `src/lib/documents` + the hook + all of
+`page-views`: **428 passed, 6 skipped**, one file failing (`useTaskSubTasks.integration.test.tsx`,
+needs a Postgres this worktree lacks and prints its own opt-out).
+
+### Note on review signal
+
+Two of the CodeRabbit findings on this PR were real defects (absent-content coercion, and this
+race), one was a correct factual catch (the changelog claim), and one was rejected on verified
+grounds (SWR). Worth weighting accordingly rather than treating the bot as noise.
+
 ## Deliberately not done
 
 - **No Yjs, CRDT, or collab code.** `RichEditor.tsx`'s extension list is untouched. Phases B+.

--- a/.pu-reports/pu-mp-conflict-409.md
+++ b/.pu-reports/pu-mp-conflict-409.md
@@ -360,6 +360,58 @@ existing debounce tests already cover that a scheduled timeout produces a PATCH.
 `page-views`: **430 passed, 6 skipped**, with the same single Postgres-dependent integration file
 failing for want of a database.
 
+## Round 5 — proactive critique pass (no reviewer prompted these)
+
+Two defects found by self-critique rather than by review, both consequences of earlier rounds, both
+now tested and mutation-checked.
+
+### The store advertised a save that no longer existed
+
+`saveWithDebounce` cleared the pending timer and then returned early on the conflict path **without
+nulling `saveTimeout` in the store** — so `documents.get(pageId).saveTimeout` kept a handle to a
+timer that had already been cancelled. Every later reader of that field was being lied to,
+including the round-4 reschedule assertion. It is now dropped on that path only; doing it on the
+normal path too would mean a second store write per keystroke and a re-render of every subscriber
+for nothing.
+
+### `PageSetupButton` became a dead end this PR created
+
+Converting content mode saves first. Round 3 put a guard inside `saveDocument`, so that save now
+returns `false` while a conflict is parked — and the existing message, *"Please save your changes
+before converting"*, became advice the user **cannot act on**, because the guard is precisely what
+stops them saving. It now says *"Resolve the editing conflict on this page before converting"* when
+a conflict is parked, and keeps the original wording on the genuinely-just-failed path.
+
+Writing the test for that second branch turned up something worth recording: the only reachable way
+to get `saveDocument` → `false` with **no** conflict parked is a 409 whose follow-up refetch fails
+(`decideConflictOutcome` returns an error rather than offering a resolution it cannot honour). Every
+other false return implies a parked conflict. The test uses that exact path, so it documents the
+contract rather than a hypothetical.
+
+### Round 5 mutation checks
+
+| # | Mutation | Test that went red |
+|---|---|---|
+| M21 | leave the stale `saveTimeout` handle in the store | `given a conflict arrives with a debounce already queued, should drop the cleared handle` |
+| M22 | invert `PageSetupButton`'s conflict branch | both `PageSetupButton` message tests |
+
+### One mutation that does NOT go red, stated honestly
+
+**M3 — removing `forceSave`'s own `canScheduleSave` check — survives.** This is not a coverage gap
+that can be closed by a better test; it is a fact about the code. Round 3 added the guard inside
+`saveDocument`, which returns `false` *before* `markAsSaving`, so `forceSave` with and without its
+own check produce byte-identical observable outcomes. The check is kept deliberately as defence in
+depth — removing a guard in a data-loss fix to improve a mutation score would be optimising the
+metric rather than the code — but it is not measured, and the test file now says so at the
+assertion rather than implying coverage it does not have.
+
+By contrast M2 (`saveWithDebounce`'s guard) initially survived for the same reason and **was**
+closable, because that guard has a distinct observable effect the deeper one cannot produce: it
+stops a timer being scheduled at all. The test now asserts that, and M2 is red again. The
+difference is worth stating: one guard was genuinely redundant, the other only looked it.
+
+**Battery status: 22 mutations, 21 red, 1 (M3) knowingly subsumed.**
+
 ## Deliberately not done
 
 - **No Yjs, CRDT, or collab code.** `RichEditor.tsx`'s extension list is untouched. Phases B+.

--- a/.pu-reports/pu-mp-conflict-409.md
+++ b/.pu-reports/pu-mp-conflict-409.md
@@ -301,6 +301,65 @@ Two of the CodeRabbit findings on this PR were real defects (absent-content coer
 race), one was a correct factual catch (the changelog claim), and one was rejected on verified
 grounds (SWR). Worth weighting accordingly rather than treating the bot as noise.
 
+## Round 4 — two consequences of the round-3 fix
+
+Both accepted; both are follow-on effects of closing the guard properly, which is normal for a
+change of this shape.
+
+### A. Edits made during the retry were stranded
+
+With the guard correctly closed for the whole retry, `saveWithDebounce` returns early **without
+creating a timeout**. So text typed while the retry was in flight became dirty with nothing
+scheduled for it, and clearing the conflict on success scheduled nothing either — it sat unsaved
+until the next keystroke, blur or manual save.
+
+After a successful retry, if the document is still dirty, `resolveConflict` now schedules a save
+for the current content (`saveWithDebounce` added to its deps). Note the document IS still dirty in
+exactly this case: `saveDocument` only calls `markAsSaved` when the saved content still matches the
+buffer, which a mid-retry edit makes false.
+
+### B. Two views on one page could both resolve
+
+Round 3 moved the Gate to props but left `isResolvingConflict` as per-instance `useState` — so I
+had only half-addressed the earlier design note. With the centre panel and an agent pane
+(`PagePaneView`) both showing a page — a combination we know occurs — each held its own boolean:
+one banner's buttons disabled, the other's live. Two clicks meant two PATCHes with the same
+`expectedRevision`; the server takes one and 409s the other, parking a spurious conflict on the
+conflict that was just resolved.
+
+Fixed at the root, with no new lock abstraction: `resolvingConflicts: Set<pageId>` on
+`useDocumentManagerStore`. One flag per page, shared by every mount. `resolveConflict` returns
+early if a resolution is already in flight (the actual serialization), and every Gate's buttons
+disable together (the UI consequence). Cleared in `clearDocument`/`clearAllDocuments` alongside
+`conflicts`.
+
+### A flaky test I wrote and then removed
+
+My first version of the round-4 reschedule test asserted the second PATCH actually fired, which
+depended on the real 1000 ms debounce landing inside a `waitFor` window — it passed, then failed 3
+runs in a row, then passed. Two separate causes: a `waitFor` timeout equal to vitest's default 5 s
+test timeout (so the test died before `waitFor` could report), and genuine timing sensitivity after
+that was raised.
+
+It now asserts the **scheduling** instead — after resolution the document is still dirty AND
+`saveTimeout` is defined — which is precisely what Thread A said was missing ("nothing ever
+schedules it") and carries no timing dependence. Verified stable across 5 consecutive runs. The
+existing debounce tests already cover that a scheduled timeout produces a PATCH.
+
+### Round 4 mutation checks
+
+| # | Mutation | Test that went red |
+|---|---|---|
+| M18 | drop the reschedule of edits made during the retry | `given an edit made while the retry is in flight, should schedule it once the conflict clears` |
+| M19 | drop the serialization guard so both banners can resolve | `given two views on the same page, should let only one resolution PATCH go out` |
+| M20 | make the resolving flag per-instance again (invisible to other views) | same two-views test |
+
+### Round 4 gates
+
+`bunx tsc --noEmit` exits 0; `bun run lint` 15/15; `src/lib/documents` + the hook + all of
+`page-views`: **430 passed, 6 skipped**, with the same single Postgres-dependent integration file
+failing for want of a database.
+
 ## Deliberately not done
 
 - **No Yjs, CRDT, or collab code.** `RichEditor.tsx`'s extension list is untouched. Phases B+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Editing a document at the same time as someone else no longer throws away what you typed** —
+  when a colleague or an AI agent saved the same document while you had unsaved text, PageSpace
+  used to quietly replace everything in your editor with their version and tell you your copy "has
+  been updated". Whatever you had written was gone, with no way to get it back. Your text now stays
+  exactly where it is. A banner appears saying someone else saved the document, autosaving pauses
+  so nothing is sent behind your back, and you choose: **Keep mine**, which saves your text over
+  theirs, or **Use theirs**, which loads their version and drops your unsaved changes. You can
+  expand the banner to read their version first, so the choice is not blind. Whichever you pick,
+  the save goes through cleanly instead of colliding a second time.
+
 - **Browsing a session's files now requires permission to run code, as starting a shell always
   did** — the file browser, the diff view and the "show this file at that commit" reader were
   reachable by anyone who could see the session, even though the Shell button beside them was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   exactly where it is. A banner appears saying someone else saved the document, autosaving pauses
   so nothing is sent behind your back, and you choose: **Keep mine**, which saves your text over
   theirs, or **Use theirs**, which loads their version and drops your unsaved changes. You can
-  expand the banner to read their version first, so the choice is not blind. Whichever you pick,
-  the save goes through cleanly instead of colliding a second time.
+  expand the banner to read their version first, so the choice is not blind. Use theirs simply
+  loads their version and saves nothing; and if someone saves again while you are still deciding,
+  Keep mine re-prompts you with that newer version instead of failing.
 
 - **Browsing a session's files now requires permission to run code, as starting a shell always
   did** — the file browser, the diff view and the "show this file at that commit" reader were

--- a/apps/web/src/components/layout/middle-content/content-header/PageSetupButton.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PageSetupButton.tsx
@@ -78,7 +78,16 @@ export function PageSetupButton({ pageId }: PageSetupButtonProps) {
 
         const saveResult = await saveDocument(doc.content);
         if (!saveResult) {
-          toast.error('Please save your changes before converting');
+          // A parked save conflict blocks writes until the user picks a
+          // version, so "save first" would be advice they cannot follow.
+          const blockedByConflict = useDocumentManagerStore
+            .getState()
+            .conflicts.has(pageId);
+          toast.error(
+            blockedByConflict
+              ? 'Resolve the editing conflict on this page before converting'
+              : 'Please save your changes before converting'
+          );
           return;
         }
       }

--- a/apps/web/src/components/layout/middle-content/content-header/__tests__/PageSetupButton.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/__tests__/PageSetupButton.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: vi.fn(() => ({ id: 'socket-123' })),
+}));
+
+import { PageSetupButton } from '../PageSetupButton';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
+
+const pageId = 'page-123';
+
+/**
+ * Converting content mode saves the document first. This PR made a parked save
+ * conflict block every write, so that save now returns false — and the old
+ * "save your changes first" message became advice the user cannot act on,
+ * because the guard is exactly what stops them saving. These tests pin which
+ * message each state produces so the branch is not later deleted as redundant.
+ */
+describe('PageSetupButton content-mode conversion', () => {
+  beforeEach(() => {
+    useDocumentManagerStore.setState({
+      documents: new Map(),
+      activeDocumentId: null,
+      savingDocuments: new Set(),
+      conflicts: new Map(),
+      resolvingConflicts: new Set(),
+    });
+    vi.clearAllMocks();
+    // jsdom does not implement window.confirm; the conversion flow gates on it.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    // The SWR page fetch, so the button renders enabled in 'html' mode.
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ contentMode: 'html' }),
+    } as Response);
+  });
+
+  const openAndPickMarkdown = async () => {
+    const user = userEvent.setup();
+    await waitFor(() => expect(screen.getByRole('button')).toBeEnabled());
+    await user.click(screen.getByRole('button'));
+    await user.click(await screen.findByRole('menuitemradio', { name: /markdown/i }));
+  };
+
+  it('given a parked conflict, should tell the user to resolve it rather than to save first', async () => {
+    useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+    useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+    useDocumentManagerStore.getState().setConflict(pageId, {
+      remoteContent: 'their text',
+      remoteRevision: 4,
+      detectedAt: 1,
+    });
+
+    render(<PageSetupButton pageId={pageId} />);
+    await openAndPickMarkdown();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Resolve the editing conflict on this page before converting'
+      )
+    );
+  });
+
+  it('given a save that fails without parking a conflict, should keep the save-your-changes message', async () => {
+    useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+    useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+
+    // A 409 whose follow-up refetch fails: saveDocument returns false but parks
+    // NO conflict (it will not offer a resolution it cannot honour), which is
+    // the reachable path where "save your changes" is still the right advice.
+    let patched = false;
+    vi.mocked(fetchWithAuth).mockImplementation((_url, init) => {
+      if (init?.method === 'PATCH') {
+        patched = true;
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: () => Promise.resolve({ error: 'Page was modified', currentRevision: 4 }),
+        } as Response);
+      }
+      if (patched) return Promise.reject(new Error('network down'));
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ contentMode: 'html' }),
+      } as Response);
+    });
+
+    render(<PageSetupButton pageId={pageId} />);
+    await openAndPickMarkdown();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Please save your changes before converting')
+    );
+    expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -9,6 +9,7 @@ import { CanvasFrame } from '@/components/canvas/CanvasFrame';
 import { ErrorBoundary } from '@/components/ai/shared';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { useDocument } from '@/hooks/useDocument';
+import DocumentConflictGate from '@/components/layout/middle-content/page-views/document/DocumentConflictGate';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useSocket } from '@/hooks/useSocket';
@@ -237,6 +238,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
 
   return (
     <div ref={containerRef} className="h-full flex flex-col relative">
+      <DocumentConflictGate pageId={pageId} previewMode="plain" />
       <div className="relative flex flex-wrap items-center border-b">
         <button
           className={`px-4 py-2 ${activeTab === 'view' ? 'border-b-2 border-blue-500' : ''}`}

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -86,6 +86,9 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   } = useDocument(pageId);
 
   const content = documentState?.content ?? '';
@@ -238,7 +241,12 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
 
   return (
     <div ref={containerRef} className="h-full flex flex-col relative">
-      <DocumentConflictGate pageId={pageId} previewMode="plain" />
+      <DocumentConflictGate
+        conflict={conflict}
+        onResolve={resolveConflict}
+        isResolving={isResolvingConflict}
+        previewMode="plain"
+      />
       <div className="relative flex flex-wrap items-center border-b">
         <button
           className={`px-4 py-2 ${activeTab === 'view' ? 'border-b-2 border-blue-500' : ''}`}

--- a/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, useCallback, useRef, useId } from 'react';
 import dynamic from 'next/dynamic';
 import { useDocument } from '@/hooks/useDocument';
+import DocumentConflictGate from '@/components/layout/middle-content/page-views/document/DocumentConflictGate';
 import { motion, AnimatePresence } from 'motion/react';
 import { usePageContentSocket } from '@/hooks/usePageContentSocket';
 import type { PageEventPayload } from '@/lib/websocket';
@@ -260,6 +261,7 @@ const CodePageView = ({ pageId, driveId: driveIdProp }: CodePageViewProps) => {
       transition={{ duration: 0.2 }}
       className="h-full flex flex-col relative"
     >
+      <DocumentConflictGate pageId={pageId} previewMode="plain" />
       {/* Language selector toolbar */}
       <div className="flex items-center gap-2 px-4 py-2 border-b border-[var(--separator)]">
         <Select value={language} onValueChange={setLanguage}>

--- a/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/code/CodePageView.tsx
@@ -93,6 +93,9 @@ const CodePageView = ({ pageId, driveId: driveIdProp }: CodePageViewProps) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   } = useDocument(pageId);
 
   // Store forceSave in ref to prevent cleanup effects from re-running
@@ -261,7 +264,12 @@ const CodePageView = ({ pageId, driveId: driveIdProp }: CodePageViewProps) => {
       transition={{ duration: 0.2 }}
       className="h-full flex flex-col relative"
     >
-      <DocumentConflictGate pageId={pageId} previewMode="plain" />
+      <DocumentConflictGate
+        conflict={conflict}
+        onResolve={resolveConflict}
+        isResolving={isResolvingConflict}
+        previewMode="plain"
+      />
       {/* Language selector toolbar */}
       <div className="flex items-center gap-2 px-4 py-2 border-b border-[var(--separator)]">
         <Select value={language} onValueChange={setLanguage}>

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictBanner.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictBanner.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import React, { useMemo, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { Button } from '@/components/ui/button';
+import type {
+  ConflictResolutionChoice,
+  DocumentConflict,
+} from '@/lib/documents/conflict-resolution';
+
+interface DocumentConflictBannerProps {
+  conflict: DocumentConflict;
+  contentMode?: 'html' | 'markdown';
+  onResolve: (choice: ConflictResolutionChoice) => void;
+  isResolving?: boolean;
+}
+
+/**
+ * Persistent (never auto-dismissing) banner shown while a save conflict is
+ * parked. It stays until the user picks a side — the local buffer is untouched
+ * and autosave is paused for as long as it is visible.
+ *
+ * Both choices overwrite something, so the copy says so plainly and the parked
+ * server copy is viewable inline: the user should be able to see the other
+ * version before deciding, without leaving the editor. Deliberately makes no
+ * promise about recovering the discarded side — page history is written on
+ * every mutation but there is no UI or endpoint that lets a user restore it,
+ * and the rows expire after 30 days.
+ */
+const DocumentConflictBanner = ({
+  conflict,
+  contentMode = 'html',
+  onResolve,
+  isResolving = false,
+}: DocumentConflictBannerProps) => {
+  const [showRemote, setShowRemote] = useState(false);
+
+  // The parked copy is another user's content — sanitize before rendering it.
+  const sanitizedRemote = useMemo(
+    () => (contentMode === 'markdown' ? null : DOMPurify.sanitize(conflict.remoteContent)),
+    [conflict.remoteContent, contentMode]
+  );
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="document-conflict-banner"
+      className="bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-800 px-4 py-3"
+    >
+      <div className="max-w-4xl mx-auto flex flex-col gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="text-sm text-amber-900 dark:text-amber-100">
+            <p className="font-medium">
+              Someone else saved this document while you were editing it.
+            </p>
+            <p className="mt-0.5 text-amber-800 dark:text-amber-200">
+              Your unsaved changes are still in the editor and have not been sent. Saving is
+              paused until you choose. <strong>Keep mine</strong> replaces their version in the
+              document; <strong>Use theirs</strong> discards your unsaved changes.
+            </p>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <Button
+              size="sm"
+              variant="default"
+              disabled={isResolving}
+              onClick={() => onResolve('keep-mine')}
+            >
+              Keep mine
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isResolving}
+              onClick={() => onResolve('use-theirs')}
+            >
+              Use theirs
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            className="text-sm underline text-amber-900 dark:text-amber-100"
+            aria-expanded={showRemote}
+            onClick={() => setShowRemote((shown) => !shown)}
+          >
+            {showRemote ? 'Hide their version' : 'View their version'}
+          </button>
+          {showRemote && (
+            <div
+              data-testid="document-conflict-remote-preview"
+              className="mt-2 max-h-64 overflow-auto rounded border border-amber-200 dark:border-amber-800 bg-background/60 p-3 text-sm"
+            >
+              {sanitizedRemote === null ? (
+                <pre className="whitespace-pre-wrap break-words font-mono text-xs">
+                  {conflict.remoteContent}
+                </pre>
+              ) : (
+                <div
+                  className="prose prose-sm dark:prose-invert max-w-none"
+                  // Sanitized immediately above; this is another user's saved
+                  // page content, rendered read-only for comparison.
+                  dangerouslySetInnerHTML={{ __html: sanitizedRemote }}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DocumentConflictBanner;

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictBanner.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictBanner.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import React, { useMemo, useState } from 'react';
-import DOMPurify from 'dompurify';
 import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { sanitizeHtmlAllowlist } from '@/components/ai/shared/chat/tool-calls/content-utils';
 import type {
   ConflictResolutionChoice,
   DocumentConflict,
@@ -10,7 +15,12 @@ import type {
 
 interface DocumentConflictBannerProps {
   conflict: DocumentConflict;
-  contentMode?: 'html' | 'markdown';
+  /**
+   * How to show the parked copy. 'rich' renders sanitized HTML (prose
+   * documents); 'plain' shows it verbatim in a <pre> (markdown, code, sheet
+   * JSON, canvas JSON — anything where markup is the content, not formatting).
+   */
+  previewMode?: 'rich' | 'plain';
   onResolve: (choice: ConflictResolutionChoice) => void;
   isResolving?: boolean;
 }
@@ -29,16 +39,22 @@ interface DocumentConflictBannerProps {
  */
 const DocumentConflictBanner = ({
   conflict,
-  contentMode = 'html',
+  previewMode = 'rich',
   onResolve,
   isResolving = false,
 }: DocumentConflictBannerProps) => {
   const [showRemote, setShowRemote] = useState(false);
 
-  // The parked copy is another user's content — sanitize before rendering it.
+  // The parked copy is another user's content, so it goes through the app's
+  // shared allowlist sanitizer. Deferred until the disclosure is actually
+  // opened — most users resolve without ever looking, and parsing a large
+  // document synchronously on the frame the 409 lands is a needless hitch.
   const sanitizedRemote = useMemo(
-    () => (contentMode === 'markdown' ? null : DOMPurify.sanitize(conflict.remoteContent)),
-    [conflict.remoteContent, contentMode]
+    () =>
+      showRemote && previewMode === 'rich'
+        ? sanitizeHtmlAllowlist(conflict.remoteContent)
+        : '',
+    [showRemote, previewMode, conflict.remoteContent]
   );
 
   return (
@@ -80,35 +96,31 @@ const DocumentConflictBanner = ({
           </div>
         </div>
 
-        <div>
-          <button
-            type="button"
-            className="text-sm underline text-amber-900 dark:text-amber-100"
-            aria-expanded={showRemote}
-            onClick={() => setShowRemote((shown) => !shown)}
-          >
+        <Collapsible open={showRemote} onOpenChange={setShowRemote}>
+          <CollapsibleTrigger className="text-sm underline text-amber-900 dark:text-amber-100">
             {showRemote ? 'Hide their version' : 'View their version'}
-          </button>
-          {showRemote && (
+          </CollapsibleTrigger>
+          <CollapsibleContent>
             <div
               data-testid="document-conflict-remote-preview"
               className="mt-2 max-h-64 overflow-auto rounded border border-amber-200 dark:border-amber-800 bg-background/60 p-3 text-sm"
             >
-              {sanitizedRemote === null ? (
+              {previewMode === 'plain' ? (
                 <pre className="whitespace-pre-wrap break-words font-mono text-xs">
                   {conflict.remoteContent}
                 </pre>
               ) : (
                 <div
                   className="prose prose-sm dark:prose-invert max-w-none"
-                  // Sanitized immediately above; this is another user's saved
-                  // page content, rendered read-only for comparison.
+                  // Sanitized through the shared allowlist immediately above;
+                  // this is another user's saved page content, rendered
+                  // read-only for comparison.
                   dangerouslySetInnerHTML={{ __html: sanitizedRemote }}
                 />
               )}
             </div>
-          )}
-        </div>
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictGate.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictGate.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from 'react';
+import { useDocument } from '@/hooks/useDocument';
+import DocumentConflictBanner from './DocumentConflictBanner';
+
+interface DocumentConflictGateProps {
+  pageId: string;
+  previewMode?: 'rich' | 'plain';
+}
+
+/**
+ * Drop-in conflict surface for every editor built on `useDocument`.
+ *
+ * `useDocument` pauses autosave for a page while a conflict is parked, so any
+ * view that can save MUST also offer a way to resolve one — otherwise saving
+ * stops for the rest of the session with nothing on screen to explain it. This
+ * component is that guarantee in one line: it renders nothing until a conflict
+ * exists for `pageId`, so views can mount it unconditionally.
+ */
+const DocumentConflictGate = ({ pageId, previewMode }: DocumentConflictGateProps) => {
+  const { conflict, resolveConflict, isResolvingConflict } = useDocument(pageId);
+
+  if (!conflict) return null;
+
+  return (
+    <DocumentConflictBanner
+      conflict={conflict}
+      previewMode={previewMode}
+      onResolve={resolveConflict}
+      isResolving={isResolvingConflict}
+    />
+  );
+};
+
+export default DocumentConflictGate;

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictGate.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentConflictGate.tsx
@@ -1,34 +1,53 @@
 "use client";
 
 import React from 'react';
-import { useDocument } from '@/hooks/useDocument';
 import DocumentConflictBanner from './DocumentConflictBanner';
+import type {
+  ConflictResolutionChoice,
+  DocumentConflict,
+} from '@/lib/documents/conflict-resolution';
 
 interface DocumentConflictGateProps {
-  pageId: string;
+  /** From the view's OWN `useDocument(pageId)` — see the note below. */
+  conflict: DocumentConflict | undefined;
+  onResolve: (choice: ConflictResolutionChoice) => void;
+  isResolving?: boolean;
   previewMode?: 'rich' | 'plain';
 }
 
 /**
- * Drop-in conflict surface for every editor built on `useDocument`.
+ * Conflict surface for every editor built on `useDocument`.
  *
  * `useDocument` pauses autosave for a page while a conflict is parked, so any
  * view that can save MUST also offer a way to resolve one — otherwise saving
  * stops for the rest of the session with nothing on screen to explain it. This
- * component is that guarantee in one line: it renders nothing until a conflict
- * exists for `pageId`, so views can mount it unconditionally.
+ * component is that guarantee in one place: it renders nothing until a conflict
+ * exists, so views mount it unconditionally.
+ *
+ * It takes the conflict and the resolver as PROPS rather than calling
+ * `useDocument` itself, deliberately. A second hook instance for the same page
+ * would mint a second `sessionId` (`useDocumentSaving`), and that value is sent
+ * as `changeGroupId` — which `applyPageMutation` threads into both
+ * `createPageVersion` and `logActivityWithTx`. A resolution save from its own
+ * instance would therefore land in its own change group, splitting the version
+ * and activity grouping at exactly the moment a user resolved a conflict. It
+ * would also give the view and this component two independent `isResolving`
+ * booleans for one logical operation.
  */
-const DocumentConflictGate = ({ pageId, previewMode }: DocumentConflictGateProps) => {
-  const { conflict, resolveConflict, isResolvingConflict } = useDocument(pageId);
-
+const DocumentConflictGate = ({
+  conflict,
+  onResolve,
+  isResolving,
+  previewMode,
+}: DocumentConflictGateProps) => {
   if (!conflict) return null;
 
   return (
     <DocumentConflictBanner
       conflict={conflict}
       previewMode={previewMode}
-      onResolve={resolveConflict}
-      isResolving={isResolvingConflict}
+      onResolve={onResolve}
+      isResolving={isResolving}
     />
   );
 };

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -18,6 +18,8 @@ import { useFindStore } from '@/stores/useFindStore';
 import { dispatchFind, getPluginMatches } from '@/lib/editor/find-plugin';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
+import DocumentConflictBanner from './DocumentConflictBanner';
+import type { ConflictResolutionChoice } from '@/lib/documents/conflict-resolution';
 
 interface DocumentViewProps {
   pageId: string;
@@ -51,7 +53,23 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
+    conflict,
+    resolveConflict,
   } = useDocument(pageId);
+
+  const [isResolvingConflict, setIsResolvingConflict] = useState(false);
+
+  const handleResolveConflict = useCallback(
+    async (choice: ConflictResolutionChoice) => {
+      setIsResolvingConflict(true);
+      try {
+        await resolveConflict(choice);
+      } finally {
+        setIsResolvingConflict(false);
+      }
+    },
+    [resolveConflict]
+  );
 
   // Track editor focus state for pull-to-refresh
   useEffect(() => {
@@ -330,6 +348,17 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Save conflict — persistent until the user picks a side. The local
+          buffer is untouched and autosave is paused while this is shown. */}
+      {conflict && (
+        <DocumentConflictBanner
+          conflict={conflict}
+          contentMode={documentState?.contentMode || 'html'}
+          onResolve={handleResolveConflict}
+          isResolving={isResolvingConflict}
+        />
+      )}
 
       {/* Read-only indicator */}
       {isReadOnly && (

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -18,8 +18,7 @@ import { useFindStore } from '@/stores/useFindStore';
 import { dispatchFind, getPluginMatches } from '@/lib/editor/find-plugin';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
-import DocumentConflictBanner from './DocumentConflictBanner';
-import type { ConflictResolutionChoice } from '@/lib/documents/conflict-resolution';
+import DocumentConflictGate from './DocumentConflictGate';
 
 interface DocumentViewProps {
   pageId: string;
@@ -53,23 +52,7 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
-    conflict,
-    resolveConflict,
   } = useDocument(pageId);
-
-  const [isResolvingConflict, setIsResolvingConflict] = useState(false);
-
-  const handleResolveConflict = useCallback(
-    async (choice: ConflictResolutionChoice) => {
-      setIsResolvingConflict(true);
-      try {
-        await resolveConflict(choice);
-      } finally {
-        setIsResolvingConflict(false);
-      }
-    },
-    [resolveConflict]
-  );
 
   // Track editor focus state for pull-to-refresh
   useEffect(() => {
@@ -351,14 +334,10 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
 
       {/* Save conflict — persistent until the user picks a side. The local
           buffer is untouched and autosave is paused while this is shown. */}
-      {conflict && (
-        <DocumentConflictBanner
-          conflict={conflict}
-          contentMode={documentState?.contentMode || 'html'}
-          onResolve={handleResolveConflict}
-          isResolving={isResolvingConflict}
-        />
-      )}
+      <DocumentConflictGate
+        pageId={pageId}
+        previewMode={documentState?.contentMode === 'markdown' ? 'plain' : 'rich'}
+      />
 
       {/* Read-only indicator */}
       {isReadOnly && (

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -52,6 +52,9 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   } = useDocument(pageId);
 
   // Track editor focus state for pull-to-refresh
@@ -335,7 +338,9 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
       {/* Save conflict — persistent until the user picks a side. The local
           buffer is untouched and autosave is paused while this is shown. */}
       <DocumentConflictGate
-        pageId={pageId}
+        conflict={conflict}
+        onResolve={resolveConflict}
+        isResolving={isResolvingConflict}
         previewMode={documentState?.contentMode === 'markdown' ? 'plain' : 'rich'}
       />
 

--- a/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictBanner.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictBanner.test.tsx
@@ -55,11 +55,11 @@ describe('DocumentConflictBanner', () => {
     expect(preview.querySelector('script')).toBeNull();
   });
 
-  it('given markdown content mode, should show the other version as plain text', () => {
+  it('given plain preview mode, should show the other version verbatim', () => {
     render(
       <DocumentConflictBanner
         conflict={{ ...conflict, remoteContent: '# their heading' }}
-        contentMode="markdown"
+        previewMode="plain"
         onResolve={vi.fn()}
       />
     );

--- a/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictBanner.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictBanner.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DocumentConflictBanner from '../DocumentConflictBanner';
+
+const conflict = {
+  remoteContent: '<p>their text</p>',
+  remoteRevision: 11,
+  detectedAt: 1,
+};
+
+describe('DocumentConflictBanner', () => {
+  it('given a conflict, should say the local changes are unsent and what each choice overwrites', () => {
+    render(<DocumentConflictBanner conflict={conflict} onResolve={vi.fn()} />);
+
+    const banner = screen.getByTestId('document-conflict-banner');
+    expect(banner.textContent).toContain('Your unsaved changes are still in the editor');
+    expect(banner.textContent).toContain('have not been sent');
+    expect(banner.textContent).toContain('replaces their version in the document');
+    expect(banner.textContent).toContain('discards your unsaved changes');
+  });
+
+  it('should not promise the discarded version is recoverable', () => {
+    render(<DocumentConflictBanner conflict={conflict} onResolve={vi.fn()} />);
+
+    const banner = screen.getByTestId('document-conflict-banner');
+    expect(banner.textContent).not.toContain('recoverable');
+    expect(banner.textContent).not.toContain('history');
+  });
+
+  it('given the user asks to see the other version, should render the parked remote content', () => {
+    render(<DocumentConflictBanner conflict={conflict} onResolve={vi.fn()} />);
+
+    expect(screen.queryByTestId('document-conflict-remote-preview')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View their version' }));
+
+    expect(screen.getByTestId('document-conflict-remote-preview').textContent).toContain(
+      'their text'
+    );
+  });
+
+  it('given remote content carrying a script, should render it sanitized', () => {
+    render(
+      <DocumentConflictBanner
+        conflict={{ ...conflict, remoteContent: '<p>hi</p><script>alert(1)</script>' }}
+        onResolve={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View their version' }));
+
+    const preview = screen.getByTestId('document-conflict-remote-preview');
+    expect(preview.textContent).toContain('hi');
+    expect(preview.querySelector('script')).toBeNull();
+  });
+
+  it('given markdown content mode, should show the other version as plain text', () => {
+    render(
+      <DocumentConflictBanner
+        conflict={{ ...conflict, remoteContent: '# their heading' }}
+        contentMode="markdown"
+        onResolve={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View their version' }));
+
+    const preview = screen.getByTestId('document-conflict-remote-preview');
+    expect(preview.querySelector('pre')?.textContent).toBe('# their heading');
+  });
+
+  it('given Keep mine is clicked, should resolve with keep-mine', () => {
+    const onResolve = vi.fn();
+    render(<DocumentConflictBanner conflict={conflict} onResolve={onResolve} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep mine' }));
+
+    expect(onResolve).toHaveBeenCalledWith('keep-mine');
+  });
+
+  it('given Use theirs is clicked, should resolve with use-theirs', () => {
+    const onResolve = vi.fn();
+    render(<DocumentConflictBanner conflict={conflict} onResolve={onResolve} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use theirs' }));
+
+    expect(onResolve).toHaveBeenCalledWith('use-theirs');
+  });
+
+  it('given a resolution in flight, should disable both choices', () => {
+    render(<DocumentConflictBanner conflict={conflict} onResolve={vi.fn()} isResolving />);
+
+    expect(screen.getByRole('button', { name: 'Keep mine' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Use theirs' })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictGate.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictGate.test.tsx
@@ -1,63 +1,37 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
-import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
-import { useDirtyStore } from '@/stores/useDirtyStore';
-
-vi.mock('@/lib/auth/auth-fetch', () => ({
-  fetchWithAuth: vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve({ content: 'saved', revision: 12 }),
-  }),
-}));
-
-vi.mock('@/hooks/useSocket', () => ({
-  useSocket: vi.fn(() => ({ id: 'socket-123' })),
-}));
-
-vi.mock('sonner', () => ({
-  toast: { error: vi.fn() },
-}));
-
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import DocumentConflictGate from '../DocumentConflictGate';
 
-const pageId = 'page-123';
+const conflict = {
+  remoteContent: '<p>their text</p>',
+  remoteRevision: 11,
+  detectedAt: 1,
+};
 
 describe('DocumentConflictGate', () => {
-  beforeEach(() => {
-    useDocumentManagerStore.setState({
-      documents: new Map(),
-      activeDocumentId: null,
-      savingDocuments: new Set(),
-      conflicts: new Map(),
-    });
-    useDirtyStore.setState({ dirtyFlags: {} });
-    vi.clearAllMocks();
-  });
-
   it('given no conflict, should render nothing so views can mount it unconditionally', () => {
-    useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
-
-    const { container } = render(<DocumentConflictGate pageId={pageId} />);
+    const { container } = render(
+      <DocumentConflictGate conflict={undefined} onResolve={vi.fn()} />
+    );
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('given a parked conflict, should surface the resolve UI', () => {
-    useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
-
-    render(<DocumentConflictGate pageId={pageId} />);
-
-    act(() => {
-      useDocumentManagerStore.getState().setConflict(pageId, {
-        remoteContent: 'their text',
-        remoteRevision: 11,
-        detectedAt: 1,
-      });
-    });
+  it('given a conflict, should surface the resolve UI', () => {
+    render(<DocumentConflictGate conflict={conflict} onResolve={vi.fn()} />);
 
     expect(screen.getByTestId('document-conflict-banner')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Keep mine' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Use theirs' })).toBeInTheDocument();
+  });
+
+  it('should pass the caller-owned resolver straight through', () => {
+    const onResolve = vi.fn();
+    render(<DocumentConflictGate conflict={conflict} onResolve={onResolve} />);
+
+    screen.getByRole('button', { name: 'Keep mine' }).click();
+
+    expect(onResolve).toHaveBeenCalledWith('keep-mine');
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictGate.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/__tests__/DocumentConflictGate.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
+import { useDirtyStore } from '@/stores/useDirtyStore';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ content: 'saved', revision: 12 }),
+  }),
+}));
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: vi.fn(() => ({ id: 'socket-123' })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+import DocumentConflictGate from '../DocumentConflictGate';
+
+const pageId = 'page-123';
+
+describe('DocumentConflictGate', () => {
+  beforeEach(() => {
+    useDocumentManagerStore.setState({
+      documents: new Map(),
+      activeDocumentId: null,
+      savingDocuments: new Set(),
+      conflicts: new Map(),
+    });
+    useDirtyStore.setState({ dirtyFlags: {} });
+    vi.clearAllMocks();
+  });
+
+  it('given no conflict, should render nothing so views can mount it unconditionally', () => {
+    useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+
+    const { container } = render(<DocumentConflictGate pageId={pageId} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('given a parked conflict, should surface the resolve UI', () => {
+    useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+
+    render(<DocumentConflictGate pageId={pageId} />);
+
+    act(() => {
+      useDocumentManagerStore.getState().setConflict(pageId, {
+        remoteContent: 'their text',
+        remoteRevision: 11,
+        detectedAt: 1,
+      });
+    });
+
+    expect(screen.getByTestId('document-conflict-banner')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Keep mine' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use theirs' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -163,6 +163,9 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSaveNow,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   } = useSheetPersistence({ pageId: page.id, socket, resetHistory });
 
   // Pull-to-refresh handler
@@ -843,7 +846,12 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
 
   return (
     <div className="flex h-full flex-col">
-      <DocumentConflictGate pageId={page.id} previewMode="plain" />
+      <DocumentConflictGate
+        conflict={conflict}
+        onResolve={resolveConflict}
+        isResolving={isResolvingConflict}
+        previewMode="plain"
+      />
       <SheetFormulaBar
         isRange={selection.type === 'range'}
         selectionAddress={selectionAddress}

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import DocumentConflictGate from '@/components/layout/middle-content/page-views/document/DocumentConflictGate';
 import { TreePage, usePageTree } from '@/hooks/usePageTree';
 import { useSocket } from '@/hooks/useSocket';
 import { useAuth } from '@/hooks/useAuth';
@@ -842,6 +843,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
 
   return (
     <div className="flex h-full flex-col">
+      <DocumentConflictGate pageId={page.id} previewMode="plain" />
       <SheetFormulaBar
         isRange={selection.type === 'range'}
         selectionAddress={selectionAddress}

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/useSheetPersistence.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/useSheetPersistence.ts
@@ -29,6 +29,9 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   } = useDocument(pageId);
 
   // Keep forceSave/isDirty/content in refs so the empty-dep listeners below never
@@ -122,5 +125,8 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
     saveWithDebounce,
     forceSave,
     forceSaveNow,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   };
 };

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { type Editor } from '@tiptap/react';
 import { useDocument } from '@/hooks/useDocument';
+import DocumentConflictGate from '@/components/layout/middle-content/page-views/document/DocumentConflictGate';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
 import { useEditingStore } from '@/stores/useEditingStore';
 
@@ -73,6 +74,7 @@ export function TaskListDescriptionContent({
 
   return (
     <div className={className}>
+      <DocumentConflictGate pageId={pageId} />
       <RichEditor
         value={content}
         onChange={handleChange}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
@@ -31,6 +31,9 @@ export function TaskListDescriptionContent({
     saveWithDebounce,
     forceSave,
     initializeAndActivate,
+    conflict,
+    resolveConflict,
+    isResolvingConflict,
   } = useDocument(pageId);
 
   // Seed the store from the parent's already-loaded page content to avoid a
@@ -74,7 +77,11 @@ export function TaskListDescriptionContent({
 
   return (
     <div className={className}>
-      <DocumentConflictGate pageId={pageId} />
+      <DocumentConflictGate
+        conflict={conflict}
+        onResolve={resolveConflict}
+        isResolving={isResolvingConflict}
+      />
       <RichEditor
         value={content}
         onChange={handleChange}

--- a/apps/web/src/hooks/__tests__/useDocument.test.ts
+++ b/apps/web/src/hooks/__tests__/useDocument.test.ts
@@ -28,6 +28,7 @@ describe('useDocument dirty flag integration', () => {
       activeDocumentId: null,
       savingDocuments: new Set(),
       conflicts: new Map(),
+      resolvingConflicts: new Set(),
     });
     useDirtyStore.setState({ dirtyFlags: {} });
     vi.clearAllMocks();
@@ -434,6 +435,104 @@ describe('useDocument dirty flag integration', () => {
 
       expect(saved).toBe(false);
       expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given an edit made while the retry is in flight, should schedule it once the conflict clears', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      let releaseRetry: (value: Response) => void = () => {};
+      vi.mocked(fetchWithAuth).mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          releaseRetry = resolve;
+        })
+      );
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      let resolution: Promise<boolean> | undefined;
+      act(() => {
+        resolution = result.current.resolveConflict('keep-mine');
+      });
+
+      // The user keeps typing while the retry is open. The autosave guard is
+      // correctly closed, so nothing is scheduled for this text — that is the
+      // window in which an edit could be stranded.
+      act(() => {
+        result.current.updateContent('my text, typed during the retry');
+      });
+      expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+      expect(
+        useDocumentManagerStore.getState().documents.get(pageId)?.saveTimeout
+      ).toBeUndefined();
+
+      await act(async () => {
+        releaseRetry({
+          ok: true,
+          json: () => Promise.resolve({ content: 'my text', revision: 12 }),
+        } as Response);
+        await resolution;
+      });
+
+      // Resolution done, and the mid-retry edit is no longer stranded: it is
+      // still dirty AND a save is now scheduled for it. Asserted on the
+      // scheduling rather than on the fired request, so the real 1000ms
+      // debounce cannot make this test timing-dependent.
+      const doc = useDocumentManagerStore.getState().documents.get(pageId);
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+      expect(doc?.content).toBe('my text, typed during the retry');
+      expect(doc?.isDirty).toBe(true);
+      expect(doc?.saveTimeout).toBeDefined();
+
+      clearTimeout(doc?.saveTimeout);
+    });
+
+    it('given two views on the same page, should let only one resolution PATCH go out', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      let releaseRetry: (value: Response) => void = () => {};
+      vi.mocked(fetchWithAuth).mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          releaseRetry = resolve;
+        })
+      );
+
+      // Two independent mounts of the same page — the centre panel and an
+      // agent pane both showing it.
+      const viewA = renderHook(() => useDocument(pageId));
+      const viewB = renderHook(() => useDocument(pageId));
+
+      let firstClick: Promise<boolean> | undefined;
+      act(() => {
+        firstClick = viewA.result.current.resolveConflict('keep-mine');
+      });
+
+      // The other view's banner is disabled too, because the flag is shared.
+      expect(viewB.result.current.isResolvingConflict).toBe(true);
+
+      let secondClick: boolean | undefined;
+      await act(async () => {
+        secondClick = await viewB.result.current.resolveConflict('keep-mine');
+      });
+
+      expect(secondClick).toBe(false);
+      expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        releaseRetry({
+          ok: true,
+          json: () => Promise.resolve({ content: 'my text', revision: 12 }),
+        } as Response);
+        await firstClick;
+      });
+
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+      expect(viewA.result.current.isResolvingConflict).toBe(false);
     });
 
     it('given a resolution save that fails, should leave the conflict parked for another try', async () => {

--- a/apps/web/src/hooks/__tests__/useDocument.test.ts
+++ b/apps/web/src/hooks/__tests__/useDocument.test.ts
@@ -280,8 +280,49 @@ describe('useDocument dirty flag integration', () => {
       });
 
       expect(fetchWithAuth).not.toHaveBeenCalled();
+      // The debounce guard's own job, distinct from the deeper guard inside
+      // saveDocument: no timer is scheduled at all, so typing during a
+      // conflict does not queue a save per keystroke that would each be
+      // refused when they fire.
+      expect(
+        useDocumentManagerStore.getState().documents.get(pageId)?.saveTimeout
+      ).toBeUndefined();
     });
 
+    it('given a conflict arrives with a debounce already queued, should drop the cleared handle', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      // A save is queued BEFORE the conflict is known.
+      act(() => {
+        result.current.saveWithDebounce('my text', 60_000);
+      });
+      const queued = useDocumentManagerStore.getState().documents.get(pageId)?.saveTimeout;
+      expect(queued).toBeDefined();
+
+      // The conflict lands, then the user types again.
+      parkConflict(pageId);
+      await act(async () => {
+        result.current.saveWithDebounce('my text, more', 0);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+
+      // The queued timer was cancelled, and the store no longer advertises a
+      // pending save that does not exist — a stale handle here makes
+      // `saveTimeout` lie to every later reader of it.
+      expect(
+        useDocumentManagerStore.getState().documents.get(pageId)?.saveTimeout
+      ).toBeUndefined();
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    // NOTE: forceSave's own `canScheduleSave` check is defence in depth — the
+    // guard inside saveDocument produces the identical outcome (it returns
+    // false before markAsSaving), so removing forceSave's check does NOT turn
+    // this test red. It is kept deliberately, not because it is measured here.
     it('given a pending conflict, forceSave should not fire a PATCH', async () => {
       const pageId = 'page-123';
       useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);

--- a/apps/web/src/hooks/__tests__/useDocument.test.ts
+++ b/apps/web/src/hooks/__tests__/useDocument.test.ts
@@ -376,6 +376,90 @@ describe('useDocument dirty flag integration', () => {
       expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
     });
 
+    it('given a resolution save in flight, should let neither typing nor forceSave issue a PATCH', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      // Hold the resolution PATCH open so we can act during its flight window.
+      let releaseRetry: (value: Response) => void = () => {};
+      const retryInFlight = new Promise<Response>((resolve) => {
+        releaseRetry = resolve;
+      });
+      vi.mocked(fetchWithAuth).mockReturnValueOnce(retryInFlight);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      let resolution: Promise<boolean> | undefined;
+      act(() => {
+        resolution = result.current.resolveConflict('keep-mine');
+      });
+
+      // Exactly one request so far: the resolution retry itself.
+      expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+
+      // The user keeps typing, and hits Cmd-S, while the retry is still open.
+      await act(async () => {
+        result.current.saveWithDebounce('my text, still typing', 0);
+        await result.current.forceSave();
+        await new Promise((r) => setTimeout(r, 5));
+      });
+
+      // Still one — no stale-revision PATCH raced the retry.
+      expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        releaseRetry({
+          ok: true,
+          json: () => Promise.resolve({ content: 'my text', revision: 12 }),
+        } as Response);
+        await resolution;
+      });
+
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+    });
+
+    it('given a parked conflict, a direct saveDocument without the resolution opt-in should not PATCH', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      parkConflict(pageId);
+
+      const { result } = renderHook(() => useDocumentSaving(pageId));
+
+      let saved: boolean | undefined;
+      await act(async () => {
+        saved = await result.current.saveDocument('my text');
+      });
+
+      expect(saved).toBe(false);
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given a resolution save that fails, should leave the conflict parked for another try', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Server error' }),
+      } as Response);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      let resolved: boolean | undefined;
+      await act(async () => {
+        resolved = await result.current.resolveConflict('keep-mine');
+      });
+
+      expect(resolved).toBe(false);
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(true);
+      expect(useDocumentManagerStore.getState().documents.get(pageId)?.content).toBe('my text');
+    });
+
     it('given no local document record, should refuse to resolve rather than save an empty document', async () => {
       const pageId = 'page-123';
       parkConflict(pageId);

--- a/apps/web/src/hooks/__tests__/useDocument.test.ts
+++ b/apps/web/src/hooks/__tests__/useDocument.test.ts
@@ -27,6 +27,7 @@ describe('useDocument dirty flag integration', () => {
       documents: new Map(),
       activeDocumentId: null,
       savingDocuments: new Set(),
+      conflicts: new Map(),
     });
     useDirtyStore.setState({ dirtyFlags: {} });
     vi.clearAllMocks();
@@ -103,12 +104,13 @@ describe('useDocument dirty flag integration', () => {
       expect(useDirtyStore.getState().isDirty(pageId)).toBe(true);
     });
 
-    it('given a 409 conflict response, should show conflict toast, refetch, and not throw', async () => {
+    it('given a 409 conflict response, should preserve the local buffer and park the server copy', async () => {
       const pageId = 'page-123';
       const { toast } = await import('sonner');
 
-      useDocumentManagerStore.getState().upsertDocument(pageId, 'content', 'html', 3);
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my unsaved edits', 'html', 3);
       useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      useDirtyStore.getState().setDirty(pageId, true);
 
       vi.mocked(fetchWithAuth).mockResolvedValueOnce({
         ok: false,
@@ -124,18 +126,97 @@ describe('useDocument dirty flag integration', () => {
 
       let saveResult: boolean | undefined;
       await act(async () => {
-        saveResult = await result.current.saveDocument('content');
+        saveResult = await result.current.saveDocument('my unsaved edits');
       });
 
       expect(saveResult).toBe(false);
+
+      // The user's text is untouched — this is the whole point of the fix.
+      const doc = useDocumentManagerStore.getState().documents.get(pageId);
+      expect(doc?.content).toBe('my unsaved edits');
+      expect(doc?.isDirty).toBe(true);
+      expect(useDirtyStore.getState().isDirty(pageId)).toBe(true);
+
+      // The server's copy is parked, not merged.
+      const conflict = useDocumentManagerStore.getState().conflicts.get(pageId);
+      expect(conflict?.remoteContent).toBe('newer content');
+      expect(conflict?.remoteRevision).toBe(4);
+      expect(typeof conflict?.detectedAt).toBe('number');
+
       expect(toast.error).toHaveBeenCalledWith(
-        'Document was modified elsewhere. Your local copy has been updated.',
+        'Document was modified elsewhere. Your unsaved changes are still here — choose which version to keep.',
         { id: `conflict-${pageId}` },
       );
+    });
+
+    it('given a 409 whose refetch fails, should keep local edits and park no conflict', async () => {
+      const pageId = 'page-123';
+
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my unsaved edits', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      useDirtyStore.getState().setDirty(pageId, true);
+
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ error: 'Page was modified', currentRevision: 4, expectedRevision: 3 }),
+      } as Response);
+      vi.mocked(fetchWithAuth).mockRejectedValueOnce(new Error('network down'));
+
+      const { result } = renderHook(() => useDocumentSaving(pageId));
+
+      let saveResult: boolean | undefined;
+      await act(async () => {
+        saveResult = await result.current.saveDocument('my unsaved edits');
+      });
+
+      expect(saveResult).toBe(false);
       const doc = useDocumentManagerStore.getState().documents.get(pageId);
-      expect(doc?.content).toBe('newer content');
-      expect(doc?.revision).toBe(4);
-      expect(doc?.isDirty).toBe(false);
+      expect(doc?.content).toBe('my unsaved edits');
+      expect(doc?.isDirty).toBe(true);
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+    });
+
+    it('given a 409, should cancel the pending debounce so the autosave loop cannot re-fire', async () => {
+      const pageId = 'page-123';
+
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my unsaved edits', 'html', 3);
+      const pendingTimeout = setTimeout(() => {}, 60_000);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true, saveTimeout: pendingTimeout });
+
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ error: 'Page was modified', currentRevision: 4, expectedRevision: 3 }),
+      } as Response);
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ content: 'newer content', revision: 4 }),
+      } as Response);
+
+      const { result } = renderHook(() => useDocumentSaving(pageId));
+
+      await act(async () => {
+        await result.current.saveDocument('my unsaved edits');
+      });
+
+      expect(useDocumentManagerStore.getState().documents.get(pageId)?.saveTimeout).toBeUndefined();
+      clearTimeout(pendingTimeout);
+    });
+
+    it('given an explicit expectedRevision, should send it instead of the stale stored revision', async () => {
+      const pageId = 'page-123';
+
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'content', 'html', 3);
+
+      const { result } = renderHook(() => useDocumentSaving(pageId));
+
+      await act(async () => {
+        await result.current.saveDocument('content', { expectedRevision: 9 });
+      });
+
+      const opts = vi.mocked(fetchWithAuth).mock.calls[0][1] as { body: string };
+      expect(JSON.parse(opts.body)).toMatchObject({ expectedRevision: 9 });
     });
 
     it('given a save with revision, should send expectedRevision in request body', async () => {
@@ -172,6 +253,141 @@ describe('useDocument dirty flag integration', () => {
       });
 
       expect(useDirtyStore.getState().isDirty(pageId)).toBe(true);
+    });
+  });
+
+  describe('useDocument conflict resolution', () => {
+    const parkConflict = (pageId: string) => {
+      useDocumentManagerStore.getState().setConflict(pageId, {
+        remoteContent: 'their text',
+        remoteRevision: 11,
+        detectedAt: 1,
+      });
+    };
+
+    it('given a pending conflict, saveWithDebounce should not fire a PATCH', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      await act(async () => {
+        result.current.saveWithDebounce('my text', 0);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given a pending conflict, forceSave should not fire a PATCH', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      let saved: boolean | undefined;
+      await act(async () => {
+        saved = await result.current.forceSave();
+      });
+
+      expect(saved).toBe(false);
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given keep-mine, should re-save local content against the remote revision and clear the conflict', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      useDirtyStore.getState().setDirty(pageId, true);
+      parkConflict(pageId);
+
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ content: 'my text', revision: 12 }),
+      } as Response);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      await act(async () => {
+        await result.current.resolveConflict('keep-mine');
+      });
+
+      const opts = vi.mocked(fetchWithAuth).mock.calls[0][1] as { method: string; body: string };
+      expect(opts.method).toBe('PATCH');
+      expect(JSON.parse(opts.body)).toMatchObject({ content: 'my text', expectedRevision: 11 });
+
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+      const doc = useDocumentManagerStore.getState().documents.get(pageId);
+      expect(doc?.content).toBe('my text');
+      expect(doc?.revision).toBe(12);
+    });
+
+    it('given keep-mine that 409s again, should keep the local text and re-park the fresh conflict', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      parkConflict(pageId);
+
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ error: 'Page was modified', currentRevision: 13, expectedRevision: 11 }),
+      } as Response);
+      vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ content: 'even newer', revision: 13 }),
+      } as Response);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      await act(async () => {
+        await result.current.resolveConflict('keep-mine');
+      });
+
+      expect(useDocumentManagerStore.getState().documents.get(pageId)?.content).toBe('my text');
+      const conflict = useDocumentManagerStore.getState().conflicts.get(pageId);
+      expect(conflict?.remoteContent).toBe('even newer');
+      expect(conflict?.remoteRevision).toBe(13);
+    });
+
+    it('given use-theirs, should adopt the remote copy, clear dirty, and send no PATCH', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+      useDocumentManagerStore.getState().updateDocument(pageId, { isDirty: true });
+      useDirtyStore.getState().setDirty(pageId, true);
+      parkConflict(pageId);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      await act(async () => {
+        await result.current.resolveConflict('use-theirs');
+      });
+
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+      const doc = useDocumentManagerStore.getState().documents.get(pageId);
+      expect(doc?.content).toBe('their text');
+      expect(doc?.revision).toBe(11);
+      expect(doc?.isDirty).toBe(false);
+      expect(useDirtyStore.getState().isDirty(pageId)).toBe(false);
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
+    });
+
+    it('given no pending conflict, resolveConflict should be a no-op', async () => {
+      const pageId = 'page-123';
+      useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      await act(async () => {
+        await result.current.resolveConflict('keep-mine');
+      });
+
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+      expect(useDocumentManagerStore.getState().documents.get(pageId)?.content).toBe('my text');
     });
   });
 

--- a/apps/web/src/hooks/__tests__/useDocument.test.ts
+++ b/apps/web/src/hooks/__tests__/useDocument.test.ts
@@ -376,6 +376,25 @@ describe('useDocument dirty flag integration', () => {
       expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(false);
     });
 
+    it('given no local document record, should refuse to resolve rather than save an empty document', async () => {
+      const pageId = 'page-123';
+      parkConflict(pageId);
+      // Conflict parked but the document record is gone from the store.
+      expect(useDocumentManagerStore.getState().documents.has(pageId)).toBe(false);
+
+      const { result } = renderHook(() => useDocument(pageId));
+
+      let resolved: boolean | undefined;
+      await act(async () => {
+        resolved = await result.current.resolveConflict('keep-mine');
+      });
+
+      expect(resolved).toBe(false);
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+      // The conflict stays parked — nothing was silently overwritten.
+      expect(useDocumentManagerStore.getState().conflicts.has(pageId)).toBe(true);
+    });
+
     it('given no pending conflict, resolveConflict should be a no-op', async () => {
       const pageId = 'page-123';
       useDocumentManagerStore.getState().upsertDocument(pageId, 'my text', 'html', 3);

--- a/apps/web/src/hooks/useDocument.ts
+++ b/apps/web/src/hooks/useDocument.ts
@@ -9,6 +9,7 @@ import {
   canScheduleSave,
   decideConflictOutcome,
   planConflictResolution,
+  readContent,
   type ConflictResolutionChoice,
   type ConflictResponseBody,
   type RemotePageSnapshot,
@@ -185,6 +186,7 @@ export const useDocument = (pageId: string) => {
     useCallback((state) => state.conflicts.get(pageId), [pageId])
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [isResolvingConflict, setIsResolvingConflict] = useState(false);
 
   const initializeAndActivate = useCallback(async () => {
     setIsLoading(true);
@@ -308,8 +310,18 @@ export const useDocument = (pageId: string) => {
       const conflict = state.conflicts.get(pageId);
       if (!conflict) return false;
 
-      const localContent = state.documents.get(pageId)?.content ?? '';
-      const plan = planConflictResolution(choice, { localContent, conflict });
+      // Mirror of the remote-side guard in decideConflictOutcome: "no local
+      // record" must never become "save an empty document over their work".
+      const local = readContent(state.documents.get(pageId)?.content);
+      if (!local.present) {
+        toast.error(
+          'Your local copy of this document is no longer loaded, so it cannot be compared. Reopen the page to see the current version.',
+          { id: `conflict-${pageId}` }
+        );
+        return false;
+      }
+
+      const plan = planConflictResolution(choice, { localContent: local.content, conflict });
 
       if (plan.action === 'adopt-remote') {
         const now = Date.now();
@@ -321,18 +333,21 @@ export const useDocument = (pageId: string) => {
           lastUpdateTime: now,
         });
         useDirtyStore.getState().clearDirty(pageId);
-        useDocumentManagerStore.getState().clearConflict(pageId);
+        state.clearConflict(pageId);
         return true;
       }
 
       // Clear first so the save is not blocked by its own conflict guard;
       // a repeat 409 parks a fresh one.
       state.clearConflict(pageId);
-      const saved = await saving
-        .saveDocument(plan.contentToSave, { expectedRevision: plan.expectedRevision })
-        .catch(() => false);
-
-      return saved;
+      setIsResolvingConflict(true);
+      try {
+        return await saving
+          .saveDocument(plan.contentToSave, { expectedRevision: plan.expectedRevision })
+          .catch(() => false);
+      } finally {
+        setIsResolvingConflict(false);
+      }
     },
     [pageId, saving]
   );
@@ -348,6 +363,7 @@ export const useDocument = (pageId: string) => {
     forceSave,
     conflict,
     resolveConflict,
+    isResolvingConflict,
     clearDocument: documentState.clearDocument,
   };
 };

--- a/apps/web/src/hooks/useDocument.ts
+++ b/apps/web/src/hooks/useDocument.ts
@@ -205,7 +205,10 @@ export const useDocument = (pageId: string) => {
     useCallback((state) => state.conflicts.get(pageId), [pageId])
   );
   const [isLoading, setIsLoading] = useState(false);
-  const [isResolvingConflict, setIsResolvingConflict] = useState(false);
+  // Store-level, so every view mounting this page shares one resolution state.
+  const isResolvingConflict = useDocumentManagerStore(
+    useCallback((state) => state.resolvingConflicts.has(pageId), [pageId])
+  );
 
   const initializeAndActivate = useCallback(async () => {
     setIsLoading(true);
@@ -329,6 +332,12 @@ export const useDocument = (pageId: string) => {
       const conflict = state.conflicts.get(pageId);
       if (!conflict) return false;
 
+      // Serialize: a page can be open in more than one view, each rendering its
+      // own banner. Without this, two clicks send two PATCHes with the same
+      // expectedRevision — the server takes one and 409s the other, parking a
+      // spurious conflict on the conflict that was just resolved.
+      if (state.resolvingConflicts.has(pageId)) return false;
+
       // Mirror of the remote-side guard in decideConflictOutcome: "no local
       // record" must never become "save an empty document over their work".
       const local = readContent(state.documents.get(pageId)?.content);
@@ -361,7 +370,7 @@ export const useDocument = (pageId: string) => {
       // cleared only once the retry has actually succeeded; a repeat 409 leaves
       // the fresher snapshot `saveDocument` just parked in its place, and any
       // other failure leaves the banner up so the user can try again.
-      setIsResolvingConflict(true);
+      state.setResolvingConflict(pageId, true);
       try {
         const saved = await saving
           .saveDocument(plan.contentToSave, {
@@ -372,14 +381,22 @@ export const useDocument = (pageId: string) => {
 
         if (saved) {
           useDocumentManagerStore.getState().clearConflict(pageId);
+
+          // Edits made DURING the retry were blocked by the (correctly closed)
+          // autosave guard, so nothing is scheduled for them. Without this they
+          // sit unsaved until the next keystroke, blur or manual save.
+          const afterSave = useDocumentManagerStore.getState().documents.get(pageId);
+          if (afterSave?.isDirty) {
+            saveWithDebounce(afterSave.content);
+          }
         }
 
         return saved;
       } finally {
-        setIsResolvingConflict(false);
+        useDocumentManagerStore.getState().setResolvingConflict(pageId, false);
       }
     },
-    [pageId, saving]
+    [pageId, saving, saveWithDebounce]
   );
 
   return {

--- a/apps/web/src/hooks/useDocument.ts
+++ b/apps/web/src/hooks/useDocument.ts
@@ -67,7 +67,26 @@ export const useDocumentSaving = (pageId: string) => {
   }, []);
 
   const saveDocument = useCallback(
-    async (content: string, options?: { expectedRevision?: number }) => {
+    async (
+      content: string,
+      options?: { expectedRevision?: number; resolvingConflict?: boolean }
+    ) => {
+      // Deepest guard: while a conflict is parked the stored revision is
+      // known-stale, so ONLY the resolution path may write. This is an explicit
+      // per-call opt-in rather than a temporary clear of the shared conflict
+      // state — clearing it early would open the debounce/forceSave guards for
+      // the whole duration of the awaited retry, letting a keystroke fire a
+      // second PATCH with the stale revision and park a phantom conflict for a
+      // save that actually succeeded.
+      if (
+        !options?.resolvingConflict &&
+        !canScheduleSave({
+          hasPendingConflict: useDocumentManagerStore.getState().conflicts.has(pageId),
+        })
+      ) {
+        return false;
+      }
+
       try {
         const saveStartTime = Date.now();
 
@@ -337,14 +356,25 @@ export const useDocument = (pageId: string) => {
         return true;
       }
 
-      // Clear first so the save is not blocked by its own conflict guard;
-      // a repeat 409 parks a fresh one.
-      state.clearConflict(pageId);
+      // The conflict stays PARKED for the whole retry, so the autosave guards
+      // stay closed and a keystroke mid-flight cannot race this PATCH. It is
+      // cleared only once the retry has actually succeeded; a repeat 409 leaves
+      // the fresher snapshot `saveDocument` just parked in its place, and any
+      // other failure leaves the banner up so the user can try again.
       setIsResolvingConflict(true);
       try {
-        return await saving
-          .saveDocument(plan.contentToSave, { expectedRevision: plan.expectedRevision })
+        const saved = await saving
+          .saveDocument(plan.contentToSave, {
+            expectedRevision: plan.expectedRevision,
+            resolvingConflict: true,
+          })
           .catch(() => false);
+
+        if (saved) {
+          useDocumentManagerStore.getState().clearConflict(pageId);
+        }
+
+        return saved;
       } finally {
         setIsResolvingConflict(false);
       }

--- a/apps/web/src/hooks/useDocument.ts
+++ b/apps/web/src/hooks/useDocument.ts
@@ -5,6 +5,14 @@ import { useDirtyStore } from '@/stores/useDirtyStore';
 import { toast } from 'sonner';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocket } from './useSocket';
+import {
+  canScheduleSave,
+  decideConflictOutcome,
+  planConflictResolution,
+  type ConflictResolutionChoice,
+  type ConflictResponseBody,
+  type RemotePageSnapshot,
+} from '@/lib/documents/conflict-resolution';
 
 export const useDocumentState = (pageId: string) => {
   const document = useDocumentManagerStore(
@@ -58,14 +66,14 @@ export const useDocumentSaving = (pageId: string) => {
   }, []);
 
   const saveDocument = useCallback(
-    async (content: string) => {
+    async (content: string, options?: { expectedRevision?: number }) => {
       try {
         const saveStartTime = Date.now();
 
         markAsSaving(pageId);
 
         const docBeforeSave = useDocumentManagerStore.getState().documents.get(pageId);
-        const expectedRevision = docBeforeSave?.revision;
+        const expectedRevision = options?.expectedRevision ?? docBeforeSave?.revision;
 
         const headers: Record<string, string> = {
           'Content-Type': 'application/json',
@@ -82,29 +90,50 @@ export const useDocumentSaving = (pageId: string) => {
 
         if (!response.ok) {
           if (response.status === 409) {
-            console.warn(
-              `[conflict] Page ${pageId}: local edits discarded. Content was:`,
-              content
-            );
-            toast.error('Document was modified elsewhere. Your local copy has been updated.', {
-              id: `conflict-${pageId}`,
-            });
+            // NEVER replace the user's buffer here. Park the server's copy
+            // beside it and let the user choose; `content` / `isDirty` and the
+            // dirty store are deliberately left exactly as they are.
+            const conflictBody: ConflictResponseBody | null = await response
+              .json()
+              .catch(() => null);
+
+            let remotePage: RemotePageSnapshot | null = null;
             try {
               const freshResponse = await fetchWithAuth(`/api/pages/${pageId}`);
               if (freshResponse.ok) {
-                const freshPage = await freshResponse.json();
-                useDocumentManagerStore.getState().updateDocument(pageId, {
-                  content: freshPage.content ?? '',
-                  revision: freshPage.revision,
-                  isDirty: false,
-                  lastSaved: Date.now(),
-                  lastUpdateTime: Date.now(),
-                });
-                useDirtyStore.getState().clearDirty(pageId);
+                remotePage = (await freshResponse.json()) as RemotePageSnapshot;
               }
             } catch {
-              // Refetch failed — user can still manually refresh
+              // Leave remotePage null — decideConflictOutcome reports an error
+              // rather than offering a resolution we cannot honour.
             }
+
+            const outcome = decideConflictOutcome({
+              conflictBody,
+              remotePage,
+              detectedAt: Date.now(),
+            });
+
+            // Cancel any debounce queued before the conflict was detected —
+            // otherwise it fires, 409s again, and the toast loops.
+            const pending = useDocumentManagerStore.getState().documents.get(pageId);
+            if (pending?.saveTimeout) {
+              clearTimeout(pending.saveTimeout);
+              useDocumentManagerStore
+                .getState()
+                .updateDocument(pageId, { saveTimeout: undefined });
+            }
+
+            if (outcome.kind === 'conflict') {
+              useDocumentManagerStore.getState().setConflict(pageId, outcome.conflict);
+              toast.error(
+                'Document was modified elsewhere. Your unsaved changes are still here — choose which version to keep.',
+                { id: `conflict-${pageId}` }
+              );
+            } else {
+              toast.error(outcome.message, { id: `conflict-${pageId}` });
+            }
+
             clearSavingState(pageId);
             return false;
           }
@@ -152,6 +181,9 @@ export const useDocument = (pageId: string) => {
   const documentState = useDocumentState(pageId);
   const saving = useDocumentSaving(pageId);
   const { setActiveDocument } = useActiveDocument();
+  const conflict = useDocumentManagerStore(
+    useCallback((state) => state.conflicts.get(pageId), [pageId])
+  );
   const [isLoading, setIsLoading] = useState(false);
 
   const initializeAndActivate = useCallback(async () => {
@@ -219,6 +251,11 @@ export const useDocument = (pageId: string) => {
     [pageId]
   );
 
+  const hasPendingConflict = useCallback(
+    () => useDocumentManagerStore.getState().conflicts.has(pageId),
+    [pageId]
+  );
+
   const saveWithDebounce = useCallback(
     (content: string, delay = 1000) => {
       const document = useDocumentManagerStore.getState().documents.get(pageId);
@@ -226,13 +263,19 @@ export const useDocument = (pageId: string) => {
         clearTimeout(document.saveTimeout);
       }
 
+      // A parked conflict means our revision is known-stale: another PATCH
+      // would 409 again and the debounce would keep re-firing.
+      if (!canScheduleSave({ hasPendingConflict: hasPendingConflict() })) return;
+
       const timeout = setTimeout(() => {
+        // Re-check: a conflict can be detected during the debounce window.
+        if (!canScheduleSave({ hasPendingConflict: hasPendingConflict() })) return;
         saving.saveDocument(content).catch(console.error);
       }, delay);
 
       useDocumentManagerStore.getState().updateDocument(pageId, { saveTimeout: timeout });
     },
-    [pageId, saving]
+    [pageId, saving, hasPendingConflict]
   );
 
   const forceSave = useCallback(async () => {
@@ -243,8 +286,56 @@ export const useDocument = (pageId: string) => {
       clearTimeout(document.saveTimeout);
     }
 
+    if (!canScheduleSave({ hasPendingConflict: hasPendingConflict() })) return false;
+
     return saving.saveDocument(document.content);
-  }, [pageId, saving]);
+  }, [pageId, saving, hasPendingConflict]);
+
+  /**
+   * Apply the user's choice from the conflict banner.
+   *
+   * `keep-mine` re-saves the local text against the revision we observed, so it
+   * cannot 409 on the same conflict; if a THIRD party has saved since, the
+   * retry 409s again and `saveDocument` re-parks a fresh conflict with the newer
+   * remote content — the local text is still never replaced.
+   *
+   * `use-theirs` adopts the server copy locally; no PATCH is needed because the
+   * server already holds it.
+   */
+  const resolveConflict = useCallback(
+    async (choice: ConflictResolutionChoice) => {
+      const state = useDocumentManagerStore.getState();
+      const conflict = state.conflicts.get(pageId);
+      if (!conflict) return false;
+
+      const localContent = state.documents.get(pageId)?.content ?? '';
+      const plan = planConflictResolution(choice, { localContent, conflict });
+
+      if (plan.action === 'adopt-remote') {
+        const now = Date.now();
+        state.updateDocument(pageId, {
+          content: plan.contentToAdopt,
+          revision: plan.revision,
+          isDirty: false,
+          lastSaved: now,
+          lastUpdateTime: now,
+        });
+        useDirtyStore.getState().clearDirty(pageId);
+        useDocumentManagerStore.getState().clearConflict(pageId);
+        return true;
+      }
+
+      // Clear first so the save is not blocked by its own conflict guard;
+      // a repeat 409 parks a fresh one.
+      state.clearConflict(pageId);
+      const saved = await saving
+        .saveDocument(plan.contentToSave, { expectedRevision: plan.expectedRevision })
+        .catch(() => false);
+
+      return saved;
+    },
+    [pageId, saving]
+  );
 
   return {
     document: documentState.document,
@@ -255,6 +346,8 @@ export const useDocument = (pageId: string) => {
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
+    conflict,
+    resolveConflict,
     clearDocument: documentState.clearDocument,
   };
 };

--- a/apps/web/src/hooks/useDocument.ts
+++ b/apps/web/src/hooks/useDocument.ts
@@ -289,7 +289,16 @@ export const useDocument = (pageId: string) => {
 
       // A parked conflict means our revision is known-stale: another PATCH
       // would 409 again and the debounce would keep re-firing.
-      if (!canScheduleSave({ hasPendingConflict: hasPendingConflict() })) return;
+      if (!canScheduleSave({ hasPendingConflict: hasPendingConflict() })) {
+        // Drop the handle we just cleared so the store does not advertise a
+        // pending save that no longer exists. Only on this path — the normal
+        // one overwrites it below, and a second write per keystroke would
+        // re-render every subscriber for nothing.
+        if (document?.saveTimeout) {
+          useDocumentManagerStore.getState().updateDocument(pageId, { saveTimeout: undefined });
+        }
+        return;
+      }
 
       const timeout = setTimeout(() => {
         // Re-check: a conflict can be detected during the debounce window.

--- a/apps/web/src/lib/documents/__tests__/conflict-resolution.test.ts
+++ b/apps/web/src/lib/documents/__tests__/conflict-resolution.test.ts
@@ -3,8 +3,27 @@ import {
   decideConflictOutcome,
   planConflictResolution,
   canScheduleSave,
+  readContent,
   type DocumentConflict,
 } from '../conflict-resolution';
+
+describe('readContent', () => {
+  it('given undefined, should report the content as absent', () => {
+    expect(readContent(undefined)).toEqual({ present: false });
+  });
+
+  it('given null, should report an explicitly empty document', () => {
+    expect(readContent(null)).toEqual({ present: true, content: '' });
+  });
+
+  it('given a string, should report it present', () => {
+    expect(readContent('text')).toEqual({ present: true, content: 'text' });
+  });
+
+  it('given an empty string, should report it present rather than absent', () => {
+    expect(readContent('')).toEqual({ present: true, content: '' });
+  });
+});
 
 describe('decideConflictOutcome', () => {
   it('given a refetched remote page with a revision, should park it as a conflict', () => {
@@ -31,6 +50,19 @@ describe('decideConflictOutcome', () => {
       kind: 'conflict',
       conflict: { remoteContent: '', remoteRevision: 9, detectedAt: 5 },
     });
+  });
+
+  it('given a remote page with an absent content field, should error rather than offer an empty document', () => {
+    // Coercing absent content to '' would let "Use theirs" wipe the local text.
+    const outcome = decideConflictOutcome({
+      conflictBody: { currentRevision: 4 },
+      remotePage: { revision: 4 },
+      detectedAt: 1000,
+    });
+
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind !== 'error') throw new Error('expected error');
+    expect(outcome.message).toContain('still here');
   });
 
   it('given a remote page without a revision, should fall back to currentRevision from the 409 body', () => {

--- a/apps/web/src/lib/documents/__tests__/conflict-resolution.test.ts
+++ b/apps/web/src/lib/documents/__tests__/conflict-resolution.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideConflictOutcome,
+  planConflictResolution,
+  canScheduleSave,
+  type DocumentConflict,
+} from '../conflict-resolution';
+
+describe('decideConflictOutcome', () => {
+  it('given a refetched remote page with a revision, should park it as a conflict', () => {
+    const outcome = decideConflictOutcome({
+      conflictBody: { error: 'Page was modified', currentRevision: 4, expectedRevision: 3 },
+      remotePage: { content: 'their text', revision: 4 },
+      detectedAt: 1000,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'conflict',
+      conflict: { remoteContent: 'their text', remoteRevision: 4, detectedAt: 1000 },
+    });
+  });
+
+  it('given a remote page with null content, should treat it as an empty remote document', () => {
+    const outcome = decideConflictOutcome({
+      conflictBody: { currentRevision: 9 },
+      remotePage: { content: null, revision: 9 },
+      detectedAt: 5,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'conflict',
+      conflict: { remoteContent: '', remoteRevision: 9, detectedAt: 5 },
+    });
+  });
+
+  it('given a remote page without a revision, should fall back to currentRevision from the 409 body', () => {
+    const outcome = decideConflictOutcome({
+      conflictBody: { currentRevision: 7, expectedRevision: 6 },
+      remotePage: { content: 'their text' },
+      detectedAt: 2,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'conflict',
+      conflict: { remoteContent: 'their text', remoteRevision: 7, detectedAt: 2 },
+    });
+  });
+
+  it('given the refetch failed, should return an error rather than a conflict', () => {
+    const outcome = decideConflictOutcome({
+      conflictBody: { currentRevision: 4 },
+      remotePage: null,
+      detectedAt: 1000,
+    });
+
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind !== 'error') throw new Error('expected error');
+    expect(outcome.message).toContain('still here');
+  });
+
+  it('given no revision is recoverable from either source, should return an error', () => {
+    const outcome = decideConflictOutcome({
+      conflictBody: { error: 'Page was modified' },
+      remotePage: { content: 'their text' },
+      detectedAt: 1000,
+    });
+
+    expect(outcome.kind).toBe('error');
+  });
+
+  it('given a missing 409 body, should still park a conflict when the remote page carries a revision', () => {
+    const outcome = decideConflictOutcome({
+      conflictBody: null,
+      remotePage: { content: 'their text', revision: 12 },
+      detectedAt: 3,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'conflict',
+      conflict: { remoteContent: 'their text', remoteRevision: 12, detectedAt: 3 },
+    });
+  });
+});
+
+describe('planConflictResolution', () => {
+  const conflict: DocumentConflict = {
+    remoteContent: 'their text',
+    remoteRevision: 11,
+    detectedAt: 1,
+  };
+
+  it('given keep-mine, should save the local content against the remote revision', () => {
+    expect(planConflictResolution('keep-mine', { localContent: 'my text', conflict })).toEqual({
+      action: 'save-local',
+      contentToSave: 'my text',
+      expectedRevision: 11,
+    });
+  });
+
+  it('given use-theirs, should adopt the remote content and revision', () => {
+    expect(planConflictResolution('use-theirs', { localContent: 'my text', conflict })).toEqual({
+      action: 'adopt-remote',
+      contentToAdopt: 'their text',
+      revision: 11,
+    });
+  });
+});
+
+describe('canScheduleSave', () => {
+  it('given no pending conflict, should allow the save', () => {
+    expect(canScheduleSave({ hasPendingConflict: false })).toBe(true);
+  });
+
+  it('given a pending conflict, should block the save so the autosave loop cannot re-409', () => {
+    expect(canScheduleSave({ hasPendingConflict: true })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/documents/conflict-resolution.ts
+++ b/apps/web/src/lib/documents/conflict-resolution.ts
@@ -93,9 +93,17 @@ export interface ConflictResolutionInput {
  *
  * `keep-mine` re-saves the local content with `expectedRevision` set to the
  * revision we just observed, so the retry compare-and-swaps against the version
- * that caused the conflict instead of the stale one. The other person's text is
- * not destroyed: every `applyPageMutation` writes a `page_versions` row, so
- * their revision is already in page history.
+ * that caused the conflict instead of the stale one.
+ *
+ * `keep-mine` IS destructive to the other person's text from the user's point of
+ * view, and the UI must say so. Every `applyPageMutation` does write a
+ * `page_versions` row, so their revision is durably stored — but that is an
+ * operator-level fact, not a recovery path: `history/route.ts` is GET-only,
+ * there is no restore endpoint, no UI reads page history, and the rows expire
+ * after 30 days. Do not turn this into a reassurance to the user that their
+ * colleague's version can be recovered. Instead the banner shows the parked
+ * remote content inline so the choice is informed. (Multiplayer Documents epic,
+ * Phase A — task `jc5su9gmeohiyo3ulzu7o143`.)
  */
 export function planConflictResolution(
   choice: ConflictResolutionChoice,

--- a/apps/web/src/lib/documents/conflict-resolution.ts
+++ b/apps/web/src/lib/documents/conflict-resolution.ts
@@ -27,6 +27,23 @@ export interface RemotePageSnapshot {
   revision?: number;
 }
 
+/**
+ * The result of reading a content field that may be absent OR explicitly empty.
+ *
+ * These two are NOT the same and conflating them is destructive in both
+ * directions: an absent REMOTE content coerced to '' lets "Use theirs" wipe the
+ * user's text, and an absent LOCAL content coerced to '' lets "Keep mine" save
+ * an empty document over someone else's work. `?? ''` cannot express the
+ * difference, so it is banned at these boundaries — use `readContent`.
+ */
+export type ContentRead = { present: true; content: string } | { present: false };
+
+/** `null` means an empty document. `undefined` means we do not have it. */
+export function readContent(content: string | null | undefined): ContentRead {
+  if (content === undefined) return { present: false };
+  return { present: true, content: content ?? '' };
+}
+
 export type ConflictDecision =
   | { kind: 'conflict'; conflict: DocumentConflict }
   | { kind: 'error'; message: string };
@@ -57,6 +74,15 @@ export function decideConflictOutcome(input: ConflictDecisionInput): ConflictDec
     };
   }
 
+  const remote = readContent(remotePage.content);
+  if (!remote.present) {
+    return {
+      kind: 'error',
+      message:
+        'Document was modified elsewhere and the current version could not be read. Your changes are still here — try saving again.',
+    };
+  }
+
   const remoteRevision = remotePage.revision ?? conflictBody?.currentRevision;
 
   if (remoteRevision === undefined) {
@@ -70,7 +96,7 @@ export function decideConflictOutcome(input: ConflictDecisionInput): ConflictDec
   return {
     kind: 'conflict',
     conflict: {
-      remoteContent: remotePage.content ?? '',
+      remoteContent: remote.content,
       remoteRevision,
       detectedAt,
     },

--- a/apps/web/src/lib/documents/conflict-resolution.ts
+++ b/apps/web/src/lib/documents/conflict-resolution.ts
@@ -1,0 +1,128 @@
+/**
+ * Pure decision core for save conflicts (HTTP 409 on PATCH /api/pages/[pageId]).
+ *
+ * The rule this module exists to enforce: a 409 NEVER replaces the user's
+ * buffer. The server's copy is parked alongside the local one until the user
+ * picks a side. Everything here is pure — no zustand, no sonner, no fetch —
+ * so the effectful shell (useDocument) stays a thin translation layer.
+ */
+
+/** The server's copy, parked while the user decides what to do with it. */
+export interface DocumentConflict {
+  remoteContent: string;
+  remoteRevision: number;
+  detectedAt: number;
+}
+
+/** Body of the 409 response (`route.ts` returns error/currentRevision/expectedRevision). */
+export interface ConflictResponseBody {
+  error?: string;
+  currentRevision?: number;
+  expectedRevision?: number;
+}
+
+/** The refetched server page, or null when the refetch itself failed. */
+export interface RemotePageSnapshot {
+  content?: string | null;
+  revision?: number;
+}
+
+export type ConflictDecision =
+  | { kind: 'conflict'; conflict: DocumentConflict }
+  | { kind: 'error'; message: string };
+
+export interface ConflictDecisionInput {
+  conflictBody: ConflictResponseBody | null;
+  remotePage: RemotePageSnapshot | null;
+  detectedAt: number;
+}
+
+/**
+ * Turn a 409 (plus whatever the follow-up refetch produced) into either a
+ * parked conflict or a plain error.
+ *
+ * A conflict is only offerable when we have BOTH the server's content (to show
+ * under "Use theirs") and its revision (so "Keep mine" can re-save against a
+ * revision that cannot 409 again). Missing either, we report an error and leave
+ * the local buffer dirty — the user's text is never the thing we drop.
+ */
+export function decideConflictOutcome(input: ConflictDecisionInput): ConflictDecision {
+  const { conflictBody, remotePage, detectedAt } = input;
+
+  if (!remotePage) {
+    return {
+      kind: 'error',
+      message:
+        'Document was modified elsewhere and the current version could not be loaded. Your changes are still here — try saving again.',
+    };
+  }
+
+  const remoteRevision = remotePage.revision ?? conflictBody?.currentRevision;
+
+  if (remoteRevision === undefined) {
+    return {
+      kind: 'error',
+      message:
+        'Document was modified elsewhere and its version number is unknown. Your changes are still here — try saving again.',
+    };
+  }
+
+  return {
+    kind: 'conflict',
+    conflict: {
+      remoteContent: remotePage.content ?? '',
+      remoteRevision,
+      detectedAt,
+    },
+  };
+}
+
+export type ConflictResolutionChoice = 'keep-mine' | 'use-theirs';
+
+export type ConflictResolutionPlan =
+  | { action: 'save-local'; contentToSave: string; expectedRevision: number }
+  | { action: 'adopt-remote'; contentToAdopt: string; revision: number };
+
+export interface ConflictResolutionInput {
+  localContent: string;
+  conflict: DocumentConflict;
+}
+
+/**
+ * What each resolution choice means, as data.
+ *
+ * `keep-mine` re-saves the local content with `expectedRevision` set to the
+ * revision we just observed, so the retry compare-and-swaps against the version
+ * that caused the conflict instead of the stale one. The other person's text is
+ * not destroyed: every `applyPageMutation` writes a `page_versions` row, so
+ * their revision is already in page history.
+ */
+export function planConflictResolution(
+  choice: ConflictResolutionChoice,
+  input: ConflictResolutionInput
+): ConflictResolutionPlan {
+  if (choice === 'keep-mine') {
+    return {
+      action: 'save-local',
+      contentToSave: input.localContent,
+      expectedRevision: input.conflict.remoteRevision,
+    };
+  }
+
+  return {
+    action: 'adopt-remote',
+    contentToAdopt: input.conflict.remoteContent,
+    revision: input.conflict.remoteRevision,
+  };
+}
+
+/**
+ * Whether the autosave loop may fire a PATCH.
+ *
+ * While a conflict is parked, the local revision is known-stale: another PATCH
+ * would 409 again, re-park, and (because typing keeps rescheduling the debounce)
+ * loop forever. Saves resume once the user resolves.
+ */
+export function canScheduleSave(input: { hasPendingConflict: boolean }): boolean {
+  return !input.hasPendingConflict;
+}

--- a/apps/web/src/stores/useDocumentManagerStore.ts
+++ b/apps/web/src/stores/useDocumentManagerStore.ts
@@ -22,6 +22,14 @@ export interface DocumentManagerState {
    * buffer is still the user's own text and autosave is paused for that page.
    */
   conflicts: Map<string, DocumentConflict>;
+  /**
+   * Pages with a conflict resolution currently in flight. Store-level, not
+   * per-hook state: a page can be mounted by more than one view at once (the
+   * centre panel and an agent pane via PagePaneView), and each would otherwise
+   * hold its own boolean — leaving one banner's buttons live while the other's
+   * are disabled, so two resolutions could fire the same expectedRevision.
+   */
+  resolvingConflicts: Set<string>;
 
   upsertDocument: (pageId: string, content: string, contentMode: 'html' | 'markdown', revision?: number) => void;
   updateDocument: (pageId: string, updates: Partial<DocumentState>) => void;
@@ -34,6 +42,7 @@ export interface DocumentManagerState {
   clearAllDocuments: () => void;
   setConflict: (pageId: string, conflict: DocumentConflict) => void;
   clearConflict: (pageId: string) => void;
+  setResolvingConflict: (pageId: string, resolving: boolean) => void;
 }
 
 export const useDocumentManagerStore = create<DocumentManagerState>((set, get) => ({
@@ -41,6 +50,7 @@ export const useDocumentManagerStore = create<DocumentManagerState>((set, get) =
   activeDocumentId: null,
   savingDocuments: new Set(),
   conflicts: new Map(),
+  resolvingConflicts: new Set(),
 
   upsertDocument: (pageId, content, contentMode, revision) => {
     const state = get();
@@ -122,10 +132,14 @@ export const useDocumentManagerStore = create<DocumentManagerState>((set, get) =
     const newConflicts = new Map(state.conflicts);
     newConflicts.delete(pageId);
 
+    const newResolving = new Set(state.resolvingConflicts);
+    newResolving.delete(pageId);
+
     set({
       documents: newDocuments,
       savingDocuments: newSaving,
       conflicts: newConflicts,
+      resolvingConflicts: newResolving,
       activeDocumentId: state.activeDocumentId === pageId ? null : state.activeDocumentId,
     });
   },
@@ -136,6 +150,7 @@ export const useDocumentManagerStore = create<DocumentManagerState>((set, get) =
       activeDocumentId: null,
       savingDocuments: new Set(),
       conflicts: new Map(),
+      resolvingConflicts: new Set(),
     });
   },
 
@@ -143,6 +158,15 @@ export const useDocumentManagerStore = create<DocumentManagerState>((set, get) =
     const newConflicts = new Map(get().conflicts);
     newConflicts.set(pageId, conflict);
     set({ conflicts: newConflicts });
+  },
+
+  setResolvingConflict: (pageId, resolving) => {
+    const state = get();
+    if (state.resolvingConflicts.has(pageId) === resolving) return;
+    const next = new Set(state.resolvingConflicts);
+    if (resolving) next.add(pageId);
+    else next.delete(pageId);
+    set({ resolvingConflicts: next });
   },
 
   clearConflict: (pageId) => {

--- a/apps/web/src/stores/useDocumentManagerStore.ts
+++ b/apps/web/src/stores/useDocumentManagerStore.ts
@@ -1,4 +1,7 @@
 import { create } from 'zustand';
+import type { DocumentConflict } from '@/lib/documents/conflict-resolution';
+
+export type { DocumentConflict };
 
 export interface DocumentState {
   id: string;
@@ -15,6 +18,12 @@ export interface DocumentManagerState {
   documents: Map<string, DocumentState>;
   activeDocumentId: string | null;
   savingDocuments: Set<string>;
+  /**
+   * Server copies parked by a 409 while the user decides what to keep.
+   * Deliberately NOT merged into `documents` — an entry here means the local
+   * buffer is still the user's own text and autosave is paused for that page.
+   */
+  conflicts: Map<string, DocumentConflict>;
 
   upsertDocument: (pageId: string, content: string, contentMode: 'html' | 'markdown', revision?: number) => void;
   updateDocument: (pageId: string, updates: Partial<DocumentState>) => void;
@@ -25,12 +34,15 @@ export interface DocumentManagerState {
   markAsSaved: (pageId: string) => void;
   clearDocument: (pageId: string) => void;
   clearAllDocuments: () => void;
+  setConflict: (pageId: string, conflict: DocumentConflict) => void;
+  clearConflict: (pageId: string) => void;
 }
 
 export const useDocumentManagerStore = create<DocumentManagerState>((set, get) => ({
   documents: new Map(),
   activeDocumentId: null,
   savingDocuments: new Set(),
+  conflicts: new Map(),
 
   upsertDocument: (pageId, content, contentMode, revision) => {
     const state = get();
@@ -109,9 +121,13 @@ export const useDocumentManagerStore = create<DocumentManagerState>((set, get) =
     const newSaving = new Set(state.savingDocuments);
     newSaving.delete(pageId);
 
+    const newConflicts = new Map(state.conflicts);
+    newConflicts.delete(pageId);
+
     set({
       documents: newDocuments,
       savingDocuments: newSaving,
+      conflicts: newConflicts,
       activeDocumentId: state.activeDocumentId === pageId ? null : state.activeDocumentId,
     });
   },
@@ -121,6 +137,21 @@ export const useDocumentManagerStore = create<DocumentManagerState>((set, get) =
       documents: new Map(),
       activeDocumentId: null,
       savingDocuments: new Set(),
+      conflicts: new Map(),
     });
+  },
+
+  setConflict: (pageId, conflict) => {
+    const newConflicts = new Map(get().conflicts);
+    newConflicts.set(pageId, conflict);
+    set({ conflicts: newConflicts });
+  },
+
+  clearConflict: (pageId) => {
+    const state = get();
+    if (!state.conflicts.has(pageId)) return;
+    const newConflicts = new Map(state.conflicts);
+    newConflicts.delete(pageId);
+    set({ conflicts: newConflicts });
   },
 }));

--- a/apps/web/src/stores/useDocumentManagerStore.ts
+++ b/apps/web/src/stores/useDocumentManagerStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import type { DocumentConflict } from '@/lib/documents/conflict-resolution';
 
-export type { DocumentConflict };
-
 export interface DocumentState {
   id: string;
   content: string;


### PR DESCRIPTION
PR 1 of the **Multiplayer Documents (Yjs CRDT)** epic, Phase A — hardening the write path before any Yjs code lands. Client-side only; no server changes.

## The bug

When a save PATCHed with a stale `expectedRevision`, the server returned 409 and the client refetched the server's copy, **wrote it over the user's editor buffer**, cleared `isDirty` and `useDirtyStore`, and logged the lost text to `console.warn`. The toast — "your local copy has been updated" — described a data loss as a sync. This is live in production today. An existing test asserted that behaviour; that assertion is rewritten here.

## What this does

**The local buffer is never replaced.** On 409 the server's copy is parked in a `conflicts` slot on `useDocumentManagerStore` — a separate map, never merged into `documents` — and the user picks a side.

- **Autosave pauses while a conflict is parked.** The guard lives at three depths: `saveWithDebounce` (at schedule time *and* inside the timeout, since a conflict can be detected during the 1000 ms window), `forceSave`, and `saveDocument` itself. The 409 handler also cancels any debounce queued before detection — without it the debounce re-fires, 409s again, and the toast loops.
- **Persistent banner** (no timeout, no auto-dismiss) with **Keep mine** — re-saves with `expectedRevision = remoteRevision` so the retry can't 409 on the same collision — and **Use theirs**, which adopts the server copy locally and sends no PATCH.
- **"View their version"** renders the parked content read-only (allowlist-sanitized HTML, or `<pre>` for non-prose editors) so the choice is informed rather than blind.
- **A repeat 409 during resolution re-parks a fresh conflict** with the newer content instead of erroring. The user's text still survives.

**New pure module** `apps/web/src/lib/documents/conflict-resolution.ts` holds the decision core — what a 409 becomes, the plan per choice, the save predicate, and a `readContent` narrowing primitive. No zustand, sonner, or fetch; `detectedAt` is injected rather than read from the clock.

## Why five view files are touched

Not scope creep — a dependency. `useDocument` has **five** consumers (`DocumentView`, `CodePageView`, `CanvasPageView`, `TaskListDescription`, `useSheetPersistence`/`SheetView`) and all five write through the guarded save path. The guard lives in the hook, so all five stop autosaving when a conflict is parked. Had the resolution UI stayed only in `DocumentView`, a 409 on a Canvas or Sheet page would pause saving forever with nothing on screen to explain it — worse than the original bug. `DocumentConflictGate` renders `null` until a conflict exists, so each view mounts it unconditionally.

## Review rounds

Four rounds of review found real defects beyond the original scope. Each is fixed and mutation-checked:

1. **Absent vs empty content**, both directions. `remotePage.content ?? ''` let "Use theirs" replace the user's text with nothing; the mirror in `resolveConflict` let "Keep mine" save an *empty document over the other person's work*. Fixed at the root with one `readContent` primitive (`undefined` → absent, `null` → empty), since `?? ''` cannot express the distinction and it was being asked twice.
2. **The resolution-save race.** `resolveConflict` cleared the conflict *before* awaiting the retry, opening the autosave guards for the whole request — a keystroke could fire a second PATCH with the stale revision and park a phantom conflict for a save that succeeded. The conflict now stays parked; `saveDocument` takes an explicit per-call `resolvingConflict` opt-in instead.
3. **Stranded mid-retry edits.** With the guard correctly closed, text typed during the retry had nothing scheduled for it. A successful resolution now reschedules if the document is still dirty.
4. **Two views, two booleans.** `isResolvingConflict` was per-instance state, so a page open in both the centre panel and an agent pane could resolve twice with the same `expectedRevision`. It now lives in the store keyed by `pageId`, which serializes the resolution and disables every banner together.

5. **Proactive critique round (nobody prompted these).** The store kept advertising a `saveTimeout` handle for a timer it had already cancelled. And `PageSetupButton` became a dead end this PR itself created: round 3's guard makes the pre-conversion save return `false` during a conflict, so *"Please save your changes before converting"* was advice the user could not act on — it now says to resolve the conflict instead.

## A claim deliberately NOT made

The task brief asked me to tell users the discarded version stays recoverable from page history. **It does not.** `applyPageMutation` does write a `page_versions` row every time, so the data is durably stored — but `history/route.ts` is GET-only, there is no restore endpoint, no UI reads page history, and rows expire after 30 days. The banner therefore says plainly what each choice overwrites, and shows the other version inline so the promise isn't needed. A test asserts the banner contains neither "recoverable" nor "history".

## Validation

Strict TDD; every test mutation-checked by breaking the mechanism it guards and confirming it goes red. **22 mutations, 21 red** — including restoring the original data-losing 409 handler, restoring the resolution race, removing each guard independently, and re-adding the false history copy. One mutation (removing `forceSave`'s own guard) knowingly does **not** go red: round 3's deeper guard inside `saveDocument` returns before `markAsSaving`, so the outer check has no distinct observable effect. It is kept as defence in depth, and the test file says so rather than implying coverage it lacks. Full table in `.pu-reports/pu-mp-conflict-409.md`.

- `bun run typecheck` (monorepo root) — 17/17
- `bun run lint` — 15/15
- `src/lib/documents` + the hook + all of `page-views` — 430 passed, 6 skipped

The one locally failing file, `useTaskSubTasks.integration.test.tsx`, needs a migrated Postgres this worktree lacks and prints its own opt-out; it is unrelated to this change and passes in CI.

## Deliberately not done

No Yjs/CRDT/collab code (Phases B+; `RichEditor.tsx`'s extension list untouched). No server changes — the 409 contract already returns `currentRevision`/`expectedRevision` and is correct. No page-history or restore UI. No three-way merge; character-level merge is the CRDT's job. Also flagged but not fixed: `DocumentView`'s socket handler still drops remote updates while you're dirty, and `hooks/usePageContent.ts` PATCHes the same endpoint with no `expectedRevision` at all (silent last-write-wins) — both different code paths, noted as territory the CRDT must cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYUox29nyZTLpexYB5EfPk

