### PR TITLE
feat(drive-envs): environments UI — sidebar, spawn, management, usage (launch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Environments: a place in a drive that stays** — a drive can now hold named environments, and a
+  session can run inside one instead of in a sandbox that disappears when you close it. Everything
+  in an environment — your files, what you installed, what you configured — is still there the next
+  time anyone in the drive opens a session in it, because it is one machine with one filesystem that
+  everybody in the drive shares. Name them for what they are for: “dev”, “staging”, “data-import”.
+  Ephemeral sessions have not changed and are still the default; an environment is something you
+  deliberately make.
+- **Environments live in the sidebar beside your sessions, not inside them** — each one shows its
+  name and a dot for whether its machine is up, and the sessions running in it are listed
+  underneath, so you can see at a glance who is working on which filesystem. An environment with
+  nothing running in it still appears: it is infrastructure your drive keeps, not something that
+  vanishes on an idle afternoon. Starting a new session in a drive that has environments asks where
+  it should run — a fresh sandbox, or in one of them.
+- **Creating, renaming, rebuilding and deleting an environment** — all four are for drive owners and
+  admins, and the two destructive ones say what they destroy before they do it. Deleting refuses
+  while sessions are still running inside and then offers to end them, naming both halves of what
+  that means; rebuilding says plainly that the environment comes back BLANK, with its name intact
+  and nothing else. Anyone else in the drive sees the environments and can work in them, without the
+  controls they could not use anyway.
+- **Environments have their own line on your usage page** — what a drive's environments cost to keep
+  is listed per environment, by name, separately from your agent sessions. It was previously folded
+  into a single "Unattributed agent" line, which named the wrong thing and skewed the share each
+  agent appeared to account for; both are now right.
+
 - **Agents can hand work to each other from anywhere, not just from a browser tab** — asking an
   assistant to spawn or message a worker used to fail with "the calling request carries no session
   credentials to dispatch with" whenever the request had not come from a logged-in browser. That

--- a/apps/web/src/app/api/agent-workspaces/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/route.ts
@@ -245,8 +245,10 @@ export async function POST(request: Request) {
   let driveId = typeof body.driveId === 'string' && body.driveId.length > 0 ? body.driveId : null;
   const agentPageId =
     typeof body.agentPageId === 'string' && body.agentPageId.length > 0 ? body.agentPageId : null;
-  // The environment to run inside, when one is named. Accepted but not yet
-  // OFFERED anywhere — no UI sends it, which is what "ships dark" means here.
+  // The environment to run inside, when one is named. The spawn palette now
+  // offers it ("in <env name>", beside the ephemeral default), so this is a
+  // live field rather than the dark one #2441 landed. Omitted and `null` still
+  // mean the same thing they always did: the ordinary ephemeral sandbox.
   // It is NOT validated in this route: whether the env exists and belongs to
   // `driveId` is `spawnAgentSession`'s check, made there so every future caller
   // inherits it rather than each one re-deriving it.

--- a/apps/web/src/app/settings/usage/page.tsx
+++ b/apps/web/src/app/settings/usage/page.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, CheckCircle, AlertTriangle } from 'lucide-react';
 import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
 import { UsageBreakdownCard } from '@/components/billing/UsageBreakdownCard';
 import { AgentSessionUsageCard } from '@/components/billing/AgentSessionUsageCard';
+import { EnvironmentUsageCard } from '@/components/billing/EnvironmentUsageCard';
 import { ConcurrencyCard } from '@/components/billing/ConcurrencyCard';
 import { AutomationsCard } from '@/components/billing/AutomationsCard';
 import { StorageUsageCard } from '@/components/billing/StorageUsageCard';
@@ -66,6 +67,7 @@ export default function UsagePage() {
       <CreditBalanceCard />
       <UsageBreakdownCard />
       <AgentSessionUsageCard />
+      <EnvironmentUsageCard />
       <ConcurrencyCard />
       <AutomationsCard />
       <StorageUsageCard />

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -157,7 +157,11 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // environments to offer). Shares its SWR key with the sidebar's environment
   // rows, so an environment created there is offered here without a second
   // request.
-  const { envs: paletteEnvs } = useDriveEnvs(spawnTarget?.driveId ?? null);
+  // `isLoading` is consumed, not discarded, and that is load-bearing rather
+  // than tidy: `envs` is `[]` BOTH while the listing is in flight and when the
+  // drive genuinely has none, so a step decision that reads only `.length`
+  // cannot tell "no environments" from "not answered yet". See `step` below.
+  const { envs: paletteEnvs, isLoading: paletteEnvsLoading } = useDriveEnvs(spawnTarget?.driveId ?? null);
 
   const paletteAgents = useMemo(
     () => (spawnTarget ? (agentsByDrive.find((entry) => entry.driveId === spawnTarget.driveId)?.agents ?? []) : []),
@@ -180,6 +184,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       driveName={spawnTarget?.driveName ?? null}
       agents={paletteAgents}
       envs={paletteEnvs}
+      envsLoading={paletteEnvsLoading}
       canRunSandbox={canRunSandbox}
       pick={spawnPick}
       spawning={spawning}
@@ -212,6 +217,7 @@ function SpawnSessionPalette({
   driveName,
   agents,
   envs,
+  envsLoading,
   canRunSandbox,
   pick,
   spawning,
@@ -226,8 +232,16 @@ function SpawnSessionPalette({
   /**
    * The drive's environments. EMPTY IS THE COMMON CASE and it removes the step
    * entirely — a drive that has never made one never sees a question about it.
+   *
+   * Always read together with `envsLoading`: an empty array on its own does not
+   * mean "this drive has none".
    */
   envs: DriveEnvDTO[];
+  /**
+   * Whether that listing is still in flight. The step machine WAITS on this
+   * rather than treating a not-yet-arrived listing as an answer — see `step`.
+   */
+  envsLoading: boolean;
   /**
    * Whether the requester can actually run this drive's sandbox (the
    * actor-aware server verdict: kill switch + the payer's tier + the
@@ -256,34 +270,72 @@ function SpawnSessionPalette({
     if (open) setName('');
   }, [open, pick]);
 
-  // WHICH OF THE THREE STEPS IS ON SCREEN, decided in one place rather than by
-  // three ternaries that could disagree. The environment step exists only when
-  // there is something to choose between: no environments in the drive means
+  // WHICH OF THE FOUR STEPS IS ON SCREEN, decided in one place rather than by
+  // ternaries that could disagree. The environment step exists only when there
+  // is something to choose between: no environments in the drive means
   // `pick.envId` is never asked for and the flow is the original two steps.
-  const step: 'target' | 'env' | 'name' =
-    pick === null ? 'target' : pick.envId === undefined && envs.length > 0 ? 'env' : 'name';
+  //
+  // `'pending'` is the step that stops a race, and it is not cosmetic. The
+  // listing is `[]` while it is still in flight, so a step machine reading only
+  // `envs.length` treats "not answered yet" as "this drive has none" — and the
+  // two failure modes that follows are both silent. A fast pick lands straight
+  // on the name step and spawns with `envId: null`, quietly ephemeral in a
+  // drive that HAS environments; or the listing arrives while the user is
+  // already typing a name, the step recomputes to `'env'`, and the name form is
+  // replaced mid-keystroke (with `setName('')` wiping what they wrote). Both
+  // are likeliest from a cold cache — opening the palette from a header that
+  // never rendered the sidebar's environment rows and so never warmed the key.
+  //
+  // Waiting is therefore the only honest answer while the question is open. It
+  // costs a beat exactly once per drive, and never once the SWR key is warm.
+  const step: 'target' | 'pending' | 'env' | 'name' =
+    pick === null
+      ? 'target'
+      : pick.envId !== undefined
+        ? 'name'
+        : envsLoading
+          ? 'pending'
+          : envs.length > 0
+            ? 'env'
+            : 'name';
   const chosenEnv = pick?.envId ? (envs.find((env) => env.id === pick.envId) ?? null) : null;
 
   return (
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
-      title={step === 'target' ? 'New session' : step === 'env' ? 'Where should it run?' : 'Name your session'}
+      title={
+        step === 'target'
+          ? 'New session'
+          : step === 'env' || step === 'pending'
+            ? 'Where should it run?'
+            : 'Name your session'
+      }
       description={
         step === 'name'
           ? chosenEnv
             ? `In ${chosenEnv.name} · leave blank to use "${pick?.label ?? 'this session'}"`
             : `Leave blank to use "${pick?.label ?? 'this session'}"`
-          : step === 'env'
-            ? 'A session in an environment shares that environment’s files, and they stay there when the session ends.'
-            : driveName
-              ? `Choose an agent to start a session with in ${driveName}`
-              : 'Choose an agent to start a session with'
+          : step === 'pending'
+            ? 'Checking this drive for environments…'
+            : step === 'env'
+              ? 'A session in an environment shares that environment’s files, and they stay there when the session ends.'
+              : driveName
+                ? `Choose an agent to start a session with in ${driveName}`
+                : 'Choose an agent to start a session with'
       }
       showCloseButton={false}
       className="max-w-[420px]"
     >
-      {step === 'env' ? (
+      {step === 'pending' ? (
+        /* Deliberately inert — no input to focus and nothing selectable. The
+           question ("where should it run?") is already on screen; only its
+           options are missing, so this holds the user's place rather than
+           showing them a form that is about to be replaced. */
+        <div className="p-4 text-sm text-muted-foreground" role="status">
+          Looking for environments in this drive…
+        </div>
+      ) : step === 'env' ? (
         <>
           <CommandInput placeholder="Search environments…" autoFocus />
           <CommandList>

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, SquareTerminal } from 'lucide-react';
+import { Bot, Boxes, SquareTerminal, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 
 import {
@@ -14,7 +14,9 @@ import {
 import { post } from '@/lib/auth/auth-fetch';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
+import { useDriveEnvs } from '@/hooks/drive-envs/useDriveEnvs';
 import type { DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
+import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 
 export type SpawnKind = 'agent' | 'shell' | 'assistant';
 
@@ -24,6 +26,22 @@ export interface SpawnPick {
   agentPageId: string | null;
   /** The sensible default: the agent's title, "Shell", or "Global Assistant". */
   label: string;
+  /**
+   * WHERE the session runs, in three states rather than two.
+   *
+   * `undefined` = not chosen yet, which is what makes the environment step
+   * appear; `null` = the ephemeral default (the session owns its own sandbox,
+   * gone when it ends); a string = the drive environment it runs INSIDE,
+   * sharing that environment's persistent filesystem with every other session
+   * in it. The `undefined`/`null` split is load-bearing: "ephemeral" is a real
+   * choice a user makes, not the absence of one, so it cannot be the same value
+   * as "has not answered yet".
+   *
+   * A drive with no environments never shows the step, and the pick goes
+   * straight to naming with this left unset — the flow is byte-for-byte what it
+   * was before environments existed.
+   */
+  envId?: string | null;
 }
 
 /**
@@ -55,14 +73,14 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   const [spawning, setSpawning] = useState(false);
 
   const spawn = useCallback(
-    async (input: { driveId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
+    async (input: { driveId: string | null; envId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
       if (spawning) return;
       setSpawning(true);
       try {
         if (input.kind === 'shell') {
           const created = await post<{ session: { workspaceId: string }; shellId: string; shellName: string }>(
             '/api/agent-workspaces',
-            { driveId: input.driveId, firstThing: 'shell', name: input.name },
+            { driveId: input.driveId, envId: input.envId, firstThing: 'shell', name: input.name },
           );
           setSpawnTarget(null);
           setSpawnPick(null);
@@ -79,7 +97,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         }
         const created = await post<{ session: { workspaceId: string }; conversationId: string }>(
           '/api/agent-workspaces',
-          { driveId: input.driveId, agentPageId: input.agentPageId, name: input.name },
+          { driveId: input.driveId, envId: input.envId, agentPageId: input.agentPageId, name: input.name },
         );
         setSpawnTarget(null);
         setSpawnPick(null);
@@ -120,10 +138,26 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   const handleSubmitName = useCallback(
     (name: string) => {
       if (!spawnTarget || !spawnPick) return;
-      void spawn({ driveId: spawnTarget.driveId, agentPageId: spawnPick.agentPageId, kind: spawnPick.kind, name });
+      void spawn({
+        driveId: spawnTarget.driveId,
+        // `undefined` (the step was skipped because the drive has none) and
+        // `null` (the user chose ephemeral) mean the same thing to the server.
+        envId: spawnPick.envId ?? null,
+        agentPageId: spawnPick.agentPageId,
+        kind: spawnPick.kind,
+        name,
+      });
     },
     [spawn, spawnTarget, spawnPick],
   );
+
+  // The targeted drive's environments — ONE fetch, keyed on whichever drive the
+  // palette is currently open for, and none at all while it is closed or the
+  // target is the global assistant (which lives outside any drive and so has no
+  // environments to offer). Shares its SWR key with the sidebar's environment
+  // rows, so an environment created there is offered here without a second
+  // request.
+  const { envs: paletteEnvs } = useDriveEnvs(spawnTarget?.driveId ?? null);
 
   const paletteAgents = useMemo(
     () => (spawnTarget ? (agentsByDrive.find((entry) => entry.driveId === spawnTarget.driveId)?.agents ?? []) : []),
@@ -145,6 +179,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       open={spawnTarget !== null}
       driveName={spawnTarget?.driveName ?? null}
       agents={paletteAgents}
+      envs={paletteEnvs}
       canRunSandbox={canRunSandbox}
       pick={spawnPick}
       spawning={spawning}
@@ -154,6 +189,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         setSpawnPick(null);
       }}
       onPickTarget={setSpawnPick}
+      onPickEnv={(envId) => setSpawnPick((current) => (current ? { ...current, envId } : current))}
       onSubmitName={handleSubmitName}
     />
   );
@@ -175,16 +211,23 @@ function SpawnSessionPalette({
   open,
   driveName,
   agents,
+  envs,
   canRunSandbox,
   pick,
   spawning,
   onOpenChange,
   onPickTarget,
+  onPickEnv,
   onSubmitName,
 }: {
   open: boolean;
   driveName: string | null;
   agents: DriveWithAgents['agents'];
+  /**
+   * The drive's environments. EMPTY IS THE COMMON CASE and it removes the step
+   * entirely — a drive that has never made one never sees a question about it.
+   */
+  envs: DriveEnvDTO[];
   /**
    * Whether the requester can actually run this drive's sandbox (the
    * actor-aware server verdict: kill switch + the payer's tier + the
@@ -201,6 +244,8 @@ function SpawnSessionPalette({
   spawning: boolean;
   onOpenChange: (open: boolean) => void;
   onPickTarget: (pick: SpawnPick) => void;
+  /** `null` is the ephemeral default — a real answer, not a cleared one. */
+  onPickEnv: (envId: string | null) => void;
   onSubmitName: (name: string) => void;
 }) {
   const [name, setName] = useState('');
@@ -211,22 +256,64 @@ function SpawnSessionPalette({
     if (open) setName('');
   }, [open, pick]);
 
+  // WHICH OF THE THREE STEPS IS ON SCREEN, decided in one place rather than by
+  // three ternaries that could disagree. The environment step exists only when
+  // there is something to choose between: no environments in the drive means
+  // `pick.envId` is never asked for and the flow is the original two steps.
+  const step: 'target' | 'env' | 'name' =
+    pick === null ? 'target' : pick.envId === undefined && envs.length > 0 ? 'env' : 'name';
+  const chosenEnv = pick?.envId ? (envs.find((env) => env.id === pick.envId) ?? null) : null;
+
   return (
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
-      title={pick ? 'Name your session' : 'New session'}
+      title={step === 'target' ? 'New session' : step === 'env' ? 'Where should it run?' : 'Name your session'}
       description={
-        pick
-          ? `Leave blank to use "${pick.label}"`
-          : driveName
-            ? `Choose an agent to start a session with in ${driveName}`
-            : 'Choose an agent to start a session with'
+        step === 'name'
+          ? chosenEnv
+            ? `In ${chosenEnv.name} · leave blank to use "${pick?.label ?? 'this session'}"`
+            : `Leave blank to use "${pick?.label ?? 'this session'}"`
+          : step === 'env'
+            ? 'A session in an environment shares that environment’s files, and they stay there when the session ends.'
+            : driveName
+              ? `Choose an agent to start a session with in ${driveName}`
+              : 'Choose an agent to start a session with'
       }
       showCloseButton={false}
       className="max-w-[420px]"
     >
-      {pick ? (
+      {step === 'env' ? (
+        <>
+          <CommandInput placeholder="Search environments…" autoFocus />
+          <CommandList>
+            <CommandGroup>
+              {/* The ephemeral default leads, because it is what every session
+                  was before environments existed and what most still should be. */}
+              <CommandItem
+                value="ephemeral-New sandbox"
+                disabled={spawning}
+                onSelect={() => onPickEnv(null)}
+              >
+                <Zap className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                <span className="truncate">New sandbox</span>
+                <span className="ml-auto shrink-0 text-xs text-muted-foreground">Ephemeral</span>
+              </CommandItem>
+              {envs.map((env) => (
+                <CommandItem
+                  key={env.id}
+                  value={`${env.id}-in ${env.name}`}
+                  disabled={spawning}
+                  onSelect={() => onPickEnv(env.id)}
+                >
+                  <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <span className="truncate">in {env.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </>
+      ) : step === 'name' ? (
         <form
           className="p-3"
           onSubmit={(event) => {
@@ -244,7 +331,7 @@ function SpawnSessionPalette({
               event.preventDefault();
               onSubmitName(name);
             }}
-            placeholder={pick.label}
+            placeholder={pick?.label ?? 'Session'}
             disabled={spawning}
             className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
           />

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -161,7 +161,12 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // than tidy: `envs` is `[]` BOTH while the listing is in flight and when the
   // drive genuinely has none, so a step decision that reads only `.length`
   // cannot tell "no environments" from "not answered yet". See `step` below.
-  const { envs: paletteEnvs, isLoading: paletteEnvsLoading } = useDriveEnvs(spawnTarget?.driveId ?? null);
+  const {
+    envs: paletteEnvs,
+    isLoading: paletteEnvsLoading,
+    error: paletteEnvsError,
+    mutate: retryPaletteEnvs,
+  } = useDriveEnvs(spawnTarget?.driveId ?? null);
 
   const paletteAgents = useMemo(
     () => (spawnTarget ? (agentsByDrive.find((entry) => entry.driveId === spawnTarget.driveId)?.agents ?? []) : []),
@@ -185,6 +190,8 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       agents={paletteAgents}
       envs={paletteEnvs}
       envsLoading={paletteEnvsLoading}
+      envsError={paletteEnvsError}
+      onRetryEnvs={retryPaletteEnvs}
       canRunSandbox={canRunSandbox}
       pick={spawnPick}
       spawning={spawning}
@@ -218,6 +225,8 @@ function SpawnSessionPalette({
   agents,
   envs,
   envsLoading,
+  envsError,
+  onRetryEnvs,
   canRunSandbox,
   pick,
   spawning,
@@ -242,6 +251,13 @@ function SpawnSessionPalette({
    * rather than treating a not-yet-arrived listing as an answer — see `step`.
    */
   envsLoading: boolean;
+  /**
+   * Whether that listing FAILED. The third fact `[]` collapses, and the one
+   * that survives after `envsLoading` goes false — so it needs its own step
+   * for the same reason loading did.
+   */
+  envsError: unknown;
+  onRetryEnvs: () => void;
   /**
    * Whether the requester can actually run this drive's sandbox (the
    * actor-aware server verdict: kill switch + the payer's tier + the
@@ -288,16 +304,25 @@ function SpawnSessionPalette({
   //
   // Waiting is therefore the only honest answer while the question is open. It
   // costs a beat exactly once per drive, and never once the SWR key is warm.
-  const step: 'target' | 'pending' | 'env' | 'name' =
+  //
+  // `'error'` is the same argument one step further. A FAILED listing also
+  // leaves `envs` at `[]`, and unlike loading it never resolves on its own —
+  // so without its own step the palette would sail past a question it could
+  // not ask and spawn ephemerally into a drive whose environments it simply
+  // failed to read. That is the silent-wrong-answer case again, just reached
+  // by a different route.
+  const step: 'target' | 'pending' | 'error' | 'env' | 'name' =
     pick === null
       ? 'target'
       : pick.envId !== undefined
         ? 'name'
         : envsLoading
           ? 'pending'
-          : envs.length > 0
-            ? 'env'
-            : 'name';
+          : envsError != null
+            ? 'error'
+            : envs.length > 0
+              ? 'env'
+              : 'name';
   const chosenEnv = pick?.envId ? (envs.find((env) => env.id === pick.envId) ?? null) : null;
 
   return (
@@ -307,7 +332,7 @@ function SpawnSessionPalette({
       title={
         step === 'target'
           ? 'New session'
-          : step === 'env' || step === 'pending'
+          : step === 'env' || step === 'pending' || step === 'error'
             ? 'Where should it run?'
             : 'Name your session'
       }
@@ -318,6 +343,8 @@ function SpawnSessionPalette({
             : `Leave blank to use "${pick?.label ?? 'this session'}"`
           : step === 'pending'
             ? 'Checking this drive for environments…'
+            : step === 'error'
+              ? 'This drive’s environments could not be loaded.'
             : step === 'env'
               ? 'A session in an environment shares that environment’s files, and they stay there when the session ends.'
               : driveName
@@ -334,6 +361,36 @@ function SpawnSessionPalette({
            showing them a form that is about to be replaced. */
         <div className="p-4 text-sm text-muted-foreground" role="status">
           Looking for environments in this drive…
+        </div>
+      ) : step === 'error' ? (
+        /* Not a hard block. The user came here to start a session and may
+           genuinely want an ephemeral one — but that has to be a CHOICE they
+           make knowing the environment list is missing, not a default they
+           fall into because a request failed. Retry first, escape hatch
+           second, both spelled out. */
+        <div className="space-y-3 p-4">
+          <p className="text-sm text-muted-foreground">
+            We could not check which environments this drive has. Try again, or start a session in a
+            new sandbox of its own.
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-input px-3 py-1.5 text-sm hover:bg-accent"
+              onClick={onRetryEnvs}
+              disabled={spawning}
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
+              onClick={() => onPickEnv(null)}
+              disabled={spawning}
+            >
+              Use a new sandbox
+            </button>
+          </div>
         </div>
       ) : step === 'env' ? (
         <>

--- a/apps/web/src/components/billing/EnvironmentUsageCard.tsx
+++ b/apps/web/src/components/billing/EnvironmentUsageCard.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect } from 'react';
+import useSWR from 'swr';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Boxes } from 'lucide-react';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { formatCreditCount } from '@/lib/subscription/credits';
+import { useSocketStore } from '@/stores/useSocketStore';
+
+interface EnvironmentRow {
+  envId: string | null;
+  label: string;
+  spendCents: number;
+  calls: number;
+  sharePct: number;
+}
+
+interface EnvironmentUsageResponse {
+  byEnvironment: EnvironmentRow[];
+}
+
+const fetcher = async (url: string): Promise<EnvironmentUsageResponse> => {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+  return response.json();
+};
+
+/**
+ * Per-environment persistence cost this billing period — reads the same
+ * `GET /api/credits/breakdown` payload as `UsageBreakdownCard` and
+ * `AgentSessionUsageCard` (its `byEnvironment` field), so all three share one
+ * SWR cache entry rather than issuing three requests.
+ *
+ * It is a SEPARATE card from "Agent sessions" for the reason the aggregator
+ * splits the rows at all: an environment is a drive's shared machine, kept
+ * because someone deliberately made it, and its charge is for a disk that
+ * exists whether or not anyone ran anything. Folded into the agent list it
+ * showed up as "Unattributed agent", which named the wrong thing entirely.
+ *
+ * No runtime column, unlike the agent-session card: these charges are metered
+ * per GB-month against a window, not a wall clock, so every one of them carries
+ * a zero duration.
+ */
+export function EnvironmentUsageCard() {
+  const socket = useSocketStore((state) => state.socket);
+  const connect = useSocketStore((state) => state.connect);
+
+  const { data, error, isLoading, mutate } = useSWR<EnvironmentUsageResponse>(
+    '/api/credits/breakdown',
+    fetcher,
+    { refreshInterval: 0, revalidateOnFocus: false },
+  );
+
+  useEffect(() => {
+    connect();
+  }, [connect]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onUpdate = () => mutate();
+    socket.on('credits:updated', onUpdate);
+    return () => {
+      socket.off('credits:updated', onUpdate);
+    };
+  }, [socket, mutate]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Boxes className="h-5 w-5" />
+          Environments
+        </CardTitle>
+        <CardDescription>Stored environment filesystems and their cost this period</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-full" />
+          </div>
+        ) : error || !data ? (
+          <p className="text-sm text-muted-foreground">
+            Could not load your environment usage. Please refresh and try again.
+          </p>
+        ) : data.byEnvironment.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No environment usage yet this period. Environments you create in a drive keep their files
+            between sessions, and appear here once they do.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {data.byEnvironment.map((environment) => (
+              <div
+                key={environment.envId ?? environment.label}
+                className="flex items-center justify-between gap-2 text-sm"
+              >
+                <span className="truncate font-medium">{environment.label}</span>
+                <span className="shrink-0 tabular-nums text-xs text-muted-foreground">
+                  {formatCreditCount(environment.spendCents)} cr · {environment.sharePct}%
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -2,7 +2,20 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { ChevronDown, ChevronRight, FileText, Folder, Plus, Search, SquareTerminal, X } from 'lucide-react';
+import {
+  Boxes,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Search,
+  SquareTerminal,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { useSWRConfig } from 'swr';
 
@@ -35,7 +48,7 @@ import {
 } from '@/stores/agent-workspace/workspace-tree-view';
 import type { WorkspaceNode } from '@pagespace/lib/agent-workspaces/workspace-node';
 import type { WorkspaceNodeTarget } from '@pagespace/lib/agent-workspaces/workspace-node-wire';
-import { fetchWithAuth, del } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth, del, patch, post, ApiRequestError } from '@/lib/auth/auth-fetch';
 import {
   isAgentWorkspacesKey,
   isWorkspaceListingKey,
@@ -45,7 +58,11 @@ import {
 } from '@/components/agents/panes/workspace-conversations';
 import { decideClosePane } from '@/components/agents/panes/close-pane';
 import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
+import { partitionSessionsByEnv, type EnvGroup } from './env-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
+import { DeleteDriveEnvDialog, DriveEnvNameDialog, RebuildDriveEnvDialog } from './DriveEnvDialogs';
+import { useDriveEnvs, driveEnvsKey } from '@/hooks/drive-envs/useDriveEnvs';
+import type { DriveEnvStatus } from '@pagespace/lib/drive-envs/env-contract';
 
 /**
  * The Agents console's left sidebar: **Drive → Session → Pane.**
@@ -217,6 +234,16 @@ interface SessionListEntry {
    */
   workspaceId: string;
   driveId: string | null;
+  /**
+   * The persistent ENVIRONMENT this session runs inside, or null for the
+   * ordinary ephemeral one. It is what the sidebar nests by: two sessions
+   * carrying the same value are two windows onto one filesystem, so grouping by
+   * it groups by the disk rather than by a label (see the field's docblock on
+   * `session-contract.ts`). It also changes what `sandboxStatus` below reads —
+   * for an env-bound session that status is the ENVIRONMENT's machine, shared
+   * with every other session in it.
+   */
+  envId: string | null;
   name: string;
   sandboxStatus: 'none' | 'starting' | 'running' | 'ended';
   conversations: SessionConversationEntry[];
@@ -423,8 +450,39 @@ function SessionList({
     [groups, hasSearch],
   );
 
+  // Which drives this user may ADMINISTER — environment CRUD is drive
+  // OWNER/ADMIN, so the affordances that need it are not rendered at all for a
+  // plain member rather than rendered and refused. Same source and same helper
+  // the drive footer's manage controls use; a drive the roster does not hold
+  // (an orphan group) is simply absent from the set, which reads as "no".
+  const manageableDriveIds = useMemo(
+    () => new Set(drives.filter((d) => canManageDrive(d)).map((d) => d.id)),
+    [drives],
+  );
+
   const [createDriveOpen, setCreateDriveOpen] = useState(false);
   const { openSpawn, openAssistantSpawn, paletteElement } = useSpawnSession(agentsByDrive, onChanged);
+
+  // ONE "New environment" dialog for the whole list, parameterized by which
+  // drive asked — the same shape `useSpawnSession` gives the spawn palette.
+  // Every group header would otherwise carry its own copy of a dialog that can
+  // only ever be open once.
+  const [newEnvTarget, setNewEnvTarget] = useState<{ driveId: string; driveName: string | null } | null>(null);
+  const { mutate: globalMutate } = useSWRConfig();
+
+  const createEnvironment = useCallback(
+    async (name: string): Promise<DriveEnvWriteOutcome> => {
+      if (!newEnvTarget) return 'done';
+      try {
+        await post(`/api/drives/${encodeURIComponent(newEnvTarget.driveId)}/envs`, { name });
+      } catch (error) {
+        return reportDriveEnvWriteFailure(error, 'Could not create the environment');
+      }
+      globalMutate(driveEnvsKey(newEnvTarget.driveId));
+      return 'done';
+    },
+    [newEnvTarget, globalMutate],
+  );
 
   // Sessions are always deliberately named now — both groups open the same
   // naming step. The ASSISTANT group has nothing to pick (the assistant IS
@@ -450,9 +508,29 @@ function SessionList({
           onChange={setSearchQuery}
           onAction={driveId ? () => handleNewSession(driveId, null) : () => setCreateDriveOpen(true)}
           actionLabel={driveId ? 'New session' : 'New drive'}
+          // Drive-scoped mode suppresses its own group header (the drive is the
+          // whole surface), so this is where its environment affordance has to
+          // live — beside "New session", which is the act it sits next to
+          // everywhere else too. Global mode has no single drive to create one
+          // in, so it keeps just the two it had.
+          onNewEnvironment={
+            driveId && manageableDriveIds.has(driveId)
+              ? () =>
+                  setNewEnvTarget({
+                    driveId,
+                    driveName: drives.find((d) => d.id === driveId)?.name ?? null,
+                  })
+              : undefined
+          }
         />
       )}
-      {visibleGroups.map((group) => (
+      {visibleGroups.map((group) => {
+        // Environments belong to a real, live drive. The Assistant group is not
+        // one (it is the drive-less bucket) and a trashed drive must not be
+        // offered infrastructure it is on its way out of — both fall back to a
+        // flat list of sessions, which is what they had before.
+        const isLiveDrive = group.driveId !== ASSISTANT_GROUP_KEY && !trashedDriveIds.has(group.driveId);
+        return (
         <div key={group.driveId}>
           {/* `group.driveId` is always a real string (never undefined), so
               this alone already covers global mode (every group differs from
@@ -466,15 +544,44 @@ function SessionList({
                   ? undefined
                   : () => handleNewSession(group.driveId, group.driveName)
               }
+              newEnvironmentLabel={`New environment in ${group.driveName ?? 'this drive'}`}
+              onNewEnvironment={
+                isLiveDrive && manageableDriveIds.has(group.driveId)
+                  ? () => setNewEnvTarget({ driveId: group.driveId, driveName: group.driveName })
+                  : undefined
+              }
             />
           )}
-          {group.sessions.map((session) => (
-            <SessionRow key={session.workspaceId} session={session} agentNamesById={agentNamesById} />
-          ))}
+          <DriveGroupRows
+            driveId={group.driveId}
+            sessions={group.sessions}
+            agentNamesById={agentNamesById}
+            canManage={manageableDriveIds.has(group.driveId)}
+            // Three things switch it off. `canSpawn` is the authentication gate
+            // — the same one that nulls the sessions SWR key, because a surface
+            // that will not show a signed-out visitor anything has no business
+            // fetching a drive's infrastructure on their behalf. Search is a
+            // FLAT find over session names (the header says so), and an
+            // environment whose sessions were all filtered out would otherwise
+            // sit there as an empty container claiming to be a match — so while
+            // a query is active every matching session renders at drive level
+            // and the environment rows step aside.
+            showEnvironments={canSpawn && isLiveDrive && !hasSearch}
+          />
         </div>
-      ))}
+        );
+      })}
       {notice}
       {paletteElement}
+      <DriveEnvNameDialog
+        open={newEnvTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setNewEnvTarget(null);
+        }}
+        mode="create"
+        driveName={newEnvTarget?.driveName ?? null}
+        onSubmit={createEnvironment}
+      />
       {!driveId && <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />}
     </div>
   );
@@ -486,11 +593,14 @@ function SessionSearchHeader({
   onChange,
   onAction,
   actionLabel,
+  onNewEnvironment,
 }: {
   value: string;
   onChange: (value: string) => void;
   onAction: () => void;
   actionLabel: string;
+  /** Omitted for anyone who cannot administer the drive — environment CRUD is OWNER/ADMIN. */
+  onNewEnvironment?: () => void;
 }) {
   return (
     <div className="flex items-center gap-1 pl-2 pr-4 pb-1 pt-1.5">
@@ -504,6 +614,17 @@ function SessionSearchHeader({
           onChange={(event) => onChange(event.target.value)}
         />
       </div>
+      {onNewEnvironment && (
+        <button
+          type="button"
+          aria-label="New environment"
+          title="New environment"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={onNewEnvironment}
+        >
+          <Boxes className="size-3.5" />
+        </button>
+      )}
       <button
         type="button"
         aria-label={actionLabel}
@@ -521,10 +642,15 @@ function SessionGroupHeader({
   label,
   newSessionLabel,
   onNewSession,
+  newEnvironmentLabel,
+  onNewEnvironment,
 }: {
   label: string;
   newSessionLabel?: string;
   onNewSession?: () => void;
+  newEnvironmentLabel?: string;
+  /** Omitted for anyone who cannot administer the drive — environment CRUD is OWNER/ADMIN. */
+  onNewEnvironment?: () => void;
 }) {
   return (
     <div className="flex items-center justify-between gap-1 pl-2 pr-4 pb-0.5 pt-1.5">
@@ -532,15 +658,304 @@ function SessionGroupHeader({
         <Folder className="size-4 shrink-0" aria-hidden="true" />
         <span className="truncate">{label}</span>
       </span>
-      {onNewSession && (
-        <button
-          type="button"
-          aria-label={newSessionLabel ?? 'New session'}
-          className="shrink-0 text-muted-foreground hover:text-foreground"
-          onClick={onNewSession}
-        >
-          <Plus className="size-3.5" />
-        </button>
+      <span className="flex shrink-0 items-center gap-1">
+        {onNewEnvironment && (
+          <button
+            type="button"
+            aria-label={newEnvironmentLabel ?? 'New environment'}
+            title={newEnvironmentLabel ?? 'New environment'}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={onNewEnvironment}
+          >
+            <Boxes className="size-3.5" />
+          </button>
+        )}
+        {onNewSession && (
+          <button
+            type="button"
+            aria-label={newSessionLabel ?? 'New session'}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={onNewSession}
+          >
+            <Plus className="size-3.5" />
+          </button>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * What a caller should do with the dialog after an environment write.
+ *
+ * `'retry'` is reserved for the ONE refusal the user can fix without leaving
+ * the dialog: a name already taken in this drive. Every other failure — a
+ * plan's environment ceiling, a role that turned out not to be enough, the
+ * network — is toasted and the dialog closes, because retyping the name would
+ * not change the answer.
+ */
+type DriveEnvWriteOutcome = 'done' | 'retry';
+
+function reportDriveEnvWriteFailure(error: unknown, fallbackTitle: string): DriveEnvWriteOutcome {
+  const description = error instanceof Error ? error.message : 'Please try again.';
+  const nameTaken = error instanceof ApiRequestError && error.status === 409;
+  toast.error(nameTaken ? 'That name is already used in this drive' : fallbackTitle, {
+    description: nameTaken ? 'Environment names are unique within a drive.' : description,
+  });
+  return nameTaken ? 'retry' : 'done';
+}
+
+/**
+ * One drive group's contents: its ENVIRONMENTS, then its loose sessions.
+ *
+ * The two are siblings on purpose. A drive contains environments AND sessions
+ * at the same level — an environment is not a folder someone filed sessions
+ * into, it is a machine the drive owns, and a session either runs inside one or
+ * owns its own sandbox. Nesting a session under its environment is therefore
+ * showing which filesystem it sees, not organising a list.
+ *
+ * The environments fetch lives HERE, one hook per rendered drive group, rather
+ * than as one bulk read in the parent: a group is where a drive id first exists
+ * as a single value, the listing is small and cached per drive, and the spawn
+ * palette shares the key so opening it costs nothing extra.
+ */
+function DriveGroupRows({
+  driveId,
+  sessions,
+  agentNamesById,
+  canManage,
+  showEnvironments,
+}: {
+  driveId: string;
+  sessions: SessionListEntry[];
+  agentNamesById: Map<string, string>;
+  canManage: boolean;
+  showEnvironments: boolean;
+}) {
+  const { envs, mutate: refreshEnvs } = useDriveEnvs(driveId, { enabled: showEnvironments });
+
+  // With environments off (the Assistant bucket, a trashed drive, an active
+  // search) this hands back every session as loose, which is exactly the flat
+  // list this surface rendered before environments existed.
+  const { envGroups, looseSessions } = useMemo(
+    () => (showEnvironments ? partitionSessionsByEnv(sessions, envs) : { envGroups: [], looseSessions: sessions }),
+    [showEnvironments, sessions, envs],
+  );
+
+  return (
+    <>
+      {envGroups.map((group) => (
+        <DriveEnvRow
+          key={group.envId}
+          driveId={driveId}
+          group={group}
+          canManage={canManage}
+          agentNamesById={agentNamesById}
+          onEnvsChanged={refreshEnvs}
+        />
+      ))}
+      {looseSessions.map((session) => (
+        <SessionRow key={session.workspaceId} session={session} agentNamesById={agentNamesById} />
+      ))}
+    </>
+  );
+}
+
+/**
+ * An environment's status, as a dot — the only badge an environment row carries.
+ *
+ * Always rendered, unlike a session's dot, and that difference is the point. A
+ * session's dot appears when it has a sandbox and is absent otherwise, because
+ * a session without one is just a conversation. An environment without a
+ * machine is still an environment: it is drive infrastructure that exists,
+ * costs its keep, and provisions on first use. A dot that disappeared would say
+ * the environment had, so `'none'` gets a dimmed dot and a name for the state
+ * rather than nothing at all.
+ */
+function EnvStatusDot({ status }: { status: DriveEnvStatus | null }) {
+  const { className, label } =
+    status === 'running'
+      ? { className: 'bg-emerald-500', label: 'Environment running' }
+      : status === 'stopped'
+        ? { className: 'bg-amber-500', label: 'Environment stopped' }
+        : status === 'none'
+          ? { className: 'bg-muted-foreground/40', label: 'Environment not started yet' }
+          : { className: 'bg-muted-foreground/40', label: 'Environment status unknown' };
+  // `role="img"` so the label is announced — aria-label on a bare span is not.
+  return <span role="img" aria-label={label} className={cn('size-1.5 shrink-0 rounded-full', className)} />;
+}
+
+/**
+ * ONE ENVIRONMENT: name, status dot, and the sessions running inside it.
+ *
+ * It renders **even with no sessions**, and that is deliberate rather than an
+ * oversight about empty states. An environment is infrastructure someone
+ * created on purpose and is billed for; a row that vanished whenever nobody
+ * happened to be working would recreate exactly the ephemeral mental model
+ * environments exist to replace.
+ *
+ * Management is drive OWNER/ADMIN, so a member gets a row with no menu at all
+ * rather than a menu that refuses — the same way the group header withholds its
+ * "New environment" button. An ORPHAN (a session naming an environment this
+ * drive's listing did not return) also gets no menu: there is no row here to
+ * act on, and offering to rename or destroy something we cannot see would be
+ * guessing.
+ */
+function DriveEnvRow({
+  driveId,
+  group,
+  canManage,
+  agentNamesById,
+  onEnvsChanged,
+}: {
+  driveId: string;
+  group: EnvGroup<SessionListEntry>;
+  canManage: boolean;
+  agentNamesById: Map<string, string>;
+  onEnvsChanged: () => void;
+}) {
+  const { mutate } = useSWRConfig();
+  // Expanded by default: an environment's whole claim is that it is a place you
+  // come back to, and its sessions are the reason to look at it.
+  const [expanded, setExpanded] = useState(true);
+  const [renaming, setRenaming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [rebuilding, setRebuilding] = useState(false);
+
+  const displayName = group.envName ?? group.envId;
+  const isOrphan = group.envName === null;
+  const envPath = `/api/drives/${encodeURIComponent(driveId)}/envs/${encodeURIComponent(group.envId)}`;
+
+  const renameEnv = useCallback(
+    async (name: string): Promise<DriveEnvWriteOutcome> => {
+      try {
+        await patch(envPath, { name });
+      } catch (error) {
+        return reportDriveEnvWriteFailure(error, 'Could not rename the environment');
+      }
+      onEnvsChanged();
+      return 'done';
+    },
+    [envPath, onEnvsChanged],
+  );
+
+  const deleteEnv = useCallback(
+    async ({ force }: { force: boolean }): Promise<{ blockedByLiveSessions: number } | null> => {
+      try {
+        await del(force ? `${envPath}?force=true` : envPath);
+      } catch (error) {
+        // The ONE refusal that is not an ending: sessions are still live inside
+        // the environment, and the dialog escalates to the forced delete rather
+        // than closing. `liveSessionCount` is the server's — this listing only
+        // holds the viewer's own sessions, so a teammate's is invisible here.
+        if (error instanceof ApiRequestError && error.status === 409) {
+          const body = error.body as { reason?: unknown; liveSessionCount?: unknown } | null;
+          if (body?.reason === 'live_sessions') {
+            return { blockedByLiveSessions: typeof body.liveSessionCount === 'number' ? body.liveSessionCount : 0 };
+          }
+        }
+        toast.error('Could not delete the environment', {
+          description: error instanceof Error ? error.message : 'Please try again.',
+        });
+        return null;
+      }
+      onEnvsChanged();
+      // Deleting an environment CASCADES its sessions away, so the sessions
+      // listing is stale the moment this resolves — not just the env listing.
+      void mutate(isWorkspaceListingKey);
+      toast.success(`Deleted “${displayName}”`);
+      return null;
+    },
+    [envPath, onEnvsChanged, mutate, displayName],
+  );
+
+  const rebuildEnv = useCallback(async () => {
+    try {
+      await post(`${envPath}/rebuild`);
+    } catch (error) {
+      toast.error('Could not rebuild the environment', {
+        description: error instanceof Error ? error.message : 'Please try again.',
+      });
+      return;
+    }
+    onEnvsChanged();
+    // The sessions listing goes stale too, for the same reason the delete path
+    // refreshes it: an env-bound session's `sandboxStatus` is read off the
+    // ENVIRONMENT's row, not its own, so replacing the environment's machine
+    // changes what every session inside it should be rendering. Without this
+    // the rows keep claiming `running` against a machine that no longer exists.
+    void mutate(isWorkspaceListingKey);
+    toast.success(`“${displayName}” was rebuilt`, { description: 'It came back blank.' });
+  }, [envPath, onEnvsChanged, mutate, displayName]);
+
+  const menuItems: RowMenuItem[] = useMemo(
+    () => [
+      { label: 'Rename', icon: Pencil, onSelect: () => setRenaming(true) },
+      { label: 'Rebuild to blank', icon: RefreshCw, onSelect: () => setRebuilding(true), destructive: true },
+      { label: 'Delete environment', icon: Trash2, onSelect: () => setDeleting(true), destructive: true },
+    ],
+    [],
+  );
+
+  const rowInner = (
+    <>
+      <button
+        type="button"
+        aria-label={expanded ? `Collapse ${displayName}` : `Expand ${displayName}`}
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded((value) => !value)}
+      >
+        {expanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+      </button>
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <EnvStatusDot status={group.status} />
+        <span className="truncate font-medium text-foreground">{displayName}</span>
+      </span>
+    </>
+  );
+
+  const rowClassName = 'gap-1 rounded-md px-1.5 py-1 text-xs hover:bg-accent';
+
+  return (
+    <div data-testid={`sidebar-env-${group.envId}`}>
+      {canManage && !isOrphan ? (
+        <RowMenu items={menuItems} menuLabel="Environment actions" className={rowClassName}>
+          {rowInner}
+        </RowMenu>
+      ) : (
+        <div className={cn('group flex w-full items-center', rowClassName)}>{rowInner}</div>
+      )}
+
+      <DriveEnvNameDialog
+        open={renaming}
+        onOpenChange={setRenaming}
+        mode="rename"
+        initialName={group.envName ?? ''}
+        onSubmit={renameEnv}
+      />
+      <DeleteDriveEnvDialog
+        open={deleting}
+        onOpenChange={setDeleting}
+        envName={displayName}
+        onDelete={deleteEnv}
+      />
+      <RebuildDriveEnvDialog
+        open={rebuilding}
+        onOpenChange={setRebuilding}
+        envName={displayName}
+        onRebuild={rebuildEnv}
+      />
+
+      {expanded && (
+        <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">
+          {group.sessions.map((session) => (
+            <SessionRow key={session.workspaceId} session={session} agentNamesById={agentNamesById} />
+          ))}
+          {group.sessions.length === 0 && (
+            <div className="px-2 py-1 text-xs text-muted-foreground">No sessions running in here</div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -513,8 +513,11 @@ function SessionList({
           // live — beside "New session", which is the act it sits next to
           // everywhere else too. Global mode has no single drive to create one
           // in, so it keeps just the two it had.
+          // `!trashedDriveIds.has` for the same reason the group-header path
+          // checks `isLiveDrive`: a drive on its way to deletion must not be
+          // offered new infrastructure inside it.
           onNewEnvironment={
-            driveId && manageableDriveIds.has(driveId)
+            driveId && !trashedDriveIds.has(driveId) && manageableDriveIds.has(driveId)
               ? () =>
                   setNewEnvTarget({
                     driveId,
@@ -732,7 +735,7 @@ function DriveGroupRows({
   canManage: boolean;
   showEnvironments: boolean;
 }) {
-  const { envs, mutate: refreshEnvs } = useDriveEnvs(driveId, { enabled: showEnvironments });
+  const { envs, error: envsError, mutate: refreshEnvs } = useDriveEnvs(driveId, { enabled: showEnvironments });
 
   // With environments off (the Assistant bucket, a trashed drive, an active
   // search) this hands back every session as loose, which is exactly the flat
@@ -744,6 +747,29 @@ function DriveGroupRows({
 
   return (
     <>
+      {/* A FAILED LISTING SAYS SO. Without this the drive reads as one that
+          simply has no environments, and any env-bound session in it falls
+          through to an orphan group — a correct mechanism reached for the wrong
+          reason, and one the user cannot act on because nothing told them a
+          read failed. The retry is the affordance; the sessions below still
+          render, because a drive's sessions do not depend on this request. */}
+      {showEnvironments && envsError != null && (
+        <div className="flex items-center justify-between gap-2 px-2 py-1 text-xs text-muted-foreground">
+          <span className="truncate">Could not load environments</span>
+          <button
+            type="button"
+            /* "Try again", not "Retry": the sidebar already has a Retry for the
+               SESSIONS listing, and when both requests fail the two sit feet
+               apart. Distinct words are the difference between one control and
+               two identical ones the user has to guess between. */
+            aria-label="Try again loading environments"
+            className="shrink-0 underline hover:text-foreground"
+            onClick={refreshEnvs}
+          >
+            Try again
+          </button>
+        </div>
+      )}
       {envGroups.map((group) => (
         <DriveEnvRow
           key={group.envId}
@@ -822,8 +848,13 @@ function DriveEnvRow({
   const [deleting, setDeleting] = useState(false);
   const [rebuilding, setRebuilding] = useState(false);
 
-  const displayName = group.envName ?? group.envId;
   const isOrphan = group.envName === null;
+  // An orphan has no name to show and its id is not one: a raw CUID is not a
+  // thing a user has ever seen or could recognise, and printing it would read
+  // as the environment's name rather than as the absence of one. What we
+  // actually know is that a session claims an environment this drive's listing
+  // did not return — so say that, and keep the id out of the interface.
+  const displayName = group.envName ?? 'Unavailable environment';
   const envPath = `/api/drives/${encodeURIComponent(driveId)}/envs/${encodeURIComponent(group.envId)}`;
 
   const renameEnv = useCallback(

--- a/apps/web/src/components/layout/left-sidebar/DriveEnvDialogs.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DriveEnvDialogs.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+/**
+ * The three dialogs an environment's management needs — the naming one, and the
+ * two destructive ones.
+ *
+ * They live together because their COPY is the feature. An environment is a
+ * drive's shared, persistent filesystem: everyone in the drive works on the
+ * same disk, so both destructive verbs destroy other people's work as well as
+ * the caller's, and neither is recoverable. What each dialog has to do, then,
+ * is name the consequence in the words a user would use — "everything in it,
+ * for everyone in this drive" — rather than ask a generic "are you sure?".
+ *
+ * Every one of them registers with `useEditingStore` while open
+ * (`useEditingSession`), which is the repo rule for a surface holding text the
+ * user typed: a background revalidation or an auth refresh landing mid-type
+ * must not tear the dialog down under them.
+ */
+
+import { useEffect, useId, useRef, useState } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { MAX_DRIVE_ENV_NAME_LENGTH } from '@pagespace/lib/drive-envs/env-contract';
+import { useEditingSession } from '@/stores/useEditingSession';
+
+/**
+ * Create or rename — one dialog, because an environment has exactly one
+ * editable attribute and there is no kind to choose (the epic deleted the enum
+ * rather than never writing it; see `env-contract.ts`).
+ *
+ * `onSubmit` answers what should happen to the dialog, not whether the write
+ * succeeded — `'retry'` keeps it open with the user's text intact. That exists
+ * for exactly one refusal: a name already taken in the drive, which is the most
+ * likely failure and the only one retyping fixes. Everything else closes.
+ */
+export function DriveEnvNameDialog({
+  open,
+  onOpenChange,
+  mode,
+  driveName,
+  initialName,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: 'create' | 'rename';
+  /** Named in the create dialog's description, when the caller has it. */
+  driveName?: string | null;
+  /** The current name, for a rename. */
+  initialName?: string;
+  onSubmit: (name: string) => Promise<'done' | 'retry'>;
+}) {
+  const [name, setName] = useState(initialName ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const inputId = useId();
+
+  // Seeded on the OPEN TRANSITION, not on every `initialName` change — and the
+  // ref is what makes that true. `initialName` is the environment's CURRENT
+  // name, so it moves whenever the listing revalidates (a teammate renaming the
+  // same environment, a refetch after some unrelated write). With it in the
+  // dependency list, any such revalidation while this dialog is open would
+  // overwrite what the user had typed. Reading `open`'s previous value instead
+  // means the seed happens exactly once per opening, which is what the create
+  // and rename flows both actually want.
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpen.current) setName(initialName ?? '');
+    wasOpen.current = open;
+  }, [open, initialName]);
+
+  useEditingSession(`drive-env-name-${inputId}`, open, 'form', { componentName: 'DriveEnvNameDialog' });
+
+  const trimmed = name.trim();
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      if ((await onSubmit(trimmed)) === 'done') onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{mode === 'create' ? 'New environment' : 'Rename environment'}</DialogTitle>
+          <DialogDescription>
+            {mode === 'create'
+              ? `A persistent machine ${driveName ? `${driveName}'s` : 'this drive’s'} sessions can run inside, sharing one filesystem that survives every session that ends. Name it for what it is for — “dev”, “staging”, “data-import”.`
+              : 'Sessions running inside it are unaffected — the name is a label, not an address.'}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor={inputId} className="text-right">
+                Name
+              </Label>
+              <Input
+                id={inputId}
+                value={name}
+                maxLength={MAX_DRIVE_ENV_NAME_LENGTH}
+                onChange={(event) => setName(event.target.value)}
+                className="col-span-3"
+                autoFocus
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={submitting || trimmed.length === 0}>
+              {submitting
+                ? mode === 'create'
+                  ? 'Creating…'
+                  : 'Renaming…'
+                : mode === 'create'
+                  ? 'Create'
+                  : 'Rename'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Delete, in two questions rather than one.
+ *
+ * The first is the ordinary confirm. The server REFUSES that one while sessions
+ * are live inside the environment (409), and the second question is what the
+ * refusal escalates to: forcing is a materially different act — it ends other
+ * people's running sessions before it destroys the disk — so it gets its own
+ * confirm, its own button label, and a sentence naming both halves. `?force=`
+ * is never sent by the first press, and the escalation is only ever reached by
+ * the server saying it is needed.
+ *
+ * `liveSessionCount` is the SERVER's count, not the sidebar's: this listing is
+ * scoped to the viewer's own sessions, so a teammate's session running in the
+ * environment is invisible here and is exactly the case the warning exists for.
+ */
+export function DeleteDriveEnvDialog({
+  open,
+  onOpenChange,
+  envName,
+  onDelete,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  envName: string;
+  /** Resolves to the live-session count when the server refused; null once it is done. */
+  onDelete: (options: { force: boolean }) => Promise<{ blockedByLiveSessions: number } | null>;
+}) {
+  const [liveSessionCount, setLiveSessionCount] = useState<number | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Every re-open starts at the first question. Without this a dialog that was
+  // escalated, cancelled, and reopened would offer the force button up front.
+  useEffect(() => {
+    if (open) setLiveSessionCount(null);
+  }, [open]);
+
+  const run = async (force: boolean) => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const refusal = await onDelete({ force });
+      if (refusal) {
+        setLiveSessionCount(refusal.blockedByLiveSessions);
+        return;
+      }
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const forcing = liveSessionCount !== null;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {forcing ? `End ${liveSessionCount === 1 ? 'a session' : 'sessions'} and delete “${envName}”?` : `Delete “${envName}”?`}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {forcing
+              ? `${liveSessionCount} ${liveSessionCount === 1 ? 'session is' : 'sessions are'} still running in this environment. Deleting it now ends ${liveSessionCount === 1 ? 'that session' : 'those sessions'} and destroys the shared filesystem — every file in it, for everyone in this drive. This cannot be undone.`
+              : 'Its machine is torn down and its filesystem is destroyed — every file in it, for everyone in this drive. This cannot be undone. Conversations from sessions that ran inside it stay in each agent’s history.'}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+          {/* `onSelect`-preventing wrapper is unnecessary here: the action's own
+              handler keeps the dialog open by not calling `onOpenChange`, and
+              radix closes on click, so the escalation uses a plain button. */}
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={submitting}
+            onClick={() => void run(forcing)}
+          >
+            {submitting
+              ? 'Deleting…'
+              : forcing
+                ? `End ${liveSessionCount === 1 ? 'session' : 'sessions'} and delete`
+                : 'Delete environment'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+/**
+ * Rebuild — the only verb that replaces an environment's machine.
+ *
+ * WIPE TO BLANK is the founder-ratified meaning, and the copy says exactly
+ * that: the environment keeps its id, its name and its address, and keeps
+ * nothing else. It is the answer to a machine past saving, so the dialog names
+ * both what survives and what does not, in that order.
+ */
+export function RebuildDriveEnvDialog({
+  open,
+  onOpenChange,
+  envName,
+  onRebuild,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  envName: string;
+  onRebuild: () => Promise<void>;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Rebuild “{envName}”?</AlertDialogTitle>
+          <AlertDialogDescription>
+            The environment comes back BLANK. Its machine is destroyed and a new, empty one takes its
+            place — every file, package and setting in it is gone, for everyone in this drive, and
+            nothing is restored. The environment keeps its name, so anything pointed at it still
+            finds it. This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={submitting}
+            onClick={async (event) => {
+              event.preventDefault();
+              setSubmitting(true);
+              try {
+                await onRebuild();
+                onOpenChange(false);
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {submitting ? 'Rebuilding…' : 'Rebuild to blank'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -205,9 +205,19 @@ interface EnvFixture {
  * Default empty, so every pre-environments test in this file keeps describing a
  * drive that has none and its flat session list is unchanged.
  */
-const respondWithSessions = (sessions: SessionFixture[], envs: EnvFixture[] = []) => {
+const respondWithSessions = (
+  sessions: SessionFixture[],
+  envs: EnvFixture[] = [],
+  /**
+   * Fails the ENVIRONMENTS endpoint only, leaving the sessions listing healthy.
+   * A function so a test can flip it between renders (fail, then retry and
+   * succeed) without rebuilding the whole implementation.
+   */
+  envsFail: () => boolean = () => false,
+) => {
   mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {
     if (typeof url === 'string' && url.includes('/envs')) {
+      if (envsFail()) return { ok: false, status: 500, json: async () => ({}) };
       return {
         ok: true,
         status: 200,
@@ -1929,6 +1939,163 @@ describe('AgentsSidebar', () => {
       await waitFor(() => expect(screen.getByText('renamed-elsewhere')).toBeDefined());
 
       expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('half-typed');
+    });
+
+    /**
+     * THE SPAWN PALETTE'S ENVIRONMENT STEP.
+     *
+     * Every other spawn test in this file runs against a drive with NO
+     * environments, which is exactly why the loading race below survived
+     * review: `envs` is `[]` while the listing is in flight and `[]` when the
+     * drive genuinely has none, and only a fixture WITH environments can tell
+     * the two apart.
+     */
+    test('offers "in <env name>" targets with the ephemeral default leading, and carries the chosen envId into the POST', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [
+        { id: 'env-1', name: 'staging', status: 'running' },
+        { id: 'env-2', name: 'dev', status: 'none' },
+      ]);
+      mockPost.mockResolvedValue({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      renderSidebar();
+
+      await screen.findByTestId('sidebar-env-env-1');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+
+      // The environment step, not the name step: the drive has environments.
+      expect(await screen.findByText('in staging')).toBeDefined();
+      expect(screen.getByText('in dev')).toBeDefined();
+      // The ephemeral default leads — it is what every session was before
+      // environments existed and what most still should be.
+      const options = screen.getAllByRole('option').map((el) => el.textContent ?? '');
+      expect(options[0]).toContain('New sandbox');
+
+      await user.click(screen.getByText('in staging'));
+
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      await user.type(nameInput, 'work in staging');
+      fireEvent.submit(nameInput.closest('form')!);
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
+          driveId: 'drive-1',
+          envId: 'env-1',
+          agentPageId: 'agent-1',
+          name: 'work in staging',
+        }),
+      );
+    });
+
+    test('choosing the ephemeral default from the environment step posts envId null', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      mockPost.mockResolvedValue({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      renderSidebar();
+
+      await screen.findByTestId('sidebar-env-env-1');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+      await user.click(await screen.findByText('New sandbox'));
+
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      fireEvent.submit(nameInput.closest('form')!);
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
+          driveId: 'drive-1',
+          envId: null,
+          agentPageId: 'agent-1',
+          name: '',
+        }),
+      );
+    });
+
+    test('WAITS for the environments listing rather than treating an in-flight fetch as "this drive has none"', async () => {
+      const user = userEvent.setup();
+      // The listing never settles while the user picks. `envs` is `[]`
+      // throughout — indistinguishable from an environment-less drive to any
+      // step machine that reads only `.length`, which is the bug: the palette
+      // would jump to the name step and spawn `envId: null` into a drive that
+      // HAS environments.
+      let releaseEnvs: (() => void) | null = null;
+      const envsLanded = new Promise<void>((resolve) => {
+        releaseEnvs = resolve;
+      });
+      mockFetchWithAuth.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/envs')) {
+          await envsLanded;
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              envs: [{ id: 'env-1', name: 'staging', status: 'running', driveId: 'drive-1', createdAt: '2026-08-01T00:00:00.000Z' }],
+            }),
+          };
+        }
+        return { ok: true, status: 200, json: async () => ({ sessions: [] }) };
+      });
+      renderSidebar();
+
+      await screen.findByPlaceholderText('Search sessions…');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+
+      // Held, not advanced: no name form to type a name into and spawn from.
+      expect(await screen.findByText(/Looking for environments/i)).toBeDefined();
+      expect(screen.queryByPlaceholderText('Researcher')).toBeNull();
+
+      await act(async () => {
+        releaseEnvs!();
+        await envsLanded;
+      });
+
+      // Once the answer arrives the real question is asked.
+      expect(await screen.findByText('in staging')).toBeDefined();
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    test('a failed environments listing says so and offers a way back, instead of passing the drive off as having none', async () => {
+      const user = userEvent.setup();
+      // ONLY the envs endpoint fails. The sessions listing is fine, which is
+      // the case that matters: without a notice the drive is indistinguishable
+      // from one that simply has no environments, and the env-bound session
+      // below silently becomes an orphan for a reason nobody can see.
+      let envsShouldFail = true;
+      respondWithSessions(
+        [envSession('ses-env', 'env-1', 'inside staging')],
+        [{ id: 'env-1', name: 'staging', status: 'running' }],
+        () => envsShouldFail,
+      );
+      renderSidebar();
+
+      expect(await screen.findByText('Could not load environments')).toBeDefined();
+      // The session is still shown — a drive's sessions do not depend on this
+      // request — but under a group that admits it does not know the name.
+      expect(screen.getByText('Unavailable environment')).toBeDefined();
+      expect(screen.getByText('inside staging')).toBeDefined();
+
+      envsShouldFail = false;
+      await user.click(screen.getByLabelText('Try again loading environments'));
+
+      expect(await screen.findByText('staging')).toBeDefined();
+      expect(screen.queryByText('Could not load environments')).toBeNull();
+      expect(screen.queryByText('Unavailable environment')).toBeNull();
+    });
+
+    test('an orphan group never prints the raw env id — an id is not a name a user could recognise', async () => {
+      respondWithSessions([envSession('ses-env', 'env-missing-xyz', 'inside something')], []);
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-missing-xyz');
+      expect(within(envRow).getByText('Unavailable environment')).toBeDefined();
+      expect(screen.queryByText('env-missing-xyz')).toBeNull();
     });
 
     test('an active search flattens the list — a matching env-bound session shows, its environment steps aside', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -2098,6 +2098,61 @@ describe('AgentsSidebar', () => {
       expect(screen.queryByText('env-missing-xyz')).toBeNull();
     });
 
+    test('a FAILED env listing does not let the palette spawn ephemerally by default — it says so and offers a way out', async () => {
+      const user = userEvent.setup();
+      let envsShouldFail = true;
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }], () => envsShouldFail);
+      mockPost.mockResolvedValue({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      renderSidebar();
+
+      await screen.findByPlaceholderText('Search sessions…');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+
+      // A failed listing leaves `envs` at [] with loading finished — the exact
+      // shape of "this drive has none". Sailing past it would spawn ephemeral
+      // in a drive that HAS environments, silently.
+      expect(await screen.findByText(/could not check which environments/i)).toBeDefined();
+      expect(screen.queryByPlaceholderText('Researcher')).toBeNull();
+      expect(mockPost).not.toHaveBeenCalled();
+
+      envsShouldFail = false;
+      await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+      // Recovered: the real question gets asked after all.
+      expect(await screen.findByText('in staging')).toBeDefined();
+    });
+
+    test('the failed-listing escape hatch spawns ephemerally only as an explicit choice', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }], () => true);
+      mockPost.mockResolvedValue({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      renderSidebar();
+
+      await screen.findByPlaceholderText('Search sessions…');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+      await user.click(await screen.findByRole('button', { name: 'Use a new sandbox' }));
+
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      fireEvent.submit(nameInput.closest('form')!);
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
+          driveId: 'drive-1',
+          envId: null,
+          agentPageId: 'agent-1',
+          name: '',
+        }),
+      );
+    });
+
     test('an active search flattens the list — a matching env-bound session shows, its environment steps aside', async () => {
       const user = userEvent.setup();
       respondWithSessions(

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -24,7 +24,7 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SWRConfig } from 'swr';
+import { SWRConfig, useSWRConfig } from 'swr';
 
 const mockPush = vi.fn();
 const mockUseAuth = vi.fn();
@@ -83,6 +83,7 @@ vi.mock('@/hooks/page-agents/usePageAgents', () => ({
 const mockFetchWithAuth = vi.fn();
 const mockPost = vi.fn();
 const mockDel = vi.fn();
+const mockPatch = vi.fn();
 vi.mock('@/lib/auth/auth-fetch', async (importOriginal) => {
   // `ApiRequestError` is re-exported from the REAL module (not hand-rolled)
   // so the component's `instanceof` check on a mocked-`del` rejection stays
@@ -93,6 +94,7 @@ vi.mock('@/lib/auth/auth-fetch', async (importOriginal) => {
     fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
     post: (...args: unknown[]) => mockPost(...args),
     del: (...args: unknown[]) => mockDel(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
   };
 });
 
@@ -103,7 +105,13 @@ vi.mock('../DriveFooter', () => ({ default: () => <div /> }));
 vi.mock('../DashboardFooter', () => ({ default: () => <div /> }));
 
 const mockToastError = vi.hoisted(() => vi.fn());
-vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => mockToastError(...args) } }));
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
 
 import { within } from '@testing-library/react';
 import { ApiRequestError } from '@/lib/auth/auth-fetch';
@@ -136,6 +144,8 @@ interface SessionFixture {
   /** The rolling-deploy compat twin the DTO still carries; nothing reads it. */
   sessionId: string;
   driveId: string | null;
+  /** The persistent environment this session runs inside — absent means the ephemeral default. */
+  envId?: string | null;
   name: string;
   sandboxStatus: 'none' | 'starting' | 'running' | 'ended';
   conversations: { conversationId: string; title: string | null; agentPageId: string | null }[];
@@ -183,9 +193,29 @@ const SESSION: SessionFixture = {
   shells: [],
 };
 
-/** Serve a listing the way the ROUTE serves one: threads, shells, and the tree. */
-const respondWithSessions = (sessions: SessionFixture[]) => {
+interface EnvFixture {
+  id: string;
+  name: string;
+  status: 'none' | 'running' | 'stopped';
+}
+
+/**
+ * Serve a listing the way the ROUTE serves one: threads, shells, and the tree —
+ * plus the drive's ENVIRONMENTS, which the sidebar reads from a second endpoint.
+ * Default empty, so every pre-environments test in this file keeps describing a
+ * drive that has none and its flat session list is unchanged.
+ */
+const respondWithSessions = (sessions: SessionFixture[], envs: EnvFixture[] = []) => {
   mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {
+    if (typeof url === 'string' && url.includes('/envs')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          envs: envs.map((env) => ({ driveId: 'drive-1', createdAt: '2026-08-01T00:00:00.000Z', ...env })),
+        }),
+      };
+    }
     // A node WRITE that never settles, so what these assertions read is the
     // optimistic apply — what the user sees the instant they click. The same
     // discipline the store's own suite runs on.
@@ -220,6 +250,34 @@ const renderSidebar = () =>
       <AgentsSidebar />
     </SWRConfig>,
   );
+
+/**
+ * The sidebar plus a handle on the SWR cache it is actually using.
+ *
+ * `renderSidebar` gives each test its own isolated provider, which is what
+ * keeps them from leaking cache into each other — and also means the `mutate`
+ * exported from `swr` addresses a different cache entirely. A test that needs
+ * to force a revalidation (rather than wait for one the component never
+ * schedules) has to reach the provider from INSIDE it, which is what this
+ * one-line probe is for.
+ */
+const renderSidebarWithMutate = () => {
+  const captured: { revalidate: (key: string) => Promise<unknown> } = {
+    revalidate: async () => undefined,
+  };
+  const Probe = () => {
+    const { mutate } = useSWRConfig();
+    captured.revalidate = (key: string) => mutate(key);
+    return null;
+  };
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <Probe />
+      <AgentsSidebar />
+    </SWRConfig>,
+  );
+  return captured;
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -854,6 +912,7 @@ describe('AgentsSidebar', () => {
       await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
       expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
         driveId: 'drive-1',
+        envId: null,
         agentPageId: 'agent-1',
         name: '',
       });
@@ -882,6 +941,7 @@ describe('AgentsSidebar', () => {
       // Drive-scoped, not the global assistant group: driveId stays 'drive-1'.
       expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
         driveId: 'drive-1',
+        envId: null,
         agentPageId: null,
         name: '',
       });
@@ -1325,6 +1385,7 @@ describe('AgentsSidebar', () => {
       await waitFor(() =>
         expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
           driveId: null,
+          envId: null,
           agentPageId: null,
           name: 'my assistant session',
         }),
@@ -1442,6 +1503,7 @@ describe('AgentsSidebar', () => {
       await waitFor(() =>
         expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
           driveId: 'drive-1',
+          envId: null,
           agentPageId: 'agent-1',
           name: 'my session',
         }),
@@ -1471,6 +1533,7 @@ describe('AgentsSidebar', () => {
       await waitFor(() =>
         expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
           driveId: null,
+          envId: null,
           agentPageId: null,
           name: '',
         }),
@@ -1659,6 +1722,228 @@ describe('AgentsSidebar', () => {
         expect(screen.queryByText('Global Assistant')).toBeNull();
         expect(await screen.findByText('No sessions match your search')).toBeDefined();
       });
+    });
+  });
+  /**
+   * ENVIRONMENTS — a drive's persistent, named machines.
+   *
+   * The three invariants that make the surface honest:
+   *  - an environment renders EVEN WITH NO SESSIONS (it is infrastructure the
+   *    drive pays for, not a container that appears when used),
+   *  - a session carrying `envId` renders INSIDE its environment rather than
+   *    beside it, because that field says which filesystem it sees,
+   *  - management is drive OWNER/ADMIN, so a plain member gets no affordances
+   *    at all rather than affordances that refuse.
+   */
+  describe('environments', () => {
+    const envSession = (workspaceId: string, envId: string | null, name: string): SessionFixture => ({
+      workspaceId,
+      sessionId: workspaceId,
+      driveId: 'drive-1',
+      envId,
+      name,
+      sandboxStatus: 'running',
+      conversations: [],
+      shells: [],
+    });
+
+    beforeEach(() => {
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha')] });
+    });
+
+    test('renders an environment with no sessions in it — infrastructure does not disappear when idle', async () => {
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'none' }]);
+      renderSidebar();
+
+      expect(await screen.findByText('staging')).toBeDefined();
+      expect(mockFetchWithAuth).toHaveBeenCalledWith('/api/drives/drive-1/envs');
+      expect(screen.getByText('No sessions running in here')).toBeDefined();
+    });
+
+    test("nests an env-bound session under its environment and leaves a loose one at drive level", async () => {
+      respondWithSessions(
+        [envSession('ses-env', 'env-1', 'inside staging'), envSession('ses-loose', null, 'ephemeral one')],
+        [{ id: 'env-1', name: 'staging', status: 'running' }],
+      );
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      expect(within(envRow).getByText('inside staging')).toBeDefined();
+      expect(within(envRow).queryByText('ephemeral one')).toBeNull();
+      expect(screen.getByText('ephemeral one')).toBeDefined();
+    });
+
+    test("renders the environment's derived status as a dot, named for what the state is", async () => {
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'stopped' }]);
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      expect(within(envRow).getByLabelText('Environment stopped')).toBeDefined();
+    });
+
+    test('offers no environment management to a member who cannot administer the drive', async () => {
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha', { isOwned: false, role: 'MEMBER' })] });
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'none' }]);
+      renderSidebar();
+
+      // The environment itself is still visible — a member may spawn sessions
+      // inside one, so hiding it would hide a capability they have.
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      expect(within(envRow).getByText('staging')).toBeDefined();
+      expect(within(envRow).queryByLabelText('Environment actions')).toBeNull();
+      expect(screen.queryByLabelText('New environment')).toBeNull();
+    });
+
+    test('an admin gets the "New environment" affordance, and creating one POSTs just a name', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], []);
+      mockPost.mockResolvedValue({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', status: 'none' } });
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText('New environment'));
+      await user.type(await screen.findByLabelText('Name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create' }));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs', { name: 'dev' }),
+      );
+    });
+
+    test('deleting refuses first, then escalates to the forced delete only after the server says sessions are live', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      mockDel.mockRejectedValueOnce(
+        new ApiRequestError('Sessions are still running in this environment', 409, {
+          reason: 'live_sessions',
+          liveSessionCount: 2,
+        }),
+      );
+      mockDel.mockResolvedValueOnce({ deleted: true });
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Delete environment'));
+      // The first press never carries ?force= — that is the whole guard.
+      await user.click(await screen.findByRole('button', { name: 'Delete environment' }));
+      await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/api/drives/drive-1/envs/env-1'));
+
+      // The refusal escalates in place, naming both halves of what force does.
+      expect(await screen.findByText(/2 sessions are still running/)).toBeDefined();
+      expect(screen.getByText(/destroys the shared filesystem/)).toBeDefined();
+      await user.click(screen.getByRole('button', { name: 'End sessions and delete' }));
+      await waitFor(() =>
+        expect(mockDel).toHaveBeenCalledWith('/api/drives/drive-1/envs/env-1?force=true'),
+      );
+    });
+
+    test('the rebuild confirm says the environment comes back blank before it POSTs', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      mockPost.mockResolvedValue({ rebuilt: true });
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Rebuild to blank'));
+
+      expect(await screen.findByText(/comes back BLANK/)).toBeDefined();
+      expect(mockPost).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: 'Rebuild to blank' }));
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs/env-1/rebuild'),
+      );
+    });
+
+    test('renaming PATCHes the name and nothing else — there is no kind to change', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'none' }]);
+      mockPatch.mockResolvedValue({ env: { id: 'env-1', name: 'prod-mirror' } });
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Rename'));
+
+      const input = await screen.findByLabelText('Name');
+      await user.clear(input);
+      await user.type(input, 'prod-mirror');
+      await user.click(screen.getByRole('button', { name: 'Rename' }));
+
+      await waitFor(() =>
+        expect(mockPatch).toHaveBeenCalledWith('/api/drives/drive-1/envs/env-1', { name: 'prod-mirror' }),
+      );
+    });
+
+    test('rebuilding re-reads the SESSIONS listing too — an env-bound session\'s status is the environment\'s', async () => {
+      const user = userEvent.setup();
+      respondWithSessions(
+        [envSession('ses-env', 'env-1', 'inside staging')],
+        [{ id: 'env-1', name: 'staging', status: 'running' }],
+      );
+      mockPost.mockResolvedValue({ rebuilt: true });
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      const sessionReadsBefore = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => url === '/api/agent-workspaces?driveId=drive-1',
+      ).length;
+
+      await user.click(within(envRow).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Rebuild to blank'));
+      await user.click(screen.getByRole('button', { name: 'Rebuild to blank' }));
+      await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs/env-1/rebuild'));
+
+      // Rebuild replaces the environment's machine, and an env-bound session
+      // reads its `sandboxStatus` off the ENVIRONMENT's row — so leaving the
+      // sessions listing alone would leave every row inside claiming 'running'
+      // against a machine that no longer exists.
+      await waitFor(() =>
+        expect(
+          mockFetchWithAuth.mock.calls.filter(([url]) => url === '/api/agent-workspaces?driveId=drive-1').length,
+        ).toBeGreaterThan(sessionReadsBefore),
+      );
+    });
+
+    test('a revalidation while the rename dialog is open does not overwrite what the user typed', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'none' }]);
+      const swr = renderSidebarWithMutate();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Rename'));
+
+      const input = (await screen.findByLabelText('Name')) as HTMLInputElement;
+      await user.clear(input);
+      await user.type(input, 'half-typed');
+
+      // The listing comes back with the environment renamed by someone else,
+      // which moves the dialog's `initialName` under it. The seed is bound to
+      // the OPEN transition, so the user's half-typed text survives.
+      respondWithSessions([], [{ id: 'env-1', name: 'renamed-elsewhere', status: 'none' }]);
+      await act(async () => {
+        await swr.revalidate('/api/drives/drive-1/envs');
+      });
+      await waitFor(() => expect(screen.getByText('renamed-elsewhere')).toBeDefined());
+
+      expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('half-typed');
+    });
+
+    test('an active search flattens the list — a matching env-bound session shows, its environment steps aside', async () => {
+      const user = userEvent.setup();
+      respondWithSessions(
+        [envSession('ses-env', 'env-1', 'inside staging')],
+        [{ id: 'env-1', name: 'staging', status: 'running' }],
+      );
+      renderSidebar();
+
+      await screen.findByTestId('sidebar-env-env-1');
+      await user.type(screen.getByPlaceholderText('Search sessions…'), 'inside');
+
+      expect(screen.getByText('inside staging')).toBeDefined();
+      expect(screen.queryByTestId('sidebar-env-env-1')).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/layout/left-sidebar/__tests__/env-groups.test.ts
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/env-groups.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The environment partition's three load-bearing rules: an empty environment
+ * still exists, a session is never dropped, and the ordering is the drive
+ * listing's own name order.
+ */
+import { describe, it, expect } from 'vitest';
+import { partitionSessionsByEnv } from '../env-groups';
+import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+
+const env = (over: Partial<DriveEnvDTO> & { id: string; name: string }): DriveEnvDTO => ({
+  driveId: 'drive-1',
+  status: 'none',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  ...over,
+});
+
+const session = (workspaceId: string, envId: string | null) => ({ workspaceId, envId });
+
+describe('partitionSessionsByEnv', () => {
+  it('given an environment with no sessions, should still render a group — infrastructure is not ephemera', () => {
+    const r = partitionSessionsByEnv([], [env({ id: 'env-1', name: 'staging' })]);
+    expect(r.envGroups).toHaveLength(1);
+    expect(r.envGroups[0]).toMatchObject({ envId: 'env-1', envName: 'staging', sessions: [] });
+    expect(r.looseSessions).toEqual([]);
+  });
+
+  it('given env-bound and loose sessions, should nest the bound ones and leave the rest at drive level', () => {
+    const r = partitionSessionsByEnv(
+      [session('a', 'env-1'), session('b', null), session('c', 'env-1')],
+      [env({ id: 'env-1', name: 'staging' })],
+    );
+    expect(r.envGroups[0].sessions.map((s) => s.workspaceId)).toEqual(['a', 'c']);
+    expect(r.looseSessions.map((s) => s.workspaceId)).toEqual(['b']);
+  });
+
+  it('given a session naming an environment the listing omitted, should surface it as an orphan rather than drop it', () => {
+    const r = partitionSessionsByEnv([session('a', 'env-missing')], []);
+    expect(r.looseSessions).toEqual([]);
+    expect(r.envGroups).toHaveLength(1);
+    expect(r.envGroups[0]).toMatchObject({ envId: 'env-missing', envName: null, status: null });
+    expect(r.envGroups[0].sessions.map((s) => s.workspaceId)).toEqual(['a']);
+  });
+
+  it('orders listed environments by name and puts orphans last', () => {
+    const r = partitionSessionsByEnv(
+      [session('a', 'env-orphan')],
+      [env({ id: 'env-z', name: 'zebra' }), env({ id: 'env-a', name: 'alpha' })],
+    );
+    expect(r.envGroups.map((g) => g.envId)).toEqual(['env-a', 'env-z', 'env-orphan']);
+  });
+
+  it('carries each environment’s derived status through, so the row can render a dot without a second lookup', () => {
+    const r = partitionSessionsByEnv([], [env({ id: 'env-1', name: 'staging', status: 'running' })]);
+    expect(r.envGroups[0].status).toBe('running');
+  });
+});

--- a/apps/web/src/components/layout/left-sidebar/env-groups.ts
+++ b/apps/web/src/components/layout/left-sidebar/env-groups.ts
@@ -1,0 +1,90 @@
+/**
+ * Splits one drive group's sessions into its ENVIRONMENTS and its loose
+ * sessions — pure and side-effect free, the environment-level counterpart to
+ * `session-groups.ts`.
+ *
+ * The mental model this encodes: a drive contains environments AND sessions at
+ * the same level, and an environment contains sessions. A session's `envId`
+ * says which filesystem it is a window onto (see the field's docblock on
+ * `session-contract.ts`), so grouping by it is grouping by shared disk — not by
+ * a label someone attached.
+ *
+ * Two rules are borrowed from `session-groups.ts` deliberately, because they
+ * are the same two problems one level down:
+ *
+ *  - **The listing is the roster.** Every environment the drive returns gets a
+ *    group even with zero sessions. An environment is infrastructure the user
+ *    deliberately created and pays for; it does not disappear when nothing is
+ *    running in it, and a surface that hid empty ones would make "my
+ *    environment is gone" the normal reading of an idle afternoon.
+ *  - **A session is never dropped.** A session naming an environment the
+ *    listing omits (a member whose env read failed, a row deleted between the
+ *    two fetches) becomes an ORPHAN group rather than vanishing, with a null
+ *    name the render layer falls back from.
+ */
+
+import type { DriveEnvDTO, DriveEnvStatus } from '@pagespace/lib/drive-envs/env-contract';
+
+export interface EnvGroup<T> {
+  envId: string;
+  /** Null for an orphan — an env a session names but the drive's listing did not return. */
+  envName: string | null;
+  /** Null for an orphan, for the same reason: there is no row here to derive one from. */
+  status: DriveEnvStatus | null;
+  sessions: T[];
+}
+
+export interface EnvPartition<T> {
+  envGroups: EnvGroup<T>[];
+  /** The drive's ordinary ephemeral sessions — each owns its own sandbox. */
+  looseSessions: T[];
+}
+
+function byEnvDisplayName<T>(a: EnvGroup<T>, b: EnvGroup<T>): number {
+  const nameA = a.envName ?? a.envId;
+  const nameB = b.envName ?? b.envId;
+  return nameA.localeCompare(nameB) || a.envId.localeCompare(b.envId);
+}
+
+export function partitionSessionsByEnv<T extends { envId: string | null }>(
+  sessions: readonly T[],
+  envs: readonly DriveEnvDTO[],
+): EnvPartition<T> {
+  const sessionsByEnv = new Map<string, T[]>();
+  const looseSessions: T[] = [];
+  for (const session of sessions) {
+    // Truthiness rather than `!== null`: an older client bundle (or a listing
+    // served mid-deploy) can hand back a session with the field simply absent,
+    // and "I do not know" has to read as the ephemeral default — never as a
+    // group keyed on `undefined`, which would collect every such session into
+    // one phantom environment.
+    if (!session.envId) {
+      looseSessions.push(session);
+      continue;
+    }
+    sessionsByEnv.set(session.envId, [...(sessionsByEnv.get(session.envId) ?? []), session]);
+  }
+
+  const listedIds = new Set(envs.map((env) => env.id));
+
+  const listedGroups = envs
+    .map((env) => ({
+      envId: env.id,
+      envName: env.name,
+      status: env.status,
+      sessions: sessionsByEnv.get(env.id) ?? [],
+    }))
+    .sort(byEnvDisplayName);
+
+  const orphanGroups = [...sessionsByEnv.keys()]
+    .filter((envId) => !listedIds.has(envId))
+    .map((envId) => ({
+      envId,
+      envName: null,
+      status: null,
+      sessions: sessionsByEnv.get(envId) ?? [],
+    }))
+    .sort(byEnvDisplayName);
+
+  return { envGroups: [...listedGroups, ...orphanGroups], looseSessions };
+}

--- a/apps/web/src/components/layout/left-sidebar/env-groups.ts
+++ b/apps/web/src/components/layout/left-sidebar/env-groups.ts
@@ -34,7 +34,8 @@ export interface EnvGroup<T> {
   sessions: T[];
 }
 
-export interface EnvPartition<T> {
+/** Not exported — nothing outside this module names it; callers infer it from `partitionSessionsByEnv`. */
+interface EnvPartition<T> {
   envGroups: EnvGroup<T>[];
   /** The drive's ordinary ephemeral sessions — each owns its own sandbox. */
   looseSessions: T[];

--- a/apps/web/src/hooks/drive-envs/useDriveEnvs.ts
+++ b/apps/web/src/hooks/drive-envs/useDriveEnvs.ts
@@ -1,0 +1,55 @@
+import useSWR from 'swr';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+
+/**
+ * A drive's environments, for every surface that needs them.
+ *
+ * ONE key per drive, exported, because two surfaces read the same list and one
+ * of them writes it: the sidebar's environment rows and the spawn palette's
+ * "in <env>" targets both mount `useDriveEnvs`, and creating or deleting an
+ * environment has to refresh whichever of the two is not the one that did it.
+ * Sharing the key makes that a single `mutate(driveEnvsKey(driveId))` instead
+ * of a callback chain between components that never meet.
+ *
+ * A REFUSAL IS NOT AN ERROR STATE HERE. The listing is member-gated, and a
+ * caller who cannot read it (a stale drive id, a membership just revoked)
+ * should see a drive with no environments — not a broken sidebar. So `envs`
+ * is always an array, and `error` is surfaced separately for the one caller
+ * that wants to say something about it.
+ */
+
+export const driveEnvsKey = (driveId: string | null | undefined): string | null =>
+  driveId ? `/api/drives/${encodeURIComponent(driveId)}/envs` : null;
+
+async function envsFetcher(url: string): Promise<{ envs: DriveEnvDTO[] }> {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to list environments (${response.status})`);
+  return response.json();
+}
+
+export function useDriveEnvs(
+  driveId: string | null | undefined,
+  options?: { enabled?: boolean },
+): {
+  envs: DriveEnvDTO[];
+  isLoading: boolean;
+  error: unknown;
+  mutate: () => void;
+} {
+  const enabled = options?.enabled ?? true;
+  const { data, error, isLoading, mutate } = useSWR<{ envs: DriveEnvDTO[] }>(
+    enabled ? driveEnvsKey(driveId) : null,
+    envsFetcher,
+    {
+      revalidateOnFocus: false,
+      // An environment is created and destroyed deliberately, by a person, and
+      // its derived status only moves when a machine is provisioned or torn
+      // down. Nothing here changes on its own often enough to poll for — the
+      // acts that DO change it all run through this hook's own `mutate`.
+      refreshInterval: 0,
+    },
+  );
+
+  return { envs: data?.envs ?? [], isLoading, error, mutate: () => void mutate() };
+}

--- a/apps/web/src/hooks/drive-envs/useDriveEnvs.ts
+++ b/apps/web/src/hooks/drive-envs/useDriveEnvs.ts
@@ -12,11 +12,19 @@ import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
  * Sharing the key makes that a single `mutate(driveEnvsKey(driveId))` instead
  * of a callback chain between components that never meet.
  *
- * A REFUSAL IS NOT AN ERROR STATE HERE. The listing is member-gated, and a
+ * A REFUSAL DOES NOT EMPTY THE SIDEBAR. The listing is member-gated, and a
  * caller who cannot read it (a stale drive id, a membership just revoked)
- * should see a drive with no environments — not a broken sidebar. So `envs`
- * is always an array, and `error` is surfaced separately for the one caller
- * that wants to say something about it.
+ * should still get a usable drive rather than a broken sidebar — so `envs` is
+ * always an array and never throws at the render site.
+ *
+ * But an empty array is NOT a synonym for "this drive has none", and callers
+ * must not treat it as one. Three different facts collapse into `[]`: the
+ * request is still in flight, the request failed, or the drive really has no
+ * environments. `isLoading` and `error` are returned so a caller can tell them
+ * apart, and both of this hook's callers do: the palette's step machine waits
+ * on `isLoading` rather than spawning ephemerally into a drive whose listing
+ * had not landed, and the sidebar renders a retry notice on `error` rather
+ * than silently presenting a drive as environment-less.
  */
 
 export const driveEnvsKey = (driveId: string | null | undefined): string | null =>

--- a/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
@@ -5,6 +5,7 @@ import {
   USAGE_FALLBACK_LOOKBACK_MS,
   type UsageLedgerRow,
 } from '../usage-breakdown';
+import { SANDBOX_STORAGE_MODELS } from '@pagespace/lib/monitoring/usage-source';
 
 const PERIOD = { periodStart: '2026-06-01T00:00:00.000Z', periodEnd: '2026-07-01T00:00:00.000Z' };
 
@@ -17,6 +18,8 @@ const row = (over: Partial<UsageLedgerRow>): UsageLedgerRow => ({
   pageId: null,
   pageTitle: null,
   durationMs: null,
+  sessionId: null,
+  envName: null,
   ...over,
 });
 
@@ -269,6 +272,108 @@ describe('aggregateUsageBreakdown', () => {
         PERIOD,
       );
       expect(r.byAgentSession.map((m) => m.pageId)).toEqual(['big', 'small']);
+    });
+  });
+
+  describe('byEnvironment (drive environments)', () => {
+    // What the storage meter actually writes for an environment's disk:
+    // source 'terminal' like a session's, no pageId at all, the env id on the
+    // shared analytics `sessionId` column, and the model label as the ONLY
+    // thing distinguishing it from a session's storage row.
+    const envStorageRow = (over: Partial<UsageLedgerRow>): UsageLedgerRow =>
+      row({
+        source: 'terminal',
+        model: SANDBOX_STORAGE_MODELS.env,
+        provider: 'sprites',
+        totalTokens: 0,
+        durationMs: 0,
+        pageId: null,
+        pageTitle: null,
+        ...over,
+      });
+
+    /** A session's RUNTIME row, for the cases that need agent spend beside the env's. */
+    const agentSessionRow = (over: Partial<UsageLedgerRow>): UsageLedgerRow =>
+      row({ source: 'terminal', model: 'terminal-machine', provider: 'sprites', totalTokens: 0, ...over });
+
+    it('given an env storage row, should never render it as an "Unattributed agent" — the bug this section exists for', () => {
+      const r = aggregateUsageBreakdown(
+        [envStorageRow({ sessionId: 'env-1', envName: 'staging', chargeMillicents: 8_000 })],
+        PERIOD,
+      );
+      expect(r.byAgentSession).toEqual([]);
+      expect(r.byEnvironment).toHaveLength(1);
+      expect(r.byEnvironment[0]).toMatchObject({ envId: 'env-1', label: 'staging', spendCents: 8, calls: 1 });
+    });
+
+    it('given env storage beside real agent spend, should keep it out of the agent section\'s sharePct denominator', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          agentSessionRow({ pageId: 'page-a', pageTitle: 'A', chargeMillicents: 7_500 }),
+          agentSessionRow({ pageId: 'page-b', pageTitle: 'B', chargeMillicents: 2_500 }),
+          // Ten times the agents' combined spend. If it were still counted in
+          // the terminal denominator, both shares below would collapse to a few
+          // percent.
+          envStorageRow({ sessionId: 'env-1', envName: 'staging', chargeMillicents: 100_000 }),
+        ],
+        PERIOD,
+      );
+      expect(r.byAgentSession.find((m) => m.pageId === 'page-a')!.sharePct).toBe(75);
+      expect(r.byAgentSession.find((m) => m.pageId === 'page-b')!.sharePct).toBe(25);
+    });
+
+    it('given a session storage row, should leave it in the agent section — only the ENV label moves', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          row({
+            source: 'terminal',
+            model: SANDBOX_STORAGE_MODELS.session,
+            provider: 'sprites',
+            pageId: 'agent-page-1',
+            pageTitle: 'My Agent',
+            chargeMillicents: 4_000,
+            durationMs: 0,
+            totalTokens: 0,
+          }),
+        ],
+        PERIOD,
+      );
+      expect(r.byAgentSession.map((m) => m.pageId)).toEqual(['agent-page-1']);
+      expect(r.byEnvironment).toEqual([]);
+    });
+
+    it('given several charges for one environment, should sum them into a single row', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          envStorageRow({ sessionId: 'env-1', envName: 'staging', chargeMillicents: 4_000 }),
+          envStorageRow({ sessionId: 'env-1', envName: 'staging', chargeMillicents: 6_000 }),
+        ],
+        PERIOD,
+      );
+      expect(r.byEnvironment).toHaveLength(1);
+      expect(r.byEnvironment[0]).toMatchObject({ envId: 'env-1', spendCents: 10, calls: 2 });
+    });
+
+    it('given an env whose row is gone, should label it "Deleted environment" rather than dropping its spend', () => {
+      const r = aggregateUsageBreakdown(
+        [envStorageRow({ sessionId: 'env-gone', envName: null, chargeMillicents: 3_000 })],
+        PERIOD,
+      );
+      expect(r.byEnvironment[0]).toMatchObject({ envId: 'env-gone', label: 'Deleted environment', spendCents: 3 });
+    });
+
+    it('computes sharePct against ENVIRONMENT spend, and sorts by spend descending', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          row({ source: 'chat', chargeMillicents: 900_000 }),
+          agentSessionRow({ pageId: 'page-a', pageTitle: 'A', chargeMillicents: 500_000 }),
+          envStorageRow({ sessionId: 'env-small', envName: 'dev', chargeMillicents: 2_500 }),
+          envStorageRow({ sessionId: 'env-big', envName: 'staging', chargeMillicents: 7_500 }),
+        ],
+        PERIOD,
+      );
+      expect(r.byEnvironment.map((e) => e.envId)).toEqual(['env-big', 'env-small']);
+      expect(r.byEnvironment.map((e) => e.sharePct)).toEqual([75, 25]);
     });
   });
 });

--- a/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
@@ -362,6 +362,20 @@ describe('aggregateUsageBreakdown', () => {
       expect(r.byEnvironment[0]).toMatchObject({ envId: 'env-gone', label: 'Deleted environment', spendCents: 3 });
     });
 
+    it('given a charge that recorded no env id at all, should say "Unknown environment" — not claim a deletion it cannot know', () => {
+      const r = aggregateUsageBreakdown(
+        [envStorageRow({ sessionId: null, envName: null, chargeMillicents: 5_000 })],
+        PERIOD,
+      );
+      expect(r.byEnvironment[0]).toMatchObject({
+        envId: null,
+        label: 'Unknown environment',
+        spendCents: 5,
+      });
+      // Still out of the agent section, which is the point of the split.
+      expect(r.byAgentSession).toEqual([]);
+    });
+
     it('computes sharePct against ENVIRONMENT spend, and sorts by spend descending', () => {
       const r = aggregateUsageBreakdown(
         [

--- a/apps/web/src/lib/subscription/usage-breakdown-query.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown-query.ts
@@ -10,11 +10,13 @@ import { and, eq, gte, lte } from '@pagespace/db/operators';
 import { creditBalances, creditLedger } from '@pagespace/db/schema/credits';
 import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
 import { pages } from '@pagespace/db/schema/core';
+import { driveEnvs } from '@pagespace/db/schema/drive-envs';
 import { aggregateUsageBreakdown, resolveUsageWindow, type UsageBreakdown } from './usage-breakdown';
 
 /**
- * Spend-by-feature, spend-by-model, and (for source:'terminal') spend-by-agent-session
- * for the user's current billing period. Spend is the ledger's precise charged amount
+ * Spend-by-feature, spend-by-model, spend-by-agent-session and spend-by-environment
+ * (the last two both from source:'terminal' rows, split by the storage meter's model
+ * label) for the user's current billing period. Spend is the ledger's precise charged amount
  * (`chargeMillicents`, post-markup) — never the raw provider `cost`. The join drops
  * usage rows whose AI log has been purged by retention, which is acceptable for a
  * "recent usage" view.
@@ -58,10 +60,20 @@ export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakd
       pageId: aiUsageLogs.pageId,
       pageTitle: pages.title,
       durationMs: aiUsageLogs.duration,
+      // ENVIRONMENT attribution. `aiUsageLogs.sessionId` is a shared analytics
+      // column many sources write, so this join is only MEANINGFUL for the env
+      // storage rows the aggregator selects by model — every other row simply
+      // fails to match a `drive_envs` id and comes back with a null name, which
+      // the aggregator never reads. Left-joined (not inner) so a DELETED
+      // environment still surfaces its spend, under "Deleted environment",
+      // rather than disappearing — the same rule `pages` follows above.
+      sessionId: aiUsageLogs.sessionId,
+      envName: driveEnvs.name,
     })
     .from(creditLedger)
     .innerJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
     .leftJoin(pages, eq(aiUsageLogs.pageId, pages.id))
+    .leftJoin(driveEnvs, eq(aiUsageLogs.sessionId, driveEnvs.id))
     .where(
       and(
         eq(creditLedger.userId, userId),

--- a/apps/web/src/lib/subscription/usage-breakdown.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown.ts
@@ -12,6 +12,7 @@
 
 import {
   normalizeUsageSource,
+  SANDBOX_STORAGE_MODELS,
   USAGE_SOURCE_LABELS,
   type AIUsageSource,
 } from '@pagespace/lib/monitoring/usage-source';
@@ -28,6 +29,14 @@ export interface UsageLedgerRow {
   pageTitle: string | null;
   /** Active-window duration in milliseconds (source:'terminal' rows only). */
   durationMs: number | null;
+  /**
+   * The shared analytics session column. For an ENVIRONMENT storage charge
+   * (`model: SANDBOX_STORAGE_MODELS.env`) it carries the `drive_envs` id — the
+   * only handle those rows have, since they are page-less by construction.
+   */
+  sessionId: string | null;
+  /** The environment's name, pre-joined by the query — null once the env row is gone. */
+  envName: string | null;
 }
 
 export interface UsageBreakdownPeriod {
@@ -99,11 +108,37 @@ export interface UsageAgentSessionRow {
   sharePct: number;
 }
 
+/**
+ * One environment's persistence spend this period.
+ *
+ * Its OWN section, deliberately not a line in `byAgentSession`. An env storage
+ * row is `source: 'terminal'` with no `pageId`, so it used to fall into that
+ * view's catch-all "Unattributed agent" bucket — and once environments are a
+ * thing users create and name, a drive's shared machine reading as an
+ * unattributed agent is simply a wrong answer, not a rounding one. It is also
+ * excluded from that section's denominator, so an agent's share of agent spend
+ * no longer moves when an unrelated environment is billed for its disk.
+ *
+ * There is no `activeSeconds`: an environment is billed for the disk it keeps,
+ * not for a wall-clock window, and every one of these rows carries a zero
+ * duration. Reporting "0s" beside a real charge would read as a bug.
+ */
+export interface UsageEnvironmentRow {
+  /** `drive_envs.id`, or null for a charge whose env id was never recorded. */
+  envId: string | null;
+  label: string;
+  spendCents: number;
+  calls: number;
+  /** Share of ENVIRONMENT spend (not overall spend) this environment accounts for. */
+  sharePct: number;
+}
+
 export interface UsageBreakdown extends UsageBreakdownPeriod {
   totalSpendCents: number;
   byFeature: UsageFeatureRow[];
   byModel: UsageModelRow[];
   byAgentSession: UsageAgentSessionRow[];
+  byEnvironment: UsageEnvironmentRow[];
 }
 
 /** Internal accumulator (spend tracked in millicents for precision). */
@@ -130,8 +165,10 @@ export function aggregateUsageBreakdown(
   const featureBuckets = new Map<AIUsageSource, Bucket>();
   const modelBuckets = new Map<string, Bucket & { model: string; provider: string }>();
   const agentSessionBuckets = new Map<string, { millicents: number; calls: number; activeSeconds: number; pageId: string | null; label: string }>();
+  const environmentBuckets = new Map<string, { millicents: number; calls: number; envId: string | null; label: string }>();
   let totalMillicents = 0;
   let agentSessionMillicents = 0;
+  let environmentMillicents = 0;
 
   for (const r of rows) {
     const charge = r.chargeMillicents ?? 0;
@@ -155,7 +192,21 @@ export function aggregateUsageBreakdown(
     mb.calls += 1;
     modelBuckets.set(key, mb);
 
-    if (source === 'terminal') {
+    if (source === 'terminal' && r.model === SANDBOX_STORAGE_MODELS.env) {
+      // An ENVIRONMENT's disk. Split off BEFORE the per-agent bucketing below,
+      // which is the whole point: these rows have no `pageId` and would
+      // otherwise land in its "Unattributed agent" line and its denominator.
+      // The env id rides on `sessionId` (see `sandbox-storage-billing.ts`) and
+      // the name is resolved by the query; a name that no longer resolves means
+      // the env was deleted, which is a fact worth showing rather than hiding.
+      environmentMillicents += charge;
+      const envKey = r.sessionId ?? '__unidentified_env__';
+      const envLabel = r.envName ?? 'Deleted environment';
+      const eb = environmentBuckets.get(envKey) ?? { millicents: 0, calls: 0, envId: r.sessionId, label: envLabel };
+      eb.millicents += charge;
+      eb.calls += 1;
+      environmentBuckets.set(envKey, eb);
+    } else if (source === 'terminal') {
       agentSessionMillicents += charge;
       // Rows without a resolvable page (pre-attribution history, or a session
       // with no backing page e.g. the global assistant) collapse into one
@@ -204,6 +255,16 @@ export function aggregateUsageBreakdown(
     }))
     .sort((a, b) => b.spendCents - a.spendCents);
 
+  const byEnvironment: UsageEnvironmentRow[] = Array.from(environmentBuckets.values())
+    .map((b) => ({
+      envId: b.envId,
+      label: b.label,
+      spendCents: millicentsToCents(b.millicents),
+      calls: b.calls,
+      sharePct: sharePct(b.millicents, environmentMillicents),
+    }))
+    .sort((a, b) => b.spendCents - a.spendCents);
+
   return {
     periodStart: period.periodStart,
     periodEnd: period.periodEnd,
@@ -211,5 +272,6 @@ export function aggregateUsageBreakdown(
     byFeature,
     byModel,
     byAgentSession,
+    byEnvironment,
   };
 }

--- a/apps/web/src/lib/subscription/usage-breakdown.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown.ts
@@ -201,7 +201,13 @@ export function aggregateUsageBreakdown(
       // the env was deleted, which is a fact worth showing rather than hiding.
       environmentMillicents += charge;
       const envKey = r.sessionId ?? '__unidentified_env__';
-      const envLabel = r.envName ?? 'Deleted environment';
+      // TWO different unknowns, told apart rather than merged. A row WITH an
+      // env id whose name did not resolve names an environment that is gone —
+      // "Deleted environment" is a fact. A row with NO env id establishes no
+      // such thing: the charge simply never recorded which environment it was
+      // for, so calling it deleted asserts something we do not know. Both keep
+      // their spend visible either way; only the claim differs.
+      const envLabel = r.envName ?? (r.sessionId ? 'Deleted environment' : 'Unknown environment');
       const eb = environmentBuckets.get(envKey) ?? { millicents: 0, calls: 0, envId: r.sessionId, label: envLabel };
       eb.millicents += charge;
       eb.calls += 1;

--- a/packages/lib/src/monitoring/usage-source.ts
+++ b/packages/lib/src/monitoring/usage-source.ts
@@ -52,3 +52,25 @@ export const USAGE_SOURCE_LABELS: Record<AIUsageSource, string> = {
   terminal: 'Terminal',
   other: 'Other',
 };
+
+/**
+ * The `model` labels the sandbox storage meter writes for a persistence charge —
+ * one per BILLED UNIT, not per substrate.
+ *
+ * They live here, beside the source vocabulary, because they are read by two
+ * sides that must not drift: the meter that stamps them
+ * (`services/sandbox/sandbox-storage-billing.ts`) and the usage breakdown that
+ * splits an environment's storage out of the per-agent section
+ * (`apps/web/src/lib/subscription/usage-breakdown.ts`). Both rows carry
+ * `source: 'terminal'` and no `pageId`, so this label is the ONLY thing that
+ * says which of the two a charge is — which is why it cannot be a string
+ * literal spelled at each end.
+ *
+ * `session` keeps the string it has always been written under: renaming it
+ * would split one meter's history across two labels in every existing usage
+ * breakdown.
+ */
+export const SANDBOX_STORAGE_MODELS = {
+  session: 'terminal-machine-storage',
+  env: 'drive-env-storage',
+} as const;

--- a/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
@@ -51,6 +51,7 @@ import { driveEnvs } from '@pagespace/db/schema/drive-envs';
 import { lookupDriveOwnerId } from '../../billing/sandbox-payer';
 import { MACHINE_MARKUP_BPS } from '../../billing/credit-pricing';
 import { AIMonitoring } from '../../monitoring/ai-monitoring';
+import { SANDBOX_STORAGE_MODELS } from '../../monitoring/usage-source';
 import {
   reconcileSandboxStorage,
   type ReconcileSandboxStorageDeps,
@@ -150,14 +151,13 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
       // bigger guest, a GPU host or another platform keeps billing under this
       // same label.
       //
-      // What this label does NOT yet do is separate the two in the usage
-      // breakdown's per-agent section: that view buckets every `source:
-      // 'terminal'` row by `pageId`, and an env has none, so env storage lands
-      // in the same "Unattributed agent" line as global-assistant session
-      // storage. Only the by-model view distinguishes them today. Ratified as
-      // acceptable for this slice; envs get their own breakdown section as a
-      // binding requirement on the Environments UI task.
-      model: subjectKind === 'env' ? 'drive-env-storage' : 'terminal-machine-storage',
+      // This label is also what the usage breakdown splits on: an env row and a
+      // session row both carry `source: 'terminal'` and no `pageId`, so the
+      // model string is the ONLY thing that says which of the two a charge is.
+      // Hence the shared constant rather than a literal spelled at each end —
+      // the breakdown's environments section keys off the same value
+      // (`apps/web/src/lib/subscription/usage-breakdown.ts`).
+      model: subjectKind === 'env' ? SANDBOX_STORAGE_MODELS.env : SANDBOX_STORAGE_MODELS.session,
       // One feature bucket for both: this is sandbox persistence either way, and
       // splitting the source would fragment the usage breakdown's totals.
       source: 'terminal',


### PR DESCRIPTION
Makes drive environments user-visible. Everything #2441 shipped dark now has a surface: the sidebar renders environments, the spawn palette targets them, admins manage them, and their storage spend stops describing itself as an unattributed agent.

## Sidebar — environments beside sessions, not inside them

A drive contains environments **AND** sessions at the same level; an environment contains sessions. `env-groups.ts` partitions one drive group into both rather than treating an environment as a folder someone filed sessions into. Nesting a session under its environment shows *which filesystem it sees* — `envId` is the shared disk, not a label.

Two rules are borrowed from `session-groups.ts` deliberately, because they are the same two problems one level down:

- **The listing is the roster.** An environment with zero sessions still renders. It is infrastructure someone deliberately created and is billed for; a row that vanished whenever nobody happened to be working would recreate exactly the ephemeral mental model environments exist to replace.
- **A session is never dropped.** One naming an environment the listing did not return (a member whose env read failed, a row deleted between the two fetches) becomes an ORPHAN group with a null name the render layer falls back from, rather than disappearing.

An **active search flattens the list**: the search is a flat find over session names, so an environment whose sessions were all filtered out would otherwise sit there as an empty container claiming to be a match.

The status dot **always renders**, unlike a session's, and that difference is the point. A session without a sandbox is just a conversation; an environment without a machine is still an environment — it exists, costs its keep, and provisions on first use. A dot that disappeared would say the environment had.

## Spawn — "in \<env name\>"

`SpawnPick.envId` is three-state on purpose: `undefined` = not asked yet (what makes the step appear), `null` = the ephemeral default, a string = the environment. "Ephemeral" is a real choice a user makes, not the absence of one, so it cannot be the same value as "has not answered yet". **A drive with no environments never sees the step** and the flow is byte-for-byte what it was.

## Management — ADMIN/OWNER, and the copy is the feature

Create (name only — there is no kind), rename, rebuild, delete. Role-gated affordances: a member gets **no menu at all** rather than a menu that refuses, matching how the header withholds its "New environment" button. Orphans get no menu either — there is no row here to act on.

Both destructive verbs destroy other people's work, so both name the consequence:

- **Delete** sends no `?force=` on the first press. The server refuses while sessions are live (409 `live_sessions`), and the dialog escalates *in place* to a second confirm naming both halves — it ends those sessions **and** destroys the shared filesystem, for everyone in the drive. The count is the server's: this listing holds only the viewer's own sessions, so a teammate's is invisible here and is exactly the case the warning exists for.
- **Rebuild** says the environment comes back **BLANK**, keeping its name and nothing else.

All three dialogs register with `useEditingStore` per repo rule.

## Usage — environments get their own section

`model: 'drive-env-storage'` rows are split off **before** the per-agent bucketing. That is the whole fix: they carry `source: 'terminal'` and no `pageId`, so they landed in the "Unattributed agent" line *and* in that section's `sharePct` denominator. Once environments are things users create and name, a drive's shared machine reading as an unattributed agent is a wrong answer, not a rounding one — and an agent's share of agent spend no longer moves when an unrelated environment is billed for its disk.

The env id rides on the shared analytics `sessionId` column, LEFT-joined to `drive_envs` for the name — left, not inner, so a **deleted** environment still surfaces its spend as "Deleted environment" rather than silently vanishing. The join is on a PK, so no row fan-out. The model label is now a shared constant (`SANDBOX_STORAGE_MODELS`), since it is the only thing distinguishing an env charge from a session charge and was previously a literal spelled at both ends. No `activeSeconds` column: these are metered per GB-month, not against a wall clock, so every row carries a zero duration and "0s" beside a real charge would read as a bug.

### This reclassification is RETROACTIVE, not forward-only

The aggregator reads the ledger, so **every historical `drive-env-storage` row moves too** — it is not scoped to charges written after this merge. Concretely, for any past period a user opens: spend that previously appeared in "Unattributed agent" now appears in the Environments section instead, and because those millicents also leave the agent section's denominator, **the `sharePct` shown against past agent sessions will change** (each agent's share goes up, since the denominator shrinks). Totals are unaffected — `totalSpendCents` and the by-feature/by-model views are untouched.

This is intended: the old numbers were wrong in both places, and leaving history mislabelled to keep old screenshots stable would mean the same charge reads as two different things depending on when you look. Flagging it explicitly because the diff reads as forward-only and a reviewer could reasonably assume past periods were left alone.

### Known cost: per-drive `/envs` fanout

On the **global** sidebar the environments fetch is one request per rendered drive group, because a group is where a drive id first exists as a single value. For a user in many drives that is a burst of small requests on mount. Deliberate for this slice — the listing is small, cached per drive, and shares its SWR key with the spawn palette so opening the palette costs nothing extra — but a bulk `GET /api/drives/envs` returning envs for every accessible drive in one round trip is the obvious follow-up, and the sidebar is the only caller that would need to change. Drive-scoped mode (the common case) issues exactly one request either way.

## Changelog

Environments entries added. The #2441 file-access permission tightening already landed its own entry on master (CHANGELOG.md:102) — verified rather than duplicated.

## Two defects found and fixed in self-review

Both were in the inherited WIP, both now covered by tests that were **mutation-checked red**:

1. **The rename dialog's seeding contradicted its own comment.** It claimed to seed on open only, but `initialName` was in the effect's dependency list — so a listing revalidation while the dialog was open (a teammate renaming the same environment) would overwrite what the user had typed. Now bound to the open *transition* via a ref.
2. **Rebuild never refreshed the sessions listing.** An env-bound session's `sandboxStatus` is read off the **environment's** row, so replacing the environment's machine leaves every session inside claiming `running` against a machine that no longer exists. Delete already did this; rebuild now does too.

## Review fixes (second commit)

1. **HIGH — the spawn palette raced its own env fetch.** `envs` is `[]` both while loading and when the drive truly has none, so the step machine treated "not answered yet" as an answer. Two silent failure modes: a fast pick spawned `envId: null` into a drive that *has* environments, or the listing landed mid-keystroke and replaced the name form (wiping the typed text via the `setName('')` effect). Now gated on `isLoading` with an explicit `'pending'` step. Added the missing palette env-step tests — "in \<env name\>" items render with the ephemeral default leading, the chosen `envId` reaches the POST body, and a held-open fetch does not advance the flow. Every pre-existing spawn test ran with `envs: []`, which is exactly why this survived.
2. **MED-HIGH — the envs failure path was silent.** `useDriveEnvs` returned `error` and no caller read it (its docblock claimed otherwise — corrected). A 500 rendered every env-bound session as an orphan group headed by a **raw CUID**. Now: a "Could not load environments" notice with a retry on the drive group, and orphans read **"Unavailable environment"** instead of an id. The orphan mechanism is unchanged — only what it says when it has no name.
3. **LOW** — the agent-workspaces route's "ships dark / no UI sends it" comment is no longer true; updated.
4. **LOW** — drive-scoped "New environment" now requires a live drive (trashed drives were offered new infrastructure); `EnvPartition` unexported (nothing names it).

## Review fixes (third commit — CodeRabbit)

Both findings were the same mistake in different places: treating an absence of information as information.

5. **The palette handled the env listing being SLOW but not it FAILING.** A failed uncached request leaves `envs: []` with `isLoading: false` — byte for byte the shape of "this drive has none" — so it sailed past the question and spawned `envId: null` into a drive whose environments it had failed to read. The error twin of finding 1. Now its own `error` step: **Try again** first, an explicit **Use a new sandbox** second. Not a hard block — an ephemeral session stays reachable, but as a choice rather than a default.
6. **The usage breakdown called every unresolved environment "Deleted".** A row carrying an env id whose name did not resolve really does name a gone environment; a row with *no* env id establishes nothing — the charge never recorded which environment it was for. That case now reads **"Unknown environment"**. Both keep their spend; only the claim differs.

Both threads replied to and resolved.

## Verification

- `bun run typecheck` — 17/17 successful (full monorepo, after `bun run build`)
- `bun run lint` — 15/15 successful
- `bun run knip:check` — within baseline
- **web suite: 1199/1201 files, 18003 tests passing** against a provisioned Postgres. The one failure is `chat-mutation-matrix.integration` — the known local-only ordering failure that passes on CI.
- `packages/lib` drive-envs + sandbox suites: **126/126** on a correctly-provisioned DB.
- Sidebar suite: **88/88** (was 79 before this work; 9 new environment tests). Usage-breakdown suite 29/29.
- Mutation checks: disabling the env/agent split turns 5 usage tests red; removing the `isLoading` gate turns the race test red; forcing the `error` branch off turns both failed-listing tests red; reverting each of the two self-review fixes turns its own new test red.

**Caveat, stated plainly:** this worktree's local Postgres provisioning proved unreliable late in the session (a pre-existing instance on :5432 was emptied mid-run by something outside this task), so the *final* full `packages/lib` sweep reported ~12 integration files erroring with `relation "..." does not exist` — a provisioning failure signature, not assertion failures, and including files this PR does not touch (pkce, webhooks, rate-limiting). The same drive-envs suites passed 126/126 earlier in the session with these exact changes in the tree. CI provisions the DB properly; please treat CI as the authority on those files.

Note the two `packages/lib` changes are value-preserving: one new exported const, and two string literals replaced by references to it with identical values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent drive environments with shared filesystems and organized session grouping in the sidebar.
  * Create, rename, rebuild, and delete environments with status indicators and permission-aware controls.
  * Select an environment—or explicitly choose an ephemeral sandbox—when starting sessions.
  * Added per-environment usage and storage reporting to the usage settings page.
* **Bug Fixes**
  * Improved loading, retry, and handling of deleted, empty, or unavailable environments.
* **Documentation**
  * Updated the changelog with environment lifecycle, visibility, placement, and usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->