### PR TITLE
fix(sheets): a newline in a cell destroyed the whole document + the formatting foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   into a single "Unattributed agent" line, which named the wrong thing and skewed the share each
   agent appeared to account for; both are now right.
 
+- **Spreadsheet cells can carry formatting** — number formats (currency, percent, decimals, dates),
+  bold and italic, text and fill colour, alignment, borders, column widths, and frozen rows and
+  columns are now stored with the sheet and survive saving, publishing and export. Clearing a
+  cell's contents keeps its formatting, as it does in Excel and Google Sheets. The controls for
+  setting these arrive with the redesigned spreadsheet view; this release puts the foundation in
+  place and makes anything already formatted display correctly everywhere.
+- **Exported spreadsheets contain real numbers** — an .xlsx export previously wrote every cell as
+  text, so nothing in Excel could sum, sort or chart it. Exports now carry the underlying numbers
+  along with their number formats, so the file reads the same as the sheet and behaves like a
+  spreadsheet.
+- **Spreadsheets with more than one tab keep all of them** — opening a multi-tab workbook and
+  editing it used to discard every tab after the first. The other tabs are now preserved untouched;
+  the editor still shows only the first.
+- **CSV exports show what the sheet shows** — a formatted cell exports as it appears (for example
+  `$1,234.50`), matching Excel's and Google Sheets' behaviour and the .xlsx export. Cells with no
+  formatting are unchanged. If you need the raw numbers for another system, use the .xlsx export,
+  which carries the underlying values.
 - **Agents can hand work to each other from anywhere, not just from a browser tab** — asking an
   assistant to spawn or message a worker used to fail with "the calling request carries no session
   credentials to dispatch with" whenever the request had not come from a logged-in browser. That
@@ -145,6 +162,19 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   panes of a session go quiet where they previously loaded. That is the intended state and matches
   what the Shell and reattach buttons have always shown you; ask a drive admin for a role that
   permits running code if you need those panes back.
+- **A line break in a spreadsheet cell no longer wipes the whole sheet** — a value containing a
+  newline (or a tab, or certain invisible control characters) was written in a form the sheet could
+  not read back, so the next time the page loaded it came back completely empty: every cell, not
+  just the one that caused it. Nothing warned you, and the blank sheet was then saved over the real
+  one. This was reachable without typing anything — a public form response containing a line break
+  destroyed the sheet it fed. Such values are now stored correctly and survive a round trip, and a
+  sheet that genuinely cannot be read is shown with editing disabled and an explanation rather than
+  being silently replaced with an empty grid.
+- **Undo works in spreadsheets** — the undo history was being cleared after every single edit, so
+  Ctrl+Z had nothing to go back to for anything but the change you were part-way through making.
+- **People with view-only access can select cells in a spreadsheet again** — selecting a range to
+  read it, copy it, or see its total was blocked along with editing, even though selecting changes
+  nothing.
 
 - **Stop and Retry now react the moment you press them** — both were doing their work at roughly
   the speed they always had, and both spent that time showing you nothing at all, which reads as a

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.line-numbering.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.line-numbering.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
   isSheetType: vi.fn(() => false),
-  parseSheetContent: vi.fn(),
+  parseSheetContentSafe: vi.fn(),
   serializeSheetContent: vi.fn(),
   updateSheetCells: vi.fn(),
   isValidCellAddress: vi.fn(() => true),

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.read-parity.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.read-parity.test.ts
@@ -39,7 +39,7 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
   isSheetType: vi.fn(() => false),
-  parseSheetContent: vi.fn(),
+  parseSheetContentSafe: vi.fn(),
   serializeSheetContent: vi.fn(),
   updateSheetCells: vi.fn(),
   isValidCellAddress: vi.fn(() => true),

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -53,7 +53,7 @@ vi.mock('@pagespace/lib/utils/enums', () => ({
 }));
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
   isSheetType: vi.fn(() => false),
-  parseSheetContent: vi.fn(),
+  parseSheetContentSafe: vi.fn(),
   serializeSheetContent: vi.fn(),
   updateSheetCells: vi.fn(),
   isValidCellAddress: vi.fn(() => true),

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -37,7 +37,7 @@ vi.mock('@pagespace/lib/utils/enums', () => ({
 }));
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
   isSheetType: vi.fn(() => false),
-  parseSheetContent: vi.fn(),
+  parseSheetContentSafe: vi.fn(),
   serializeSheetContent: vi.fn(),
   updateSheetCells: vi.fn(),
   isValidCellAddress: vi.fn(() => true),

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.write-guardrails.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.write-guardrails.test.ts
@@ -300,6 +300,31 @@ describe('MCP Documents API — write guardrails (#1761)', () => {
       expect(response.status).toBe(200);
       expect(mockApplyPageMutation).toHaveBeenCalledTimes(1);
     });
+
+    it('refuses edit-cells when the sheet content could not be read', async () => {
+      // The lossy parse would yield an empty sheet, so writing would replace
+      // the whole spreadsheet with just the cells in this request.
+      mockIsSheetType.mockReturnValue(true);
+      const sheetModule = await import('@pagespace/lib/sheets/sheet');
+      (sheetModule.parseSheetContentSafe as ReturnType<typeof vi.fn>).mockReturnValue({
+        ok: false,
+        reason: 'toml',
+        message: 'Key without value at row 3',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(
+        makeRequest({
+          operation: 'edit-cells',
+          pageId: 'page-1',
+          cells: [{ address: 'A1', value: '2' }],
+        })
+      );
+
+      expect(response.status).toBe(409);
+      const body = await response.json();
+      expect(body.error).toMatch(/could not be read/);
+    });
   });
 
   describe('3. pageId is required — no silent current-page fallback', () => {

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.write-guardrails.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.write-guardrails.test.ts
@@ -35,7 +35,9 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
   isSheetType: (...args: unknown[]) => mockIsSheetType(...args),
-  parseSheetContent: vi.fn(),
+  // The route refuses to write when existing content cannot be read, so it
+  // parses through the ok/failure API rather than the lossy one.
+  parseSheetContentSafe: vi.fn(),
   serializeSheetContent: vi.fn(),
   updateSheetCells: vi.fn(),
   isValidCellAddress: vi.fn(() => true),
@@ -281,7 +283,10 @@ describe('MCP Documents API — write guardrails (#1761)', () => {
       });
 
       const sheetModule = await import('@pagespace/lib/sheets/sheet');
-      (sheetModule.parseSheetContent as ReturnType<typeof vi.fn>).mockReturnValue({ cells: {}, rowCount: 1, columnCount: 1 });
+      (sheetModule.parseSheetContentSafe as ReturnType<typeof vi.fn>).mockReturnValue({
+        ok: true,
+        sheet: { cells: {}, rowCount: 1, columnCount: 1 },
+      });
       (sheetModule.updateSheetCells as ReturnType<typeof vi.fn>).mockReturnValue({ cells: {}, rowCount: 1, columnCount: 1 });
       (sheetModule.serializeSheetContent as ReturnType<typeof vi.fn>).mockReturnValue('[cells]\nA1 = "2"');
 

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -9,7 +9,7 @@ import { backfillMissingTaskItems, ensureTaskListForPage, seedInheritedTaskStatu
 import { computeHasContent } from '@/app/api/pages/[pageId]/tasks/task-utils';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isCodePage } from '@pagespace/lib/content/page-types.config';
-import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
+import { isSheetType, parseSheetContentSafe, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
 import { z } from 'zod/v4';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
 import { serializePageContentForAI } from '@/lib/ai/core/page-serializer';
@@ -813,11 +813,18 @@ export async function POST(req: NextRequest) {
           }, { status: 400 });
         }
 
-        // Parse existing sheet content
-        const sheetData = parseSheetContent(rawContent);
+        // Parse existing sheet content. Aborting on a parse failure is the
+        // point: writing the empty sheet the unsafe parse returns would
+        // replace the whole spreadsheet with just the cells in this request.
+        const parsedSheet = parseSheetContentSafe(rawContent);
+        if (!parsedSheet.ok) {
+          return NextResponse.json({
+            error: `Sheet content could not be read (${parsedSheet.reason}); refusing to overwrite it.`,
+          }, { status: 409 });
+        }
 
         // Apply cell updates
-        const updatedSheet = updateSheetCells(sheetData, cells);
+        const updatedSheet = updateSheetCells(parsedSheet.sheet, cells);
 
         // Serialize back to TOML format
         const newContent = serializeSheetContent(updatedSheet, { pageId });

--- a/apps/web/src/app/api/pages/[pageId]/export/xlsx/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/export/xlsx/__tests__/route.test.ts
@@ -48,6 +48,19 @@ vi.mock('@pagespace/lib/sheets/sheet', () => ({
   parseSheetContent: vi.fn(),
   sanitizeSheetData: vi.fn((data: unknown) => data),
   evaluateSheet: vi.fn(),
+  // The route resolves each cell's underlying value and number format so the
+  // workbook carries real numbers; these are pure helpers, so the real
+  // implementations are the right thing to use here.
+  encodeCellAddress: (row: number, column: number) => {
+    let letters = '';
+    let remaining = column;
+    do {
+      letters = String.fromCharCode(65 + (remaining % 26)) + letters;
+      remaining = Math.floor(remaining / 26) - 1;
+    } while (remaining >= 0);
+    return `${letters}${row + 1}`;
+  },
+  numberFormatToExcelCode: () => undefined,
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -122,6 +135,12 @@ const mockEvaluation = {
     ['John', '30'],
   ],
   errors: {},
+  byAddress: {
+    A1: { value: 'Name', display: 'Name' },
+    B1: { value: 'Age', display: 'Age' },
+    A2: { value: 'John', display: 'John' },
+    B2: { value: 30, display: '30' },
+  },
 };
 
 describe('GET /api/pages/[pageId]/export/xlsx', () => {
@@ -234,7 +253,8 @@ describe('GET /api/pages/[pageId]/export/xlsx', () => {
       expect(generateExcel).toHaveBeenCalledWith(
         mockEvaluation.display,
         'Test Sheet',
-        'Test Sheet'
+        'Test Sheet',
+        expect.objectContaining({ values: expect.any(Array) })
       );
     });
 
@@ -344,6 +364,7 @@ describe('GET /api/pages/[pageId]/export/xlsx', () => {
       vi.mocked(evaluateSheet).mockReturnValue({
         display: [['10', '20', '30']],
         errors: {},
+        byAddress: {},
       } as never);
 
       await GET(createRequest(), { params: mockParams });
@@ -351,7 +372,8 @@ describe('GET /api/pages/[pageId]/export/xlsx', () => {
       expect(generateExcel).toHaveBeenCalledWith(
         [['10', '20', '30']],
         'Test Sheet',
-        'Test Sheet'
+        'Test Sheet',
+        expect.objectContaining({ values: expect.any(Array) })
       );
     });
 
@@ -365,6 +387,7 @@ describe('GET /api/pages/[pageId]/export/xlsx', () => {
       vi.mocked(evaluateSheet).mockReturnValue({
         display: [],
         errors: {},
+        byAddress: {},
       } as never);
 
       const response = await GET(createRequest(), { params: mockParams });
@@ -373,7 +396,8 @@ describe('GET /api/pages/[pageId]/export/xlsx', () => {
       expect(generateExcel).toHaveBeenCalledWith(
         [],
         'Test Sheet',
-        'Test Sheet'
+        'Test Sheet',
+        expect.objectContaining({ values: [] })
       );
     });
 
@@ -385,6 +409,7 @@ describe('GET /api/pages/[pageId]/export/xlsx', () => {
       vi.mocked(evaluateSheet).mockReturnValue({
         display: largeDisplay,
         errors: {},
+        byAddress: {},
       } as never);
       vi.mocked(generateExcel).mockReturnValue(Buffer.alloc(100000) as never);
 

--- a/apps/web/src/app/api/pages/[pageId]/export/xlsx/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/export/xlsx/route.ts
@@ -7,7 +7,13 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalViewPage } from '@/lib/auth';
-import { parseSheetContent, sanitizeSheetData, evaluateSheet } from '@pagespace/lib/sheets/sheet';
+import {
+  parseSheetContent,
+  sanitizeSheetData,
+  evaluateSheet,
+  encodeCellAddress,
+  numberFormatToExcelCode,
+} from '@pagespace/lib/sheets/sheet';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 
@@ -60,8 +66,27 @@ export async function GET(req: Request, context: { params: Promise<{ pageId: str
       pageTitle: page.title,
     });
 
-    // Generate Excel from evaluated display values
-    const excelBuffer = generateExcel(evaluation.display, page.title, page.title);
+    // Generate Excel from the evaluated display values, plus the underlying
+    // values and number formats so the workbook holds real numbers rather than
+    // formatted text — otherwise nothing in the export sums or charts.
+    const excelBuffer = generateExcel(evaluation.display, page.title, page.title, {
+      values: evaluation.display.map((row, rowIndex) =>
+        row.map((_, columnIndex) => {
+          const cell = evaluation.byAddress[encodeCellAddress(rowIndex, columnIndex)];
+          return cell?.error ? cell.display : cell?.value;
+        })
+      ),
+      numberFormats: evaluation.display.map((row, rowIndex) =>
+        row.map((_, columnIndex) => {
+          const cell = evaluation.byAddress[encodeCellAddress(rowIndex, columnIndex)];
+          return numberFormatToExcelCode(cell?.format?.number);
+        })
+      ),
+      columnWidths: Array.from({ length: sheetData.columnCount }, (_, columnIndex) => {
+        const key = encodeCellAddress(0, columnIndex).replace(/\d+$/, '');
+        return sheetData.columnWidths?.[key];
+      }),
+    });
 
     // Create a sanitized filename
     const filename = sanitizeFilename(page.title) || 'sheet';

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -139,7 +139,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const socket = useSocket();
   const { user } = useAuth();
-  const isReadOnly = useSheetPermissions(page.id, user?.id);
+  const lacksEditPermission = useSheetPermissions(page.id, user?.id);
   const { tree } = usePageTree(page.driveId);
   const externalReferences = useMemo(() => collectExternalReferences(sheet), [sheet]);
   const flattenedPages = useMemo(() => (tree && tree.length > 0 ? flattenTree(tree) : []), [tree]);
@@ -159,6 +159,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
 
   const {
     documentState,
+    loadError,
     updateContent,
     updateContentFromServer,
     saveWithDebounce,
@@ -167,6 +168,17 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     resolveConflict,
     isResolvingConflict,
   } = useSheetPersistence({ pageId: page.id, socket, resetHistory });
+
+  // Editing is blocked either by permissions or by a load failure. When the
+  // stored content could not be parsed we must not let edits through: saving
+  // would overwrite content we were unable to read.
+  const isReadOnly = lacksEditPermission || loadError !== null;
+
+  // Two different reasons to refuse an edit deserve two different messages;
+  // blaming permissions for a load failure sends the user to the wrong place.
+  const readOnlyReason = loadError
+    ? 'This sheet could not be loaded, so editing is disabled'
+    : "You don't have permission to edit this sheet";
 
   // Pull-to-refresh handler
   const handleRefresh = useCallback(async () => {
@@ -265,7 +277,18 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
         const updated = updater(previous);
         const sanitized = sanitizeSheetData({ ...updated });
         if (shouldPersist) {
-          const serialized = serializeSheetContent(sanitized);
+          let serialized: string;
+          try {
+            serialized = serializeSheetContent(sanitized);
+          } catch (error) {
+            // `serializeSheetContent` refuses to emit content it cannot parse
+            // back. Uncaught here it would escape a React state update and
+            // blank the page; instead, reject the edit and keep the last good
+            // state, which is also what the user would want.
+            console.error('Failed to serialize sheet; edit not applied:', error);
+            toast.error('That change could not be saved and was undone.');
+            return previous;
+          }
           updateContent(serialized);
           saveWithDebounce(serialized);
         }
@@ -279,7 +302,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
   const startCellEdit = useCallback(
     (row: number, column: number, key?: string) => {
       if (isReadOnly) {
-        toast.error("You don't have permission to edit this sheet");
+        toast.error(readOnlyReason);
         return;
       }
 
@@ -361,7 +384,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
   const handleCommitFormula = useCallback(
     (value: string) => {
       if (isReadOnly) {
-        toast.error("You don't have permission to edit this sheet");
+        toast.error(readOnlyReason);
         return;
       }
       setFormulaValue(value);
@@ -372,7 +395,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
 
   const handleAddRow = useCallback(() => {
     if (isReadOnly) {
-      toast.error("You don't have permission to edit this sheet");
+      toast.error(readOnlyReason);
       return;
     }
     applySheetUpdate(addRow);
@@ -380,7 +403,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
 
   const handleAddColumn = useCallback(() => {
     if (isReadOnly) {
-      toast.error("You don't have permission to edit this sheet");
+      toast.error(readOnlyReason);
       return;
     }
     applySheetUpdate(addColumn);
@@ -416,8 +439,9 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
 
   const handleCellMouseDown = useCallback(
     (row: number, column: number, event: React.MouseEvent) => {
-      if (isReadOnly) return;
-
+      // Selection is not a mutation: a view-only user still needs to select a
+      // range to read it, copy it, and see the sum/average footer. Editing is
+      // gated at each write site instead.
       event.preventDefault();
       const cell = clampSelection({ row, column }, sheet);
 
@@ -444,7 +468,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
         gridRef.current?.focus({ preventScroll: true });
       });
     },
-    [sheet, editingCell, isReadOnly, closeContextMenu]
+    [sheet, editingCell, closeContextMenu]
   );
 
   const handleCellRightClick = useCallback(
@@ -690,7 +714,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
       // Handle Delete and Backspace as instant delete actions
       if (key === 'Delete' || key === 'Backspace') {
         if (isReadOnly) {
-          toast.error("You don't have permission to edit this sheet");
+          toast.error(readOnlyReason);
           return;
         }
 
@@ -842,7 +866,14 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
   }, [sheet.columnCount, sheet.rowCount, sheet]);
 
   // Global keyboard shortcuts (Ctrl/Cmd + S / Z / Y) — attached once, ref-driven.
-  useSheetKeyboardShortcuts({ onSave: forceSaveNow, onUndo: handleUndo, onRedo: handleRedo });
+  // Ctrl+S must not write when the document failed to load: there is nothing
+  // legitimate to save, and the write would only bump the revision.
+  const handleSaveShortcut = useCallback(() => {
+    if (isReadOnly) return;
+    forceSaveNow();
+  }, [isReadOnly, forceSaveNow]);
+
+  useSheetKeyboardShortcuts({ onSave: handleSaveShortcut, onUndo: handleUndo, onRedo: handleRedo });
 
   return (
     <div className="flex h-full flex-col">
@@ -852,6 +883,15 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
         isResolving={isResolvingConflict}
         previewMode="plain"
       />
+      {loadError && (
+        <div
+          role="alert"
+          className="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive"
+        >
+          This sheet could not be loaded, so editing is disabled to protect your data. Reload the
+          page to try again; if it keeps failing, the stored content needs repair.
+        </div>
+      )}
       <SheetFormulaBar
         isRange={selection.type === 'range'}
         selectionAddress={selectionAddress}

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -325,7 +325,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
       // Announce edit mode to screen readers
       announce(`Editing cell ${cellAddress}`);
     },
-    [sheet.cells, isReadOnly, announce]
+    [sheet.cells, isReadOnly, readOnlyReason, announce]
   );
 
   // Commit cell edit
@@ -390,7 +390,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
       setFormulaValue(value);
       applySheetUpdate((previous) => applyCellWrite(previous, currentAddress, value));
     },
-    [applySheetUpdate, currentAddress, isReadOnly]
+    [applySheetUpdate, currentAddress, isReadOnly, readOnlyReason]
   );
 
   const handleAddRow = useCallback(() => {
@@ -399,7 +399,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
       return;
     }
     applySheetUpdate(addRow);
-  }, [applySheetUpdate, isReadOnly]);
+  }, [applySheetUpdate, isReadOnly, readOnlyReason]);
 
   const handleAddColumn = useCallback(() => {
     if (isReadOnly) {
@@ -407,7 +407,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
       return;
     }
     applySheetUpdate(addColumn);
-  }, [applySheetUpdate, isReadOnly]);
+  }, [applySheetUpdate, isReadOnly, readOnlyReason]);
 
   // Undo handler
   const handleUndo = useCallback(() => {
@@ -749,7 +749,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
         cell: next
       });
     },
-    [isReadOnly, selection, sheet, editingCell, startCellEdit, handleCopy, applySheetUpdate, setFormulaValue, announce]
+    [isReadOnly, readOnlyReason, selection, sheet, editingCell, startCellEdit, handleCopy, applySheetUpdate, setFormulaValue, announce]
   );
 
   const handleFormulaKeyDown = useCallback(

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -271,31 +271,45 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     triggerPattern: sheetTriggerPattern,
   });
 
+  /**
+   * Serialize and hand off to the store, returning false if serialization
+   * refused.
+   *
+   * `serializeSheetContent` re-parses its own output and throws rather than
+   * emit something that would read back as an empty sheet. Every caller runs
+   * inside a React event or state update, where an uncaught throw escapes to
+   * the nearest error boundary and blanks the view — so the failure is turned
+   * into a declined change here instead.
+   */
+  const persistSheet = useCallback(
+    (sheet: SheetData): boolean => {
+      try {
+        const serialized = serializeSheetContent(sheet);
+        updateContent(serialized);
+        saveWithDebounce(serialized);
+        return true;
+      } catch (error) {
+        console.error('Failed to serialize sheet; change not applied:', error);
+        toast.error('That change could not be saved and was undone.');
+        return false;
+      }
+    },
+    [saveWithDebounce, updateContent]
+  );
+
   const applySheetUpdate = useCallback(
     (updater: (previous: SheetData) => SheetData, shouldPersist = true) => {
       setSheet((previous) => {
         const updated = updater(previous);
         const sanitized = sanitizeSheetData({ ...updated });
-        if (shouldPersist) {
-          let serialized: string;
-          try {
-            serialized = serializeSheetContent(sanitized);
-          } catch (error) {
-            // `serializeSheetContent` refuses to emit content it cannot parse
-            // back. Uncaught here it would escape a React state update and
-            // blank the page; instead, reject the edit and keep the last good
-            // state, which is also what the user would want.
-            console.error('Failed to serialize sheet; edit not applied:', error);
-            toast.error('That change could not be saved and was undone.');
-            return previous;
-          }
-          updateContent(serialized);
-          saveWithDebounce(serialized);
+        if (shouldPersist && !persistSheet(sanitized)) {
+          // Serialization refused; keep the last good state.
+          return previous;
         }
         return sanitized;
       });
     },
-    [saveWithDebounce, updateContent, setSheet]
+    [persistSheet, setSheet]
   );
 
   // Start editing a cell with optional initial key
@@ -414,28 +428,22 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     if (isReadOnly || !canUndo) return;
 
     const previousState = undo();
-    if (previousState) {
-      const serialized = serializeSheetContent(previousState);
-      updateContent(serialized);
-      saveWithDebounce(serialized);
+    if (previousState && persistSheet(previousState)) {
       toast.success('Undo', { duration: 1500 });
       announce('Undo performed');
     }
-  }, [isReadOnly, canUndo, undo, updateContent, saveWithDebounce, announce]);
+  }, [isReadOnly, canUndo, undo, persistSheet, announce]);
 
   // Redo handler
   const handleRedo = useCallback(() => {
     if (isReadOnly || !canRedo) return;
 
     const nextState = redo();
-    if (nextState) {
-      const serialized = serializeSheetContent(nextState);
-      updateContent(serialized);
-      saveWithDebounce(serialized);
+    if (nextState && persistSheet(nextState)) {
       toast.success('Redo', { duration: 1500 });
       announce('Redo performed');
     }
-  }, [isReadOnly, canRedo, redo, updateContent, saveWithDebounce, announce]);
+  }, [isReadOnly, canRedo, redo, persistSheet, announce]);
 
   const handleCellMouseDown = useCallback(
     (row: number, column: number, event: React.MouseEvent) => {

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
@@ -81,14 +81,19 @@ vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastError(...a)
 
 import SheetView from '../SheetView';
 
-const page = {
-  id: 'page-1',
-  title: 'Budget',
-  driveId: 'drive-1',
-  parentId: null,
-  type: 'SHEET',
-  content: '',
-} as never;
+type SheetViewProps = React.ComponentProps<typeof SheetView>;
+type TestPage = SheetViewProps['page'];
+
+/** A minimal TreePage; SheetView reads only these fields. */
+const makePage = (content: string): TestPage =>
+  ({
+    id: 'page-1',
+    title: 'Budget',
+    driveId: 'drive-1',
+    parentId: null,
+    type: 'SHEET',
+    content,
+  }) as unknown as TestPage;
 
 const contentWith = (cells: Record<string, string>) => {
   const sheet = createEmptySheet();
@@ -105,14 +110,14 @@ describe('SheetView', () => {
   });
 
   it('renders the grid without crashing', () => {
-    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+    render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
 
     expect(screen.getByRole('grid')).toBeTruthy();
     expect(screen.getByText('hello')).toBeTruthy();
   });
 
   it('shows no load-failure banner when the sheet reads fine', () => {
-    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+    render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
 
     expect(screen.queryByRole('alert')).toBeNull();
   });
@@ -122,7 +127,7 @@ describe('SheetView', () => {
     // straight over content we merely failed to parse.
     loadError.current = 'Key without value at row 3';
 
-    render(<SheetView page={{ ...page, content: 'broken' }} />);
+    render(<SheetView page={makePage('broken')} />);
 
     const alert = screen.getByRole('alert');
     expect(alert.textContent).toContain('could not be loaded');
@@ -134,7 +139,7 @@ describe('SheetView', () => {
     // did parse, and be able to select and copy it.
     loadError.current = 'unparseable';
 
-    render(<SheetView page={{ ...page, content: 'broken' }} />);
+    render(<SheetView page={makePage('broken')} />);
 
     expect(screen.getByRole('grid')).toBeTruthy();
   });
@@ -148,7 +153,7 @@ describe('SheetView', () => {
     // asserting only that cells exist passes even with selection blocked.
     lacksEditPermission.current = true;
 
-    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+    render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
 
     expect(cellAt('A1').getAttribute('aria-selected')).toBe('true');
 
@@ -161,7 +166,7 @@ describe('SheetView', () => {
   it('lets a view-only user drag out a range', () => {
     lacksEditPermission.current = true;
 
-    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+    render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
 
     fireEvent.mouseDown(cellAt('A1'));
     fireEvent.mouseEnter(cellAt('B2'));
@@ -176,7 +181,7 @@ describe('SheetView', () => {
   it('marks cells read-only for a view-only user', () => {
     lacksEditPermission.current = true;
 
-    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+    render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
 
     expect(screen.getAllByRole('gridcell')[0].getAttribute('aria-readonly')).toBe('true');
   });
@@ -188,7 +193,7 @@ describe('SheetView', () => {
     const content = serializeSheetContent(sheet);
     documentState.current = { content, isDirty: false };
 
-    render(<SheetView page={{ ...page, content }} />);
+    render(<SheetView page={makePage(content)} />);
 
     expect(screen.getByText('$1,234.50')).toBeTruthy();
   });

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
@@ -15,17 +15,26 @@ import { createEmptySheet, serializeSheetContent } from '@pagespace/lib/sheets/s
 const documentState: { current: { content: string; isDirty: boolean } | undefined } = {
   current: undefined,
 };
-const loadError: { current: string | null } = { current: null };
 const lacksEditPermission = { current: false };
 
-vi.mock('../hooks/useSheetPersistence', () => ({
-  useSheetPersistence: () => ({
-    documentState: documentState.current,
-    loadError: loadError.current,
+/**
+ * `useSheetPersistence` runs for real; only its boundary to the store and the
+ * network is mocked. That is deliberate — SheetView's read-only gating is
+ * driven by the `loadError` that hook derives, so stubbing the hook would test
+ * the stub. This way an unparseable document really does flow through
+ * `parseSheetContentSafe` into the banner and the gating.
+ */
+vi.mock('@/hooks/useDocument', () => ({
+  useDocument: () => ({
+    document: documentState.current ? { ...documentState.current } : undefined,
+    isLoading: false,
+    isSaving: false,
+    initializeAndActivate: vi.fn(),
     updateContent: vi.fn(),
     updateContentFromServer: vi.fn(),
     saveWithDebounce: vi.fn(),
-    forceSaveNow: vi.fn(),
+    forceSave: vi.fn().mockResolvedValue(undefined),
+    clearDocument: vi.fn(),
     conflict: null,
     resolveConflict: vi.fn(),
     isResolvingConflict: false,
@@ -95,6 +104,9 @@ const makePage = (content: string): TestPage =>
     content,
   }) as unknown as TestPage;
 
+/** Carries the SheetDoc magic but a malformed body, so parsing genuinely fails. */
+const UNPARSEABLE = '#%PAGESPACE_SHEETDOC v1\nthis is [not toml';
+
 const contentWith = (cells: Record<string, string>) => {
   const sheet = createEmptySheet();
   Object.assign(sheet.cells, cells);
@@ -103,7 +115,6 @@ const contentWith = (cells: Record<string, string>) => {
 
 describe('SheetView', () => {
   beforeEach(() => {
-    loadError.current = null;
     lacksEditPermission.current = false;
     documentState.current = { content: contentWith({ A1: 'hello' }), isDirty: false };
     toastError.mockClear();
@@ -124,10 +135,11 @@ describe('SheetView', () => {
 
   it('surfaces a banner when the stored content could not be read', () => {
     // The alternative is handing the editor an empty sheet, which autosaves
-    // straight over content we merely failed to parse.
-    loadError.current = 'Key without value at row 3';
+    // straight over content we merely failed to parse. The failure is derived
+    // from real content through the real hook, not injected.
+    documentState.current = { content: UNPARSEABLE, isDirty: false };
 
-    render(<SheetView page={makePage('broken')} />);
+    render(<SheetView page={makePage(UNPARSEABLE)} />);
 
     const alert = screen.getByRole('alert');
     expect(alert.textContent).toContain('could not be loaded');
@@ -137,9 +149,9 @@ describe('SheetView', () => {
   it('still renders the grid while the load error is showing', () => {
     // The banner must not replace the view — a user should still see whatever
     // did parse, and be able to select and copy it.
-    loadError.current = 'unparseable';
+    documentState.current = { content: UNPARSEABLE, isDirty: false };
 
-    render(<SheetView page={makePage('broken')} />);
+    render(<SheetView page={makePage(UNPARSEABLE)} />);
 
     expect(screen.getByRole('grid')).toBeTruthy();
   });

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
@@ -3,6 +3,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { createEmptySheet, serializeSheetContent } from '@pagespace/lib/sheets/sheet';
 
+// `serializeSheetContent` refuses to emit content it cannot parse back, so it
+// can throw on an edit. Spying lets a test force that without a contrived
+// document.
+vi.mock('@pagespace/lib/sheets/sheet', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/sheets/sheet')>();
+  return { ...actual, serializeSheetContent: vi.fn(actual.serializeSheetContent) };
+});
+
 /**
  * Render coverage for SheetView.
  *
@@ -116,6 +124,9 @@ const contentWith = (cells: Record<string, string>) => {
 describe('SheetView', () => {
   beforeEach(() => {
     lacksEditPermission.current = false;
+    // A primed `mockImplementationOnce` that never fires would leak into the
+    // next test's setup, so clear any leftover between tests.
+    vi.mocked(serializeSheetContent).mockClear();
     documentState.current = { content: contentWith({ A1: 'hello' }), isDirty: false };
     toastError.mockClear();
   });
@@ -196,6 +207,28 @@ describe('SheetView', () => {
     render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
 
     expect(screen.getAllByRole('gridcell')[0].getAttribute('aria-readonly')).toBe('true');
+  });
+
+  it('survives a serialization failure instead of blanking the page', () => {
+    // The throw happens inside a React state updater. Uncaught, it escapes to
+    // the nearest error boundary and takes the whole view with it. "+ Row" is
+    // the shortest path that definitely reaches the persist helper.
+    render(<SheetView page={makePage(contentWith({ A1: 'hello' }))} />);
+
+    vi.mocked(serializeSheetContent).mockImplementationOnce(() => {
+      throw new Error('Refusing to emit a SheetDoc that cannot be parsed back');
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add row' })[0]);
+
+    // The toast is the load-bearing assertion: it only appears if the throw
+    // was caught. `fireEvent` does not rethrow, so asserting "did not throw"
+    // passes with or without the guard.
+    expect(toastError).toHaveBeenCalledWith('That change could not be saved and was undone.');
+
+    // And the view survived, still showing the last good value.
+    expect(screen.getByRole('grid')).toBeTruthy();
+    expect(screen.getByText('hello')).toBeTruthy();
   });
 
   it('renders a formatted value the way the engine computed it', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/SheetView.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createEmptySheet, serializeSheetContent } from '@pagespace/lib/sheets/sheet';
+
+/**
+ * Render coverage for SheetView.
+ *
+ * Everything else under `sheet/` is a pure helper or a hook, so until this file
+ * existed the component itself had never been mounted in a test — including the
+ * read-only gating, the load-failure banner, and the guard that stops a
+ * serialization error escaping a React state update.
+ */
+
+const documentState: { current: { content: string; isDirty: boolean } | undefined } = {
+  current: undefined,
+};
+const loadError: { current: string | null } = { current: null };
+const lacksEditPermission = { current: false };
+
+vi.mock('../hooks/useSheetPersistence', () => ({
+  useSheetPersistence: () => ({
+    documentState: documentState.current,
+    loadError: loadError.current,
+    updateContent: vi.fn(),
+    updateContentFromServer: vi.fn(),
+    saveWithDebounce: vi.fn(),
+    forceSaveNow: vi.fn(),
+    conflict: null,
+    resolveConflict: vi.fn(),
+    isResolvingConflict: false,
+  }),
+}));
+
+vi.mock('../hooks/useSheetPermissions', () => ({
+  useSheetPermissions: () => lacksEditPermission.current,
+}));
+
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => null }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }));
+vi.mock('@/hooks/usePageTree', () => ({ usePageTree: () => ({ tree: [] }) }));
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/stores/useEditingSession', () => ({ useEditingSession: vi.fn() }));
+
+// Mirrors the real hook's surface; SheetView reads `query` and `actions`.
+vi.mock('@/hooks/useSuggestion', () => ({
+  useSuggestion: () => ({
+    handleValueChange: vi.fn(),
+    handleKeyDown: vi.fn(),
+    isOpen: false,
+    position: null,
+    items: [],
+    selectedIndex: 0,
+    loading: false,
+    error: null,
+    query: '',
+    actions: { selectSuggestion: vi.fn(), close: vi.fn() },
+  }),
+}));
+
+vi.mock('@/components/providers/SuggestionProvider', () => ({
+  SuggestionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSuggestionContext: () => ({ isOpen: false, position: null, items: [] }),
+}));
+
+vi.mock(
+  '@/components/layout/middle-content/page-views/document/DocumentConflictGate',
+  () => ({ default: () => null })
+);
+
+vi.mock('@/components/ui/pull-to-refresh', () => ({
+  PullToRefresh: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/custom-scroll-area', () => ({
+  CustomScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastError(...a) } }));
+
+import SheetView from '../SheetView';
+
+const page = {
+  id: 'page-1',
+  title: 'Budget',
+  driveId: 'drive-1',
+  parentId: null,
+  type: 'SHEET',
+  content: '',
+} as never;
+
+const contentWith = (cells: Record<string, string>) => {
+  const sheet = createEmptySheet();
+  Object.assign(sheet.cells, cells);
+  return serializeSheetContent(sheet);
+};
+
+describe('SheetView', () => {
+  beforeEach(() => {
+    loadError.current = null;
+    lacksEditPermission.current = false;
+    documentState.current = { content: contentWith({ A1: 'hello' }), isDirty: false };
+    toastError.mockClear();
+  });
+
+  it('renders the grid without crashing', () => {
+    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+
+    expect(screen.getByRole('grid')).toBeTruthy();
+    expect(screen.getByText('hello')).toBeTruthy();
+  });
+
+  it('shows no load-failure banner when the sheet reads fine', () => {
+    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('surfaces a banner when the stored content could not be read', () => {
+    // The alternative is handing the editor an empty sheet, which autosaves
+    // straight over content we merely failed to parse.
+    loadError.current = 'Key without value at row 3';
+
+    render(<SheetView page={{ ...page, content: 'broken' }} />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('could not be loaded');
+    expect(alert.textContent).toContain('editing is disabled');
+  });
+
+  it('still renders the grid while the load error is showing', () => {
+    // The banner must not replace the view — a user should still see whatever
+    // did parse, and be able to select and copy it.
+    loadError.current = 'unparseable';
+
+    render(<SheetView page={{ ...page, content: 'broken' }} />);
+
+    expect(screen.getByRole('grid')).toBeTruthy();
+  });
+
+  const cellAt = (address: string) =>
+    screen.getByRole('grid').querySelector(`[data-cell="${address}"]`) as HTMLElement;
+
+  it('lets a view-only user select a cell', () => {
+    // Selection is not a mutation: a viewer needs it to read a range, copy it,
+    // and see the sum/average footer. This is the behaviour, not the render —
+    // asserting only that cells exist passes even with selection blocked.
+    lacksEditPermission.current = true;
+
+    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+
+    expect(cellAt('A1').getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.mouseDown(cellAt('B2'));
+
+    expect(cellAt('B2').getAttribute('aria-selected')).toBe('true');
+    expect(cellAt('A1').getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('lets a view-only user drag out a range', () => {
+    lacksEditPermission.current = true;
+
+    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+
+    fireEvent.mouseDown(cellAt('A1'));
+    fireEvent.mouseEnter(cellAt('B2'));
+
+    // The whole rectangle is selected, which is what makes the footer stats
+    // and a range copy work for someone who cannot edit.
+    for (const address of ['A1', 'A2', 'B1', 'B2']) {
+      expect(cellAt(address).getAttribute('aria-selected'), address).toBe('true');
+    }
+  });
+
+  it('marks cells read-only for a view-only user', () => {
+    lacksEditPermission.current = true;
+
+    render(<SheetView page={{ ...page, content: contentWith({ A1: 'hello' }) }} />);
+
+    expect(screen.getAllByRole('gridcell')[0].getAttribute('aria-readonly')).toBe('true');
+  });
+
+  it('renders a formatted value the way the engine computed it', () => {
+    const sheet = createEmptySheet();
+    sheet.cells.B1 = '1234.5';
+    sheet.formats = { B1: { number: { kind: 'currency', currency: 'USD' } } };
+    const content = serializeSheetContent(sheet);
+    documentState.current = { content, isDirty: false };
+
+    render(<SheetView page={{ ...page, content }} />);
+
+    expect(screen.getByText('$1,234.50')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/useSheetHistory.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/__tests__/useSheetHistory.test.ts
@@ -223,3 +223,84 @@ describe('useSheetHistory', () => {
     expect(result.current.sheet).toEqual(initialSheet);
   });
 });
+
+describe('useSheetHistory presentation changes', () => {
+  /**
+   * The change-detection compared only cells/rowCount/columnCount, so a
+   * formatting-only edit counted as a no-op: it was sent to the server but
+   * dropped from state, and the next edit serialized the stale state and
+   * deleted the formatting again. Every persisted field must be compared.
+   */
+  const change = (
+    label: string,
+    mutate: (previous: SheetData) => SheetData,
+    initial: SheetData = createTestSheet({ A1: '10' })
+  ) => {
+    it(`records a change to ${label}`, () => {
+      const { result } = renderHook(() => useSheetHistory(initial));
+
+      act(() => {
+        result.current.setSheet(mutate);
+      });
+
+      expect(result.current.canUndo, label).toBe(true);
+    });
+  };
+
+  change('a cell format', (prev) => ({ ...prev, formats: { A1: { bold: true } } }));
+  change('a column format', (prev) => ({ ...prev, columnFormats: { A: { align: 'right' } } }));
+  change('a column width', (prev) => ({ ...prev, columnWidths: { A: 180 } }));
+  change('a row height', (prev) => ({ ...prev, rowHeights: { '1': 32 } }));
+  change('frozen rows', (prev) => ({ ...prev, frozenRows: 1 }));
+  change('frozen columns', (prev) => ({ ...prev, frozenColumns: 2 }));
+  change('the sheet name', (prev) => ({ ...prev, sheetName: 'Renamed' }));
+  change(
+    'a carried-through tab',
+    (prev) => ({
+      ...prev,
+      extraSheets: [
+        {
+          name: 'Second',
+          order: 1,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: {},
+          cells: {},
+          ranges: {},
+          dependencies: {},
+        },
+      ],
+    })
+  );
+  change('a named range', (prev) => ({ ...prev, ranges: { myRange: { ref: 'A1:B2' } } }));
+
+  it('undoes a formatting-only edit back to unformatted', () => {
+    const initial = createTestSheet({ A1: '10' });
+    const { result } = renderHook(() => useSheetHistory(initial));
+
+    act(() => {
+      result.current.setSheet((prev) => ({ ...prev, formats: { A1: { bold: true } } }));
+    });
+    expect(result.current.sheet.formats).toEqual({ A1: { bold: true } });
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.sheet.formats).toBeUndefined();
+  });
+
+  it('still treats an identical sheet as no change', () => {
+    const initial: SheetData = {
+      ...createTestSheet({ A1: '10' }),
+      formats: { A1: { bold: true } },
+      columnWidths: { A: 180 },
+    };
+    const { result } = renderHook(() => useSheetHistory(initial));
+
+    act(() => {
+      // A new object with the same content — e.g. a re-serialize round trip.
+      result.current.setSheet((prev) => ({ ...prev, formats: { ...prev.formats } }));
+    });
+
+    expect(result.current.canUndo).toBe(false);
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/__tests__/useSheetPersistence.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/__tests__/useSheetPersistence.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { createEmptySheet, serializeSheetContent } from '@pagespace/lib/sheets/sheet';
+
+/**
+ * Regression tests for the sheet's history-reset and load-failure handling.
+ *
+ * The bug these guard: the reset effect depended on the whole `documentState`
+ * object, which the store recreates on every write. Every local keystroke
+ * therefore looked like a fresh server load and cleared the undo stack, so
+ * Ctrl+Z did nothing in practice.
+ */
+
+type DocumentState = { content: string; isDirty: boolean };
+
+const documentRef: { current: DocumentState | undefined } = { current: undefined };
+const updateContentSpy = vi.fn();
+
+vi.mock('@/hooks/useDocument', () => ({
+  useDocument: () => ({
+    // A NEW object each render, exactly like the real store.
+    document: documentRef.current ? { ...documentRef.current } : undefined,
+    isLoading: false,
+    isSaving: false,
+    initializeAndActivate: vi.fn(),
+    updateContent: updateContentSpy,
+    updateContentFromServer: vi.fn(),
+    saveWithDebounce: vi.fn(),
+    forceSave: vi.fn().mockResolvedValue(undefined),
+    clearDocument: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn() }));
+
+import { useSheetPersistence } from '../useSheetPersistence';
+
+const sheetContent = (cells: Record<string, string>) => {
+  const sheet = createEmptySheet();
+  Object.assign(sheet.cells, cells);
+  return serializeSheetContent(sheet);
+};
+
+describe('useSheetPersistence', () => {
+  beforeEach(() => {
+    documentRef.current = undefined;
+    updateContentSpy.mockClear();
+  });
+
+  const renderPersistence = (resetHistory: (sheet: unknown) => void) =>
+    renderHook(() =>
+      useSheetPersistence({
+        pageId: 'page-1',
+        socket: null,
+        resetHistory: resetHistory as never,
+      })
+    );
+
+  it('resets history once when content first loads', () => {
+    const resetHistory = vi.fn();
+    documentRef.current = { content: sheetContent({ A1: '1' }), isDirty: false };
+
+    renderPersistence(resetHistory);
+
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT reset history when a local edit echoes back through the store', () => {
+    const resetHistory = vi.fn();
+    documentRef.current = { content: sheetContent({ A1: '1' }), isDirty: false };
+
+    const { result, rerender } = renderPersistence(resetHistory);
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+    resetHistory.mockClear();
+
+    // A local edit: the view calls updateContent, then the store re-renders us
+    // with a brand-new documentState object carrying that same content.
+    const edited = sheetContent({ A1: '1', B1: '2' });
+    act(() => {
+      result.current.updateContent(edited);
+    });
+    documentRef.current = { content: edited, isDirty: true };
+    rerender();
+
+    // If this fires, the undo stack has just been wiped mid-edit.
+    expect(resetHistory).not.toHaveBeenCalled();
+  });
+
+  it('still resets history when genuinely new server content arrives', () => {
+    const resetHistory = vi.fn();
+    documentRef.current = { content: sheetContent({ A1: '1' }), isDirty: false };
+
+    const { rerender } = renderPersistence(resetHistory);
+    resetHistory.mockClear();
+
+    documentRef.current = { content: sheetContent({ A1: '999' }), isDirty: false };
+    rerender();
+
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-reset when the store re-renders with identical content', () => {
+    const resetHistory = vi.fn();
+    documentRef.current = { content: sheetContent({ A1: '1' }), isDirty: false };
+
+    const { rerender } = renderPersistence(resetHistory);
+    resetHistory.mockClear();
+
+    // Same content, new object identity — e.g. an isDirty/lastSaved toggle.
+    documentRef.current = { content: documentRef.current.content, isDirty: true };
+    rerender();
+
+    expect(resetHistory).not.toHaveBeenCalled();
+  });
+
+  it('reports a load error and does not hand an empty sheet to the editor', () => {
+    const resetHistory = vi.fn();
+    documentRef.current = {
+      content: '#%PAGESPACE_SHEETDOC v1\nthis is [not toml',
+      isDirty: false,
+    };
+
+    const { result } = renderPersistence(resetHistory);
+
+    expect(result.current.loadError).toBeTruthy();
+    // Critically: no reset with an empty sheet, which would autosave over the
+    // content we failed to read.
+    expect(resetHistory).not.toHaveBeenCalled();
+  });
+
+  it('clears the load error once parseable content arrives', () => {
+    const resetHistory = vi.fn();
+    documentRef.current = {
+      content: '#%PAGESPACE_SHEETDOC v1\nthis is [not toml',
+      isDirty: false,
+    };
+
+    const { result, rerender } = renderPersistence(resetHistory);
+    expect(result.current.loadError).toBeTruthy();
+
+    documentRef.current = { content: sheetContent({ A1: '5' }), isDirty: false };
+    rerender();
+
+    expect(result.current.loadError).toBeNull();
+    expect(resetHistory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/__tests__/useSheetPersistence.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/__tests__/useSheetPersistence.test.ts
@@ -28,6 +28,11 @@ vi.mock('@/hooks/useDocument', () => ({
     saveWithDebounce: vi.fn(),
     forceSave: vi.fn().mockResolvedValue(undefined),
     clearDocument: vi.fn(),
+    // Threaded through to the view's conflict gate; mirrored here so the mock
+    // keeps matching the real hook's surface.
+    conflict: null,
+    resolveConflict: vi.fn(),
+    isResolvingConflict: false,
   }),
 }));
 
@@ -47,13 +52,17 @@ describe('useSheetPersistence', () => {
     updateContentSpy.mockClear();
   });
 
-  const renderPersistence = (resetHistory: (sheet: unknown) => void) =>
-    renderHook(() =>
-      useSheetPersistence({
-        pageId: 'page-1',
-        socket: null,
-        resetHistory: resetHistory as never,
-      })
+  // `rerender()` is called with no props by most tests, so the page id falls
+  // back to the initial one unless a test is deliberately navigating.
+  const renderPersistence = (resetHistory: (sheet: unknown) => void, pageId = 'page-1') =>
+    renderHook(
+      (props: { id: string } | undefined) =>
+        useSheetPersistence({
+          pageId: props?.id ?? pageId,
+          socket: null,
+          resetHistory: resetHistory as never,
+        }),
+      { initialProps: { id: pageId } as { id: string } | undefined }
     );
 
   it('resets history once when content first loads', () => {
@@ -111,6 +120,29 @@ describe('useSheetPersistence', () => {
     rerender();
 
     expect(resetHistory).not.toHaveBeenCalled();
+  });
+
+  it('resets history when navigating to a different page with identical content', () => {
+    // Two fresh sheets serialize identically. Matching on content alone would
+    // read the new page's first load as this page's local echo, leaving the
+    // previous page's undo stack in place — an undo could then write the
+    // previous page's state into this one.
+    const resetHistory = vi.fn();
+    const shared = sheetContent({ A1: 'same' });
+    documentRef.current = { content: shared, isDirty: false };
+
+    const { result, rerender } = renderPersistence(resetHistory, 'page-1');
+    resetHistory.mockClear();
+
+    // An edit on page-1 records the echo for page-1.
+    act(() => {
+      result.current.updateContent(shared);
+    });
+
+    // Navigate to page-2, whose stored content happens to be byte-identical.
+    rerender({ id: 'page-2' });
+
+    expect(resetHistory).toHaveBeenCalledTimes(1);
   });
 
   it('reports a load error and does not hand an empty sheet to the editor', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/useSheetPersistence.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/useSheetPersistence.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Socket } from 'socket.io-client';
-import { parseSheetContent, sanitizeSheetData, type SheetData } from '@pagespace/lib/sheets/sheet';
+import { parseSheetContentSafe, sanitizeSheetData, type SheetData } from '@pagespace/lib/sheets/sheet';
 import { useDocument } from '@/hooks/useDocument';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import type { PageEventPayload } from '@/lib/websocket';
@@ -25,7 +25,7 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
   const {
     document: documentState,
     initializeAndActivate,
-    updateContent,
+    updateContent: baseUpdateContent,
     updateContentFromServer,
     saveWithDebounce,
     forceSave,
@@ -33,6 +33,10 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
     resolveConflict,
     isResolvingConflict,
   } = useDocument(pageId);
+
+  // Non-null when the stored content could not be parsed; the view uses this to
+  // disable editing rather than overwrite content it failed to read.
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Keep forceSave/isDirty/content in refs so the empty-dep listeners below never
   // re-subscribe and always see the latest values.
@@ -53,13 +57,48 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
     initializeAndActivate();
   }, [initializeAndActivate, pageId]);
 
-  // Reset history whenever content is (re)loaded from the server so undo cannot
+  // Content this hook has already reconciled — either loaded from the server or
+  // echoed back from a local edit. Used to tell those two apart below.
+  const knownContentRef = useRef<string | null>(null);
+
+  // Record locally-originated content before it round-trips through the store,
+  // so the reset effect can recognise the echo and leave history alone.
+  const updateContent = useCallback(
+    (content: string) => {
+      knownContentRef.current = content;
+      baseUpdateContent(content);
+    },
+    [baseUpdateContent]
+  );
+
+  // Reset history when content is (re)loaded from the server, so undo cannot
   // walk back into stale state.
+  //
+  // This deliberately keys on the content string rather than on `documentState`.
+  // `documentState` is a fresh object on every store write, so depending on it
+  // fired this effect after every local keystroke and cleared the undo stack —
+  // undo was dead in practice. Comparing content means only genuinely new,
+  // server-originated content resets history.
   useEffect(() => {
-    if (documentState) {
-      resetHistory(sanitizeSheetData(parseSheetContent(documentState.content)));
+    const content = documentState?.content;
+    if (content === undefined || content === knownContentRef.current) {
+      return;
     }
-  }, [documentState, resetHistory]);
+
+    knownContentRef.current = content;
+
+    const parsed = parseSheetContentSafe(content);
+    if (!parsed.ok) {
+      // The content exists but cannot be read. Do NOT hand an empty sheet to
+      // the editor: it would autosave that empty sheet straight over the user's
+      // data. Surface the failure and let the view disable editing.
+      setLoadError(parsed.message);
+      return;
+    }
+
+    setLoadError(null);
+    resetHistory(sanitizeSheetData(parsed.sheet));
+  }, [documentState?.content, resetHistory]);
 
   // Socket updates — uses refs to avoid re-subscribing on every content change.
   useEffect(() => {
@@ -120,6 +159,7 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
 
   return {
     documentState,
+    loadError,
     updateContent,
     updateContentFromServer,
     saveWithDebounce,

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/useSheetPersistence.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/hooks/useSheetPersistence.ts
@@ -59,16 +59,22 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
 
   // Content this hook has already reconciled — either loaded from the server or
   // echoed back from a local edit. Used to tell those two apart below.
-  const knownContentRef = useRef<string | null>(null);
+  //
+  // Scoped to the page: two different pages can hold byte-identical content
+  // (two fresh empty sheets serialize the same), and a bare content match
+  // would then treat the new page's first load as this page's echo, leaving
+  // the previous page's undo stack in place. An undo could then write the
+  // previous page's state into this one.
+  const knownContentRef = useRef<{ pageId: string; content: string } | null>(null);
 
   // Record locally-originated content before it round-trips through the store,
   // so the reset effect can recognise the echo and leave history alone.
   const updateContent = useCallback(
     (content: string) => {
-      knownContentRef.current = content;
+      knownContentRef.current = { pageId, content };
       baseUpdateContent(content);
     },
-    [baseUpdateContent]
+    [baseUpdateContent, pageId]
   );
 
   // Reset history when content is (re)loaded from the server, so undo cannot
@@ -81,11 +87,15 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
   // server-originated content resets history.
   useEffect(() => {
     const content = documentState?.content;
-    if (content === undefined || content === knownContentRef.current) {
+    const known = knownContentRef.current;
+    if (
+      content === undefined ||
+      (known !== null && known.pageId === pageId && known.content === content)
+    ) {
       return;
     }
 
-    knownContentRef.current = content;
+    knownContentRef.current = { pageId, content };
 
     const parsed = parseSheetContentSafe(content);
     if (!parsed.ok) {
@@ -98,7 +108,7 @@ export const useSheetPersistence = ({ pageId, socket, resetHistory }: UseSheetPe
 
     setLoadError(null);
     resetHistory(sanitizeSheetData(parsed.sheet));
-  }, [documentState?.content, resetHistory]);
+  }, [pageId, documentState?.content, resetHistory]);
 
   // Socket updates — uses refs to avoid re-subscribing on every content change.
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/useSheetHistory.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/useSheetHistory.ts
@@ -3,6 +3,28 @@ import type { SheetData } from '@pagespace/lib/sheets/sheet';
 
 const MAX_HISTORY_SIZE = 50;
 
+/**
+ * Whether two sheet states are equivalent for undo purposes.
+ *
+ * Every field that is persisted must be compared here. Anything omitted
+ * becomes a change the editor silently drops from memory while still saving it
+ * — the worst of both worlds, because the next edit then writes the stale
+ * state back over it.
+ */
+const isSameSheetState = (a: SheetData, b: SheetData): boolean =>
+  a.rowCount === b.rowCount &&
+  a.columnCount === b.columnCount &&
+  a.frozenRows === b.frozenRows &&
+  a.frozenColumns === b.frozenColumns &&
+  a.sheetName === b.sheetName &&
+  JSON.stringify(a.cells) === JSON.stringify(b.cells) &&
+  JSON.stringify(a.formats) === JSON.stringify(b.formats) &&
+  JSON.stringify(a.columnFormats) === JSON.stringify(b.columnFormats) &&
+  JSON.stringify(a.columnWidths) === JSON.stringify(b.columnWidths) &&
+  JSON.stringify(a.rowHeights) === JSON.stringify(b.rowHeights) &&
+  JSON.stringify(a.ranges) === JSON.stringify(b.ranges) &&
+  JSON.stringify(a.extraSheets) === JSON.stringify(b.extraSheets);
+
 interface HistoryState {
   past: SheetData[];
   present: SheetData;
@@ -51,12 +73,15 @@ export function useSheetHistory(initialSheet: SheetData): UseSheetHistoryReturn 
       setHistory((prev) => {
         const newPresent = typeof updater === 'function' ? updater(prev.present) : updater;
 
-        // If the sheet hasn't actually changed, don't add to history
-        if (
-          JSON.stringify(newPresent.cells) === JSON.stringify(prev.present.cells) &&
-          newPresent.rowCount === prev.present.rowCount &&
-          newPresent.columnCount === prev.present.columnCount
-        ) {
+        // If the sheet hasn't actually changed, don't add to history.
+        //
+        // This must consider presentation as well as values: a sheet carries
+        // formats, column widths, row heights and frozen panes beside its
+        // cells, and comparing only `cells` would treat "make A1 bold" as a
+        // no-op — discarding it from state while it had already been sent to
+        // the server, so the next edit would serialize the stale state and
+        // delete the formatting again.
+        if (isSameSheetState(newPresent, prev.present)) {
           return prev;
         }
 

--- a/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
+++ b/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
@@ -190,7 +190,7 @@ How to read it:
 
 1. **Guessing Excel functions.** VLOOKUP, XLOOKUP, INDEX, MATCH, SUMIF, SUMIFS, COUNTIF, AVERAGEIF, TEXT, DATE, DATEDIF, EOMONTH, TEXTJOIN, SPLIT, PROPER, MEDIAN, STDEV, PRODUCT, ROUNDUP, ROUNDDOWN, TRUNC, EXP, LN, LOG, ARRAYFORMULA — none exist. Only the table above is real. For conditional aggregation, add a helper column of \`IF(...)\` values and SUM it.
 2. **Unbounded ranges.** \`=SUM(A:A)\` is a parse error. Always use bounded ranges like \`A2:A50\`.
-3. **Newlines in cell values.** Never put a line break inside a cell value — the stored TOML cannot represent it, and a sheet whose serialization fails to parse comes back **empty** (silent data loss). Keep every cell single-line.
+3. **Newlines in cell values.** A line break inside a cell value is stored correctly and survives a round trip. The grid renders it on one line unless the cell is set to wrap, so prefer single-line values for readability — but a multi-line value is safe, not destructive.
 4. **Leading \`=\` on literal text.** Any value starting with \`=\` becomes a formula; there is no apostrophe-escape. Don't start plain-text values with \`=\`.
 5. **Text in numeric ranges.** One non-numeric string inside \`SUM\`'s range errors the whole formula (AVERAGE skips it instead). Keep data columns clean; don't mix "N/A" into number columns — leave the cell empty.
 6. **FIND/SEARCH on a miss is an error**, not -1 or blank. Wrap in \`IFERROR\` if absence is expected.

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -59,8 +59,15 @@ vi.mock('@pagespace/lib/content/page-types.config', () => ({
     isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
     isCodePage: vi.fn((type) => type === 'CODE'),
 }));
+// `edit_sheet_cells` parses through the ok/failure API so it can refuse to
+// write over content it could not read; the mock has to expose that, or the
+// tool throws before it reaches the branch under test.
+const mockParseSheetContentSafe = vi.fn(() => ({
+  ok: true as const,
+  sheet: { rowCount: 10, columnCount: 5 },
+}));
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
-    parseSheetContent: vi.fn(() => ({ rowCount: 10, columnCount: 5 })),
+    parseSheetContentSafe: (...args: unknown[]) => mockParseSheetContentSafe(...args as []),
     serializeSheetContent: vi.fn(() => ''),
     updateSheetCells: vi.fn((data) => data),
     isValidCellAddress: vi.fn((addr) => /^[A-Z]+\d+$/.test(addr.toUpperCase())),
@@ -2080,6 +2087,42 @@ describe('page-write-tools', () => {
           context
         )
       ).rejects.toThrow('User authentication required');
+    });
+
+    it('refuses to edit a sheet whose stored content could not be read', async () => {
+      // Writing here would replace the whole spreadsheet with just these cells.
+      mockParseSheetContentSafe.mockReturnValueOnce({
+        ok: false as never,
+        reason: 'toml',
+        message: 'Key without value at row 3',
+      } as never);
+
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1',
+        title: 'Budget',
+        type: 'SHEET',
+        content: '#%PAGESPACE_SHEETDOC v1\nthis is [not toml',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.edit_sheet_cells.execute!(
+          { pageId: 'page-1', cells: [{ address: 'A1', value: 'test' }] },
+          context
+        )
+      ).rejects.toThrow(/could not be read/);
     });
 
     it('returns error for non-sheet pages', async () => {

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -13,7 +13,7 @@ import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 import { isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes, getPageTypeConfig } from '@pagespace/lib/content/page-types.config';
-import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets/sheet';
+import { parseSheetContentSafe, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets/sheet';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation } from '@pagespace/lib/monitoring/activity-logger';
 import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format';
@@ -1515,11 +1515,18 @@ export const pageWriteTools = {
           throw new Error(`Invalid cell addresses: ${examples}. Use A1-style format (e.g., A1, B2, AA100).`);
         }
 
-        // Parse the existing sheet content
-        const sheetData = parseSheetContent(page.content);
+        // Parse the existing sheet content. A parse failure must abort: writing
+        // the empty sheet the unsafe parse returns would replace the whole
+        // spreadsheet with just the cells in this call.
+        const parsedSheet = parseSheetContentSafe(page.content);
+        if (!parsedSheet.ok) {
+          throw new Error(
+            `This sheet's stored content could not be read (${parsedSheet.reason}), so it cannot be edited without losing data. It needs repair first.`
+          );
+        }
 
         // Apply the cell updates
-        const updatedSheet = updateSheetCells(sheetData, cells);
+        const updatedSheet = updateSheetCells(parsedSheet.sheet, cells);
 
         // Serialize back to TOML format
         const newContent = serializeSheetContent(updatedSheet, { pageId: page.id });

--- a/apps/web/src/services/api/__tests__/form-target-service.test.ts
+++ b/apps/web/src/services/api/__tests__/form-target-service.test.ts
@@ -100,6 +100,13 @@ const sheetPage = {
   revision: 1,
 };
 
+/**
+ * Carries the SheetDoc magic but a malformed body. The lossy parse turns this
+ * into an EMPTY sheet, so appending to it would store a document containing
+ * only the appended cells — replacing the user's entire spreadsheet.
+ */
+const UNREADABLE_SHEET = '#%PAGESPACE_SHEETDOC v1\nthis is [not toml';
+
 describe('createFormTarget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -122,6 +129,21 @@ describe('createFormTarget', () => {
         notificationEmail: null,
       },
     ]);
+  });
+
+  it('refuses to write headers when the sheet could not be read', async () => {
+    mockFindById.mockResolvedValue({ ...sheetPage, content: UNREADABLE_SHEET });
+
+    await expect(
+      createFormTarget({
+        sheetPageId: 'sheet-1',
+        fields,
+        createdBy: 'user-1',
+        mutationContext: { userId: 'user-1' },
+      })
+    ).rejects.toThrow(/could not be read/);
+
+    expect(mockApplyPageMutation).not.toHaveBeenCalled();
   });
 
   it('writes the header row and creates the grant in the same transaction (atomic)', async () => {
@@ -386,6 +408,36 @@ describe('appendFormSubmission', () => {
     mockTxSelectLimit.mockResolvedValue([{ ...sheetPage, revision: 5 }]);
     mockTxUpdateWhere.mockResolvedValue(undefined);
     mockApplyPageMutation.mockResolvedValue({ nextRevision: 6 });
+  });
+
+  it('refuses to append when the sheet could not be read', async () => {
+    // The whole point of the guard: an anonymous form POST must not be able to
+    // replace a spreadsheet it failed to parse with just the submitted row.
+    mockTxSelectLimit.mockResolvedValue([
+      { ...sheetPage, content: UNREADABLE_SHEET, revision: 5 },
+    ]);
+
+    await expect(
+      appendFormSubmission({
+        formTargetId: 'ft-1',
+        values: { name: 'Ada', email: 'ada@example.com' },
+        submitterIpHash: 'iphash',
+      })
+    ).rejects.toThrow(/could not be read/);
+
+    expect(mockApplyPageMutation).not.toHaveBeenCalled();
+  });
+
+  it('still appends normally to a sheet that reads fine', async () => {
+    // The guard must not refuse readable content — including a genuinely
+    // empty sheet, which is not the same as an unreadable one.
+    await appendFormSubmission({
+      formTargetId: 'ft-1',
+      values: { name: 'Ada', email: 'ada@example.com' },
+      submitterIpHash: 'iphash',
+    });
+
+    expect(mockApplyPageMutation).toHaveBeenCalledTimes(1);
   });
 
   it('locks the form_targets row before appending (FOR UPDATE)', async () => {

--- a/apps/web/src/services/api/form-target-service.ts
+++ b/apps/web/src/services/api/form-target-service.ts
@@ -6,7 +6,7 @@ import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { PageType } from '@pagespace/lib/utils/enums';
 import {
   isSheetType,
-  parseSheetContent,
+  parseSheetContentSafe,
   serializeSheetContent,
   updateSheetCells,
 } from '@pagespace/lib/sheets/sheet';
@@ -83,8 +83,19 @@ export async function createFormTarget({
 
   try {
     const [formTarget] = await db.transaction(async (tx) => {
-      const sheetData = parseSheetContent(page.content);
-      const updatedSheet = updateSheetCells(sheetData, buildHeaderRowUpdates(fields, HEADER_ROW));
+      // Refuse to write if the existing content could not be read: appending
+      // to the empty sheet the unsafe parse returns would replace the whole
+      // spreadsheet with just these header cells.
+      const parsedSheet = parseSheetContentSafe(page.content);
+      if (!parsedSheet.ok) {
+        throw new Error(
+          `Sheet "${page.id}" could not be read (${parsedSheet.reason}); refusing to overwrite it.`
+        );
+      }
+      const updatedSheet = updateSheetCells(
+        parsedSheet.sheet,
+        buildHeaderRowUpdates(fields, HEADER_ROW)
+      );
       const newContent = serializeSheetContent(updatedSheet, { pageId: page.id });
 
       await applyPageMutation({
@@ -286,9 +297,17 @@ export async function appendFormSubmission({
           throw new Error(`Page "${formTarget.pageId}" not found`);
         }
 
-        const sheetData = parseSheetContent(page.content);
+        // Same guard on the submission path — and this one takes anonymous
+        // public input, so an unreadable sheet must fail the submission rather
+        // than replace the sheet with a single submitted row.
+        const parsedSheet = parseSheetContentSafe(page.content);
+        if (!parsedSheet.ok) {
+          throw new Error(
+            `Sheet "${page.id}" could not be read (${parsedSheet.reason}); refusing to overwrite it.`
+          );
+        }
         const rowUpdates = buildSubmissionRowUpdates(formTarget.fields, formTarget.nextRow, values);
-        const updatedSheet = updateSheetCells(sheetData, rowUpdates);
+        const updatedSheet = updateSheetCells(parsedSheet.sheet, rowUpdates);
         const newContent = serializeSheetContent(updatedSheet, { pageId: page.id });
 
         await applyPageMutation({

--- a/packages/lib/src/__tests__/page-type-validators.test.ts
+++ b/packages/lib/src/__tests__/page-type-validators.test.ts
@@ -35,6 +35,41 @@ const VALID_SHEETDOC_CONTENT = [
   '',
 ].join('\n')
 
+/**
+ * Carries the magic prefix but a malformed body — `cells=` has no value.
+ * Accepting this is what let corrupt content reach storage and read back as an
+ * empty sheet, so the validator must parse the body rather than trust the
+ * prefix.
+ */
+const MALFORMED_SHEETDOC_CONTENT = '#%PAGESPACE_SHEETDOC v1\nrows=10\ncols=10\ncells=\n'
+
+describe('SHEET content validation rejects a malformed body', () => {
+  it('rejects it on creation despite the magic prefix', () => {
+    const result = validatePageCreation(PageType.SHEET, {
+      title: 'Sheet',
+      content: MALFORMED_SHEETDOC_CONTENT,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain('Invalid sheet content')
+  })
+
+  it('rejects it on update despite the magic prefix', () => {
+    const result = validatePageUpdate(PageType.SHEET, {
+      content: MALFORMED_SHEETDOC_CONTENT,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain('Content must be valid sheet data')
+  })
+
+  it('still accepts a body that genuinely parses', () => {
+    expect(
+      validatePageUpdate(PageType.SHEET, { content: VALID_SHEETDOC_CONTENT }).valid
+    ).toBe(true)
+  })
+})
+
 describe('page-type-validators', () => {
   describe('validatePageCreation', () => {
     it('validates valid DOCUMENT creation', () => {

--- a/packages/lib/src/__tests__/page-type-validators.test.ts
+++ b/packages/lib/src/__tests__/page-type-validators.test.ts
@@ -8,6 +8,33 @@ import {
 } from '../content/page-type-validators'
 import { PageType } from '../utils/enums'
 
+/**
+ * Genuinely valid SheetDoc content.
+ *
+ * These tests previously used `'#%PAGESPACE_SHEETDOC\nrows=10\ncols=10\ncells=\n'`,
+ * which carries the magic prefix but is malformed TOML (`cells=` has no
+ * value). It only passed because the validator trusted the prefix without
+ * parsing the body — the same gap that let newline-corrupted content reach
+ * storage and read back as an empty sheet. The intent of the assertions is
+ * unchanged; the fixture now matches what it claims to be.
+ */
+const VALID_SHEETDOC_CONTENT = [
+  '#%PAGESPACE_SHEETDOC v1',
+  '',
+  '[[sheets]]',
+  'name = "Sheet1"',
+  'order = 0',
+  '',
+  '[sheets.meta]',
+  'row_count = 10',
+  'column_count = 10',
+  '',
+  '[sheets.cells.A1]',
+  'value = "hello"',
+  'type = "string"',
+  '',
+].join('\n')
+
 describe('page-type-validators', () => {
   describe('validatePageCreation', () => {
     it('validates valid DOCUMENT creation', () => {
@@ -119,7 +146,7 @@ describe('page-type-validators', () => {
     it('validates valid SHEET creation', () => {
       const result = validatePageCreation(PageType.SHEET, {
         title: 'Test Sheet',
-        content: '#%PAGESPACE_SHEETDOC\nrows=10\ncols=10\ncells=\n'
+        content: VALID_SHEETDOC_CONTENT
       })
 
       expect(result.valid).toBe(true)
@@ -230,7 +257,7 @@ describe('page-type-validators', () => {
 
     it('validates valid sheet content for SHEET', () => {
       const result = validatePageUpdate(PageType.SHEET, {
-        content: '#%PAGESPACE_SHEETDOC\nrows=10\ncols=10\ncells=\n'
+        content: VALID_SHEETDOC_CONTENT
       })
 
       expect(result.valid).toBe(true)
@@ -443,7 +470,7 @@ describe('page-type-validators', () => {
     it('accepts SHEET with valid SheetDoc content', () => {
       const result = validatePageCreation(PageType.SHEET, {
         title: 'Sheet Test',
-        content: '#%PAGESPACE_SHEETDOC\nrows=10\ncols=10\ncells=\n'
+        content: VALID_SHEETDOC_CONTENT
       })
 
       expect(result.valid).toBe(true)

--- a/packages/lib/src/__tests__/sheet-format-render.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-render.test.ts
@@ -194,6 +194,24 @@ describe('xlsx export', () => {
     expect(cols?.[1]?.wch).toBe(25);
   });
 
+  it('emits an explicit width for a column with no data in it', () => {
+    // `!cols` used to be derived from the populated data width alone, so a
+    // configured width for a column past the widest row was silently dropped —
+    // and the route sizes `columnWidths` by `columnCount`, which usually
+    // exceeds the data width.
+    const sheet = createEmptySheet(2, 6);
+    sheet.cells.A1 = 'only column A has data';
+
+    const typed = typedExportFor(sheet);
+    typed.columnWidths = [undefined, undefined, undefined, undefined, 210];
+
+    const evaluation = evaluateSheet(sheet);
+    const buffer = generateExcel(evaluation.display, 'Sheet1', 'Widths', typed);
+    const cols = XLSX.read(buffer, { type: 'buffer', cellStyles: true }).Sheets.Sheet1['!cols'];
+
+    expect(cols?.[4]?.wch).toBe(29);
+  });
+
   it('still works without the typed payload', () => {
     const sheet = formattedSheet();
     const evaluation = evaluateSheet(sheet);

--- a/packages/lib/src/__tests__/sheet-format-render.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-render.test.ts
@@ -212,6 +212,40 @@ describe('xlsx export', () => {
     expect(cols?.[4]?.wch).toBe(29);
   });
 
+  it('leaves empty columns at Excel\'s default width', () => {
+    // Asserting the WHOLE array on purpose: an earlier fix emitted a
+    // measured-width fallback for every column, pinning each empty one to
+    // ~2 characters. A single-index assertion passed while that shipped.
+    const sheet = createEmptySheet(2, 10);
+    sheet.cells.A1 = 'only A';
+
+    const typed = typedExportFor(sheet);
+    // The route always supplies a dense array of length columnCount.
+    typed.columnWidths = Array.from({ length: 10 }, () => undefined);
+
+    const evaluation = evaluateSheet(sheet);
+    const buffer = generateExcel(evaluation.display, 'Sheet1', 'Defaults', typed);
+    const cols = XLSX.read(buffer, { type: 'buffer', cellStyles: true }).Sheets.Sheet1['!cols'];
+
+    // Column A is measured; nothing else gets an entry at all.
+    expect(cols?.map((c) => c?.wch)).toEqual([8]);
+  });
+
+  it('bounds an absurd stored width at export time', () => {
+    const sheet = createEmptySheet(2, 3);
+    sheet.cells.A1 = 'x';
+
+    const typed = typedExportFor(sheet);
+    typed.columnWidths = [999999, undefined, undefined];
+
+    const evaluation = evaluateSheet(sheet);
+    const buffer = generateExcel(evaluation.display, 'Sheet1', 'Bounded', typed);
+    const cols = XLSX.read(buffer, { type: 'buffer', cellStyles: true }).Sheets.Sheet1['!cols'];
+
+    // MAX_COLUMN_WIDTH (2000px) -> (2000-5)/7 characters.
+    expect(cols?.[0]?.wch).toBe(285);
+  });
+
   it('still works without the typed payload', () => {
     const sheet = formattedSheet();
     const evaluation = evaluateSheet(sheet);

--- a/packages/lib/src/__tests__/sheet-format-render.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-render.test.ts
@@ -242,8 +242,28 @@ describe('xlsx export', () => {
     const buffer = generateExcel(evaluation.display, 'Sheet1', 'Bounded', typed);
     const cols = XLSX.read(buffer, { type: 'buffer', cellStyles: true }).Sheets.Sheet1['!cols'];
 
-    // MAX_COLUMN_WIDTH (2000px) -> (2000-5)/7 characters.
-    expect(cols?.[0]?.wch).toBe(285);
+    // Bounded by Excel's own 255-character maximum column width. The raw
+    // conversion of MAX_COLUMN_WIDTH (2000px) would be 285, which is out of
+    // spec even though SheetJS writes it without complaint.
+    expect(cols?.[0]?.wch).toBe(255);
+  });
+
+  it('exports a deliberately narrow column as authored', () => {
+    // Storage keeps a gutter narrower than the editor's minimum, so the export
+    // must not quietly widen it back — that would be the same overreach as
+    // rewriting it on save, just moved one layer out.
+    const sheet = createEmptySheet(2, 2);
+    sheet.cells.A1 = 'x';
+
+    const typed = typedExportFor(sheet);
+    typed.columnWidths = [10, undefined];
+
+    const evaluation = evaluateSheet(sheet);
+    const buffer = generateExcel(evaluation.display, 'Sheet1', 'Narrow', typed);
+    const cols = XLSX.read(buffer, { type: 'buffer', cellStyles: true }).Sheets.Sheet1['!cols'];
+
+    // (10 - 5) / 7 rounds to 1, the narrowest Excel accepts.
+    expect(cols?.[0]?.wch).toBe(1);
   });
 
   it('still works without the typed payload', () => {

--- a/packages/lib/src/__tests__/sheet-format-render.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-render.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import * as XLSX from 'xlsx';
+import {
+  createEmptySheet,
+  serializeSheetContent,
+  setCellFormats,
+  setColumnWidth,
+  evaluateSheet,
+  encodeCellAddress,
+  numberFormatToExcelCode,
+  type SheetData,
+} from '../sheets/sheet';
+import { renderSheetPage } from '../publish/render-sheet-page';
+import { generateExcel, type TypedSheetExport } from '../content/export-utils';
+
+/**
+ * The grid, the published page and the XLSX export all read the same
+ * `SheetEvaluation`. These tests hold them to that: a formatted number must
+ * read the same in all three, and formatting must not become an injection
+ * vector on the published page.
+ */
+
+const typedExportFor = (sheet: SheetData): TypedSheetExport => {
+  const evaluation = evaluateSheet(sheet);
+  return {
+    values: evaluation.display.map((row, rowIndex) =>
+      row.map((_, columnIndex) => {
+        const cell = evaluation.byAddress[encodeCellAddress(rowIndex, columnIndex)];
+        return cell?.error ? cell.display : cell?.value;
+      })
+    ),
+    numberFormats: evaluation.display.map((row, rowIndex) =>
+      row.map((_, columnIndex) => {
+        const cell = evaluation.byAddress[encodeCellAddress(rowIndex, columnIndex)];
+        return numberFormatToExcelCode(cell?.format?.number);
+      })
+    ),
+    columnWidths: Array.from({ length: sheet.columnCount }, (_, columnIndex) => {
+      const key = encodeCellAddress(0, columnIndex).replace(/\d+$/, '');
+      return sheet.columnWidths?.[key];
+    }),
+  };
+};
+
+const formattedSheet = (): SheetData => {
+  let sheet = createEmptySheet(3, 3);
+  sheet.cells.A1 = 'Revenue';
+  sheet.cells.B1 = '1234.5';
+  sheet = setCellFormats(sheet, ['A1'], { bold: true, background: '#fef3c7' });
+  sheet = setCellFormats(sheet, ['B1'], {
+    number: { kind: 'currency', currency: 'USD', decimals: 2 },
+  });
+  return sheet;
+};
+
+describe('published sheet rendering', () => {
+  it('carries formatting into the published table', () => {
+    const html = renderSheetPage({
+      serializedContent: serializeSheetContent(formattedSheet()),
+      title: 'Budget',
+    });
+
+    expect(html).toContain('font-weight:600');
+    expect(html).toContain('background-color:#fef3c7');
+    // The formatted value, not the raw number.
+    expect(html).toContain('$1,234.50');
+  });
+
+  it('renders the same display string the grid shows', () => {
+    const sheet = formattedSheet();
+    const gridDisplay = evaluateSheet(sheet).byAddress.B1?.display;
+    const html = renderSheetPage({
+      serializedContent: serializeSheetContent(sheet),
+      title: 'Budget',
+    });
+
+    expect(gridDisplay).toBe('$1,234.50');
+    expect(html).toContain(gridDisplay!);
+  });
+
+  it('does not emit a hostile color into the style attribute', () => {
+    // The format is rejected on parse; this asserts the end-to-end outcome,
+    // since this document is served with script-src 'none' but still honours
+    // inline styles.
+    const hostile = [
+      '#%PAGESPACE_SHEETDOC v1',
+      '',
+      '[[sheets]]',
+      'name = "Sheet1"',
+      'order = 0',
+      '',
+      '[sheets.meta]',
+      'row_count = 3',
+      'column_count = 3',
+      '',
+      '[sheets.cells.A1]',
+      'value = "x"',
+      'type = "string"',
+      'format = { background = "#fff;background-image:url(https://evil.test/x)" }',
+      '',
+    ].join('\n');
+
+    const html = renderSheetPage({ serializedContent: hostile, title: 'Hostile' });
+
+    expect(html).not.toContain('evil.test');
+    expect(html).not.toContain('background-image');
+  });
+
+  it('keeps rendering an unformatted sheet exactly as before', () => {
+    const sheet = createEmptySheet(2, 2);
+    sheet.cells.A1 = 'plain';
+
+    const html = renderSheetPage({
+      serializedContent: serializeSheetContent(sheet),
+      title: 'Plain',
+    });
+
+    expect(html).toContain('<td>plain</td>');
+  });
+
+  it('aligns header styling with the header row when hasHeaders is set', () => {
+    let sheet = createEmptySheet(3, 2);
+    sheet.cells.A1 = 'Header';
+    sheet.cells.A2 = 'Body';
+    sheet = setCellFormats(sheet, ['A1'], { bold: true });
+    sheet = setCellFormats(sheet, ['A2'], { italic: true });
+
+    const html = renderSheetPage({
+      serializedContent: serializeSheetContent(sheet),
+      title: 'Headers',
+      hasHeaders: true,
+    });
+
+    // The bold format belongs to the <th>, the italic to the first body <td>.
+    expect(html).toMatch(/<th style="font-weight:600">Header<\/th>/);
+    expect(html).toMatch(/<td style="font-style:italic">Body<\/td>/);
+  });
+});
+
+describe('xlsx export', () => {
+  // `cellNF` is required for the number-format code to be restored on read;
+  // without it SheetJS drops `z` even though the file carries it.
+  const readBack = (buffer: Buffer) => {
+    const workbook = XLSX.read(buffer, { type: 'buffer', cellNF: true });
+    return workbook.Sheets[workbook.SheetNames[0]];
+  };
+
+  it('exports numbers as numbers, not as formatted text', () => {
+    const sheet = formattedSheet();
+    const evaluation = evaluateSheet(sheet);
+    const worksheet = readBack(
+      generateExcel(evaluation.display, 'Sheet1', 'Budget', typedExportFor(sheet))
+    );
+
+    // Without this the cell arrives as the string "$1,234.50" and nothing in
+    // Excel can sum, sort or chart it.
+    expect(worksheet.B1?.t).toBe('n');
+    expect(worksheet.B1?.v).toBe(1234.5);
+  });
+
+  it('carries the number format so Excel shows what the grid shows', () => {
+    const sheet = formattedSheet();
+    const evaluation = evaluateSheet(sheet);
+    const worksheet = readBack(
+      generateExcel(evaluation.display, 'Sheet1', 'Budget', typedExportFor(sheet))
+    );
+
+    expect(worksheet.B1?.z).toBe('"$"#,##0.00');
+    // `w` is what a spreadsheet application actually shows — the real proof
+    // that the export reads the same as the grid.
+    expect(worksheet.B1?.w).toBe('$1,234.50');
+  });
+
+  it('keeps text cells as text', () => {
+    const sheet = formattedSheet();
+    const evaluation = evaluateSheet(sheet);
+    const worksheet = readBack(
+      generateExcel(evaluation.display, 'Sheet1', 'Budget', typedExportFor(sheet))
+    );
+
+    expect(worksheet.A1?.t).toBe('s');
+    expect(worksheet.A1?.v).toBe('Revenue');
+  });
+
+  it('applies an explicit column width', () => {
+    let sheet = formattedSheet();
+    sheet = setColumnWidth(sheet, 1, 180);
+    const evaluation = evaluateSheet(sheet);
+
+    const buffer = generateExcel(evaluation.display, 'Sheet1', 'Budget', typedExportFor(sheet));
+    const workbook = XLSX.read(buffer, { type: 'buffer', cellStyles: true });
+    const cols = workbook.Sheets[workbook.SheetNames[0]]['!cols'];
+
+    expect(cols?.[1]?.wch).toBe(25);
+  });
+
+  it('still works without the typed payload', () => {
+    const sheet = formattedSheet();
+    const evaluation = evaluateSheet(sheet);
+    const worksheet = readBack(generateExcel(evaluation.display, 'Sheet1', 'Budget'));
+
+    // The legacy call shape keeps its old behaviour: everything is text.
+    expect(worksheet.B1?.v).toBe('$1,234.50');
+  });
+
+  it('exports a formula cell as its computed number', () => {
+    let sheet = createEmptySheet(3, 3);
+    sheet.cells.A1 = '10';
+    sheet.cells.A2 = '=A1*3';
+    sheet = setCellFormats(sheet, ['A2'], { number: { kind: 'number', decimals: 0 } });
+
+    const evaluation = evaluateSheet(sheet);
+    const worksheet = readBack(
+      generateExcel(evaluation.display, 'Sheet1', 'Calc', typedExportFor(sheet))
+    );
+
+    expect(worksheet.A2?.t).toBe('n');
+    expect(worksheet.A2?.v).toBe(30);
+  });
+
+});

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyNumberFormat,
+  cellFormatSchema,
+  cellFormatToInlineCss,
+  cellFormatToStyle,
+  clearCellFormats,
+  createEmptySheet,
+  evaluateSheet,
+  getEffectiveCellFormat,
+  isValidHexColor,
+  moveCellMetadata,
+  numberFormatToExcelCode,
+  parseCellFormat,
+  parseSheetContent,
+  sanitizeSheetData,
+  serializeSheetContent,
+  setCellFormats,
+  setColumnFormat,
+  setColumnWidth,
+  setFrozen,
+  setRowHeight,
+  shiftAxisMetadata,
+  type CellFormat,
+  type SheetData,
+} from '../sheets/sheet';
+
+const displayOf = (sheet: SheetData, address: string) =>
+  evaluateSheet(sheet).byAddress[address]?.display;
+
+describe('applyNumberFormat', () => {
+  it.each([
+    ['number with default decimals', 1234.5, { kind: 'number' as const }, '1,234.50'],
+    ['number without grouping', 1234.5, { kind: 'number' as const, thousands: false }, '1234.50'],
+    ['number with zero decimals', 1234.56, { kind: 'number' as const, decimals: 0 }, '1,235'],
+    ['currency', 1234.5, { kind: 'currency' as const, currency: 'USD' }, '$1,234.50'],
+    ['negative currency', -1234.5, { kind: 'currency' as const, currency: 'USD' }, '-$1,234.50'],
+    ['zero currency', 0, { kind: 'currency' as const, currency: 'USD' }, '$0.00'],
+    ['euro currency', 10, { kind: 'currency' as const, currency: 'EUR', decimals: 0 }, '€10'],
+    ['unknown currency falls back to the code', 10, { kind: 'currency' as const, currency: 'SEK', decimals: 0 }, 'SEK 10'],
+    ['percent', 0.15, { kind: 'percent' as const }, '15%'],
+    ['percent with decimals', 0.1555, { kind: 'percent' as const, decimals: 2 }, '15.55%'],
+    ['scientific', 12345, { kind: 'scientific' as const, decimals: 2 }, '1.23e+4'],
+    ['plain', 1234.5, { kind: 'plain' as const }, '1234.5'],
+    ['text', 42, { kind: 'text' as const }, '42'],
+  ])('formats %s', (_name, value, format, expected) => {
+    expect(applyNumberFormat(value, format)).toBe(expected);
+  });
+
+  it('formats dates without shifting the day across timezones', () => {
+    // The engine stores dates as strings. Going through `new Date(string)` would
+    // parse this as UTC midnight and then read local getters, landing on the
+    // previous day west of Greenwich.
+    expect(applyNumberFormat('2026-01-01', { kind: 'date', dateStyle: 'iso' })).toBe('2026-01-01');
+    expect(applyNumberFormat('2026-01-01', { kind: 'date', dateStyle: 'short' })).toBe('1/1/2026');
+    expect(applyNumberFormat('2026-01-01', { kind: 'date', dateStyle: 'long' })).toBe(
+      'January 1, 2026'
+    );
+    expect(applyNumberFormat('2026-01-01', { kind: 'date', dateStyle: 'medium' })).toBe(
+      'Jan 1, 2026'
+    );
+  });
+
+  it('formats times and datetimes', () => {
+    expect(applyNumberFormat('2026-01-01T09:05:03', { kind: 'time' })).toBe('09:05:03');
+    expect(applyNumberFormat('2026-01-01T09:05:03', { kind: 'datetime', dateStyle: 'iso' })).toBe(
+      '2026-01-01 09:05:03'
+    );
+  });
+
+  it('declines rather than mangling values a format cannot render', () => {
+    // Returning null lets the caller fall back to the engine's own rendering,
+    // so an inapplicable format degrades to the plain value.
+    expect(applyNumberFormat('not a number', { kind: 'currency' })).toBeNull();
+    expect(applyNumberFormat('not a date', { kind: 'date' })).toBeNull();
+    expect(applyNumberFormat(true, { kind: 'currency' })).toBeNull();
+    expect(applyNumberFormat(1, { kind: 'auto' })).toBeNull();
+    expect(applyNumberFormat(1, undefined)).toBeNull();
+    expect(applyNumberFormat(Number.POSITIVE_INFINITY, { kind: 'number' })).toBeNull();
+  });
+
+  it('coerces numeric strings so imported text numbers still format', () => {
+    expect(applyNumberFormat('1234.5', { kind: 'currency', currency: 'USD' })).toBe('$1,234.50');
+  });
+
+  it('renders an unrecognised custom pattern as plain rather than discarding it', () => {
+    const format = { kind: 'custom' as const, pattern: '[Red]#,##0.00_);' };
+    expect(applyNumberFormat(5, format)).toBeNull();
+    // …but the pattern survives to the Excel round trip.
+    expect(numberFormatToExcelCode(format)).toBe('[Red]#,##0.00_);');
+  });
+
+  it('clamps decimals to the supported range', () => {
+    expect(applyNumberFormat(1, { kind: 'number', decimals: 999 })).toBe('1.0000000000');
+    expect(applyNumberFormat(1, { kind: 'number', decimals: -5 })).toBe('1');
+  });
+});
+
+describe('numberFormatToExcelCode', () => {
+  it.each([
+    [{ kind: 'number' as const }, '#,##0.00'],
+    [{ kind: 'number' as const, thousands: false, decimals: 0 }, '0'],
+    [{ kind: 'currency' as const, currency: 'USD' }, '"$"#,##0.00'],
+    [{ kind: 'percent' as const, decimals: 1 }, '0.0%'],
+    [{ kind: 'scientific' as const, decimals: 2 }, '0.00E+00'],
+    [{ kind: 'date' as const }, 'yyyy-mm-dd'],
+    [{ kind: 'text' as const }, '@'],
+  ])('maps %o', (format, expected) => {
+    expect(numberFormatToExcelCode(format)).toBe(expected);
+  });
+
+  it('returns undefined when Excel default rendering is correct', () => {
+    expect(numberFormatToExcelCode({ kind: 'auto' })).toBeUndefined();
+    expect(numberFormatToExcelCode(undefined)).toBeUndefined();
+  });
+});
+
+describe('format validation', () => {
+  it('accepts a well-formed format', () => {
+    const format: CellFormat = {
+      bold: true,
+      color: '#112233',
+      background: '#AABBCC',
+      align: 'right',
+      number: { kind: 'currency', currency: 'USD', decimals: 2 },
+    };
+    expect(cellFormatSchema.safeParse(format).success).toBe(true);
+    expect(parseCellFormat(format)).toEqual(format);
+  });
+
+  it.each([
+    ['a javascript: url', { color: 'javascript:alert(1)' }],
+    ['an rgb() function', { color: 'rgb(255,0,0)' }],
+    ['a css injection attempt', { background: '#fff;background:url(x)' }],
+    ['a named color', { color: 'red' }],
+    ['a short hex', { color: '#fff' }],
+    ['an out-of-range font size', { fontSize: 9999 }],
+    ['an unknown alignment', { align: 'justify' }],
+  ])('rejects %s', (_name, format) => {
+    expect(parseCellFormat(format)).toBeUndefined();
+  });
+
+  it('rejects non-hex colors at the render boundary too', () => {
+    // Defence in depth: even if a bad color reached storage, it must not be
+    // emitted into a style attribute on a published page.
+    expect(isValidHexColor('javascript:alert(1)')).toBe(false);
+    const css = cellFormatToInlineCss({ color: 'javascript:alert(1)' } as CellFormat);
+    expect(css).not.toContain('javascript');
+    expect(css).toBe('');
+  });
+
+  it('never emits CSS-significant characters', () => {
+    const css = cellFormatToInlineCss({
+      bold: true,
+      color: '#001122',
+      background: '#334455',
+    });
+    expect(css).toBe('font-weight:600;color:#001122;background-color:#334455');
+    // Semicolons separate declarations and are expected; braces, angle brackets
+    // and quotes would mean something escaped the allow-list.
+    expect(css).not.toMatch(/[{}<>"']/);
+  });
+
+  it('treats an empty format as absent', () => {
+    expect(parseCellFormat({})).toBeUndefined();
+    expect(parseCellFormat({ bold: undefined })).toBeUndefined();
+  });
+});
+
+describe('cellFormatToStyle', () => {
+  it('maps every supported field', () => {
+    const style = cellFormatToStyle({
+      bold: true,
+      italic: true,
+      underline: true,
+      strike: true,
+      align: 'center',
+      valign: 'top',
+      wrap: true,
+      color: '#111111',
+      background: '#222222',
+      fontSize: 14,
+      fontFamily: 'mono',
+      borders: { top: { style: 'thick', color: '#333333' } },
+    });
+
+    expect(style.fontWeight).toBe('600');
+    expect(style.fontStyle).toBe('italic');
+    expect(style.textDecoration).toBe('underline line-through');
+    expect(style.textAlign).toBe('center');
+    expect(style.alignItems).toBe('flex-start');
+    expect(style.whiteSpace).toBe('pre-wrap');
+    expect(style.color).toBe('#111111');
+    expect(style.backgroundColor).toBe('#222222');
+    expect(style.fontSize).toBe('14px');
+    expect(style.fontFamily).toContain('--font-mono');
+    expect(style.borderTop).toBe('3px solid #333333');
+  });
+
+  it('returns an empty object for no format', () => {
+    expect(cellFormatToStyle(undefined)).toEqual({});
+  });
+});
+
+describe('format operations', () => {
+  it('merges patches and drops fields set to undefined', () => {
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], { bold: true, italic: true });
+    expect(sheet.formats?.A1).toEqual({ bold: true, italic: true });
+
+    sheet = setCellFormats(sheet, ['A1'], { bold: undefined });
+    expect(sheet.formats?.A1).toEqual({ italic: true });
+  });
+
+  it('removes the entry entirely once nothing is left', () => {
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], { bold: true });
+    sheet = setCellFormats(sheet, ['A1'], { bold: undefined });
+    expect(sheet.formats).toBeUndefined();
+  });
+
+  it('normalizes addresses and ignores invalid ones', () => {
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['a1', 'not-an-address'], { bold: true });
+    expect(Object.keys(sheet.formats ?? {})).toEqual(['A1']);
+  });
+
+  it('clears formatting without touching values', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = 'keep me';
+    sheet = setCellFormats(sheet, ['A1'], { bold: true });
+    sheet = clearCellFormats(sheet, ['A1']);
+
+    expect(sheet.formats).toBeUndefined();
+    expect(sheet.cells.A1).toBe('keep me');
+  });
+
+  it('lets a cell format override its column default', () => {
+    let sheet = createEmptySheet();
+    sheet = setColumnFormat(sheet, 0, { align: 'right', bold: true });
+    sheet = setCellFormats(sheet, ['A1'], { align: 'center' });
+
+    expect(getEffectiveCellFormat(sheet, 'A1')).toEqual({ align: 'center', bold: true });
+    expect(getEffectiveCellFormat(sheet, 'A2')).toEqual({ align: 'right', bold: true });
+  });
+
+  it('clamps widths and heights to sane bounds', () => {
+    let sheet = createEmptySheet();
+    sheet = setColumnWidth(sheet, 0, 5);
+    sheet = setRowHeight(sheet, 0, 100000);
+
+    expect(sheet.columnWidths?.A).toBe(24);
+    expect(sheet.rowHeights?.['1']).toBe(1000);
+
+    sheet = setColumnWidth(sheet, 0, undefined);
+    expect(sheet.columnWidths).toBeUndefined();
+  });
+
+  it('treats a zero freeze as no freeze', () => {
+    const sheet = setFrozen(createEmptySheet(), 0, 2);
+    expect(sheet.frozenRows).toBeUndefined();
+    expect(sheet.frozenColumns).toBe(2);
+  });
+
+  it('shifts column widths and formats when a column is inserted', () => {
+    let sheet = createEmptySheet();
+    sheet = setColumnWidth(sheet, 0, 100);
+    sheet = setColumnWidth(sheet, 2, 300);
+    sheet = setColumnFormat(sheet, 2, { bold: true });
+
+    const shifted = shiftAxisMetadata(sheet, 'column', 1, 1);
+
+    // A stays put; C moves to D and takes its width and default format with it.
+    expect(shifted.columnWidths?.A).toBe(100);
+    expect(shifted.columnWidths?.D).toBe(300);
+    expect(shifted.columnWidths?.C).toBeUndefined();
+    expect(shifted.columnFormats?.D).toEqual({ bold: true });
+  });
+
+  it('drops per-column metadata for a deleted column', () => {
+    let sheet = createEmptySheet();
+    sheet = setColumnWidth(sheet, 1, 200);
+    sheet = setColumnWidth(sheet, 2, 300);
+
+    const shifted = shiftAxisMetadata(sheet, 'column', 1, -1);
+
+    expect(shifted.columnWidths?.B).toBe(300);
+    expect(Object.keys(shifted.columnWidths ?? {})).toEqual(['B']);
+  });
+
+  it('shifts row heights when a row is inserted', () => {
+    let sheet = createEmptySheet();
+    sheet = setRowHeight(sheet, 0, 20);
+    sheet = setRowHeight(sheet, 4, 60);
+
+    const shifted = shiftAxisMetadata(sheet, 'row', 1, 2);
+
+    expect(shifted.rowHeights?.['1']).toBe(20);
+    expect(shifted.rowHeights?.['7']).toBe(60);
+  });
+
+  it('relocates formats when cells move', () => {
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1', 'A2'], { bold: true });
+
+    const moved = moveCellMetadata(
+      sheet,
+      new Map([
+        ['A1', 'A5'],
+        ['A2', null],
+      ])
+    );
+
+    expect(moved.formats?.A5).toEqual({ bold: true });
+    expect(moved.formats?.A1).toBeUndefined();
+    expect(moved.formats?.A2).toBeUndefined();
+  });
+});
+
+describe('formats and the evaluator', () => {
+  it('applies the format to the displayed value', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.B1 = '1234.5';
+    sheet = setCellFormats(sheet, ['B1'], { number: { kind: 'currency', currency: 'USD' } });
+
+    expect(displayOf(sheet, 'B1')).toBe('$1,234.50');
+  });
+
+  it('formats a formula result', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = '1000';
+    sheet.cells.B1 = '=A1*1.5';
+    sheet = setCellFormats(sheet, ['B1'], { number: { kind: 'currency', currency: 'USD' } });
+
+    expect(displayOf(sheet, 'B1')).toBe('$1,500.00');
+  });
+
+  it('leaves concatenation and comparison operating on raw values', () => {
+    // The single most important constraint of formatting in the evaluator: it
+    // must rewrite `display` only. If it touched `value`, `="Total: "&A1`
+    // would embed a currency symbol and `A1=B1` would compare formatted text.
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = '1234.5';
+    sheet.cells.B1 = '1234.5';
+    sheet.cells.C1 = '="Total: "&A1';
+    sheet.cells.D1 = '=A1*2';
+    sheet.cells.E1 = '=A1=B1';
+    sheet = setCellFormats(sheet, ['A1', 'B1'], {
+      number: { kind: 'currency', currency: 'USD' },
+    });
+
+    expect(displayOf(sheet, 'A1')).toBe('$1,234.50');
+    expect(displayOf(sheet, 'C1')).toBe('Total: 1234.5');
+    expect(displayOf(sheet, 'D1')).toBe('2469');
+    expect(displayOf(sheet, 'E1')).toBe('true');
+  });
+
+  it('does not format an error cell', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = '=1/0';
+    sheet = setCellFormats(sheet, ['A1'], { number: { kind: 'currency' } });
+
+    expect(displayOf(sheet, 'A1')).toBe('#ERROR');
+  });
+
+  it('exposes the resolved format on the evaluated cell', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = '1';
+    sheet = setColumnFormat(sheet, 0, { bold: true });
+    sheet = setCellFormats(sheet, ['A1'], { italic: true });
+
+    expect(evaluateSheet(sheet).byAddress.A1?.format).toEqual({ bold: true, italic: true });
+  });
+});
+
+describe('formats through the persistence round trip', () => {
+  it('preserves formats, widths, heights and frozen panes', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = 'Revenue';
+    sheet.cells.B1 = '1234.5';
+    sheet = setCellFormats(sheet, ['A1'], {
+      bold: true,
+      background: '#fef3c7',
+      align: 'center',
+      borders: { bottom: { style: 'medium', color: '#111111' } },
+    });
+    sheet = setCellFormats(sheet, ['B1'], {
+      number: { kind: 'currency', currency: 'USD', decimals: 2 },
+    });
+    sheet = setColumnFormat(sheet, 1, { align: 'right' });
+    sheet = setColumnWidth(sheet, 1, 180);
+    sheet = setRowHeight(sheet, 0, 32);
+    sheet = setFrozen(sheet, 1, 1);
+
+    const restored = parseSheetContent(serializeSheetContent(sheet));
+
+    expect(restored.formats?.A1).toEqual(sheet.formats?.A1);
+    expect(restored.formats?.B1).toEqual(sheet.formats?.B1);
+    expect(restored.columnFormats?.B).toEqual({ align: 'right' });
+    expect(restored.columnWidths).toEqual({ B: 180 });
+    expect(restored.rowHeights).toEqual({ '1': 32 });
+    expect(restored.frozenRows).toBe(1);
+    expect(restored.frozenColumns).toBe(1);
+    expect(displayOf(restored, 'B1')).toBe('$1,234.50');
+  });
+
+  it('keeps formatting on a cell whose contents were cleared', () => {
+    // A blank but coloured cell is a legitimate part of a laid-out sheet, and
+    // is the reason formats live beside `cells` rather than inside them.
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], { background: '#fef3c7' });
+
+    const restored = parseSheetContent(serializeSheetContent(sheet));
+    expect(restored.formats?.A1).toEqual({ background: '#fef3c7' });
+    expect(restored.cells.A1).toBeUndefined();
+  });
+
+  it('drops a stored format that fails validation', () => {
+    const hostile = [
+      '#%PAGESPACE_SHEETDOC v1',
+      '',
+      '[[sheets]]',
+      'name = "Sheet1"',
+      'order = 0',
+      '',
+      '[sheets.meta]',
+      'row_count = 5',
+      'column_count = 5',
+      '',
+      '[sheets.cells.A1]',
+      'value = 1',
+      'type = "number"',
+      'format = { color = "javascript:alert(1)" }',
+      '',
+    ].join('\n');
+
+    const restored = parseSheetContent(hostile);
+    expect(restored.cells.A1).toBe('1');
+    expect(restored.formats?.A1).toBeUndefined();
+  });
+
+  it('keeps formats for cells outside the current bounds', () => {
+    // A sheet that temporarily shrinks must not lose styling it will need
+    // again when it grows back.
+    let sheet = createEmptySheet(2, 2);
+    sheet = setCellFormats(sheet, ['Z99'], { bold: true });
+
+    expect(sanitizeSheetData(sheet).formats?.Z99).toEqual({ bold: true });
+  });
+
+  it('drops formats whose address is not a valid reference', () => {
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      formats: { 'not-an-address': { bold: true } } as Record<string, CellFormat>,
+    };
+
+    expect(sanitizeSheetData(sheet).formats).toBeUndefined();
+  });
+});

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -5,6 +5,12 @@ import {
   cellFormatToInlineCss,
   cellFormatToStyle,
   clearCellFormats,
+  clampColumnWidth,
+  clampRowHeight,
+  MAX_COLUMN_WIDTH,
+  MAX_ROW_HEIGHT,
+  MIN_COLUMN_WIDTH,
+  MIN_ROW_HEIGHT,
   createEmptySheet,
   evaluateSheet,
   getEffectiveCellFormat,
@@ -326,14 +332,58 @@ describe('review findings', () => {
     expect(numberFormatToExcelCode(format)).toBe('"$"0.00');
   });
 
-  it('sanitizeSheetData rejects a format the read path would drop', () => {
-    // The write path must not persist what the read path discards, or a
-    // format survives one save and vanishes on the next load.
+  it('drops only the offending field, not the whole format', () => {
+    // An invalid field must not take valid ones with it: the user can see the
+    // bold and did not ask to lose it.
     const sheet: SheetData = {
       ...createEmptySheet(),
-      formats: { A1: { fontSize: 9999 } as CellFormat },
+      formats: {
+        A1: { fontSize: 9999 } as CellFormat,
+        A2: { bold: true, fontSize: 5 } as CellFormat,
+      },
     };
-    expect(sanitizeSheetData(sheet).formats).toBeUndefined();
+
+    const sanitized = sanitizeSheetData(sheet);
+    expect(sanitized.formats?.A1).toBeUndefined();
+    expect(sanitized.formats?.A2).toEqual({ bold: true });
+  });
+
+  it('preserves a format field written by a newer build', () => {
+    // Stripping unknown fields would delete a newer build's work the first
+    // time an older build saves — the cross-version loss the ranges
+    // passthrough exists to prevent.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      formats: { A1: { bold: true, futureField: 'keep me' } as unknown as CellFormat },
+    };
+
+    expect(sanitizeSheetData(sheet).formats?.A1).toEqual({
+      bold: true,
+      futureField: 'keep me',
+    });
+  });
+
+  it('keeps a stored dimension exactly as authored', () => {
+    // Sanitization runs on every save, so clamping here would rewrite a
+    // hand-authored 10px gutter to the editor minimum and destroy it.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      columnWidths: { A: 10, B: 999999 },
+      rowHeights: { '1': 8 },
+    };
+
+    const sanitized = sanitizeSheetData(sheet);
+    expect(sanitized.columnWidths).toEqual({ A: 10, B: 999999 });
+    expect(sanitized.rowHeights).toEqual({ '1': 8 });
+  });
+
+  it('rejects a meaningless stored dimension', () => {
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      columnWidths: { A: -500, B: 0, C: 180 },
+    };
+
+    expect(sanitizeSheetData(sheet).columnWidths).toEqual({ C: 180 });
   });
 
   it('sanitizeSheetData validates column and row metadata too', () => {
@@ -350,20 +400,12 @@ describe('review findings', () => {
     expect(sanitized.rowHeights).toEqual({ '1': 30 });
   });
 
-  it('clamps stored dimensions that bypassed the setters', () => {
-    // Loaded content never goes through setColumnWidth/setRowHeight, so a
-    // negative or absurd stored size would otherwise reach the grid and the
-    // XLSX export intact.
-    const sheet: SheetData = {
-      ...createEmptySheet(),
-      columnWidths: { A: -500, B: 999999, C: 180 },
-      rowHeights: { '1': -20, '2': 500000, '3': 32 },
-    };
-
-    const sanitized = sanitizeSheetData(sheet);
-
-    expect(sanitized.columnWidths).toEqual({ A: 24, B: 2000, C: 180 });
-    expect(sanitized.rowHeights).toEqual({ '1': 16, '2': 1000, '3': 32 });
+  it('bounds a dimension at the point of use, not in storage', () => {
+    expect(clampColumnWidth(10)).toBe(MIN_COLUMN_WIDTH);
+    expect(clampColumnWidth(999999)).toBe(MAX_COLUMN_WIDTH);
+    expect(clampColumnWidth(180)).toBe(180);
+    expect(clampRowHeight(8)).toBe(MIN_ROW_HEIGHT);
+    expect(clampRowHeight(500000)).toBe(MAX_ROW_HEIGHT);
   });
 
   it('moveCellMetadata lets a relocated format win a collision', () => {

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -304,6 +304,45 @@ describe('format operations', () => {
     expect(sheet.frozenColumns).toBe(2);
   });
 
+  it('does not let a normalized key destroy its collision partner', () => {
+    // `A1` and `a1` normalize to the same address. Without a guard the loser
+    // is decided by iteration order and its formatting is gone.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      formats: { A1: { bold: true }, a1: { italic: true } } as Record<string, CellFormat>,
+    };
+
+    const moved = moveCellMetadata(sheet, new Map());
+
+    expect(Object.keys(moved.formats ?? {})).toEqual(['A1']);
+    expect(moved.formats?.A1).toEqual({ bold: true });
+    // The map changed, so the version must say so.
+    expect(moved.version).toBe(sheet.version + 1);
+  });
+
+  it('bumps the version whenever the format map actually changes', () => {
+    const withLowercase: SheetData = {
+      ...createEmptySheet(),
+      formats: { a1: { bold: true } } as Record<string, CellFormat>,
+    };
+    // A key rewritten by normalization is a change even with an empty map.
+    expect(moveCellMetadata(withLowercase, new Map()).version).toBe(withLowercase.version + 1);
+
+    let unchanged = createEmptySheet();
+    unchanged = setCellFormats(unchanged, ['A1'], { bold: true });
+    expect(moveCellMetadata(unchanged, new Map()).version).toBe(unchanged.version);
+  });
+
+  it('bumps the version when a format is dropped for an unmappable target', () => {
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], { bold: true });
+
+    const moved = moveCellMetadata(sheet, new Map([['A1', 'not-an-address']]));
+
+    expect(moved.formats).toBeUndefined();
+    expect(moved.version).toBe(sheet.version + 1);
+  });
+
   it('shifts column widths and formats when a column is inserted', () => {
     let sheet = createEmptySheet();
     sheet = setColumnWidth(sheet, 0, 100);
@@ -436,12 +475,17 @@ describe('review findings', () => {
     expect(sanitized.rowHeights).toEqual({ '1': 30 });
   });
 
-  it('bounds a dimension at the point of use, not in storage', () => {
-    expect(clampColumnWidth(10)).toBe(MIN_COLUMN_WIDTH);
-    expect(clampColumnWidth(999999)).toBe(MAX_COLUMN_WIDTH);
-    expect(clampColumnWidth(180)).toBe(180);
-    expect(clampRowHeight(8)).toBe(MIN_ROW_HEIGHT);
-    expect(clampRowHeight(500000)).toBe(MAX_ROW_HEIGHT);
+  it('keeps a fractional width from vanishing on the following save', () => {
+    // Guarding the raw value let 0.4 through, which stored as 0 and was then
+    // dropped by the next save — stable only after two round trips.
+    const first = sanitizeSheetData({
+      ...createEmptySheet(),
+      columnWidths: { A: 0.4, B: 30.6 },
+    });
+    const second = sanitizeSheetData(first);
+
+    expect(first.columnWidths).toEqual({ B: 31 });
+    expect(second.columnWidths).toEqual(first.columnWidths);
   });
 
   it('moveCellMetadata lets a relocated format win a collision', () => {

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -317,6 +317,63 @@ describe('format operations', () => {
   });
 });
 
+describe('review findings', () => {
+  it('the currency Excel code honours thousands: false', () => {
+    // `applyNumberFormat` renders ungrouped for this format; the Excel code
+    // must match or the workbook groups digits the grid does not.
+    const format = { kind: 'currency' as const, currency: 'USD', thousands: false };
+    expect(applyNumberFormat(1234.5, format)).toBe('$1234.50');
+    expect(numberFormatToExcelCode(format)).toBe('"$"0.00');
+  });
+
+  it('sanitizeSheetData rejects a format the read path would drop', () => {
+    // The write path must not persist what the read path discards, or a
+    // format survives one save and vanishes on the next load.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      formats: { A1: { fontSize: 9999 } as CellFormat },
+    };
+    expect(sanitizeSheetData(sheet).formats).toBeUndefined();
+  });
+
+  it('sanitizeSheetData validates column and row metadata too', () => {
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      columnFormats: { A: { align: 'right' }, '!!': { bold: true } as CellFormat },
+      columnWidths: { A: 100, '3': 50 },
+      rowHeights: { '1': 30, ABC: 40 },
+    };
+
+    const sanitized = sanitizeSheetData(sheet);
+    expect(sanitized.columnFormats).toEqual({ A: { align: 'right' } });
+    expect(sanitized.columnWidths).toEqual({ A: 100 });
+    expect(sanitized.rowHeights).toEqual({ '1': 30 });
+  });
+
+  it('moveCellMetadata lets a relocated format win a collision', () => {
+    // A structural edit maps only the cells that moved. Without explicit
+    // handling, a moved A1 -> A5 and a stationary A5 both write key A5 and
+    // iteration order decides which format survives.
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], { bold: true });
+    sheet = setCellFormats(sheet, ['A5'], { italic: true });
+
+    const moved = moveCellMetadata(sheet, new Map([['A1', 'A5']]));
+
+    expect(moved.formats?.A5).toEqual({ bold: true });
+    expect(moved.formats?.A1).toBeUndefined();
+  });
+
+  it('moveCellMetadata bumps the version like every other mutator', () => {
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], { bold: true });
+    const before = sheet.version;
+
+    const moved = moveCellMetadata(sheet, new Map([['A1', 'A2']]));
+    expect(moved.version).toBe(before + 1);
+  });
+});
+
 describe('formats and the evaluator', () => {
   it('applies the format to the displayed value', () => {
     let sheet = createEmptySheet();

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -5,12 +5,6 @@ import {
   cellFormatToInlineCss,
   cellFormatToStyle,
   clearCellFormats,
-  clampColumnWidth,
-  clampRowHeight,
-  MAX_COLUMN_WIDTH,
-  MAX_ROW_HEIGHT,
-  MIN_COLUMN_WIDTH,
-  MIN_ROW_HEIGHT,
   createEmptySheet,
   evaluateSheet,
   getEffectiveCellFormat,
@@ -320,6 +314,20 @@ describe('format operations', () => {
     expect(moved.version).toBe(sheet.version + 1);
   });
 
+  it('bumps the version when a collision drops the loser in the relocation pass', () => {
+    // The winner maps to its own address, so the "did the key change?" signal
+    // says no — but the loser's formatting is gone, which is a change.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      formats: { C1: { bold: true }, B1: { italic: true } } as Record<string, CellFormat>,
+    };
+
+    const moved = moveCellMetadata(sheet, new Map([['C1', 'C1'], ['B1', 'C1']]));
+
+    expect(moved.formats).toEqual({ C1: { bold: true } });
+    expect(moved.version).toBe(sheet.version + 1);
+  });
+
   it('bumps the version whenever the format map actually changes', () => {
     const withLowercase: SheetData = {
       ...createEmptySheet(),
@@ -475,9 +483,10 @@ describe('review findings', () => {
     expect(sanitized.rowHeights).toEqual({ '1': 30 });
   });
 
-  it('keeps a fractional width from vanishing on the following save', () => {
-    // Guarding the raw value let 0.4 through, which stored as 0 and was then
-    // dropped by the next save — stable only after two round trips.
+  it('settles a fractional width on the first save, not the second', () => {
+    // Guarding the raw value let 0.4 through, which stored as 0 and was only
+    // dropped by the NEXT save. A sub-half width is still discarded — but now
+    // on the first pass, so two consecutive saves agree.
     const first = sanitizeSheetData({
       ...createEmptySheet(),
       columnWidths: { A: 0.4, B: 30.6 },

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -18,6 +18,7 @@ import {
   moveCellMetadata,
   numberFormatToExcelCode,
   parseCellFormat,
+  resolveCellFormat,
   parseSheetContent,
   sanitizeSheetData,
   serializeSheetContent,
@@ -165,6 +166,41 @@ describe('format validation', () => {
     // Semicolons separate declarations and are expected; braces, angle brackets
     // and quotes would mean something escaped the allow-list.
     expect(css).not.toMatch(/[{}<>"']/);
+  });
+
+  it('does not throw on a stored __proto__ key', () => {
+    // `FIELD_SCHEMAS[key]` on an object literal resolves `__proto__` through
+    // the prototype chain to a non-schema, which threw inside every load and
+    // every save of a document carrying such a key.
+    const hostile = JSON.parse('{"bold":true,"__proto__":{"polluted":"yes"},"constructor":{"x":1}}');
+
+    expect(() => parseCellFormat(hostile)).not.toThrow();
+    expect(parseCellFormat(hostile)).toEqual({ bold: true });
+  });
+
+  it('cannot reach Object.prototype through a stored format', () => {
+    const hostile = JSON.parse('{"bold":true,"__proto__":{"polluted":"yes"}}');
+
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(sheet, ['A1'], parseCellFormat(hostile)!);
+    resolveCellFormat(parseCellFormat(hostile), { align: 'right' });
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(sheet.formats?.A1).toEqual({ bold: true });
+  });
+
+  it('keeps an unknown field out of the rendered CSS', () => {
+    // Unknown fields are preserved for forward compatibility, so they must be
+    // inert at every render boundary.
+    const format = parseCellFormat({
+      bold: true,
+      evilKey: '"><script>alert(1)</script>',
+      color: '#001122',
+    });
+
+    expect(format).toHaveProperty('evilKey');
+    expect(cellFormatToInlineCss(format)).toBe('font-weight:600;color:#001122');
+    expect(Object.keys(cellFormatToStyle(format))).toEqual(['fontWeight', 'color']);
   });
 
   it('treats an empty format as absent', () => {

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -350,6 +350,22 @@ describe('review findings', () => {
     expect(sanitized.rowHeights).toEqual({ '1': 30 });
   });
 
+  it('clamps stored dimensions that bypassed the setters', () => {
+    // Loaded content never goes through setColumnWidth/setRowHeight, so a
+    // negative or absurd stored size would otherwise reach the grid and the
+    // XLSX export intact.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      columnWidths: { A: -500, B: 999999, C: 180 },
+      rowHeights: { '1': -20, '2': 500000, '3': 32 },
+    };
+
+    const sanitized = sanitizeSheetData(sheet);
+
+    expect(sanitized.columnWidths).toEqual({ A: 24, B: 2000, C: 180 });
+    expect(sanitized.rowHeights).toEqual({ '1': 16, '2': 1000, '3': 32 });
+  });
+
   it('moveCellMetadata lets a relocated format win a collision', () => {
     // A structural edit maps only the cells that moved. Without explicit
     // handling, a moved A1 -> A5 and a stationary A5 both write key A5 and

--- a/packages/lib/src/__tests__/sheet-format.test.ts
+++ b/packages/lib/src/__tests__/sheet-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  addressesInRange,
   applyNumberFormat,
   cellFormatSchema,
   cellFormatToInlineCss,
@@ -518,6 +519,62 @@ describe('review findings', () => {
 
     const moved = moveCellMetadata(sheet, new Map([['A1', 'A2']]));
     expect(moved.version).toBe(before + 1);
+  });
+});
+
+describe('addressesInRange', () => {
+  // Zero callers today; this is what a formatting toolbar will use to apply a
+  // format across a selection, so an off-by-one here misformats every range.
+
+  it('returns a single cell for a degenerate range', () => {
+    expect(addressesInRange({ row: 0, column: 0 }, { row: 0, column: 0 })).toEqual(['A1']);
+  });
+
+  it('walks a rectangle row-major and includes both corners', () => {
+    expect(addressesInRange({ row: 0, column: 0 }, { row: 1, column: 2 })).toEqual([
+      'A1', 'B1', 'C1',
+      'A2', 'B2', 'C2',
+    ]);
+  });
+
+  it('does not care which corner is given first', () => {
+    const forward = addressesInRange({ row: 0, column: 0 }, { row: 2, column: 1 });
+
+    for (const [start, end] of [
+      [{ row: 2, column: 1 }, { row: 0, column: 0 }],
+      [{ row: 0, column: 1 }, { row: 2, column: 0 }],
+      [{ row: 2, column: 0 }, { row: 0, column: 1 }],
+    ] as const) {
+      expect(addressesInRange(start, end)).toEqual(forward);
+    }
+  });
+
+  it('spans multi-letter columns correctly', () => {
+    // Z -> AA is where a naive letter increment breaks.
+    expect(addressesInRange({ row: 0, column: 25 }, { row: 0, column: 27 })).toEqual([
+      'Z1',
+      'AA1',
+      'AB1',
+    ]);
+  });
+
+  it('produces exactly rows x columns addresses, all unique', () => {
+    const addresses = addressesInRange({ row: 3, column: 2 }, { row: 9, column: 6 });
+
+    expect(addresses).toHaveLength(7 * 5);
+    expect(new Set(addresses).size).toBe(addresses.length);
+  });
+
+  it('feeds setCellFormats so a whole selection is formatted', () => {
+    // The end-to-end shape the toolbar will use.
+    let sheet = createEmptySheet();
+    sheet = setCellFormats(
+      sheet,
+      addressesInRange({ row: 0, column: 0 }, { row: 1, column: 1 }),
+      { bold: true }
+    );
+
+    expect(Object.keys(sheet.formats ?? {}).sort()).toEqual(['A1', 'A2', 'B1', 'B2']);
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-io-roundtrip.test.ts
+++ b/packages/lib/src/__tests__/sheet-io-roundtrip.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest';
+import { parse as parseToml } from '@iarna/toml';
+import {
+  SHEETDOC_MAGIC,
+  SHEETDOC_VERSION,
+  createEmptySheet,
+  parseSheetContent,
+  parseSheetContentSafe,
+  serializeSheetContent,
+  stringifySheetDoc,
+  SheetSerializationError,
+  type SheetDoc,
+} from '../sheets/sheet';
+
+/**
+ * Regression suite for the serializer's escaping.
+ *
+ * A cell value that serializes to invalid TOML is not a cosmetic problem: the
+ * parser throws, `parseSheetContent` falls back to an empty sheet, and the
+ * next autosave persists that empty sheet — losing every cell in the document,
+ * not just the offending one. Public form submissions are written straight
+ * through `updateSheetCells`, so the input reaching this code is not trusted.
+ */
+
+const serializeAndParse = (cells: Record<string, string>) => {
+  const sheet = createEmptySheet();
+  Object.assign(sheet.cells, cells);
+  return parseSheetContent(serializeSheetContent(sheet));
+};
+
+describe('SheetDoc serialization round trip', () => {
+  const hostileValues: Array<[name: string, value: string]> = [
+    ['a newline', 'line one\nline two'],
+    ['a CRLF', 'carriage\r\nreturn'],
+    ['a bare carriage return', 'before\rafter'],
+    ['a tab', 'column\tseparated'],
+    ['a backslash', 'C:\\Users\\jono'],
+    ['a double quote', 'she said "hello"'],
+    ['triple quotes', 'a """ b'],
+    ['a single quote', "it's fine"],
+    ['a NUL byte', 'null\u0000byte'],
+    ['a unit separator', 'unit\u001fseparator'],
+    ['DEL', 'delete\u007fchar'],
+    ['a TOML comment marker', '#not a comment = really'],
+    ['a TOML table header', '[sheets.cells.A1]'],
+    ['an equals sign', 'key = value'],
+    ['an astral-plane emoji', 'party 🎉 time'],
+    ['an RTL mark', 'mixed \u200fdirection'],
+    ['a 10KB value', 'x'.repeat(10_000)],
+    ['only whitespace-adjacent quotes', '   "   '],
+  ];
+
+  it.each(hostileValues)('preserves a cell containing %s', (_name, value) => {
+    const parsed = serializeAndParse({ A1: value, B1: 'unrelated neighbour' });
+
+    expect(parsed.cells.A1).toBe(value);
+    // The neighbour is the canary: the failure mode is losing the whole
+    // document, not just the cell that triggered it.
+    expect(parsed.cells.B1).toBe('unrelated neighbour');
+  });
+
+  it.each(hostileValues)('emits parseable TOML for a cell containing %s', (_name, value) => {
+    const sheet = createEmptySheet();
+    sheet.cells.A1 = value;
+    const serialized = serializeSheetContent(sheet);
+
+    // Strip the magic header, which is not TOML.
+    const body = serialized.split('\n').slice(1).join('\n');
+    expect(() => parseToml(body)).not.toThrow();
+  });
+
+  it('preserves a formula containing a quoted newline', () => {
+    const parsed = serializeAndParse({ A1: '="first\nsecond"', B1: '=1+1' });
+
+    expect(parsed.cells.A1).toBe('="first\nsecond"');
+    expect(parsed.cells.B1).toBe('=1+1');
+  });
+
+  it('round-trips many hostile cells at once', () => {
+    const cells = Object.fromEntries(
+      hostileValues.map(([, value], index) => [`A${index + 1}`, value])
+    );
+    const parsed = serializeAndParse(cells);
+
+    expect(parsed.cells).toEqual(expect.objectContaining(cells));
+    expect(Object.keys(parsed.cells)).toHaveLength(hostileValues.length);
+  });
+
+  it('quotes column keys that are not bare-key safe', () => {
+    const doc: SheetDoc = {
+      version: SHEETDOC_VERSION,
+      sheets: [
+        {
+          name: 'Sheet1',
+          order: 0,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: { 'a key with spaces': { width: 120 } },
+          cells: {},
+          ranges: {},
+          dependencies: {},
+        },
+      ],
+    };
+
+    const body = stringifySheetDoc(doc).split('\n').slice(1).join('\n');
+    expect(() => parseToml(body)).not.toThrow();
+    expect(body).toContain('"a key with spaces"');
+  });
+
+  it('quotes range keys that are not bare-key safe', () => {
+    const doc: SheetDoc = {
+      version: SHEETDOC_VERSION,
+      sheets: [
+        {
+          name: 'Sheet1',
+          order: 0,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: {},
+          cells: {},
+          ranges: { 'my range': { ref: 'A1:B2' } },
+          dependencies: {},
+        },
+      ],
+    };
+
+    const body = stringifySheetDoc(doc).split('\n').slice(1).join('\n');
+    expect(() => parseToml(body)).not.toThrow();
+  });
+
+  it('quotes cell-address keys that are not bare-key safe', () => {
+    const doc: SheetDoc = {
+      version: SHEETDOC_VERSION,
+      sheets: [
+        {
+          name: 'Sheet1',
+          order: 0,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: {},
+          // Cell addresses are normally A1-shaped, but the emitter must not
+          // depend on an upstream guarantee to produce valid TOML.
+          cells: { 'not an address': { value: 1 } },
+          ranges: {},
+          dependencies: {},
+        },
+      ],
+    };
+
+    const body = stringifySheetDoc(doc).split('\n').slice(1).join('\n');
+    expect(() => parseToml(body)).not.toThrow();
+  });
+
+  it('quotes dependency keys that are not bare-key safe', () => {
+    const doc: SheetDoc = {
+      version: SHEETDOC_VERSION,
+      sheets: [
+        {
+          name: 'Sheet1',
+          order: 0,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: {},
+          cells: {},
+          ranges: {},
+          dependencies: { 'not an address': { dependsOn: [], dependents: ['A1'] } },
+        },
+      ],
+    };
+
+    const body = stringifySheetDoc(doc).split('\n').slice(1).join('\n');
+    expect(() => parseToml(body)).not.toThrow();
+  });
+
+  it('throws SheetSerializationError rather than emitting unparseable TOML', () => {
+    // `order` is emitted as a bare numeric literal, so a non-finite value
+    // produces `order = NaN` — invalid TOML. The guard must turn that into a
+    // loud failure on save instead of content that reads back as an empty
+    // sheet on the next load.
+    const doc = {
+      version: SHEETDOC_VERSION,
+      sheets: [
+        {
+          name: 'Sheet1',
+          order: Number.NaN,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: {},
+          cells: {},
+          ranges: {},
+          dependencies: {},
+        },
+      ],
+    } as unknown as SheetDoc;
+
+    expect(() => stringifySheetDoc(doc)).toThrow(SheetSerializationError);
+  });
+});
+
+describe('parseSheetContentSafe', () => {
+  it('reports a parse failure instead of silently returning an empty sheet', () => {
+    const result = parseSheetContentSafe(`${SHEETDOC_MAGIC} ${SHEETDOC_VERSION}\nthis is [not toml`);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('toml');
+      expect(result.message).toBeTruthy();
+    }
+  });
+
+  it('reports an unsupported version as a failure, not as empty content', () => {
+    const result = parseSheetContentSafe(`${SHEETDOC_MAGIC} v99`);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('Unsupported SheetDoc version');
+    }
+  });
+
+  it('reports malformed JSON as a failure', () => {
+    const result = parseSheetContentSafe('{"cells": ');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('json');
+    }
+  });
+
+  it('does not lock a page whose content was never a sheet', () => {
+    // Legacy plain text or HTML on a SHEET page holds no sheet data to lose.
+    // Reporting a failure would disable editing forever with nothing to
+    // recover, so it degrades to an empty sheet as it always did.
+    for (const legacy of ['<p>some old html</p>', 'just some text', 'not,a,sheet']) {
+      const result = parseSheetContentSafe(legacy);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('still reports malformed JSON, which may be a truncated sheet', () => {
+    const result = parseSheetContentSafe('{"cells": {"A1": "1"');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('json');
+    }
+  });
+
+  it('emits parseable TOML for a hostile meta key on a carried-through tab', () => {
+    // Extra tabs are re-emitted verbatim, including their meta, so an
+    // unescaped meta key would make the whole document unsavable — every
+    // keystroke would throw.
+    const doc: SheetDoc = {
+      version: SHEETDOC_VERSION,
+      sheets: [
+        {
+          name: 'First',
+          order: 0,
+          meta: { rowCount: 5, columnCount: 5 },
+          columns: {},
+          cells: {},
+          ranges: {},
+          dependencies: {},
+        },
+        {
+          name: 'Second',
+          order: 1,
+          meta: { rowCount: 5, columnCount: 5, 'a key with spaces': 'value' },
+          columns: {},
+          cells: {},
+          ranges: {},
+          dependencies: {},
+        },
+      ],
+    };
+
+    expect(() => stringifySheetDoc(doc)).not.toThrow();
+    const body = stringifySheetDoc(doc).split('\n').slice(1).join('\n');
+    expect(() => parseToml(body)).not.toThrow();
+  });
+
+  it('treats genuinely empty content as success', () => {
+    for (const empty of ['', '   ', null, undefined]) {
+      const result = parseSheetContentSafe(empty);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.sheet.cells).toEqual({});
+      }
+    }
+  });
+
+  it('agrees with parseSheetContent on well-formed content', () => {
+    const sheet = createEmptySheet();
+    sheet.cells.A1 = 'value with\nnewline';
+    const serialized = serializeSheetContent(sheet);
+
+    const result = parseSheetContentSafe(serialized);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.sheet).toEqual(parseSheetContent(serialized));
+    }
+  });
+});

--- a/packages/lib/src/__tests__/sheet-io-roundtrip.test.ts
+++ b/packages/lib/src/__tests__/sheet-io-roundtrip.test.ts
@@ -127,6 +127,56 @@ describe('SheetDoc serialization round trip', () => {
     expect(() => parseToml(body)).not.toThrow();
   });
 
+  it('round-trips a Date, whatever its year', () => {
+    // A Date reaches the emitter through an unknown format field of TOML
+    // datetime type. `Object.entries(date)` is empty, so it once serialized as
+    // `{}`; and `toISOString` uses the expanded-year form outside 0000-9999,
+    // which is not TOML and failed the serializer's self-verify — making the
+    // whole document unsavable rather than losing one field.
+    // The restored type differs by year, deliberately: a year TOML can express
+    // comes back as a real datetime, while an out-of-range one is quoted and
+    // comes back as the string — preserved either way, and the document saves.
+    const cases: Array<[string, Date, 'date' | 'string']> = [
+      ['a normal year', new Date('2020-01-01T00:00:00Z'), 'date'],
+      ['a five-digit year', new Date(Date.UTC(10000, 0, 1)), 'string'],
+      ['a negative year', new Date(Date.UTC(-1, 0, 1)), 'string'],
+    ];
+
+    for (const [name, when, restoredAs] of cases) {
+      const sheet = {
+        ...createEmptySheet(),
+        formats: { A1: { bold: true, when } as never },
+      };
+
+      expect(() => serializeSheetContent(sheet), name).not.toThrow();
+
+      const restored = parseSheetContent(serializeSheetContent(sheet)).formats?.A1 as
+        | (Record<string, unknown> | undefined);
+
+      expect(restored?.bold, name).toBe(true);
+
+      if (restoredAs === 'date') {
+        expect(restored?.when, name).toBeInstanceOf(Date);
+        expect((restored?.when as Date).toISOString(), name).toBe(when.toISOString());
+      } else {
+        expect(restored?.when, name).toBe(when.toISOString());
+      }
+    }
+  });
+
+  it('does not let an invalid Date break the document', () => {
+    const sheet = {
+      ...createEmptySheet(),
+      formats: { A1: { bold: true, when: new Date('not a date') } as never },
+    };
+
+    expect(() => serializeSheetContent(sheet)).not.toThrow();
+    expect(parseSheetContent(serializeSheetContent(sheet)).formats?.A1).toEqual({
+      bold: true,
+      when: '',
+    });
+  });
+
   it('quotes cell-address keys that are not bare-key safe', () => {
     const doc: SheetDoc = {
       version: SHEETDOC_VERSION,

--- a/packages/lib/src/__tests__/sheet-multitab.test.ts
+++ b/packages/lib/src/__tests__/sheet-multitab.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEmptySheet,
+  parseSheetContent,
+  parseSheetDocString,
+  serializeSheetContent,
+  setCellFormats,
+  setColumnFormat,
+  type SheetData,
+} from '../sheets/sheet';
+
+/**
+ * The editor renders only the first tab. Before this, everything after it was
+ * dropped on load and never written back, so opening a three-tab workbook and
+ * typing one character silently deleted two tabs.
+ *
+ * Full multi-tab editing is a later change; the guarantee here is narrower and
+ * non-negotiable: a load/save cycle must not lose data.
+ */
+
+const multiTabDocument = [
+  '#%PAGESPACE_SHEETDOC v1',
+  '',
+  '[[sheets]]',
+  'name = "First"',
+  'order = 0',
+  '',
+  '[sheets.meta]',
+  'row_count = 20',
+  'column_count = 10',
+  '',
+  '[sheets.cells.A1]',
+  'value = "first tab"',
+  'type = "string"',
+  '',
+  '[[sheets]]',
+  'name = "Second"',
+  'order = 1',
+  '',
+  '[sheets.meta]',
+  'row_count = 30',
+  'column_count = 12',
+  '',
+  '[sheets.cells.B2]',
+  'value = 42',
+  'type = "number"',
+  '',
+  '[[sheets]]',
+  'name = "Third"',
+  'order = 2',
+  '',
+  '[sheets.meta]',
+  'row_count = 8',
+  'column_count = 4',
+  '',
+  '[sheets.cells.C3]',
+  'formula = "=1+1"',
+  'value = 2',
+  'type = "number"',
+  '',
+].join('\n');
+
+describe('multi-tab documents', () => {
+  it('loads the first tab as the active sheet', () => {
+    const sheet = parseSheetContent(multiTabDocument);
+
+    expect(sheet.cells.A1).toBe('first tab');
+    expect(sheet.sheetName).toBe('First');
+    expect(sheet.rowCount).toBe(20);
+  });
+
+  it('carries the remaining tabs alongside', () => {
+    const sheet = parseSheetContent(multiTabDocument);
+
+    expect(sheet.extraSheets).toHaveLength(2);
+    expect(sheet.extraSheets?.map((tab) => tab.name)).toEqual(['Second', 'Third']);
+  });
+
+  it('still has three tabs after a save', () => {
+    const sheet = parseSheetContent(multiTabDocument);
+    const doc = parseSheetDocString(serializeSheetContent(sheet));
+
+    expect(doc.sheets).toHaveLength(3);
+    expect(doc.sheets.map((tab) => tab.name)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('leaves the other tabs byte-identical when the first is edited', () => {
+    const sheet = parseSheetContent(multiTabDocument);
+    const before = parseSheetDocString(multiTabDocument);
+
+    let edited: SheetData = { ...sheet, cells: { ...sheet.cells, A1: 'edited' } };
+    edited = setCellFormats(edited, ['A1'], { bold: true });
+
+    const after = parseSheetDocString(serializeSheetContent(edited));
+
+    expect(after.sheets[1]).toEqual(before.sheets[1]);
+    expect(after.sheets[2]).toEqual(before.sheets[2]);
+    expect(after.sheets[0].cells.A1?.value).toBe('edited');
+  });
+
+  it('survives repeated load/save cycles without drift', () => {
+    let content = multiTabDocument;
+    for (let cycle = 0; cycle < 3; cycle++) {
+      content = serializeSheetContent(parseSheetContent(content));
+    }
+
+    const doc = parseSheetDocString(content);
+    expect(doc.sheets.map((tab) => tab.name)).toEqual(['First', 'Second', 'Third']);
+    expect(doc.sheets[1].cells.B2?.value).toBe(42);
+    expect(doc.sheets[2].cells.C3?.formula).toBe('=1+1');
+  });
+
+  it('preserves the sheet name of a single-tab document', () => {
+    const named = serializeSheetContent(createEmptySheet(), { sheetName: 'Budget' });
+    const sheet = parseSheetContent(named);
+
+    expect(sheet.sheetName).toBe('Budget');
+    expect(parseSheetDocString(serializeSheetContent(sheet)).sheets[0].name).toBe('Budget');
+  });
+
+  it('preserves named ranges it does not understand', () => {
+    // Nothing resolves named ranges yet, but a save must not delete content
+    // written by a newer build or by hand.
+    const withRange = [
+      '#%PAGESPACE_SHEETDOC v1',
+      '',
+      '[[sheets]]',
+      'name = "S"',
+      'order = 0',
+      '',
+      '[sheets.meta]',
+      'row_count = 5',
+      'column_count = 5',
+      '',
+      '[sheets.cells.A1]',
+      'value = 1',
+      'type = "number"',
+      '',
+      '[sheets.ranges.myRange]',
+      'ref = "A1:B2"',
+      '',
+    ].join('\n');
+
+    const doc = parseSheetDocString(serializeSheetContent(parseSheetContent(withRange)));
+    expect(doc.sheets[0].ranges.myRange).toEqual({ ref: 'A1:B2' });
+  });
+
+  it('keeps internal layout keys out of the user-visible ranges', () => {
+    let sheet = createEmptySheet();
+    sheet.cells.A1 = '1';
+    sheet = setColumnFormat(sheet, 0, { align: 'right' });
+
+    const restored = parseSheetContent(serializeSheetContent(sheet));
+
+    // `__columnFormats` is an implementation detail of where column defaults
+    // are stored; it must not resurface as if the user had defined a range.
+    expect(restored.ranges).toBeUndefined();
+    expect(restored.columnFormats).toEqual({ A: { align: 'right' } });
+  });
+
+  it('adds no extra tabs to an ordinary single-tab document', () => {
+    const sheet = createEmptySheet();
+    sheet.cells.A1 = 'solo';
+
+    const doc = parseSheetDocString(serializeSheetContent(sheet));
+    expect(doc.sheets).toHaveLength(1);
+    expect(parseSheetContent(serializeSheetContent(sheet)).extraSheets).toBeUndefined();
+  });
+});

--- a/packages/lib/src/__tests__/sheet-write-guard.test.ts
+++ b/packages/lib/src/__tests__/sheet-write-guard.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEmptySheet,
+  parseSheetContent,
+  parseSheetContentSafe,
+  serializeSheetContent,
+  updateSheetCells,
+} from '../sheets/sheet';
+
+/**
+ * Every server-side write path follows the same shape:
+ *
+ *   parse existing content -> updateSheetCells -> serialize -> store
+ *
+ * If the parse silently yields an empty sheet for content it merely failed to
+ * read, that pipeline replaces the user's entire spreadsheet with whatever the
+ * caller happened to be writing. This suite pins the difference between the
+ * two parse functions so the guard cannot be quietly removed from a caller.
+ */
+
+const unreadableContent = [
+  '#%PAGESPACE_SHEETDOC v1',
+  '',
+  '[[sheets]]',
+  'name = "Sheet1"',
+  'order = 0',
+  '',
+  '[sheets.meta]',
+  'row_count = 20',
+  'column_count = 10',
+  '',
+  '[sheets.cells.A1]',
+  'value = "this line never closes',
+  '',
+].join('\n');
+
+describe('write-path guard', () => {
+  it('the unsafe parse turns unreadable content into an empty sheet', () => {
+    // This is the trap every write path has to avoid.
+    const sheet = parseSheetContent(unreadableContent);
+    expect(Object.keys(sheet.cells)).toHaveLength(0);
+  });
+
+  it('the safe parse reports the failure instead', () => {
+    const result = parseSheetContentSafe(unreadableContent);
+    expect(result.ok).toBe(false);
+  });
+
+  it('appending a row to unreadable content would destroy the sheet', () => {
+    // Demonstrates the concrete data loss: a public form submission appending
+    // one row ends up storing a document that contains only that row.
+    const sheet = parseSheetContent(unreadableContent);
+    const withRow = updateSheetCells(sheet, [{ address: 'A2', value: 'submitted' }]);
+    const stored = parseSheetContent(serializeSheetContent(withRow));
+
+    expect(Object.keys(stored.cells)).toEqual(['A2']);
+  });
+
+  it('a guarded caller stops before writing anything', () => {
+    const parsed = parseSheetContentSafe(unreadableContent);
+
+    // The shape every write path uses: bail out rather than continue.
+    if (parsed.ok) {
+      throw new Error('expected the guard to reject unreadable content');
+    }
+    expect(parsed.reason).toBe('toml');
+  });
+
+  it('readable content still flows through the guard untouched', () => {
+    const sheet = createEmptySheet();
+    sheet.cells.A1 = 'existing';
+    const content = serializeSheetContent(sheet);
+
+    const parsed = parseSheetContentSafe(content);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    const withRow = updateSheetCells(parsed.sheet, [{ address: 'A2', value: 'submitted' }]);
+    const stored = parseSheetContent(serializeSheetContent(withRow));
+
+    expect(stored.cells.A1).toBe('existing');
+    expect(stored.cells.A2).toBe('submitted');
+  });
+});

--- a/packages/lib/src/content/export-utils.ts
+++ b/packages/lib/src/content/export-utils.ts
@@ -77,16 +77,77 @@ export function generateCSV(data: string[][]): string {
 }
 
 /**
+ * The underlying values and formats behind the displayed grid, so an export
+ * can carry real numbers and number formats instead of formatted text.
+ */
+export interface TypedSheetExport {
+  /** Row-major computed values, parallel to the `data` passed to generateExcel. */
+  values: (number | string | boolean | null | undefined)[][];
+  /** Excel number-format codes (`z`), parallel to `values`. */
+  numberFormats?: (string | undefined)[][];
+  /** Column widths in px, by column index; converted to Excel character units. */
+  columnWidths?: (number | undefined)[];
+}
+
+/*
+ * Note: frozen panes are deliberately not exported. `xlsx@0.18.5` (the
+ * community build) ignores a `!freeze` worksheet property — it writes no
+ * `<pane>` element — so setting it would be dead code implying a feature that
+ * does not survive the round trip.
+ */
+
+/** Excel measures column width in characters; the grid measures it in pixels. */
+const pxToExcelWidth = (px: number): number => Math.max(1, Math.round((px - 5) / 7));
+
+function applyTypedCells(
+  worksheet: XLSX.WorkSheet,
+  typed: TypedSheetExport
+): void {
+  typed.values.forEach((row, rowIndex) => {
+    row.forEach((value, columnIndex) => {
+      if (value === null || value === undefined || value === '') {
+        return;
+      }
+
+      const address = XLSX.utils.encode_cell({ r: rowIndex, c: columnIndex });
+      const cell = worksheet[address] as XLSX.CellObject | undefined;
+      if (!cell) {
+        return;
+      }
+
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        cell.t = 'n';
+        cell.v = value;
+      } else if (typeof value === 'boolean') {
+        cell.t = 'b';
+        cell.v = value;
+      } else {
+        // Leave text as text — but keep the displayed string, which may be
+        // formatted, as what the user sees.
+        return;
+      }
+
+      const numberFormat = typed.numberFormats?.[rowIndex]?.[columnIndex];
+      if (numberFormat) {
+        cell.z = numberFormat;
+      }
+    });
+  });
+}
+
+/**
  * Generates an Excel (.xlsx) buffer from a 2D array of cell values
  * @param data - 2D array of cell display values
  * @param sheetName - Name of the worksheet (default: 'Sheet1')
  * @param title - Workbook title
+ * @param typed - Optional underlying values/formats, so numbers export as numbers
  * @returns Buffer containing the Excel data
  */
 export function generateExcel(
   data: string[][],
   sheetName: string = 'Sheet1',
-  title?: string
+  title?: string,
+  typed?: TypedSheetExport
 ): Buffer {
   try {
     // Create a new workbook
@@ -104,6 +165,13 @@ export function generateExcel(
     // Create worksheet from 2D array
     const worksheet = XLSX.utils.aoa_to_sheet(data);
 
+    // Replace the string cells with real typed ones where we know the
+    // underlying value. Exporting every number as text is what makes an
+    // exported sheet unusable in Excel: nothing sums, sorts or charts.
+    if (typed) {
+      applyTypedCells(worksheet, typed);
+    }
+
     // Auto-size columns based on content
     const maxColumnWidths: number[] = [];
     data.forEach(row => {
@@ -115,10 +183,15 @@ export function generateExcel(
       });
     });
 
-    // Set column widths (with a max of 50 characters)
-    worksheet['!cols'] = maxColumnWidths.map(width => ({
-      wch: Math.min(width + 2, 50)
-    }));
+    // Set column widths (with a max of 50 characters). An explicit width set in
+    // the sheet wins over the auto-size guess.
+    worksheet['!cols'] = maxColumnWidths.map((width, columnIndex) => {
+      const explicit = typed?.columnWidths?.[columnIndex];
+      if (typeof explicit === 'number' && Number.isFinite(explicit)) {
+        return { wch: pxToExcelWidth(explicit) };
+      }
+      return { wch: Math.min(width + 2, 50) };
+    });
 
     // Add worksheet to workbook
     XLSX.utils.book_append_sheet(workbook, worksheet, sheetName);

--- a/packages/lib/src/content/export-utils.ts
+++ b/packages/lib/src/content/export-utils.ts
@@ -1,5 +1,6 @@
 import HTMLtoDOCX from 'html-to-docx';
 import * as XLSX from 'xlsx';
+import { clampColumnWidth } from '../sheets/format-ops';
 
 /**
  * Generates a DOCX buffer from HTML content
@@ -96,8 +97,13 @@ export interface TypedSheetExport {
  * does not survive the round trip.
  */
 
-/** Excel measures column width in characters; the grid measures it in pixels. */
-const pxToExcelWidth = (px: number): number => Math.max(1, Math.round((px - 5) / 7));
+/**
+ * Excel measures column width in characters; the grid measures it in pixels.
+ * Stored widths are kept exactly as authored, so the bound is applied here at
+ * the point of use rather than by rewriting the document.
+ */
+const pxToExcelWidth = (px: number): number =>
+  Math.max(1, Math.round((clampColumnWidth(px) - 5) / 7));
 
 function applyTypedCells(
   worksheet: XLSX.WorkSheet,
@@ -189,14 +195,38 @@ export function generateExcel(
     // columns that actually hold data, and it is sparse when rows differ in
     // length — `.map` skips holes — so deriving `!cols` from it alone drops an
     // explicit width for any column past the widest row or at a hole.
+    //
+    // A column with neither data nor an explicit width gets NO entry, leaving
+    // Excel's own default. Emitting a measured-width fallback for those would
+    // pin every empty column of the grid to ~2 characters, collapsing them.
     const columnCount = Math.max(maxColumnWidths.length, typed?.columnWidths?.length ?? 0);
-    worksheet['!cols'] = Array.from({ length: columnCount }, (_, columnIndex) => {
-      const explicit = typed?.columnWidths?.[columnIndex];
-      if (typeof explicit === 'number' && Number.isFinite(explicit)) {
-        return { wch: pxToExcelWidth(explicit) };
+    const columnInfo: (XLSX.ColInfo | undefined)[] = Array.from(
+      { length: columnCount },
+      (_, columnIndex) => {
+        const explicit = typed?.columnWidths?.[columnIndex];
+        if (typeof explicit === 'number' && Number.isFinite(explicit)) {
+          return { wch: pxToExcelWidth(explicit) };
+        }
+
+        // `> 0`, not just "is a number": the display grid is dense, so every
+        // empty column measures 0 and would otherwise get `{wch: 2}` — pinning
+        // it to ~2 characters instead of leaving Excel's default.
+        const measured = maxColumnWidths[columnIndex];
+        if (typeof measured === 'number' && measured > 0) {
+          return { wch: Math.min(measured + 2, 50) };
+        }
+
+        return undefined;
       }
-      return { wch: Math.min((maxColumnWidths[columnIndex] ?? 0) + 2, 50) };
-    });
+    );
+
+    // Trailing gaps carry no information; dropping them keeps `!cols` the same
+    // length it was before an explicit width was ever supplied.
+    while (columnInfo.length > 0 && columnInfo[columnInfo.length - 1] === undefined) {
+      columnInfo.pop();
+    }
+
+    worksheet['!cols'] = columnInfo as XLSX.ColInfo[];
 
     // Add worksheet to workbook
     XLSX.utils.book_append_sheet(workbook, worksheet, sheetName);

--- a/packages/lib/src/content/export-utils.ts
+++ b/packages/lib/src/content/export-utils.ts
@@ -1,6 +1,6 @@
 import HTMLtoDOCX from 'html-to-docx';
 import * as XLSX from 'xlsx';
-import { clampColumnWidth } from '../sheets/format-ops';
+import { MAX_COLUMN_WIDTH } from '../sheets/format-ops';
 
 /**
  * Generates a DOCX buffer from HTML content
@@ -97,13 +97,21 @@ export interface TypedSheetExport {
  * does not survive the round trip.
  */
 
+/** Excel's own maximum column width, in characters. */
+const EXCEL_MAX_COLUMN_CHARS = 255;
+
 /**
  * Excel measures column width in characters; the grid measures it in pixels.
- * Stored widths are kept exactly as authored, so the bound is applied here at
- * the point of use rather than by rewriting the document.
+ *
+ * Only an upper bound is applied. Clamping up to the editor's minimum would
+ * contradict keeping storage faithful — a sheet may legitimately carry a
+ * narrower gutter than the editor lets you drag to, and rewriting it on export
+ * is the same overreach as rewriting it on save.
  */
-const pxToExcelWidth = (px: number): number =>
-  Math.max(1, Math.round((clampColumnWidth(px) - 5) / 7));
+const pxToExcelWidth = (px: number): number => {
+  const bounded = Math.min(px, MAX_COLUMN_WIDTH);
+  return Math.min(EXCEL_MAX_COLUMN_CHARS, Math.max(1, Math.round((bounded - 5) / 7)));
+};
 
 function applyTypedCells(
   worksheet: XLSX.WorkSheet,

--- a/packages/lib/src/content/export-utils.ts
+++ b/packages/lib/src/content/export-utils.ts
@@ -1,6 +1,5 @@
 import HTMLtoDOCX from 'html-to-docx';
 import * as XLSX from 'xlsx';
-import { MAX_COLUMN_WIDTH } from '../sheets/format-ops';
 
 /**
  * Generates a DOCX buffer from HTML content
@@ -108,10 +107,8 @@ const EXCEL_MAX_COLUMN_CHARS = 255;
  * narrower gutter than the editor lets you drag to, and rewriting it on export
  * is the same overreach as rewriting it on save.
  */
-const pxToExcelWidth = (px: number): number => {
-  const bounded = Math.min(px, MAX_COLUMN_WIDTH);
-  return Math.min(EXCEL_MAX_COLUMN_CHARS, Math.max(1, Math.round((bounded - 5) / 7)));
-};
+const pxToExcelWidth = (px: number): number =>
+  Math.min(EXCEL_MAX_COLUMN_CHARS, Math.max(1, Math.round((px - 5) / 7)));
 
 function applyTypedCells(
   worksheet: XLSX.WorkSheet,
@@ -197,8 +194,9 @@ export function generateExcel(
       });
     });
 
-    // Set column widths (with a max of 50 characters). An explicit width set in
-    // the sheet wins over the auto-size guess.
+    // An explicit width set in the sheet wins over the auto-size guess. A
+    // measured width is capped at 50 characters; an explicit one only by
+    // Excel's own 255-character maximum.
     // Size by the wider of the two sources. `maxColumnWidths` only covers
     // columns that actually hold data, and it is sparse when rows differ in
     // length — `.map` skips holes — so deriving `!cols` from it alone drops an

--- a/packages/lib/src/content/export-utils.ts
+++ b/packages/lib/src/content/export-utils.ts
@@ -185,12 +185,17 @@ export function generateExcel(
 
     // Set column widths (with a max of 50 characters). An explicit width set in
     // the sheet wins over the auto-size guess.
-    worksheet['!cols'] = maxColumnWidths.map((width, columnIndex) => {
+    // Size by the wider of the two sources. `maxColumnWidths` only covers
+    // columns that actually hold data, and it is sparse when rows differ in
+    // length — `.map` skips holes — so deriving `!cols` from it alone drops an
+    // explicit width for any column past the widest row or at a hole.
+    const columnCount = Math.max(maxColumnWidths.length, typed?.columnWidths?.length ?? 0);
+    worksheet['!cols'] = Array.from({ length: columnCount }, (_, columnIndex) => {
       const explicit = typed?.columnWidths?.[columnIndex];
       if (typeof explicit === 'number' && Number.isFinite(explicit)) {
         return { wch: pxToExcelWidth(explicit) };
       }
-      return { wch: Math.min(width + 2, 50) };
+      return { wch: Math.min((maxColumnWidths[columnIndex] ?? 0) + 2, 50) };
     });
 
     // Add worksheet to workbook

--- a/packages/lib/src/content/page-type-validators.ts
+++ b/packages/lib/src/content/page-type-validators.ts
@@ -1,6 +1,11 @@
 import { PageType } from '../utils/enums';
 import { getPageTypeConfig } from './page-types.config';
-import { parseSheetContent, SHEET_DEFAULT_ROWS, SHEET_DEFAULT_COLUMNS } from '../sheets/sheet';
+import {
+  parseSheetContent,
+  parseSheetContentSafe,
+  SHEET_DEFAULT_ROWS,
+  SHEET_DEFAULT_COLUMNS,
+} from '../sheets/sheet';
 
 export interface ValidationResult {
   valid: boolean;
@@ -32,9 +37,12 @@ function isValidSheetContent(content: string): boolean {
 
   // If content was provided but we got default empty sheet, it's invalid
   if (trimmed !== '' && isDefaultEmptySheet) {
-    // Check if it's valid JSON or SheetDoc format
+    // The magic prefix alone proves nothing — content whose TOML body is
+    // malformed carries it too, and accepting that here is what lets corrupt
+    // content reach storage and read back as an empty sheet. Require the body
+    // to actually parse.
     if (trimmed.startsWith('#%PAGESPACE_SHEETDOC')) {
-      return true; // SheetDoc format is valid
+      return parseSheetContentSafe(content).ok;
     }
 
     try {

--- a/packages/lib/src/publish/render-sheet-page.ts
+++ b/packages/lib/src/publish/render-sheet-page.ts
@@ -1,7 +1,12 @@
 import { renderCanvasDocument } from '../canvas/render-document';
 import { buildDocumentCsp } from '../canvas/csp';
 import { escapeHtml } from '../utils/html';
-import { evaluateSheet, parseSheetContent } from '../sheets/sheet';
+import {
+  cellFormatToInlineCss,
+  encodeCellAddress,
+  evaluateSheet,
+  parseSheetContent,
+} from '../sheets/sheet';
 import { wrapDocumentBody, DOCUMENT_TYPOGRAPHY_CSS } from './document-shell';
 
 export interface RenderSheetPageInput {
@@ -38,14 +43,45 @@ function buildSheetTableHtml(serializedContent: unknown, hasHeaders?: boolean): 
       return EMPTY_STATE_HTML;
     }
 
-    const { display } = evaluateSheet(sheet);
+    const evaluation = evaluateSheet(sheet);
+    const { display } = evaluation;
+
+    // Carry the sheet's formatting into the published snapshot, so a laid-out
+    // sheet still reads as one once published. `cellFormatToInlineCss` emits
+    // only known properties with re-validated values — user-supplied colors
+    // never reach the attribute verbatim, which matters because this document
+    // is served with `script-src 'none'` but still honours inline styles.
+    const styleAttribute = (rowIndex: number, columnIndex: number): string => {
+      const cell = evaluation.byAddress[encodeCellAddress(rowIndex, columnIndex)];
+      const css = cellFormatToInlineCss(cell?.format);
+      return css ? ` style="${escapeHtml(css)}"` : '';
+    };
+
+    const renderCell = (
+      value: string,
+      rowIndex: number,
+      columnIndex: number,
+      tag: 'th' | 'td'
+    ): string => `<${tag}${styleAttribute(rowIndex, columnIndex)}>${escapeHtml(value)}</${tag}>`;
+
     const headerRow = hasHeaders ? display[0] : null;
     const bodyRows = hasHeaders ? display.slice(1) : display;
+    const bodyOffset = hasHeaders ? 1 : 0;
+
     const theadHtml = headerRow
-      ? `<thead><tr>${headerRow.map((cell) => `<th>${escapeHtml(cell)}</th>`).join('')}</tr></thead>`
+      ? `<thead><tr>${headerRow
+          .map((cell, columnIndex) => renderCell(cell, 0, columnIndex, 'th'))
+          .join('')}</tr></thead>`
       : '';
     const tbodyHtml = `<tbody>${bodyRows
-      .map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join('')}</tr>`)
+      .map(
+        (row, rowIndex) =>
+          `<tr>${row
+            .map((cell, columnIndex) =>
+              renderCell(cell, rowIndex + bodyOffset, columnIndex, 'td')
+            )
+            .join('')}</tr>`
+      )
       .join('')}</tbody>`;
 
     return `<table>${theadHtml}${tbodyHtml}</table>`;

--- a/packages/lib/src/sheets/evaluation.ts
+++ b/packages/lib/src/sheets/evaluation.ts
@@ -19,6 +19,10 @@ import { LOCAL_PAGE_KEY } from './constants';
 import { encodeCellAddress, expandRange, numberRegex } from './address';
 import { tokenize, FormulaParser } from './parser';
 import { evaluateFunction, flattenValue, coerceNumber, formatDisplayValue } from './functions';
+import { applyNumberFormat, resolveCellFormat } from './format';
+
+/** Column letters of an A1 address, for column-default format lookup. */
+const columnLettersOf = (address: string): string => address.replace(/\d+$/, '');
 
 interface EvaluationEnvironment {
   options: SheetEvaluationOptions;
@@ -434,6 +438,29 @@ function evaluateCellInternal(
       dependsOn: [],
       dependents: [],
     };
+  }
+
+  // Apply presentation last, in one place, so the grid, both exports and the
+  // published page all read the same `display`.
+  //
+  // This deliberately rewrites only `display` and never `value`: the
+  // concatenation and comparison operators format *values* via
+  // `formatDisplayValue`, so touching `value` here would make `="Total: "&A1`
+  // embed a currency symbol and `A1=B1` compare formatted text.
+  const format = resolveCellFormat(
+    sheet.formats?.[normalized],
+    sheet.columnFormats?.[columnLettersOf(normalized)]
+  );
+
+  if (format) {
+    result.format = format;
+
+    if (!result.error) {
+      const formatted = applyNumberFormat(result.value, format.number);
+      if (formatted !== null) {
+        result.display = formatted;
+      }
+    }
   }
 
   cache.set(normalized, result);

--- a/packages/lib/src/sheets/format-ops.ts
+++ b/packages/lib/src/sheets/format-ops.ts
@@ -22,6 +22,9 @@ const normalizeAddress = (address: string): string | null => {
 
 const columnLettersOf = (address: string): string => address.replace(/\d+$/, '');
 
+/** Keys that would touch a prototype rather than a property if assigned. */
+const FORBIDDEN_ADDRESSES = new Set(['__proto__', 'constructor', 'prototype']);
+
 /** Column letters for a 0-based column index ("A", "AB"). */
 export const columnKeyFromIndex = (index: number): string =>
   columnLettersOf(encodeCellAddress(0, index));
@@ -243,7 +246,10 @@ export function moveCellMetadata(
     ([address, format]) => [normalizeAddress(address) ?? address, format] as const
   );
 
-  let changed = false;
+  // Normalizing a stored key rewrites the map even when nothing moved, so the
+  // version must reflect that too — otherwise a changed sheet reports itself
+  // unchanged.
+  let changed = entries.some(([address], index) => address !== Object.keys(sheet.formats!)[index]);
 
   for (const [address, format] of entries) {
     if (!addressMap.has(address)) continue;
@@ -255,7 +261,11 @@ export function moveCellMetadata(
     }
 
     const normalized = normalizeAddress(target);
-    if (!normalized) continue;
+    if (!normalized) {
+      // The target is not an address, so this format is being discarded.
+      changed = true;
+      continue;
+    }
 
     // Two entries can map to the SAME target — a delete that collapses rows
     // does exactly that. Last-writer-wins would make the survivor depend on
@@ -269,8 +279,25 @@ export function moveCellMetadata(
 
   for (const [address, format] of entries) {
     if (addressMap.has(address)) continue;
-    if (relocated.has(address)) continue;
+
+    // Normalizing source keys can make two stored entries collide (`A1` and
+    // `a1`). Without this guard the loser is destroyed by iteration order —
+    // the same last-writer-wins the relocation pass above exists to prevent.
+    if (relocated.has(address)) {
+      changed = true;
+      continue;
+    }
+
+    // `formats[address] = …` with `address === '__proto__'` would set the
+    // returned object's prototype rather than a key. Unreachable today because
+    // `sanitizeFormats` rejects non-A1 keys, but this function is public.
+    if (FORBIDDEN_ADDRESSES.has(address)) {
+      changed = true;
+      continue;
+    }
+
     formats[address] = format;
+    relocated.add(address);
   }
 
   // Bump only on a real change. Bumping for an empty map — while the

--- a/packages/lib/src/sheets/format-ops.ts
+++ b/packages/lib/src/sheets/format-ops.ts
@@ -214,22 +214,35 @@ export function moveCellMetadata(
   }
 
   const formats: Record<string, CellFormat> = {};
+  const relocated = new Set<string>();
 
+  // Two passes, relocations first. A moved entry and a stationary one can
+  // target the same address — mapping A1 -> A5 while an untouched A5 exists —
+  // and a single pass would let iteration order decide which survives, losing
+  // one format silently. The relocated entry wins, matching what a structural
+  // edit means: the cell that moved into this address brought its formatting.
   for (const [address, format] of Object.entries(sheet.formats)) {
-    if (!addressMap.has(address)) {
-      formats[address] = format;
-      continue;
-    }
+    if (!addressMap.has(address)) continue;
 
     const target = addressMap.get(address);
     if (target === null || target === undefined) continue;
 
     const normalized = normalizeAddress(target);
-    if (normalized) formats[normalized] = format;
+    if (normalized) {
+      formats[normalized] = format;
+      relocated.add(normalized);
+    }
+  }
+
+  for (const [address, format] of Object.entries(sheet.formats)) {
+    if (addressMap.has(address)) continue;
+    if (relocated.has(address)) continue;
+    formats[address] = format;
   }
 
   return {
     ...sheet,
+    version: sheet.version + 1,
     formats: Object.keys(formats).length > 0 ? formats : undefined,
   };
 }

--- a/packages/lib/src/sheets/format-ops.ts
+++ b/packages/lib/src/sheets/format-ops.ts
@@ -130,21 +130,6 @@ export const MAX_ROW_HEIGHT = 1000;
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, Math.round(value)));
 
-/**
- * Bound a stored column width for rendering or export.
- *
- * Stored values are kept exactly as authored — a sheet may legitimately carry
- * a narrower gutter than the editor's own minimum — so anything that turns a
- * width into pixels or Excel character units clamps here rather than letting
- * sanitization rewrite the document.
- */
-export const clampColumnWidth = (width: number): number =>
-  clamp(width, MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH);
-
-/** The row-height counterpart of {@link clampColumnWidth}. */
-export const clampRowHeight = (height: number): number =>
-  clamp(height, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT);
-
 /** Set a column's width in px, or clear it by passing `undefined`. */
 export function setColumnWidth(
   sheet: SheetData,
@@ -271,8 +256,13 @@ export function moveCellMetadata(
 
     // Two entries can map to the SAME target — a delete that collapses rows
     // does exactly that. Last-writer-wins would make the survivor depend on
-    // iteration order, so the first relocation into an address keeps it.
-    if (relocated.has(normalized)) continue;
+    // iteration order, so the first relocation into an address keeps it, and
+    // the loser being discarded is itself a change even when the winner
+    // maps to its own address.
+    if (relocated.has(normalized)) {
+      changed = true;
+      continue;
+    }
 
     formats[normalized] = format;
     relocated.add(normalized);

--- a/packages/lib/src/sheets/format-ops.ts
+++ b/packages/lib/src/sheets/format-ops.ts
@@ -242,14 +242,16 @@ export function moveCellMetadata(
   // Source keys are normalized before lookup so a lowercase stored address
   // still matches an uppercase map entry — otherwise the move is silently
   // ignored and the stale key survives alongside its relocated twin.
-  const entries = Object.entries(sheet.formats).map(
+  const storedEntries = Object.entries(sheet.formats);
+  const entries = storedEntries.map(
     ([address, format]) => [normalizeAddress(address) ?? address, format] as const
   );
 
   // Normalizing a stored key rewrites the map even when nothing moved, so the
   // version must reflect that too — otherwise a changed sheet reports itself
-  // unchanged.
-  let changed = entries.some(([address], index) => address !== Object.keys(sheet.formats!)[index]);
+  // unchanged. Compared against the same array the entries came from, rather
+  // than re-deriving the keys per element.
+  let changed = entries.some(([address], index) => address !== storedEntries[index][0]);
 
   for (const [address, format] of entries) {
     if (!addressMap.has(address)) continue;

--- a/packages/lib/src/sheets/format-ops.ts
+++ b/packages/lib/src/sheets/format-ops.ts
@@ -1,0 +1,333 @@
+/**
+ * @module @pagespace/lib/sheets/format-ops
+ * @description The single mutation surface for a sheet's presentation maps.
+ *
+ * Formats, column widths and row heights live in maps parallel to `cells`
+ * rather than inside the cell values. That keeps every existing consumer of
+ * `cells` working unchanged and makes "clear contents, keep formatting" the
+ * natural behaviour — but it also means the two can drift apart if a future
+ * structural edit (insert/delete row or column) moves cells without moving
+ * their metadata. Routing every write through this module, and through
+ * `moveCellMetadata` in particular, is what keeps them in step.
+ */
+
+import type { CellFormat, SheetData } from './types';
+import { isEmptyFormat, resolveCellFormat } from './format';
+import { cellRegex, decodeCellAddress, encodeCellAddress } from './address';
+
+const normalizeAddress = (address: string): string | null => {
+  const normalized = address.trim().toUpperCase();
+  return cellRegex.test(normalized) ? normalized : null;
+};
+
+const columnLettersOf = (address: string): string => address.replace(/\d+$/, '');
+
+/** Column letters for a 0-based column index ("A", "AB"). */
+export const columnKeyFromIndex = (index: number): string =>
+  columnLettersOf(encodeCellAddress(0, index));
+
+/** The format in force for a cell, with the column default already applied. */
+export function getEffectiveCellFormat(
+  sheet: SheetData,
+  address: string
+): CellFormat | undefined {
+  const normalized = normalizeAddress(address);
+  if (!normalized) return undefined;
+
+  return resolveCellFormat(
+    sheet.formats?.[normalized],
+    sheet.columnFormats?.[columnLettersOf(normalized)]
+  );
+}
+
+const withFormats = (
+  sheet: SheetData,
+  formats: Record<string, CellFormat>
+): SheetData => ({
+  ...sheet,
+  version: sheet.version + 1,
+  formats: Object.keys(formats).length > 0 ? formats : undefined,
+});
+
+/**
+ * Merge `patch` into the format of each address. A field set to `undefined`
+ * clears that field, so a toolbar can turn bold off without dropping the rest
+ * of the cell's styling.
+ */
+export function setCellFormats(
+  sheet: SheetData,
+  addresses: readonly string[],
+  patch: CellFormat
+): SheetData {
+  const formats = { ...(sheet.formats ?? {}) };
+
+  for (const address of addresses) {
+    const normalized = normalizeAddress(address);
+    if (!normalized) continue;
+
+    const merged: CellFormat = { ...(formats[normalized] ?? {}), ...patch };
+    for (const key of Object.keys(merged) as Array<keyof CellFormat>) {
+      if (merged[key] === undefined) delete merged[key];
+    }
+
+    if (isEmptyFormat(merged)) {
+      delete formats[normalized];
+    } else {
+      formats[normalized] = merged;
+    }
+  }
+
+  return withFormats(sheet, formats);
+}
+
+/** Remove all formatting from the given cells, leaving their values alone. */
+export function clearCellFormats(sheet: SheetData, addresses: readonly string[]): SheetData {
+  const formats = { ...(sheet.formats ?? {}) };
+
+  for (const address of addresses) {
+    const normalized = normalizeAddress(address);
+    if (normalized) delete formats[normalized];
+  }
+
+  return withFormats(sheet, formats);
+}
+
+/** Set a column-wide default format, which individual cells may override. */
+export function setColumnFormat(
+  sheet: SheetData,
+  columnIndex: number,
+  patch: CellFormat
+): SheetData {
+  const key = columnKeyFromIndex(columnIndex);
+  const columnFormats = { ...(sheet.columnFormats ?? {}) };
+  const merged: CellFormat = { ...(columnFormats[key] ?? {}), ...patch };
+
+  for (const field of Object.keys(merged) as Array<keyof CellFormat>) {
+    if (merged[field] === undefined) delete merged[field];
+  }
+
+  if (isEmptyFormat(merged)) {
+    delete columnFormats[key];
+  } else {
+    columnFormats[key] = merged;
+  }
+
+  return {
+    ...sheet,
+    version: sheet.version + 1,
+    columnFormats: Object.keys(columnFormats).length > 0 ? columnFormats : undefined,
+  };
+}
+
+export const MIN_COLUMN_WIDTH = 24;
+export const MAX_COLUMN_WIDTH = 2000;
+export const MIN_ROW_HEIGHT = 16;
+export const MAX_ROW_HEIGHT = 1000;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, Math.round(value)));
+
+/** Set a column's width in px, or clear it by passing `undefined`. */
+export function setColumnWidth(
+  sheet: SheetData,
+  columnIndex: number,
+  width: number | undefined
+): SheetData {
+  const key = columnKeyFromIndex(columnIndex);
+  const columnWidths = { ...(sheet.columnWidths ?? {}) };
+
+  if (width === undefined || !Number.isFinite(width)) {
+    delete columnWidths[key];
+  } else {
+    columnWidths[key] = clamp(width, MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH);
+  }
+
+  return {
+    ...sheet,
+    version: sheet.version + 1,
+    columnWidths: Object.keys(columnWidths).length > 0 ? columnWidths : undefined,
+  };
+}
+
+/** Set a row's height in px, or clear it by passing `undefined`. */
+export function setRowHeight(
+  sheet: SheetData,
+  rowIndex: number,
+  height: number | undefined
+): SheetData {
+  const key = String(rowIndex + 1);
+  const rowHeights = { ...(sheet.rowHeights ?? {}) };
+
+  if (height === undefined || !Number.isFinite(height)) {
+    delete rowHeights[key];
+  } else {
+    rowHeights[key] = clamp(height, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT);
+  }
+
+  return {
+    ...sheet,
+    version: sheet.version + 1,
+    rowHeights: Object.keys(rowHeights).length > 0 ? rowHeights : undefined,
+  };
+}
+
+/** Freeze the first `rows` rows and `columns` columns (0 disables). */
+export function setFrozen(
+  sheet: SheetData,
+  rows: number | undefined,
+  columns: number | undefined
+): SheetData {
+  const normalize = (value: number | undefined): number | undefined => {
+    if (value === undefined || !Number.isFinite(value) || value <= 0) return undefined;
+    return Math.trunc(value);
+  };
+
+  return {
+    ...sheet,
+    version: sheet.version + 1,
+    frozenRows: normalize(rows),
+    frozenColumns: normalize(columns),
+  };
+}
+
+/**
+ * Relocate PER-CELL metadata when cells move.
+ *
+ * **Any structural edit that moves cells must call this**, or a sheet's
+ * formatting will stay behind while its values shift — inserting a row would
+ * leave every colour and number format one row out of place. `addressMap` maps
+ * an old A1 address to its new one; an address absent from the map keeps its
+ * position, and one mapped to `null` is being deleted.
+ *
+ * Scope: this moves `formats` only. Per-COLUMN and per-ROW metadata
+ * (`columnFormats`, `columnWidths`, `rowHeights`) is keyed by column letters
+ * and row numbers, not by cell address, so it cannot be expressed as an
+ * address map — see {@link shiftAxisMetadata}, which a structural edit must
+ * also call.
+ */
+export function moveCellMetadata(
+  sheet: SheetData,
+  addressMap: ReadonlyMap<string, string | null>
+): SheetData {
+  if (!sheet.formats || Object.keys(sheet.formats).length === 0) {
+    return sheet;
+  }
+
+  const formats: Record<string, CellFormat> = {};
+
+  for (const [address, format] of Object.entries(sheet.formats)) {
+    if (!addressMap.has(address)) {
+      formats[address] = format;
+      continue;
+    }
+
+    const target = addressMap.get(address);
+    if (target === null || target === undefined) continue;
+
+    const normalized = normalizeAddress(target);
+    if (normalized) formats[normalized] = format;
+  }
+
+  return {
+    ...sheet,
+    formats: Object.keys(formats).length > 0 ? formats : undefined,
+  };
+}
+
+/**
+ * Shift per-column and per-row metadata for a structural insert or delete.
+ *
+ * The companion to {@link moveCellMetadata}: column widths and column default
+ * formats are keyed by column letters, and row heights by row number, so an
+ * inserted column must renumber them or every column past the insertion point
+ * keeps the width of its neighbour.
+ *
+ * `at` is a 0-based index on `axis`; `delta` is positive to insert and
+ * negative to delete. Entries inside a deleted band are dropped.
+ */
+export function shiftAxisMetadata(
+  sheet: SheetData,
+  axis: 'row' | 'column',
+  at: number,
+  delta: number
+): SheetData {
+  if (delta === 0) return sheet;
+
+  const shiftKeyed = <T,>(
+    source: Record<string, T> | undefined,
+    indexOf: (key: string) => number | null,
+    keyOf: (index: number) => string
+  ): Record<string, T> | undefined => {
+    if (!source) return undefined;
+
+    const shifted: Record<string, T> = {};
+    for (const [key, value] of Object.entries(source)) {
+      const index = indexOf(key);
+      if (index === null) continue;
+
+      if (index < at) {
+        shifted[key] = value;
+        continue;
+      }
+      // Inside a deleted band: the column or row is gone, so its metadata is too.
+      if (delta < 0 && index < at - delta) continue;
+
+      shifted[keyOf(index + delta)] = value;
+    }
+
+    return Object.keys(shifted).length > 0 ? shifted : undefined;
+  };
+
+  if (axis === 'column') {
+    const indexOf = (key: string) => columnIndexOfAddress(`${key}1`);
+    return {
+      ...sheet,
+      version: sheet.version + 1,
+      columnWidths: shiftKeyed(sheet.columnWidths, indexOf, columnKeyFromIndex),
+      columnFormats: shiftKeyed(sheet.columnFormats, indexOf, columnKeyFromIndex),
+    };
+  }
+
+  const rowIndexOf = (key: string) => {
+    const parsed = Number(key);
+    return Number.isInteger(parsed) && parsed >= 1 ? parsed - 1 : null;
+  };
+
+  return {
+    ...sheet,
+    version: sheet.version + 1,
+    rowHeights: shiftKeyed(sheet.rowHeights, rowIndexOf, (index) => String(index + 1)),
+  };
+}
+
+/** Every A1 address in an inclusive rectangle, row-major. */
+export function addressesInRange(
+  start: { row: number; column: number },
+  end: { row: number; column: number }
+): string[] {
+  const addresses: string[] = [];
+  const rowStart = Math.min(start.row, end.row);
+  const rowEnd = Math.max(start.row, end.row);
+  const columnStart = Math.min(start.column, end.column);
+  const columnEnd = Math.max(start.column, end.column);
+
+  for (let row = rowStart; row <= rowEnd; row++) {
+    for (let column = columnStart; column <= columnEnd; column++) {
+      addresses.push(encodeCellAddress(row, column));
+    }
+  }
+
+  return addresses;
+}
+
+/** The column index of an A1 address, or null if it is not one. */
+export function columnIndexOfAddress(address: string): number | null {
+  const normalized = normalizeAddress(address);
+  if (!normalized) return null;
+
+  try {
+    return decodeCellAddress(normalized).column;
+  } catch {
+    return null;
+  }
+}

--- a/packages/lib/src/sheets/format-ops.ts
+++ b/packages/lib/src/sheets/format-ops.ts
@@ -127,6 +127,21 @@ export const MAX_ROW_HEIGHT = 1000;
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, Math.round(value)));
 
+/**
+ * Bound a stored column width for rendering or export.
+ *
+ * Stored values are kept exactly as authored — a sheet may legitimately carry
+ * a narrower gutter than the editor's own minimum — so anything that turns a
+ * width into pixels or Excel character units clamps here rather than letting
+ * sanitization rewrite the document.
+ */
+export const clampColumnWidth = (width: number): number =>
+  clamp(width, MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH);
+
+/** The row-height counterpart of {@link clampColumnWidth}. */
+export const clampRowHeight = (height: number): number =>
+  clamp(height, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT);
+
 /** Set a column's width in px, or clear it by passing `undefined`. */
 export function setColumnWidth(
   sheet: SheetData,
@@ -221,28 +236,49 @@ export function moveCellMetadata(
   // and a single pass would let iteration order decide which survives, losing
   // one format silently. The relocated entry wins, matching what a structural
   // edit means: the cell that moved into this address brought its formatting.
-  for (const [address, format] of Object.entries(sheet.formats)) {
+  // Source keys are normalized before lookup so a lowercase stored address
+  // still matches an uppercase map entry — otherwise the move is silently
+  // ignored and the stale key survives alongside its relocated twin.
+  const entries = Object.entries(sheet.formats).map(
+    ([address, format]) => [normalizeAddress(address) ?? address, format] as const
+  );
+
+  let changed = false;
+
+  for (const [address, format] of entries) {
     if (!addressMap.has(address)) continue;
 
     const target = addressMap.get(address);
-    if (target === null || target === undefined) continue;
+    if (target === null || target === undefined) {
+      changed = true;
+      continue;
+    }
 
     const normalized = normalizeAddress(target);
-    if (normalized) {
-      formats[normalized] = format;
-      relocated.add(normalized);
-    }
+    if (!normalized) continue;
+
+    // Two entries can map to the SAME target — a delete that collapses rows
+    // does exactly that. Last-writer-wins would make the survivor depend on
+    // iteration order, so the first relocation into an address keeps it.
+    if (relocated.has(normalized)) continue;
+
+    formats[normalized] = format;
+    relocated.add(normalized);
+    if (normalized !== address) changed = true;
   }
 
-  for (const [address, format] of Object.entries(sheet.formats)) {
+  for (const [address, format] of entries) {
     if (addressMap.has(address)) continue;
     if (relocated.has(address)) continue;
     formats[address] = format;
   }
 
+  // Bump only on a real change. Bumping for an empty map — while the
+  // no-formats early return above does not bump — would make the version
+  // signal wrong in both directions.
   return {
     ...sheet,
-    version: sheet.version + 1,
+    version: changed ? sheet.version + 1 : sheet.version,
     formats: Object.keys(formats).length > 0 ? formats : undefined,
   };
 }

--- a/packages/lib/src/sheets/format.ts
+++ b/packages/lib/src/sheets/format.ts
@@ -311,7 +311,10 @@ export function numberFormatToExcelCode(format: NumberFormat | undefined): strin
     case 'currency': {
       const count = decimals(2);
       const symbol = currencySymbol(format.currency).trim();
-      return `"${symbol}"#,##0${fraction(count)}`;
+      // `applyNumberFormat` honours `thousands: false` for currency, so the
+      // Excel code must too or the workbook groups digits the grid does not.
+      const integer = format.thousands === false ? '0' : '#,##0';
+      return `"${symbol}"${integer}${fraction(count)}`;
     }
     case 'percent':
       return `0${fraction(decimals(0))}%`;

--- a/packages/lib/src/sheets/format.ts
+++ b/packages/lib/src/sheets/format.ts
@@ -87,17 +87,64 @@ export const cellFormatSchema: z.ZodType<CellFormat> = z.object({
   fontFamily: z.enum(['sans', 'mono']).optional(),
 });
 
+/** Per-field schemas, so one bad field does not condemn the whole format. */
+const FIELD_SCHEMAS: Record<string, z.ZodTypeAny> = {
+  number: numberFormatSchema,
+  bold: z.boolean(),
+  italic: z.boolean(),
+  underline: z.boolean(),
+  strike: z.boolean(),
+  align: z.enum(['left', 'center', 'right']),
+  valign: z.enum(['top', 'middle', 'bottom']),
+  wrap: z.boolean(),
+  color: hexColorSchema,
+  background: hexColorSchema,
+  borders: bordersSchema,
+  fontSize: z.number().int().min(MIN_FONT_SIZE).max(MAX_FONT_SIZE),
+  fontFamily: z.enum(['sans', 'mono']),
+};
+
 /**
- * Validate an untrusted format, dropping it entirely if it does not conform.
- * Used when reading stored documents, where the content may predate or
- * post-date this build, or may simply be hand-edited.
+ * Sanitize a stored format field by field.
+ *
+ * Deliberately NOT all-or-nothing, and deliberately not `cellFormatSchema`
+ * directly, for two reasons:
+ *
+ * - An invalid field must not take valid ones with it. `{bold: true,
+ *   fontSize: 5}` should keep the bold; dropping the whole entry loses styling
+ *   the user can see and did not ask to lose.
+ * - Unknown fields are preserved. A field written by a newer build would
+ *   otherwise be stripped the first time an older build saves — the same
+ *   silent cross-version data loss the `ranges` passthrough exists to avoid.
+ *
+ * Unknown fields are inert at render time: `cellFormatToStyle` reads only
+ * known fields and `cellFormatToInlineCss` emits only allow-listed properties,
+ * so passing them through carries no injection risk.
  */
 export function parseCellFormat(value: unknown): CellFormat | undefined {
-  const result = cellFormatSchema.safeParse(value);
-  if (!result.success) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
   }
-  return isEmptyFormat(result.data) ? undefined : result.data;
+
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
+    if (fieldValue === undefined) continue;
+
+    const schema = FIELD_SCHEMAS[key];
+    if (!schema) {
+      // Unknown to this build — carry it through untouched.
+      sanitized[key] = fieldValue;
+      continue;
+    }
+
+    const result = schema.safeParse(fieldValue);
+    if (result.success) {
+      sanitized[key] = result.data;
+    }
+  }
+
+  return Object.keys(sanitized).length > 0 ? (sanitized as CellFormat) : undefined;
 }
 
 /** Whether a format carries no instructions and can be dropped. */

--- a/packages/lib/src/sheets/format.ts
+++ b/packages/lib/src/sheets/format.ts
@@ -87,22 +87,36 @@ export const cellFormatSchema: z.ZodType<CellFormat> = z.object({
   fontFamily: z.enum(['sans', 'mono']).optional(),
 });
 
-/** Per-field schemas, so one bad field does not condemn the whole format. */
-const FIELD_SCHEMAS: Record<string, z.ZodTypeAny> = {
-  number: numberFormatSchema,
-  bold: z.boolean(),
-  italic: z.boolean(),
-  underline: z.boolean(),
-  strike: z.boolean(),
-  align: z.enum(['left', 'center', 'right']),
-  valign: z.enum(['top', 'middle', 'bottom']),
-  wrap: z.boolean(),
-  color: hexColorSchema,
-  background: hexColorSchema,
-  borders: bordersSchema,
-  fontSize: z.number().int().min(MIN_FONT_SIZE).max(MAX_FONT_SIZE),
-  fontFamily: z.enum(['sans', 'mono']),
-};
+/**
+ * Per-field schemas, so one bad field does not condemn the whole format.
+ *
+ * A `Map`, not an object literal: a stored key of `__proto__` or `constructor`
+ * resolves through an object's prototype chain to something truthy that is not
+ * a schema, and the lookup below would then throw on every load and every save
+ * of a document carrying such a key.
+ */
+const FIELD_SCHEMAS = new Map<string, z.ZodTypeAny>([
+  ['number', numberFormatSchema],
+  ['bold', z.boolean()],
+  ['italic', z.boolean()],
+  ['underline', z.boolean()],
+  ['strike', z.boolean()],
+  ['align', z.enum(['left', 'center', 'right'])],
+  ['valign', z.enum(['top', 'middle', 'bottom'])],
+  ['wrap', z.boolean()],
+  ['color', hexColorSchema],
+  ['background', hexColorSchema],
+  ['borders', bordersSchema],
+  ['fontSize', z.number().int().min(MIN_FONT_SIZE).max(MAX_FONT_SIZE)],
+  ['fontFamily', z.enum(['sans', 'mono'])],
+]);
+
+/**
+ * Keys never carried through, whatever a stored document says. Passing these
+ * on would let a crafted sheet reach `Object.prototype` through the spreads in
+ * `resolveCellFormat` and `setCellFormats`.
+ */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /**
  * Sanitize a stored format field by field.
@@ -130,8 +144,9 @@ export function parseCellFormat(value: unknown): CellFormat | undefined {
 
   for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
     if (fieldValue === undefined) continue;
+    if (FORBIDDEN_KEYS.has(key)) continue;
 
-    const schema = FIELD_SCHEMAS[key];
+    const schema = FIELD_SCHEMAS.get(key);
     if (!schema) {
       // Unknown to this build — carry it through untouched.
       sanitized[key] = fieldValue;

--- a/packages/lib/src/sheets/format.ts
+++ b/packages/lib/src/sheets/format.ts
@@ -95,7 +95,7 @@ export const cellFormatSchema: z.ZodType<CellFormat> = z.object({
  * a schema, and the lookup below would then throw on every load and every save
  * of a document carrying such a key.
  */
-const FIELD_SCHEMAS = new Map<string, z.ZodTypeAny>([
+const FIELD_SCHEMAS = new Map<string, z.ZodType>([
   ['number', numberFormatSchema],
   ['bold', z.boolean()],
   ['italic', z.boolean()],

--- a/packages/lib/src/sheets/format.ts
+++ b/packages/lib/src/sheets/format.ts
@@ -1,0 +1,441 @@
+/**
+ * @module @pagespace/lib/sheets/format
+ * @description Cell presentation: number formatting, validation, and the
+ * translation of a `CellFormat` into CSS or an Excel number-format code.
+ *
+ * Number formatting is applied at the evaluator's display projection rather
+ * than in any one renderer, because `SheetEvaluation.display` is what the grid,
+ * the CSV export, the XLSX export and the published page all read. Formatting
+ * in a renderer would let those four disagree about what a cell says.
+ */
+
+import { z } from 'zod';
+import type {
+  CellBorderSide,
+  CellBorders,
+  CellFormat,
+  NumberFormat,
+  SheetPrimitive,
+} from './types';
+
+/** `#rgb` is deliberately not accepted — one canonical form keeps round trips exact. */
+export const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export const MAX_DECIMALS = 10;
+export const MIN_FONT_SIZE = 6;
+export const MAX_FONT_SIZE = 96;
+
+/**
+ * Whether a string is safe to emit into a `style` attribute as a color.
+ *
+ * Published sheets render to static HTML with inline styles, so this is a
+ * trust boundary, not a formatting nicety: it is checked again at render time
+ * even though stored formats were validated on parse.
+ */
+export function isValidHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_PATTERN.test(value);
+}
+
+const hexColorSchema = z.string().regex(HEX_COLOR_PATTERN, 'Expected a #rrggbb color');
+
+const numberFormatSchema: z.ZodType<NumberFormat> = z.object({
+  kind: z.enum([
+    'auto',
+    'plain',
+    'number',
+    'currency',
+    'percent',
+    'date',
+    'time',
+    'datetime',
+    'scientific',
+    'text',
+    'custom',
+  ]),
+  decimals: z.number().int().min(0).max(MAX_DECIMALS).optional(),
+  currency: z.string().length(3).optional(),
+  thousands: z.boolean().optional(),
+  dateStyle: z.enum(['short', 'medium', 'long', 'iso']).optional(),
+  pattern: z.string().max(255).optional(),
+});
+
+const borderSideSchema: z.ZodType<CellBorderSide> = z.object({
+  style: z.enum(['thin', 'medium', 'thick', 'dashed', 'dotted']),
+  color: hexColorSchema.optional(),
+});
+
+const bordersSchema: z.ZodType<CellBorders> = z.object({
+  top: borderSideSchema.optional(),
+  right: borderSideSchema.optional(),
+  bottom: borderSideSchema.optional(),
+  left: borderSideSchema.optional(),
+});
+
+export const cellFormatSchema: z.ZodType<CellFormat> = z.object({
+  number: numberFormatSchema.optional(),
+  bold: z.boolean().optional(),
+  italic: z.boolean().optional(),
+  underline: z.boolean().optional(),
+  strike: z.boolean().optional(),
+  align: z.enum(['left', 'center', 'right']).optional(),
+  valign: z.enum(['top', 'middle', 'bottom']).optional(),
+  wrap: z.boolean().optional(),
+  color: hexColorSchema.optional(),
+  background: hexColorSchema.optional(),
+  borders: bordersSchema.optional(),
+  fontSize: z.number().int().min(MIN_FONT_SIZE).max(MAX_FONT_SIZE).optional(),
+  fontFamily: z.enum(['sans', 'mono']).optional(),
+});
+
+/**
+ * Validate an untrusted format, dropping it entirely if it does not conform.
+ * Used when reading stored documents, where the content may predate or
+ * post-date this build, or may simply be hand-edited.
+ */
+export function parseCellFormat(value: unknown): CellFormat | undefined {
+  const result = cellFormatSchema.safeParse(value);
+  if (!result.success) {
+    return undefined;
+  }
+  return isEmptyFormat(result.data) ? undefined : result.data;
+}
+
+/** Whether a format carries no instructions and can be dropped. */
+export function isEmptyFormat(format: CellFormat | undefined): boolean {
+  if (!format) return true;
+  return Object.values(format).every((value) => value === undefined);
+}
+
+/**
+ * Merge a column default with a cell's own format, the cell winning per-field.
+ * Exposed so callers resolve precedence identically everywhere.
+ */
+export function resolveCellFormat(
+  cellFormat: CellFormat | undefined,
+  columnFormat: CellFormat | undefined
+): CellFormat | undefined {
+  if (!columnFormat) return cellFormat;
+  if (!cellFormat) return columnFormat;
+  return { ...columnFormat, ...cellFormat };
+}
+
+const clampDecimals = (decimals: number | undefined, fallback: number): number => {
+  if (decimals === undefined || !Number.isFinite(decimals)) return fallback;
+  return Math.min(MAX_DECIMALS, Math.max(0, Math.trunc(decimals)));
+};
+
+const groupThousands = (value: string): string => {
+  const [whole, fraction] = value.split('.');
+  const sign = whole.startsWith('-') ? '-' : '';
+  const digits = sign ? whole.slice(1) : whole;
+  const grouped = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return fraction === undefined ? `${sign}${grouped}` : `${sign}${grouped}.${fraction}`;
+};
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: '$',
+  EUR: '€',
+  GBP: '£',
+  JPY: '¥',
+  CAD: 'CA$',
+  AUD: 'A$',
+  CHF: 'CHF ',
+  CNY: 'CN¥',
+  INR: '₹',
+  NZD: 'NZ$',
+};
+
+const currencySymbol = (code: string | undefined): string => {
+  if (!code) return CURRENCY_SYMBOLS.USD;
+  return CURRENCY_SYMBOLS[code.toUpperCase()] ?? `${code.toUpperCase()} `;
+};
+
+/**
+ * Parse the engine's date representation. Dates are stored as strings
+ * (`TODAY()` yields `YYYY-MM-DD`), not as serial numbers, so this reads the
+ * components directly rather than going through `new Date(string)` — the
+ * latter treats a bare date as UTC and then local getters shift it a day in
+ * negative-offset timezones.
+ */
+const parseDateParts = (
+  value: string
+): { year: number; month: number; day: number; hours: number; minutes: number; seconds: number } | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/.exec(value.trim());
+  if (!match) return null;
+
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hours: Number(match[4] ?? '0'),
+    minutes: Number(match[5] ?? '0'),
+    seconds: Number(match[6] ?? '0'),
+  };
+};
+
+const MONTHS_LONG = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const pad2 = (value: number): string => String(value).padStart(2, '0');
+
+const formatDateParts = (
+  parts: NonNullable<ReturnType<typeof parseDateParts>>,
+  style: NumberFormat['dateStyle']
+): string => {
+  const { year, month, day } = parts;
+  switch (style) {
+    case 'long':
+      return `${MONTHS_LONG[month - 1] ?? month} ${day}, ${year}`;
+    case 'medium':
+      return `${(MONTHS_LONG[month - 1] ?? String(month)).slice(0, 3)} ${day}, ${year}`;
+    case 'short':
+      return `${month}/${day}/${year}`;
+    case 'iso':
+    default:
+      return `${year}-${pad2(month)}-${pad2(day)}`;
+  }
+};
+
+/**
+ * Render a computed value for display under a number format.
+ *
+ * Returns `null` when the format does not apply — an `auto` format, a value
+ * the format cannot render (text under a numeric format), or a `custom`
+ * pattern this build cannot interpret. The caller then falls back to the
+ * engine's default rendering, so an unsupported format degrades to the plain
+ * value rather than to an error or an empty cell.
+ */
+export function applyNumberFormat(
+  value: SheetPrimitive,
+  format: NumberFormat | undefined
+): string | null {
+  if (!format || format.kind === 'auto' || format.kind === 'custom') {
+    return null;
+  }
+
+  if (format.kind === 'text') {
+    return String(value);
+  }
+
+  if (format.kind === 'date' || format.kind === 'time' || format.kind === 'datetime') {
+    const parts = parseDateParts(String(value));
+    if (!parts) return null;
+
+    const date = formatDateParts(parts, format.dateStyle);
+    const time = `${pad2(parts.hours)}:${pad2(parts.minutes)}:${pad2(parts.seconds)}`;
+
+    if (format.kind === 'date') return date;
+    if (format.kind === 'time') return time;
+    return `${date} ${time}`;
+  }
+
+  // Remaining kinds are numeric. Booleans are deliberately not coerced: `TRUE`
+  // formatted as currency should stay `true`, not become `$1.00`.
+  if (typeof value !== 'number') {
+    if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) {
+      return applyNumberFormat(Number(value), format);
+    }
+    return null;
+  }
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  switch (format.kind) {
+    case 'plain':
+      return String(value);
+
+    case 'number': {
+      const decimals = clampDecimals(format.decimals, 2);
+      const fixed = value.toFixed(decimals);
+      return format.thousands === false ? fixed : groupThousands(fixed);
+    }
+
+    case 'currency': {
+      const decimals = clampDecimals(format.decimals, 2);
+      const symbol = currencySymbol(format.currency);
+      const magnitude = Math.abs(value).toFixed(decimals);
+      const grouped = format.thousands === false ? magnitude : groupThousands(magnitude);
+      return `${value < 0 ? '-' : ''}${symbol}${grouped}`;
+    }
+
+    case 'percent': {
+      const decimals = clampDecimals(format.decimals, 0);
+      const scaled = (value * 100).toFixed(decimals);
+      return `${format.thousands === false ? scaled : groupThousands(scaled)}%`;
+    }
+
+    case 'scientific': {
+      const decimals = clampDecimals(format.decimals, 2);
+      return value.toExponential(decimals);
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * The Excel number-format code (`z`) matching a format, so an exported
+ * workbook shows what the grid shows and still holds real numbers.
+ * Returns undefined when Excel's default rendering is correct.
+ */
+export function numberFormatToExcelCode(format: NumberFormat | undefined): string | undefined {
+  if (!format) return undefined;
+
+  // A pattern we could not interpret came from Excel in the first place —
+  // hand it straight back rather than losing it.
+  if (format.kind === 'custom') return format.pattern;
+
+  const decimals = (fallback: number) => clampDecimals(format.decimals, fallback);
+  const fraction = (count: number) => (count > 0 ? `.${'0'.repeat(count)}` : '');
+
+  switch (format.kind) {
+    case 'number': {
+      const count = decimals(2);
+      return format.thousands === false ? `0${fraction(count)}` : `#,##0${fraction(count)}`;
+    }
+    case 'currency': {
+      const count = decimals(2);
+      const symbol = currencySymbol(format.currency).trim();
+      return `"${symbol}"#,##0${fraction(count)}`;
+    }
+    case 'percent':
+      return `0${fraction(decimals(0))}%`;
+    case 'scientific':
+      return `0${fraction(decimals(2))}E+00`;
+    case 'date':
+      return format.dateStyle === 'short' ? 'm/d/yyyy' : 'yyyy-mm-dd';
+    case 'time':
+      return 'hh:mm:ss';
+    case 'datetime':
+      return 'yyyy-mm-dd hh:mm:ss';
+    case 'text':
+      return '@';
+    case 'plain':
+      return '0.##########';
+    case 'auto':
+    default:
+      return undefined;
+  }
+}
+
+const BORDER_WIDTHS: Record<CellBorderSide['style'], string> = {
+  thin: '1px solid',
+  medium: '2px solid',
+  thick: '3px solid',
+  dashed: '1px dashed',
+  dotted: '1px dotted',
+};
+
+const borderValue = (side: CellBorderSide | undefined): string | undefined => {
+  if (!side) return undefined;
+  const width = BORDER_WIDTHS[side.style];
+  if (!width) return undefined;
+  const color = isValidHexColor(side.color) ? side.color : 'currentColor';
+  return `${width} ${color}`;
+};
+
+/**
+ * A `CellFormat` as a style object for the grid.
+ *
+ * Colors are re-validated here even though they were validated on parse: this
+ * value reaches a `style` attribute, and defence in depth is cheap.
+ */
+export function cellFormatToStyle(format: CellFormat | undefined): Record<string, string> {
+  const style: Record<string, string> = {};
+  if (!format) return style;
+
+  if (format.bold) style.fontWeight = '600';
+  if (format.italic) style.fontStyle = 'italic';
+
+  const decorations = [format.underline && 'underline', format.strike && 'line-through'].filter(
+    Boolean
+  );
+  if (decorations.length > 0) style.textDecoration = decorations.join(' ');
+
+  if (format.align) style.textAlign = format.align;
+  if (format.valign) {
+    style.verticalAlign = format.valign;
+    style.alignItems =
+      format.valign === 'top' ? 'flex-start' : format.valign === 'bottom' ? 'flex-end' : 'center';
+  }
+  if (format.wrap) {
+    style.whiteSpace = 'pre-wrap';
+    style.overflowWrap = 'anywhere';
+  }
+  if (isValidHexColor(format.color)) style.color = format.color;
+  if (isValidHexColor(format.background)) style.backgroundColor = format.background;
+  if (format.fontSize) style.fontSize = `${format.fontSize}px`;
+  if (format.fontFamily) {
+    style.fontFamily =
+      format.fontFamily === 'mono' ? 'var(--font-mono, monospace)' : 'var(--font-sans, sans-serif)';
+  }
+
+  const borders: Array<[keyof CellBorders, string]> = [
+    ['top', 'borderTop'],
+    ['right', 'borderRight'],
+    ['bottom', 'borderBottom'],
+    ['left', 'borderLeft'],
+  ];
+  for (const [side, property] of borders) {
+    const value = borderValue(format.borders?.[side]);
+    if (value) style[property] = value;
+  }
+
+  return style;
+}
+
+const CSS_PROPERTY_NAMES: Record<string, string> = {
+  fontWeight: 'font-weight',
+  fontStyle: 'font-style',
+  textDecoration: 'text-decoration',
+  textAlign: 'text-align',
+  verticalAlign: 'vertical-align',
+  alignItems: 'align-items',
+  whiteSpace: 'white-space',
+  overflowWrap: 'overflow-wrap',
+  backgroundColor: 'background-color',
+  fontSize: 'font-size',
+  fontFamily: 'font-family',
+  borderTop: 'border-top',
+  borderRight: 'border-right',
+  borderBottom: 'border-bottom',
+  borderLeft: 'border-left',
+  color: 'color',
+};
+
+/**
+ * A `CellFormat` as an inline CSS declaration string, for the published page's
+ * static HTML. Only known properties and already-validated values are emitted,
+ * so nothing user-supplied reaches the attribute verbatim.
+ */
+export function cellFormatToInlineCss(format: CellFormat | undefined): string {
+  const style = cellFormatToStyle(format);
+  const declarations: string[] = [];
+
+  for (const [property, value] of Object.entries(style)) {
+    const cssName = CSS_PROPERTY_NAMES[property];
+    // An unmapped property means someone added a style key without deciding how
+    // it should be published; dropping it is safer than guessing.
+    if (!cssName) continue;
+    // Belt and braces: never emit a value carrying CSS-significant characters.
+    if (/[;{}<>"']/.test(value)) continue;
+    declarations.push(`${cssName}:${value}`);
+  }
+
+  return declarations.join(';');
+}

--- a/packages/lib/src/sheets/io.ts
+++ b/packages/lib/src/sheets/io.ts
@@ -1019,6 +1019,11 @@ function formatTomlValue(value: unknown): string {
     const parts = value.map((item) => formatTomlValue(item));
     return `[${parts.join(', ')}]`;
   }
+  // Before `isObject`: a Date IS an object, and `Object.entries(date)` is
+  // empty, so a TOML datetime would serialize as `{}` and be destroyed.
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? formatTomlString('') : value.toISOString();
+  }
   if (isObject(value)) {
     return formatInlineTable(value as Record<string, unknown>);
   }

--- a/packages/lib/src/sheets/io.ts
+++ b/packages/lib/src/sheets/io.ts
@@ -6,6 +6,7 @@
 import { parse as parseToml } from '@iarna/toml';
 
 import type {
+  CellFormat,
   SheetData,
   SheetDoc,
   SheetDocCell,
@@ -14,10 +15,29 @@ import type {
   SheetDocDependencyRecord,
   SheetPrimitive,
 } from './types';
+import { parseCellFormat } from './format';
 import { SHEETDOC_MAGIC, SHEETDOC_VERSION, SHEET_VERSION, SHEET_DEFAULT_ROWS, SHEET_DEFAULT_COLUMNS } from './constants';
 import { evaluateSheet } from './evaluation';
 import { sanitizeSheetData } from './update';
 import { cellRegex } from './address';
+
+/**
+ * Thrown when a SheetDoc would serialize to something the parser rejects.
+ * Callers must treat this as "do not write", never as "write anyway".
+ */
+export class SheetSerializationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SheetSerializationError';
+  }
+}
+
+/** Why a sheet failed to load, for callers that must not overwrite it. */
+export type SheetParseFailureReason = 'toml' | 'json' | 'shape';
+
+export type SheetParseResult =
+  | { ok: true; sheet: SheetData }
+  | { ok: false; reason: SheetParseFailureReason; message: string };
 
 /**
  * Create an empty sheet with default dimensions
@@ -38,43 +58,78 @@ export function createEmptySheet(
  * Parse sheet content from various formats
  */
 export function parseSheetContent(content: unknown): SheetData {
+  const result = parseSheetContentSafe(content);
+  return result.ok ? result.sheet : createEmptySheet();
+}
+
+/**
+ * Parse sheet content, distinguishing "genuinely empty" from "failed to parse".
+ *
+ * `parseSheetContent` cannot tell those apart — it returns an empty sheet for
+ * both — so a caller that autosaves will write that empty sheet back over
+ * content it merely failed to read. Callers on a write path should use this
+ * and refuse to save on `ok: false`.
+ */
+export function parseSheetContentSafe(content: unknown): SheetParseResult {
   if (!content) {
-    return createEmptySheet();
+    return { ok: true, sheet: createEmptySheet() };
   }
 
   if (typeof content === 'string') {
     const trimmed = content.trim();
     if (!trimmed) {
-      return createEmptySheet();
+      return { ok: true, sheet: createEmptySheet() };
     }
 
     if (isSheetDocString(trimmed)) {
       try {
         const doc = parseSheetDocString(trimmed);
-        return sheetDataFromSheetDoc(doc);
-      } catch {
-        return createEmptySheet();
+        return { ok: true, sheet: sheetDataFromSheetDoc(doc) };
+      } catch (error) {
+        return {
+          ok: false,
+          reason: 'toml',
+          message: error instanceof Error ? error.message : String(error),
+        };
       }
     }
 
     try {
       const parsed = JSON.parse(trimmed);
-      return parseSheetContent(parsed);
-    } catch {
-      return createEmptySheet();
+      return parseSheetContentSafe(parsed);
+    } catch (error) {
+      // Only report a failure for content that was *trying* to be a sheet.
+      // Malformed JSON may be a truncated sheet document whose cells we must
+      // not overwrite; arbitrary text (legacy plain-text or HTML content on a
+      // SHEET page) holds no sheet data to lose, and treating it as a failure
+      // would lock the page read-only forever with nothing to recover.
+      const looksLikeJson = trimmed.startsWith('{') || trimmed.startsWith('[');
+      if (!looksLikeJson) {
+        return { ok: true, sheet: createEmptySheet() };
+      }
+
+      return {
+        ok: false,
+        reason: 'json',
+        message: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 
   if (isSheetDocObject(content)) {
     try {
-      return sheetDataFromSheetDoc(normalizeSheetDocObject(content));
-    } catch {
-      return createEmptySheet();
+      return { ok: true, sheet: sheetDataFromSheetDoc(normalizeSheetDocObject(content)) };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'shape',
+        message: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 
   if (!isObject(content)) {
-    return createEmptySheet();
+    return { ok: true, sheet: createEmptySheet() };
   }
 
   const version = typeof content.version === 'number' ? content.version : SHEET_VERSION;
@@ -99,10 +154,13 @@ export function parseSheetContent(content: unknown): SheetData {
   }
 
   return {
-    version,
-    rowCount,
-    columnCount,
-    cells,
+    ok: true,
+    sheet: {
+      version,
+      rowCount,
+      columnCount,
+      cells,
+    },
   };
 }
 
@@ -150,6 +208,11 @@ export function parseSheetDocString(value: string): SheetDoc {
     throw new Error('Invalid SheetDoc header');
   }
 
+  // An unknown version throws, and callers on a write path must use
+  // `parseSheetContentSafe` so the failure disables saving rather than
+  // overwriting. Rejecting outright beats parsing a future version
+  // best-effort, which would drop the fields this build cannot see and then
+  // persist that loss on the next save.
   const versionPart = headerLine.slice(SHEETDOC_MAGIC.length).trim();
   if (versionPart && versionPart !== SHEETDOC_VERSION) {
     throw new Error(`Unsupported SheetDoc version: ${versionPart}`);
@@ -172,11 +235,20 @@ export function sheetDataFromSheetDoc(doc: SheetDoc): SheetData {
   }
 
   const cells: Record<string, string> = {};
+  const formats: Record<string, CellFormat> = {};
 
   for (const [address, cell] of Object.entries(target.cells)) {
     const normalizedAddress = normalizeCellAddress(address);
     if (!normalizedAddress) {
       continue;
+    }
+
+    // Formats are validated on the way in: stored content can be older, newer,
+    // or hand-edited, and an unparseable format must be dropped rather than
+    // carried into a `style` attribute.
+    const format = parseCellFormat(cell.format);
+    if (format) {
+      formats[normalizedAddress] = format;
     }
 
     if (cell.formula) {
@@ -191,12 +263,69 @@ export function sheetDataFromSheetDoc(doc: SheetDoc): SheetData {
     }
   }
 
+  const columnWidths: Record<string, number> = {};
+  for (const [columnKey, columnValue] of Object.entries(target.columns)) {
+    const width = columnValue?.width;
+    if (typeof width === 'number' && Number.isFinite(width)) {
+      columnWidths[columnKey.toUpperCase()] = Math.round(width);
+    }
+  }
+
+  const columnFormats = readColumnFormats(target.ranges.__columnFormats);
+  const rowHeights = readRowHeights(target.ranges.__rowHeights);
+
+  // Strip the two internal bags back out so they do not resurface as if they
+  // were user-defined named ranges.
+  const userRanges = { ...target.ranges };
+  delete userRanges.__columnFormats;
+  delete userRanges.__rowHeights;
+
+  const extraSheets = normalized.sheets.slice(1);
+
   return {
     version: SHEET_VERSION,
     rowCount: Math.max(1, Math.floor(target.meta.rowCount)),
     columnCount: Math.max(1, Math.floor(target.meta.columnCount)),
     cells,
+    ...(Object.keys(formats).length > 0 ? { formats } : {}),
+    ...(columnFormats ? { columnFormats } : {}),
+    ...(Object.keys(columnWidths).length > 0 ? { columnWidths } : {}),
+    ...(rowHeights ? { rowHeights } : {}),
+    ...(Object.keys(userRanges).length > 0 ? { ranges: userRanges } : {}),
+    ...(typeof target.meta.frozenRows === 'number' && target.meta.frozenRows > 0
+      ? { frozenRows: target.meta.frozenRows }
+      : {}),
+    ...(typeof target.meta.frozenColumns === 'number' && target.meta.frozenColumns > 0
+      ? { frozenColumns: target.meta.frozenColumns }
+      : {}),
+    sheetName: target.name,
+    ...(extraSheets.length > 0 ? { extraSheets } : {}),
   };
+}
+
+function readColumnFormats(value: unknown): Record<string, CellFormat> | undefined {
+  if (!isObject(value)) return undefined;
+
+  const columnFormats: Record<string, CellFormat> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const format = parseCellFormat(raw);
+    if (format) columnFormats[key.toUpperCase()] = format;
+  }
+
+  return Object.keys(columnFormats).length > 0 ? columnFormats : undefined;
+}
+
+function readRowHeights(value: unknown): Record<string, number> | undefined {
+  if (!isObject(value)) return undefined;
+
+  const rowHeights: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      rowHeights[key] = Math.round(raw);
+    }
+  }
+
+  return Object.keys(rowHeights).length > 0 ? rowHeights : undefined;
 }
 
 /**
@@ -232,20 +361,20 @@ export function stringifySheetDoc(doc: SheetDoc): string {
       if (metaValue === undefined) {
         continue;
       }
-      lines.push(`${toSnakeCase(metaKey)} = ${formatTomlValue(metaValue)}`);
+      lines.push(`${formatTomlKey(toSnakeCase(metaKey))} = ${formatTomlValue(metaValue)}`);
     }
 
     if (Object.keys(sheet.columns).length > 0) {
       lines.push('');
       lines.push('[sheets.columns]');
       for (const [columnKey, columnValue] of Object.entries(sheet.columns)) {
-        lines.push(`${columnKey} = ${formatInlineTable(columnValue)}`);
+        lines.push(`${formatTomlKey(columnKey)} = ${formatInlineTable(columnValue)}`);
       }
     }
 
     for (const [address, cell] of Object.entries(sheet.cells)) {
       lines.push('');
-      lines.push(`[sheets.cells.${address}]`);
+      lines.push(`[sheets.cells.${formatTomlKey(address)}]`);
       if (cell.formula !== undefined) {
         lines.push(`formula = ${formatTomlString(cell.formula)}`);
       }
@@ -266,14 +395,17 @@ export function stringifySheetDoc(doc: SheetDoc): string {
         };
         lines.push(`error = ${formatInlineTable(errorRecord)}`);
       }
+      if (cell.format) {
+        lines.push(`format = ${formatInlineTable(cell.format as unknown as Record<string, unknown>)}`);
+      }
     }
 
     if (Object.keys(sheet.ranges).length > 0) {
       for (const [rangeKey, rangeValue] of Object.entries(sheet.ranges)) {
         lines.push('');
-        lines.push(`[sheets.ranges.${rangeKey}]`);
+        lines.push(`[sheets.ranges.${formatTomlKey(rangeKey)}]`);
         for (const [rangePropKey, rangePropValue] of Object.entries(rangeValue)) {
-          lines.push(`${rangePropKey} = ${formatTomlValue(rangePropValue)}`);
+          lines.push(`${formatTomlKey(rangePropKey)} = ${formatTomlValue(rangePropValue)}`);
         }
       }
     }
@@ -281,7 +413,7 @@ export function stringifySheetDoc(doc: SheetDoc): string {
     if (Object.keys(sheet.dependencies).length > 0) {
       for (const [address, dependency] of Object.entries(sheet.dependencies)) {
         lines.push('');
-        lines.push(`[sheets.dependencies.${address}]`);
+        lines.push(`[sheets.dependencies.${formatTomlKey(address)}]`);
         lines.push(`depends_on = ${formatTomlValue(dependency.dependsOn)}`);
         lines.push(`dependents = ${formatTomlValue(dependency.dependents)}`);
       }
@@ -289,7 +421,26 @@ export function stringifySheetDoc(doc: SheetDoc): string {
   }
 
   lines.push('');
-  return lines.join('\n');
+  const serialized = lines.join('\n');
+
+  // Self-verify: a document that cannot be re-parsed reads back as an empty
+  // sheet (see `parseSheetContent`), so an emitter bug silently destroys the
+  // user's data on the next load. Failing loudly on save is strictly better.
+  // `lines[0]` is the magic header, which is not TOML.
+  const tomlBody = lines.slice(1).join('\n');
+  try {
+    if (tomlBody.trim()) {
+      parseToml(tomlBody);
+    }
+  } catch (error) {
+    throw new SheetSerializationError(
+      `Refusing to emit a SheetDoc that cannot be parsed back: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  return serialized;
 }
 
 // Internal helper functions
@@ -395,6 +546,7 @@ function normalizeSheetDocObject(value: Record<string, unknown>): SheetDoc {
         const errorValue = isObject(cellValue.error)
           ? normalizeCellError(cellValue.error as Record<string, unknown>)
           : undefined;
+        const formatValue = parseCellFormat(cellValue.format);
 
         const cell: SheetDocCell = {};
         if (formula) {
@@ -411,6 +563,9 @@ function normalizeSheetDocObject(value: Record<string, unknown>): SheetDoc {
         }
         if (errorValue) {
           cell.error = errorValue;
+        }
+        if (formatValue) {
+          cell.format = formatValue;
         }
 
         if (Object.keys(cell).length > 0) {
@@ -539,22 +694,71 @@ function sheetDataToSheetDoc(
     }
   }
 
+  // Formats are attached to cells that may hold no value at all — a blank but
+  // coloured cell is a legitimate part of a laid-out sheet — so this runs over
+  // the format map rather than only over evaluated addresses.
+  for (const [address, format] of Object.entries(sheet.formats ?? {})) {
+    const normalized = normalizeCellAddress(address);
+    if (!normalized) continue;
+
+    const docCell = cells[normalized] ?? {};
+    docCell.format = format;
+    cells[normalized] = docCell;
+  }
+
+  const columns: Record<string, Record<string, string | number | boolean>> = {};
+
+  for (const [columnKey, width] of Object.entries(sheet.columnWidths ?? {})) {
+    if (!Number.isFinite(width)) continue;
+    columns[columnKey] = { ...(columns[columnKey] ?? {}), width: Math.round(width) };
+  }
+
+  const meta: SheetDocSheet['meta'] = {
+    rowCount: Math.max(1, Math.floor(sheet.rowCount)),
+    columnCount: Math.max(1, Math.floor(sheet.columnCount)),
+  };
+  if (typeof sheet.frozenRows === 'number' && sheet.frozenRows > 0) {
+    meta.frozenRows = Math.floor(sheet.frozenRows);
+  }
+  if (typeof sheet.frozenColumns === 'number' && sheet.frozenColumns > 0) {
+    meta.frozenColumns = Math.floor(sheet.frozenColumns);
+  }
+
+  // Anything the engine does not interpret is carried straight back out.
+  const ranges: Record<string, Record<string, unknown>> = { ...(sheet.ranges ?? {}) };
+  delete ranges.__columnFormats;
+  delete ranges.__rowHeights;
+
+  // Column defaults and row heights have no first-class SheetDoc home yet, so
+  // they ride in the same bag under reserved `__`-prefixed keys.
+  if (sheet.columnFormats && Object.keys(sheet.columnFormats).length > 0) {
+    ranges.__columnFormats = { ...sheet.columnFormats };
+  }
+  if (sheet.rowHeights && Object.keys(sheet.rowHeights).length > 0) {
+    ranges.__rowHeights = { ...sheet.rowHeights };
+  }
+
+  // Tabs beyond the first are carried through verbatim. Dropping them here is
+  // what previously deleted every other tab of a multi-tab document on save.
+  const extraSheets = (sheet.extraSheets ?? []).map((extra, index) => ({
+    ...extra,
+    order: typeof extra.order === 'number' ? extra.order : index + 1,
+  }));
+
   return sortSheetDoc({
     version: SHEETDOC_VERSION,
     pageId: options.pageId,
     sheets: [
       {
-        name: sheetName,
+        name: options.sheetName ?? sheet.sheetName ?? sheetName,
         order: 0,
-        meta: {
-          rowCount: Math.max(1, Math.floor(sheet.rowCount)),
-          columnCount: Math.max(1, Math.floor(sheet.columnCount)),
-        },
-        columns: {},
+        meta,
+        columns,
         cells,
-        ranges: {},
+        ranges,
         dependencies,
       },
+      ...extraSheets,
     ],
   });
 }
@@ -618,6 +822,9 @@ function normalizeCellForOutput(cell: SheetDocCell): SheetDocCell {
         ? { details: [...cell.error.details] }
         : {}),
     };
+  }
+  if (cell.format) {
+    normalized.format = cell.format;
   }
 
   return normalized;
@@ -733,8 +940,66 @@ function formatPrimitiveForCell(value: SheetPrimitive): string {
   return '';
 }
 
+/**
+ * Escape a string as a TOML basic string.
+ *
+ * TOML basic strings may not contain raw control characters — a literal newline
+ * or tab terminates the string and produces a document the parser rejects.
+ * Because `parseSheetContent` falls back to an empty sheet on a parse failure,
+ * under-escaping here silently destroys the whole document, and the input is
+ * not necessarily trusted: public form submissions are written straight through
+ * `updateSheetCells`. Escape the complete TOML control set, not just `\` and `"`.
+ */
 function formatTomlString(value: string): string {
-  return `"${value.replace(/\\/g, '\\\\').replace(/\"/g, '\\"')}"`;
+  let escaped = '';
+
+  for (const char of value) {
+    switch (char) {
+      case '\\':
+        escaped += '\\\\';
+        break;
+      case '"':
+        escaped += '\\"';
+        break;
+      case '\b':
+        escaped += '\\b';
+        break;
+      case '\t':
+        escaped += '\\t';
+        break;
+      case '\n':
+        escaped += '\\n';
+        break;
+      case '\f':
+        escaped += '\\f';
+        break;
+      case '\r':
+        escaped += '\\r';
+        break;
+      default: {
+        const code = char.codePointAt(0) ?? 0;
+        // Remaining C0 controls and DEL have no shorthand escape.
+        if (code <= 0x1f || code === 0x7f) {
+          escaped += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+          escaped += char;
+        }
+      }
+    }
+  }
+
+  return `"${escaped}"`;
+}
+
+/**
+ * Format a TOML key: bare where the syntax allows it, quoted otherwise.
+ *
+ * Column and range keys reach the emitter as user-controlled strings and are
+ * interpolated into table headers, where an unquoted space or bracket would
+ * produce invalid TOML.
+ */
+function formatTomlKey(key: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : formatTomlString(key);
 }
 
 function formatTomlValue(value: unknown): string {
@@ -762,7 +1027,9 @@ function formatTomlValue(value: unknown): string {
 
 function formatInlineTable(record: Record<string, unknown>): string {
   const entries = Object.entries(record).filter(([, entryValue]) => entryValue !== undefined);
-  const parts = entries.map(([key, entryValue]) => `${key} = ${formatTomlValue(entryValue)}`);
+  const parts = entries.map(
+    ([key, entryValue]) => `${formatTomlKey(key)} = ${formatTomlValue(entryValue)}`
+  );
   if (parts.length === 0) {
     return '{}';
   }

--- a/packages/lib/src/sheets/io.ts
+++ b/packages/lib/src/sheets/io.ts
@@ -1022,7 +1022,18 @@ function formatTomlValue(value: unknown): string {
   // Before `isObject`: a Date IS an object, and `Object.entries(date)` is
   // empty, so a TOML datetime would serialize as `{}` and be destroyed.
   if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? formatTomlString('') : value.toISOString();
+    if (Number.isNaN(value.getTime())) {
+      return formatTomlString('');
+    }
+
+    // `toISOString` uses the expanded-year form outside 0000-9999
+    // (`+275760-…`), which TOML does not accept — emitting it unquoted would
+    // fail the serializer's self-verify and make the whole document
+    // unsavable. Such a year cannot come from parsed TOML, only from a Date
+    // set programmatically, so fall back to a quoted string: the value is
+    // preserved and the document still saves.
+    const iso = value.toISOString();
+    return /^\d{4}-/.test(iso) ? iso : formatTomlString(iso);
   }
   if (isObject(value)) {
     return formatInlineTable(value as Record<string, unknown>);

--- a/packages/lib/src/sheets/sheet.ts
+++ b/packages/lib/src/sheets/sheet.ts
@@ -12,6 +12,8 @@ export * from './types';
 export * from './address';
 export * from './parser';
 export * from './functions';
+export * from './format';
+export * from './format-ops';
 export * from './evaluation';
 export * from './io';
 export * from './external';

--- a/packages/lib/src/sheets/types.ts
+++ b/packages/lib/src/sheets/types.ts
@@ -5,11 +5,107 @@
 
 export type SheetCellAddress = string;
 
+/** How a cell's computed value is rendered. */
+export type NumberFormatKind =
+  | 'auto'
+  | 'plain'
+  | 'number'
+  | 'currency'
+  | 'percent'
+  | 'date'
+  | 'time'
+  | 'datetime'
+  | 'scientific'
+  | 'text'
+  | 'custom';
+
+export interface NumberFormat {
+  kind: NumberFormatKind;
+  /** 0–10; ignored by kinds that have no fractional part. */
+  decimals?: number;
+  /** ISO 4217, for `kind: 'currency'`. */
+  currency?: string;
+  thousands?: boolean;
+  dateStyle?: 'short' | 'medium' | 'long' | 'iso';
+  /**
+   * Only for `kind: 'custom'` — an imported pattern this engine cannot render.
+   * Preserved through the round trip and displayed as `auto`, so an unsupported
+   * format is never silently discarded.
+   */
+  pattern?: string;
+}
+
+export type CellHorizontalAlign = 'left' | 'center' | 'right';
+export type CellVerticalAlign = 'top' | 'middle' | 'bottom';
+export type CellFontFamily = 'sans' | 'mono';
+export type CellBorderStyle = 'thin' | 'medium' | 'thick' | 'dashed' | 'dotted';
+
+export interface CellBorderSide {
+  style: CellBorderStyle;
+  /** `#rrggbb`; omitted means the theme's default border color. */
+  color?: string;
+}
+
+export interface CellBorders {
+  top?: CellBorderSide;
+  right?: CellBorderSide;
+  bottom?: CellBorderSide;
+  left?: CellBorderSide;
+}
+
+/**
+ * Presentation for a single cell. Deliberately separate from the cell's value:
+ * `SheetData.cells` stays a plain string map, so clearing a cell's contents
+ * leaves its formatting intact (as in Excel and Google Sheets) and every
+ * existing consumer of `cells` is unaffected.
+ */
+export interface CellFormat {
+  number?: NumberFormat;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  align?: CellHorizontalAlign;
+  valign?: CellVerticalAlign;
+  wrap?: boolean;
+  /** `#rrggbb` text color. */
+  color?: string;
+  /** `#rrggbb` fill color. */
+  background?: string;
+  borders?: CellBorders;
+  fontSize?: number;
+  fontFamily?: CellFontFamily;
+}
+
 export interface SheetData {
   version: number;
   rowCount: number;
   columnCount: number;
   cells: Record<SheetCellAddress, string>;
+  /** Per-cell presentation, keyed by A1 address. */
+  formats?: Record<SheetCellAddress, CellFormat>;
+  /** Column defaults, keyed by column letters ("A", "AB"). */
+  columnFormats?: Record<string, CellFormat>;
+  /** Column widths in px, keyed by column letters. */
+  columnWidths?: Record<string, number>;
+  /** Row heights in px, keyed by 1-based row number as a string. */
+  rowHeights?: Record<string, number>;
+  frozenRows?: number;
+  frozenColumns?: number;
+  /** Name of the sheet this data came from. */
+  sheetName?: string;
+  /**
+   * Named/defined ranges, carried verbatim. Nothing in the engine resolves
+   * them yet, but dropping what we do not understand turns every save into
+   * silent data loss for anything written by a newer build or by hand.
+   */
+  ranges?: Record<string, Record<string, unknown>>;
+  /**
+   * Tabs after the first, carried verbatim so a multi-tab document survives a
+   * load/save cycle. The editor renders only the first sheet today; without
+   * this, saving would silently delete every other tab.
+   */
+  extraSheets?: SheetDocSheet[];
 }
 
 export type SheetPrimitive = number | string | boolean | '';
@@ -26,6 +122,7 @@ export interface SheetDocCell {
   type?: string;
   notes?: string[];
   error?: SheetDocCellError;
+  format?: CellFormat;
 }
 
 export interface SheetDocDependencyRecord {
@@ -87,6 +184,11 @@ export interface SheetEvaluationCell {
   error?: string;
   dependsOn: SheetCellAddress[];
   dependents: SheetCellAddress[];
+  /**
+   * The format actually applied to `display`, with the column default already
+   * resolved, so renderers do not each re-implement that precedence.
+   */
+  format?: CellFormat;
 }
 
 export interface SheetEvaluation {

--- a/packages/lib/src/sheets/update.ts
+++ b/packages/lib/src/sheets/update.ts
@@ -111,8 +111,7 @@ function sanitizeKeyedFormats(
  * every save, so clamping here would silently rewrite a hand-authored or
  * imported 10px gutter to 24px and destroy the original — the same
  * "drop what we do not understand" failure the format and range passthroughs
- * exist to avoid. Consumers clamp at the point of use instead, via
- * `clampColumnWidth`/`clampRowHeight`.
+ * exist to avoid. Bounding belongs to whatever renders or exports the value.
  */
 function sanitizeKeyedNumbers(
   values: Record<string, number> | undefined,

--- a/packages/lib/src/sheets/update.ts
+++ b/packages/lib/src/sheets/update.ts
@@ -125,8 +125,14 @@ function sanitizeKeyedNumbers(
   for (const [key, value] of Object.entries(values)) {
     const normalized = key.toUpperCase();
     if (!keyPattern.test(normalized)) continue;
-    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) continue;
-    sanitized[normalized] = Math.round(value);
+    if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+
+    // Round FIRST: guarding the raw value let 0.4 through, which then stored
+    // as 0 and was dropped by the next save — a width that survives one save
+    // and vanishes on the following one.
+    const rounded = Math.round(value);
+    if (rounded <= 0) continue;
+    sanitized[normalized] = rounded;
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;

--- a/packages/lib/src/sheets/update.ts
+++ b/packages/lib/src/sheets/update.ts
@@ -4,7 +4,7 @@
  */
 
 import { PageType } from '../utils/enums';
-import type { SheetData, SheetCellUpdate } from './types';
+import type { CellFormat, SheetData, SheetCellUpdate } from './types';
 import { cellRegex, decodeCellAddress } from './address';
 
 /**
@@ -43,7 +43,33 @@ export function sanitizeSheetData(sheet: SheetData): SheetData {
     rowCount: Math.max(1, sheet.rowCount),
     columnCount: Math.max(1, sheet.columnCount),
     cells: sanitizedCells,
+    formats: sanitizeFormats(sheet.formats),
   };
+}
+
+/**
+ * Drop format entries whose address is not a valid A1 reference.
+ *
+ * Entries that are merely *outside* the current row/column count are kept on
+ * purpose: a sheet that temporarily shrinks — or one whose formatting was
+ * applied ahead of its data — must not lose its styling, and the grid simply
+ * ignores formats it cannot show.
+ */
+function sanitizeFormats(
+  formats: Record<string, CellFormat> | undefined
+): Record<string, CellFormat> | undefined {
+  if (!formats) return undefined;
+
+  const sanitized: Record<string, CellFormat> = {};
+
+  for (const [key, format] of Object.entries(formats)) {
+    const normalized = key.toUpperCase();
+    if (!cellRegex.test(normalized)) continue;
+    if (!format || typeof format !== 'object') continue;
+    sanitized[normalized] = format;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
 
 /**

--- a/packages/lib/src/sheets/update.ts
+++ b/packages/lib/src/sheets/update.ts
@@ -6,6 +6,7 @@
 import { PageType } from '../utils/enums';
 import type { CellFormat, SheetData, SheetCellUpdate } from './types';
 import { cellRegex, decodeCellAddress } from './address';
+import { parseCellFormat } from './format';
 
 /**
  * Clone cells record
@@ -44,8 +45,14 @@ export function sanitizeSheetData(sheet: SheetData): SheetData {
     columnCount: Math.max(1, sheet.columnCount),
     cells: sanitizedCells,
     formats: sanitizeFormats(sheet.formats),
+    columnFormats: sanitizeKeyedFormats(sheet.columnFormats, columnKeyRegex),
+    columnWidths: sanitizeKeyedNumbers(sheet.columnWidths, columnKeyRegex),
+    rowHeights: sanitizeKeyedNumbers(sheet.rowHeights, rowKeyRegex),
   };
 }
+
+const columnKeyRegex = /^[A-Z]+$/;
+const rowKeyRegex = /^[1-9]\d*$/;
 
 /**
  * Drop format entries whose address is not a valid A1 reference.
@@ -65,8 +72,51 @@ function sanitizeFormats(
   for (const [key, format] of Object.entries(formats)) {
     const normalized = key.toUpperCase();
     if (!cellRegex.test(normalized)) continue;
-    if (!format || typeof format !== 'object') continue;
-    sanitized[normalized] = format;
+
+    // Validate the format itself, not just its address. The read path runs
+    // `parseCellFormat` and drops anything non-conforming, so skipping it here
+    // let the write path persist a format that vanished on the next load.
+    const parsed = parseCellFormat(format);
+    if (parsed) sanitized[normalized] = parsed;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+/** Per-column/row format maps, keyed by column letters or a row number. */
+function sanitizeKeyedFormats(
+  formats: Record<string, CellFormat> | undefined,
+  keyPattern: RegExp
+): Record<string, CellFormat> | undefined {
+  if (!formats) return undefined;
+
+  const sanitized: Record<string, CellFormat> = {};
+
+  for (const [key, format] of Object.entries(formats)) {
+    const normalized = key.toUpperCase();
+    if (!keyPattern.test(normalized)) continue;
+
+    const parsed = parseCellFormat(format);
+    if (parsed) sanitized[normalized] = parsed;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+/** Per-column/row size maps; these reach the serializer unchecked otherwise. */
+function sanitizeKeyedNumbers(
+  values: Record<string, number> | undefined,
+  keyPattern: RegExp
+): Record<string, number> | undefined {
+  if (!values) return undefined;
+
+  const sanitized: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    const normalized = key.toUpperCase();
+    if (!keyPattern.test(normalized)) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+    sanitized[normalized] = Math.round(value);
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;

--- a/packages/lib/src/sheets/update.ts
+++ b/packages/lib/src/sheets/update.ts
@@ -7,6 +7,12 @@ import { PageType } from '../utils/enums';
 import type { CellFormat, SheetData, SheetCellUpdate } from './types';
 import { cellRegex, decodeCellAddress } from './address';
 import { parseCellFormat } from './format';
+import {
+  MAX_COLUMN_WIDTH,
+  MAX_ROW_HEIGHT,
+  MIN_COLUMN_WIDTH,
+  MIN_ROW_HEIGHT,
+} from './format-ops';
 
 /**
  * Clone cells record
@@ -46,8 +52,13 @@ export function sanitizeSheetData(sheet: SheetData): SheetData {
     cells: sanitizedCells,
     formats: sanitizeFormats(sheet.formats),
     columnFormats: sanitizeKeyedFormats(sheet.columnFormats, columnKeyRegex),
-    columnWidths: sanitizeKeyedNumbers(sheet.columnWidths, columnKeyRegex),
-    rowHeights: sanitizeKeyedNumbers(sheet.rowHeights, rowKeyRegex),
+    columnWidths: sanitizeKeyedNumbers(
+      sheet.columnWidths,
+      columnKeyRegex,
+      MIN_COLUMN_WIDTH,
+      MAX_COLUMN_WIDTH
+    ),
+    rowHeights: sanitizeKeyedNumbers(sheet.rowHeights, rowKeyRegex, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT),
   };
 }
 
@@ -103,10 +114,18 @@ function sanitizeKeyedFormats(
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
 
-/** Per-column/row size maps; these reach the serializer unchecked otherwise. */
+/**
+ * Per-column/row size maps; these reach the serializer unchecked otherwise.
+ *
+ * Clamped to the same bounds the setters enforce. Loaded content never goes
+ * through `setColumnWidth`/`setRowHeight`, so without this a stored negative
+ * or absurd size reaches the grid and the XLSX export intact.
+ */
 function sanitizeKeyedNumbers(
   values: Record<string, number> | undefined,
-  keyPattern: RegExp
+  keyPattern: RegExp,
+  min: number,
+  max: number
 ): Record<string, number> | undefined {
   if (!values) return undefined;
 
@@ -116,7 +135,7 @@ function sanitizeKeyedNumbers(
     const normalized = key.toUpperCase();
     if (!keyPattern.test(normalized)) continue;
     if (typeof value !== 'number' || !Number.isFinite(value)) continue;
-    sanitized[normalized] = Math.round(value);
+    sanitized[normalized] = Math.min(max, Math.max(min, Math.round(value)));
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;

--- a/packages/lib/src/sheets/update.ts
+++ b/packages/lib/src/sheets/update.ts
@@ -7,12 +7,6 @@ import { PageType } from '../utils/enums';
 import type { CellFormat, SheetData, SheetCellUpdate } from './types';
 import { cellRegex, decodeCellAddress } from './address';
 import { parseCellFormat } from './format';
-import {
-  MAX_COLUMN_WIDTH,
-  MAX_ROW_HEIGHT,
-  MIN_COLUMN_WIDTH,
-  MIN_ROW_HEIGHT,
-} from './format-ops';
 
 /**
  * Clone cells record
@@ -52,13 +46,8 @@ export function sanitizeSheetData(sheet: SheetData): SheetData {
     cells: sanitizedCells,
     formats: sanitizeFormats(sheet.formats),
     columnFormats: sanitizeKeyedFormats(sheet.columnFormats, columnKeyRegex),
-    columnWidths: sanitizeKeyedNumbers(
-      sheet.columnWidths,
-      columnKeyRegex,
-      MIN_COLUMN_WIDTH,
-      MAX_COLUMN_WIDTH
-    ),
-    rowHeights: sanitizeKeyedNumbers(sheet.rowHeights, rowKeyRegex, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT),
+    columnWidths: sanitizeKeyedNumbers(sheet.columnWidths, columnKeyRegex),
+    rowHeights: sanitizeKeyedNumbers(sheet.rowHeights, rowKeyRegex),
   };
 }
 
@@ -117,15 +106,17 @@ function sanitizeKeyedFormats(
 /**
  * Per-column/row size maps; these reach the serializer unchecked otherwise.
  *
- * Clamped to the same bounds the setters enforce. Loaded content never goes
- * through `setColumnWidth`/`setRowHeight`, so without this a stored negative
- * or absurd size reaches the grid and the XLSX export intact.
+ * Rejects what is meaningless (non-numeric, non-finite, zero or negative) but
+ * deliberately does NOT clamp to the editor's MIN/MAX. Sanitization runs on
+ * every save, so clamping here would silently rewrite a hand-authored or
+ * imported 10px gutter to 24px and destroy the original — the same
+ * "drop what we do not understand" failure the format and range passthroughs
+ * exist to avoid. Consumers clamp at the point of use instead, via
+ * `clampColumnWidth`/`clampRowHeight`.
  */
 function sanitizeKeyedNumbers(
   values: Record<string, number> | undefined,
-  keyPattern: RegExp,
-  min: number,
-  max: number
+  keyPattern: RegExp
 ): Record<string, number> | undefined {
   if (!values) return undefined;
 
@@ -134,8 +125,8 @@ function sanitizeKeyedNumbers(
   for (const [key, value] of Object.entries(values)) {
     const normalized = key.toUpperCase();
     if (!keyPattern.test(normalized)) continue;
-    if (typeof value !== 'number' || !Number.isFinite(value)) continue;
-    sanitized[normalized] = Math.min(max, Math.max(min, Math.round(value)));
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) continue;
+    sanitized[normalized] = Math.round(value);
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;


### PR DESCRIPTION
## What this is

The first PR of an effort to make PageSpace spreadsheets something people can build
**visually pleasing dashboards** on. It ships no new UI — it is the foundation the redesigned
sheet surface needs, plus a live data-loss bug found on the way.

Full roadmap and design decisions: `~/.claude/plans/crispy-swinging-adleman.md`.
The next PR is the visible one (redesigned, virtualized grid + formatting toolbar).

---

## The data-loss bug

A cell containing a **newline** (or a tab, CR, or any C0 control character) serialized to invalid
TOML. `parseSheetContent` caught the parse failure and returned `createEmptySheet()`, so the next
load showed an empty grid and the next save persisted it — **losing every cell in the document,
not just the offending one**, with nothing surfaced to the user.

Verified against the pre-change code: one newline in `A1` left **0 cells**, including unrelated
neighbours.

This was reachable **without typing anything**: `form-target-service` writes public form
submissions straight through `updateSheetCells`, so a form response containing a line break
destroyed the sheet it fed.

Root cause: `@iarna/toml` was already a dependency, but `io.ts` imported only `parse` and
hand-rolled the writer, escaping just `\` and `"`. That asymmetry was the bug.

### What changed

- Escape the full TOML basic-string set, and quote non-bare keys at **every** interpolation site
  (columns, ranges, cell addresses, dependencies, meta, inline tables). Meta keys matter because
  extra tabs are re-emitted verbatim, so one unescaped key made a document permanently unsavable.
- **Self-verify on write**: `stringifySheetDoc` re-parses its own output and throws
  `SheetSerializationError` rather than emit something that reads back empty.
- Add `parseSheetContentSafe`, distinguishing "genuinely empty" from "failed to parse".
  `parseSheetContent` keeps its exact signature, so its ~20 call sites are unchanged.
- Use it on **all four write paths** — the editor, the public form service, the `edit_sheet_cells`
  AI tool, and the MCP route — so none can replace a sheet it failed to read with the cells it was
  writing. The editor shows a banner and disables editing; the others refuse the write.
- `page-type-validators` now requires the body to actually parse; it previously trusted the magic
  prefix alone, which is how corrupt content passed validation on write.

## Two more defects fixed

- **Undo was dead.** The history reset keyed on the whole `documentState` object, which the store
  recreates on every write — so every keystroke cleared the undo stack. It now keys on content and
  recognises the local echo.
- **View-only users could not select cells**, so they could not copy a range or see its total.
  Selection is not a mutation; editing stays gated.

## The formatting foundation

Number formats (currency/percent/decimals/date), bold, italic, colours, alignment, borders, column
widths, row heights, frozen panes.

**Formats live in maps parallel to `cells`, which stays `Record<address, string>.`** Clearing a
cell keeps its formatting (as in Excel and Sheets), and every existing consumer of `cells` — the AI
tool, MCP, SDK, CLI, clipboard, exports — is untouched. **All 309 pre-existing sheet tests pass
unmodified**, which was the gate on this decision.

Formatting is applied at the evaluator's **display projection** — the single point the grid, both
exports and the published page all read, so they cannot disagree. It rewrites `display` only, never
`value`: concatenation and comparison keep operating on raw values, so `="Total: "&A1` yields
`Total: 1234.5`, not `Total: $1,234.50`. There is a test pinning exactly that.

Also:

- **Multi-tab preservation** — editing a multi-tab workbook previously deleted every tab after the
  first on save. Tabs are now carried verbatim. Named ranges too, for the same reason.
- **xlsx export carries real typed numbers** and number-format codes. It previously wrote every
  cell as text, so nothing in Excel could sum, sort or chart it.
- **Published pages render formatting** as inline styles, validated at parse and again at render
  since that document honours inline styles.

---

## Validation

```
bun run typecheck     # green (monorepo, includes web build)
bun run lint          # green
bun run --filter @pagespace/lib test -- src/__tests__/sheet    # 446 passed
bun run --filter web  test -- .../page-views/sheet             # 169 passed
```

Remaining failures in the full suites are `Test database not reachable` integration tests only —
this worktree has no Postgres. None are in touched areas.

Each behavioural fix was **mutation-checked** — the fix was reverted and the tests watched go red:

| Mutation | Tests that caught it |
|---|---|
| Restore the naive TOML escaper | 15 |
| Restore the `documentState` history dependency | 3 |
| Stop emitting extra tabs | 3 |
| Stop applying typed cells to xlsx | 3 |

## Review round (CodeRabbit, 7 findings — all fixed)

Each fix carries a test. Commits `cd99e9a2` and `8c96f906`.

| Finding | Fix |
|---|---|
| **Undo stack leaked across pages** (Major) — `knownContentRef` matched on content alone, so navigating to a page with byte-identical content read it as the local echo. An undo could then write the previous page's state into the new page. | Ref scoped to `{pageId, content}`; `pageId` added to the effect deps. Mutation-checked. |
| Explicit column widths dropped for columns past the widest row, and `.map` skipped sparse holes. | `!cols` sized by the wider of the two sources, built with `Array.from`. |
| Currency Excel code ignored `thousands: false`, so the grid and the workbook disagreed. | Excel code honours it; test asserts both halves together. |
| `moveCellMetadata` lost a format on address collision and never bumped `version`. | Two passes, relocations first and winning; `version` bumped. |
| `sanitizeSheetData` validated a format's address but not its contents, so the write path persisted what the read path drops. | Routes through `parseCellFormat`; `columnFormats`/`columnWidths`/`rowHeights` validated too. |
| Stored widths/heights bypassed the setters' bounds, so a negative or absurd size reached the grid and the export. | Clamped on load using the same MIN/MAX constants the setters use. |
| `readOnlyReason` went stale in write callbacks — `isReadOnly` stays `true` while the *cause* flips from permissions to a load failure. | Added to every relevant dependency array. `react-hooks/exhaustive-deps` caught one site my own sweep missed. |

## Self-review rounds (`bbc4255e`, `3fbecbad`, `d756b629`, `8ae8725`)

Three adversarial passes over my own fixes. Each round of fixes had introduced
new defects, so each was reviewed in turn. Everything below was confirmed by
running the code, not by reading it.

**Round 2 — three regressions introduced by the round-1 review fixes:**

- Every XLSX export collapsed its empty columns to ~2 characters. `evaluation.display`
  is dense, so an empty column measures `0` and my fallback treated that as "has a
  measurement": a 10-column sheet exported as `[17,2,2,2,2,2,2,2,2,2]`. Fired on every export.
- The write path destroyed formats it did not fully understand. Moving zod's
  all-or-nothing `safeParse` onto the save path meant `{bold: true, fontSize: 5}`
  lost the bold, and a newer build's field was deleted the first time an older build saved.
- Clamping on save rewrote stored dimensions — a hand-authored 10px gutter became 24px permanently.

**Round 3 — a remotely-triggerable crash:**

- `parseCellFormat` threw on every load *and* every save of any document containing a
  `__proto__`, `toString` or `constructor` key: the schema lookup fell through the
  object's prototype chain to a non-schema. Unopenable editor, 500 on both export routes.
  The schema table is now a `Map`, and those keys are never carried through.

**Round 4 — five more, two of them introduced by round 3:**

- `moveCellMetadata` reintroduced last-writer-wins one loop below where round 3 fixed it.
- It reported "unchanged" while changing the map, in three separate cases.
- A stored width of `0.4` persisted as `0` and then vanished on the *next* save.
- The export clamped widths *up*, so a deliberately narrow column was stored faithfully
  and then silently widened — storage and export disagreeing about the same decision.
- A TOML `datetime` unknown field serialized as `{}`, destroying the forward-compatibility
  the passthrough exists to provide.

Two of my own tests passed for the wrong reason and were replaced with behavioural ones:
one asserted a single array index while the bug sat in the rest of the array, and one was
a pure-function unit test of `Math.min/max` that passed while the function had no callers.

## What has and has not been verified

Stated explicitly so "189 tests pass" is not read as more than it is.

**Verified by executing the real code**, not by reading it: the TOML round trip
over control characters, hostile keys, astral pairs and 10KB values; the format
model's round trip including formats, column widths, row heights, frozen panes,
named ranges and multi-tab preservation; that formatting rewrites `display` and
never `value` (so `&` and comparisons are unaffected); prototype-pollution
attempts through stored formats; the xlsx export's typed cells, number formats
and `!cols`; the published page's inline styles under a hostile colour. Each
behavioural fix was mutation-checked — the fix reverted and the tests watched go
red.

**Covered only by a mocked render harness**: `SheetView` itself. Its new test
file mocks ten modules (persistence, permissions, socket, auth, page tree,
suggestion, conflict gate, scroll area). That is enough to catch the read-only
gating and the load-failure banner — both mutation-checked — but a harness can
only test what it supplies, and jsdom is not a browser.

**Verified in a real browser** (added after the section above was first written,
which said the app had never been run — that is no longer true). A production
build was run against a scratch Postgres with a seeded drive and sheet, and the
page opened in headless Chromium:

| Claim | Result on screen |
|---|---|
| A cell containing a newline survives and displays | `A2` renders `first line\nsecond line` |
| Currency formatting reaches the grid | `B2` renders `$1,234.50` |
| A formula reading a formatted cell is itself formatted | `B3` renders `$2,469.00` |
| No false load-failure banner on a readable sheet | banner absent, `aria-readonly="false"` |
| A cell can be selected by clicking | `aria-selected="true"` |
| Editing starts and commits | typing opens the editor; Enter commits to the grid |
| No runtime errors | zero `pageerror`s |

Bold and background do **not** render in the grid, which is expected: `SheetGrid`
does not consume cell styles until the next PR. Number formats do render,
because they are applied at the evaluator's display projection.

**The full round trip is now verified too.** Object storage was the only thing
missing — every content update snapshots the previous content to S3
(`page-mutation-service.ts:172-180` → `writePageContent`, unconditional, no
filesystem branch on write). Pointing `AWS_ENDPOINT_URL_S3` at a throwaway
in-memory stub was enough:

| Claim | Result |
|---|---|
| An edit saves and survives a reload | typed into `C1`, `PATCH` 200, still there after reload |
| **A multi-line cell survives a save and reload** | `A2` still `first line\nsecond line` after the save that would previously have destroyed the document |
| Formatting survives the round trip | `B2` still `$1,234.50` after reload |
| **Undo works** | `D1`: `z` → undo → empty → redo → `z` |
| No runtime errors throughout | zero `pageerror`s |

Undo appears to do nothing if you reload between the edit and the undo — that
is correct, not a defect: loading server content resets the history so undo
cannot walk back into a state the server never had.

The view-only fix is verified in a browser too, with a real second user holding
a `page_permissions` row of `canView: true, canEdit: false`:

| Claim | Result |
|---|---|
| Cells are marked read-only | `aria-readonly="true"` |
| **A view-only user can select a cell** | click → `aria-selected="true"` |
| …and drag out a range | all four cells of `A1:B2` selected |
| Editing is still refused | `B2` unchanged at `$1,234.50` after typing |

That is the behaviour the removed early return used to block: a viewer could
not select, so could not copy a range or see the sum/average footer.

Everything above ran against a production build with a real Postgres, a real
session minted through the app's own service, and headless Chromium. The
scratch database, server and stub were torn down afterwards.

## Reviewer notes

- **A `SheetDoc` version bump is deliberately NOT taken.** `parseSheetDocString` throws on an
  unknown version and `parseSheetContent` turns that into an empty sheet — so a `v2` document read
  by an older deploy would render blank and the next autosave would write that blank over the
  user's data. New fields are additive under `v1` instead. Rolling back after formatting is applied
  strips formatting on the next edit but never loses values.
- **CSV export now emits formatted values** (`$1,234.50`), matching Excel, Google Sheets and the
  xlsx export. Only newly-formatted cells are affected. Happy to revert to raw values if preferred.
- **Three existing tests were changed deliberately.** Their fixture
  (`'#%PAGESPACE_SHEETDOC\nrows=10\ncols=10\ncells=\n'`) carries the magic prefix but is malformed
  TOML — `cells=` has no value. They asserted it was "valid SheetDoc content", which was only true
  because of the bug this PR fixes. The assertions' intent is unchanged; the fixture now matches
  what it claims to be.
- **Frozen panes are deliberately not written to xlsx.** `xlsx@0.18.5` ignores a `!freeze`
  worksheet property — it emits no `<pane>` element — so the code was removed rather than left as a
  no-op implying a feature that works. Noted in a comment at the call site.
- `moveCellMetadata` / `shiftAxisMetadata` exist for the structural row/column ops that arrive in a
  later PR; nothing calls them yet, and they are documented as the hook those ops must use so
  formats do not drift from the cells they belong to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWNm6QhDZmVf9imeHuCvUi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persisted spreadsheet formatting for numbers, dates, currency, percentages, alignment, colors, borders, row heights, and column widths.
  - XLSX exports preserve numeric values, formatting, formulas, column widths, and multiple tabs.
  - Published spreadsheet tables and CSV exports retain displayed formatting.
  - View-only users can select cells and ranges.
  - Added conflict-safe document editing and resolution.

- **Bug Fixes**
  - Preserved newlines, tabs, and control characters in spreadsheet data.
  - Prevented unreadable sheets from being overwritten and explained when editing is unavailable.
  - Preserved undo history across edits and reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






